### PR TITLE
Ensures CI tests with Go 1.16

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - go-version: ${{ env.GO_VERSION }}
+          - go-version: "1.17"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
           - go-version: "1.16"  # temporarily support go 1.16 per #37
 
     steps:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -41,10 +41,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - go-version: ${{ env.GO_VERSION }}
+          - go-version: "1.16"  # temporarily support go 1.16 per #37
+
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go-version }}
 
       - uses: actions/checkout@v2
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/tetratelabs/wazero
 
+// temporarily support go 1.16 per #37
 go 1.16
 
 require github.com/stretchr/testify v1.5.1


### PR DESCRIPTION
This ensures we temporarily support go 1.16 per #37

Notably, this does not attempt to run linters or other optional tasks as we use go 1.17 features such as `go run` against a versioned tag.