### PR TITLE
Adds initial WebAssembly Text Format (%.wat) parser

### DIFF
--- a/wasm/wat/lexer.go
+++ b/wasm/wat/lexer.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 )
 
-// parseToken allows a parser to inspect a token without necessarily allocating strings
+// tokenParser is what the lexer calls for each token in the input.
 //
 // * tokenType is the token type
 // * tokenBytes are the UTF-8 bytes representing the token. Do not modify this.
@@ -17,7 +17,7 @@ import (
 //
 // Note: Do not include the line and column number in a parsing error as that will be attached automatically. Line and
 // column are here for storing the source location, such as for use in runtime stack traces.
-type parseToken func(tok tokenType, tokenBytes []byte, line, col int) error
+type tokenParser func(tok tokenType, tokenBytes []byte, line, col int) error
 
 var (
 	constantLParen = []byte{'('}
@@ -31,7 +31,7 @@ var (
 // * line is the source line number determined by unescaped '\n' characters of the error or EOF
 // * col is the UTF-8 column number of the error or EOF
 // * err is an error invoking the parser, dangling block comments or unexpected characters.
-func lex(parser parseToken, source []byte) (line int, col int, err error) {
+func lex(parser tokenParser, source []byte) (line int, col int, err error) {
 	// i is the source index to begin reading, inclusive.
 	i := 0
 	// end is the source index to stop reading, exclusive.

--- a/wasm/wat/lexer_test.go
+++ b/wasm/wat/lexer_test.go
@@ -440,7 +440,7 @@ func TestLex(t *testing.T) {
 func TestLex_Errors(t *testing.T) {
 	tests := []struct {
 		name         string
-		parser       parseToken
+		parser       tokenParser
 		input        []byte
 		expectedLine int
 		expectedCol  int
@@ -591,7 +591,7 @@ func TestLex_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			parser := tc.parser
 			if parser == nil {
-				parser = noopParseToken
+				parser = noopTokenParser
 			}
 			line, col, err := lex(parser, tc.input)
 			require.Equal(t, tc.expectedLine, line)
@@ -611,7 +611,7 @@ func lexTokens(t *testing.T, input string) []*token {
 	return tokens
 }
 
-var noopParseToken parseToken = func(_ tokenType, _ []byte, _, _ int) error {
+var noopTokenParser tokenParser = func(_ tokenType, _ []byte, _, _ int) error {
 	return nil
 }
 
@@ -647,7 +647,7 @@ func BenchmarkLex(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				line, col, err := lex(noopParseToken, bm.data)
+				line, col, err := lex(noopTokenParser, bm.data)
 				if err != nil {
 					panic(fmt.Errorf("%d:%d: %w", line, col, err))
 				}

--- a/wasm/wat/module.go
+++ b/wasm/wat/module.go
@@ -1,0 +1,58 @@
+package wat
+
+// textModule corresponds to the text format of a WebAssembly module, and is an intermediate representation prior to
+// wasm.Module.
+//
+// Note: nothing is required per specification. Ex `(module)` is valid!
+//
+// See https://www.w3.org/TR/wasm-core-1/#functions%E2%91%A7
+type textModule struct {
+	// name is optional and starts with '$'. For example, "$test".
+	// See https://www.w3.org/TR/wasm-core-1/#modules%E2%91%A0%E2%91%A2
+	//
+	// Note: The name may also be stored in the wasm.Module CustomSection under the key "name" subsection 0.
+	// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
+	name string
+
+	// imports are the module textImport added in insertion order.
+	imports []*textImport
+
+	// startFunction is the function to call during wasm.Store Instantiate. The value is a textFunc.name, such as "$main",
+	// or its equivalent raw numeric index, such as "2".
+	//
+	// Note: When in raw numeric form, this is relative to Import functions.
+	// See https://www.w3.org/TR/wasm-core-1/#start-function%E2%91%A4
+	startFunction string
+}
+
+// textFunc corresponds to the text format of a WebAssembly textFunc.
+//
+// Note: nothing is required per specification. Ex `(func)` is valid!
+//
+// See https://www.w3.org/TR/wasm-core-1/#functions%E2%91%A7
+type textFunc struct {
+	// name is optional and starts with '$'. For example, "$main".
+	//
+	// This name is only used for debugging. At runtime, functions are called based on raw numeric index. The function
+	// index space begins with imported functions, followed by any defined in this module.
+	// See https://www.w3.org/TR/wasm-core-1/#functions%E2%91%A7
+	//
+	// Note: The name may also be stored in the wasm.Module CustomSection under the key "name" subsection 1.
+	// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
+	name string
+}
+
+// textImport corresponds to the text format of a WebAssembly import.
+//
+// See https://www.w3.org/TR/wasm-core-1/#imports%E2%91%A0
+type textImport struct {
+	// module is the possibly empty module name to import. Ex. "" or "Math"
+	//
+	// Note: This is not necessarily the textModule.name, so it does not need to begin with '$'!
+	module string
+	// name is the possibly empty entity name to import. Ex. "" or "PI"
+	//
+	// Note: This is not necessarily the actual entity name (ex. textFunc.name), so it does not need to begin with '$'!
+	name string
+	desc *textFunc // TODO: oneOf textFunc,textTable,textMem,textGlobal
+}

--- a/wasm/wat/parser.go
+++ b/wasm/wat/parser.go
@@ -160,7 +160,7 @@ func (p *ModuleParser) parseImport(tok tokenType, tokenBytes []byte, _, _ int) e
 	return nil
 }
 
-func (p *ModuleParser) startImportField(fieldName []byte) (tokenParser, error) {
+func (p *ModuleParser) importFieldHandler(fieldName []byte) (tokenParser, error) {
 	switch string(fieldName) {
 	case "func":
 		p.currentField = fieldModuleImportFunc

--- a/wasm/wat/parser.go
+++ b/wasm/wat/parser.go
@@ -1,0 +1,230 @@
+package wat
+
+import (
+	"fmt"
+)
+
+type ModuleParser struct {
+	source                     []byte
+	m                          *textModule
+	parenDepth, skipUntilDepth int
+	// currentStringCount allows us to unquote the Import.module and Import.name fields, differentiating empty from
+	// never set, without making Import.module and Import.name pointers.
+	currentStringCount int
+	pf                 fieldHandler // TODO: crappy name
+	pt                 parseToken   // TODO: crappy name
+	// afterInlining sets the scope to return to after parsing a function.
+	// This is needed because a function can be defined at module scope or an inner scope such as an import.
+	// TODO: https://www.w3.org/TR/wasm-core-1/#abbreviations%E2%91%A8
+	afterInlining parseToken
+	currentImport *textImport
+	currentFunc   *textFunc
+}
+
+// fieldHandler returns a parseToken index that resumes parsing after "($fieldName". This must handle all tokens until
+// reaching a final tokenRParen. This implies nested paren handling.
+type fieldHandler func(fieldName []byte) (parseToken, error)
+
+func (p *ModuleParser) parse(tok tokenType, tokenBytes []byte, line, col int) error {
+	if p.skipUntilDepth == 0 {
+		return p.pt(tok, tokenBytes, line, col)
+	}
+	if tok == tokenLParen {
+		p.parenDepth = p.parenDepth + 1
+	} else if tok == tokenRParen {
+		if p.parenDepth == p.skipUntilDepth {
+			p.skipUntilDepth = 0
+		}
+		p.parenDepth = p.parenDepth - 1
+	}
+	return nil
+}
+
+func (p *ModuleParser) startField(tok tokenType, tokenBytes []byte, _, _ int) error {
+	if tok != tokenKeyword {
+		return fmt.Errorf("%s has a %s where a field name was expected", p.errorContext(), tok)
+	}
+
+	np, err := p.pf(tokenBytes)
+	if err != nil {
+		return err
+	}
+	p.pt = np
+	return nil
+}
+
+func (p *ModuleParser) startModule(fieldName []byte) (parseToken, error) {
+	if string(fieldName) == "module" {
+		return p.parseModule, nil
+	} else {
+		return nil, fmt.Errorf("%s should not have the field: %s", p.errorContext(), string(fieldName))
+	}
+}
+
+func (p *ModuleParser) parseModule(tok tokenType, tokenBytes []byte, _, _ int) error {
+	switch tok {
+	case tokenID:
+		name := string(tokenBytes)
+		if p.m.name != "" {
+			return fmt.Errorf("%s has a redundant name: %s", p.errorContext(), name)
+		}
+		p.m.name = name
+	case tokenLParen:
+		p.pt = p.startField       // after this look for a field name
+		p.pf = p.startModuleField // this defines the field names accepted
+		return nil
+	case tokenRParen: // end of module
+	default:
+		return p.unexpectedToken(tok, tokenBytes)
+	}
+	return nil
+}
+
+func (p *ModuleParser) startModuleField(fieldName []byte) (parseToken, error) {
+	switch string(fieldName) {
+	case "import":
+		p.currentImport = &textImport{}
+		p.m.imports = append(p.m.imports, p.currentImport)
+		return p.parseImport, nil
+	case "start": // TODO: only one is allowed
+		return p.parseStart, nil
+	}
+	return nil, fmt.Errorf("%s should not have the field: %s", p.errorContext(), string(fieldName))
+}
+
+func (p *ModuleParser) parseImport(tok tokenType, tokenBytes []byte, _, _ int) error {
+	switch tok {
+	case tokenString: // Ex. "" or "foo" including quotes!
+		name := string(tokenBytes[1 : len(tokenBytes)-1]) // unquote
+		if p.currentStringCount == 0 {
+			p.currentImport.module = name
+		} else if p.currentImport.name != "" {
+			return fmt.Errorf("%s has a redundant name: %s", p.errorContext(), name)
+		} else {
+			p.currentImport.name = name
+		}
+		p.currentStringCount = p.currentStringCount + 1
+	case tokenLParen: // start field
+		p.pt = p.startField       // after this look for a field name
+		p.pf = p.startImportField // this defines the field names accepted
+		return nil
+	case tokenRParen: // end of this import
+		switch p.currentStringCount {
+		case 0:
+			return fmt.Errorf("%s is missing its module and name", p.errorContext())
+		case 1:
+			return fmt.Errorf("%s is missing its name", p.errorContext())
+		}
+		if p.currentImport.desc == nil {
+			return fmt.Errorf("%s is missing its descripton", p.errorContext())
+		}
+		p.currentImport = nil
+		p.currentStringCount = 0
+		p.pt = p.parseModule
+	default:
+		return p.unexpectedToken(tok, tokenBytes)
+	}
+	return nil
+}
+
+func (p *ModuleParser) startImportField(fieldName []byte) (parseToken, error) {
+	switch string(fieldName) {
+	case "func":
+		p.currentFunc = &textFunc{}
+		p.currentImport.desc = p.currentFunc
+		p.afterInlining = p.parseImport
+		return p.parseFunc, nil
+	}
+	return nil, fmt.Errorf("%s should not have the field: %s", p.errorContext(), string(fieldName))
+}
+
+func (p *ModuleParser) parseFunc(tok tokenType, tokenBytes []byte, _, _ int) error {
+	switch tok {
+	case tokenID: // Ex. $main
+		name := string(tokenBytes)
+		if p.currentFunc.name != "" {
+			return fmt.Errorf("%s has a redundant name: %s", p.errorContext(), name)
+		}
+		p.currentFunc.name = name
+	case tokenRParen: // end of this func
+		p.currentFunc = nil
+		// There are two places a func ends: after inlining or after its module field.
+		// Ex. (module (import "" "hello" (func $hello)) (func $goodbye))
+		//                                    inlined ^   module field ^
+		if p.afterInlining != nil {
+			p.pt = p.afterInlining
+			p.afterInlining = nil
+		} else {
+			p.pt = p.parseModule
+		}
+	default:
+		return p.unexpectedToken(tok, tokenBytes)
+	}
+	return nil
+}
+
+func (p *ModuleParser) parseStart(tok tokenType, tokenBytes []byte, _, _ int) error {
+	switch tok {
+	case tokenUN, tokenID: // Ex. $main or 2
+		funcidx := string(tokenBytes)
+		if p.m.startFunction != "" {
+			return fmt.Errorf("%s has a redundant funcidx: %s", p.errorContext(), funcidx)
+		}
+		p.m.startFunction = funcidx
+	case tokenRParen: // end of this start
+		if p.m.startFunction == "" {
+			return fmt.Errorf("%s is missing its funcidx", p.errorContext())
+		}
+		p.pt = p.parseModule
+	default:
+		return p.unexpectedToken(tok, tokenBytes)
+	}
+	return nil
+}
+
+func (p *ModuleParser) startFile(tok tokenType, _ []byte, _, _ int) error {
+	if tok != tokenLParen {
+		return fmt.Errorf("expected '(', but found %s", tok)
+	}
+	p.parenDepth = p.parenDepth + 1
+	p.pt = p.startField
+	p.pf = p.startModule
+	return nil
+}
+
+// ParseModule parses the configured source into a module. This function returns when the source is exhausted or an
+// error occurs.
+//
+// Here's a description of the return values:
+// * m is the result of parsing or nil on error
+// * line is the source line number determined by unescaped '\n' characters of the error or EOF
+// * col is the UTF-8 column number of the error or EOF
+// * err is an error invoking the parser, dangling block comments or unexpected characters.
+func ParseModule(source []byte) (m *textModule, line int, col int, err error) {
+	m = &textModule{}
+	p := ModuleParser{source: source}
+	p.pt = p.startFile
+	p.m = m
+	line, col, err = lex(p.parse, p.source)
+	return m, line, col, err
+}
+
+func (p *ModuleParser) unexpectedToken(tok tokenType, tokenBytes []byte) error {
+	if tok == tokenLParen || tok == tokenRParen {
+		return fmt.Errorf("%s has an unexpected %s", p.errorContext(), tok)
+	}
+	return fmt.Errorf("%s has an unexpected %s: %s", p.errorContext(), tok, tokenBytes)
+}
+
+func (p *ModuleParser) errorContext() string {
+	if p.currentImport != nil {
+		i := len(p.m.imports)
+		if p.currentImport.desc != nil {
+			return fmt.Sprintf("import[%d].func", i) // TODO: func, table, memory or global
+		}
+		return fmt.Sprintf("import[%d]", i)
+	} else if p.m.startFunction != "" {
+		return "start"
+	}
+	return "module"
+}

--- a/wasm/wat/parser.go
+++ b/wasm/wat/parser.go
@@ -134,7 +134,8 @@ func (p *ModuleParser) moduleFieldHandler(fieldName []byte) (tokenParser, error)
 
 func (p *ModuleParser) parseImport(tok tokenType, tokenBytes []byte, _, _ int) error {
 	switch tok {
-	case tokenString: // Ex. "" or "foo" including quotes!
+	case tokenString:
+		// Note: tokenString is minimum length two on account of quotes. Ex. "" or "foo"
 		name := string(tokenBytes[1 : len(tokenBytes)-1]) // unquote
 		if p.currentStringCount == 0 {
 			p.currentImportModule = name

--- a/wasm/wat/parser.go
+++ b/wasm/wat/parser.go
@@ -91,7 +91,7 @@ func (p *ModuleParser) startField(tok tokenType, tokenBytes []byte, _, _ int) (e
 	return
 }
 
-// initialFieldHandler parses the top-level fields in the WebAssembly source.
+// initialFieldHandler returns a tokenParser for the top-level fields in the WebAssembly source.
 func (p *ModuleParser) initialFieldHandler(fieldName []byte) (tokenParser, error) {
 	if string(fieldName) == "module" {
 		p.currentField = fieldModule

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -1,0 +1,217 @@
+package wat
+
+import (
+	"fmt"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/bytecodealliance/wasmtime-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseModule(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *textModule
+	}{
+		{
+			name:     "empty",
+			input:    "(module)",
+			expected: &textModule{},
+		},
+		{
+			name:     "only name",
+			input:    "(module $tools)",
+			expected: &textModule{name: "$tools"},
+		},
+		{
+			name:     "import func empty",
+			input:    "(module (import \"foo\" \"bar\" (func)))", // ok empty sig
+			expected: &textModule{imports: []*textImport{{module: "foo", name: "bar", desc: &textFunc{}}}},
+		},
+		{
+			name: "start imported function by name",
+			input: `(module
+	(import "" "hello" (func $hello))
+	(start $hello)
+)`,
+			expected: &textModule{
+				imports:       []*textImport{{name: "hello", desc: &textFunc{name: "$hello"}}},
+				startFunction: "$hello",
+			},
+		},
+		{
+			name: "start imported function by index",
+			input: `(module
+	(import "" "hello" (func))
+	(start 0)
+)`,
+			expected: &textModule{
+				imports:       []*textImport{{name: "hello", desc: &textFunc{}}},
+				startFunction: "0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			m, line, col, err := ParseModule([]byte(tc.input))
+			require.NoError(t, err, "%d:%d: %s", line, col, err)
+			require.Equal(t, tc.expected, m)
+		})
+	}
+}
+
+func TestParseModule_Errors(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []byte
+		expectedLine int
+		expectedCol  int
+		expectedErr  string
+	}{
+		{
+			name:         "no module",
+			input:        []byte("()"),
+			expectedLine: 1,
+			expectedCol:  2,
+			expectedErr:  "module has a ) where a field name was expected",
+		},
+		{
+			name:         "module invalid name",
+			input:        []byte("(module test)"), // must start with $
+			expectedLine: 1,
+			expectedCol:  9,
+			expectedErr:  "module has an unexpected keyword: test",
+		},
+		{
+			name:         "module double name",
+			input:        []byte("(module $foo $bar)"),
+			expectedLine: 1,
+			expectedCol:  14,
+			expectedErr:  "module has a redundant name: $bar",
+		},
+		{
+			name:         "module empty field",
+			input:        []byte("(module $foo ())"),
+			expectedLine: 1,
+			expectedCol:  15,
+			expectedErr:  "module has a ) where a field name was expected",
+		},
+		{
+			name:         "module trailing )",
+			input:        []byte("(module $foo ))"),
+			expectedLine: 1,
+			expectedCol:  15,
+			expectedErr:  "found ')' before '('",
+		},
+		{
+			name:         "import missing module",
+			input:        []byte("(module (import))"),
+			expectedLine: 1,
+			expectedCol:  16,
+			expectedErr:  "import[1] is missing its module and name",
+		},
+		{
+			name:         "import missing name",
+			input:        []byte("(module (import \"\"))"),
+			expectedLine: 1,
+			expectedCol:  19,
+			expectedErr:  "import[1] is missing its name",
+		},
+		{
+			name:         "import unquoted module",
+			input:        []byte("(module (import foo bar))"),
+			expectedLine: 1,
+			expectedCol:  17,
+			expectedErr:  "import[1] has an unexpected keyword: foo",
+		},
+		{
+			name:         "import double name",
+			input:        []byte("(module (import \"foo\" \"bar\" \"baz\")"),
+			expectedLine: 1,
+			expectedCol:  29,
+			expectedErr:  "import[1] has a redundant name: baz",
+		},
+		{
+			name:         "import missing desc",
+			input:        []byte("(module (import \"foo\" \"bar\"))"),
+			expectedLine: 1,
+			expectedCol:  28,
+			expectedErr:  "import[1] is missing its descripton",
+		},
+		{
+			name:         "import desc empty",
+			input:        []byte("(module (import \"foo\" \"bar\"())"),
+			expectedLine: 1,
+			expectedCol:  29,
+			expectedErr:  "import[1] has a ) where a field name was expected",
+		},
+		{
+			name:         "import func invalid name",
+			input:        []byte("(module (import \"foo\" \"bar\" (func baz)))"),
+			expectedLine: 1,
+			expectedCol:  35,
+			expectedErr:  "import[1].func has an unexpected keyword: baz",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			_, line, col, err := ParseModule(tc.input)
+			require.Equal(t, tc.expectedLine, line)
+			require.Equal(t, tc.expectedCol, col)
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func BenchmarkParseExample(b *testing.B) {
+	simpleExample := []byte(`(module
+	(import "" "hello" (func $hello))
+	(start $hello)
+)`)
+
+	b.Run("vs utf8.Valid", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if !utf8.Valid(simpleExample) {
+				panic("unexpected")
+			}
+		}
+	})
+	// Not a fair comparison as we are only parsing and not writing back %.wasm
+	// If possible, we should find a way to isolate only the lexing C Functions.
+	b.Run("vs wasmtime.Wat2Wasm", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, err := wasmtime.Wat2Wasm(string(simpleExample))
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+	b.Run("vs wat.lex(noop)", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			line, col, err := lex(noopParseToken, simpleExample)
+			if err != nil {
+				panic(fmt.Errorf("%d:%d: %w", line, col, err))
+			}
+		}
+	})
+	b.Run("ParseModule", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, line, col, err := ParseModule(simpleExample)
+			if err != nil {
+				panic(fmt.Errorf("%d:%d: %w", line, col, err))
+			}
+		}
+	})
+}

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -63,7 +63,7 @@ func TestParseModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := ParseModule([]byte(tc.input))
+			m, err := parseModule([]byte(tc.input))
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, m)
 		})
@@ -157,7 +157,7 @@ func TestParseModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ParseModule(tc.input)
+			_, err := parseModule(tc.input)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -197,10 +197,10 @@ func BenchmarkParseExample(b *testing.B) {
 			}
 		}
 	})
-	b.Run("ParseModule", func(b *testing.B) {
+	b.Run("parseModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_, err := ParseModule(simpleExample)
+			_, err := parseModule(simpleExample)
 			if err != nil {
 				panic(err)
 			}

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -13,22 +13,22 @@ func TestParseModule(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected *textModule
+		expected *module
 	}{
 		{
 			name:     "empty",
 			input:    "(module)",
-			expected: &textModule{},
+			expected: &module{},
 		},
 		{
 			name:     "only name",
 			input:    "(module $tools)",
-			expected: &textModule{name: "$tools"},
+			expected: &module{name: "$tools"},
 		},
 		{
 			name:     "import func empty",
 			input:    "(module (import \"foo\" \"bar\" (func)))", // ok empty sig
-			expected: &textModule{imports: []*textImport{{module: "foo", name: "bar", desc: &textImportFunc{}}}},
+			expected: &module{imports: []*_import{{module: "foo", name: "bar", importFunc: &importFunc{}}}},
 		},
 		{
 			name: "start imported function by name",
@@ -36,8 +36,8 @@ func TestParseModule(t *testing.T) {
 	(import "" "hello" (func $hello))
 	(start $hello)
 )`,
-			expected: &textModule{
-				imports:       []*textImport{{name: "hello", desc: &textImportFunc{name: "$hello"}}},
+			expected: &module{
+				imports:       []*_import{{name: "hello", importFunc: &importFunc{name: "$hello"}}},
 				startFunction: "$hello",
 			},
 		},
@@ -47,8 +47,8 @@ func TestParseModule(t *testing.T) {
 	(import "" "hello" (func))
 	(start 0)
 )`,
-			expected: &textModule{
-				imports:       []*textImport{{name: "hello", desc: &textImportFunc{}}},
+			expected: &module{
+				imports:       []*_import{{name: "hello", importFunc: &importFunc{}}},
 				startFunction: "0",
 			},
 		},
@@ -117,12 +117,12 @@ func TestParseModule_Errors(t *testing.T) {
 			expectedErr: "1:29: redundant name: baz in import[0]",
 		},
 		{
-			name:        "import missing desc",
+			name:        "import missing importFunc",
 			input:       []byte("(module (import \"foo\" \"bar\"))"),
 			expectedErr: "1:28: expected descripton in import[0]",
 		},
 		{
-			name:        "import desc empty",
+			name:        "import importFunc empty",
 			input:       []byte("(module (import \"foo\" \"bar\"())"),
 			expectedErr: "1:29: expected field, but found ) in import[0]",
 		},

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -28,7 +28,7 @@ func TestParseModule(t *testing.T) {
 		{
 			name:     "import func empty",
 			input:    "(module (import \"foo\" \"bar\" (func)))", // ok empty sig
-			expected: &textModule{imports: []*textImport{{module: "foo", name: "bar", desc: &textFunc{}}}},
+			expected: &textModule{imports: []*textImport{{module: "foo", name: "bar", desc: &textImportFunc{}}}},
 		},
 		{
 			name: "start imported function by name",
@@ -37,7 +37,7 @@ func TestParseModule(t *testing.T) {
 	(start $hello)
 )`,
 			expected: &textModule{
-				imports:       []*textImport{{name: "hello", desc: &textFunc{name: "$hello"}}},
+				imports:       []*textImport{{name: "hello", desc: &textImportFunc{name: "$hello"}}},
 				startFunction: "$hello",
 			},
 		},
@@ -48,7 +48,7 @@ func TestParseModule(t *testing.T) {
 	(start 0)
 )`,
 			expected: &textModule{
-				imports:       []*textImport{{name: "hello", desc: &textFunc{}}},
+				imports:       []*textImport{{name: "hello", desc: &textImportFunc{}}},
 				startFunction: "0",
 			},
 		},

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -16,8 +16,8 @@ type module struct {
 	// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
 	name string
 
-	// imports are added in insertion order.
-	imports []*_import
+	// importFuncs are imports describing functions "(import... (func...))" added in insertion order.
+	importFuncs []*importFunc
 
 	// startFunction is the function to call during wasm.Store Instantiate. The value is a importFunc.name, such as
 	// "$main", or its equivalent raw numeric index, such as "2".
@@ -28,12 +28,25 @@ type module struct {
 	startFunction string
 }
 
-// importFunc corresponds to the text format of a WebAssembly function import description.
+// importFunc corresponds to the text format of a WebAssembly function import.
 //
-// Note: nothing is required per specification. Ex `(func)` is valid!
+// Note: nothing is required per specification. Ex `(import "" "" (func))` is valid!
 //
 // See https://www.w3.org/TR/wasm-core-1/#imports%E2%91%A0
 type importFunc struct {
+	// importIndex is the zero-based index in module.imports. This is needed because imports are not always functions.
+	importIndex int
+
+	// module is the possibly empty module name to import. Ex. "" or "Math"
+	//
+	// Note: This is not necessarily the module.name, so it does not need to begin with '$'!
+	module string
+
+	// name is the possibly empty entity name to import. Ex. "" or "PI"
+	//
+	// Note: This is not necessarily the funcName, so it does not need to begin with '$'!
+	name string
+
 	// name is optional and starts with '$'. For example, "$main".
 	//
 	// This name is only used for debugging. At runtime, functions are called based on raw numeric index. The function
@@ -42,25 +55,9 @@ type importFunc struct {
 	//
 	// Note: The name may also be stored in the wasm.Module CustomSection under the key "name" subsection 1.
 	// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
-	name string
+	funcName string
 
 	// TODO: typeuse https://www.w3.org/TR/wasm-core-1/#text-typeuse
-}
-
-// _import corresponds to the text format of a WebAssembly import.
-//
-// See https://www.w3.org/TR/wasm-core-1/#imports%E2%91%A0
-type _import struct { // note: this is named _import because import is reserved in golang
-	// module is the possibly empty module name to import. Ex. "" or "Math"
-	//
-	// Note: This is not necessarily the module.name, so it does not need to begin with '$'!
-	module string
-	// name is the possibly empty entity name to import. Ex. "" or "PI"
-	//
-	// Note: This is not necessarily the entity name defined in this module, so it does not need to begin with '$'!
-	name string
-	// importFunc is set when the "import" field is
-	importFunc *importFunc // TODO: oneOf func, table, mem, global
 }
 
 // formatError allows control over the format of formatError.Error

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -3,7 +3,7 @@ package wat
 import "fmt"
 
 // textModule corresponds to the text format of a WebAssembly module, and is an intermediate representation prior to
-// wasm.Module.
+// wasm.Module. This is primarily needed to resolve symbolic indexes like "$main" to raw numeric ones.
 //
 // Note: nothing is required per specification. Ex `(module)` is valid!
 //
@@ -16,13 +16,14 @@ type textModule struct {
 	// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
 	name string
 
-	// imports are the module textImport added in insertion order.
+	// imports are added in insertion order.
 	imports []*textImport
 
-	// startFunction is the function to call during wasm.Store Instantiate. The value is a textImportFunc.name, such as "$main",
-	// or its equivalent raw numeric index, such as "2".
+	// startFunction is the function to call during wasm.Store Instantiate. The value is a textImportFunc.name, such as
+	// "$main", or its equivalent raw numeric index, such as "2".
 	//
-	// Note: When in raw numeric form, this is relative to Import functions.
+	// Note: When in raw numeric form, this is relative to imports. See wasm.Module StartSection for more.
+	//
 	// See https://www.w3.org/TR/wasm-core-1/#start-function%E2%91%A4
 	startFunction string
 }

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -75,6 +75,9 @@ type formatError struct {
 }
 
 func (e *formatError) Error() string {
+	if e.context == "" { // error starting the file
+		return fmt.Sprintf("%d:%d: %v", e.line, e.col, e.cause)
+	}
 	return fmt.Sprintf("%d:%d: %v in %s", e.line, e.col, e.cause, e.context)
 }
 

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -47,7 +47,7 @@ type importFunc struct {
 	// Note: This is not necessarily the funcName, so it does not need to begin with '$'!
 	name string
 
-	// name is optional and starts with '$'. For example, "$main".
+	// funcName starts with '$'. For example, "$main".
 	//
 	// This name is only used for debugging. At runtime, functions are called based on raw numeric index. The function
 	// index space begins with imported functions, followed by any defined in this module.

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -1,5 +1,7 @@
 package wat
 
+import "fmt"
+
 // textModule corresponds to the text format of a WebAssembly module, and is an intermediate representation prior to
 // wasm.Module.
 //
@@ -55,4 +57,23 @@ type textImport struct {
 	// Note: This is not necessarily the actual entity name (ex. textFunc.name), so it does not need to begin with '$'!
 	name string
 	desc *textFunc // TODO: oneOf textFunc,textTable,textMem,textGlobal
+}
+
+// textFormatError allows control over the format of textFormatError.Error
+type textFormatError struct {
+	// line is the source line number determined by unescaped '\n' characters of the error or EOF
+	line int
+	// Col is the UTF-8 column number of the error or EOF
+	col int
+	// Context is where symbolically the error occurred. Ex "imports[1].desc"
+	context string
+	cause   error
+}
+
+func (e *textFormatError) Error() string {
+	return fmt.Sprintf("%d:%d: %v in %s", e.line, e.col, e.cause, e.context)
+}
+
+func (e *textFormatError) Unwrap() error {
+	return e.cause
 }

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -19,7 +19,7 @@ type textModule struct {
 	// imports are the module textImport added in insertion order.
 	imports []*textImport
 
-	// startFunction is the function to call during wasm.Store Instantiate. The value is a textFunc.name, such as "$main",
+	// startFunction is the function to call during wasm.Store Instantiate. The value is a textImportFunc.name, such as "$main",
 	// or its equivalent raw numeric index, such as "2".
 	//
 	// Note: When in raw numeric form, this is relative to Import functions.
@@ -27,12 +27,12 @@ type textModule struct {
 	startFunction string
 }
 
-// textFunc corresponds to the text format of a WebAssembly textFunc.
+// textImportFunc corresponds to the text format of a WebAssembly function import description.
 //
 // Note: nothing is required per specification. Ex `(func)` is valid!
 //
-// See https://www.w3.org/TR/wasm-core-1/#functions%E2%91%A7
-type textFunc struct {
+// See https://www.w3.org/TR/wasm-core-1/#imports%E2%91%A0
+type textImportFunc struct {
 	// name is optional and starts with '$'. For example, "$main".
 	//
 	// This name is only used for debugging. At runtime, functions are called based on raw numeric index. The function
@@ -54,9 +54,9 @@ type textImport struct {
 	module string
 	// name is the possibly empty entity name to import. Ex. "" or "PI"
 	//
-	// Note: This is not necessarily the actual entity name (ex. textFunc.name), so it does not need to begin with '$'!
+	// Note: This is not necessarily the entity name defined in this module, so it does not need to begin with '$'!
 	name string
-	desc *textFunc // TODO: oneOf textFunc,textTable,textMem,textGlobal
+	desc *textImportFunc // TODO: oneOf func, table, mem, global
 }
 
 // textFormatError allows control over the format of textFormatError.Error


### PR DESCRIPTION
This builds on the lexing layer to parse the WebAssembly Text Format.

The PR after this will convert the following text format to a `wasm.Module`

```wat
(module
	(import "" "hello" (func $hello))
	(start $hello)
)
```