### PR TITLE
Enforces uniqueness within symbolic indices

### DIFF
--- a/wasm/module.go
+++ b/wasm/module.go
@@ -1,7 +1,5 @@
 package wasm
 
-import "sort"
-
 // DecodeModule parses the configured source into a wasm.Module. This function returns when the source is exhausted or
 // an error occurs. The result can be initialized for use via Store.Instantiate.
 //
@@ -333,18 +331,6 @@ type NameMap []*NameAssoc
 type NameAssoc struct {
 	Index Index
 	Name  string
-}
-
-// NewNameMap constructs a new NameMap from the given name to index map and returns it ordered by index ascending.
-func NewNameMap(m map[string]Index) NameMap {
-	result := make(NameMap, 0, len(m))
-	for n, idx := range m {
-		result = append(result, &NameAssoc{Name: n, Index: idx})
-	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Index < result[j].Index
-	})
-	return result
 }
 
 // IndirectNameMap associates an index with an association of names.

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -1,5 +1,7 @@
 package wasm
 
+import "sort"
+
 // DecodeModule parses the configured source into a wasm.Module. This function returns when the source is exhausted or
 // an error occurs. The result can be initialized for use via Store.Instantiate.
 //
@@ -331,6 +333,20 @@ type NameMap []*NameAssoc
 type NameAssoc struct {
 	Index Index
 	Name  string
+}
+
+// NewNameMap constructs a new NameMap from the given name to index map and returns it ordered by index ascending.
+func NewNameMap(m map[string]Index) NameMap {
+	result := make(NameMap, len(m))
+	i := 0
+	for n, idx := range m {
+		result[i] = &NameAssoc{Name: n, Index: idx}
+		i++
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Index < result[j].Index
+	})
+	return result
 }
 
 // IndirectNameMap associates an index with an association of names.

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -337,11 +337,9 @@ type NameAssoc struct {
 
 // NewNameMap constructs a new NameMap from the given name to index map and returns it ordered by index ascending.
 func NewNameMap(m map[string]Index) NameMap {
-	result := make(NameMap, len(m))
-	i := 0
+	result := make(NameMap, 0, len(m))
 	for n, idx := range m {
-		result[i] = &NameAssoc{Name: n, Index: idx}
-		i++
+		result = append(result, &NameAssoc{Name: n, Index: idx})
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Index < result[j].Index

--- a/wasm/text/bind.go
+++ b/wasm/text/bind.go
@@ -2,6 +2,7 @@ package text
 
 import (
 	"fmt"
+
 	"github.com/tetratelabs/wazero/wasm"
 )
 
@@ -132,17 +133,16 @@ func checkIndexInRange(idx *index, count uint32, context string, contextArg0 int
 
 // mergeLocalNames produces wasm.NameSection LocalNames. This has to be done post-parse as types can be defined after
 // functions that use them.
-func mergeLocalNames(m *module, typeParamIDContext map[wasm.Index]idContext) wasm.IndirectNameMap {
+func mergeLocalNames(m *module, typeParamNames map[wasm.Index]wasm.NameMap) wasm.IndirectNameMap {
 	paramNames := m.names.LocalNames
 	j, jLen := 0, len(paramNames)
-	if typeParamIDContext == nil && jLen == 0 {
+	if typeParamNames == nil && jLen == 0 {
 		return nil
 	}
 
 	// Parameters can be named on the type, and overridden via a function. This loop collects the final name for each
 	// function's parameters regardless of if it is an imported function or module defined.
 	var result wasm.IndirectNameMap
-	typeParamNames := map[wasm.Index]wasm.NameMap{}
 	funcIndexSize := uint32(len(m.typeUses))
 	for i := uint32(0); i < funcIndexSize; i++ {
 		// Seek to see if we have any function-defined parameter names
@@ -159,15 +159,12 @@ func mergeLocalNames(m *module, typeParamIDContext map[wasm.Index]idContext) was
 
 		// Use any inlined names or default to any on the type
 		typeIndex := m.typeUses[i].typeIndex.numeric
-		typeNames, hasType := typeParamIDContext[typeIndex]
+		typeNames, hasType := typeParamNames[typeIndex]
 		var localNames wasm.NameMap
 		if inlinedNames == nil && !hasType {
 			continue
 		} else if inlinedNames == nil {
-			if localNames, hasType = typeParamNames[typeIndex]; !hasType {
-				localNames = wasm.NewNameMap(typeNames)
-				typeParamNames[typeIndex] = localNames
-			}
+			localNames = typeNames
 		} else {
 			// On conflict, choose the function names, as merge rules aren't defined in the specification. If there are
 			// names on the function, the user added them. They may not intend to inherit names they didn't define!

--- a/wasm/text/bind_test.go
+++ b/wasm/text/bind_test.go
@@ -400,7 +400,7 @@ func TestMergeLocalNames(t *testing.T) {
 	tests := []struct {
 		name                string
 		inputModule         *module
-		inputTypeParamNames map[wasm.Index]wasm.NameMap
+		inputTypeParamNames map[wasm.Index]idContext
 		expected            wasm.IndirectNameMap
 	}{
 		{
@@ -420,11 +420,11 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "wasi_snapshot_preview1", name: "args_get"}},
 				names:       &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
-				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}},
+			inputTypeParamNames: map[wasm.Index]idContext{
+				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -435,12 +435,12 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "wasi_snapshot_preview1", name: "args_get"}},
 				names: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
-						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 					},
 				},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -451,11 +451,11 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "", name: ""}, {module: "wasi_snapshot_preview1", name: "args_get"}},
 				names:       &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
-				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}},
+			inputTypeParamNames: map[wasm.Index]idContext{
+				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -466,12 +466,12 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "", name: ""}, {module: "wasi_snapshot_preview1", name: "args_get"}},
 				names: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
