### PR TITLE
WIP: Adds user-level interface for WebAssembly 1.0 features

### DIFF
--- a/wasm/store.go
+++ b/wasm/store.go
@@ -158,6 +158,9 @@ func (s *Store) Instantiate(module *Module, name string) error {
 	return nil
 }
 
+// CallFunction invokes an exported function with the supplied arguments and returns index-coordinated arrays of results
+// and their value types. Any error returned pertains to the runtime: For example, if the function isn't exported or an
+// unrecoverable error happened while attempting to invoke the function.
 func (s *Store) CallFunction(moduleName, funcName string, args ...uint64) (returns []uint64, returnTypes []ValueType, err error) {
 	m, ok := s.ModuleInstances[moduleName]
 	if !ok {
@@ -180,6 +183,25 @@ func (s *Store) CallFunction(moduleName, funcName string, args ...uint64) (retur
 
 	ret, err := s.engine.Call(f, args...)
 	return ret, f.Signature.ReturnTypes, err
+}
+
+// FunctionByName returns a function of the given name or false for any failure including it not being exported.
+func (s *Store) FunctionByName(moduleName string, funcName string) (*FunctionInstance, bool) {
+	m, ok := s.ModuleInstances[moduleName]
+	if !ok {
+		return nil, false
+	}
+
+	exp, ok := m.Exports[funcName]
+	if !ok {
+		return nil, false
+	}
+
+	if exp.Kind != ExportKindFunction {
+		return nil, false
+	}
+
+	return exp.Function, true
 }
 
 func (s *Store) resolveImports(module *Module, target *ModuleInstance) error {

--- a/wasm/v1_0/wasm.go
+++ b/wasm/v1_0/wasm.go
@@ -1,0 +1,149 @@
+// Package v1_0 is a user-level API only supporting features that exist in Wasm 1.0
+// See https://www.w3.org/TR/wasm-core-1/
+package v1_0
+
+import (
+	"fmt"
+
+	"github.com/tetratelabs/wazero/wasm"
+)
+
+// ValueType represents numeric types a Function can accept as an argument or return as a result.
+// See https://www.w3.org/TR/wasm-core-1/#value-types%E2%91%A0
+type ValueType byte
+
+const (
+	I32 ValueType = iota
+	I64
+	F32
+	F64
+)
+
+// String returns the name of k.
+func (v ValueType) String() string {
+	switch v {
+	case I32:
+		return "i32"
+	case I64:
+		return "i64"
+	case F32:
+		return "f32"
+	case F64:
+		return "f64"
+	}
+	return fmt.Sprintf("valueType(%d)", v)
+}
+
+// Module is a WebAssembly module allowing access to exported functions.
+type Module interface {
+	// Name returns the case-sensitive name of the Module.
+	Name() string
+
+	// FunctionByName returns a function of the given name or false for any failure including it not being exported.
+	FunctionByName(name string) (f Function, ok bool)
+}
+
+// Function is a WebAssembly function. This can be called multiple times, though not in different goroutines.
+//
+// As this package is scoped to only spec version 1.0, only one or no result is returned.
+// See https://www.w3.org/TR/wasm-core-1/#function-types%E2%91%A0
+type Function interface {
+	// Name returns the case-sensitive name of the Function.
+	Name() string
+
+	// ParameterTypes returns a possibly empty slice of parameter types of the Call signature.
+	ParameterTypes() []ValueType
+
+	// ResultType returns the result type of the Call signature or false if there is none.
+	ResultType() (resultType ValueType, hasResult bool)
+
+	// Call invokes the function with the given parameters and returns the result or an error on runtime exception.
+	//
+	// Parameters will coerce according to types indicated in ParameterTypes and the result to ResultType.
+	//
+	// Call never panics, as doing so would leak runtime implementation details which could create a security problem.
+	// You must check the runtime error on each invocation and handle accordingly. Otherwise, you can misinterpret a
+	// zero result as a success.
+	Call(parameters ...uint64) (uint64, error)
+}
+
+// NewModule returns a WebAssembly v1.0 view of the given wasm.Store or false if the module doesn't exist or isn't 1.0.
+func NewModule(s *wasm.Store, moduleName string) (Module, bool) {
+	if _, ok := s.ModuleInstances[moduleName]; !ok {
+		return nil, false
+	} else {
+		// TODO check the Wasm version
+		return &module{s, moduleName}, true
+	}
+}
+
+type module struct {
+	s *wasm.Store
+	n string
+}
+
+func (m *module) Name() string {
+	return m.n
+}
+
+func (m *module) FunctionByName(name string) (Function, bool) {
+	if f, ok := m.s.FunctionByName(m.n, name); !ok {
+		return nil, false
+	} else {
+		return &function{m, f, name}, true
+	}
+}
+
+type function struct {
+	m *module
+	f *wasm.FunctionInstance
+	n string
+}
+
+func (f *function) Name() string {
+	return f.n
+}
+
+func (f *function) ParameterTypes() []ValueType {
+	var result []ValueType
+	for _, t := range f.f.Signature.InputTypes {
+		result = append(result, f.convertValueType(t))
+	}
+	return result
+}
+
+func (f *function) convertValueType(t wasm.ValueType) ValueType {
+	var r ValueType
+	switch t {
+	case wasm.ValueTypeI32:
+		r = I32
+	case wasm.ValueTypeI64:
+		r = I64
+	case wasm.ValueTypeF32:
+		r = F32
+	case wasm.ValueTypeF64:
+		r = F64
+	default:
+		panic(fmt.Sprintf("invalid function %s/%s: value type %d is unexpected in Wasm is unexpected in Wasm 1.0", f.m.n, f.n, t))
+	}
+	return r
+}
+
+func (f *function) ResultType() (resultType ValueType, hasResult bool) {
+	switch len(f.f.Signature.ReturnTypes) {
+	case 0:
+		return 0, false
+	case 1:
+		return f.convertValueType(f.f.Signature.ReturnTypes[0]), true
+	default:
+		panic(fmt.Sprintf("invalid function %s/%s: more than one value type is unexpected in Wasm 1.0", f.m.n, f.n))
+	}
+}
+
+func (f *function) Call(parameters ...uint64) (uint64, error) {
+	ret, _, err := f.m.s.CallFunction(f.m.n, f.n, parameters...)
+	if len(ret) == 0 {
+		return 0, err
+	}
+	return ret[0], err
+}

--- a/wasm/v1_0/wasm_test.go
+++ b/wasm/v1_0/wasm_test.go
@@ -1,0 +1,31 @@
+package v1_0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueType_String(t *testing.T) {
+	tests := []struct {
+		input    ValueType
+		expected string
+	}{
+		{I32, "i32"},
+		{I64, "i64"},
+		{F32, "f32"},
+		{F64, "f64"},
+	}
+
+	for _, tc := range tests {
+		tc := tc // pin! see https://github.com/kyoh86/scopelint for why
+
+		t.Run(tc.expected, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.input.String())
+		})
+	}
+
+	t.Run("unexpected", func(t *testing.T) {
+		require.Equal(t, "valueType(255)", ValueType(255).String())
+	})
+}


### PR DESCRIPTION
This adds a user-level interface narrowed to features supported in 1.0.
The implementation is not optimized to perform better in this case, but
it could. The main point of this is to feel out the API prior to doing
too much work.

In the future, we'd hide most apis currently exposed as internal. This
starts the discussion of the minimum viable interface for those invoking
functions, without requiring 1 impl per version of Wasm.
