### PR TITLE
wat: support import functions with inlined types

### DIFF
--- a/wasm/wat/names_test.go
+++ b/wasm/wat/names_test.go
@@ -31,16 +31,16 @@ func TestEncodeNameSection(t *testing.T) {
 // TestEncodeNameSection_OnlyFuncName shows that we don't rely on the module name being present. For example, this isn't
 // encoded in TinyGo.
 func TestEncodeNameSection_OnlyFuncName(t *testing.T) {
-	func0, func1 := "runtime.fd_write", "runtime.args_sizes_get" // note: no leading '$'
+	func0, func1 := "runtime.args_sizes_get", "runtime.fd_write" // note: no leading '$'
 	i32 := wasm.ValueTypeI32
 	m := &module{
 		types: []*typeFunc{
-			{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}},
 			{params: []wasm.ValueType{i32, i32}, results: []wasm.ValueType{i32}},
+			{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}},
 		},
 		importFuncs: []*importFunc{
-			{importIndex: 0, typeIndex: 0, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$" + func0},
-			{importIndex: 1, typeIndex: 1, module: "wasi_snapshot_preview1", name: "args_sizes_get", funcName: "$" + func1},
+			{importIndex: 0, typeIndex: 0, module: "wasi_snapshot_preview1", name: "args_sizes_get", funcName: "$" + func0},
+			{importIndex: 1, typeIndex: 1, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$" + func1},
 		},
 	}
 

--- a/wasm/wat/parser.go
+++ b/wasm/wat/parser.go
@@ -440,9 +440,12 @@ func (p *moduleParser) errorContext() string {
 		return "module"
 	case fieldModuleStart:
 		return "module.start"
-	case fieldModuleImport, fieldModuleImportFunc, fieldModuleImportFuncParam:
+	case fieldModuleImport, fieldModuleImportFunc, fieldModuleImportFuncParam, fieldModuleImportFuncResult:
 		if p.currentField == fieldModuleImportFuncParam {
 			return fmt.Sprintf("module.import[%d].func.param[%d]", p.currentImportIndex, p.currentParamIndex)
+		}
+		if p.currentField == fieldModuleImportFuncResult {
+			return fmt.Sprintf("module.import[%d].func.result", p.currentImportIndex)
 		}
 		if p.currentField == fieldModuleImportFunc {
 			return fmt.Sprintf("module.import[%d].func", p.currentImportIndex)

--- a/wasm/wat/parser.go
+++ b/wasm/wat/parser.go
@@ -345,7 +345,7 @@ func (p *moduleParser) parseImportFuncParam(tok tokenType, tokenBytes []byte, _,
 		}
 		p.currentType.params = append(p.currentType.params, p.currentParams...)
 
-		// since multiple param fields are valid, prepare for any next.
+		// since multiple param fields are valid, ex `(func (param i32) (param i64))`, prepare for any next.
 		p.currentParams = nil
 		p.currentParamIndex++
 

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParseModule(t *testing.T) {
-	i32 := wasm.ValueTypeI32
+	i32, i64 := wasm.ValueTypeI32, wasm.ValueTypeI64
 	tests := []struct {
 		name     string
 		input    string
@@ -47,12 +47,39 @@ func TestParseModule(t *testing.T) {
 		{
 			name: "import func inlined type",
 			input: `(module
-	(import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+	(import "wasi_snapshot_preview1" "fd_write" (func $runtime.fd_write (param i32 i32 i32 i32) (result i32)))
 )`,
 			expected: &module{
 				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}}},
 				importFuncs: []*importFunc{
-					{importIndex: 0, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$fd_write"},
+					{importIndex: 0, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$runtime.fd_write"},
+				},
+			},
+		},
+		{
+			name: "import func inlined type no result",
+			input: `(module
+	(import "wasi_snapshot_preview1" "proc_exit" (func $runtime.proc_exit (param i32)))
+)`,
+			expected: &module{
+				types: []*typeFunc{{params:  []wasm.ValueType{i32}}},
+				importFuncs: []*importFunc{
+					{importIndex: 0, module: "wasi_snapshot_preview1", name: "proc_exit", funcName: "$runtime.proc_exit"},
+				},
+			},
+		},
+		{
+			name: "import func inlined type different param types",
+			input: `(module
+	(import "wasi_snapshot_preview1" "path_open" (func $runtime.path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+)`,
+			expected: &module{
+				types: []*typeFunc{{
+					params:  []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
+					results: []wasm.ValueType{i32},
+				}},
+				importFuncs: []*importFunc{
+					{importIndex: 0, module: "wasi_snapshot_preview1", name: "path_open", funcName: "$runtime.path_open"},
 				},
 			},
 		},
@@ -197,6 +224,41 @@ func TestParseModule_Errors(t *testing.T) {
 			name:        "import func invalid name",
 			input:       "(module (import \"foo\" \"bar\" (func baz)))",
 			expectedErr: "1:35: unexpected keyword: baz in module.import[0].func",
+		},
+		{
+			name:        "import func missing param0 type",
+			input:       "(module (import \"\" \"\" (func (param))))",
+			expectedErr: "1:35: expected a type in module.import[0].func.param[0]",
+		},
+		{
+			name:        "import func missing param1 type",
+			input:       "(module (import \"\" \"\" (func (param i32) (param))))",
+			expectedErr: "1:47: expected a type in module.import[0].func.param[1]",
+		},
+		{
+			name:        "import func wrong param0 type",
+			input:       "(module (import \"\" \"\" (func (param f65))))",
+			expectedErr: "1:36: unknown type: f65 in module.import[0].func.param[0]",
+		},
+		{
+			name:        "import func wrong param1 type",
+			input:       "(module (import \"\" \"\" (func (param i32) (param f65))))",
+			expectedErr: "1:48: unknown type: f65 in module.import[0].func.param[1]",
+		},
+		{
+			name:        "import func double result",
+			input:       "(module (import \"\" \"\" (func (param i32) (result i32) (result i32))))",
+			expectedErr: "1:55: redundant result field in module.import[0].func",
+		},
+		{
+			name:        "import func double result type",
+			input:       "(module (import \"\" \"\" (func (param i32) (result i32 i32))))",
+			expectedErr: "1:53: redundant type in module.import[0].func.result",
+		},
+		{
+			name:        "import func wrong result type",
+			input:       "(module (import \"\" \"\" (func (param i32) (result f65))))",
+			expectedErr: "1:49: unknown type: f65 in module.import[0].func.result",
 		},
 		{
 			name:        "import func double desc",

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -62,7 +62,7 @@ func TestParseModule(t *testing.T) {
 	(import "wasi_snapshot_preview1" "proc_exit" (func $runtime.proc_exit (param i32)))
 )`,
 			expected: &module{
-				types: []*typeFunc{{params:  []wasm.ValueType{i32}}},
+				types: []*typeFunc{{params: []wasm.ValueType{i32}}},
 				importFuncs: []*importFunc{
 					{importIndex: 0, module: "wasi_snapshot_preview1", name: "proc_exit", funcName: "$runtime.proc_exit"},
 				},


### PR DESCRIPTION
This begins support of real functions as before we hard-coded all are
nullary (void in void out). As there's a lot of refactoring left to do,
this starts only by supporting inlined type (signatures) for imported
functions. This does not handle inlined parameter names which are a bit
complicated so would make the PR too hard to review.
