### PR TITLE
Refactor namings around engine and registers

### DIFF
--- a/wasm/jit/RATIONALE.md
+++ b/wasm/jit/RATIONALE.md
@@ -67,7 +67,7 @@ case jitCallStatusCodeCallWasmFunction:
     // we can resume this caller function frame.
     currentFrame.continuationAddress = currentFrame.f.codeInitialAddress + e.continuationAddressOffset
     currentFrame.continuationStackPointer = e.currentStackPointer + nextFunc.outputNum - nextFunc.inputNum
-    currentFrame.baseStackPointer = e.currentBaseStackPointer
+    currentFrame.baseStackPointer = e.currentStackBasePointer
 ```
 
 and calling into another function in JIT engine's main loop:
@@ -80,7 +80,7 @@ and calling into another function in JIT engine's main loop:
         // Set the caller frame so we can return back to the current frame!
         caller: currentFrame,
         // Set the base pointer to the beginning of the function inputs
-        baseStackPointer: e.currentBaseStackPointer + e.currentStackPointer - nextFunc.inputNum,
+        baseStackPointer: e.currentStackBasePointer + e.currentStackPointer - nextFunc.inputNum,
     }
 ```
 
@@ -92,7 +92,7 @@ case jitStatusReturned:
     // so we just get back to the caller's frame.
     callerFrame := currentFrame.caller
     e.callFrameStack = callerFrame