-						{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+						{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 					},
 				},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -482,15 +482,15 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "wasi_snapshot_preview1", name: "args_get"}},
 				names: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
-						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 					},
 				},
 			},
-			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
-				wasm.Index(1): {{Index: wasm.Index(0), Name: "x"}, {Index: wasm.Index(0), Name: "y"}},
+			inputTypeParamNames: map[wasm.Index]idContext{
+				wasm.Index(1): {"x": wasm.Index(0), "y": wasm.Index(1)},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -501,11 +501,11 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: localGet0End}},
 				names:    &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
-				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}},
+			inputTypeParamNames: map[wasm.Index]idContext{
+				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -516,12 +516,12 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: localGet0End}},
 				names: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
-						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 					},
 				},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -532,11 +532,11 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: end}, {Body: localGet0End}},
 				names:    &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
-				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}},
+			inputTypeParamNames: map[wasm.Index]idContext{
+				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -547,12 +547,12 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: end}, {Body: localGet0End}},
 				names: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
-						{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+						{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 					},
 				},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{
@@ -563,15 +563,15 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: localGet0End}},
 				names: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
-						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+						{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 					},
 				},
 			},
-			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
-				wasm.Index(1): {{Index: wasm.Index(0), Name: "x"}, {Index: wasm.Index(0), Name: "y"}},
+			inputTypeParamNames: map[wasm.Index]idContext{
+				wasm.Index(1): {"x": wasm.Index(0), "y": wasm.Index(1)},
 			},
 			expected: wasm.IndirectNameMap{
-				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(0), Name: "argv_buf"}}},
+				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
 			},
 		},
 		{

--- a/wasm/text/bind_test.go
+++ b/wasm/text/bind_test.go
@@ -400,7 +400,7 @@ func TestMergeLocalNames(t *testing.T) {
 	tests := []struct {
 		name                string
 		inputModule         *module
-		inputTypeParamNames map[wasm.Index]idContext
+		inputTypeParamNames map[wasm.Index]wasm.NameMap
 		expected            wasm.IndirectNameMap
 	}{
 		{
@@ -420,8 +420,8 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "wasi_snapshot_preview1", name: "args_get"}},
 				names:       &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]idContext{
-				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
+			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
+				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}},
 			},
 			expected: wasm.IndirectNameMap{
 				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
@@ -451,8 +451,8 @@ func TestMergeLocalNames(t *testing.T) {
 				importFuncs: []*importFunc{{module: "", name: ""}, {module: "wasi_snapshot_preview1", name: "args_get"}},
 				names:       &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]idContext{
-				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
+			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
+				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}},
 			},
 			expected: wasm.IndirectNameMap{
 				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
@@ -486,8 +486,8 @@ func TestMergeLocalNames(t *testing.T) {
 					},
 				},
 			},
-			inputTypeParamNames: map[wasm.Index]idContext{
-				wasm.Index(1): {"x": wasm.Index(0), "y": wasm.Index(1)},
+			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
+				wasm.Index(1): {{Index: wasm.Index(0), Name: "x"}, {Index: wasm.Index(0), Name: "y"}},
 			},
 			expected: wasm.IndirectNameMap{
 				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
@@ -501,8 +501,8 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: localGet0End}},
 				names:    &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]idContext{
-				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
+			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
+				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}},
 			},
 			expected: wasm.IndirectNameMap{
 				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
@@ -532,8 +532,8 @@ func TestMergeLocalNames(t *testing.T) {
 				code:     []*wasm.Code{{Body: end}, {Body: localGet0End}},
 				names:    &wasm.NameSection{},
 			},
-			inputTypeParamNames: map[wasm.Index]idContext{
-				wasm.Index(1): {"argv": wasm.Index(0), "argv_buf": wasm.Index(1)},
+			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
+				wasm.Index(1): {{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}},
 			},
 			expected: wasm.IndirectNameMap{
 				{Index: wasm.Index(1), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},
@@ -567,8 +567,8 @@ func TestMergeLocalNames(t *testing.T) {
 					},
 				},
 			},
