### PR TITLE
Ensures pre-commit check verifies spectest coherence

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -18,7 +18,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install wast2json
-        run: |  # Needed for build.spectest. wabt includes tools including wast2json
+        run: |  # Needed for build.spectest. wabt includes wast2json
           wabt_version=1.0.24
           wabt_url=https://github.com/WebAssembly/wabt/releases/download/${wabt_version}/wabt-${wabt_version}-ubuntu.tar.gz
           curl -sSL ${wabt_url} | tar --strip-components 2 -C /usr/local/bin -xzf - wabt-${wabt_version}/bin/wast2json

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -1,20 +1,27 @@
 name: Test
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
   push:
-    branches:
-      - main
+    branches: [main]
+
+env:  # Update this prior to requiring a higher minor version in go.mod
+  GO_VERSION: "1.17"  # Latest patch
 
 jobs:
-  style:
-    name: Code style check
+  check:
+    name: Pre-commit check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.1'
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install wast2json
+        run: |  # Needed for build.spectest. wabt includes tools including wast2json
+          wabt_version=1.0.24
+          wabt_url=https://github.com/WebAssembly/wabt/releases/download/${wabt_version}/wabt-${wabt_version}-ubuntu.tar.gz
+          curl -sSL ${wabt_url} | tar --strip-components 2 -C /usr/local/bin -xzf - wabt-${wabt_version}/bin/wast2json
 
       - uses: actions/checkout@v2
 
@@ -25,8 +32,9 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-
       - run: make lint
+
+      - run: make build.spectest
 
       - run: make check
 
@@ -36,7 +44,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.1'
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ spec_version := wg-1.0
 build.spectest:
 	@rm -rf $(spectests_cases_dir) && mkdir -p $(spectests_cases_dir)
 	@cd $(spectests_cases_dir) \
-		&& curl 'https://api.github.com/repos/WebAssembly/spec/contents/test/core?ref=$(spec_version)' | jq -r '.[]| .download_url' | grep -E ".wast"| xargs wget -q
+		&& curl -sSL 'https://api.github.com/repos/WebAssembly/spec/contents/test/core?ref=$(spec_version)' | jq -r '.[]| .download_url' | grep -E ".wast"| xargs wget -q
 	@cd $(spectests_cases_dir) && for f in `find . -name '*.wast'`; do \
 		perl -pi -e 's/\((assert_return_canonical_nan|assert_return_arithmetic_nan)\s(\(invoke\s"f32.demote_f64"\s\((f[0-9]{2})\.const\s[a-z0-9.+:-]+\)\))\)/\(assert_return $$2 \(f32.const nan\)\)/g' $$f; \
 		perl -pi -e 's/\((assert_return_canonical_nan|assert_return_arithmetic_nan)\s(\(invoke\s"f64\.promote_f32"\s\((f[0-9]{2})\.const\s[a-z0-9.+:-]+\)\))\)/\(assert_return $$2 \(f64.const nan\)\)/g' $$f; \


### PR DESCRIPTION
spectests are derived from a remote location. This tests files checked
in match the commit. This also ensures the target to do so works.
