### PR TITLE
Update Go cache in Pre-commit

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -30,7 +30,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-20211231
 
       - run: make lint
 


### PR DESCRIPTION
Looks like a cache is so old that it doesn't contain any cache for goimports and golangci-lint