### PR TITLE
Text Format: reduces the amount of parsing state

### DIFF
--- a/wasm/wat/names_test.go
+++ b/wasm/wat/names_test.go
@@ -15,15 +15,15 @@ func TestEncodeNameSection(t *testing.T) {
 	// TIP: the below is the binary suffix of `wat2wasm --debug-names --debug-parser -v simple.wat` where simple.wat
 	// contains the same text as simpleExample
 	require.Equal(t, []byte{
-		0x00, /* module subsection ID zero */
-		0x07, /* 7 bytes to follow */
-		0x06, /* the module name simple is 6 characters long */
+		0x00, // module subsection ID zero
+		0x07, // 7 bytes to follow
+		0x06, // the module name simple is 6 characters long
 		's', 'i', 'm', 'p', 'l', 'e',
-		0x01, /* function subsection ID one */
-		0x08, /* 8 bytes to follow */
-		0x01, /* one function name */
-		0x00, /* the function index is zero */
-		0x05, /* the function name hello is 5 characters long */
+		0x01, // function subsection ID one
+		0x08, // 8 bytes to follow
+		0x01, // one function name
+		0x00, // the function index is zero
+		0x05, // the function name hello is 5 characters long
 		'h', 'e', 'l', 'l', 'o',
 	}, encodeNameSection(m))
 }
@@ -46,7 +46,7 @@ func TestEncodeNameSection_OnlyFuncName(t *testing.T) {
 
 	expected := append(append([]byte{
 		0x01, // function subsection ID one
-		// length includes 1 byte overhead for the function name count, and 2 bytes (index + length prefix) per name
+		// length includes overhead for size in bytes of the function name count, plus index + length prefix per name
 		byte(1 + 2 + 2 + len(func0) + len(func1)),
 		0x02, // two function names
 	},

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -133,7 +133,7 @@ func TestParseModule_Errors(t *testing.T) {
 		{
 			name:        "import missing desc",
 			input:       "(module (import \"foo\" \"bar\"))",
-			expectedErr: "1:28: missing description in module.import[0]",
+			expectedErr: "1:28: missing description field in module.import[0]",
 		},
 		{
 			name:        "import empty desc",

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -82,10 +82,10 @@ var typeFuncEmpty = &typeFunc{}
 // See https://www.w3.org/TR/wasm-core-1/#imports%E2%91%A0
 type importFunc struct {
 	// importIndex is the zero-based index in module.imports. This is needed because imports are not always functions.
-	importIndex int
+	importIndex uint32
 
 	// typeIndex is the zero-based index in module.types representing this function signature.
-	typeIndex int
+	typeIndex uint32
 
 	// module is the possibly empty module name to import. Ex. "" or "Math"
 	//


### PR DESCRIPTION
This generifies some parser state so that it can be reused next for
parsing parameter names. This also cleans up some ++ stuff.