### PR TITLE
Adds benchmarks around debug flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
 
 .PHONY: bench
 bench:
-	@go test -bench=. ./bench/*bench_test.go
+	@go test -benchmem -bench=. ./bench/*bench_test.go
 
 .PHONY: build.bench
 build.bench:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
 
 .PHONY: bench
 bench:
-	@go test -bench=. ./bench/bench_test.go
+	@go test -bench=. ./bench/*bench_test.go
 
 .PHONY: build.bench
 build.bench:

--- a/bench/debug_bench_test.go
+++ b/bench/debug_bench_test.go
@@ -1,0 +1,74 @@
+package bench
+
+import (
+	"fmt"
+	"io"
+	"testing"
+)
+
+// These benchmark guard usage at various scopes.
+const (
+	const_debug_true  = true
+	const_debug_false = false
+)
+
+var (
+	var_debug_true  = true
+	var_debug_false = false
+	arg             = map[string]string{"foo": "bar"}
+)
+
+type obj struct {
+	debug bool
+}
+
+func (o *obj) fprintf()  {
+	if o.debug {
+		fmt.Fprintf(io.Discard, "arg: %v", arg)
+	}
+}
+
+func BenchmarkFprintf(b *testing.B) {
+	// should be the same as NoOp without a const false guard as the compiler should delete the block
+	b.Run("NoOp const false", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if const_debug_false {
+				fmt.Fprintf(io.Discard, "arg: %v", arg)
+			}
+		}
+	})
+	b.Run("NoOp var false", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if var_debug_false {
+				fmt.Fprintf(io.Discard, "arg: %v", arg)
+			}
+		}
+	})
+	objFalse := obj{false}
+	b.Run("Fprintf obj false", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			objFalse.fprintf()
+		}
+	})
+	// should be the same as NoOp without a const true guard as the compiler should delete the if
+	b.Run("Fprintf const true", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if const_debug_true {
+				fmt.Fprintf(io.Discard, "arg: %v", arg)
+			}
+		}
+	})
+	b.Run("Fprintf var true", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if var_debug_true {
+				fmt.Fprintf(io.Discard, "arg: %v", arg)
+			}
+		}
+	})
+	objTrue := obj{true}
+	b.Run("Fprintf obj true", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			objTrue.fprintf()
+		}
+	})
+}

--- a/bench/debug_bench_test.go
+++ b/bench/debug_bench_test.go
@@ -22,7 +22,7 @@ type obj struct {
 	debug bool
 }
 
-func (o *obj) fprintf()  {
+func (o *obj) fprintf() {
 	if o.debug {
 		fmt.Fprintf(io.Discard, "arg: %v", arg)
 	}


### PR DESCRIPTION
I believe that this shows the cost factor of const vs var vs object
field guards on debug flags. Particularly, const can only be set via
build flags, var (and obj) via ldflags or config. There are usability
impacts so, this can help show impact.

This uses `Fprintf`, not something more arbitrary like 1+1 to show
relative impact as almost all debug guards cover a printf.

My analysis:

On my laptop, the guard on true cost is small, like 0.05ns, but in CI it
can accumulate to almost 0.18ns. If these are in extremely large loops it
could be a factor to consider retaining debug flag as compilation only
(a build flag). For example, 5-20k checks would accumulate to a
microsecond.

Besides this overhead in large loops (or inner loops), the other main
factor is that restricting to compilation means you cannot enable this
sort of debug without rebuilding your application. Given the maturity
level of Wasm, it may or may not be viable to rebuild for debug because
certain Wasm that triggers problems may not be available or knowable at
build time. On the other hand, as this flag is currently used, the
output is immense when on, and possibly not something people will use
often even if available.

"My laptop" darwin:
```cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkFprintf/NoOp_const_false-16         	1000000000	         0.2310 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/NoOp_var_false-16           	1000000000	         0.2900 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_obj_false-16        	1000000000	         0.2824 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_const_true-16       	 2440754	       467.8 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_var_true-16         	 2561073	       469.2 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_obj_true-16         	 2492377	       477.4 ns/op	     256 B/op	       7 allocs/op
```

GitHub Actions Runner (GHA) ubuntu:
```
 cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
BenchmarkFprintf/NoOp_const_false-2         	1000000000	         0.3648 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/NoOp_var_false-2           	1000000000	         0.5746 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_obj_false-2        	1000000000	         0.5400 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_const_true-2       	 1414428	       820.7 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_var_true-2         	 1419512	       828.3 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_obj_true-2         	 1400737	       853.6 ns/op	     256 B/op	       7 allocs/op
```

GHA darwin:
```
 cpu: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
BenchmarkFprintf/NoOp_const_false-3         	1000000000	         0.2855 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/NoOp_var_false-3           	1000000000	         0.5601 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_obj_false-3        	1000000000	         0.5578 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_const_true-3       	 1794757	       676.9 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_var_true-3         	 1775196	       676.7 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_obj_true-3         	 1761158	       678.9 ns/op	     256 B/op	       7 allocs/op
```

GHA windows:
```
cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
BenchmarkFprintf/NoOp_const_false-2         	1000000000	         0.2959 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/NoOp_var_false-2           	1000000000	         0.4275 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_obj_false-2        	1000000000	         0.4124 ns/op	       0 B/op	       0 allocs/op
BenchmarkFprintf/Fprintf_const_true-2       	 1880875	       632.2 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_var_true-2         	 1872980	       644.0 ns/op	     256 B/op	       7 allocs/op
BenchmarkFprintf/Fprintf_obj_true-2         	 1870275	       640.2 ns/op	     256 B/op	       7 allocs/op
```
