### PR TITLE
build: go 1.16 support by adding +build comments alongside go:build ones

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero
 
-go 1.17
+go 1.16
 
 require github.com/stretchr/testify v1.5.1
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,3 @@ module github.com/tetratelabs/wazero
 go 1.16
 
 require github.com/stretchr/testify v1.5.1
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
-)

--- a/wasm/buildoptions/callstack_overflow_disabled.go
+++ b/wasm/buildoptions/callstack_overflow_disabled.go
@@ -1,4 +1,5 @@
 //go:build disable_callstack_overflow_check
+// +build disable_callstack_overflow_check
 
 package buildoptions
 

--- a/wasm/buildoptions/callstack_overflow_enabled.go
+++ b/wasm/buildoptions/callstack_overflow_enabled.go
@@ -1,4 +1,5 @@
 //go:build !disable_callstack_overflow_check
+// +build !disable_callstack_overflow_check
 
 package buildoptions
 

--- a/wasm/buildoptions/debug_disabled.go
+++ b/wasm/buildoptions/debug_disabled.go
@@ -1,4 +1,5 @@
 //go:build !debug_mode
+// +build !debug_mode
 
 package buildoptions
 

--- a/wasm/buildoptions/debug_enabled.go
+++ b/wasm/buildoptions/debug_enabled.go
@@ -1,4 +1,5 @@
 //go:build debug_mode
+// +build debug_mode
 
 package buildoptions
 


### PR DESCRIPTION
I believe this is the way to enable both go1.16 and go1.17+ support.