### PR TITLE
jit: grow stack automatically. 

### DIFF
--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -269,8 +269,7 @@ func (e *engine) maybeGrowStack(requiredHeight uint64) {
 		// This case we need to grow the stack as the empty slots
 		// are not able to store all the stack items.
 		// So we grow the stack with the new len = currentLen*2+required.
-		required := requiredHeight - remained
-		newStack := make([]uint64, currentLen*2+(required))
+		newStack := make([]uint64, currentLen*2+(requiredHeight))
 		top := e.currentBaseStackPointer + e.currentStackPointer
 		copy(newStack[:top], e.stack[:top])
 		e.stack = newStack

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -268,7 +268,7 @@ func (e *engine) maybeGrowStack(maxStackPointer uint64) {
 	if maxStackPointer > remained {
 		// This case we need to grow the stack as the empty slots
 		// are not able to store all the stack items.
-		// So we grow the stack with the new len = currentLen*2+required.
+		// So we grow the stack with the new len = currentLen*2+maxStackPointer.
 		newStack := make([]uint64, currentLen*2+(maxStackPointer))
 		top := e.currentBaseStackPointer + e.currentStackPointer
 		copy(newStack[:top], e.stack[:top])

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -160,7 +160,7 @@ func NewEngine() wasm.Engine {
 	return newEngine()
 }
 
-const initialStackSize = 100
+const initialStackSize = 1024
 
 func newEngine() *engine {
 	e := &engine{
@@ -251,16 +251,31 @@ type compiledWasmFunction struct {
 	codeInitialAddress uintptr
 	// The same purpose as codeInitialAddress, but for memory.Buffer.
 	memoryAddress uintptr
+	// The max of the stack height this function can reach.
+	maxtStackHeight uint64
 }
 
 const (
 	builtinFunctionIndexGrowMemory = iota
 )
 
-func (e *engine) stackGrow() {
-	newStack := make([]uint64, len(e.stack)*2)
-	copy(newStack[:len(e.stack)], e.stack)
-	e.stack = newStack
+// Grow the stack size according to requiredHeight argument
+// which is the required height from the base pointer
+// for the next function frame execution.
+func (e *engine) maybeGrowStack(requiredHeight uint64) {
+	currentLen := uint64(len(e.stack))
+	remained := currentLen - e.currentBaseStackPointer
+	if requiredHeight > remained {
+		// This case we need to grow the stack as the empty slots
+		// are not able to store all the stack items.
+		// So we grow the stack with the new len = currentLen*2+required.
+		required := requiredHeight - remained
+		newStack := make([]uint64, currentLen*2+(required))
+		top := e.currentBaseStackPointer + e.currentStackPointer
+		copy(newStack[:top], e.stack[:top])
+		e.stack = newStack
+	}
+	// TODO: maybe better think about how to shrink the stack as well.
 }
 
 func (e *engine) exec(f *compiledWasmFunction) {
@@ -270,13 +285,8 @@ func (e *engine) exec(f *compiledWasmFunction) {
 		caller:                   nil,
 		continuationStackPointer: f.inputs,
 	}
-	// TODO: We should check the size of the stack,
-	// and if it's running out, grow it before calling into JITed code.
-	// It should be possible to check the necessity by statically
-	// analyzing the max height of the stack in the function.
-	if false {
-		e.stackGrow()
-	}
+	// If the Go-allocated stack is running out, we grow it before calling into JITed code.
+	e.maybeGrowStack(f.maxtStackHeight)
 	for e.callFrameStack != nil {
 		currentFrame := e.callFrameStack
 		if buildoptions.IsDebugMode {
@@ -322,13 +332,8 @@ func (e *engine) exec(f *compiledWasmFunction) {
 				// Set the base pointer to the beginning of the function inputs
 				baseStackPointer: e.currentBaseStackPointer + e.currentStackPointer - nextFunc.inputs,
 			}
-			// TODO: We should check the size of the stack,
-			// and if it's running out, grow it before calling into JITed code.
-			// It should be possible to check the necessity by statically
-			// analyzing the max height of the stack in the function.
-			if false {
-				e.stackGrow()
-			}
+			// If the Go-allocated stack is running out, we grow it before calling into JITed code.
+			e.maybeGrowStack(nextFunc.maxtStackHeight)
 			// Now move onto the callee function.
 			e.callFrameStack = frame
 			e.currentBaseStackPointer = frame.baseStackPointer

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -251,7 +251,7 @@ type compiledWasmFunction struct {
 	codeInitialAddress uintptr
 	// The same purpose as codeInitialAddress, but for memory.Buffer.
 	memoryAddress uintptr
-	// The max of the stack pointer this function can reach.
+	// The max of the stack pointer this function can reach. Lazily applied via maybeGrowStack.
 	maxStackPointer uint64
 }
 

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -85,16 +85,35 @@ func TestEngine_PreCompile(t *testing.T) {
 	require.Equal(t, prevCompiledFunctions, eng.compiledWasmFunctions)
 }
 
-func TestEngine_stackGrow(t *testing.T) {
-	eng := newEngine()
-	require.Len(t, eng.stack, initialStackSize)
-	eng.push(10)
-	require.Equal(t, uint64(1), eng.currentStackPointer)
-	require.Equal(t, uint64(10), eng.stack[eng.currentStackPointer-1])
-	eng.stackGrow()
-	require.Len(t, eng.stack, initialStackSize*2)
-	// stackGrow only grows the stack len,
-	// and must not modify neither stack pointer nor the values in the stack.
-	require.Equal(t, uint64(1), eng.currentStackPointer)
-	require.Equal(t, uint64(10), eng.stack[eng.currentStackPointer-1])
+func TestEngine_maybeGrowStack(t *testing.T) {
+	t.Run("grow", func(t *testing.T) {
+		eng := &engine{stack: make([]uint64, 10)}
+		eng.currentBaseStackPointer = 5
+		eng.push(10)
+		require.Equal(t, uint64(1), eng.currentStackPointer)
+		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		eng.maybeGrowStack(100)
+		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
+		// but we require 100 max height for the next function,
+		// so this results in making the stack length 115 = 10*2+(100(required slots)-5(remained slots)) = 20+95 = 115
+		require.Len(t, eng.stack, 115)
+		// maybeAdjustStack only shrink the stack,
+		// and must not modify neither stack pointer nor the values in the stack.
+		require.Equal(t, uint64(1), eng.currentStackPointer)
+		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+	})
+	t.Run("noop", func(t *testing.T) {
+		eng := &engine{stack: make([]uint64, 10)}
+		eng.currentBaseStackPointer = 1
+		eng.push(10)
+		require.Equal(t, uint64(1), eng.currentStackPointer)
+		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		eng.maybeGrowStack(6)
+		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
+		// and we only require 6 max height for the next function, so we have enough empty slots.
+		// so maybeGrowStack must not modify neither stack pointer, the values in the stack nor stack len.
+		require.Len(t, eng.stack, 10)
+		require.Equal(t, uint64(1), eng.currentStackPointer)
+		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+	})
 }

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -94,8 +94,8 @@ func TestEngine_maybeGrowStack(t *testing.T) {
 		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
 		eng.maybeGrowStack(100)
 		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
-		// but we require 100 max height for the next function,
-		// so this results in making the stack length 120 = 10(current len)*2+(100(requiredMaxHeight))
+		// but we require 100 max stack pointer for the next function,
+		// so this results in making the stack length 120 = 10(current len)*2+(100(maxStackPointer))
 		require.Len(t, eng.stack, 120)
 		// maybeAdjustStack only shrink the stack,
 		// and must not modify neither stack pointer nor the values in the stack.
@@ -110,7 +110,7 @@ func TestEngine_maybeGrowStack(t *testing.T) {
 		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
 		eng.maybeGrowStack(6)
 		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
-		// and we only require 6 max height for the next function, so we have enough empty slots.
+		// and we only require 6 max stack pointer for the next function, so we have enough empty slots.
 		// so maybeGrowStack must not modify neither stack pointer, the values in the stack nor stack len.
 		require.Len(t, eng.stack, 10)
 		require.Equal(t, uint64(1), eng.currentStackPointer)

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -95,8 +95,8 @@ func TestEngine_maybeGrowStack(t *testing.T) {
 		eng.maybeGrowStack(100)
 		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
 		// but we require 100 max height for the next function,
-		// so this results in making the stack length 115 = 10*2+(100(required slots)-5(remained slots)) = 20+95 = 115
-		require.Len(t, eng.stack, 115)
+		// so this results in making the stack length 120 = 10(current len)*2+(100(requiredMaxHeight))
+		require.Len(t, eng.stack, 120)
 		// maybeAdjustStack only shrink the stack,
 		// and must not modify neither stack pointer nor the values in the stack.
 		require.Equal(t, uint64(1), eng.currentStackPointer)

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -224,10 +224,11 @@ func (e *engine) compileWasmFunction(f *wasm.FunctionInstance) (*compiledWasmFun
 
 func (b *amd64Builder) newCompiledWasmFunction(code []byte) *compiledWasmFunction {
 	cf := &compiledWasmFunction{
-		codeSegment: code,
-		inputs:      uint64(len(b.f.Signature.InputTypes)),
-		returns:     uint64(len(b.f.Signature.ReturnTypes)),
-		memory:      b.f.ModuleInstance.Memory,
+		codeSegment:     code,
+		inputs:          uint64(len(b.f.Signature.InputTypes)),
+		returns:         uint64(len(b.f.Signature.ReturnTypes)),
+		memory:          b.f.ModuleInstance.Memory,
+		maxtStackHeight: b.locationStack.maxHeight,
 	}
 	if cf.memory != nil {
 		cf.memoryAddress = uintptr(unsafe.Pointer(&cf.memory.Buffer[0]))

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -228,7 +228,7 @@ func (b *amd64Builder) newCompiledWasmFunction(code []byte) *compiledWasmFunctio
 		inputs:          uint64(len(b.f.Signature.InputTypes)),
 		returns:         uint64(len(b.f.Signature.ReturnTypes)),
 		memory:          b.f.ModuleInstance.Memory,
-		maxtStackHeight: b.locationStack.maxHeight,
+		maxStackPointer: b.locationStack.maxStackPointer,
 	}
 	if cf.memory != nil {
 		cf.memoryAddress = uintptr(unsafe.Pointer(&cf.memory.Buffer[0]))

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -56,7 +56,7 @@ const (
 
 // valueLocation corresponds to each variable pushed onto the wazeroir (virtual) stack,
 // and it has the information about where it exists in the physical machine.
-// It exist in registers, or maybe on in the non-virtual physical stack allocated in memory.
+// It might exist in registers, or maybe on in the non-virtual physical stack allocated in memory.
 type valueLocation struct {
 	valueType wazeroir.SignLessType
 	// Set to -1 if the value is stored in the memory stack.

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -104,10 +104,10 @@ func newValueLocationStack() *valueLocationStack {
 }
 
 type valueLocationStack struct {
-	stack         []*valueLocation
-	sp            uint64
-	usedRegisters map[int16]struct{}
-	maxHeight     uint64
+	stack           []*valueLocation
+	sp              uint64
+	usedRegisters   map[int16]struct{}
+	maxStackPointer uint64
 }
 
 func (s *valueLocationStack) clone() *valueLocationStack {
@@ -156,8 +156,8 @@ func (s *valueLocationStack) push(loc *valueLocation) {
 	} else {
 		s.stack[s.sp] = loc
 	}
-	if s.sp > s.maxHeight {
-		s.maxHeight = s.sp
+	if s.sp > s.maxStackPointer {
+		s.maxStackPointer = s.sp
 	}
 	s.sp++
 }

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -107,6 +107,7 @@ type valueLocationStack struct {
 	stack         []*valueLocation
 	sp            uint64
 	usedRegisters map[int16]struct{}
+	maxHeight     uint64
 }
 
 func (s *valueLocationStack) clone() *valueLocationStack {
@@ -154,6 +155,9 @@ func (s *valueLocationStack) push(loc *valueLocation) {
 		s.stack = append(s.stack, loc)
 	} else {
 		s.stack[s.sp] = loc
+	}
+	if s.sp > s.maxHeight {
+		s.maxHeight = s.sp
 	}
 	s.sp++
 }

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -51,6 +51,14 @@ func TestValueLocationStack_basic(t *testing.T) {
 		actual, exp := s.stack[i], cloned.stack[i]
 		require.NotEqual(t, uintptr(unsafe.Pointer(exp)), uintptr(unsafe.Pointer(actual)))
 	}
+	// Check the max height.
+	for i := 0; i < 1000; i++ {
+		s.pushValueOnStack()
+	}
+	for i := 0; i < 1000; i++ {
+		s.pop()
+	}
+	require.Equal(t, uint64(1001), s.maxHeight)
 }
 
 func TestValueLocationStack_takeFreeRegister(t *testing.T) {

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -51,14 +51,14 @@ func TestValueLocationStack_basic(t *testing.T) {
 		actual, exp := s.stack[i], cloned.stack[i]
 		require.NotEqual(t, uintptr(unsafe.Pointer(exp)), uintptr(unsafe.Pointer(actual)))
 	}
-	// Check the max height.
+	// Check the max stack pointer.
 	for i := 0; i < 1000; i++ {
 		s.pushValueOnStack()
 	}
 	for i := 0; i < 1000; i++ {
 		s.pop()
 	}
-	require.Equal(t, uint64(1001), s.maxHeight)
+	require.Equal(t, uint64(1001), s.maxStackPointer)
 }
 
 func TestValueLocationStack_takeFreeRegister(t *testing.T) {


### PR DESCRIPTION
This commit resolves one TODO for growing stack automatically 
when the engine enters new JITed function frames and sees the necessity
to grow the stack.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

part of #65.