### PR TITLE
Centralizes name section encoding and usage

### DIFF
--- a/wasm/module.go
+++ b/wasm/module.go
@@ -91,8 +91,21 @@ type Module struct {
 	// CodeSection is index-correlated with FunctionSection and contains each function's locals and body.
 	//
 	// See https://www.w3.org/TR/wasm-core-1/#code-section%E2%91%A0
-	CodeSection    []*CodeSegment
-	DataSection    []*DataSegment
+	CodeSection []*CodeSegment
+	DataSection []*DataSegment
+	// NameSection is set when the custom section "name" was successfully decoded from the binary format.
+	//
+	// Note: This is the only custom section defined in the WebAssembly 1.0 (MVP) Binary Format. Others are in
+	// CustomSections
+	//
+	// See https://www.w3.org/TR/wasm-core-1/#name-section%E2%91%A0
+	NameSection *NameSection
+	// CustomSections is set when at least one non-standard, or otherwise unsupported custom section was found in the
+	// binary format.
+	//
+	// Note: This never contains a "name" because that is standard and parsed into the NameSection.
+	//
+	// See https://www.w3.org/TR/wasm-core-1/#custom-section%E2%91%A0
 	CustomSections map[string][]byte
 }
 
@@ -126,7 +139,7 @@ func DecodeModule(binary []byte) (*Module, error) {
 		}
 	}
 
-	ret := &Module{CustomSections: map[string][]byte{}}
+	ret := &Module{}
 	if err := ret.readSections(r); err != nil {
 		return nil, fmt.Errorf("readSections failed: %w", err)
 	}

--- a/wasm/module_test.go
+++ b/wasm/module_test.go
@@ -6,18 +6,116 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecodeModule(t *testing.T) {
+func TestModule_Encode(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       []byte
-		expected    *Module
-		expectedErr string
+		name     string
+		input    *Module
+		expected []byte
 	}{
 		{
 			name:     "empty",
-			input:    []byte("\x00asm\x01\x00\x00\x00"),
-			expected: &Module{CustomSections: map[string][]byte{}},
+			input:    &Module{},
+			expected: append(magic, version...),
 		},
+		{
+			name:  "only name section",
+			input: &Module{NameSection: &NameSection{ModuleName: "simple"}},
+			expected: append(append(magic, version...),
+				SectionIDCustom, 0x0e, // 14 bytes in this section
+				0x04, 'n', 'a', 'm', 'e',
+				subsectionIDModuleName, 0x07, // 7 bytes in this subsection
+				0x06, // the Module name simple is 6 bytes long
+				's', 'i', 'm', 'p', 'l', 'e'),
+		},
+		{
+			name: "only custom section",
+			input: &Module{CustomSections: map[string][]byte{
+				"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+			}},
+			expected: append(append(magic, version...),
+				SectionIDCustom, 0xf, // 15 bytes in this section
+				0x04, 'm', 'e', 'm', 'e',
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 0),
+		},
+		{
+			name: "name section and a custom section", // name should encode last
+			input: &Module{
+				NameSection: &NameSection{ModuleName: "simple"},
+				CustomSections: map[string][]byte{
+					"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+			},
+			expected: append(append(magic, version...),
+				SectionIDCustom, 0xf, // 15 bytes in this section
+				0x04, 'm', 'e', 'm', 'e',
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+				SectionIDCustom, 0x0e, // 14 bytes in this section
+				0x04, 'n', 'a', 'm', 'e',
+				subsectionIDModuleName, 0x07, // 7 bytes in this subsection
+				0x06, // the Module name simple is 6 bytes long
+				's', 'i', 'm', 'p', 'l', 'e'),
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			bytes := tc.input.Encode()
+			require.Equal(t, tc.expected, bytes)
+		})
+	}
+}
+
+// TestDecodeModule relies on unit tests for Module.Encode, specifically that the encoding is both known and correct.
+// This avoids having to copy/paste or share variables to assert against byte arrays.
+func TestDecodeModule(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *Module // round trip test!
+	}{
+		{
+			name:  "empty",
+			input: &Module{},
+		},
+		{
+			name:  "only name section",
+			input: &Module{NameSection: &NameSection{ModuleName: "simple"}},
+		},
+		{
+			name: "only custom section",
+			input: &Module{CustomSections: map[string][]byte{
+				"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+			}},
+		},
+		{
+			name: "name section and a custom section",
+			input: &Module{
+				NameSection: &NameSection{ModuleName: "simple"},
+				CustomSections: map[string][]byte{
+					"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			m, e := DecodeModule(tc.input.Encode())
+			require.NoError(t, e)
+			require.Equal(t, tc.input, m)
+		})
+	}
+}
+
+func TestDecodeModule_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []byte
+		expectedErr string
+	}{
 		{
 			name:        "wrong magic",
 			input:       []byte("wasm\x01\x00\x00\x00"),
@@ -34,46 +132,8 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, e := DecodeModule(tc.input)
-			if tc.expectedErr != "" {
-				require.EqualError(t, e, tc.expectedErr)
-			} else {
-				require.NoError(t, e)
-				require.Equal(t, tc.expected, m)
-			}
-		})
-	}
-}
-
-func TestModule_Encode(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    *Module
-		expected []byte
-	}{
-		{
-			name:     "empty",
-			input:    &Module{CustomSections: map[string][]byte{}},
-			expected: append(magic, version...),
-		},
-		{
-			name: "only name section",
-			input: &Module{CustomSections: map[string][]byte{
-				"name": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
-			}},
-			expected: append(append(magic, version...), SectionIDCustom,
-				byte(1+4+10), // size prefixed "name", followed by the section data
-				0x04, 'n', 'a', 'm', 'e',
-				1, 2, 3, 4, 5, 6, 7, 8, 9, 0),
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			bytes := tc.input.Encode()
-			require.Equal(t, tc.expected, bytes)
+			_, e := DecodeModule(tc.input)
+			require.EqualError(t, e, tc.expectedErr)
 		})
 	}
 }