-    e.currentBaseStackPointer = callerFrame.baseStackPointer
+    e.currentStackBasePointer = callerFrame.baseStackPointer
     e.currentStackPointer = callerFrame.continuationStackPointer
 ```
 

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -16,7 +16,7 @@ import (
 func TestEngine_veifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof((&engine{}).stack)), engineStackSliceOffset)
 	require.Equal(t, int(unsafe.Offsetof((&engine{}).currentStackPointer)), engineCurrentStackPointerOffset)
-	require.Equal(t, int(unsafe.Offsetof((&engine{}).currentBaseStackPointer)), engineCurrentBaseStackPointerOffset)
+	require.Equal(t, int(unsafe.Offsetof((&engine{}).currentStackBasePointer)), engineCurrentStackBasePointerOffset)
 	require.Equal(t, int(unsafe.Offsetof((&engine{}).jitCallStatusCode)), engineJITCallStatusCodeOffset)
 	require.Equal(t, int(unsafe.Offsetof((&engine{}).functionCallIndex)), engineFunctionCallIndexOffset)
 	require.Equal(t, int(unsafe.Offsetof((&engine{}).continuationAddressOffset)), engineContinuationAddressOffset)
@@ -98,10 +98,10 @@ func TestEngine_PreCompile(t *testing.T) {
 func TestEngine_maybeGrowStack(t *testing.T) {
 	t.Run("grow", func(t *testing.T) {
 		eng := &engine{stack: make([]uint64, 10)}
-		eng.currentBaseStackPointer = 5
+		eng.currentStackBasePointer = 5
 		eng.push(10)
 		require.Equal(t, uint64(1), eng.currentStackPointer)
-		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		require.Equal(t, uint64(10), eng.stack[eng.currentStackBasePointer+eng.currentStackPointer-1])
 		eng.maybeGrowStack(100)
 		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
 		// but we require 100 max stack pointer for the next function,
@@ -110,20 +110,20 @@ func TestEngine_maybeGrowStack(t *testing.T) {
 		// maybeAdjustStack only shrink the stack,
 		// and must not modify neither stack pointer nor the values in the stack.
 		require.Equal(t, uint64(1), eng.currentStackPointer)
-		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		require.Equal(t, uint64(10), eng.stack[eng.currentStackBasePointer+eng.currentStackPointer-1])
 	})
 	t.Run("noop", func(t *testing.T) {
 		eng := &engine{stack: make([]uint64, 10)}
-		eng.currentBaseStackPointer = 1
+		eng.currentStackBasePointer = 1
 		eng.push(10)
 		require.Equal(t, uint64(1), eng.currentStackPointer)
-		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		require.Equal(t, uint64(10), eng.stack[eng.currentStackBasePointer+eng.currentStackPointer-1])
 		eng.maybeGrowStack(6)
 		// Currently we have 9 empty slots (10 - 1(base pointer)) above base pointer for new items,
 		// and we only require 6 max stack pointer for the next function, so we have enough empty slots.
 		// so maybeGrowStack must not modify neither stack pointer, the values in the stack nor stack len.
 		require.Len(t, eng.stack, 10)
 		require.Equal(t, uint64(1), eng.currentStackPointer)
-		require.Equal(t, uint64(10), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		require.Equal(t, uint64(10), eng.stack[eng.currentStackBasePointer+eng.currentStackPointer-1])
 	})
 }

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -405,7 +405,7 @@ func (b *amd64Builder) handleSwap(o *wazeroir.OperationSwap) error {
 const globalInstanceValueOffset = 8
 
 func (b *amd64Builder) handleGlobalGet(o *wazeroir.OperationGlobalGet) error {
-	intReg, err := b.allocateRegister(gpTypeInt)
+	intReg, err := b.allocateRegister(generalPurposeRegisterTypeInt)
 	if err != nil {
 		return err
 	}
@@ -443,7 +443,7 @@ func (b *amd64Builder) handleGlobalGet(o *wazeroir.OperationGlobalGet) error {
 	wasmType := b.f.ModuleInstance.Globals[o.Index].Type.ValType
 	switch wasmType {
 	case wasm.ValueTypeF32, wasm.ValueTypeF64:
-		valueReg, err = b.allocateRegister(gpTypeFloat)
+		valueReg, err = b.allocateRegister(generalPurposeRegisterTypeFloat)
 		if err != nil {
 			return err
 		}
@@ -479,7 +479,7 @@ func (b *amd64Builder) handleGlobalSet(o *wazeroir.OperationGlobalSet) error {
 	}
 
 	// Allocate a register to hold the memory location of the target global instance.
-	intReg, err := b.allocateRegister(gpTypeInt)
+	intReg, err := b.allocateRegister(generalPurposeRegisterTypeInt)
 	if err != nil {
 		return err
 	}
@@ -911,18 +911,18 @@ func (b *amd64Builder) handleAdd(o *wazeroir.OperationAdd) error {
 	switch o.Type {
 	case wazeroir.SignLessTypeI32:
 		instruction = x86.AADDL
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 		panic("add tests!")
 	case wazeroir.SignLessTypeI64:
 		instruction = x86.AADDQ
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 	case wazeroir.SignLessTypeF32:
 		instruction = x86.AADDSS
-		tp = gpTypeFloat
+		tp = generalPurposeRegisterTypeFloat
 		panic("add tests!")
 	case wazeroir.SignLessTypeF64:
 		instruction = x86.AADDSD
-		tp = gpTypeFloat
+		tp = generalPurposeRegisterTypeFloat
 		panic("add tests!")
 	}
 
@@ -972,18 +972,18 @@ func (b *amd64Builder) handleSub(o *wazeroir.OperationSub) error {
 	switch o.Type {
 	case wazeroir.SignLessTypeI32:
 		instruction = x86.ASUBL
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 		panic("add tests!")
 	case wazeroir.SignLessTypeI64:
 		instruction = x86.ASUBQ
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 	case wazeroir.SignLessTypeF32:
 		instruction = x86.ASUBSS
-		tp = gpTypeFloat
+		tp = generalPurposeRegisterTypeFloat
 		panic("add tests!")
 	case wazeroir.SignLessTypeF64:
 		instruction = x86.ASUBSD
-		tp = gpTypeFloat
+		tp = generalPurposeRegisterTypeFloat
 		panic("add tests!")
 	}
 
@@ -1032,24 +1032,24 @@ func (b *amd64Builder) handleLe(o *wazeroir.OperationLe) error {
 	case wazeroir.SignFulTypeInt32:
 		resultConditionState = conditionalRegisterStateLE
 		instruction = x86.ACMPL
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 	case wazeroir.SignFulTypeUint32:
 		resultConditionState = conditionalRegisterStateBE
 		instruction = x86.ACMPL
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 	case wazeroir.SignFulTypeInt64:
 		resultConditionState = conditionalRegisterStateLE
 		instruction = x86.ACMPQ
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 	case wazeroir.SignFulTypeUint64:
 		resultConditionState = conditionalRegisterStateBE
 		instruction = x86.ACMPQ
-		tp = gpTypeInt
+		tp = generalPurposeRegisterTypeInt
 	case wazeroir.SignFulTypeFloat32:
-		tp = gpTypeFloat
+		tp = generalPurposeRegisterTypeFloat
 		panic("add test!")
 	case wazeroir.SignFulTypeFloat64:
-		tp = gpTypeFloat
+		tp = generalPurposeRegisterTypeFloat
 		panic("add test!")
 	}
 
@@ -1097,7 +1097,7 @@ func (b *amd64Builder) handleLe(o *wazeroir.OperationLe) error {
 }
 
 func (b *amd64Builder) handleConstI32(o *wazeroir.OperationConstI32) error {
-	reg, err := b.allocateRegister(gpTypeInt)
+	reg, err := b.allocateRegister(generalPurposeRegisterTypeInt)
 	if err != nil {
 		return err
 	}
@@ -1115,7 +1115,7 @@ func (b *amd64Builder) handleConstI32(o *wazeroir.OperationConstI32) error {
 }
 
 func (b *amd64Builder) handleConstI64(o *wazeroir.OperationConstI64) error {
-	reg, err := b.allocateRegister(gpTypeInt)
+	reg, err := b.allocateRegister(generalPurposeRegisterTypeInt)
 	if err != nil {
 		return err
 	}
@@ -1133,7 +1133,7 @@ func (b *amd64Builder) handleConstI64(o *wazeroir.OperationConstI64) error {
 }
 
 func (b *amd64Builder) handleConstF32(o *wazeroir.OperationConstF32) error {
-	reg, err := b.allocateRegister(gpTypeFloat)
+	reg, err := b.allocateRegister(generalPurposeRegisterTypeFloat)
 	if err != nil {
 		return err
 	}
@@ -1142,7 +1142,7 @@ func (b *amd64Builder) handleConstF32(o *wazeroir.OperationConstF32) error {
 
 	// We cannot directly load the value from memory to float regs,
 	// so we move it to int reg temporarily.
-	tmpReg, err := b.allocateRegister(gpTypeInt)
+	tmpReg, err := b.allocateRegister(generalPurposeRegisterTypeInt)
 	if err != nil {
 		return err
 	}
@@ -1167,7 +1167,7 @@ func (b *amd64Builder) handleConstF32(o *wazeroir.OperationConstF32) error {
 }
 
 func (b *amd64Builder) handleConstF64(o *wazeroir.OperationConstF64) error {
-	reg, err := b.allocateRegister(gpTypeFloat)
+	reg, err := b.allocateRegister(generalPurposeRegisterTypeFloat)
 	if err != nil {
 		return err
 	}
@@ -1176,7 +1176,7 @@ func (b *amd64Builder) handleConstF64(o *wazeroir.OperationConstF64) error {
 
 	// We cannot directly load the value from memory to float regs,
 	// so we move it to int reg temporarily.
-	tmpReg, err := b.allocateRegister(gpTypeInt)
+	tmpReg, err := b.allocateRegister(generalPurposeRegisterTypeInt)
 	if err != nil {
 		return err
 	}
@@ -1231,7 +1231,7 @@ func (b *amd64Builder) moveStackToRegister(loc *valueLocation) {
 
 func (b *amd64Builder) moveConditionalToGPRegister(loc *valueLocation) error {
 	// Get the free register.
-	reg, ok := b.locationStack.takeFreeRegister(gpTypeInt)
+	reg, ok := b.locationStack.takeFreeRegister(generalPurposeRegisterTypeInt)
 	if !ok {
 		// This in theory should never be reached as moveConditionalToGPRegister
 		// is called right after comparison operations, meaning that
@@ -1402,7 +1402,7 @@ func (b *amd64Builder) releaseAllRegistersToStack() {
 func (b *amd64Builder) setContinuationOffsetAtNextInstructionAndReturn() {
 	// setContinuationOffsetAtNextInstructionAndReturn is called after releasing
 	// all the registers, so at this point we always have free registers.
-	tmpReg, _ := b.locationStack.takeFreeRegister(gpTypeInt)
+	tmpReg, _ := b.locationStack.takeFreeRegister(generalPurposeRegisterTypeInt)
 	// Create the instruction for setting offset.
 	// We use tmp register to store the const, not directly movq to memory
 	// as it is not valid to move 64-bit const to memory directly.
@@ -1521,7 +1521,7 @@ func (b *amd64Builder) initializeReservedRegisters() *obj.Prog {
 
 	// initializeReservedRegisters is called at the beginning of function calls
 	// or right after function returns so at this point we always have free registers.
-	reg, _ := b.locationStack.takeFreeRegister(gpTypeInt)
+	reg, _ := b.locationStack.takeFreeRegister(generalPurposeRegisterTypeInt)
 
 	// Next we move the base pointer (engine.currentStackBasePointer) to
 	// a temporary register.

--- a/wasm/jit/jit_amd64.s
+++ b/wasm/jit/jit_amd64.s
@@ -7,6 +7,6 @@
 // jitcall(codeSegment, engine, memory uintptr)
 TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
         MOVQ codeSegment+0(FP),AX  // Load the address of native code.
-        MOVQ engine+8(FP),R12      // Load the address of engine.
+        MOVQ engine+8(FP),R13      // Load the address of engine.
         MOVQ memory+16(FP),R15     // Load the address of memory instance.
         JMP AX                     // Jump to native code.

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -538,11 +538,11 @@ func Test_popFromStackToRegister(t *testing.T) {
 
 	// Call in.
 	eng := newEngine()
-	eng.currentBaseStackPointer = 1
-	eng.stack[eng.currentBaseStackPointer+2] = 10000
-	eng.stack[eng.currentBaseStackPointer+1] = 20000
+	eng.currentStackBasePointer = 1
+	eng.stack[eng.currentStackBasePointer+2] = 10000
+	eng.stack[eng.currentStackBasePointer+1] = 20000
 	mem := newMemoryInst()
-	require.Equal(t, []uint64{0, 20000, 10000}, eng.stack[eng.currentBaseStackPointer:eng.currentBaseStackPointer+3])
+	require.Equal(t, []uint64{0, 20000, 10000}, eng.stack[eng.currentStackBasePointer:eng.currentStackBasePointer+3])
 	jitcall(
 		uintptr(unsafe.Pointer(&code[0])),
 		uintptr(unsafe.Pointer(eng)),
@@ -550,7 +550,7 @@ func Test_popFromStackToRegister(t *testing.T) {
 	)
 	// Check the sp and value.
 	require.Equal(t, uint64(2), eng.currentStackPointer)
-	require.Equal(t, []uint64{0, 30000}, eng.stack[eng.currentBaseStackPointer:eng.currentBaseStackPointer+eng.currentStackPointer])
+	require.Equal(t, []uint64{0, 30000}, eng.stack[eng.currentStackBasePointer:eng.currentStackBasePointer+eng.currentStackPointer])
 }
 
 func TestAmd64Builder_initializeReservedRegisters(t *testing.T) {
@@ -587,7 +587,7 @@ func TestAmd64Builder_allocateRegister(t *testing.T) {
 		builder := requireNewBuilder(t)
 		builder.initializeReservedRegisters()
 		// Use up all the Int regs.
-		for _, r := range gpIntRegisters {
+		for _, r := range unreservedGeneralPurposeIntRegisters {
 			builder.locationStack.markRegisterUsed(r)
 		}
 		stealTargetLocation := builder.locationStack.pushValueOnRegister(stealTarget)
@@ -611,7 +611,7 @@ func TestAmd64Builder_allocateRegister(t *testing.T) {
 
 		// Run code.
 		eng := newEngine()
-		eng.currentBaseStackPointer = 10
+		eng.currentStackBasePointer = 10
 		mem := newMemoryInst()
 		jitcall(
 			uintptr(unsafe.Pointer(&code[0])),
@@ -621,7 +621,7 @@ func TestAmd64Builder_allocateRegister(t *testing.T) {
 
 		// Check the sp and value.
 		require.Equal(t, uint64(2), eng.currentStackPointer)
-		require.Equal(t, []uint64{50, 2000}, eng.stack[eng.currentBaseStackPointer:eng.currentBaseStackPointer+eng.currentStackPointer])
+		require.Equal(t, []uint64{50, 2000}, eng.stack[eng.currentStackBasePointer:eng.currentStackBasePointer+eng.currentStackPointer])
 	})
 }
 
@@ -710,8 +710,8 @@ func TestAmd64Builder_handlePick(t *testing.T) {
 		pickTargetLocation := builder.locationStack.pushValueOnStack()
 		builder.locationStack.pushValueOnStack() // Dummy value!
 		eng.currentStackPointer = 5
-		eng.currentBaseStackPointer = 1
-		eng.stack[eng.currentBaseStackPointer+pickTargetLocation.stackPointer] = 100
+		eng.currentStackBasePointer = 1
+		eng.stack[eng.currentStackBasePointer+pickTargetLocation.stackPointer] = 100
 
 		// Now insert pick code.
 		err := builder.handlePick(o)
@@ -741,9 +741,9 @@ func TestAmd64Builder_handlePick(t *testing.T) {
 			uintptr(unsafe.Pointer(&mem.Buffer[0])),
 		)
 		// Check the stack.
-		require.Equal(t, uint64(100), eng.stack[eng.currentBaseStackPointer+pickTargetLocation.stackPointer]) // Original value shouldn't be affected.
+		require.Equal(t, uint64(100), eng.stack[eng.currentStackBasePointer+pickTargetLocation.stackPointer]) // Original value shouldn't be affected.
 		require.Equal(t, uint64(3), eng.currentStackPointer)
-		require.Equal(t, uint64(101), eng.stack[eng.currentBaseStackPointer+eng.currentStackPointer-1])
+		require.Equal(t, uint64(101), eng.stack[eng.currentStackBasePointer+eng.currentStackPointer-1])
 	})
 }
 

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -575,10 +575,10 @@ func TestAmd64Builder_initializeReservedRegisters(t *testing.T) {
 func TestAmd64Builder_allocateRegister(t *testing.T) {
 	t.Run("free", func(t *testing.T) {
 		builder := requireNewBuilder(t)
-		reg, err := builder.allocateRegister(gpTypeInt)
+		reg, err := builder.allocateRegister(generalPurposeRegisterTypeInt)
 		require.NoError(t, err)
 		require.True(t, isIntRegister(reg))
-		reg, err = builder.allocateRegister(gpTypeFloat)
+		reg, err = builder.allocateRegister(generalPurposeRegisterTypeFloat)
 		require.NoError(t, err)
 		require.True(t, isFloatRegister(reg))
 	})
@@ -594,7 +594,7 @@ func TestAmd64Builder_allocateRegister(t *testing.T) {
 		builder.movIntConstToRegister(int64(50), stealTargetLocation.register)
 		require.Equal(t, int16(stealTarget), stealTargetLocation.register)
 		require.True(t, stealTargetLocation.onRegister())
-		reg, err := builder.allocateRegister(gpTypeInt)
+		reg, err := builder.allocateRegister(generalPurposeRegisterTypeInt)
 		require.NoError(t, err)
 		require.True(t, isIntRegister(reg))
 		require.False(t, stealTargetLocation.onRegister())

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -11,8 +11,8 @@ import (
 
 // Reserved registers.
 const (
-	// reservedRegisterForEngine R12: pointer to engine instance (i.e. *engine as uintptr)
-	reservedRegisterForEngine = x86.REG_R12
+	// reservedRegisterForEngine R13: pointer to engine instance (i.e. *engine as uintptr)
+	reservedRegisterForEngine = x86.REG_R13
 	// reservedRegisterForStackBasePointer R14: stack base pointer (engine.currentStackBasePointer) in the current function call.
 	reservedRegisterForStackBasePointer = x86.REG_R14
 	// reservedRegisterMemoryPointer R15: pointer to memory space (i.e. *[]byte as uintptr).
@@ -34,7 +34,7 @@ var (
 	unreservedGeneralPurposeIntRegisters = []int16{
 		x86.REG_AX, x86.REG_CX, x86.REG_DX, x86.REG_BX,
 		x86.REG_SI, x86.REG_DI, x86.REG_R8, x86.REG_R9,
-		x86.REG_R10, x86.REG_R11,
+		x86.REG_R10, x86.REG_R11, x86.REG_R12,
 	}
 )
 

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -15,7 +15,6 @@ const (
 	reservedRegisterForEngine = x86.REG_R12
 	// reservedRegisterForStackBasePointer R14: stack base pointer (engine.currentStackBasePointer) in the current function call.
 	reservedRegisterForStackBasePointer = x86.REG_R14
-	// TODO: we use memoryReg later when we support the store/load memory operations.
 	// reservedRegisterMemoryPointer R15: pointer to memory space (i.e. *[]byte as uintptr).
 	reservedRegisterMemoryPointer = x86.REG_R15
 )

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -81,9 +81,9 @@ type valueLocation struct {
 func (v *valueLocation) registerType() (t generalPurposeRegisterType) {
 	switch v.valueType {
 	case wazeroir.SignLessTypeI32, wazeroir.SignLessTypeI64:
-		t = gpTypeInt
+		t = generalPurposeRegisterTypeInt
 	case wazeroir.SignLessTypeF32, wazeroir.SignLessTypeF64:
-		t = gpTypeFloat
+		t = generalPurposeRegisterTypeFloat
 	default:
 		panic("unreachable")
 	}
@@ -214,8 +214,8 @@ func (s *valueLocationStack) markRegisterUsed(reg int16) {
 type generalPurposeRegisterType byte
 
 const (
-	gpTypeInt generalPurposeRegisterType = iota
-	gpTypeFloat
+	generalPurposeRegisterTypeInt generalPurposeRegisterType = iota
+	generalPurposeRegisterTypeFloat
 )
 
 // Search for unused registers, and if found, returns the register
@@ -223,9 +223,9 @@ const (
 func (s *valueLocationStack) takeFreeRegister(tp generalPurposeRegisterType) (reg int16, found bool) {
 	var targetRegs []int16
 	switch tp {
-	case gpTypeFloat:
+	case generalPurposeRegisterTypeFloat:
 		targetRegs = generalPurposeFloatRegisters
-	case gpTypeInt:
+	case generalPurposeRegisterTypeInt:
 		targetRegs = unreservedGeneralPurposeIntRegisters
 	}
 	for _, candidate := range targetRegs {
@@ -244,11 +244,11 @@ func (s *valueLocationStack) takeStealTargetFromUsedRegister(tp generalPurposeRe
 		loc := s.stack[i]
 		if loc.onRegister() {
 			switch tp {
-			case gpTypeFloat:
+			case generalPurposeRegisterTypeFloat:
 				if isFloatRegister(loc.register) {
 					return loc, true
 				}
-			case gpTypeInt:
+			case generalPurposeRegisterTypeInt:
 				if isIntRegister(loc.register) {
 					return loc, true
 				}

--- a/wasm/jit/jit_value_location_amd64.go
+++ b/wasm/jit/jit_value_location_amd64.go
@@ -15,8 +15,8 @@ const (
 	reservedRegisterForEngine = x86.REG_R13
 	// reservedRegisterForStackBasePointer R14: stack base pointer (engine.currentStackBasePointer) in the current function call.
 	reservedRegisterForStackBasePointer = x86.REG_R14
-	// reservedRegisterMemoryPointer R15: pointer to memory space (i.e. *[]byte as uintptr).
-	reservedRegisterMemoryPointer = x86.REG_R15
+	// reservedRegisterForMemory R15: pointer to memory space (i.e. *[]byte as uintptr).
+	reservedRegisterForMemory = x86.REG_R15
 )
 
 var (

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -71,7 +71,7 @@ func TestValueLocationStack_basic(t *testing.T) {
 func TestValueLocationStack_takeFreeRegister(t *testing.T) {
 	s := newValueLocationStack()
 	// For int registers.
-	r, ok := s.takeFreeRegister(gpTypeInt)
+	r, ok := s.takeFreeRegister(generalPurposeRegisterTypeInt)
 	require.True(t, ok)
 	require.True(t, isIntRegister(r))
 	// Mark all the int registers used.
@@ -79,10 +79,10 @@ func TestValueLocationStack_takeFreeRegister(t *testing.T) {
 		s.markRegisterUsed(r)
 	}
 	// Now we cannot take free ones for int.
-	_, ok = s.takeFreeRegister(gpTypeInt)
+	_, ok = s.takeFreeRegister(generalPurposeRegisterTypeInt)
 	require.False(t, ok)
 	// But we still should be able to take float regs.
-	r, ok = s.takeFreeRegister(gpTypeFloat)
+	r, ok = s.takeFreeRegister(generalPurposeRegisterTypeFloat)
 	require.True(t, ok)
 	require.True(t, isFloatRegister(r))
 	// Mark all the float registers used.
@@ -90,7 +90,7 @@ func TestValueLocationStack_takeFreeRegister(t *testing.T) {
 		s.markRegisterUsed(r)
 	}
 	// Now we cannot take free ones for floats.
-	_, ok = s.takeFreeRegister(gpTypeFloat)
+	_, ok = s.takeFreeRegister(generalPurposeRegisterTypeFloat)
 	require.False(t, ok)
 }
 
@@ -103,25 +103,25 @@ func TestValueLocationStack_takeStealTargetFromUsedRegister(t *testing.T) {
 	s.push(intLocation)
 	s.push(floatLocation)
 	// Take for float.
-	target, ok := s.takeStealTargetFromUsedRegister(gpTypeFloat)
+	target, ok := s.takeStealTargetFromUsedRegister(generalPurposeRegisterTypeFloat)
 	require.True(t, ok)
 	require.Equal(t, floatLocation, target)
 	// Take for ints.
-	target, ok = s.takeStealTargetFromUsedRegister(gpTypeInt)
+	target, ok = s.takeStealTargetFromUsedRegister(generalPurposeRegisterTypeInt)
 	require.True(t, ok)
 	require.Equal(t, intLocation, target)
 	// Pop float value.
 	popped := s.pop()
 	require.Equal(t, floatLocation, popped)
 	// Now we cannot find the steal target.
-	target, ok = s.takeStealTargetFromUsedRegister(gpTypeFloat)
+	target, ok = s.takeStealTargetFromUsedRegister(generalPurposeRegisterTypeFloat)
 	require.False(t, ok)
 	require.Nil(t, target)
 	// Pop int value.
 	popped = s.pop()
 	require.Equal(t, intLocation, popped)
 	// Now we cannot find the steal target.
-	target, ok = s.takeStealTargetFromUsedRegister(gpTypeInt)
+	target, ok = s.takeStealTargetFromUsedRegister(generalPurposeRegisterTypeInt)
 	require.False(t, ok)
 	require.Nil(t, target)
 }

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -11,14 +11,25 @@ import (
 	"github.com/twitchyliquid64/golang-asm/obj/x86"
 )
 
+// TestReservedRegisters ensures that reserved registers are not contained in unreservedGeneralPurposeIntRegisters.
+func TestReservedRegisters(t *testing.T) {
+	unreserved := map[int16]struct{}{}
+	for _, r := range unreservedGeneralPurposeIntRegisters {
+		unreserved[r] = struct{}{}
+	}
+	require.NotContains(t, unreserved, reservedRegisterForEngine)
+	require.NotContains(t, unreserved, reservedRegisterForStackBasePointer)
+	require.NotContains(t, unreserved, reservedRegisterMemoryPointer)
+}
+
 func Test_isIntRegister(t *testing.T) {
-	for _, r := range gpIntRegisters {
+	for _, r := range unreservedGeneralPurposeIntRegisters {
 		require.True(t, isIntRegister(r))
 	}
 }
 
 func Test_isFloatRegister(t *testing.T) {
-	for _, r := range gpFloatRegisters {
+	for _, r := range generalPurposeFloatRegisters {
 		require.True(t, isFloatRegister(r))
 	}
 }
@@ -68,7 +79,7 @@ func TestValueLocationStack_takeFreeRegister(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, isIntRegister(r))
 	// Mark all the int registers used.
-	for _, r := range gpIntRegisters {
+	for _, r := range unreservedGeneralPurposeIntRegisters {
 		s.markRegisterUsed(r)
 	}
 	// Now we cannot take free ones for int.
@@ -79,7 +90,7 @@ func TestValueLocationStack_takeFreeRegister(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, isFloatRegister(r))
 	// Mark all the float registers used.
-	for _, r := range gpFloatRegisters {
+	for _, r := range generalPurposeFloatRegisters {
 		s.markRegisterUsed(r)
 	}
 	// Now we cannot take free ones for floats.

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -17,9 +17,9 @@ func TestReservedRegisters(t *testing.T) {
 	for _, r := range unreservedGeneralPurposeIntRegisters {
 		unreserved[r] = struct{}{}
 	}
-	require.NotContains(t, unreserved, reservedRegisterForEngine)
-	require.NotContains(t, unreserved, reservedRegisterForStackBasePointer)
-	require.NotContains(t, unreserved, reservedRegisterForMemory)
+	require.NotContains(t, unreservedGeneralPurposeIntRegisters, reservedRegisterForEngine)
+	require.NotContains(t, unreservedGeneralPurposeIntRegisters, reservedRegisterForStackBasePointer)
+	require.NotContains(t, unreservedGeneralPurposeIntRegisters, reservedRegisterForMemory)
 }
 
 func Test_isIntRegister(t *testing.T) {

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -19,7 +19,7 @@ func TestReservedRegisters(t *testing.T) {
 	}
 	require.NotContains(t, unreserved, reservedRegisterForEngine)
 	require.NotContains(t, unreserved, reservedRegisterForStackBasePointer)
-	require.NotContains(t, unreserved, reservedRegisterMemoryPointer)
+	require.NotContains(t, unreserved, reservedRegisterForMemory)
 }
 
 func Test_isIntRegister(t *testing.T) {

--- a/wasm/jit/jit_value_location_amd64_test.go
+++ b/wasm/jit/jit_value_location_amd64_test.go
@@ -13,10 +13,6 @@ import (
 
 // TestReservedRegisters ensures that reserved registers are not contained in unreservedGeneralPurposeIntRegisters.
 func TestReservedRegisters(t *testing.T) {
-	unreserved := map[int16]struct{}{}
-	for _, r := range unreservedGeneralPurposeIntRegisters {
-		unreserved[r] = struct{}{}
-	}
 	require.NotContains(t, unreservedGeneralPurposeIntRegisters, reservedRegisterForEngine)
 	require.NotContains(t, unreservedGeneralPurposeIntRegisters, reservedRegisterForStackBasePointer)
 	require.NotContains(t, unreservedGeneralPurposeIntRegisters, reservedRegisterForMemory)


### PR DESCRIPTION
- Renamed `*BaseStack*` -> `*StackBase*`
- Prefixed all the reserved registers with `reservedRegisterFor`

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>