### PR TITLE
TypeIndexPtr -> FuncTypeIndex

### DIFF
--- a/wasm/segment.go
+++ b/wasm/segment.go
@@ -20,7 +20,9 @@ const (
 type ImportDesc struct {
 	Kind byte
 
-	TypeIndexPtr  *uint32
+	// FuncTypeIndex is the index in Module.TypeSection corresponding to this import's FunctionType.
+	// This is only valid when Kind equals ImportKindFunction
+	FuncTypeIndex uint32
 	TableTypePtr  *TableType
 	MemTypePtr    *MemoryType
 	GlobalTypePtr *GlobalType
@@ -39,8 +41,8 @@ func readImportDesc(r io.Reader) (*ImportDesc, error) {
 			return nil, fmt.Errorf("read typeindex: %v", err)
 		}
 		return &ImportDesc{
-			Kind:         ImportKindFunction,
-			TypeIndexPtr: &tID,
+			Kind:          ImportKindFunction,
+			FuncTypeIndex: tID,
 		}, nil
 	case ImportKindTable:
 		tt, err := readTableType(r)

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -219,19 +219,19 @@ func (s *Store) resolveImport(target *ModuleInstance, is *ImportSegment) error {
 		return fmt.Errorf("type mismatch on export: got %#x but want %#x", e.Kind, is.Desc.Kind)
 	}
 	switch is.Desc.Kind {
-	case 0x00: // function
-		if err := s.applyFunctionImport(target, is.Desc.TypeIndexPtr, e); err != nil {
+	case ImportKindFunction:
+		if err := s.applyFunctionImport(target, is.Desc.FuncTypeIndex, e); err != nil {
 			return fmt.Errorf("applyFunctionImport: %w", err)
 		}
-	case 0x01: // table
+	case ImportKindTable:
 		if err := s.applyTableImport(target, is.Desc.TableTypePtr, e); err != nil {
 			return fmt.Errorf("applyTableImport: %w", err)
 		}
-	case 0x02: // mem
+	case ImportKindMemory:
 		if err := s.applyMemoryImport(target, is.Desc.MemTypePtr, e); err != nil {
 			return fmt.Errorf("applyMemoryImport: %w", err)
 		}
-	case 0x03: // global
+	case ImportKindGlobal:
 		if err := s.applyGlobalImport(target, is.Desc.GlobalTypePtr, e); err != nil {
 			return fmt.Errorf("applyGlobalImport: %w", err)
 		}
@@ -242,12 +242,8 @@ func (s *Store) resolveImport(target *ModuleInstance, is *ImportSegment) error {
 	return nil
 }
 
-func (s *Store) applyFunctionImport(target *ModuleInstance, typeIndexPtr *uint32, externModuleExportIsntance *ExportInstance) error {
-	if typeIndexPtr == nil {
-		return fmt.Errorf("type index is invalid")
-	}
+func (s *Store) applyFunctionImport(target *ModuleInstance, typeIndex uint32, externModuleExportIsntance *ExportInstance) error {
 	f := externModuleExportIsntance.Function
-	typeIndex := *typeIndexPtr
 	if int(typeIndex) >= len(target.Types) {
 		return fmt.Errorf("unknown type for function import")
 	}
@@ -420,7 +416,7 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 	for _, imp := range module.ImportSection {
 		switch imp.Desc.Kind {
 		case ImportKindFunction:
-			functionDeclarations = append(functionDeclarations, *imp.Desc.TypeIndexPtr)
+			functionDeclarations = append(functionDeclarations, imp.Desc.FuncTypeIndex)
 		case ImportKindGlobal:
 			globalDecalarations = append(globalDecalarations, imp.Desc.GlobalTypePtr)
 		case ImportKindMemory:

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -410,7 +410,7 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 		s.Functions = s.Functions[:prevLen]
 	})
 	var functionDeclarations []uint32
-	var globalDecalarations []*GlobalType
+	var globalDeclarations []*GlobalType
 	var memoryDeclarations []*MemoryType
 	var tableDeclarations []*TableType
 	for _, imp := range module.ImportSection {
@@ -418,7 +418,7 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 		case ImportKindFunction:
 			functionDeclarations = append(functionDeclarations, imp.Desc.FuncTypeIndex)
 		case ImportKindGlobal:
-			globalDecalarations = append(globalDecalarations, imp.Desc.GlobalTypePtr)
+			globalDeclarations = append(globalDeclarations, imp.Desc.GlobalTypePtr)
 		case ImportKindMemory:
 			memoryDeclarations = append(memoryDeclarations, imp.Desc.MemTypePtr)
 		case ImportKindTable:
@@ -428,7 +428,7 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 	importedFunctionCount := len(functionDeclarations)
 	functionDeclarations = append(functionDeclarations, module.FunctionSection...)
 	for _, g := range module.GlobalSection {
-		globalDecalarations = append(globalDecalarations, g.Type)
+		globalDeclarations = append(globalDeclarations, g.Type)
 	}
 	memoryDeclarations = append(memoryDeclarations, module.MemorySection...)
 	tableDeclarations = append(tableDeclarations, module.TableSection...)
@@ -463,7 +463,7 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 
 		if _, ok := analysisCache[codeIndex]; !ok {
 			err := analyzeFunction(
-				module, f, functionDeclarations, globalDecalarations,
+				module, f, functionDeclarations, globalDeclarations,
 				memoryDeclarations, tableDeclarations,
 			)
 			if err != nil {


### PR DESCRIPTION
It is easier to reason with the function type index as a number instead
of a pointer. It is also easier to unit test. We don't need the second
pointer guard because the import definition already checks the type (ex
func vs table) first.

This also fixes a typo