--- a/wasm/module_test.go
+++ b/wasm/module_test.go
@@ -126,6 +126,28 @@ func TestDecodeModule_Errors(t *testing.T) {
 			input:       []byte("\x00asm\x01\x00\x00\x01"),
 			expectedErr: "invalid version header",
 		},
+		{
+			name: "redundant custom section",
+			input: append(append(magic, version...),
+				SectionIDCustom, 0x09, // 9 bytes in this section
+				0x04, 'm', 'e', 'm', 'e',
+				subsectionIDModuleName, 0x03, 0x01, 'x',
+				SectionIDCustom, 0x09, // 9 bytes in this section
+				0x04, 'm', 'e', 'm', 'e',
+				subsectionIDModuleName, 0x03, 0x01, 'y'),
+			expectedErr: "readSections failed: section ID 0: malformed custom section meme",
+		},
+		{
+			name: "redundant name section",
+			input: append(append(magic, version...),
+				SectionIDCustom, 0x09, // 9 bytes in this section
+				0x04, 'n', 'a', 'm', 'e',
+				subsectionIDModuleName, 0x03, 0x01, 'x',
+				SectionIDCustom, 0x09, // 9 bytes in this section
+				0x04, 'n', 'a', 'm', 'e',
+				subsectionIDModuleName, 0x03, 0x01, 'x'),
+			expectedErr: "readSections failed: section ID 0: malformed custom section name",
+		},
 	}
 
 	for _, tt := range tests {

--- a/wasm/names.go
+++ b/wasm/names.go
@@ -9,10 +9,10 @@ import (
 	"github.com/tetratelabs/wazero/wasm/leb128"
 )
 
-// CustomNameSection represent the known custom name subsections defined in the WebAssembly Binary Format
+// NameSection represent the known custom name subsections defined in the WebAssembly Binary Format
 // See https://www.w3.org/TR/wasm-core-1/#name-section%E2%91%A0
 // See https://github.com/tetratelabs/wazero/issues/134 about adding this to Module
-type CustomNameSection struct {
+type NameSection struct {
 	// ModuleName is the symbolic identifier for a module. Ex. math
 	// The corresponding subsection is subsectionIDModuleName.
 	ModuleName string
@@ -57,7 +57,7 @@ const (
 // Note: The result can be nil because this does not encode empty subsections
 //
 // See https://www.w3.org/TR/wasm-core-1/#binary-namesec
-func (n *CustomNameSection) EncodeData() (data []byte) {
+func (n *NameSection) EncodeData() (data []byte) {
 	if n.ModuleName != "" {
 		data = append(data, encodeNameSubsection(subsectionIDModuleName, encodeSizePrefixed([]byte(n.ModuleName)))...)
 	}
@@ -72,7 +72,7 @@ func (n *CustomNameSection) EncodeData() (data []byte) {
 
 // encodeFunctionNameData encodes the data for the function name subsection.
 // See https://www.w3.org/TR/wasm-core-1/#binary-funcnamesec
-func (n *CustomNameSection) encodeFunctionNameData() []byte {
+func (n *NameSection) encodeFunctionNameData() []byte {
 	if len(n.FunctionNames) == 0 {
 		return nil
 	}
@@ -98,7 +98,7 @@ func encodeSortedAndSizePrefixed(m map[uint32]string) []byte {
 
 // encodeLocalNameData encodes the data for the local name subsection.
 // See https://www.w3.org/TR/wasm-core-1/#binary-localnamesec
-func (n *CustomNameSection) encodeLocalNameData() []byte {
+func (n *NameSection) encodeLocalNameData() []byte {
 	if len(n.LocalNames) == 0 {
 		return nil
 	}
@@ -142,7 +142,7 @@ func encodeSizePrefixed(data []byte) []byte {
 	return append(size, data...)
 }
 
-// DecodeCustomNameSection deserializes the data associated with the "name" key in SectionIDCustom according to the
+// DecodeNameSection deserializes the data associated with the "name" key in SectionIDCustom according to the
 // standard:
 //
 // * ModuleName decode from subsection 0
@@ -150,11 +150,11 @@ func encodeSizePrefixed(data []byte) []byte {
 // * LocalNames decode from subsection 2
 //
 // See https://www.w3.org/TR/wasm-core-1/#binary-namesec
-func DecodeCustomNameSection(data []byte) (result *CustomNameSection, err error) {
+func DecodeNameSection(data []byte) (result *NameSection, err error) {
 	// TODO: add leb128 functions that work on []byte and offset. While using a reader allows us to reuse reader-based
 	// leb128 functions, it is less efficient, causes untestable code and in some cases more complex vs plain []byte.
 	r := bytes.NewReader(data)
-	result = &CustomNameSection{}
+	result = &NameSection{}
 
 	// subsectionID is decoded if known, and skipped if not
 	var subsectionID uint8

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -433,18 +433,10 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 	memoryDeclarations = append(memoryDeclarations, module.MemorySection...)
 	tableDeclarations = append(tableDeclarations, module.TableSection...)
 
-	// TODO: decode during Module.Decode per #134
 	var functionNames map[uint32]string
-	if data, ok := module.CustomSections["name"]; ok {
-		if c, decodeErr := DecodeCustomNameSection(data); decodeErr == nil {
-			functionNames = c.FunctionNames
-		}
-	}
-	if functionNames == nil {
-		// We cannot guarantee the existence of "name" custom section
-		// in the binary. That is because the custom section is optional
-		// in the spec. Also, some compilers optimize it out to reduce
-		// the binary size.
+	if module.NameSection != nil && module.NameSection.FunctionNames != nil {
+		functionNames = module.NameSection.FunctionNames
+	} else {
 		functionNames = map[uint32]string{}
 	}
 

--- a/wasm/wat/convert_test.go
+++ b/wasm/wat/convert_test.go
@@ -66,13 +66,11 @@ func TestTextToBinary(t *testing.T) {
 						},
 					},
 				},
-				CustomSections: map[string][]byte{
-					"name": (&wasm.CustomNameSection{
-						FunctionNames: map[uint32]string{
-							0: "runtime.path_open",
-							1: "runtime.fd_write",
-						},
-					}).EncodeData(),
+				NameSection: &wasm.NameSection{
+					FunctionNames: map[uint32]string{
+						0: "runtime.path_open",
+						1: "runtime.fd_write",
+					},
 				},
 			},
 		},
@@ -106,13 +104,11 @@ func TestTextToBinary(t *testing.T) {
 						},
 					},
 				},
-				CustomSections: map[string][]byte{
-					"name": (&wasm.CustomNameSection{
-						FunctionNames: map[uint32]string{
-							0: "runtime.arg_sizes_get",
-							1: "runtime.fd_write",
-						},
-					}).EncodeData(),
+				NameSection: &wasm.NameSection{
+					FunctionNames: map[uint32]string{
+						0: "runtime.arg_sizes_get",
+						1: "runtime.fd_write",
+					},
 				},
 			},
 		},
@@ -132,12 +128,10 @@ func TestTextToBinary(t *testing.T) {
 					},
 				}},
 				StartSection: &zero,
-				CustomSections: map[string][]byte{
-					"name": (&wasm.CustomNameSection{
-						FunctionNames: map[uint32]string{
-							0: "hello",
-						},
-					}).EncodeData(),
+				NameSection: &wasm.NameSection{
+					FunctionNames: map[uint32]string{
+						0: "hello",
+					},
 				},
 			},
 		},
@@ -203,21 +197,19 @@ func TestTextToBinary(t *testing.T) {
 					},
 				},
 				StartSection: &four,
-				CustomSections: map[string][]byte{
-					"name": (&wasm.CustomNameSection{
-						ModuleName: "example",
-						FunctionNames: map[uint32]string{
-							0: "runtime.arg_sizes_get",
-							1: "runtime.fd_write",
-							2: "mul",
-							3: "add",
-							4: "hello",
-						},
-						LocalNames: map[uint32]map[uint32]string{
-							2: {0: "x", 1: "y"},
-							3: {0: "l", 1: "r"},
-						},
-					}).EncodeData(),
+				NameSection: &wasm.NameSection{
+					ModuleName: "example",
+					FunctionNames: map[uint32]string{
+						0: "runtime.arg_sizes_get",
+						1: "runtime.fd_write",
+						2: "mul",
+						3: "add",
+						4: "hello",
+					},
+					LocalNames: map[uint32]map[uint32]string{
+						2: {0: "x", 1: "y"},
+						3: {0: "l", 1: "r"},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
`Store.Instantiate` needs the name section when building function
instances. Before, we had to lazy decode this as it wasn't decoded along
with the other data defined by the binary format. This acknowledges that
the name section is a standard field and top-levels it in the
`wasm.Module` type. It clarifies that anything else will stay in the
`Module.CustomSections` until we support more of them (perhaps Dwarf).

This also renames `CustomNameSection` to `NameSection` because the
standard refers it that way. It is the "name section", just for whatever
reason, they decided to store it as a custom section.

Nice side effects include centralization logic of binary decoding, and
also no more double-encoding of names from the text format. Before this
change, when converting text to binary, we had to re-encode names back
into the binary format because later `Store.Instantiate` needed to read
them as raw bytes. Doing it this way saves dozens of allocations vs
before, so cool.

This also allows the name section and also the custom sections to be nil
as there's no reason to set them when we have no data.

Fixes #134
