### PR TITLE
Removes suffix Type from fields in FunctionType

### DIFF
--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -111,7 +111,7 @@ func (e *engine) Call(f *wasm.FunctionInstance, params ...uint64) (results []uin
 	}
 	// Note the top value is the tail of the results,
 	// so we assign them in reverse order.
-	results = make([]uint64, len(f.Signature.ResultTypes))
+	results = make([]uint64, len(f.Signature.Results))
 	for i := range results {
 		results[len(results)-1-i] = e.pop()
 	}
@@ -612,8 +612,8 @@ func (e *engine) compileWasmFunction(f *wasm.FunctionInstance) (*compiledWasmFun
 	cf := &compiledWasmFunction{
 		source:          f,
 		codeSegment:     code,
-		paramCount:      uint64(len(f.Signature.ParamTypes)),
-		resultCount:     uint64(len(f.Signature.ResultTypes)),
+		paramCount:      uint64(len(f.Signature.Params)),
+		resultCount:     uint64(len(f.Signature.Results)),
 		memory:          f.ModuleInstance.Memory,
 		maxStackPointer: maxStackPointer,
 	}

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -92,7 +92,7 @@ func (c *amd64Compiler) generate() ([]byte, uint64, error) {
 }
 
 func (c *amd64Compiler) pushFunctionParams() {
-	for _, t := range c.f.Signature.ParamTypes {
+	for _, t := range c.f.Signature.Params {
 		loc := c.locationStack.pushValueOnStack()
 		switch t {
 		case wasm.ValueTypeI32, wasm.ValueTypeI64:

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -51,11 +51,11 @@ func (c *amd64Compiler) movIntConstToRegister(val int64, targetRegister int16) *
 
 func TestAmd64Compiler_pushFunctionInputs(t *testing.T) {
 	f := &wasm.FunctionInstance{Signature: &wasm.FunctionType{
-		ParamTypes: []wasm.ValueType{wasm.ValueTypeF64, wasm.ValueTypeI32},
+		Params: []wasm.ValueType{wasm.ValueTypeF64, wasm.ValueTypeI32},
 	}}
 	compiler := &amd64Compiler{locationStack: newValueLocationStack(), f: f}
 	compiler.pushFunctionParams()
-	require.Equal(t, uint64(len(f.Signature.ParamTypes)), compiler.locationStack.sp)
+	require.Equal(t, uint64(len(f.Signature.Params)), compiler.locationStack.sp)
 	loc := compiler.locationStack.pop()
 	require.Equal(t, uint64(1), loc.stackPointer)
 	loc = compiler.locationStack.pop()
@@ -482,8 +482,8 @@ func TestEngine_exec_callHostFunction(t *testing.T) {
 		hostFunctionInstance := &wasm.FunctionInstance{
 			HostFunction: &hostFunc,
 			Signature: &wasm.FunctionType{
-				ParamTypes:  []wasm.ValueType{wasm.ValueTypeI64, wasm.ValueTypeI64},
-				ResultTypes: []wasm.ValueType{wasm.ValueTypeI64},
+				Params:  []wasm.ValueType{wasm.ValueTypeI64, wasm.ValueTypeI64},
+				Results: []wasm.ValueType{wasm.ValueTypeI64},
 			},
 		}
 		eng.compiledHostFunctionIndex[hostFunctionInstance] = 1

--- a/wasm/type.go
+++ b/wasm/type.go
@@ -8,7 +8,7 @@ import (
 )
 
 type FunctionType struct {
-	ParamTypes, ResultTypes []ValueType
+	Params, Results []ValueType
 }
 
 func readFunctionType(r io.Reader) (*FunctionType, error) {
@@ -44,8 +44,8 @@ func readFunctionType(r io.Reader) (*FunctionType, error) {
 	}
 
 	return &FunctionType{
-		ParamTypes:  paramTypes,
-		ResultTypes: resultTypes,
+		Params:  paramTypes,
+		Results: resultTypes,
 	}, nil
 }
 

--- a/wasm/wazeroir/compiler.go
+++ b/wasm/wazeroir/compiler.go
@@ -148,7 +148,7 @@ func Compile(f *wasm.FunctionInstance) (*CompilationResult, error) {
 	c := compiler{controlFrames: &controlFrames{}, f: f, result: CompilationResult{LabelCallers: map[string]int{}}}
 
 	// Push function arguments.
-	for _, t := range f.Signature.ParamTypes {
+	for _, t := range f.Signature.Params {
 		c.stackPush(wasmValueTypeToUnsignedType(t))
 	}
 	// Emit const expressions for locals.
@@ -160,13 +160,13 @@ func Compile(f *wasm.FunctionInstance) (*CompilationResult, error) {
 	}
 
 	// Insert the function control frame.
-	returns := make([]UnsignedType, 0, len(f.Signature.ResultTypes))
-	for _, t := range f.Signature.ResultTypes {
+	returns := make([]UnsignedType, 0, len(f.Signature.Results))
+	for _, t := range f.Signature.Results {
 		returns = append(returns, wasmValueTypeToUnsignedType(t))
 	}
 	c.controlFrames.push(&controlFrame{
 		frameID:          c.nextID(),
-		originalStackLen: len(f.Signature.ParamTypes),
+		originalStackLen: len(f.Signature.Params),
 		returns:          returns,
 		kind:             controlFrameKindFunction,
 	})
@@ -231,7 +231,7 @@ operatorSwitch:
 			originalStackLen: len(c.stack),
 			kind:             controlFrameKindBlockWithoutContinuationLabel,
 		}
-		for _, t := range bt.ResultTypes {
+		for _, t := range bt.Results {
 			frame.returns = append(frame.returns, wasmValueTypeToUnsignedType(t))
 		}
 		c.controlFrames.push(frame)
@@ -257,7 +257,7 @@ operatorSwitch:
 			originalStackLen: len(c.stack),
 			kind:             controlFrameKindLoop,
 		}
-		for _, t := range bt.ResultTypes {
+		for _, t := range bt.Results {
 			frame.returns = append(frame.returns, wasmValueTypeToUnsignedType(t))
 		}
 		c.controlFrames.push(frame)
@@ -297,7 +297,7 @@ operatorSwitch:
 			// when else opcode found later.
 			kind: controlFrameKindIfWithoutElse,
 		}
-		for _, t := range bt.ResultTypes {
+		for _, t := range bt.Results {
 			frame.returns = append(frame.returns, wasmValueTypeToUnsignedType(t))
 		}
 		c.controlFrames.push(frame)

--- a/wasm/wazeroir/interpreter.go
+++ b/wasm/wazeroir/interpreter.go
@@ -495,7 +495,7 @@ func (it *interpreter) Call(f *wasm.FunctionInstance, params ...uint64) (results
 		}
 		it.callNativeFunc(g)
 	}
-	results = make([]uint64, len(f.Signature.ResultTypes))
+	results = make([]uint64, len(f.Signature.Results))
 	for i := range results {
 		results[len(results)-1-i] = it.pop()
 	}
@@ -588,7 +588,7 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 		case OperationKindCall:
 			{
 				if op.f.hostFn != nil {
-					it.callHostFunc(op.f, it.stack[len(it.stack)-len(op.f.signature.ParamTypes):]...)
+					it.callHostFunc(op.f, it.stack[len(it.stack)-len(op.f.signature.Params):]...)
 				} else {
 					it.callNativeFunc(op.f)
 				}
@@ -604,7 +604,7 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 				}
 				// Call in.
 				if target.hostFn != nil {
-					it.callHostFunc(target, it.stack[len(it.stack)-len(target.signature.ParamTypes):]...)
+					it.callHostFunc(target, it.stack[len(it.stack)-len(target.signature.Params):]...)
 				} else {
 					it.callNativeFunc(target)
 				}
@@ -1473,8 +1473,8 @@ func funcTypeString(t *wasm.FunctionType) string {
 		// Fast stringification of byte slice.
 		// This is safe anyway as the results are copied
 		// into the return value string.
-		*(*string)(unsafe.Pointer(&t.ParamTypes)),
-		*(*string)(unsafe.Pointer(&t.ResultTypes)),
+		*(*string)(unsafe.Pointer(&t.Params)),
+		*(*string)(unsafe.Pointer(&t.Results)),
 	)
 }
 

--- a/wasm/wazeroir/signature.go
+++ b/wasm/wazeroir/signature.go
@@ -170,37 +170,37 @@ func wasmOpcodeSignature(f *wasm.FunctionInstance, op wasm.Opcode, index uint32)
 	case wasm.OpcodeSelect:
 		return signature_UnknownUnkownI32_Unknown, nil
 	case wasm.OpcodeLocalGet:
-		inputLen := uint32(len(f.Signature.ParamTypes))
+		inputLen := uint32(len(f.Signature.Params))
 		if l := f.NumLocals + inputLen; index >= l {
 			return nil, fmt.Errorf("invalid local index for local.get %d >= %d", index, l)
 		}
 		var t UnsignedType
 		if index < inputLen {
-			t = wasmValueTypeToUnsignedType(f.Signature.ParamTypes[index])
+			t = wasmValueTypeToUnsignedType(f.Signature.Params[index])
 		} else {
 			t = wasmValueTypeToUnsignedType(f.LocalTypes[index-inputLen])
 		}
 		return &signature{out: []UnsignedType{t}}, nil
 	case wasm.OpcodeLocalSet:
-		inputLen := uint32(len(f.Signature.ParamTypes))
+		inputLen := uint32(len(f.Signature.Params))
 		if l := f.NumLocals + inputLen; index >= l {
 			return nil, fmt.Errorf("invalid local index for local.get %d >= %d", index, l)
 		}
 		var t UnsignedType
 		if index < inputLen {
-			t = wasmValueTypeToUnsignedType(f.Signature.ParamTypes[index])
+			t = wasmValueTypeToUnsignedType(f.Signature.Params[index])
 		} else {
 			t = wasmValueTypeToUnsignedType(f.LocalTypes[index-inputLen])
 		}
 		return &signature{in: []UnsignedType{t}}, nil
 	case wasm.OpcodeLocalTee:
-		inputLen := uint32(len(f.Signature.ParamTypes))
+		inputLen := uint32(len(f.Signature.Params))
 		if l := f.NumLocals + inputLen; index >= l {
 			return nil, fmt.Errorf("invalid local index for local.get %d >= %d", index, l)
 		}
 		var t UnsignedType
 		if index < inputLen {
-			t = wasmValueTypeToUnsignedType(f.Signature.ParamTypes[index])
+			t = wasmValueTypeToUnsignedType(f.Signature.Params[index])
 		} else {
 			t = wasmValueTypeToUnsignedType(f.LocalTypes[index-inputLen])
 		}
@@ -353,10 +353,10 @@ func wasmOpcodeSignature(f *wasm.FunctionInstance, op wasm.Opcode, index uint32)
 
 func funcTypeToSignature(tps *wasm.FunctionType) *signature {
 	ret := &signature{}
-	for _, vt := range tps.ParamTypes {
+	for _, vt := range tps.Params {
 		ret.in = append(ret.in, wasmValueTypeToUnsignedType(vt))
 	}
-	for _, vt := range tps.ResultTypes {
+	for _, vt := range tps.Results {
 		ret.out = append(ret.out, wasmValueTypeToUnsignedType(vt))
 	}
 	return ret


### PR DESCRIPTION
Since there is no ambiguity in FunctionType about it being types, this
removes the suffix Type from its fields. I wouldn't do this, if for
example, there were mixed fields (ex type names). However, as it is, I
think this is less stuttering so overall better.
