### PR TITLE
wat: refactors symbolic index identifier handling

### DIFF
--- a/wasm/wat/bind.go
+++ b/wasm/wat/bind.go
@@ -1,0 +1,47 @@
+package wat
+
+import (
+	"fmt"
+)
+
+// bindIndices ensures any indices point are numeric or returns a FormatError if they cannot be bound.
+func bindIndices(m *module) error {
+	if m.startFunction != nil {
+		if err := bindStartFunction(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// bindStartFunction ensures the module.startFunction points to a valid numeric index or returns a FormatError if it
+// cannot be bound.
+//
+// Failure cases are when a symbolic identifier points nowhere or a numeric index is out of range.
+// Ex. (start $t0) exists, but there's no import or module defined function with that name.
+//  or (start 32) exists, but there are only 10 functions.
+func bindStartFunction(m *module) error {
+	start := m.startFunction
+
+	if start.ID == "" { // already bound to a numeric index, but we have to verify it is in range
+		if int(start.numeric) >= len(m.importFuncs) { // TODO len(m.importFuncs + m.funcs) when we add them!
+			return &FormatError{start.line, start.col, "module.start",
+				fmt.Errorf("function index %d is out of range [0..%d]", start.numeric, len(m.importFuncs)-1),
+			}
+		}
+	}
+
+	// Now, attempt to look up the symbolic name of any function imported or defined in this module.
+	for i, f := range m.importFuncs {
+		if f.funcName == start.ID {
+			start.ID = ""
+			start.numeric = uint32(i)
+			return nil
+		}
+	}
+
+	// TODO: also search functions defined in this module, once we add them!
+	return &FormatError{start.line, start.col, "module.start",
+		fmt.Errorf("unknown function name %s", start.ID),
+	}
+}

--- a/wasm/wat/bind_test.go
+++ b/wasm/wat/bind_test.go
@@ -1,0 +1,91 @@
+package wat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindIndices(t *testing.T) {
+	tests := []struct {
+		name            string
+		input, expected *module
+	}{
+		{
+			name: "start imported function by name binds to numeric index",
+			input: &module{
+				typeFuncs: []*typeFunc{typeFuncEmpty},
+				importFuncs: []*importFunc{
+					{funcName: "$one", typeInlined: typeFuncEmpty},
+					{funcName: "$two", typeInlined: typeFuncEmpty},
+				},
+				startFunction: &index{ID: "$two", line: 3, col: 9},
+			},
+			expected: &module{
+				typeFuncs: []*typeFunc{typeFuncEmpty},
+				importFuncs: []*importFunc{
+					{funcName: "$one", typeInlined: typeFuncEmpty},
+					{funcName: "$two", typeInlined: typeFuncEmpty},
+				},
+				startFunction: &index{numeric: 1, line: 3, col: 9},
+			},
+		},
+		{
+			name: "start imported function numeric index left alone",
+			input: &module{
+				typeFuncs:     []*typeFunc{typeFuncEmpty},
+				importFuncs:   []*importFunc{{name: "hello", importIndex: 0, typeInlined: typeFuncEmpty}},
+				startFunction: &index{numeric: 0, line: 3, col: 9},
+			},
+			expected: &module{
+				typeFuncs:     []*typeFunc{typeFuncEmpty},
+				importFuncs:   []*importFunc{{name: "hello", importIndex: 0, typeInlined: typeFuncEmpty}},
+				startFunction: &index{numeric: 0, line: 3, col: 9},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := bindIndices(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, tc.input)
+		})
+	}
+}
+
+func TestBindIndices_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       *module
+		expectedErr string
+	}{
+		{
+			name: "start points out of range",
+			input: &module{
+				typeFuncs:     []*typeFunc{typeFuncEmpty},
+				importFuncs:   []*importFunc{{name: "hello", importIndex: 0, typeInlined: typeFuncEmpty}},
+				startFunction: &index{numeric: 1, line: 3, col: 9},
+			},
+			expectedErr: "3:9: function index 1 is out of range [0..0] in module.start",
+		},
+		{
+			name: "start points nowhere",
+			input: &module{
+				startFunction: &index{ID: "$main", line: 1, col: 16},
+			},
+			expectedErr: "1:16: unknown function name $main in module.start",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := bindIndices(tc.input)
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/wasm/wat/convert_test.go
+++ b/wasm/wat/convert_test.go
@@ -125,23 +125,24 @@ func TestTextToBinary_Errors(t *testing.T) {
 		{
 			name:        "start, but no funcs",
 			input:       "(module (start $main))",
-			expectedErr: "1:16: unknown function name: $main in module.start",
+			expectedErr: "1:16: unknown function name $main in module.start",
 		},
 		{
-			name: "start index missing - number",
+			name: "start index out of range",
 			input: `(module
 	(import "" "hello" (func))
-	(start 1)
+	(import "" "goodbye" (func))
+	(start 3)
 )`,
-			expectedErr: "3:9: invalid function index: 1 in module.start",
+			expectedErr: "4:9: function index 3 is out of range [0..1] in module.start",
 		},
 		{
-			name: "start index missing - name",
+			name: "start points to unknown func",
 			input: `(module
 	(import "" "hello" (func $main))
 	(start $mein)
 )`,
-			expectedErr: "3:9: unknown function name: $mein in module.start",
+			expectedErr: "3:9: unknown function name $mein in module.start",
 		},
 	}
 

--- a/wasm/wat/lexer.go
+++ b/wasm/wat/lexer.go
@@ -241,30 +241,3 @@ func lex(parser tokenParser, source []byte) (line, col uint32, err error) {
 	}
 	return line, col, nil
 }
-
-// utf8Size returns the size of the UTF-8 rune based on its first byte, or zero.
-//
-// Note: The null byte (0x00) is here as it is valid in string tokens and comments. See WebAssembly/spec#1372
-//
-// Note: We don't validate the subsequent bytes make a well-formed UTF-8 rune intentionally for performance and to keep
-// lexing allocation free. Meanwhile, the impact is that we might skip over malformed bytes.
-var utf8Size = [256]int{
-	// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x00-0x0F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x10-0x1F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x20-0x2F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x30-0x3F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40-0x4F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x50-0x5F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60-0x6F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x70-0x7F
-	// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x80-0x8F
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x90-0x9F
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xA0-0xAF
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xB0-0xBF
-	0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xC0-0xCF
-	2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xD0-0xDF
-	3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // 0xE0-0xEF
-	4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xF0-0xFF
-}

--- a/wasm/wat/numbers.go
+++ b/wasm/wat/numbers.go
@@ -1,0 +1,120 @@
+package wat
+
+import (
+	"strconv"
+)
+
+// decodeUint32 decodes an uint32 from a tokenUN.
+//
+// Note: Bit length interpretation is not defined at the lexing layer, so this may fail on overflow due to invalid
+// length known at the parsing layer.
+//
+// Note: This is similar to, but cannot use strconv.Atoi because WebAssembly allows underscore characters in numeric
+// representation. See https://www.w3.org/TR/wasm-core-1/#integers%E2%91%A6
+func decodeUint32(tokenBytes []byte) (uint32, error) { // TODO: hex
+	// The max ASCII length of a uint32 is 10 (length of 4294967295). If we are at that length we can overflow.
+	//
+	// Note: There's chance we are at length 10 due to underscores, but easier to take the slow path for either reason.
+	if len(tokenBytes) > 9 {
+		v, err := decodeUint64(tokenBytes)
+		if err != nil {
+			return 0, err
+		}
+		if v > 0xffffffff {
+			return 0, &strconv.NumError{Func: "decodeU32", Num: string(tokenBytes), Err: strconv.ErrRange}
+		}
+		return uint32(v), nil
+	}
+
+	// If we are here, we know we cannot overflow uint32. The only valid characters in tokenUN are 0-9 and underscore.
+	var n uint32
+	for _, ch := range tokenBytes {
+		if ch == '_' {
+			continue
+		}
+		n = n*10 + uint32(ch-'0')
+	}
+	return n, nil
+}
+
+// decodeUint64 is like decodeUint32, but for uint64
+func decodeUint64(tokenBytes []byte) (uint64, error) { // TODO: hex
+	// The max ASCII length of a uint64 is 20 (length of 18446744073709551615). If we are at that length we can overflow.
+	//
+	// Note: There's chance we are at length 20 due to underscores, but easier to take the slow path for either reason.
+	if len(tokenBytes) > 19 {
+		return decodeUint64SlowPath(tokenBytes)
+	}
+
+	// If we are here, we know we cannot overflow uint64. The only valid characters in tokenUN are 0-9 and underscore.
+	var n uint64
+	for _, ch := range tokenBytes {
+		if ch == '_' {
+			continue
+		}
+		n = n*10 + uint64(ch-'0')
+	}
+	return n, nil
+}
+
+// decodeUint64SlowPath implements decodeUint64 for the slow path when there's a chance the result cannot fit.
+// Notably, this strips underscore characters first, so that the string length can be used to assess overflows.
+func decodeUint64SlowPath(tokenBytes []byte) (uint64, error) {
+	// We have a possible overflow, but won't know for sure due to underscores until we strip them. This strips any
+	// underscores from the token in-place.
+	n := 0
+	for _, b := range tokenBytes {
+		if b != '_' {
+			tokenBytes[n] = b
+			n++
+		}
+	}
+	tokenBytes = tokenBytes[:n]
+
+	// Now, we know there are only numbers and no underscores. This means the ASCII length is insightful.
+	switch len(tokenBytes) {
+	case 19: // cannot overflow
+		return decodeUint64(tokenBytes)
+	case 20: // only overflows depending on the last number
+		first19, err := decodeUint64(tokenBytes[0:19])
+		if err != nil {
+			return 0, err // impossible unless someone used this with an unvalidated token
+		}
+		last := uint64(tokenBytes[19] - '0')
+
+		// Remember the largest uint64 encoded in ASCII is 20 characters: "1844674407370955161" followed by "5"
+		if first19 > 1844674407370955161 /* first 19 chars of largest uint64 */ || last > 5 {
+			return 0, &strconv.NumError{Func: "decodeU64", Num: string(tokenBytes), Err: strconv.ErrRange}
+		}
+		return first19*10 + last, nil
+	default: // must overflow
+		return 0, &strconv.NumError{Func: "decodeU64", Num: string(tokenBytes), Err: strconv.ErrRange}
+	}
+}
+
+// utf8Size returns the size of the UTF-8 rune based on its first byte, or zero.
+//
+// Note: The null byte (0x00) is here as it is valid in string tokens and comments. See WebAssembly/spec#1372
+//
+// Note: We don't validate the subsequent bytes make a well-formed UTF-8 rune intentionally for performance and to keep
+// lexing allocation free. Meanwhile, the impact is that we might skip over malformed bytes.
+var utf8Size = [256]int{
+	// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x00-0x0F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x10-0x1F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x20-0x2F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x30-0x3F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40-0x4F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x50-0x5F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60-0x6F
+	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x70-0x7F
+	// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x80-0x8F
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x90-0x9F
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xA0-0xAF
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xB0-0xBF
+	0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xC0-0xCF
+	2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xD0-0xDF
+	3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // 0xE0-0xEF
+	4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xF0-0xFF
+}

--- a/wasm/wat/numbers.go
+++ b/wasm/wat/numbers.go
@@ -91,30 +91,3 @@ func decodeUint64SlowPath(tokenBytes []byte) (uint64, error) {
 		return 0, &strconv.NumError{Func: "decodeU64", Num: string(tokenBytes), Err: strconv.ErrRange}
 	}
 }
-
-// utf8Size returns the size of the UTF-8 rune based on its first byte, or zero.
-//
-// Note: The null byte (0x00) is here as it is valid in string tokens and comments. See WebAssembly/spec#1372
-//
-// Note: We don't validate the subsequent bytes make a well-formed UTF-8 rune intentionally for performance and to keep
-// lexing allocation free. Meanwhile, the impact is that we might skip over malformed bytes.
-var utf8Size = [256]int{
-	// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x00-0x0F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x10-0x1F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x20-0x2F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x30-0x3F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40-0x4F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x50-0x5F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60-0x6F
-	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x70-0x7F
-	// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x80-0x8F
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x90-0x9F
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xA0-0xAF
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xB0-0xBF
-	0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xC0-0xCF
-	2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xD0-0xDF
-	3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // 0xE0-0xEF
-	4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xF0-0xFF
-}

--- a/wasm/wat/numbers_test.go
+++ b/wasm/wat/numbers_test.go
@@ -15,12 +15,15 @@ func TestDecodeUint32(t *testing.T) {
 	}{
 		{name: "zero", input: "0", expected: 0},
 		{name: "largest uint16", input: "65535", expected: 0xffff},
+		{name: "largest uint16 with underscores", input: "6_5_5_3_5", expected: 0xffff},
+		{name: "under largest uint32 by factor of 10", input: "429496729", expected: 429496729},
+		{name: "under largest uint32 by factor of 10 with underscores", input: "4_2_9_4_9_6_7_2_9", expected: 429496729},
 		{name: "largest uint32", input: "4294967295", expected: 0xffffffff},
 		{name: "largest uint32 with underscores", input: "4_2_9_4_9_6_7_2_9_5", expected: 0xffffffff},
 		{name: "overflow by one", input: "4294967296", expectedErr: true},
 		{name: "overflow by one with underscores", input: "4_2_9_4_9_6_7_2_9_6", expectedErr: true},
-		{name: "overflow by pow", input: "42949672950", expectedErr: true},
-		{name: "overflow by pow with underscores", input: "4_2_9_4_9_6_7_2_9_5_0", expectedErr: true},
+		{name: "overflow by factor of 10", input: "42949672950", expectedErr: true},
+		{name: "overflow by factor of 10 with underscores", input: "4_2_9_4_9_6_7_2_9_5_0", expectedErr: true},
 	} {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
@@ -42,14 +45,15 @@ func TestDecodeUint64(t *testing.T) {
 		expectedErr bool
 	}{
 		{name: "zero", input: "0", expected: 0},
-		{name: "largest uint16", input: "65535", expected: 0xffff},
 		{name: "largest uint32", input: "4294967295", expected: 0xffffffff},
+		{name: "under largest uint64 by factor of 10", input: "1844674407370955161", expected: 1844674407370955161},
+		{name: "under largest uint64 by factor of 10 with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1", expected: 1844674407370955161},
 		{name: "largest uint64", input: "18446744073709551615", expected: 0xffffffffffffffff},
 		{name: "largest uint64 with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_5", expected: 0xffffffffffffffff},
 		{name: "overflow by one", input: "18446744073709551616", expectedErr: true},
 		{name: "overflow by one with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_6", expectedErr: true},
-		{name: "overflow by pow", input: "184467440737095516150", expectedErr: true},
-		{name: "overflow by pow with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_5_0", expectedErr: true},
+		{name: "overflow by factor of 10", input: "184467440737095516150", expectedErr: true},
+		{name: "overflow by factor of 10 with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_5_0", expectedErr: true},
 	} {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {

--- a/wasm/wat/numbers_test.go
+++ b/wasm/wat/numbers_test.go
@@ -1,0 +1,65 @@
+package wat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeUint32(t *testing.T) {
+	for _, tt := range []struct {
+		name, input string
+		expected    uint32
+		expectedErr bool
+	}{
+		{name: "zero", input: "0", expected: 0},
+		{name: "largest uint16", input: "65535", expected: 0xffff},
+		{name: "largest uint32", input: "4294967295", expected: 0xffffffff},
+		{name: "largest uint32 with underscores", input: "4_2_9_4_9_6_7_2_9_5", expected: 0xffffffff},
+		{name: "overflow by one", input: "4294967296", expectedErr: true},
+		{name: "overflow by one with underscores", input: "4_2_9_4_9_6_7_2_9_6", expectedErr: true},
+		{name: "overflow by pow", input: "42949672950", expectedErr: true},
+		{name: "overflow by pow with underscores", input: "4_2_9_4_9_6_7_2_9_5_0", expectedErr: true},
+	} {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := decodeUint32([]byte(tc.input))
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestDecodeUint64(t *testing.T) {
+	for _, tt := range []struct {
+		name, input string
+		expected    uint64
+		expectedErr bool
+	}{
+		{name: "zero", input: "0", expected: 0},
+		{name: "largest uint16", input: "65535", expected: 0xffff},
+		{name: "largest uint32", input: "4294967295", expected: 0xffffffff},
+		{name: "largest uint64", input: "18446744073709551615", expected: 0xffffffffffffffff},
+		{name: "largest uint64 with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_5", expected: 0xffffffffffffffff},
+		{name: "overflow by one", input: "18446744073709551616", expectedErr: true},
+		{name: "overflow by one with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_6", expectedErr: true},
+		{name: "overflow by pow", input: "184467440737095516150", expectedErr: true},
+		{name: "overflow by pow with underscores", input: "1_8_4_4_6_7_4_4_0_7_3_7_0_9_5_5_1_6_1_5_0", expectedErr: true},
+	} {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := decodeUint64([]byte(tc.input))
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/wasm/wat/parser_test.go
+++ b/wasm/wat/parser_test.go
@@ -164,11 +164,6 @@ func TestParseModule(t *testing.T) {
 			},
 		},
 		{
-			name:     "start function", // TODO: this is pointing to a funcidx not in the source!
-			input:    "(module (start $main))",
-			expected: &module{startFunction: &startFunction{"$main", 1, 16}},
-		},
-		{
 			name: "start imported function by name",
 			input: `(module
 	(import "" "hello" (func $hello))
@@ -177,7 +172,7 @@ func TestParseModule(t *testing.T) {
 			expected: &module{
 				typeFuncs:     []*typeFunc{typeFuncEmpty},
 				importFuncs:   []*importFunc{{name: "hello", funcName: "$hello", typeInlined: typeFuncEmpty}},
-				startFunction: &startFunction{"$hello", 3, 9},
+				startFunction: &index{numeric: 0, line: 3, col: 9},
 			},
 		},
 		{
@@ -189,7 +184,7 @@ func TestParseModule(t *testing.T) {
 			expected: &module{
 				typeFuncs:     []*typeFunc{typeFuncEmpty},
 				importFuncs:   []*importFunc{{name: "hello", importIndex: 0, typeInlined: typeFuncEmpty}},
-				startFunction: &startFunction{"0", 3, 9},
+				startFunction: &index{numeric: 0, line: 3, col: 9},
 			},
 		},
 	}
@@ -401,6 +396,19 @@ func TestParseModule_Errors(t *testing.T) {
 			name:        "wrong start",
 			input:       "(module (start main))",
 			expectedErr: "1:16: unexpected keyword: main in module.start",
+		},
+		{
+			name: "start points out of range",
+			input: `(module
+	(import "" "hello" (func))
+	(start 1)
+)`,
+			expectedErr: "3:9: function index 1 is out of range [0..0] in module.start",
+		},
+		{
+			name:        "start points nowhere",
+			input:       "(module (start $main))",
+			expectedErr: "1:16: unknown function name $main in module.start",
 		},
 	}
 


### PR DESCRIPTION
Before, we punted symbolic index binding until we converted into binary
format. This put logic in an awkward spot, which was ok if only the
start function, but not for generic index handling (such as type
binding).

This pulls a new file out for handling bindings, and also eagerly
validates numbers when we read an index. Most importantly, this binds
symbolic identifiers to numeric offsets on parse, which matches how
they work at runtime.
