### PR TITLE
Initialize module instance with `Exports` map

### DIFF
--- a/wasm/store.go
+++ b/wasm/store.go
@@ -334,7 +334,7 @@ func (s *Store) executeConstExpression(target *ModuleInstance, expr *ConstantExp
 	case OpcodeF32Const:
 		v, err = readFloat32(r)
 		if err != nil {
-			return nil, 0, fmt.Errorf("read f34: %w", err)
+			return nil, 0, fmt.Errorf("read f32: %w", err)
 		}
 		return v, ValueTypeF32, nil
 	case OpcodeF64Const:

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -1632,13 +1632,9 @@ func (s *Store) AddHostFunction(moduleName, funcName string, fn reflect.Value) e
 		return &FunctionType{Params: paramTypes, Results: resultTypes}, nil
 	}
 
-	m, ok := s.ModuleInstances[moduleName]
-	if !ok {
-		m = &ModuleInstance{Exports: map[string]*ExportInstance{}}
-		s.ModuleInstances[moduleName] = m
-	}
+	m := s.getModuleInstance(moduleName)
 
-	_, ok = m.Exports[funcName]
+	_, ok := m.Exports[funcName]
 	if ok {
 		return fmt.Errorf("name %s already exists in module %s", funcName, moduleName)
 	}
@@ -1667,13 +1663,9 @@ func (s *Store) AddHostFunction(moduleName, funcName string, fn reflect.Value) e
 }
 
 func (s *Store) AddGlobal(moduleName, name string, value uint64, valueType ValueType, mutable bool) error {
-	m, ok := s.ModuleInstances[moduleName]
-	if !ok {
-		m = &ModuleInstance{}
-		s.ModuleInstances[moduleName] = m
-	}
+	m := s.getModuleInstance(moduleName)
 
-	_, ok = m.Exports[name]
+	_, ok := m.Exports[name]
 	if ok {
 		return fmt.Errorf("name %s already exists in module %s", name, moduleName)
 	}
@@ -1687,13 +1679,9 @@ func (s *Store) AddGlobal(moduleName, name string, value uint64, valueType Value
 }
 
 func (s *Store) AddTableInstance(moduleName, name string, min uint32, max *uint32) error {
-	m, ok := s.ModuleInstances[moduleName]
-	if !ok {
-		m = &ModuleInstance{}
-		s.ModuleInstances[moduleName] = m
-	}
+	m := s.getModuleInstance(moduleName)
 
-	_, ok = m.Exports[name]
+	_, ok := m.Exports[name]
 	if ok {
 		return fmt.Errorf("name %s already exists in module %s", name, moduleName)
 	}
@@ -1710,13 +1698,9 @@ func (s *Store) AddTableInstance(moduleName, name string, min uint32, max *uint3
 }
 
 func (s *Store) AddMemoryInstance(moduleName, name string, min uint32, max *uint32) error {
-	m, ok := s.ModuleInstances[moduleName]
-	if !ok {
-		m = &ModuleInstance{}
-		s.ModuleInstances[moduleName] = m
-	}
+	m := s.getModuleInstance(moduleName)
 
-	_, ok = m.Exports[name]
+	_, ok := m.Exports[name]
 	if ok {
 		return fmt.Errorf("name %s already exists in module %s", name, moduleName)
 	}
@@ -1729,4 +1713,14 @@ func (s *Store) AddMemoryInstance(moduleName, name string, min uint32, max *uint
 	m.Exports[name] = &ExportInstance{Kind: ExportKindMemory, Memory: memory}
 	s.Memories = append(s.Memories, memory)
 	return nil
+}
+
+// getModuleInstance returns an existing ModuleInstance if exists, or assigns a new one.
+func (s *Store) getModuleInstance(name string) *ModuleInstance {
+	m, ok := s.ModuleInstances[name]
+	if !ok {
+		m = &ModuleInstance{Exports: map[string]*ExportInstance{}}
+		s.ModuleInstances[name] = m
+	}
+	return m
 }

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -1,0 +1,22 @@
+package wasm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetModuleInstance(t *testing.T) {
+	name := "test"
+
+	// 'jit' and 'wazeroir' package cannot be used because of circular import.
+	// Here we will use 'nil' instead. Should we have an Engine for testing?
+	s := NewStore(nil)
+
+	m1 := s.getModuleInstance(name)
+	assert.Equal(t, m1, s.ModuleInstances[name])
+	assert.NotNil(t, m1.Exports)
+
+	m2 := s.getModuleInstance(name)
+	assert.Equal(t, m1, m2)
+}

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -3,7 +3,7 @@ package wasm
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetModuleInstance(t *testing.T) {
@@ -14,9 +14,9 @@ func TestGetModuleInstance(t *testing.T) {
 	s := NewStore(nil)
 
 	m1 := s.getModuleInstance(name)
-	assert.Equal(t, m1, s.ModuleInstances[name])
-	assert.NotNil(t, m1.Exports)
+	require.Equal(t, m1, s.ModuleInstances[name])
+	require.NotNil(t, m1.Exports)
 
 	m2 := s.getModuleInstance(name)
-	assert.Equal(t, m1, m2)
+	require.Equal(t, m1, m2)
 }


### PR DESCRIPTION
Hi, Thanks for developing a great wasm runtime!

This PR fixes `panic: assignment to entry in nil map` that occurs when `AddGlobal()`, `AddTableInstance()` or `AddMemoryInstance()` is called before `AddHostFunction()`.

This panic does not occur when `AddHostFunction()` called, because `ModuleInstance` is initialized with `Exports` field in `AddHostFunction()` as follows. This PR makes sure that other functions are initialized with `Exports` field as well.
https://github.com/tetratelabs/wazero/blob/6a309797efa5361f45c6a5cb64d567ecf5ceb16d/wasm/store.go#L1637