-			inputTypeParamNames: map[wasm.Index]idContext{
-				wasm.Index(1): {"x": wasm.Index(0), "y": wasm.Index(1)},
+			inputTypeParamNames: map[wasm.Index]wasm.NameMap{
+				wasm.Index(1): {{Index: wasm.Index(0), Name: "x"}, {Index: wasm.Index(0), Name: "y"}},
 			},
 			expected: wasm.IndirectNameMap{
 				{Index: wasm.Index(0), NameMap: wasm.NameMap{{Index: wasm.Index(0), Name: "argv"}, {Index: wasm.Index(1), Name: "argv_buf"}}},

--- a/wasm/text/parser.go
+++ b/wasm/text/parser.go
@@ -83,20 +83,42 @@ type moduleParser struct {
 	indexParser *indexParser
 	funcParser  *funcParser
 
-	// typeNameToIndex is only used for resolving symbolic index names to numeric ones.
+	// typeIDContext resolves symbolic identifiers, such as "v_v" to a numeric index in wasm.Module TypeSection, such
+	// as '2'. Duplicate identifiers are not allowed by specification.
 	//
 	// Note: This is not encoded in the wasm.NameSection as there is no type name section in WebAssembly 1.0 (MVP)
-	typeNameToIndex map[string]wasm.Index
+	//
+	// See https://www.w3.org/TR/wasm-core-1/#text-context
+	typeIDContext idContext
 
-	// funcNameToIndex is only used for resolving symbolic index names to numeric ones. It contains any imported or
-	// module-defined function names and points to the function index which is preceded by imports.
+	// funcIDContext resolves symbolic identifiers, such as "main" to a numeric index in function index namespace, such
+	// as '2'. Duplicate identifiers are not allowed by specification.
+	//
+	// Note: the function index namespace starts with any wasm.ImportKindFunc in the wasm.Module TypeSection followed by
+	// the wasm.Module FunctionSection.
 	//
 	// Note: this should be updated alongside module.names FunctionNames
-	funcNameToIndex map[string]wasm.Index
+	//
+	// See https://www.w3.org/TR/wasm-core-1/#text-context
+	funcIDContext idContext
 
-	// typeParamNames are nil when no types had named (param) fields.
+	// typeParamIDContext resolves symbolic identifiers, such as "x" to a numeric index in locals namespace for each
+	// function that uses this type, yet doesn't override the symbolic IDs of the parameters.
+	//
+	// For example, given `(module (type) (type (func (param $x i32) (param i64) (param $y i32))`, the mapping would be
+	// 1 -> [{0, "x"}, {2, "y"}].
+	//
+	// Given the above mapping, if a function refers to the type alone, like `(func (type 1))`, the parameter IDs from
+	// the type become that function's locals context: [{0, "x"}, {2, "y"}]
+	//
+	// However, a type use can override IDS like this: `(func (type 1) (param $1 i32) (param $2 i64) (param $3 i32))`.
+	// In this case, the parameter IDs from the type are ignored. Ex. [{0, "1"}, {1, "2"}, {2, "3"}]
+	//
 	// Note: This is a map not a wasm.IndirectNameMap as late lookup is needed for after parsing
-	typeParamNames map[wasm.Index]wasm.NameMap
+	//
+	// See https://www.w3.org/TR/wasm-core-1/#text-functype
+	// See https://www.w3.org/TR/wasm-core-1/#type-uses%E2%91%A0
+	typeParamIDContext map[wasm.Index]idContext
 }
 
 // parse has the same signature as tokenParser and called by lex on each token.
@@ -114,8 +136,15 @@ func (p *moduleParser) parse(tok tokenType, tokenBytes []byte, line, col uint32)
 // * module is the result of parsing or nil on error
 // * err is a FormatError invoking the parser, dangling block comments or unexpected characters.
 func parseModule(source []byte) (*module, error) {
-	p := moduleParser{source: source, module: &module{names: &wasm.NameSection{}}, indexParser: &indexParser{}}
-	p.typeParser = &typeParser{m: &p}
+	p := moduleParser{
+		source:             source,
+		module:             &module{names: &wasm.NameSection{}},
+		indexParser:        &indexParser{},
+		typeIDContext:      idContext{}, // initialize contexts to reduce the amount of runtime nil checks
+		typeParamIDContext: map[wasm.Index]idContext{},
+		funcIDContext:      idContext{},
+	}
+	p.typeParser = &typeParser{m: &p, paramIDContext: idContext{}}
 	p.funcParser = &funcParser{m: &p, onBodyEnd: p.parseFuncEnd}
 
 	// A valid source must begin with the token '(', but it could be preceded by whitespace or comments. For this
@@ -130,13 +159,13 @@ func parseModule(source []byte) (*module, error) {
 	p.module.types = append(p.module.types, p.typeParser.inlinedTypes...)
 
 	// Ensure indices only point to numeric values
-	if err = bindIndices(p.module, p.typeNameToIndex, p.funcNameToIndex); err != nil {
+	if err = bindIndices(p.module, p.typeIDContext, p.funcIDContext); err != nil {
 		return nil, err
 	}
 
 	// Don't set the name section unless we found a name!
 	names := p.module.names
-	names.LocalNames = mergeLocalNames(p.module, p.typeParamNames)
+	names.LocalNames = mergeLocalNames(p.module, p.typeParamIDContext)
 	if names.ModuleName == "" && names.FunctionNames == nil && names.LocalNames == nil {
 		p.module.names = nil
 	}
@@ -178,14 +207,13 @@ func (p *moduleParser) beginField(tok tokenType, fieldName []byte, _, _ uint32) 
 		switch string(fieldName) {
 		case "type":
 			p.currentField = fieldModuleType
-			p.tokenParser = p.parseTypeName
+			p.tokenParser = p.parseTypeID
 		case "import":
 			p.currentField = fieldModuleImport
 			p.tokenParser = p.parseImportModule
 		case "func":
 			p.currentField = fieldModuleFunc
-			p.module.code = append(p.module.code, &wasm.Code{})
-			p.tokenParser = p.parseFuncName
+			p.tokenParser = p.parseFuncID
 		case "export":
 			p.currentField = fieldModuleExport
 			p.tokenParser = p.parseExportName
@@ -210,7 +238,7 @@ func (p *moduleParser) beginField(tok tokenType, fieldName []byte, _, _ uint32) 
 			})
 
 			p.currentField = fieldModuleImportFunc
-			p.tokenParser = p.parseImportFuncName
+			p.tokenParser = p.parseImportFuncID
 		} // TODO: table, memory or global
 	case fieldModuleExport:
 		// Add the next export func object and ready for parsing it.
@@ -268,7 +296,7 @@ func (p *moduleParser) parseModuleName(tok tokenType, tokenBytes []byte, line, c
 func (p *moduleParser) parseModule(tok tokenType, tokenBytes []byte, _, _ uint32) error {
 	switch tok {
 	case tokenID:
-		return fmt.Errorf("redundant name: %s", string(tokenBytes))
+		return fmt.Errorf("redundant ID %s", tokenBytes)
 	case tokenLParen:
 		p.tokenParser = p.beginField // after this look for a field name
 		return nil
@@ -280,20 +308,19 @@ func (p *moduleParser) parseModule(tok tokenType, tokenBytes []byte, _, _ uint32
 	return nil
 }
 
-// parseTypeName is the first parser inside a type field. This records the typeFunc.name if present or calls parseType
+// parseTypeID is the first parser inside a type field. This records the symbolic ID, if present, or calls parseType
 // if not found.
 //
-// Ex. A type name is present `(type $t0 (func (result i32)))`
-//                      records t0 --^   ^
-//              parseType resumes here --+
+// Ex. A type ID is present `(type $t0 (func (result i32)))`
+//                    records t0 --^   ^
+//            parseType resumes here --+
 //
-// Ex. No type name `(type (func (result i32)))`
-//       calls parseType --^
-func (p *moduleParser) parseTypeName(tok tokenType, tokenBytes []byte, line, col uint32) error {
+// Ex. No type ID `(type (func (result i32)))`
+//     calls parseType --^
+func (p *moduleParser) parseTypeID(tok tokenType, tokenBytes []byte, line, col uint32) error {
 	if tok == tokenID { // Ex. $v_v
-		p.currentValue0 = stripDollar(tokenBytes)
 		p.tokenParser = p.parseType
-		return nil
+		return p.setTypeID(tokenBytes)
 	}
 	return p.parseType(tok, tokenBytes, line, col)
 }
@@ -310,7 +337,7 @@ func (p *moduleParser) parseTypeName(tok tokenType, tokenBytes []byte, line, col
 func (p *moduleParser) parseType(tok tokenType, tokenBytes []byte, _, _ uint32) error {
 	switch tok {
 	case tokenID:
-		return errors.New("redundant name")
+		return fmt.Errorf("redundant ID %s", tokenBytes)
 	case tokenLParen: // start fields, ex. (func
 		// Err if there's a second func. Ex. (type (func) (func))
 		if uint32(len(p.module.types)) > p.currentTypeIndex {
@@ -355,26 +382,10 @@ func (p *moduleParser) parseTypeFunc(tok tokenType, tokenBytes []byte, line, col
 // the token is tokenRParen and sets the next parser to parseType on tokenRParen.
 func (p *moduleParser) parseTypeFuncEnd(tok tokenType, tokenBytes []byte, _, _ uint32) error {
 	if tok == tokenRParen {
-		sig, localNames := p.typeParser.getType()
-		idx := wasm.Index(len(p.module.types))
-
-		typeName := string(p.currentValue0)
-		if typeName != "" {
-			if p.typeNameToIndex == nil {
-				p.typeNameToIndex = map[string]wasm.Index{typeName: idx}
-			} else {
-				p.typeNameToIndex[typeName] = idx
-			}
+		sig, paramNames := p.typeParser.getType()
+		if paramNames != nil {
+			p.typeParamIDContext[p.currentTypeIndex] = paramNames
 		}
-
-		if localNames != nil {
-			if p.typeParamNames == nil {
-				p.typeParamNames = map[wasm.Index]wasm.NameMap{idx: localNames}
-			} else {
-				p.typeParamNames[idx] = localNames
-			}
-		}
-
 		p.module.types = append(p.module.types, sig)
 		p.currentValue0 = nil
 		p.currentField = fieldModuleType
@@ -467,33 +478,39 @@ func (p *moduleParser) parseImport(tok tokenType, tokenBytes []byte, _, _ uint32
 	return nil
 }
 
-// parseImportFuncName is the first parser inside an imported function field. This records the typeFunc.name if present
+// parseImportFuncID is the first parser inside an imported function field. This records the symbolic ID, if present,
 // and sets the next parser to parseImportFunc. If the token isn't a tokenID, this calls parseImportFunc.
 //
-// Ex. A function name is present `(import "Math" "PI" (func $math.pi (result f32))`
-//                                    records math.pi here --^
-//                                     parseImportFunc resumes here --^
+// Ex. A function ID is present `(import "Math" "PI" (func $math.pi (result f32))`
+//                                  records math.pi here --^
+//                                   parseImportFunc resumes here --^
 //
-// Ex. No function name `(import "Math" "PI" (func (result f32))`
-//                    calls parseImportFunc here --^
-func (p *moduleParser) parseImportFuncName(tok tokenType, tokenBytes []byte, line, col uint32) error {
+// Ex. No function ID `(import "Math" "PI" (func (result f32))`
+//                  calls parseImportFunc here --^
+func (p *moduleParser) parseImportFuncID(tok tokenType, tokenBytes []byte, line, col uint32) error {
 	if tok == tokenID { // Ex. $main
-		p.addFuncName(tokenBytes)
 		p.tokenParser = p.parseImportFunc
-		return nil
+		return p.setFuncID(tokenBytes)
 	}
 	return p.parseImportFunc(tok, tokenBytes, line, col)
 }
 
-// addFuncName adds the normalized ('$' stripped) function name to the parser cache and the wasm.NameSection.
-func (p *moduleParser) addFuncName(idToken []byte) {
-	na := &wasm.NameAssoc{Index: p.currentFuncIndex, Name: string(stripDollar(idToken))}
-	p.module.names.FunctionNames = append(p.module.names.FunctionNames, na)
-	if p.funcNameToIndex == nil {
-		p.funcNameToIndex = map[string]wasm.Index{na.Name: na.Index}
-	} else {
-		p.funcNameToIndex[na.Name] = na.Index
+// setTypeID adds the normalized ('$' stripped) type ID to the typeIDContext.
+func (p *moduleParser) setTypeID(idToken []byte) error {
+	idx := p.currentTypeIndex
+	_, err := p.typeIDContext.setID(idToken, idx)
+	return err
+}
+
+// setFuncID adds the normalized ('$' stripped) function ID to the funcIDContext and the wasm.NameSection.
+func (p *moduleParser) setFuncID(idToken []byte) error {
+	idx := p.currentFuncIndex
+	id, err := p.funcIDContext.setID(idToken, idx)
+	if err != nil {
+		return err
 	}
+	p.module.names.FunctionNames = append(p.module.names.FunctionNames, &wasm.NameAssoc{Index: idx, Name: id})
+	return nil
 }
 
 // parseImportFunc is the second parser inside the imported function field. This passes control to the typeParser until
@@ -501,15 +518,15 @@ func (p *moduleParser) addFuncName(idToken []byte) {
 //
 // Ex. `(import "Math" "PI" (func $math.pi (result f32)))`
 //                           starts here --^           ^
-//             parseImportFuncEnd resumes here --+
+//                   parseImportFuncEnd resumes here --+
 //
 // Ex. If there is no signature `(import "" "main" (func))`
-//               calls parseImportFuncEnd here ---^
+//                     calls parseImportFuncEnd here ---^
 func (p *moduleParser) parseImportFunc(tok tokenType, tokenBytes []byte, line, col uint32) error {
 	p.typeParser.reset() // reset now in case there is never a tokenLParen
 	switch tok {
 	case tokenID: // Ex. (func $main $main)
-		return fmt.Errorf("redundant name: %s", tokenBytes)
+		return fmt.Errorf("redundant ID %s", tokenBytes)
 	case tokenLParen:
 		p.typeParser.beginTypeUse(p.parseImportFuncEnd, p.parseImportFuncEnd) // start fields, ex. (param or (result
 		return nil
@@ -521,11 +538,11 @@ func (p *moduleParser) parseImportFunc(tok tokenType, tokenBytes []byte, line, c
 // and/or importFunc.typeInlined and sets the next parser to parseImport.
 func (p *moduleParser) parseImportFuncEnd(tok tokenType, tokenBytes []byte, _, _ uint32) error {
 	if tok == tokenRParen {
-		tu, paramNames := p.typeParser.getTypeUse()
+		tu, paramIDs := p.typeParser.getTypeUse()
 		p.module.typeUses = append(p.module.typeUses, tu)
-		if paramNames != nil {
-			p.module.names.LocalNames =
-				append(p.module.names.LocalNames, &wasm.NameMapAssoc{Index: p.currentFuncIndex, NameMap: paramNames})
+		if paramIDs != nil {
+			na := &wasm.NameMapAssoc{Index: p.currentFuncIndex, NameMap: wasm.NewNameMap(paramIDs)}
+			p.module.names.LocalNames = append(p.module.names.LocalNames, na)
 		}
 		p.currentField = fieldModuleImport
 		p.tokenParser = p.parseImport
@@ -534,20 +551,19 @@ func (p *moduleParser) parseImportFuncEnd(tok tokenType, tokenBytes []byte, _, _
 	return unexpectedToken(tok, tokenBytes)
 }
 
-// parseFuncName is the first parser inside a function field. This records the function name if present and sets the
-// next parser to parseFunc. If the token isn't a tokenID, this calls parseFunc.
+// parseFuncID is the first parser inside a function field. This records the function ID, if present, and sets the next
+// parser to parseFunc. If the token isn't a tokenID, this calls parseFunc.
 //
-// Ex. A function name is present `(module (func $math.pi (result f32))`
-//                        records math.pi here --^
-//                               parseFunc resumes here --^
+// Ex. A function ID is present `(module (func $math.pi (result f32))`
+//                      records math.pi here --^
+//                             parseFunc resumes here --^
 //
-// Ex. No function name `(module (func (result f32))`
-//              calls parseFunc here --^
-func (p *moduleParser) parseFuncName(tok tokenType, tokenBytes []byte, line, col uint32) error {
+// Ex. No function ID `(module (func (result f32))`
+//            calls parseFunc here --^
+func (p *moduleParser) parseFuncID(tok tokenType, tokenBytes []byte, line, col uint32) error {
 	if tok == tokenID { // Ex. $main
-		p.addFuncName(tokenBytes)
 		p.tokenParser = p.parseFunc
-		return nil
+		return p.setFuncID(tokenBytes)
 	}
 	return p.parseFunc(tok, tokenBytes, line, col)
 }
@@ -570,7 +586,7 @@ func (p *moduleParser) parseFunc(tok tokenType, tokenBytes []byte, line, col uin
 	p.typeParser.reset() // reset now in case there is never a tokenLParen
 	switch tok {
 	case tokenID: // Ex. (func $main $main)
-		return fmt.Errorf("redundant name: %s", tokenBytes)
+		return fmt.Errorf("redundant ID %s", tokenBytes)
 	case tokenLParen: // start fields, ex. (local or (i32.const
 		p.typeParser.beginTypeUse(p.parseFuncBody, p.parseFuncBodyField)
 		return nil
@@ -590,15 +606,16 @@ func (p *moduleParser) parseFuncBodyField(tok tokenType, tokenBytes []byte, line
 // and/or Func.typeInlined and sets the next parser to parse.
 func (p *moduleParser) parseFuncEnd(tok tokenType, tokenBytes []byte, _, _ uint32) error {
 	if tok == tokenRParen {
-		tu, paramNames := p.typeParser.getTypeUse()
+		tu, paramIDs := p.typeParser.getTypeUse()
 		p.module.typeUses = append(p.module.typeUses, tu)
-		if paramNames != nil {
-			p.module.names.LocalNames =
-				append(p.module.names.LocalNames, &wasm.NameMapAssoc{Index: p.currentFuncIndex, NameMap: paramNames})
+		p.module.code = append(p.module.code, &wasm.Code{Body: p.funcParser.getBody()})
+
+		// TODO: locals and also check they don't conflict with parameter IDs on the type use
+		// Note: locals may be unverifiable wrt ID collision if the type isn't known, yet (ex func before type)
+		if paramIDs != nil {
+			na := &wasm.NameMapAssoc{Index: p.currentFuncIndex, NameMap: wasm.NewNameMap(paramIDs)}
+			p.module.names.LocalNames = append(p.module.names.LocalNames, na)
 		}
-		code := p.module.code[p.currentFuncIndex-uint32(len(p.module.importFuncs))]
-		// TODO: localTypes
-		code.Body = p.funcParser.getBody()
 
 		// Multiple funcs are allowed, so advance in case there's a next.
 		p.currentFuncIndex++

--- a/wasm/text/type_parser.go
+++ b/wasm/text/type_parser.go
@@ -67,28 +67,29 @@ type typeParser struct {
 	// See https://www.w3.org/TR/wasm-core-1/#type-uses%E2%91%A0
 	currentTypeIndex *index
 
-	// currentParams allow us to accumulate typeFunc.params across multiple fields, as well support abbreviated
+	// currentParams allow us to accumulate wasm.FunctionType Params across multiple fields, as well support abbreviated
 	// anonymous parameters. ex. both (param i32) (param i32) and (param i32 i32) formats.
 	// See https://www.w3.org/TR/wasm-core-1/#abbreviations%E2%91%A2
 	currentParams []wasm.ValueType
 
-	// currentParamNames accumulates any typeFunc.params for the current type. Ex. $x names (param $x i32)
+	// paramIDContext accumulates any symbolic identifier to numeric index mappings for the currentParams.
+	// Ex. x is the symbolic ID, and name, of the parameter (param $x i32)
 	//
-	// Note: names can be missing because they were never assigned, ex. (param i32), or due to abbreviated format which
-	// does not support names. Ex. (param i32 i32)
+	// Note: IDs can be missing because they were never assigned, ex. (param i32), or due to abbreviated format which
+	// does not support it. Ex. (param i32 i32)
 	// See https://www.w3.org/TR/wasm-core-1/#abbreviations%E2%91%A2
-	currentParamNames wasm.NameMap
+	paramIDContext idContext
 
 	// currentParamField is a field index and used to give an appropriate errorContext. Due to abbreviation it may be
 	// unrelated to the length of currentParams
-	currentParamField uint32
-
-	// currentLocalName is the name of the currentParamField, added on tokenRParen to currentParamNames
-	currentLocalName []byte
+	currentParamField wasm.Index
 
 	// foundParam allows us to check if we found a type in a "param" field. We can't use currentParamField because when
 	// parameters are abbreviated, ex. (param i32 i32), the currentParamField will be less than the type count.
 	foundParam bool
+
+	// foundID is true when the field at currentParamField had an ID. Ex. (param $x i32)
+	foundID bool
 
 	// currentResults is empty until set, and only set once as WebAssembly 1.0 only supports up to one result.
 	currentResults []wasm.ValueType
@@ -158,7 +159,9 @@ func (p *typeParser) beginType(onTypeEnd tokenParser) {
 func (p *typeParser) reset() {
 	p.currentTypeIndex = nil
 	p.currentParams = nil
-	p.currentParamNames = nil
+	if len(p.paramIDContext) > 0 {
+		p.paramIDContext = idContext{}
+	}
 	p.currentParamField = 0
 	p.currentResults = nil
 }
@@ -176,9 +179,8 @@ func (p *typeParser) beginParamOrResult(tok tokenType, tokenBytes []byte, line, 
 		switch string(tokenBytes) {
 		case "param":
 			p.state = parsingParam
-			p.foundParam = false
-			p.currentLocalName = nil
-			p.m.tokenParser = p.parseParamName
+			p.foundParam, p.foundID = false, false
+			p.m.tokenParser = p.parseParamID
 			return nil
 		case "result":
 			p.state = parsingResult
@@ -204,22 +206,31 @@ func (p *typeParser) parseMoreParamsOrResult(tok tokenType, tokenBytes []byte, l
 	return p.onTypeEnd(tok, tokenBytes, line, col)
 }
 
-// parseParamName is the first parser inside a param field. This records the name if present or calls parseParam if not
+// parseParamID is the first parser inside a param field. This records the ID if present or calls parseParam if not
 // found.
 //
-// Ex. A param name is present `(param $x i32)`
-//                         records x --^  ^
-//              parseParam resumes here --+
+// Ex. A param ID is present `(param $x i32)`
+//                       records x --^  ^
+//            parseParam resumes here --+
 //
-// Ex. No param name `(param i32)`
-//        calls parseParam --^
-func (p *typeParser) parseParamName(tok tokenType, tokenBytes []byte, line, col uint32) error {
+// Ex. No param ID `(param i32)`
+//      calls parseParam --^
+func (p *typeParser) parseParamID(tok tokenType, tokenBytes []byte, line, col uint32) error {
 	if tok == tokenID { // Ex. $len
-		p.currentLocalName = stripDollar(tokenBytes)
+		p.foundID = true
 		p.m.tokenParser = p.parseParam
-		return nil
+		return p.setParamID(tokenBytes)
 	}
 	return p.parseParam(tok, tokenBytes, line, col)
+}
+
+// setParamID adds the normalized ('$' stripped) parameter ID to the paramIDContext and the wasm.NameSection.
+func (p *typeParser) setParamID(idToken []byte) error {
+	// Note: currentParamField is the index of the param field, but due to mixing and matching of abbreviated params
+	// it can be less than the param index. Ex. (param i32 i32) (param $v i32) is param field 2, but the 3rd param.
+	idx := wasm.Index(len(p.currentParams))
+	_, err := p.paramIDContext.setID(idToken, idx)
+	return err
 }
 
 // parseParam is the last parser inside the param field. This records value type and continues if it is an abbreviated
@@ -238,14 +249,14 @@ func (p *typeParser) parseParamName(tok tokenType, tokenBytes []byte, line, col 
 func (p *typeParser) parseParam(tok tokenType, tokenBytes []byte, _, _ uint32) error {
 	switch tok {
 	case tokenID: // Ex. $len
-		return errors.New("redundant name")
+		return fmt.Errorf("redundant ID %s", tokenBytes)
 	case tokenKeyword: // Ex. i32
 		vt, err := parseValueType(tokenBytes)
 		if err != nil {
 			return err
 		}
-		if p.foundParam && p.currentLocalName != nil {
-			return errors.New("cannot name parameters in abbreviated form")
+		if p.foundParam && p.foundID {
+			return errors.New("cannot assign IDs to parameters in abbreviated form")
 		}
 		p.currentParams = append(p.currentParams, vt)
 		p.foundParam = true
@@ -253,16 +264,6 @@ func (p *typeParser) parseParam(tok tokenType, tokenBytes []byte, _, _ uint32) e
 		if !p.foundParam {
 			return errors.New("expected a type")
 		}
-
-		// Note: currentParamField is the index of the param field, but due to mixing and matching of abbreviated params
-		// it can be less than the param index. Ex. (param i32 i32) (param $v i32) is param field 2, but the 3rd param.
-		if p.currentLocalName != nil {
-			p.currentParamNames = append(p.currentParamNames, &wasm.NameAssoc{
-				Index: uint32(len(p.currentParams) - 1),
-				Name:  string(p.currentLocalName),
-			})
-		}
-
 		// since multiple param fields are valid, ex `(func (param i32) (param i64))`, prepare for any next.
 		p.currentParamField++
 		p.state = parsingParamOrResult
@@ -314,9 +315,11 @@ var typeFuncEmpty = &wasm.FunctionType{}
 
 // getTypeUse finalizes any current params or result and returns the current typeIndex and/or type. localNames are only
 // returned if defined inline.
-func (p *typeParser) getTypeUse() (ty *typeUse, paramNames wasm.NameMap) {
+func (p *typeParser) getTypeUse() (ty *typeUse, paramIDs map[string]wasm.Index) {
 	ty = &typeUse{typeIndex: p.currentTypeIndex}
-	paramNames = p.currentParamNames
+	if len(p.paramIDContext) > 0 {
+		paramIDs = p.paramIDContext
+	}
 
 	// Don't conflate lack of verification type with nullary
 	if ty.typeIndex != nil && funcTypeEquals(typeFuncEmpty, p.currentParams, p.currentResults) {
@@ -360,8 +363,10 @@ func funcTypeEquals(f *wasm.FunctionType, params []wasm.ValueType, results []was
 // getType finalizes any current params or result and returns the current type and any paramNames for it.
 //
 // If the current type is in typeParser.inlinedTypes, it is removed prior to returning.
-func (p *typeParser) getType() (sig *wasm.FunctionType, paramNames wasm.NameMap) {
-	paramNames = p.currentParamNames
+func (p *typeParser) getType() (sig *wasm.FunctionType, paramIDs map[string]wasm.Index) {
+	if len(p.paramIDContext) > 0 {
+		paramIDs = p.paramIDContext
+	}
 
 	// Search inlined types in case a matching type was found after its type use.
 	for i, t := range p.inlinedTypes {

--- a/wasm/text/types.go
+++ b/wasm/text/types.go
@@ -87,8 +87,19 @@ type index struct {
 	col uint32
 }
 
+// idContext is an association of symbolic IDs to numeric indices.
+//
+// The Web Assembly Text Format allows use of symbolic identifiers, ex "$main", instead of numeric indices for most
+// sections, notably types, functions and parameters. For example, if a function is defined with the tokenID "$main",
+// the start section can use that symbolic ID instead of its numeric offset in the code section. These IDs require two
+// features, uniqueness and lookup, as implemented with a map. The key is stripped of the leading '$' to match other
+// tools, as described in stripDollar
+//
+// See https://www.w3.org/TR/wasm-core-1/#text-context
 type idContext map[string]wasm.Index
 
+// setID ensures the given tokenID is unique within this context and raises an error if not. The resulting mapping is
+// stripped of the leading '$' to match other tools, as described in stripDollar.
 func (ctx idContext) setID(idToken []byte, idx uint32) (string, error) {
 	id := string(stripDollar(idToken))
 	if _, ok := ctx[id]; ok {

--- a/wasm/text/types.go
+++ b/wasm/text/types.go
@@ -87,6 +87,17 @@ type index struct {
 	col uint32
 }
 
+type idContext map[string]wasm.Index
+
+func (ctx idContext) setID(idToken []byte, idx uint32) (string, error) {
+	id := string(stripDollar(idToken))
+	if _, ok := ctx[id]; ok {
+		return id, fmt.Errorf("duplicate ID %s", idToken)
+	}
+	ctx[id] = idx
+	return id, nil
+}
+
 // importFunc corresponds to the text format of a WebAssembly function import.
 //
 // Note: the type usage of this import is at module.typeUses the same index as module.importFuncs

--- a/wasm/text/types_test.go
+++ b/wasm/text/types_test.go
@@ -5,7 +5,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/wazero/wasm"
 )
+
+func TestIdContext_SetId(t *testing.T) {
+	ctx := idContext{}
+	t.Run("set when empty", func(t *testing.T) {
+		id, err := ctx.setID([]byte("$x"), wasm.Index(0))
+		require.NoError(t, err)
+		require.Equal(t, "x", id) // strips "$" to be like the name section
+		require.Equal(t, idContext{"x": wasm.Index(0)}, ctx)
+	})
+	t.Run("set when exists fails", func(t *testing.T) {
+		_, err := ctx.setID([]byte("$x"), wasm.Index(0))
+		require.EqualError(t, err, "duplicate ID $x")        // keeps the original $ prefix
+		require.Equal(t, idContext{"x": wasm.Index(0)}, ctx) // no change
+	})
+}
 
 func TestFormatError_Error(t *testing.T) {
 	t.Run("with context", func(t *testing.T) {


### PR DESCRIPTION
> An identifier context is well-formed if no index space contains duplicate identifiers.

We weren't checking this, and now we are!. This comes at a cost, though,
but I don't see a good alternative to initializing maps wrt uniqueness.

```
BenchmarkCodecExample/text.DecodeModule
BenchmarkCodecExample/text.DecodeModule-16           	   78700	     14460 ns/op	    7328 B/op	     323 allocs/op
```

After
```
BenchmarkCodecExample/text.DecodeModule
BenchmarkCodecExample/text.DecodeModule-16           	   74214	     16921 ns/op	    8288 B/op	     333 allocs/op
```

See https://www.w3.org/TR/wasm-core-1/#text-context