### PR TITLE
Consolidate runtime errors

### DIFF
--- a/wasm/errors.go
+++ b/wasm/errors.go
@@ -2,7 +2,7 @@ package wasm
 
 import "errors"
 
-// All the erros were returned by Engine during the excecution of Wasm functions,
+// All the erros are returned by Engine during the excecution of Wasm functions,
 // and they indicate that the Wasm virtual machine's state is unrecoverable.
 var (
 	// ErrRuntimeCallStackOverflow indicates that there are too many function calls,

--- a/wasm/errors.go
+++ b/wasm/errors.go
@@ -9,6 +9,6 @@ var (
 	ErrRuntimeIntegerDivideByZero        = errors.New("integer divide by zero")
 	ErrRuntimeUnreachable                = errors.New("unreachable")
 	ErrRuntimeOutOfBoundsMemoryAccess    = errors.New("out of bounds memory access")
-	ErrRuntimeOutOfBoundsTableAcces      = errors.New("out of bounds table access")
+	ErrRuntimeInvalidTableAcces          = errors.New("invalid table access")
 	ErrRuntimeIndirectCallTypeMismatch   = errors.New("indirect call type mismatch")
 )

--- a/wasm/errors.go
+++ b/wasm/errors.go
@@ -2,4 +2,13 @@ package wasm
 
 import "errors"
 
-var ErrCallStackOverflow = errors.New("callstack overflow")
+var (
+	ErrRuntimeCallStackOverflow          = errors.New("callstack overflow")
+	ErrRuntimeInvalidConversionToInteger = errors.New("invalid conversion to integer")
+	ErrRuntimeIntegerOverflow            = errors.New("integer overflow")
+	ErrRuntimeIntegerDivideByZero        = errors.New("integer divide by zero")
+	ErrRuntimeUnreachable                = errors.New("unreachable")
+	ErrRuntimeOutOfBoundsMemoryAccess    = errors.New("out of bounds memory access")
+	ErrRuntimeOutOfBoundsTableAcces      = errors.New("out of bounds table access")
+	ErrRuntimeIndirectCallTypeMismatch   = errors.New("indirect call type mismatch")
+)

--- a/wasm/errors.go
+++ b/wasm/errors.go
@@ -2,13 +2,30 @@ package wasm
 
 import "errors"
 
+// All the erros were returned by Engine during the excecution of Wasm functions,
+// and they indicate that the Wasm virtual machine's state is unrecoverable.
 var (
-	ErrRuntimeCallStackOverflow          = errors.New("callstack overflow")
+	// ErrRuntimeCallStackOverflow indicates that there are too many function calls,
+	// and the engine terminated the execution.
+	ErrRuntimeCallStackOverflow = errors.New("callstack overflow")
+	// ErrRuntimeInvalidConversionToInteger indicates the Wasm function tries to
+	// convert NaN floating point value to integers during trunc variant instructions.
 	ErrRuntimeInvalidConversionToInteger = errors.New("invalid conversion to integer")
-	ErrRuntimeIntegerOverflow            = errors.New("integer overflow")
-	ErrRuntimeIntegerDivideByZero        = errors.New("integer divide by zero")
-	ErrRuntimeUnreachable                = errors.New("unreachable")
-	ErrRuntimeOutOfBoundsMemoryAccess    = errors.New("out of bounds memory access")
-	ErrRuntimeInvalidTableAcces          = errors.New("invalid table access")
-	ErrRuntimeIndirectCallTypeMismatch   = errors.New("indirect call type mismatch")
+	// ErrRuntimeIntegerOverflow indicates that an integer arithmatic resulted in
+	// overflow value. For example, when the program tried to truncate a float value
+	// which doesn't fit in the range of target integer.
+	ErrRuntimeIntegerOverflow = errors.New("integer overflow")
+	// ErrRuntimeIntegerDivideByZero indicates that an integer div or rem instructions
+	// was executed with 0 as the divisor.
+	ErrRuntimeIntegerDivideByZero = errors.New("integer divide by zero")
+	// ErrRuntimeUnreachable means "unreachable" instruction was executed by the program.
+	ErrRuntimeUnreachable = errors.New("unreachable")
+	// ErrRuntimeOutOfBoundsMemoryAccess indicates that the program tried to access the
+	// region beyond the linear memory.
+	ErrRuntimeOutOfBoundsMemoryAccess = errors.New("out of bounds memory access")
+	// ErrRuntimeInvalidTableAcces means either offset to the table was out of bounds of table, or
+	// the target element in the table was uninitialized during call_indirect instruction.
+	ErrRuntimeInvalidTableAcces = errors.New("invalid table access")
+	// ErrRuntimeIndirectCallTypeMismatch indicates that the type check failed during call_indirect.
+	ErrRuntimeIndirectCallTypeMismatch = errors.New("indirect call type mismatch")
 )

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -111,7 +111,6 @@ func (e *engine) Call(f *wasm.FunctionInstance, params ...uint64) (results []uin
 				}
 				runtimeErr, ok := v.(error)
 				if ok {
-					// TODO: wrtap the floating point exception or etc as wasm.ErrRuntime**
 					err = fmt.Errorf("wasm runtime error: %w", runtimeErr)
 				} else {
 					err = fmt.Errorf("wasm runtime error: %v", v)
@@ -265,14 +264,14 @@ const (
 	jitCallStatusCodeUnreachable
 	// jitCallStatusCodeInvalidFloatToIntConversion means a invalid conversion of integer to floats happened.
 	jitCallStatusCodeInvalidFloatToIntConversion
-	// TODO:
-	jitCallStatusIntegerOverflow
 	// jitCallStatusCodeMemoryOutOfBounds means a out of bounds memory access happened.
 	jitCallStatusCodeMemoryOutOfBounds
-	// jitCallStatusCodeTableOutOfBounds means the offset to table exceeds the length of table during call_indirect.
-	jitCallStatusCodeTableOutOfBounds
+	// TODO:
+	jitCallStatusCodeInvalidTableAccess
 	// jitCallStatusCodeTypeMismatchOnIndirectCall means the type check failed during call_indirect.
 	jitCallStatusCodeTypeMismatchOnIndirectCall
+	jitCallStatusIntegerOverflow
+	jitCallStatusIntegerDivisionByZero
 )
 
 func (s jitCallStatusCode) String() (ret string) {
@@ -478,14 +477,16 @@ func (e *engine) execFunction(f *compiledFunction) {
 			currentFrame.continuationAddress = currentFrame.compiledFunction.codeInitialAddress + e.continuationAddressOffset
 		case jitCallStatusIntegerOverflow:
 			panic(wasm.ErrRuntimeIntegerOverflow)
+		case jitCallStatusIntegerDivisionByZero:
+			panic(wasm.ErrRuntimeIntegerDivideByZero)
 		case jitCallStatusCodeInvalidFloatToIntConversion:
 			panic(wasm.ErrRuntimeInvalidConversionToInteger)
 		case jitCallStatusCodeUnreachable:
 			panic(wasm.ErrRuntimeUnreachable)
 		case jitCallStatusCodeMemoryOutOfBounds:
 			panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
-		case jitCallStatusCodeTableOutOfBounds:
-			panic(wasm.ErrRuntimeOutOfBoundsTableAcces)
+		case jitCallStatusCodeInvalidTableAccess:
+			panic(wasm.ErrRuntimeInvalidTableAcces)
 		case jitCallStatusCodeTypeMismatchOnIndirectCall:
 			panic(wasm.ErrRuntimeIndirectCallTypeMismatch)
 		}

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -111,6 +111,7 @@ func (e *engine) Call(f *wasm.FunctionInstance, params ...uint64) (results []uin
 				}
 				runtimeErr, ok := v.(error)
 				if ok {
+					// TODO: wrtap the floating point exception or etc as wasm.ErrRuntime**
 					err = fmt.Errorf("wasm runtime error: %w", runtimeErr)
 				} else {
 					err = fmt.Errorf("wasm runtime error: %v", v)
@@ -200,7 +201,7 @@ var callStackCeiling = uint64(buildoptions.CallStackCeiling)
 func (e *engine) callFramePush(callee *callFrame) {
 	e.callFrameNum++
 	if callStackCeiling < e.callFrameNum {
-		panic(wasm.ErrCallStackOverflow)
+		panic(wasm.ErrRuntimeCallStackOverflow)
 	}
 
 	// Push the new frame to the top of stack.
@@ -474,20 +475,15 @@ func (e *engine) execFunction(f *compiledFunction) {
 			}
 			currentFrame.continuationAddress = currentFrame.compiledFunction.codeInitialAddress + e.continuationAddressOffset
 		case jitCallStatusCodeInvalidFloatToIntConversion:
-			// TODO: have wasm.ErrInvalidFloatToIntConversion and use it here.
-			panic("invalid float to int conversion")
+			panic(wasm.ErrRuntimeInvalidConversionToInteger)
 		case jitCallStatusCodeUnreachable:
-			// TODO: have wasm.ErrUnreachable and use it here.
-			panic("unreachable")
+			panic(wasm.ErrRuntimeUnreachable)
 		case jitCallStatusCodeMemoryOutOfBounds:
-			// TODO: have wasm.ErrMemoryOutOfBounds and use it here.
-			panic("out of bounds memory access")
+			panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
 		case jitCallStatusCodeTableOutOfBounds:
-			// TODO: have wasm.ErrTableOutOfBounds and use it here.
-			panic("out of bounds table access")
+			panic(wasm.ErrRuntimeOutOfBoundsTableAcces)
 		case jitCallStatusCodeTypeMismatchOnIndirectCall:
-			// TODO: have wasm.ErrTypeMismatchOnIndirectCall and use it here.
-			panic("type mismatch on indirect function call")
+			panic(wasm.ErrRuntimeIndirectCallTypeMismatch)
 		}
 	}
 }

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -265,6 +265,8 @@ const (
 	jitCallStatusCodeUnreachable
 	// jitCallStatusCodeInvalidFloatToIntConversion means a invalid conversion of integer to floats happened.
 	jitCallStatusCodeInvalidFloatToIntConversion
+	// TODO:
+	jitCallStatusIntegerOverflow
 	// jitCallStatusCodeMemoryOutOfBounds means a out of bounds memory access happened.
 	jitCallStatusCodeMemoryOutOfBounds
 	// jitCallStatusCodeTableOutOfBounds means the offset to table exceeds the length of table during call_indirect.
@@ -474,6 +476,8 @@ func (e *engine) execFunction(f *compiledFunction) {
 				}
 			}
 			currentFrame.continuationAddress = currentFrame.compiledFunction.codeInitialAddress + e.continuationAddressOffset
+		case jitCallStatusIntegerOverflow:
+			panic(wasm.ErrRuntimeIntegerOverflow)
 		case jitCallStatusCodeInvalidFloatToIntConversion:
 			panic(wasm.ErrRuntimeInvalidConversionToInteger)
 		case jitCallStatusCodeUnreachable:

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -264,9 +264,10 @@ const (
 	jitCallStatusCodeUnreachable
 	// jitCallStatusCodeInvalidFloatToIntConversion means a invalid conversion of integer to floats happened.
 	jitCallStatusCodeInvalidFloatToIntConversion
-	// jitCallStatusCodeMemoryOutOfBounds means a out of bounds memory access happened.
+	// jitCallStatusCodeMemoryOutOfBounds means an out of bounds memory access happened.
 	jitCallStatusCodeMemoryOutOfBounds
-	// TODO:
+	// jitCallStatusCodeInvalidTableAccess means either offset to the table was out of bounds of table, or
+	// the target element in the table was uninitialized during call_indirect instruction.
 	jitCallStatusCodeInvalidTableAccess
 	// jitCallStatusCodeTypeMismatchOnIndirectCall means the type check failed during call_indirect.
 	jitCallStatusCodeTypeMismatchOnIndirectCall

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -109,7 +109,7 @@ func TestEngine_fac(t *testing.T) {
 	}
 
 	_, _, err = store.CallFunction("test", "fac-rec", 1073741824)
-	require.True(t, errors.Is(err, wasm.ErrCallStackOverflow))
+	require.True(t, errors.Is(err, wasm.ErrRuntimeCallStackOverflow))
 }
 
 func TestEngine_unreachable(t *testing.T) {

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -1,7 +1,6 @@
 package jit
 
 import (
-	"errors"
 	"os"
 	"reflect"
 	"sync"
@@ -109,7 +108,7 @@ func TestEngine_fac(t *testing.T) {
 	}
 
 	_, _, err = store.CallFunction("test", "fac-rec", 1073741824)
-	require.True(t, errors.Is(err, wasm.ErrRuntimeCallStackOverflow))
+	require.ErrorIs(t, err, wasm.ErrRuntimeCallStackOverflow)
 }
 
 func TestEngine_unreachable(t *testing.T) {

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1075,7 +1075,7 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 	checkIfInitialized.To.Offset = int64(wasm.UninitializedTableElelemtTypeID)
 	c.addInstruction(checkIfInitialized)
 
-	// Jump if the type matches.
+	// Jump if the target is initialized element.
 	jumpIfInitialized := c.newProg()
 	jumpIfInitialized.To.Type = obj.TYPE_BRANCH
 	jumpIfInitialized.As = x86.AJNE

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -1826,10 +1826,6 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		return err
 	}
 
-	if x2.register == quotientRegister || x2.register == remainderRegister {
-		panic("a?")
-	}
-
 	// Check if the x2 equals zero.
 	checkDivisorZero := c.newProg()
 	if is32Bit {
@@ -1856,9 +1852,6 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 	c.addSetJmpOrigins(jmpIfNotZero)
 
 	// Ensure that previously existing values on AX and DX registers are saved and unused.
-	if x2.register == quotientRegister || x2.register == remainderRegister {
-		panic("aa?")
-	}
 	c.locationStack.markRegisterUnused(quotientRegister)
 	c.locationStack.markRegisterUnused(remainderRegister)
 

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -2799,17 +2799,6 @@ func TestAmd64Compiler_compilPopcnt(t *testing.T) {
 	})
 }
 
-// The division by zero error must be caught by Go's runtime via x86's exception caught by kernel.
-func getDivisionByZeroErrorRecoverFunc(t *testing.T) func() {
-	return func() {
-		if e := recover(); e != nil {
-			err, ok := e.(error)
-			require.True(t, ok)
-			require.Equal(t, "runtime error: integer divide by zero", err.Error())
-		}
-	}
-}
-
 func TestAmd64Compiler_compile_and_or_xor_shl_shr_rotl_rotr(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -3107,7 +3096,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
 						const dxValue uint64 = 111111
-						for i, vs := range []struct {
+						for _, vs := range []struct {
 							x1Value, x2Value uint32
 						}{
 							{x1Value: 2, x2Value: 1},
@@ -3115,12 +3104,13 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 							{x1Value: 0, x2Value: 2},
 							{x1Value: 1, x2Value: 0},
 							{x1Value: 0, x2Value: 0},
+							{x1Value: 0x80000000, x2Value: 0xffffffff}, // This equals (-2^63 / -1) and results in overflow.
 							// Following cases produce different resulting bit patterns for signed and unsigned.
 							{x1Value: 0xffffffff /* -1 in signed 32bit */, x2Value: 1},
 							{x1Value: 0xffffffff /* -1 in signed 32bit */, x2Value: 0xfffffffe /* -2 in signed 32bit */},
 						} {
 							vs := vs
-							t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+							t.Run(fmt.Sprintf("%d/%d", vs.x1Value, vs.x2Value), func(t *testing.T) {
 
 								env := newJITEnvironment()
 								compiler := requireNewCompiler(t)
@@ -3180,10 +3170,15 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 								require.NoError(t, err)
 
 								// Run code.
-								if vs.x2Value == 0 {
-									defer getDivisionByZeroErrorRecoverFunc(t)()
-								}
 								env.exec(code)
+
+								if vs.x2Value == 0 {
+									require.Equal(t, jitCallStatusIntegerDivisionByZero, env.jitStatus())
+									return
+								} else if signed.signed && int32(vs.x2Value) == -1 && int32(vs.x1Value) == int32(math.MinInt32) {
+									require.Equal(t, jitCallStatusIntegerOverflow, env.jitStatus())
+									return
+								}
 
 								// Verify the stack is in the form of ["any value previously used by DX" + x1 / x2]
 								require.Equal(t, uint64(1), env.stackPointer())
@@ -3258,7 +3253,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
 						const dxValue uint64 = 111111
-						for i, vs := range []struct {
+						for _, vs := range []struct {
 							x1Value, x2Value uint64
 						}{
 							{x1Value: 2, x2Value: 1},
@@ -3266,12 +3261,13 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 							{x1Value: 0, x2Value: 1},
 							{x1Value: 1, x2Value: 0},
 							{x1Value: 0, x2Value: 0},
+							{x1Value: 0x8000000000000000, x2Value: 0xffffffffffffffff}, // This equals (-2^63 / -1) and results in overflow.
 							// Following cases produce different resulting bit patterns for signed and unsigned.
 							{x1Value: 0xffffffffffffffff /* -1 in signed 64bit */, x2Value: 1},
 							{x1Value: 0xffffffffffffffff /* -1 in signed 64bit */, x2Value: 0xfffffffffffffffe /* -2 in signed 64bit */},
 						} {
 							vs := vs
-							t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+							t.Run(fmt.Sprintf("%d/%d", vs.x1Value, vs.x2Value), func(t *testing.T) {
 
 								env := newJITEnvironment()
 								compiler := requireNewCompiler(t)
@@ -3329,11 +3325,17 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 								// Generate the code under test.
 								code, _, _, err := compiler.generate()
 								require.NoError(t, err)
+
 								// Run code.
-								if vs.x2Value == 0 {
-									defer getDivisionByZeroErrorRecoverFunc(t)()
-								}
 								env.exec(code)
+
+								if vs.x2Value == 0 {
+									require.Equal(t, jitCallStatusIntegerDivisionByZero, env.jitStatus())
+									return
+								} else if signed.signed && int64(vs.x2Value) == -1 && int64(vs.x1Value) == int64(math.MinInt64) {
+									require.Equal(t, jitCallStatusIntegerOverflow, env.jitStatus())
+									return
+								}
 
 								// Verify the stack is in the form of ["any value previously used by DX" + x1 / x2]
 								require.Equal(t, uint64(1), env.stackPointer())
@@ -3626,10 +3628,11 @@ func TestAmd64Compiler_compileRem(t *testing.T) {
 								require.NoError(t, err)
 
 								// Run code.
-								if vs.x2Value == 0 {
-									defer getDivisionByZeroErrorRecoverFunc(t)()
-								}
 								env.exec(code)
+								if vs.x2Value == 0 {
+									require.Equal(t, jitCallStatusIntegerDivisionByZero, env.jitStatus())
+									return
+								}
 
 								// Verify the stack is in the form of ["any value previously used by DX" + x1 / x2]
 								require.Equal(t, uint64(1), env.stackPointer())
@@ -3780,13 +3783,13 @@ func TestAmd64Compiler_compileRem(t *testing.T) {
 								// Generate the code under test.
 								code, _, _, err := compiler.generate()
 								require.NoError(t, err)
-								// Run code.
-								if vs.x2Value == 0 {
-									defer getDivisionByZeroErrorRecoverFunc(t)()
-								}
 
 								// Run code.
 								env.exec(code)
+								if vs.x2Value == 0 {
+									require.Equal(t, jitCallStatusIntegerDivisionByZero, env.jitStatus())
+									return
+								}
 
 								// Verify the stack is in the form of ["any value previously used by DX" + x1 / x2]
 								require.Equal(t, uint64(1), env.stackPointer())
@@ -5740,7 +5743,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 
 		// Place the offfset value.
 		loc := compiler.locationStack.pushValueOnStack()
-		env.stack()[loc.stackPointer] = 1000000000
+		env.stack()[loc.stackPointer] = 10
 
 		// Now emit the code.
 		compiler.initializeReservedRegisters()
@@ -5754,7 +5757,40 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 		// Run code.
 		env.exec(code)
 
-		require.Equal(t, jitCallStatusCodeTableOutOfBounds, env.jitStatus())
+		require.Equal(t, jitCallStatusCodeInvalidTableAccess, env.jitStatus())
+	})
+
+	t.Run("uninitialized", func(t *testing.T) {
+		env := newJITEnvironment()
+		table := make([]wasm.TableElement, 10)
+		env.setTable(table)
+
+		compiler := requireNewCompiler(t)
+		targetOperation := &wazeroir.OperationCallIndirect{}
+		targetOffset := &wazeroir.OperationConstI32{Value: uint32(0)}
+		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
+		compiler.f = &wasm.FunctionInstance{ModuleInstance: &wasm.ModuleInstance{Types: []*wasm.TypeInstance{{
+			Type: &wasm.FunctionType{}, TypeID: 1000}}}}
+		// and the typeID doesn't match the table[targetOffset]'s type ID.
+		table[0] = wasm.TableElement{FunctionTypeID: wasm.UninitializedTableElelemtTypeID}
+
+		// Place the offfset value.
+		err := compiler.compileConstI32(targetOffset)
+		require.NoError(t, err)
+
+		// Now emit the code.
+		compiler.initializeReservedRegisters()
+		require.NoError(t, compiler.compileCallIndirect(targetOperation))
+
+		// Generate the code under test.
+		compiler.returnFunction()
+		code, _, _, err := compiler.generate()
+		require.NoError(t, err)
+
+		// Run code.
+		env.exec(code)
+
+		require.Equal(t, jitCallStatusCodeInvalidTableAccess, env.jitStatus())
 	})
 
 	t.Run("type not match", func(t *testing.T) {

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -3104,7 +3104,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 							{x1Value: 0, x2Value: 2},
 							{x1Value: 1, x2Value: 0},
 							{x1Value: 0, x2Value: 0},
-							{x1Value: 0x80000000, x2Value: 0xffffffff}, // This equals (-2^63 / -1) and results in overflow.
+							{x1Value: 0x80000000, x2Value: 0xffffffff}, // This is equivalent to (-2^31 / -1) and results in overflow.
 							// Following cases produce different resulting bit patterns for signed and unsigned.
 							{x1Value: 0xffffffff /* -1 in signed 32bit */, x2Value: 1},
 							{x1Value: 0xffffffff /* -1 in signed 32bit */, x2Value: 0xfffffffe /* -2 in signed 32bit */},
@@ -3176,6 +3176,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 									require.Equal(t, jitCallStatusIntegerDivisionByZero, env.jitStatus())
 									return
 								} else if signed.signed && int32(vs.x2Value) == -1 && int32(vs.x1Value) == int32(math.MinInt32) {
+									// (-2^31 / -1) = 2 ^31 is larger than the upper limit of 32-bit signed integer.
 									require.Equal(t, jitCallStatusIntegerOverflow, env.jitStatus())
 									return
 								}
@@ -3333,6 +3334,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 									require.Equal(t, jitCallStatusIntegerDivisionByZero, env.jitStatus())
 									return
 								} else if signed.signed && int64(vs.x2Value) == -1 && int64(vs.x1Value) == int64(math.MinInt64) {
+									// (-2^63 / -1) = 2 ^63 is larger than the upper limit of 64-bit signed integer.
 									require.Equal(t, jitCallStatusIntegerOverflow, env.jitStatus())
 									return
 								}

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -3262,7 +3262,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 							{x1Value: 0, x2Value: 1},
 							{x1Value: 1, x2Value: 0},
 							{x1Value: 0, x2Value: 0},
-							{x1Value: 0x8000000000000000, x2Value: 0xffffffffffffffff}, // This equals (-2^63 / -1) and results in overflow.
+							{x1Value: 0x8000000000000000, x2Value: 0xffffffffffffffff}, // This is equivalent to (-2^63 / -1) and results in overflow.
 							// Following cases produce different resulting bit patterns for signed and unsigned.
 							{x1Value: 0xffffffffffffffff /* -1 in signed 64bit */, x2Value: 1},
 							{x1Value: 0xffffffffffffffff /* -1 in signed 64bit */, x2Value: 0xfffffffffffffffe /* -2 in signed 64bit */},

--- a/wasm/spectests/cases/call_indirect.wast
+++ b/wasm/spectests/cases/call_indirect.wast
@@ -42,15 +42,15 @@
 
   (table funcref
     (elem
-      $const-i32 $const-i64 $const-f32 $const-f64 ;; 4
-      $id-i32 $id-i64 $id-f32 $id-f64 ;; 8
-      $f32-i32 $i32-i64 $f64-f32 $i64-f64 ;; 12
-      $fac-i64 $fib-i64 $even $odd ;; 16
-      $runaway $mutual-runaway1 $mutual-runaway2 ;; 19
-      $over-i32-duplicate $over-i64-duplicate ;; 21
-      $over-f32-duplicate $over-f64-duplicate ;; 23
-      $fac-i32 $fac-f32 $fac-f64 ;; 26
-      $fib-i32 $fib-f32 $fib-f64 ;; 29
+      $const-i32 $const-i64 $const-f32 $const-f64
+      $id-i32 $id-i64 $id-f32 $id-f64
+      $f32-i32 $i32-i64 $f64-f32 $i64-f64
+      $fac-i64 $fib-i64 $even $odd
+      $runaway $mutual-runaway1 $mutual-runaway2
+      $over-i32-duplicate $over-i64-duplicate
+      $over-f32-duplicate $over-f64-duplicate
+      $fac-i32 $fac-f32 $fac-f64
+      $fib-i32 $fib-f32 $fib-f64
     )
   )
 

--- a/wasm/spectests/cases/call_indirect.wast
+++ b/wasm/spectests/cases/call_indirect.wast
@@ -42,15 +42,15 @@
 
   (table funcref
     (elem
-      $const-i32 $const-i64 $const-f32 $const-f64
-      $id-i32 $id-i64 $id-f32 $id-f64
-      $f32-i32 $i32-i64 $f64-f32 $i64-f64
-      $fac-i64 $fib-i64 $even $odd
-      $runaway $mutual-runaway1 $mutual-runaway2
-      $over-i32-duplicate $over-i64-duplicate
-      $over-f32-duplicate $over-f64-duplicate
-      $fac-i32 $fac-f32 $fac-f64
-      $fib-i32 $fib-f32 $fib-f64
+      $const-i32 $const-i64 $const-f32 $const-f64 ;; 4
+      $id-i32 $id-i64 $id-f32 $id-f64 ;; 8
+      $f32-i32 $i32-i64 $f64-f32 $i64-f64 ;; 12
+      $fac-i64 $fib-i64 $even $odd ;; 16
+      $runaway $mutual-runaway1 $mutual-runaway2 ;; 19
+      $over-i32-duplicate $over-i64-duplicate ;; 21
+      $over-f32-duplicate $over-f64-duplicate ;; 23
+      $fac-i32 $fac-f32 $fac-f64 ;; 26
+      $fib-i32 $fib-f32 $fib-f64 ;; 29
     )
   )
 

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -159,7 +159,7 @@ func (c command) expectedError() (err error) {
 	switch c.Text {
 	case "out of bounds memory access":
 		err = wasm.ErrRuntimeOutOfBoundsMemoryAccess
-	case "indirect call type mismatch", "indirect call" /* this is at line 152 in linking.wast*/ :
+	case "indirect call type mismatch", "indirect call":
 		err = wasm.ErrRuntimeIndirectCallTypeMismatch
 	case "undefined element", "undefined":
 		err = wasm.ErrRuntimeInvalidTableAcces

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -150,7 +150,7 @@ func (v commandActionVal) toUint64() uint64 {
 	}
 }
 
-// Returns the expected runtime errors when the command type equals assert_trap
+// Returns the expected runtime error when the command type equals assert_trap
 // which expectes engines to emit the errors corresponding command.Text field.
 func (c command) expectedError() (err error) {
 	if c.CommandType != "assert_trap" {

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -154,9 +154,9 @@ func (c command) expectedError() (err error) {
 	switch c.Text {
 	case "out of bounds memory access":
 		err = wasm.ErrRuntimeOutOfBoundsMemoryAccess
-	case "indirect call type mismatch":
+	case "indirect call type mismatch", "indirect call" /* this is at line 152 in linking.wast*/ :
 		err = wasm.ErrRuntimeIndirectCallTypeMismatch
-	case "undefined element":
+	case "undefined element", "undefined":
 		err = wasm.ErrRuntimeOutOfBoundsTableAcces
 	case "integer overflow":
 		err = wasm.ErrRuntimeIntegerOverflow

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -2,7 +2,6 @@ package spectests
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -366,8 +365,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 								msg += " in module " + c.Action.Module
 							}
 							_, _, err := store.CallFunction(moduleName, c.Action.Field, args...)
-							require.Error(t, err, msg)
-							require.True(t, errors.Is(err, wasm.ErrRuntimeCallStackOverflow), msg)
+							require.ErrorIs(t, err, wasm.ErrRuntimeCallStackOverflow, msg)
 						default:
 							t.Fatalf("unsupported action type type: %v", c)
 						}

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -157,7 +157,7 @@ func (c command) expectedError() (err error) {
 	case "indirect call type mismatch", "indirect call" /* this is at line 152 in linking.wast*/ :
 		err = wasm.ErrRuntimeIndirectCallTypeMismatch
 	case "undefined element", "undefined":
-		err = wasm.ErrRuntimeOutOfBoundsTableAcces
+		err = wasm.ErrRuntimeInvalidTableAcces
 	case "integer overflow":
 		err = wasm.ErrRuntimeIntegerOverflow
 	case "invalid conversion to integer":
@@ -168,7 +168,7 @@ func (c command) expectedError() (err error) {
 		err = wasm.ErrRuntimeUnreachable
 	default:
 		if strings.HasPrefix(c.Text, "uninitialized") {
-			err = wasm.ErrRuntimeOutOfBoundsTableAcces
+			err = wasm.ErrRuntimeInvalidTableAcces
 		}
 	}
 	return

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -150,7 +150,12 @@ func (v commandActionVal) toUint64() uint64 {
 	}
 }
 
+// Returns the expected runtime errors when the command type equals assert_trap
+// which expectes engines to emit the errors corresponding command.Text field.
 func (c command) expectedError() (err error) {
+	if c.CommandType != "assert_trap" {
+		panic("unreachable")
+	}
 	switch c.Text {
 	case "out of bounds memory access":
 		err = wasm.ErrRuntimeOutOfBoundsMemoryAccess

--- a/wasm/spectests/spec_test.go
+++ b/wasm/spectests/spec_test.go
@@ -150,7 +150,7 @@ func (v commandActionVal) toUint64() uint64 {
 	}
 }
 
-// Returns the expected runtime error when the command type equals assert_trap
+// expectedError returns the expected runtime error when the command type equals assert_trap
 // which expectes engines to emit the errors corresponding command.Text field.
 func (c command) expectedError() (err error) {
 	if c.CommandType != "assert_trap" {

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -1847,9 +1847,11 @@ func newTableInstance(min uint32, max *uint32) *TableInstance {
 	}
 	for i := range tableInst.Table {
 		tableInst.Table[i] = TableElement{
-			// We use math.MaxUint64 to represent the uninitialized elements.
-			FunctionAddress: math.MaxUint32,
+			FunctionTypeID: UninitializedTableElelemtTypeID,
 		}
 	}
 	return tableInst
 }
+
+// We use math.MaxUint64 to represent the uninitialized elements.
+var UninitializedTableElelemtTypeID FunctionTypeID = math.MaxUint64

--- a/wasm/wazeroir/interpreter.go
+++ b/wasm/wazeroir/interpreter.go
@@ -577,7 +577,7 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 		case OperationKindCallIndirect:
 			{
 				offset := it.pop()
-				if offset > uint64(len(table.Table)) {
+				if offset >= uint64(len(table.Table)) {
 					panic(wasm.ErrRuntimeOutOfBoundsTableAcces)
 				}
 				target, ok := it.functions[table.Table[offset].FunctionAddress]
@@ -640,8 +640,14 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 				base := op.us[1] + it.pop()
 				switch UnsignedType(op.b1) {
 				case UnsignedTypeI32, UnsignedTypeF32:
+					if uint64(len(memoryInst.Buffer)) < base+4 {
+						panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+					}
 					it.push(uint64(binary.LittleEndian.Uint32(memoryInst.Buffer[base:])))
 				case UnsignedTypeI64, UnsignedTypeF64:
+					if uint64(len(memoryInst.Buffer)) < base+8 {
+						panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+					}
 					it.push(binary.LittleEndian.Uint64(memoryInst.Buffer[base:]))
 				}
 				frame.pc++
@@ -649,6 +655,9 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 		case OperationKindLoad8:
 			{
 				base := op.us[1] + it.pop()
+				if uint64(len(memoryInst.Buffer)) < base+1 {
+					panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+				}
 				switch SignedInt(op.b1) {
 				case SignedInt32, SignedInt64:
 					it.push(uint64(int8(memoryInst.Buffer[base])))
@@ -660,6 +669,9 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 		case OperationKindLoad16:
 			{
 				base := op.us[1] + it.pop()
+				if uint64(len(memoryInst.Buffer)) < base+2 {
+					panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+				}
 				switch SignedInt(op.b1) {
 				case SignedInt32, SignedInt64:
 					it.push(uint64(int16(binary.LittleEndian.Uint16(memoryInst.Buffer[base:]))))
@@ -671,6 +683,9 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 		case OperationKindLoad32:
 			{
 				base := op.us[1] + it.pop()
+				if uint64(len(memoryInst.Buffer)) < base+4 {
+					panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+				}
 				if op.b1 == 1 {
 					it.push(uint64(int32(binary.LittleEndian.Uint32(memoryInst.Buffer[base:]))))
 				} else {
@@ -684,8 +699,14 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 				base := op.us[1] + it.pop()
 				switch UnsignedType(op.b1) {
 				case UnsignedTypeI32, UnsignedTypeF32:
+					if uint64(len(memoryInst.Buffer)) < base+4 {
+						panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+					}
 					binary.LittleEndian.PutUint32(memoryInst.Buffer[base:], uint32(val))
 				case UnsignedTypeI64, UnsignedTypeF64:
+					if uint64(len(memoryInst.Buffer)) < base+8 {
+						panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+					}
 					binary.LittleEndian.PutUint64(memoryInst.Buffer[base:], val)
 				}
 				frame.pc++
@@ -694,6 +715,9 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 			{
 				val := byte(it.pop())
 				base := op.us[1] + it.pop()
+				if uint64(len(memoryInst.Buffer)) < base+1 {
+					panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+				}
 				memoryInst.Buffer[base] = val
 				frame.pc++
 			}
@@ -701,6 +725,9 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 			{
 				val := uint16(it.pop())
 				base := op.us[1] + it.pop()
+				if uint64(len(memoryInst.Buffer)) < base+2 {
+					panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+				}
 				binary.LittleEndian.PutUint16(memoryInst.Buffer[base:], val)
 				frame.pc++
 			}
@@ -708,6 +735,9 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 			{
 				val := uint32(it.pop())
 				base := op.us[1] + it.pop()
+				if uint64(len(memoryInst.Buffer)) < base+4 {
+					panic(wasm.ErrRuntimeOutOfBoundsMemoryAccess)
+				}
 				binary.LittleEndian.PutUint32(memoryInst.Buffer[base:], val)
 				frame.pc++
 			}


### PR DESCRIPTION
This commit centralizes which runtime errors are possibly returned by engines, 
and document all of them on under which condition they occur.

Notably, now our spectest for `assert_trap` not only checks if the runtime returns error,
but also checks the type of error. This way, we can ensure that 
interpreter and JIT engines return exactly the same error for the same condition.
In order to achieve that, I found some discrepancies in the semantics between 
JIT and interpreter and resolved them. Notably, I refactored the code for division and 
remainder calculation in JIT so that they are alined with interpreter and spectests.

