### PR TITLE
wat: enforces signature order

### DIFF
--- a/wasm/wat/convert.go
+++ b/wasm/wat/convert.go
@@ -25,7 +25,11 @@ func TextToBinary(source []byte) (result *wasm.Module, err error) {
 	// difference is that the text format has type names and the binary format does not.
 	result = &wasm.Module{}
 	for _, t := range m.types {
-		result.TypeSection = append(result.TypeSection, &wasm.FunctionType{Params: t.params, Results: t.results})
+		var results []wasm.ValueType
+		if t.result != 0 {
+			results = []wasm.ValueType{t.result}
+		}
+		result.TypeSection = append(result.TypeSection, &wasm.FunctionType{Params: t.params, Results: results})
 	}
 
 	// Now, handle any imported functions. Notably, we retain the same insertion order as defined in the text format in
@@ -35,7 +39,7 @@ func TextToBinary(source []byte) (result *wasm.Module, err error) {
 			Module: f.module, Name: f.name,
 			Desc: &wasm.ImportDesc{
 				Kind:          wasm.ImportKindFunction,
-				FuncTypeIndex: uint32(f.typeIndex),
+				FuncTypeIndex: f.typeIndex,
 			},
 		})
 	}

--- a/wasm/wat/names_test.go
+++ b/wasm/wat/names_test.go
@@ -35,8 +35,8 @@ func TestEncodeNameSection_OnlyFuncName(t *testing.T) {
 	i32 := wasm.ValueTypeI32
 	m := &module{
 		types: []*typeFunc{
-			{params: []wasm.ValueType{i32, i32}, results: []wasm.ValueType{i32}},
-			{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}},
+			{params: []wasm.ValueType{i32, i32}, result: i32},
+			{params: []wasm.ValueType{i32, i32, i32, i32}, result: i32},
 		},
 		importFuncs: []*importFunc{
 			{importIndex: 0, typeIndex: 0, module: "wasi_snapshot_preview1", name: "args_sizes_get", funcName: "$" + func0},

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -278,6 +278,11 @@ func TestParseModule_Errors(t *testing.T) {
 			expectedErr: "1:15: found ')' before '('",
 		},
 		{
+			name:        "module name after import",
+			input:       "(module (import \"\" \"\" (func) $Math)",
+			expectedErr: "1:30: unexpected id: $Math in module.import[0]",
+		},
+		{
 			name:        "import missing module",
 			input:       "(module (import))",
 			expectedErr: "1:16: missing module and name in module.import[0]",

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -209,32 +209,6 @@ func TestParseModule(t *testing.T) {
 	}
 }
 
-func TestParseValueType(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected wasm.ValueType
-	}{
-		{"i32", wasm.ValueTypeI32},
-		{"i64", wasm.ValueTypeI64},
-		{"f32", wasm.ValueTypeF32},
-		{"f64", wasm.ValueTypeF64},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.input, func(t *testing.T) {
-			m, err := parseValueType([]byte(tc.input))
-			require.NoError(t, err)
-			require.Equal(t, tc.expected, m)
-		})
-	}
-	t.Run("unknown type", func(t *testing.T) {
-		_, err := parseValueType([]byte("f65"))
-		require.EqualError(t, err, "unknown type: f65")
-	})
-}
-
 func TestParseModule_Errors(t *testing.T) {
 	tests := []struct{ name, input, expectedErr string }{
 		{

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestParseModule(t *testing.T) {
+	typeFuncEmpty := &typeFunc{}
 	i32, i64 := wasm.ValueTypeI32, wasm.ValueTypeI64
+
 	tests := []struct {
 		name     string
 		input    string
@@ -50,7 +52,7 @@ func TestParseModule(t *testing.T) {
 	(import "wasi_snapshot_preview1" "fd_write" (func $runtime.fd_write (param i32) (param i32) (param i32) (param i32) (result i32)))
 )`,
 			expected: &module{
-				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}}},
+				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, result: i32}},
 				importFuncs: []*importFunc{
 					{importIndex: 0, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$runtime.fd_write"},
 				},
@@ -62,7 +64,7 @@ func TestParseModule(t *testing.T) {
 	(import "wasi_snapshot_preview1" "fd_write" (func $runtime.fd_write (param i32 i32 i32 i32) (result i32)))
 )`,
 			expected: &module{
-				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}}},
+				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, result: i32}},
 				importFuncs: []*importFunc{
 					{importIndex: 0, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$runtime.fd_write"},
 				},
@@ -76,7 +78,7 @@ func TestParseModule(t *testing.T) {
 	(import "wasi_snapshot_preview1" "fd_write" (func $runtime.fd_write (param i32) (param i32 i32) (param i32) (result i32)))
 )`,
 			expected: &module{
-				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}}},
+				types: []*typeFunc{{params: []wasm.ValueType{i32, i32, i32, i32}, result: i32}},
 				importFuncs: []*importFunc{
 					{importIndex: 0, module: "wasi_snapshot_preview1", name: "fd_write", funcName: "$runtime.fd_write"},
 				},
@@ -98,7 +100,7 @@ func TestParseModule(t *testing.T) {
 			name:  "import func inlined type no param",
 			input: `(module (import "" "" (func (result i32))))`,
 			expected: &module{
-				types:       []*typeFunc{{results: []wasm.ValueType{i32}}},
+				types:       []*typeFunc{{result: i32}},
 				importFuncs: []*importFunc{{}},
 			},
 		},
@@ -109,8 +111,8 @@ func TestParseModule(t *testing.T) {
 )`,
 			expected: &module{
 				types: []*typeFunc{{
-					params:  []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
-					results: []wasm.ValueType{i32},
+					params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
+					result: i32,
 				}},
 				importFuncs: []*importFunc{
 					{importIndex: 0, module: "wasi_snapshot_preview1", name: "path_open", funcName: "$runtime.path_open"},
@@ -124,8 +126,8 @@ func TestParseModule(t *testing.T) {
 )`,
 			expected: &module{
 				types: []*typeFunc{{
-					params:  []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
-					results: []wasm.ValueType{i32},
+					params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
+					result: i32,
 				}},
 				importFuncs: []*importFunc{
 					{importIndex: 0, module: "wasi_snapshot_preview1", name: "path_open", funcName: "$runtime.path_open"},
@@ -140,8 +142,8 @@ func TestParseModule(t *testing.T) {
 )`,
 			expected: &module{
 				types: []*typeFunc{
-					{params: []wasm.ValueType{i32, i32}, results: []wasm.ValueType{i32}},
-					{params: []wasm.ValueType{i32, i32, i32, i32}, results: []wasm.ValueType{i32}},
+					{params: []wasm.ValueType{i32, i32}, result: i32},
+					{params: []wasm.ValueType{i32, i32, i32, i32}, result: i32},
 				},
 				importFuncs: []*importFunc{
 					{importIndex: 0, typeIndex: 0, module: "wasi_snapshot_preview1", name: "arg_sizes_get", funcName: "$runtime.arg_sizes_get"},
@@ -157,7 +159,7 @@ func TestParseModule(t *testing.T) {
 )`,
 			expected: &module{
 				types: []*typeFunc{
-					{params: []wasm.ValueType{i32, i32}, results: []wasm.ValueType{i32}},
+					{params: []wasm.ValueType{i32, i32}, result: i32},
 				},
 				importFuncs: []*importFunc{
 					{importIndex: 0, typeIndex: 0, module: "wasi_snapshot_preview1", name: "args_get", funcName: "$runtime.args_get"},
@@ -321,6 +323,11 @@ func TestParseModule_Errors(t *testing.T) {
 			expectedErr: "1:35: unexpected keyword: baz in module.import[0].func",
 		},
 		{
+			name:        "import func invalid token",
+			input:       "(module (import \"foo\" \"bar\" (func ($param))))",
+			expectedErr: "1:36: unexpected id: $param in module.import[0].func",
+		},
+		{
 			name:        "import func double name",
 			input:       "(module (import \"foo\" \"bar\" (func $baz $qux)))",
 			expectedErr: "1:40: redundant name: $qux in module.import[0].func",
@@ -348,7 +355,7 @@ func TestParseModule_Errors(t *testing.T) {
 		{
 			name:        "import func double result",
 			input:       "(module (import \"\" \"\" (func (param i32) (result i32) (result i32))))",
-			expectedErr: "1:55: redundant result field in module.import[0].func",
+			expectedErr: "1:54: unexpected '(' in module.import[0].func",
 		},
 		{
 			name:        "import func double result type",
@@ -379,6 +386,21 @@ func TestParseModule_Errors(t *testing.T) {
 			name:        "import func wrong result token",
 			input:       "(module (import \"\" \"\" (func (result () ))))",
 			expectedErr: "1:37: unexpected '(' in module.import[0].func.result",
+		},
+		{
+			name:        "import func name after param",
+			input:       "(module (import \"\" \"\" (func (param i32) $main)))",
+			expectedErr: "1:41: unexpected id: $main in module.import[0].func",
+		},
+		{
+			name:        "import func name after result",
+			input:       "(module (import \"\" \"\" (func (result i32) $main)))",
+			expectedErr: "1:42: unexpected id: $main in module.import[0].func",
+		},
+		{
+			name:        "import func param after result",
+			input:       "(module (import \"\" \"\" (func (result i32) (param i32))))",
+			expectedErr: "1:42: unexpected '(' in module.import[0].func",
 		},
 		{
 			name:        "import func double desc",

--- a/wasm/wat/type_parser.go
+++ b/wasm/wat/type_parser.go
@@ -187,19 +187,18 @@ func (p *typeParser) findOrAddType(m *module) (typeIndex uint32) {
 	return
 }
 
-func parseValueType(tokenBytes []byte) (vt wasm.ValueType, err error) {
+func parseValueType(tokenBytes []byte) (wasm.ValueType, error) {
 	t := string(tokenBytes)
 	switch t {
 	case "i32":
-		vt = wasm.ValueTypeI32
+		return wasm.ValueTypeI32, nil
 	case "i64":
-		vt = wasm.ValueTypeI64
+		return wasm.ValueTypeI64, nil
 	case "f32":
-		vt = wasm.ValueTypeF32
+		return wasm.ValueTypeF32, nil
 	case "f64":
-		vt = wasm.ValueTypeF64
+		return wasm.ValueTypeF64, nil
 	default:
-		err = fmt.Errorf("unknown type: %s", t)
+		return 0, fmt.Errorf("unknown type: %s", t)
 	}
-	return
 }

--- a/wasm/wat/type_parser.go
+++ b/wasm/wat/type_parser.go
@@ -1,0 +1,206 @@
+package wat
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/tetratelabs/wazero/wasm"
+)
+
+// typeParsingState is used to give an appropriate typeParser.errorContext
+type typeParsingState byte
+
+const (
+	parsingParamOrResult typeParsingState = iota
+	parsingParam
+	parsingResult
+	parsingComplete
+)
+
+// typeParser parses an inlined type from a field such as "type" or "func". Unlike normal parsers, this is not used for
+// an entire field (enclosed by parens). Rather, this only handles "param" and "result" inner fields in the correct
+// order.
+//
+// Ex. `(module (import (func $main (param i32))))`
+//   This parses after the name     ^---------^
+//
+// Ex. `(module (type (param i32) (result i64)))`
+//   This parses here ^----------------------^
+//
+// Ex. `(module (import (func)))`
+//   This parses nothing (because there is no type)
+//
+// typeParser is reusable. The caller resets when reaching the appropriate tokenRParen via beginParsingParamsOrResult.
+type typeParser struct {
+	// m is used as a function pointer to moduleParser.tokenParser. This updates based on state changes.
+	m *moduleParser
+
+	// onTypeEnd is invoked when the grammar "(param)* (result)?" completes.
+	//
+	// Note: this is called when neither a "param" nor a "result" field are found, or on any field following a "param"
+	// that is not a "result".
+	onTypeEnd tokenParser
+
+	// state is initially parsingParamOrResult and updated alongside tokenParser
+	state typeParsingState
+
+	// currentParams allow us to accumulate typeFunc.params across multiple fields, as well support abbreviated
+	// anonymous parameters. ex. both (param i32) (param i32) and (param i32 i32) formats.
+	// See https://www.w3.org/TR/wasm-core-1/#abbreviations%E2%91%A2
+	currentParams []wasm.ValueType
+
+	// currentParamIndex is used to give an appropriate errorContext
+	currentParamIndex uint32
+
+	// foundParam allows us to check if we found a type in a "param" field. We can't use currentParamIndex because when
+	// parameters are abbreviated, ex. (param i32 i32), the currentParamIndex will be less than the type count.
+	foundParam bool
+
+	// currentResult is zero until set, and only set once as WebAssembly 1.0 only supports up to one result.
+	currentResult wasm.ValueType
+}
+
+// beginParsingParamsOrResult sets moduleParser.tokenParser to beginParamOrResult after resetting internal fields.
+// This should only be called when reaching the first tokenLParen after the optional field name (tokenID).
+//
+// Ex. Given the source `(module (import (func $main (param i32))))`
+//         Set this result to the next parser here --^
+//             This result restores control to onTypeEnd here --^
+//
+// The onTypeEnd parameter is invoked once any "param" and "result" fields have been consumed.
+//
+// NOTE: An empty function is valid and will not reach a tokenLParen! Ex. `(module (import (func)))`
+func (p *typeParser) beginParsingParamsOrResult(onTypeEnd tokenParser) {
+	p.onTypeEnd = onTypeEnd
+	p.state = parsingParamOrResult
+	p.m.tokenParser = p.beginParamOrResult
+	p.currentParams = nil
+	p.currentParamIndex = 0
+	p.currentResult = 0
+}
+
+// beginParamOrResult is a tokenParser called after a tokenLParen and accepts either a "param" or a "result" field
+// (tokenKeyword).
+func (p *typeParser) beginParamOrResult(tok tokenType, tokenBytes []byte, line, col uint32) error {
+	if tok == tokenKeyword {
+		switch string(tokenBytes) {
+		case "param":
+			p.state = parsingParam
+			p.foundParam = false
+			p.m.tokenParser = p.parseParam
+		case "result":
+			p.state = parsingResult
+			p.m.tokenParser = p.parseResult
+		case "type": // cannot repeat
+			return errors.New("TODO: (module (import (func (type")
+		}
+		return nil
+	}
+	// If we reach here, it is a syntax error, so punt it to onTypeEnd. Ex. (func ($param i32))
+	return p.onTypeEnd(tok, tokenBytes, line, col)
+}
+
+func (p *typeParser) parseMoreParamsOrResult(tok tokenType, tokenBytes []byte, line, col uint32) error {
+	if tok == tokenLParen {
+		p.state = parsingParamOrResult
+		p.m.tokenParser = p.beginParamOrResult
+		return nil
+	}
+	// If we reached this point, we have one or more parameters, but no result. Ex. (func (param i32)) or (func)
+	return p.onTypeEnd(tok, tokenBytes, line, col)
+}
+
+func (p *typeParser) parseParam(tok tokenType, tokenBytes []byte, _, _ uint32) error {
+	switch tok {
+	case tokenID: // Ex. $len
+		return errors.New("TODO param name ex (param $len i32), but not in abbreviation ex (param $x i32 $y i32)")
+	case tokenKeyword: // Ex. i32
+		vt, err := parseValueType(tokenBytes)
+		if err != nil {
+			return err
+		}
+		p.currentParams = append(p.currentParams, vt)
+		p.foundParam = true
+	case tokenRParen: // end of this field
+		if !p.foundParam {
+			return errors.New("expected a type")
+		}
+
+		// since multiple param fields are valid, ex `(func (param i32) (param i64))`, prepare for any next.
+		p.currentParamIndex++
+		p.state = parsingParamOrResult
+		p.m.tokenParser = p.parseMoreParamsOrResult
+	default:
+		return unexpectedToken(tok, tokenBytes)
+	}
+	return nil
+}
+
+// parseResult is a tokenParser inside a "result" field (tokenKeyword). When this field completes (tokenRParen), control
+// transitions to parseComplete.
+func (p *typeParser) parseResult(tok tokenType, tokenBytes []byte, _, _ uint32) error {
+	switch tok {
+	case tokenKeyword: // Ex. i32
+		if p.currentResult != 0 {
+			return errors.New("redundant type")
+		}
+		vt, err := parseValueType(tokenBytes)
+		if err != nil {
+			return err
+		}
+		p.currentResult = vt
+	case tokenRParen: // end of this field
+		if p.currentResult == 0 {
+			return errors.New("expected a type")
+		}
+		p.m.tokenParser = p.onTypeEnd
+		p.state = parsingComplete
+	default:
+		return unexpectedToken(tok, tokenBytes)
+	}
+	return nil
+}
+
+func (p *typeParser) errorContext() string {
+	switch p.state {
+	case parsingParam:
+		return fmt.Sprintf(".param[%d]", p.currentParamIndex)
+	case parsingResult:
+		return ".result"
+	}
+	return ""
+}
+
+// findOrAddType returns the index in module.types of a possibly empty type matching any current params or result.
+func (p *typeParser) findOrAddType(m *module) (typeIndex uint32) {
+	// search for an existing signature that matches the current type
+	for i, t := range m.types {
+		if bytes.Equal(p.currentParams, t.params) && p.currentResult == t.result {
+			return uint32(i)
+		}
+	}
+
+	// if we didn't find a match, we need to insert a new type and use it
+	typeIndex = uint32(len(m.types))
+	m.types = append(m.types, &typeFunc{p.currentParams, p.currentResult})
+	return
+}
+
+func parseValueType(tokenBytes []byte) (wasm.ValueType, error) {
+	t := string(tokenBytes)
+	var vt wasm.ValueType
+	switch t {
+	case "i32":
+		vt = wasm.ValueTypeI32
+	case "i64":
+		vt = wasm.ValueTypeI64
+	case "f32":
+		vt = wasm.ValueTypeF32
+	case "f64":
+		vt = wasm.ValueTypeF64
+	default:
+		return 0, fmt.Errorf("unknown type: %s", t)
+	}
+	return vt, nil
+}

--- a/wasm/wat/type_parser.go
+++ b/wasm/wat/type_parser.go
@@ -187,9 +187,8 @@ func (p *typeParser) findOrAddType(m *module) (typeIndex uint32) {
 	return
 }
 
-func parseValueType(tokenBytes []byte) (wasm.ValueType, error) {
+func parseValueType(tokenBytes []byte) (vt wasm.ValueType, err error) {
 	t := string(tokenBytes)
-	var vt wasm.ValueType
 	switch t {
 	case "i32":
 		vt = wasm.ValueTypeI32
@@ -200,7 +199,7 @@ func parseValueType(tokenBytes []byte) (wasm.ValueType, error) {
 	case "f64":
 		vt = wasm.ValueTypeF64
 	default:
-		return 0, fmt.Errorf("unknown type: %s", t)
+		err = fmt.Errorf("unknown type: %s", t)
 	}
-	return vt, nil
+	return
 }

--- a/wasm/wat/type_parser_test.go
+++ b/wasm/wat/type_parser_test.go
@@ -1,0 +1,35 @@
+package wat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/wazero/wasm"
+)
+
+func TestParseValueType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected wasm.ValueType
+	}{
+		{"i32", wasm.ValueTypeI32},
+		{"i64", wasm.ValueTypeI64},
+		{"f32", wasm.ValueTypeF32},
+		{"f64", wasm.ValueTypeF64},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.input, func(t *testing.T) {
+			m, err := parseValueType([]byte(tc.input))
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, m)
+		})
+	}
+	t.Run("unknown type", func(t *testing.T) {
+		_, err := parseValueType([]byte("f65"))
+		require.EqualError(t, err, "unknown type: f65")
+	})
+}

--- a/wasm/wat/types.go
+++ b/wasm/wat/types.go
@@ -65,15 +65,12 @@ type typeFunc struct {
 	// See https://www.w3.org/TR/wasm-core-1/#result-types%E2%91%A0
 	params []wasm.ValueType
 
-	// results are the possibly empty sequence of value types returned by a function with this signature.
+	// result is the value type of the signature or zero if there is none.
 	//
-	// Note: In WebAssembly 1.0 (MVP), there can be at most one result.
+	// Note: We use this shortcut instead of a slice because in WebAssembly 1.0 (MVP), there can be at most one result.
 	// See https://www.w3.org/TR/wasm-core-1/#result-types%E2%91%A0
-	results []wasm.ValueType
+	result wasm.ValueType
 }
-
-// typeFuncEmpty represents a nullary function type. Ex. `(type (func))`
-var typeFuncEmpty = &typeFunc{}
 
 // importFunc corresponds to the text format of a WebAssembly function import.
 //


### PR DESCRIPTION
This change does two things:
 * enforces field names are first or not present
   * Ex. (func $main) $main is the name of the func field
 * enforces the order requirements of the type grammar. (param)* result?
   * To reduce complexity, this logic is extracted to type_parser.

## Notes

### Unit test coverage is the same
There is still 100pct coverage except TODO and panics

### benchmark speed decrease and allocation increase

Extracting typeParser resulted in a performance decrease on the trivial benchmark because it initializes, but never needs a type parser. I think this is ok because in real life, %.wat files with anything non-trivial will end up with at least a few types.

decrease in speed
```
BenchmarkTextToBinaryExample/vs_wat.parseModule-16    	 1429618	       832.1 ns/op	     568 B/op	      23 allocs/op
BenchmarkTextToBinaryExample/vs_wat.parseModule-16    	 1293886	       977.1 ns/op	     664 B/op	      27 allocs/op
```

example input
```
(module $simple
	(import "" "hello" (func $hello))
	(start $hello)
)
```

Once we implement functions, we should re-do the benchmark anyway.

### Function pointer fake
The parser used by the lexer changes when fields change. It now also changes when we enter a common grammar (type use). To reduce stack depth and allocations, I'm updating moduleParser.tokenParser via a pointer to the moduleParser as it seems there's no function pointer in go.