### PR TITLE
Use wazeroir in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ another language that targets Wasm, such as Rust.
 func Test_fibonacci(t *testing.T) {
 	binary, _ := os.ReadFile("wasm/fibonacci.wasm")
 	mod, _ := wasm.DecodeModule(binary)
-	store := wasm.NewStore(naivevm.NewEngine())
+	store := wasm.NewStore(wazeroir.NewEngine())
 	store.Instantiate(mod, "test")
 
 	for _, c := range []struct {

--- a/examples/fibonacci_test.go
+++ b/examples/fibonacci_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
-	"github.com/tetratelabs/wazero/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasm/wazeroir"
 )
 
 func Test_fibonacci(t *testing.T) {
@@ -18,7 +18,7 @@ func Test_fibonacci(t *testing.T) {
 	mod, err := wasm.DecodeModule(buf)
 	require.NoError(t, err)
 
-	store := wasm.NewStore(naivevm.NewEngine())
+	store := wasm.NewStore(wazeroir.NewEngine())
 	require.NoError(t, err)
 
 	err = wasi.NewEnvironment().Register(store)

--- a/examples/file_system_test.go
+++ b/examples/file_system_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
-	"github.com/tetratelabs/wazero/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasm/wazeroir"
 )
 
 func writeFile(fs wasi.FS, path string, data []byte) error {
@@ -54,7 +54,7 @@ func Test_file_system(t *testing.T) {
 
 	wasiEnv := wasi.NewEnvironment(wasi.Preopen(".", memFS))
 
-	store := wasm.NewStore(naivevm.NewEngine())
+	store := wasm.NewStore(wazeroir.NewEngine())
 
 	err = wasiEnv.Register(store)
 	require.NoError(t, err)

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
-	"github.com/tetratelabs/wazero/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasm/wazeroir"
 )
 
 func Test_hostFunc(t *testing.T) {
@@ -21,7 +21,7 @@ func Test_hostFunc(t *testing.T) {
 	mod, err := wasm.DecodeModule((buf))
 	require.NoError(t, err)
 
-	store := wasm.NewStore(naivevm.NewEngine())
+	store := wasm.NewStore(wazeroir.NewEngine())
 
 	// Host-side implementation of get_random_string on Wasm import.
 	getRandomString := func(ctx *wasm.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {

--- a/examples/stdio_test.go
+++ b/examples/stdio_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
-	"github.com/tetratelabs/wazero/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasm/wazeroir"
 )
 
 func Test_stdio(t *testing.T) {
@@ -26,7 +26,7 @@ func Test_stdio(t *testing.T) {
 		wasi.Stdout(stdoutBuf),
 		wasi.Stderr(stderrBuf),
 	)
-	store := wasm.NewStore(naivevm.NewEngine())
+	store := wasm.NewStore(wazeroir.NewEngine())
 	err = wasiEnv.Register(store)
 	require.NoError(t, err)
 	err = store.Instantiate(mod, "test")

--- a/examples/trap_test.go
+++ b/examples/trap_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
-	"github.com/tetratelabs/wazero/wasm/naivevm"
+	"github.com/tetratelabs/wazero/wasm/wazeroir"
 )
 
 func Test_trap(t *testing.T) {
@@ -18,7 +18,7 @@ func Test_trap(t *testing.T) {
 	mod, err := wasm.DecodeModule((buf))
 	require.NoError(t, err)
 
-	store := wasm.NewStore(naivevm.NewEngine())
+	store := wasm.NewStore(wazeroir.NewEngine())
 
 	err = wasi.NewEnvironment().Register(store)
 	require.NoError(t, err)


### PR DESCRIPTION
As per #49, this commit uses wazeroir in examples to showcase that it is the default engine we recommend.