### PR TITLE
jit: support for and, or, xor, shl, shr, rotl and rotr operations

### DIFF
--- a/wasm/jit/compiler.go
+++ b/wasm/jit/compiler.go
@@ -31,6 +31,11 @@ type compiler interface {
 	compilePopcnt(o *wazeroir.OperationPopcnt) error
 	compileDiv(o *wazeroir.OperationDiv) error
 	compileRem(o *wazeroir.OperationRem) error
+	compileAnd(o *wazeroir.OperationAnd) error
+	compileOr(o *wazeroir.OperationOr) error
+	compileXor(o *wazeroir.OperationXor) error
+	compileShl(o *wazeroir.OperationShl) error
+	compileShr(o *wazeroir.OperationShr) error
 	compileEq(o *wazeroir.OperationEq) error
 	compileNe(o *wazeroir.OperationNe) error
 	compileEqz(o *wazeroir.OperationEqz) error

--- a/wasm/jit/compiler.go
+++ b/wasm/jit/compiler.go
@@ -36,6 +36,8 @@ type compiler interface {
 	compileXor(o *wazeroir.OperationXor) error
 	compileShl(o *wazeroir.OperationShl) error
 	compileShr(o *wazeroir.OperationShr) error
+	compileRotl(o *wazeroir.OperationRotl) error
+	compileRotr(o *wazeroir.OperationRotr) error
 	compileEq(o *wazeroir.OperationEq) error
 	compileNe(o *wazeroir.OperationNe) error
 	compileEqz(o *wazeroir.OperationEqz) error

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -559,9 +559,9 @@ func (e *engine) compileWasmFunction(f *wasm.FunctionInstance) (*compiledWasmFun
 		case *wazeroir.OperationShr:
 			err = compiler.compileShr(o)
 		case *wazeroir.OperationRotl:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileRotl(o)
 		case *wazeroir.OperationRotr:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileRotr(o)
 		case *wazeroir.OperationAbs:
 			err = fmt.Errorf("unsupported operation")
 		case *wazeroir.OperationNeg:

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -549,15 +549,15 @@ func (e *engine) compileWasmFunction(f *wasm.FunctionInstance) (*compiledWasmFun
 		case *wazeroir.OperationRem:
 			err = compiler.compileRem(o)
 		case *wazeroir.OperationAnd:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileAnd(o)
 		case *wazeroir.OperationOr:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileOr(o)
 		case *wazeroir.OperationXor:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileXor(o)
 		case *wazeroir.OperationShl:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileShl(o)
 		case *wazeroir.OperationShr:
-			err = fmt.Errorf("unsupported operation")
+			err = compiler.compileShr(o)
 		case *wazeroir.OperationRotl:
 			err = fmt.Errorf("unsupported operation")
 		case *wazeroir.OperationRotr:

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1383,6 +1383,26 @@ func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
 	return
 }
 
+func (c *amd64Compiler) compileRotl(o *wazeroir.OperationRotl) (err error) {
+	switch o.Type {
+	case wazeroir.UnsignedInt32:
+		err = c.emitSimpleBinaryOp(x86.AROLL)
+	case wazeroir.UnsignedInt64:
+		err = c.emitSimpleBinaryOp(x86.AROLQ)
+	}
+	return
+}
+
+func (c *amd64Compiler) compileRotr(o *wazeroir.OperationRotr) (err error) {
+	switch o.Type {
+	case wazeroir.UnsignedInt32:
+		err = c.emitSimpleBinaryOp(x86.ARORL)
+	case wazeroir.UnsignedInt64:
+		err = c.emitSimpleBinaryOp(x86.ARORQ)
+	}
+	return
+}
+
 // emitSimpleBinaryOp emits instructions to pop two values from the stack
 // and perform the given instruction on these two values and push the result
 // onto the stack.

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1319,6 +1319,8 @@ func (c *amd64Compiler) compileDivForFloats(is32Bit bool) error {
 	}
 }
 
+// compileShr emits instructions to perform and operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileAnd(o *wazeroir.OperationAnd) (err error) {
 	switch o.Type {
 	case wazeroir.UnsignedInt32:
@@ -1329,6 +1331,8 @@ func (c *amd64Compiler) compileAnd(o *wazeroir.OperationAnd) (err error) {
 	return
 }
 
+// compileShr emits instructions to perform or operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileOr(o *wazeroir.OperationOr) (err error) {
 	switch o.Type {
 	case wazeroir.UnsignedInt32:
@@ -1339,6 +1343,8 @@ func (c *amd64Compiler) compileOr(o *wazeroir.OperationOr) (err error) {
 	return
 }
 
+// compileShr emits instructions to perform xor operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileXor(o *wazeroir.OperationXor) (err error) {
 	switch o.Type {
 	case wazeroir.UnsignedInt32:
@@ -1349,6 +1355,8 @@ func (c *amd64Compiler) compileXor(o *wazeroir.OperationXor) (err error) {
 	return
 }
 
+// compileShr emits instructions to perform shift-left operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileShl(o *wazeroir.OperationShl) (err error) {
 	switch o.Type {
 	case wazeroir.UnsignedInt32:
@@ -1359,6 +1367,8 @@ func (c *amd64Compiler) compileShl(o *wazeroir.OperationShl) (err error) {
 	return
 }
 
+// compileShr emits instructions to perform shift-right operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
 	switch o.Type {
 	case wazeroir.SignedInt32:
@@ -1373,13 +1383,16 @@ func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
 	return
 }
 
+// emitSimpleBinaryOp emits instructions to pop two values from the stack
+// and perform the given instruction on these two values and push the result
+// onto the stack.
 func (c *amd64Compiler) emitSimpleBinaryOp(instruction obj.As) error {
 	x2 := c.locationStack.pop()
 	if err := c.ensureOnGeneralPurposeRegister(x2); err != nil {
 		return err
 	}
 
-	x1 := c.locationStack.peek() // Note this is peek!
+	x1 := c.locationStack.pop()
 	if err := c.ensureOnGeneralPurposeRegister(x1); err != nil {
 		return err
 	}
@@ -1395,6 +1408,9 @@ func (c *amd64Compiler) emitSimpleBinaryOp(instruction obj.As) error {
 	// We consumed x2 register after the operation here,
 	// so we release it.
 	c.locationStack.releaseRegister(x2)
+
+	result := c.locationStack.pushValueOnRegister(x1.register)
+	result.setRegisterType(x1.registerType())
 	return nil
 }
 

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1312,6 +1312,68 @@ func (c *amd64Compiler) performDivisionOnInts(is32Bit bool, signed bool) error {
 // on the top two values of float type on the stack, placing the result back onto the stack.
 // For example, stack [..., 1.0, 4.0] results in [..., 0.25].
 func (c *amd64Compiler) compileDivForFloats(is32Bit bool) error {
+	if is32Bit {
+		return c.emitSimpleBinaryOp(x86.ADIVSS)
+	} else {
+		return c.emitSimpleBinaryOp(x86.ADIVSD)
+	}
+}
+
+func (c *amd64Compiler) compileAnd(o *wazeroir.OperationAnd) (err error) {
+	switch o.Type {
+	case wazeroir.UnsignedInt32:
+		err = c.emitSimpleBinaryOp(x86.AANDL)
+	case wazeroir.UnsignedInt64:
+		err = c.emitSimpleBinaryOp(x86.AANDQ)
+	}
+	return
+}
+
+func (c *amd64Compiler) compileOr(o *wazeroir.OperationOr) (err error) {
+	switch o.Type {
+	case wazeroir.UnsignedInt32:
+		err = c.emitSimpleBinaryOp(x86.AORL)
+	case wazeroir.UnsignedInt64:
+		err = c.emitSimpleBinaryOp(x86.AORQ)
+	}
+	return
+}
+
+func (c *amd64Compiler) compileXor(o *wazeroir.OperationXor) (err error) {
+	switch o.Type {
+	case wazeroir.UnsignedInt32:
+		err = c.emitSimpleBinaryOp(x86.AXORL)
+	case wazeroir.UnsignedInt64:
+		err = c.emitSimpleBinaryOp(x86.AXORQ)
+	}
+	return
+}
+
+func (c *amd64Compiler) compileShl(o *wazeroir.OperationShl) (err error) {
+	switch o.Type {
+	case wazeroir.UnsignedInt32:
+		err = c.emitSimpleBinaryOp(x86.ASHLL)
+	case wazeroir.UnsignedInt64:
+		err = c.emitSimpleBinaryOp(x86.ASHLQ)
+	}
+	return
+}
+
+func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
+	switch o.Type {
+	case wazeroir.SignedInt32:
+		err = c.emitSimpleBinaryOp(x86.ASARL)
+	case wazeroir.SignedInt64:
+		err = c.emitSimpleBinaryOp(x86.ASARQ)
+	case wazeroir.SignedUint32:
+		err = c.emitSimpleBinaryOp(x86.ASHRL)
+	case wazeroir.SignedUint64:
+		err = c.emitSimpleBinaryOp(x86.ASHRQ)
+	}
+	return
+}
+
+func (c *amd64Compiler) emitSimpleBinaryOp(instruction obj.As) error {
 	x2 := c.locationStack.pop()
 	if err := c.ensureOnGeneralPurposeRegister(x2); err != nil {
 		return err
@@ -1322,19 +1384,15 @@ func (c *amd64Compiler) compileDivForFloats(is32Bit bool) error {
 		return err
 	}
 
-	div := c.newProg()
-	div.From.Type = obj.TYPE_REG
-	div.From.Reg = x2.register
-	div.To.Type = obj.TYPE_REG
-	div.To.Reg = x1.register
-	if is32Bit {
-		div.As = x86.ADIVSS
-	} else {
-		div.As = x86.ADIVSD
-	}
-	c.addInstruction(div)
+	inst := c.newProg()
+	inst.From.Type = obj.TYPE_REG
+	inst.From.Reg = x2.register
+	inst.To.Type = obj.TYPE_REG
+	inst.To.Reg = x1.register
+	inst.As = instruction
+	c.addInstruction(inst)
 
-	// We consumed x2 register after DIV operation here,
+	// We consumed x2 register after the operation here,
 	// so we release it.
 	c.locationStack.releaseRegister(x2)
 	return nil

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1383,6 +1383,8 @@ func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
 	return
 }
 
+// compileShr emits instructions to perform rotate-left operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileRotl(o *wazeroir.OperationRotl) (err error) {
 	switch o.Type {
 	case wazeroir.UnsignedInt32:
@@ -1393,6 +1395,8 @@ func (c *amd64Compiler) compileRotl(o *wazeroir.OperationRotl) (err error) {
 	return
 }
 
+// compileShr emits instructions to perform rotate-right operation on
+// top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileRotr(o *wazeroir.OperationRotr) (err error) {
 	switch o.Type {
 	case wazeroir.UnsignedInt32:

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1319,7 +1319,7 @@ func (c *amd64Compiler) compileDivForFloats(is32Bit bool) error {
 	}
 }
 
-// compileShr emits instructions to perform and operation on
+// compileAnd emits instructions to perform an "and" operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileAnd(o *wazeroir.OperationAnd) (err error) {
 	switch o.Type {
@@ -1331,7 +1331,7 @@ func (c *amd64Compiler) compileAnd(o *wazeroir.OperationAnd) (err error) {
 	return
 }
 
-// compileShr emits instructions to perform or operation on
+// compileOr emits instructions to perform an "or" operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileOr(o *wazeroir.OperationOr) (err error) {
 	switch o.Type {
@@ -1343,7 +1343,7 @@ func (c *amd64Compiler) compileOr(o *wazeroir.OperationOr) (err error) {
 	return
 }
 
-// compileShr emits instructions to perform xor operation on
+// compileXor emits instructions to perform an xor operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileXor(o *wazeroir.OperationXor) (err error) {
 	switch o.Type {
@@ -1355,7 +1355,7 @@ func (c *amd64Compiler) compileXor(o *wazeroir.OperationXor) (err error) {
 	return
 }
 
-// compileShr emits instructions to perform shift-left operation on
+// compileShl emits instructions to perform a shift-left operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileShl(o *wazeroir.OperationShl) (err error) {
 	switch o.Type {
@@ -1367,7 +1367,7 @@ func (c *amd64Compiler) compileShl(o *wazeroir.OperationShl) (err error) {
 	return
 }
 
-// compileShr emits instructions to perform shift-right operation on
+// compileShr emits instructions to perform a shift-right operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
 	switch o.Type {
@@ -1383,7 +1383,7 @@ func (c *amd64Compiler) compileShr(o *wazeroir.OperationShr) (err error) {
 	return
 }
 
-// compileShr emits instructions to perform rotate-left operation on
+// compileRotl emits instructions to perform a rotate-left operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileRotl(o *wazeroir.OperationRotl) (err error) {
 	switch o.Type {
@@ -1395,7 +1395,7 @@ func (c *amd64Compiler) compileRotl(o *wazeroir.OperationRotl) (err error) {
 	return
 }
 
-// compileShr emits instructions to perform rotate-right operation on
+// compileRotr emits instructions to perform a rotate-right operation on
 // top two values on the stack, and pushes the result.
 func (c *amd64Compiler) compileRotr(o *wazeroir.OperationRotr) (err error) {
 	switch o.Type {

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1409,6 +1409,8 @@ func (c *amd64Compiler) emitSimpleBinaryOp(instruction obj.As) error {
 	// so we release it.
 	c.locationStack.releaseRegister(x2)
 
+	// We already stored the result in the register used by x1
+	// so we record it.
 	result := c.locationStack.pushValueOnRegister(x1.register)
 	result.setRegisterType(x1.registerType())
 	return nil

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -2960,7 +2960,7 @@ func getDivisionByZeroErrorRecoverFunc(t *testing.T) func() {
 	}
 }
 
-func TestAmd64Compiler_compileAnd_Or_Xor_Shl_Shr(t *testing.T) {
+func TestAmd64Compiler_compile_and_or_xor_shl_shr_rotl_rotr(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		op   wazeroir.Operation


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>