### PR TITLE
jit: refactor calling convention for less instructions in function calls

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -77,7 +77,7 @@ func runBase64Benches(b *testing.B, store *wasm.Store) {
 }
 
 func runFibBenches(b *testing.B, store *wasm.Store) {
-	for _, num := range []int{5, 10, 20} {
+	for _, num := range []int{5, 10, 20, 30} {
 		num := num
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("fib_for_%d", num), func(b *testing.B) {

--- a/wasm/jit/engine_test.go
+++ b/wasm/jit/engine_test.go
@@ -57,7 +57,6 @@ func TestVerifyOffsetValue(t *testing.T) {
 	var compiledFunc compiledFunction
 	require.Equal(t, int(unsafe.Offsetof(compiledFunc.codeInitialAddress)), compiledFunctionCodeInitialAddressOffset)
 	require.Equal(t, int(unsafe.Offsetof(compiledFunc.maxStackPointer)), compiledFunctionMaxStackPointerOffset)
-	require.Equal(t, int(unsafe.Offsetof(compiledFunc.moduleInstanceAddress)), compiledFunctionModuleInstanceAddressOffset)
 
 	// Offsets for wasm.TableElement.
 	var tableElement wasm.TableElement

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -5039,7 +5039,7 @@ func (c *amd64Compiler) returnFunction() error {
 		c.addInstruction(putReturnStackBasePointer)
 	}
 
-	// 3) Jump into the address of "ra.caller".
+	// 2) Jump into the address of "ra.caller".
 	{
 		readReturnAddress := c.newProg()
 		readReturnAddress.As = x86.AMOVQ
@@ -5198,7 +5198,7 @@ func (c *amd64Compiler) readInstructionAddress(destinationRegister int16, before
 		// Now we can calculate the "offset" in the LEA instruction.
 		offset := uint32(target.Pc) - uint32(base.Pc)
 
-		// Replace the place holder bytes by the actual offset.
+		// Replace the placeholder bytes by the actual offset.
 		binary.LittleEndian.PutUint32(code[readInstructionAddress.Pc+3:], offset)
 
 		// See the comment at readInstructionAddress.From.Reg above. Here we drop the most significant bit of the third byte of the LEA instruction.
@@ -5423,7 +5423,7 @@ func (c *amd64Compiler) initializeModuleContext() error {
 	c.addInstruction(readModuleInstanceAddress)
 
 	// If the module instance address stays the same, we could skip the entire code below.
-	// The rationale/idea for this is that, in almost all use cases, users inistantiate single
+	// The rationale/idea for this is that, in almost all use cases, users instantiate a single
 	// Wasm binary and run the functions from it, rather than doing import/export on multiple
 	// binaries. As a result, this cmp and jmp instruction sequence below must be easy for
 	// x64 CPU to do branch prediction since almost 100% jump happens across function calls.

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -796,7 +796,7 @@ func (c *amd64Compiler) compileBrTable(o *wazeroir.OperationBrTable) error {
 
 	// Now we read the address of the beginning of the jump table.
 	// In the above example, this corresponds to reading the address of 0x123001.
-	readInstructionAddressCompletionCallBack := c.readInstructionAddress(tmp)
+	c.readInstructionAddress(tmp, obj.AJMP)
 
 	// Now we have the address of L0 in tmp register, and the offset to the target label in the index.register.
 	// So we could achieve the br_table jump by adding them and jump into the resulting address.
@@ -850,8 +850,6 @@ func (c *amd64Compiler) compileBrTable(o *wazeroir.OperationBrTable) error {
 			return err
 		}
 	}
-
-	readInstructionAddressCompletionCallBack(calcAbsoluteAddressOfSelectedLabel, labelInitialInstructions[0])
 
 	// Set up the callbacks to do tasks which cannot be done at the compilation phase.
 	c.onGenerateCallbacks = append(c.onGenerateCallbacks, func(code []byte) error {
@@ -4737,8 +4735,7 @@ func (c *amd64Compiler) callFunction(addr wasm.FunctionAddress, addrReg int16, f
 	//   1) Set rb.1 so that we can return back to this function properly.
 	//   2) Set engine.valueStackContext.stackBasePointer for the next function.
 	//   3) Set rc.next to specify which function is executed on the current call frame (needs to make builtin function calls).
-	//   4) Set engine.moduleContext.moduleInstanceAddress for the next function.
-	//   5) Set ra.1 so that we can return back to this function properly.
+	//   4) Set ra.1 so that we can return back to this function properly.
 
 	// First, read the address corresponding to tmpRegister+callFrameStackPointerRegister
 	// by LEA instruction which equals the address of call frame stack top.
@@ -4828,6 +4825,7 @@ func (c *amd64Compiler) callFunction(addr wasm.FunctionAddress, addrReg int16, f
 			readCompiledFunctionAddressAddress.From.Index = addrReg
 			readCompiledFunctionAddressAddress.From.Scale = 8 // because the size of *compiledFunction equals 8 bytes.
 		} else {
+			// TODO: rethink on this since if addr*8 >= math.MaxUint32, then this instruction is invalid.
 			readCompiledFunctionAddressAddress.From.Offset = int64(addr) * 8 // because the size of *compiledFunction equals 8 bytes.
 		}
 		c.addInstruction(readCompiledFunctionAddressAddress)
@@ -4844,34 +4842,11 @@ func (c *amd64Compiler) callFunction(addr wasm.FunctionAddress, addrReg int16, f
 		c.addInstruction(putCompiledFunctionFunctionAddressOnNewCallFrame)
 	}
 
-	// 4) Set engine.moduleContext.moduleInstanceAddress for the next function.
-	{
-		// Also, we have to set engine.moduleContext.ModuleInstance as
-		// it is the caller's responsibility to set the field.
-		readTargetFunctionModuleInstanceAddress := c.newProg()
-		readTargetFunctionModuleInstanceAddress.As = x86.AMOVQ
-		readTargetFunctionModuleInstanceAddress.To.Type = obj.TYPE_REG
-		readTargetFunctionModuleInstanceAddress.To.Reg = tmpRegister
-		readTargetFunctionModuleInstanceAddress.From.Type = obj.TYPE_MEM
-		readTargetFunctionModuleInstanceAddress.From.Reg = compiledFunctionAddressRegister
-		readTargetFunctionModuleInstanceAddress.From.Offset = compiledFunctionModuleInstanceAddressOffset
-		c.addInstruction(readTargetFunctionModuleInstanceAddress)
-
-		setEngineModuleInstanceAddress := c.newProg()
-		setEngineModuleInstanceAddress.As = x86.AMOVQ
-		setEngineModuleInstanceAddress.From.Type = obj.TYPE_REG
-		setEngineModuleInstanceAddress.From.Reg = tmpRegister
-		setEngineModuleInstanceAddress.To.Type = obj.TYPE_MEM
-		setEngineModuleInstanceAddress.To.Reg = reservedRegisterForEngine
-		setEngineModuleInstanceAddress.To.Offset = engineModuleContextModuleInstanceAddressOffset
-		c.addInstruction(setEngineModuleInstanceAddress)
-	}
-
-	// 5) Set ra.1 so that we can return back to this function properly.
+	// 4) Set ra.1 so that we can return back to this function properly.
 	//
 	// We have to set the return address for the current call frame (which is "ra.1" in the example).
 	// First, Get the return address into the tmpRegister.
-	readInstructionAddressCompletionCallBack := c.readInstructionAddress(tmpRegister)
+	c.readInstructionAddress(tmpRegister, obj.AJMP)
 
 	// Now we are ready to set the return address to the current call frame.
 	// This is equivalent to set "ra.1" in the example.
@@ -4901,17 +4876,6 @@ func (c *amd64Compiler) callFunction(addr wasm.FunctionAddress, addrReg int16, f
 	jmpToTargetFunction.To.Reg = compiledFunctionAddressRegister
 	jmpToTargetFunction.To.Offset = compiledFunctionCodeInitialAddressOffset
 	c.addInstruction(jmpToTargetFunction)
-
-	// In order to finalize the setting return address ("ra.1"), we need to have
-	// the instruction AFTER jmp into the target function. We emit the NOP here
-	// because in anyway this is skipped after assemble.
-	nopAfterJmpToNewFunction := c.newProg()
-	nopAfterJmpToNewFunction.As = obj.ANOP
-	c.addInstruction(nopAfterJmpToNewFunction)
-
-	// Now we are ready to complete the instruction for reading instruction address of after jmp instruction.
-	// See the comment of readInstructionAddress function for arguments.
-	readInstructionAddressCompletionCallBack(setReturnAddress, nopAfterJmpToNewFunction)
 
 	// All the registers used are temporary so we mark them unused.
 	c.locationStack.markRegisterUnused(
@@ -4950,7 +4914,7 @@ func (c *amd64Compiler) returnFunction() error {
 	}
 
 	// Obtain the temporary registers to be used in the followings.
-	regs, found := c.locationStack.takeFreeRegisters(generalPurposeRegisterTypeInt, 4)
+	regs, found := c.locationStack.takeFreeRegisters(generalPurposeRegisterTypeInt, 3)
 	if !found {
 		// This in theory never happen as all the registers must be free except addrReg.
 		return fmt.Errorf("could not find enough free registers")
@@ -4958,8 +4922,7 @@ func (c *amd64Compiler) returnFunction() error {
 	c.locationStack.markRegisterUsed(regs...)
 
 	// Alias these free tmp registers for readability.
-	decrementedCallFrameStackPointerRegister, callFrameStackTopAddressRegister,
-		moduleInstanceAddressRegister, tmpRegister := regs[0], regs[1], regs[2], regs[3]
+	decrementedCallFrameStackPointerRegister, callFrameStackTopAddressRegister, tmpRegister := regs[0], regs[1], regs[2]
 
 	// Since we return from the function, we need to decement the callframe stack pointer.
 	decCallFrameStackPointer := c.newProg()
@@ -5052,8 +5015,7 @@ func (c *amd64Compiler) returnFunction() error {
 	//
 	// What we have to do in the following is that
 	//   1) Set engine.valueStackContext.stackBasePointer to the value on "rb.caller".
-	//   2) Set engine.moduleContext.moduleInstanceAddress to the one stored in "rc.caller".
-	//   3) Jump into the address of "ra.caller".
+	//   2) Jump into the address of "ra.caller".
 
 	// 1) Set engine.valueStackContext.stackBasePointer to the value on "rb.caller"
 	{
@@ -5075,40 +5037,6 @@ func (c *amd64Compiler) returnFunction() error {
 		putReturnStackBasePointer.From.Type = obj.TYPE_REG
 		putReturnStackBasePointer.From.Reg = tmpRegister
 		c.addInstruction(putReturnStackBasePointer)
-	}
-
-	// 2) Set engine.moduleContext.moduleInstanceAddress to the one stored in "rc.caller".
-	{
-		readCompiledFunctionAddress := c.newProg()
-		readCompiledFunctionAddress.As = x86.AMOVQ
-		readCompiledFunctionAddress.To.Type = obj.TYPE_REG
-		readCompiledFunctionAddress.To.Reg = tmpRegister
-		readCompiledFunctionAddress.From.Type = obj.TYPE_MEM
-		readCompiledFunctionAddress.From.Reg = callFrameStackTopAddressRegister
-		// "rc.caller" is BELOW the top address. See the above example for detail.
-		readCompiledFunctionAddress.From.Offset = -(callFrameDataSize - callFrameCompiledFunctionOffset)
-		c.addInstruction(readCompiledFunctionAddress)
-
-		// At this point, tmpRegister holds the caller's *compiledFunction,
-		// so we are ready to read the address of the caller's module instance
-		// stored at compiledFunction.ModuleInstanceAddress.
-		readModuleInstanceAddress := c.newProg()
-		readModuleInstanceAddress.As = x86.AMOVQ
-		readModuleInstanceAddress.To.Type = obj.TYPE_REG
-		readModuleInstanceAddress.To.Reg = moduleInstanceAddressRegister
-		readModuleInstanceAddress.From.Type = obj.TYPE_MEM
-		readModuleInstanceAddress.From.Reg = tmpRegister
-		readModuleInstanceAddress.From.Offset = compiledFunctionModuleInstanceAddressOffset
-		c.addInstruction(readModuleInstanceAddress)
-
-		putModuleInstanceAddressToEngine := c.newProg()
-		putModuleInstanceAddressToEngine.As = x86.AMOVQ
-		putModuleInstanceAddressToEngine.To.Type = obj.TYPE_MEM
-		putModuleInstanceAddressToEngine.To.Reg = reservedRegisterForEngine
-		putModuleInstanceAddressToEngine.To.Offset = engineModuleContextModuleInstanceAddressOffset
-		putModuleInstanceAddressToEngine.From.Type = obj.TYPE_REG
-		putModuleInstanceAddressToEngine.From.Reg = moduleInstanceAddressRegister
-		c.addInstruction(putModuleInstanceAddressToEngine)
 	}
 
 	// 3) Jump into the address of "ra.caller".
@@ -5205,7 +5133,7 @@ func (c *amd64Compiler) callGoFunction(jitStatus jitCallStatusCode, addr wasm.Fu
 	readCurrentCallFrameReturnAddress.From.Offset = -(callFrameDataSize - callFrameReturnAddressOffset)
 	c.addInstruction(readCurrentCallFrameReturnAddress)
 
-	readInstructionAddressCompletionCallback := c.readInstructionAddress(ripRegister)
+	c.readInstructionAddress(ripRegister, obj.ARET)
 
 	// We are ready to store the return address (in ripRegister) to engine.callFrameStack[engine.callStackFramePointer-1].
 	moveRIP := c.newProg()
@@ -5220,22 +5148,16 @@ func (c *amd64Compiler) callGoFunction(jitStatus jitCallStatusCode, addr wasm.Fu
 	// Emit the return instruction.
 	c.exit(jitStatus)
 
-	nopAfterReturnInst := c.newProg()
-	nopAfterReturnInst.As = obj.ANOP
-	c.addInstruction(nopAfterReturnInst)
-
-	readInstructionAddressCompletionCallback(moveRIP, nopAfterReturnInst)
-
 	// They were temporarily used, so we mark them unused.
 	c.locationStack.markRegisterUnused(regs...)
 	return nil
 }
 
-// readInstructionAddress adds the instruction to read the target instruction's absolute address into the destinationRegister.
-// At the callsite, the returned callback must be called with two arguments:
-// instructionAfterReadInstruction is the instruction added *right after* calling this readInstructionAddress function.
-// addressAcquisitionTargetInstruction  is the instruction we want to get the absolute address.
-func (c *amd64Compiler) readInstructionAddress(destinationRegister int16) func(instructionAfterReadInstruction, addressAcquisitionTargetInstruction *obj.Prog) {
+// readInstructionAddress add a LEA instruction to read the target instruction's absolute address into the destinationRegister.
+// beforeAcquisitionTargetInstruction is the instruction kind (e.g. RET, JMP, etc.) right before the instruction
+// of which the callsite wants to aquire the absolute address.
+func (c *amd64Compiler) readInstructionAddress(destinationRegister int16, beforeAcquisitionTargetInstruction obj.As) {
+	// Emit the instruction in the form of "LEA destination [RIP + offset]".
 	readInstructionAddress := c.newProg()
 	readInstructionAddress.As = x86.ALEAQ
 	readInstructionAddress.To.Reg = destinationRegister
@@ -5244,31 +5166,41 @@ func (c *amd64Compiler) readInstructionAddress(destinationRegister int16) func(i
 	// We use place holder here as we don't yet know at this point the offset of the first instruction
 	// after return instruction.
 	readInstructionAddress.From.Offset = 0xffff
-	// Since the assembler cannot directly emit "LEA foo [rip + bar]", we use the some hack here:
+	// Since the assembler cannot directly emit "LEA destination [RIP + offset]", we use the some hack here:
 	// We intentionally use x86.REG_BP here so that the resulting instruction sequence becomes
-	// exactly the same as "LEA foo [rip + bar]" except the most significant bit of the third byte.
+	// exactly the same as "LEA destination [RIP + offset]" except the most significant bit of the third byte.
 	// We do the rewrite in onGenerateCallbacks which is invoked after the assembler emitted the code.
 	readInstructionAddress.From.Reg = x86.REG_BP
 	c.addInstruction(readInstructionAddress)
 
-	return func(instructionAfterReadInstruction, addressAcquisitionTargetInstruction *obj.Prog) {
-		c.onGenerateCallbacks = append(c.onGenerateCallbacks, func(code []byte) error {
-			// See the comment at readInstructionAddress.From.Offset.
-			binary.LittleEndian.PutUint32(code[readInstructionAddress.Pc+3:],
-				uint32(advanceUntilNonNOP(addressAcquisitionTargetInstruction).Pc)-uint32(instructionAfterReadInstruction.Pc))
-			// See the comment at readInstructionAddress.From.Reg above. Here we drop the most significant bit of the third byte of the LEA instruction.
-			code[readInstructionAddress.Pc+2] = code[readInstructionAddress.Pc+2] & 0b01111111
-			return nil
-		})
-	}
-}
+	c.onGenerateCallbacks = append(c.onGenerateCallbacks, func(code []byte) error {
+		// Advance readInstructionAddress to the next one (.Link) in order to get the instruction
+		// right after LEA because RIP points to that next instruction in LEA instruction.
+		base := readInstructionAddress.Link
 
-func advanceUntilNonNOP(in *obj.Prog) (out *obj.Prog) {
-	out = in
-	for out.As == obj.ANOP {
-		out = out.Link
-	}
-	return
+		// Find the address aquisition target instruction.
+		target := base
+		for {
+			// Advance until we have the target.As has the given instruction kind.
+			target = target.Link
+			if target.As == beforeAcquisitionTargetInstruction {
+				// At this point, target is the instruction right before the target instruction.
+				// Thus, advance one more time to make target the target instruction.
+				target = target.Link
+				break
+			}
+		}
+
+		// Now we can calculate the "offset" in the LEA instruction.
+		offset := uint32(target.Pc) - uint32(base.Pc)
+
+		// Replace the place holder bytes by the actual offset.
+		binary.LittleEndian.PutUint32(code[readInstructionAddress.Pc+3:], offset)
+
+		// See the comment at readInstructionAddress.From.Reg above. Here we drop the most significant bit of the third byte of the LEA instruction.
+		code[readInstructionAddress.Pc+2] = code[readInstructionAddress.Pc+2] & 0b01111111
+		return nil
+	})
 }
 
 // releaseAllRegistersToStack add the instructions to release all the LIVE value
@@ -5398,14 +5330,16 @@ func (c *amd64Compiler) initializeReservedStackBasePointer() {
 }
 
 func (c *amd64Compiler) initializeReservedMemoryPointer() {
-	setupMemoryRegister := c.newProg()
-	setupMemoryRegister.As = x86.AMOVQ
-	setupMemoryRegister.To.Type = obj.TYPE_REG
-	setupMemoryRegister.To.Reg = reservedRegisterForMemory
-	setupMemoryRegister.From.Type = obj.TYPE_MEM
-	setupMemoryRegister.From.Reg = reservedRegisterForEngine
-	setupMemoryRegister.From.Offset = engineModuleContextMemoryElement0AddressOffset
-	c.addInstruction(setupMemoryRegister)
+	if c.f.ModuleInstance.Memory != nil {
+		setupMemoryRegister := c.newProg()
+		setupMemoryRegister.As = x86.AMOVQ
+		setupMemoryRegister.To.Type = obj.TYPE_REG
+		setupMemoryRegister.To.Reg = reservedRegisterForMemory
+		setupMemoryRegister.From.Type = obj.TYPE_MEM
+		setupMemoryRegister.From.Reg = reservedRegisterForEngine
+		setupMemoryRegister.From.Offset = engineModuleContextMemoryElement0AddressOffset
+		c.addInstruction(setupMemoryRegister)
+	}
 }
 
 // maybeGrowValueStack adds instructions to check the necessity to grow the value stack,
@@ -5464,8 +5398,6 @@ func (c *amd64Compiler) maybeGrowValueStack() error {
 // engine.ModuleContext.ModuleInstanceAddress.
 // This is called in two cases: in function preamble, and on the return from (non-Go) function calls.
 func (c *amd64Compiler) initializeModuleContext() error {
-	// TODO: we maybe better have flag to indicate if the module context has changed,
-	// and if the flag is not set, we could skip the entire instructions in below!
 
 	// Obtain the temporary registers to be used in the followings.
 	regs, found := c.locationStack.takeFreeRegisters(generalPurposeRegisterTypeInt, 3)
@@ -5478,30 +5410,43 @@ func (c *amd64Compiler) initializeModuleContext() error {
 	// Alias these free tmp registers for readability.
 	moduleInstanceAddressRegister, tmpRegister, tmpRegister2 := regs[0], regs[1], regs[2]
 
-	// Read the module instance's address.
 	readModuleInstanceAddress := c.newProg()
 	readModuleInstanceAddress.As = x86.AMOVQ
 	readModuleInstanceAddress.To.Type = obj.TYPE_REG
 	readModuleInstanceAddress.To.Reg = moduleInstanceAddressRegister
-	readModuleInstanceAddress.From.Type = obj.TYPE_MEM
-	readModuleInstanceAddress.From.Reg = reservedRegisterForEngine
-	readModuleInstanceAddress.From.Offset = engineModuleContextModuleInstanceAddressOffset
+	readModuleInstanceAddress.From.Type = obj.TYPE_CONST
+	readModuleInstanceAddress.From.Offset = int64(uintptr(unsafe.Pointer(c.f.ModuleInstance)))
 	c.addInstruction(readModuleInstanceAddress)
 
-	// First we have to check if the module instance address is nil, which means the target is host function.
-	checkIfNilPointer := c.newProg()
-	checkIfNilPointer.As = x86.ACMPQ
-	checkIfNilPointer.From.Type = obj.TYPE_REG
-	checkIfNilPointer.From.Reg = moduleInstanceAddressRegister
-	checkIfNilPointer.To.Type = obj.TYPE_CONST
-	checkIfNilPointer.To.Offset = 0
-	c.addInstruction(checkIfNilPointer)
+	// If the module instance address stays the same, we could skip the entire code below.
+	// The rationale/idea for this is that, in almost all use cases, users inistantiate single
+	// Wasm binary and run the functions from it, rather than doing import/export on multiple
+	// binaries. As a result, this cmp and jmp instruction sequence below must be easy for
+	// x64 CPU to do branch prediction since almost 100% jump happens across function calls.
+	checkIfModuleChanged := c.newProg()
+	checkIfModuleChanged.As = x86.ACMPQ
+	checkIfModuleChanged.To.Type = obj.TYPE_REG
+	checkIfModuleChanged.To.Reg = moduleInstanceAddressRegister
+	checkIfModuleChanged.From.Type = obj.TYPE_MEM
+	checkIfModuleChanged.From.Reg = reservedRegisterForEngine
+	checkIfModuleChanged.From.Offset = engineModuleContextModuleInstanceAddressOffset
+	c.addInstruction(checkIfModuleChanged)
 
-	// Skip the moduleContext updates if the poitner is nil.
-	jmpIfNilPointer := c.newProg()
-	jmpIfNilPointer.As = x86.AJEQ
-	jmpIfNilPointer.To.Type = obj.TYPE_BRANCH
-	c.addInstruction(jmpIfNilPointer)
+	jmpIfEqual := c.newProg()
+	jmpIfEqual.As = x86.AJEQ
+	jmpIfEqual.To.Type = obj.TYPE_BRANCH
+	c.addInstruction(jmpIfEqual)
+
+	// Otherwise, we need to update fields.
+	// First, save the read module instance address to engine.moduleInstanceAddress
+	saveModuleInstanceAddress := c.newProg()
+	saveModuleInstanceAddress.As = x86.AMOVQ
+	saveModuleInstanceAddress.From.Type = obj.TYPE_REG
+	saveModuleInstanceAddress.From.Reg = moduleInstanceAddressRegister
+	saveModuleInstanceAddress.To.Type = obj.TYPE_MEM
+	saveModuleInstanceAddress.To.Reg = reservedRegisterForEngine
+	saveModuleInstanceAddress.To.Offset = engineModuleContextModuleInstanceAddressOffset
+	c.addInstruction(saveModuleInstanceAddress)
 
 	// Otherwise, we have to update the following fields:
 	// * engine.moduleContext.globalElement0Address
@@ -5511,7 +5456,11 @@ func (c *amd64Compiler) initializeModuleContext() error {
 	// * engine.moduleContext.memorySliceLen
 
 	// Update globalElement0Address.
-	{
+	//
+	// Note: if there's global.get or set instruction in the function, the existence of the globals
+	// is ensured by function validation at module instantiation phase, and that's why it is ok to
+	// skip the initialization if the module's globals slice is empty.
+	if len(c.f.ModuleInstance.Globals) > 0 {
 		// Since ModuleInstance.Globals is []*globalInstance, internally
 		// the address of the first item in the underlying array lies exactly on the globals offset.
 		// See https://go.dev/blog/slices-intro if unfamiliar.
@@ -5535,7 +5484,11 @@ func (c *amd64Compiler) initializeModuleContext() error {
 	}
 
 	// Update tableElement0Address and tableSliceLen.
-	{
+	//
+	// Note: if there's table instruction in the function, the existence of the table
+	// is ensured by function validation at module instantiation phase, and that's
+	// why it is ok to skip the initialization if the module's table doesn't exist.
+	if len(c.f.ModuleInstance.Tables) > 0 {
 		getTablesCount := c.newProg()
 		getTablesCount.As = x86.AMOVQ
 		getTablesCount.To.Type = obj.TYPE_REG
@@ -5547,23 +5500,6 @@ func (c *amd64Compiler) initializeModuleContext() error {
 		getTablesCount.From.Offset = moduleInstanceTablesOffset + 8
 		c.addInstruction(getTablesCount)
 
-		checkIfTableExist := c.newProg()
-		checkIfTableExist.As = x86.ACMPQ
-		checkIfTableExist.From.Type = obj.TYPE_REG
-		checkIfTableExist.From.Reg = tmpRegister
-		checkIfTableExist.To.Type = obj.TYPE_CONST
-		checkIfTableExist.To.Offset = 0
-		c.addInstruction(checkIfTableExist)
-
-		// Skip the updates on table related fields if the length of ModuleInstance.Tables equals 0.
-		// TODO: better zeros tableElement0Address and tableSliceLen in the non-exist case as
-		// they might be security holes.
-		jmpIfTableNotExist := c.newProg()
-		jmpIfTableNotExist.As = x86.AJEQ
-		jmpIfTableNotExist.To.Type = obj.TYPE_BRANCH
-		c.addInstruction(jmpIfTableNotExist)
-
-		// Otherwise, we update tableElement0Address and tableSliceLen.
 		// First, we need to read the *wasm.TableInstance.
 		readTableInstancePointer := c.newProg()
 		readTableInstancePointer.As = x86.AMOVQ
@@ -5624,12 +5560,14 @@ func (c *amd64Compiler) initializeModuleContext() error {
 		putTableLength.From.Type = obj.TYPE_REG
 		putTableLength.From.Reg = tmpRegister2
 		c.addInstruction(putTableLength)
-
-		c.addSetJmpOrigins(jmpIfTableNotExist)
 	}
 
 	// Update memoryElement0Address and memorySliceLen.
-	{
+	//
+	// Note: if there's memory instruction in the function, memory instance must be non-nil.
+	// That is ensured by function validation at module instantiation phase, and that's
+	// why it is ok to skip the initialization if the module's memory instance is nil.
+	if c.f.ModuleInstance.Memory != nil {
 		getMemoryInstanceAddress := c.newProg()
 		getMemoryInstanceAddress.As = x86.AMOVQ
 		getMemoryInstanceAddress.To.Type = obj.TYPE_REG
@@ -5639,21 +5577,6 @@ func (c *amd64Compiler) initializeModuleContext() error {
 		getMemoryInstanceAddress.From.Offset = moduleInstanceMemoryOffset
 		c.addInstruction(getMemoryInstanceAddress)
 
-		checkIfMemoryNil := c.newProg()
-		checkIfMemoryNil.As = x86.ACMPQ
-		checkIfMemoryNil.From.Type = obj.TYPE_REG
-		checkIfMemoryNil.From.Reg = tmpRegister
-		checkIfMemoryNil.To.Type = obj.TYPE_CONST
-		checkIfMemoryNil.To.Offset = 0
-		c.addInstruction(checkIfMemoryNil)
-
-		// Skip the updates on table related fields if the ModuleInstance.Memory == nil.
-		jmpIfMemoryNil := c.newProg()
-		jmpIfMemoryNil.As = x86.AJEQ
-		jmpIfMemoryNil.To.Type = obj.TYPE_BRANCH
-		c.addInstruction(jmpIfMemoryNil)
-
-		// Otherwise, we do updates.
 		readMemoryLength := c.newProg()
 		readMemoryLength.As = x86.AMOVQ
 		readMemoryLength.To.Type = obj.TYPE_REG
@@ -5691,44 +5614,12 @@ func (c *amd64Compiler) initializeModuleContext() error {
 		putMemoryElement0Address.From.Type = obj.TYPE_REG
 		putMemoryElement0Address.From.Reg = tmpRegister2
 		c.addInstruction(putMemoryElement0Address)
-
-		jmpDoneForNonNil := c.newProg()
-		jmpDoneForNonNil.As = obj.AJMP
-		jmpDoneForNonNil.To.Type = obj.TYPE_BRANCH
-		c.addInstruction(jmpDoneForNonNil)
-
-		zerosTmpRegister := c.newProg()
-		jmpIfMemoryNil.To.SetTarget(zerosTmpRegister)
-		zerosTmpRegister.As = x86.AXORQ
-		zerosTmpRegister.To.Type = obj.TYPE_REG
-		zerosTmpRegister.To.Reg = tmpRegister2
-		zerosTmpRegister.From.Type = obj.TYPE_REG
-		zerosTmpRegister.From.Reg = tmpRegister2
-		c.addInstruction(zerosTmpRegister)
-
-		putZeroIntoElement0Address := c.newProg()
-		putZeroIntoElement0Address.As = x86.AMOVQ
-		putZeroIntoElement0Address.To.Type = obj.TYPE_MEM
-		putZeroIntoElement0Address.To.Reg = reservedRegisterForEngine
-		putZeroIntoElement0Address.To.Offset = engineModuleContextMemoryElement0AddressOffset
-		putZeroIntoElement0Address.From.Type = obj.TYPE_REG
-		putZeroIntoElement0Address.From.Reg = tmpRegister2
-		c.addInstruction(putZeroIntoElement0Address)
-
-		putZeroIntoMemoryLen := c.newProg()
-		putZeroIntoMemoryLen.As = x86.AMOVQ
-		putZeroIntoMemoryLen.To.Type = obj.TYPE_MEM
-		putZeroIntoMemoryLen.To.Reg = reservedRegisterForEngine
-		putZeroIntoMemoryLen.To.Offset = engineModuleContextMemorySliceLenOffset
-		putZeroIntoMemoryLen.From.Type = obj.TYPE_REG
-		putZeroIntoMemoryLen.From.Reg = tmpRegister2
-		c.addInstruction(putZeroIntoMemoryLen)
-
-		c.addSetJmpOrigins(jmpDoneForNonNil)
 	}
 
 	c.locationStack.markRegisterUnused(regs...)
-	c.addSetJmpOrigins(jmpIfNilPointer)
+
+	// Set the jump target towards the next instruction for the case where module instance address hasn't changed.
+	c.addSetJmpOrigins(jmpIfEqual)
 	return nil
 }
 

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -5180,7 +5180,7 @@ func (c *amd64Compiler) readInstructionAddress(destinationRegister int16, before
 
 		// Find the address aquisition target instruction.
 		target := base
-		for {
+		for target != nil {
 			// Advance until we have the target.As has the given instruction kind.
 			target = target.Link
 			if target.As == beforeAcquisitionTargetInstruction {
@@ -5189,6 +5189,10 @@ func (c *amd64Compiler) readInstructionAddress(destinationRegister int16, before
 				target = target.Link
 				break
 			}
+		}
+
+		if target == nil {
+			return fmt.Errorf("target instruction not found for read instruction address")
 		}
 
 		// Now we can calculate the "offset" in the LEA instruction.

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -6526,7 +6526,8 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: expectedReturnValue})
 		require.NoError(t, err)
 
-		compiler.returnFunction()
+		err = compiler.returnFunction()
+		require.NoError(t, err)
 
 		// Generate the code under test.
 		code, _, _, err := compiler.generate()

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -26,11 +26,7 @@ import (
 // TODO: have some utility functions to reduce loc here: https://github.com/tetratelabs/wazero/issues/100
 
 type jitEnv struct {
-	eng     *engine
-	mem     *wasm.MemoryInstance
-	globals []*wasm.GlobalInstance
-	table   *wasm.TableInstance
-
+	eng            *engine
 	moduleInstance *wasm.ModuleInstance
 }
 
@@ -66,7 +62,7 @@ func (j *jitEnv) stackTopAsFloat64() float64 {
 }
 
 func (j *jitEnv) memory() []byte {
-	return j.mem.Buffer
+	return j.moduleInstance.Memory.Buffer
 }
 
 func (j *jitEnv) stack() []uint64 {
@@ -94,15 +90,15 @@ func (j *jitEnv) setStackPointer(sp uint64) {
 }
 
 func (j *jitEnv) addGlobals(g ...*wasm.GlobalInstance) {
-	j.globals = append(j.globals, g...)
+	j.moduleInstance.Globals = append(j.moduleInstance.Globals, g...)
 }
 
 func (j *jitEnv) getGlobal(index uint32) uint64 {
-	return j.globals[index].Val
+	return j.moduleInstance.Globals[index].Val
 }
 
 func (j *jitEnv) setTable(table []wasm.TableElement) {
-	j.table.Table = table
+	j.moduleInstance.Tables[0] = &wasm.TableInstance{Table: table}
 }
 
 func (j *jitEnv) callFrameStackPeek() *callFrame {
@@ -130,19 +126,9 @@ func (j *jitEnv) engine() *engine {
 }
 
 func (j *jitEnv) exec(code []byte) {
-	j.moduleInstance = &wasm.ModuleInstance{
-		Globals: j.globals,
-		Memory:  j.mem,
-		Tables:  []*wasm.TableInstance{j.table},
-	}
-	j.execWithModule(code, j.moduleInstance)
-}
-
-func (j *jitEnv) execWithModule(code []byte, module *wasm.ModuleInstance) {
 	compiledFunction := &compiledFunction{
-		codeSegment:           code,
-		codeInitialAddress:    uintptr(unsafe.Pointer(&code[0])),
-		moduleInstanceAddress: uintptr(unsafe.Pointer(module)),
+		codeSegment:        code,
+		codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 		source: &wasm.FunctionInstance{
 			FunctionType: &wasm.TypeInstance{Type: &wasm.FunctionType{}},
 		},
@@ -159,18 +145,22 @@ const defaultMemoryPageNumInTest = 2
 
 func newJITEnvironment() *jitEnv {
 	return &jitEnv{
-		eng:   newEngine(),
-		mem:   &wasm.MemoryInstance{Buffer: make([]byte, wasm.PageSize*defaultMemoryPageNumInTest)},
-		table: &wasm.TableInstance{},
+		eng: newEngine(),
+		moduleInstance: &wasm.ModuleInstance{
+			Memory:  &wasm.MemoryInstance{Buffer: make([]byte, wasm.PageSize*defaultMemoryPageNumInTest)},
+			Tables:  []*wasm.TableInstance{{}},
+			Globals: []*wasm.GlobalInstance{},
+		},
 	}
 }
 
-func requireNewCompiler(t *testing.T) *amd64Compiler {
+func (j *jitEnv) requireNewCompiler(t *testing.T) *amd64Compiler {
 	b, err := asm.NewBuilder("amd64", 128)
 	require.NoError(t, err)
 	return &amd64Compiler{builder: b,
 		locationStack: newValueLocationStack(),
 		labels:        map[string]*labelInfo{},
+		f:             &wasm.FunctionInstance{ModuleInstance: j.moduleInstance},
 	}
 }
 
@@ -190,7 +180,7 @@ func TestAmd64Compiler_maybeGrowValueStack(t *testing.T) {
 		for _, baseOffset := range []uint64{5, 10, 20} {
 
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
 
 			compiler.initializeReservedStackBasePointer()
 			err := compiler.maybeGrowValueStack()
@@ -219,7 +209,7 @@ func TestAmd64Compiler_maybeGrowValueStack(t *testing.T) {
 	})
 	t.Run("grow", func(t *testing.T) {
 		env := newJITEnvironment()
-		compiler := requireNewCompiler(t)
+		compiler := env.requireNewCompiler(t)
 
 		compiler.initializeReservedStackBasePointer()
 		err := compiler.maybeGrowValueStack()
@@ -257,7 +247,7 @@ func TestAmd64Compiler_maybeGrowValueStack(t *testing.T) {
 func TestAmd64Compiler_returnFunction(t *testing.T) {
 	t.Run("last return", func(t *testing.T) {
 		env := newJITEnvironment()
-		compiler := requireNewCompiler(t)
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 
@@ -299,7 +289,7 @@ func TestAmd64Compiler_returnFunction(t *testing.T) {
 		stackPointerToExpectedValue := map[uint64]uint32{}
 		for funcaddr := wasm.FunctionAddress(0); funcaddr < callFrameNums; funcaddr++ {
 			//	Each function pushes its funcaddr and soon returns.
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -335,18 +325,8 @@ func TestAmd64Compiler_returnFunction(t *testing.T) {
 
 		require.Equal(t, uint64(callFrameNums), env.callFrameStackPointer())
 
-		// To ensure that returnFunction() properly sets the moduleInstanceAddress to the
-		// return target's compiledFunction.moduleInstanceAddress, we modify the bottom frame's
-		// compiledFunction here.
-		lastModuleInstance := &wasm.ModuleInstance{}
-		expPtr := uintptr(unsafe.Pointer(lastModuleInstance))
-		engine.callFrameStack[0].compiledFunction.moduleInstanceAddress = expPtr
-
 		// Run codes.
 		env.exec(engine.callFrameTop().compiledFunction.codeSegment)
-
-		// Check the moduleInstanceAddress is properly changed.
-		require.Equal(t, expPtr, engine.moduleContext.moduleInstanceAddress)
 
 		// Check the exit status.
 		require.Equal(t, jitCallStatusCodeReturned, env.jitStatus())
@@ -420,14 +400,6 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
-				Globals: []*wasm.GlobalInstance{},
-			},
-		},
-		{
-			name: "globals nil part2",
-			moduleInstance: &wasm.ModuleInstance{
 				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Tables: []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
 			},
@@ -435,8 +407,10 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			compiler.initializeReservedStackBasePointer()
+			compiler.f.ModuleInstance = tc.moduleInstance
 
 			require.Empty(t, compiler.locationStack.usedRegisters)
 			err := compiler.initializeModuleContext()
@@ -452,8 +426,7 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run codes
-			env := newJITEnvironment()
-			env.execWithModule(code, tc.moduleInstance)
+			env.exec(code)
 
 			// Check the exit status.
 			require.Equal(t, expectedStatus, env.jitStatus())
@@ -633,7 +606,8 @@ func TestAmd64Compiler_compileBrTable(t *testing.T) {
 				} {
 					tc := tc
 					t.Run(tc.name, func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -681,9 +655,10 @@ func Test_setJITStatus(t *testing.T) {
 		jitCallStatusCodeUnreachable,
 	} {
 		t.Run(s.String(), func(t *testing.T) {
+			env := newJITEnvironment()
 
 			// Build codes.
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 			compiler.exit(s)
@@ -693,7 +668,6 @@ func Test_setJITStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run codes
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// JIT status on engine must be updated.
@@ -703,7 +677,8 @@ func Test_setJITStatus(t *testing.T) {
 }
 
 func TestAmd64Compiler_initializeReservedRegisters(t *testing.T) {
-	compiler := requireNewCompiler(t)
+	env := newJITEnvironment()
+	compiler := env.requireNewCompiler(t)
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 	compiler.exit(jitCallStatusCodeReturned)
@@ -717,7 +692,8 @@ func TestAmd64Compiler_initializeReservedRegisters(t *testing.T) {
 
 func TestAmd64Compiler_allocateRegister(t *testing.T) {
 	t.Run("free", func(t *testing.T) {
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		reg, err := compiler.allocateRegister(generalPurposeRegisterTypeInt)
 		require.NoError(t, err)
 		require.True(t, isIntRegister(reg))
@@ -727,7 +703,8 @@ func TestAmd64Compiler_allocateRegister(t *testing.T) {
 	})
 	t.Run("steal", func(t *testing.T) {
 		const stealTarget = x86.REG_AX
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 		// Use up all the Int regs.
@@ -756,7 +733,6 @@ func TestAmd64Compiler_allocateRegister(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run code.
-		env := newJITEnvironment()
 		env.exec(code)
 
 		// Check the sp and value.
@@ -766,7 +742,8 @@ func TestAmd64Compiler_allocateRegister(t *testing.T) {
 }
 
 func TestAmd64Compiler_compileLabel(t *testing.T) {
-	compiler := requireNewCompiler(t)
+	env := newJITEnvironment()
+	compiler := env.requireNewCompiler(t)
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 	label := &wazeroir.Label{FrameID: 100, Kind: wazeroir.LabelKindContinuation}
@@ -794,7 +771,8 @@ func TestAmd64Compiler_compilePick(t *testing.T) {
 
 	// The case when the original value is already in register.
 	t.Run("on reg", func(t *testing.T) {
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 
@@ -827,7 +805,6 @@ func TestAmd64Compiler_compilePick(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run code.
-		env := newJITEnvironment()
 		env.exec(code)
 
 		// Check the stack.
@@ -839,10 +816,10 @@ func TestAmd64Compiler_compilePick(t *testing.T) {
 
 	// The case when the original value is in stack.
 	t.Run("on stack", func(t *testing.T) {
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
-		env := newJITEnvironment()
 
 		// Setup the original value.
 		compiler.locationStack.pushValueOnStack() // Dummy value!
@@ -883,7 +860,8 @@ func TestAmd64Compiler_compilePick(t *testing.T) {
 func TestAmd64Compiler_compileConstI32(t *testing.T) {
 	for _, v := range []uint32{1, 1 << 5, 1 << 31} {
 		t.Run(fmt.Sprintf("%d", v), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -909,7 +887,6 @@ func TestAmd64Compiler_compileConstI32(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run code.
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// As we push the constant to the stack, the stack pointer must be incremented.
@@ -923,7 +900,8 @@ func TestAmd64Compiler_compileConstI32(t *testing.T) {
 func TestAmd64Compiler_compileConstI64(t *testing.T) {
 	for _, v := range []uint64{1, 1 << 5, 1 << 35, 1 << 63} {
 		t.Run(fmt.Sprintf("%d", v), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -949,7 +927,6 @@ func TestAmd64Compiler_compileConstI64(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run code.
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// As we push the constant to the stack, the stack pointer must be incremented.
@@ -963,7 +940,8 @@ func TestAmd64Compiler_compileConstI64(t *testing.T) {
 func TestAmd64Compiler_compileConstF32(t *testing.T) {
 	for _, v := range []float32{1, -3.23, 100.123} {
 		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -991,7 +969,6 @@ func TestAmd64Compiler_compileConstF32(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run code.
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// As we push the constant to the stack, the stack pointer must be incremented.
@@ -1005,7 +982,8 @@ func TestAmd64Compiler_compileConstF32(t *testing.T) {
 func TestAmd64Compiler_compileConstF64(t *testing.T) {
 	for _, v := range []float64{1, -3.23, 100.123} {
 		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -1033,7 +1011,6 @@ func TestAmd64Compiler_compileConstF64(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run code.
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// As we push the constant to the stack, the stack pointer must be incremented.
@@ -1048,7 +1025,9 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 	t.Run("int32", func(t *testing.T) {
 		const x1Value uint32 = 113
 		const x2Value uint32 = 41
-		compiler := requireNewCompiler(t)
+
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 		err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: x1Value})
@@ -1073,7 +1052,6 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run code.
-		env := newJITEnvironment()
 		env.exec(code)
 
 		// Check the stack.
@@ -1083,7 +1061,9 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 	t.Run("int64", func(t *testing.T) {
 		const x1Value uint64 = 1 << 35
 		const x2Value uint64 = 41
-		compiler := requireNewCompiler(t)
+
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 		err = compiler.compileConstI64(&wazeroir.OperationConstI64{Value: x1Value})
@@ -1108,7 +1088,6 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run code.
-		env := newJITEnvironment()
 		env.exec(code)
 
 		// Check the stack.
@@ -1128,7 +1107,8 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 				err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: tc.v1})
@@ -1153,7 +1133,6 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -1175,9 +1154,11 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: tc.v1})
 				require.NoError(t, err)
 				x1 := compiler.locationStack.peek()
@@ -1200,7 +1181,6 @@ func TestAmd64Compiler_compileAdd(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -1233,7 +1213,8 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 					{x1: 200, x2: 100},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -1272,7 +1253,6 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1298,7 +1278,8 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 					{x1: 0, x2: 100},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -1337,7 +1318,6 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1387,7 +1367,8 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 					{x1: float32(math.Inf(-1)), x2: float32(math.Inf(-1))},
 				} {
 					t.Run(fmt.Sprintf("x1=%f,x2=%f", tc.x1, tc.x2), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 						useUpIntRegistersFunc(compiler)
@@ -1425,7 +1406,6 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1465,7 +1445,8 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 					{x1: math.Inf(-1), x2: math.Inf(-1)},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 						useUpIntRegistersFunc(compiler)
@@ -1504,7 +1485,6 @@ func TestAmd64Compiler_emitEqOrNe(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1529,7 +1509,8 @@ func TestAmd64Compiler_compileEqz(t *testing.T) {
 		} {
 			v := v
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 
@@ -1560,7 +1541,6 @@ func TestAmd64Compiler_compileEqz(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -1575,7 +1555,8 @@ func TestAmd64Compiler_compileEqz(t *testing.T) {
 		} {
 			v := v
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 
@@ -1606,7 +1587,6 @@ func TestAmd64Compiler_compileEqz(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -1640,7 +1620,8 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 					{x1: 200, x2: 100, signed: true},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -1686,7 +1667,6 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1720,7 +1700,8 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 					{x1: math.MinInt64, x2: 100, signed: true},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -1766,7 +1747,6 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1808,9 +1788,11 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 					{x1: float32(math.Inf(-1)), x2: float32(math.Inf(-1))},
 				} {
 					t.Run(fmt.Sprintf("x1=%f,x2=%f", tc.x1, tc.x2), func(t *testing.T) {
-						// Prepare operands.
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
+
+						// Prepare operands.
 						require.NoError(t, err)
 						err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: tc.x1})
 						require.NoError(t, err)
@@ -1848,7 +1830,6 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1887,10 +1868,12 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 					{x1: math.Inf(-1), x2: math.Inf(-1)},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						// Prepare operands.
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
+
+						// Prepare operands.
 						err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: tc.x1})
 						require.NoError(t, err)
 						x1 := compiler.locationStack.peek()
@@ -1927,7 +1910,6 @@ func TestAmd64Compiler_compileLe_or_Lt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -1967,7 +1949,8 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 					{x1: 200, x2: 100, signed: true},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -2014,7 +1997,6 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -2049,7 +2031,8 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 				} {
 
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
 
@@ -2096,7 +2079,6 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -2138,10 +2120,12 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 					{x1: float32(math.Inf(-1)), x2: float32(math.Inf(-1))},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						// Prepare operands.
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
+
+						// Prepare operands.
 						err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: tc.x1})
 						require.NoError(t, err)
 						x1 := compiler.locationStack.peek()
@@ -2179,7 +2163,6 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -2218,10 +2201,12 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 					{x1: math.Inf(-1), x2: math.Inf(-1)},
 				} {
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						// Prepare operands.
-						compiler := requireNewCompiler(t)
+						env := newJITEnvironment()
+						compiler := env.requireNewCompiler(t)
 						err := compiler.emitPreamble()
 						require.NoError(t, err)
+
+						// Prepare operands.
 						err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: tc.x1})
 						require.NoError(t, err)
 						x1 := compiler.locationStack.peek()
@@ -2259,7 +2244,6 @@ func TestAmd64Compiler_compileGe_or_Gt(t *testing.T) {
 						require.NoError(t, err)
 
 						// Run code.
-						env := newJITEnvironment()
 						env.exec(code)
 
 						// Check the stack.
@@ -2280,7 +2264,8 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 	t.Run("int32", func(t *testing.T) {
 		const x1Value uint32 = 1 << 31
 		const x2Value uint32 = 51
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 		err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: x1Value})
@@ -2305,7 +2290,6 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run code.
-		env := newJITEnvironment()
 		env.exec(code)
 
 		// Check the stack.
@@ -2315,9 +2299,12 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 	t.Run("int64", func(t *testing.T) {
 		const x1Value uint64 = 1 << 35
 		const x2Value uint64 = 51
-		compiler := requireNewCompiler(t)
+
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
+
 		err = compiler.compileConstI64(&wazeroir.OperationConstI64{Value: x1Value})
 		require.NoError(t, err)
 		x1 := compiler.locationStack.peek()
@@ -2340,7 +2327,6 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run code.
-		env := newJITEnvironment()
 		env.exec(code)
 
 		// Check the stack.
@@ -2360,9 +2346,11 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: tc.v1})
 				require.NoError(t, err)
 				x1 := compiler.locationStack.peek()
@@ -2385,7 +2373,6 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2407,9 +2394,11 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: tc.v1})
 				require.NoError(t, err)
 				x1 := compiler.locationStack.peek()
@@ -2432,7 +2421,6 @@ func TestAmd64Compiler_compileSub(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2499,7 +2487,7 @@ func TestAmd64Compiler_compileMul(t *testing.T) {
 				const x2Value uint32 = 51
 				const dxValue uint64 = 111111
 
-				compiler := requireNewCompiler(t)
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 
@@ -2611,7 +2599,7 @@ func TestAmd64Compiler_compileMul(t *testing.T) {
 				const dxValue uint64 = 111111
 
 				env := newJITEnvironment()
-				compiler := requireNewCompiler(t)
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 
@@ -2686,9 +2674,11 @@ func TestAmd64Compiler_compileMul(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: tc.x1})
 				require.NoError(t, err)
 				x1 := compiler.locationStack.peek()
@@ -2711,7 +2701,6 @@ func TestAmd64Compiler_compileMul(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2737,9 +2726,11 @@ func TestAmd64Compiler_compileMul(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: tc.x1})
 				require.NoError(t, err)
 				x1 := compiler.locationStack.peek()
@@ -2762,7 +2753,6 @@ func TestAmd64Compiler_compileMul(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2783,7 +2773,8 @@ func TestAmd64Compiler_compilClz(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%032b", tc.input), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 				// Setup the target value.
@@ -2811,7 +2802,6 @@ func TestAmd64Compiler_compilClz(t *testing.T) {
 				// Generate and run the code under test.
 				code, _, _, err := compiler.generate()
 				require.NoError(t, err)
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2831,9 +2821,11 @@ func TestAmd64Compiler_compilClz(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%064b", tc.expectedLeadingZeros), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				// Setup the target value.
 				err = compiler.compileConstI64(&wazeroir.OperationConstI64{Value: tc.input})
 				require.NoError(t, err)
@@ -2859,7 +2851,6 @@ func TestAmd64Compiler_compilClz(t *testing.T) {
 				// Generate and run the code under test.
 				code, _, _, err := compiler.generate()
 				require.NoError(t, err)
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2880,9 +2871,11 @@ func TestAmd64Compiler_compilCtz(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%032b", tc.input), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				// Setup the target value.
 				err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: tc.input})
 				require.NoError(t, err)
@@ -2908,7 +2901,6 @@ func TestAmd64Compiler_compilCtz(t *testing.T) {
 				// Generate and run the code under test.
 				code, _, _, err := compiler.generate()
 				require.NoError(t, err)
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2928,7 +2920,8 @@ func TestAmd64Compiler_compilCtz(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%064b", tc.input), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 				// Setup the target value.
@@ -2956,7 +2949,6 @@ func TestAmd64Compiler_compilCtz(t *testing.T) {
 				// Generate and run the code under test.
 				code, _, _, err := compiler.generate()
 				require.NoError(t, err)
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -2979,7 +2971,8 @@ func TestAmd64Compiler_compilPopcnt(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%032b", tc.input), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 				// Setup the target value.
@@ -3004,7 +2997,6 @@ func TestAmd64Compiler_compilPopcnt(t *testing.T) {
 				// Generate and run the code under test.
 				code, _, _, err := compiler.generate()
 				require.NoError(t, err)
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -3028,9 +3020,11 @@ func TestAmd64Compiler_compilPopcnt(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%064b", tc.in), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				// Setup the target value.
 				err = compiler.compileConstI64(&wazeroir.OperationConstI64{Value: tc.in})
 				require.NoError(t, err)
@@ -3053,7 +3047,6 @@ func TestAmd64Compiler_compilPopcnt(t *testing.T) {
 				// Generate and run the code under test.
 				code, _, _, err := compiler.generate()
 				require.NoError(t, err)
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the stack.
@@ -3151,7 +3144,8 @@ func TestAmd64Compiler_compile_and_or_xor_shl_shr_rotl_rotr(t *testing.T) {
 					} {
 						vs := vs
 						t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-							compiler := requireNewCompiler(t)
+							env := newJITEnvironment()
+							compiler := env.requireNewCompiler(t)
 							err := compiler.emitPreamble()
 							require.NoError(t, err)
 
@@ -3242,8 +3236,6 @@ func TestAmd64Compiler_compile_and_or_xor_shl_shr_rotl_rotr(t *testing.T) {
 									expectedValue = uint64(bits.RotateLeft64(vs.x1, -int(vs.x2)))
 								}
 							}
-
-							env := newJITEnvironment()
 
 							// Setup the target values.
 							if locations.x1Reg != nilRegister {
@@ -3377,7 +3369,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 							t.Run(fmt.Sprintf("%d/%d", vs.x1Value, vs.x2Value), func(t *testing.T) {
 
 								env := newJITEnvironment()
-								compiler := requireNewCompiler(t)
+								compiler := env.requireNewCompiler(t)
 								err := compiler.emitPreamble()
 								require.NoError(t, err)
 
@@ -3534,7 +3526,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 							t.Run(fmt.Sprintf("%d/%d", vs.x1Value, vs.x2Value), func(t *testing.T) {
 
 								env := newJITEnvironment()
-								compiler := requireNewCompiler(t)
+								compiler := env.requireNewCompiler(t)
 								err := compiler.emitPreamble()
 								require.NoError(t, err)
 
@@ -3644,7 +3636,8 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 				err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: tc.x1})
@@ -3669,7 +3662,6 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the result.
@@ -3718,9 +3710,11 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 		} {
 			tc := tc
 			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				compiler := requireNewCompiler(t)
+				env := newJITEnvironment()
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
+
 				err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: tc.x1})
 				require.NoError(t, err)
 				x1 := compiler.locationStack.peek()
@@ -3743,7 +3737,6 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run code.
-				env := newJITEnvironment()
 				env.exec(code)
 
 				// Check the result.
@@ -3837,7 +3830,7 @@ func TestAmd64Compiler_compileRem(t *testing.T) {
 							t.Run(fmt.Sprintf("x1=%d,x2=%d", vs.x1Value, vs.x2Value), func(t *testing.T) {
 
 								env := newJITEnvironment()
-								compiler := requireNewCompiler(t)
+								compiler := env.requireNewCompiler(t)
 								err := compiler.emitPreamble()
 								require.NoError(t, err)
 
@@ -3993,7 +3986,7 @@ func TestAmd64Compiler_compileRem(t *testing.T) {
 							vs := vs
 							t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 								env := newJITEnvironment()
-								compiler := requireNewCompiler(t)
+								compiler := env.requireNewCompiler(t)
 								err := compiler.emitPreamble()
 								require.NoError(t, err)
 
@@ -4085,7 +4078,8 @@ func TestAmd64Compiler_compileF32DemoteFromF64(t *testing.T) {
 		math.Inf(1), math.Inf(-1), math.NaN(),
 	} {
 		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -4107,7 +4101,6 @@ func TestAmd64Compiler_compileF32DemoteFromF64(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run code.
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// Check the result.
@@ -4132,7 +4125,8 @@ func TestAmd64Compiler_compileF64PromoteFromF32(t *testing.T) {
 		float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN()),
 	} {
 		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -4152,7 +4146,6 @@ func TestAmd64Compiler_compileF64PromoteFromF32(t *testing.T) {
 			// Generate and run the code under test.
 			code, _, _, err := compiler.generate()
 			require.NoError(t, err)
-			env := newJITEnvironment()
 			env.exec(code)
 
 			// Check the result.
@@ -4186,11 +4179,11 @@ func TestAmd64Compiler_compileReinterpret(t *testing.T) {
 					} {
 						v := v
 						t.Run(fmt.Sprintf("%d", v), func(t *testing.T) {
-							compiler := requireNewCompiler(t)
+							env := newJITEnvironment()
+							compiler := env.requireNewCompiler(t)
 							err := compiler.emitPreamble()
 							require.NoError(t, err)
 
-							env := newJITEnvironment()
 							if originOnStack {
 								loc := compiler.locationStack.pushValueOnStack()
 								env.stack()[loc.stackPointer] = v
@@ -4267,7 +4260,8 @@ func TestAmd64Compiler_compileExtend(t *testing.T) {
 			} {
 				v := v
 				t.Run(fmt.Sprintf("%v", v), func(t *testing.T) {
-					compiler := requireNewCompiler(t)
+					env := newJITEnvironment()
+					compiler := env.requireNewCompiler(t)
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
@@ -4287,7 +4281,6 @@ func TestAmd64Compiler_compileExtend(t *testing.T) {
 					// Generate and run the code under test.
 					code, _, _, err := compiler.generate()
 					require.NoError(t, err)
-					env := newJITEnvironment()
 					env.exec(code)
 
 					require.Equal(t, uint64(1), env.stackPointer())
@@ -4358,7 +4351,8 @@ func TestAmd64Compiler_compileITruncFromF(t *testing.T) {
 				}
 
 				t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
-					compiler := requireNewCompiler(t)
+					env := newJITEnvironment()
+					compiler := env.requireNewCompiler(t)
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
@@ -4384,7 +4378,6 @@ func TestAmd64Compiler_compileITruncFromF(t *testing.T) {
 					// Generate and run the code under test.
 					code, _, _, err := compiler.generate()
 					require.NoError(t, err)
-					env := newJITEnvironment()
 					env.exec(code)
 
 					// Check the result.
@@ -4491,7 +4484,8 @@ func TestAmd64Compiler_compileFConvertFromI(t *testing.T) {
 				math.Float64bits(math.Inf(-1)),
 			} {
 				t.Run(fmt.Sprintf("%d", v), func(t *testing.T) {
-					compiler := requireNewCompiler(t)
+					env := newJITEnvironment()
+					compiler := env.requireNewCompiler(t)
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
@@ -4517,7 +4511,6 @@ func TestAmd64Compiler_compileFConvertFromI(t *testing.T) {
 					// Generate and run the code under test.
 					code, _, _, err := compiler.generate()
 					require.NoError(t, err)
-					env := newJITEnvironment()
 					env.exec(code)
 
 					// Check the result.
@@ -4606,7 +4599,8 @@ func TestAmd64Compiler_compile_abs_neg_ceil_floor(t *testing.T) {
 				math.Float64bits(math.NaN()),
 			} {
 				t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-					compiler := requireNewCompiler(t)
+					env := newJITEnvironment()
+					compiler := env.requireNewCompiler(t)
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
@@ -4744,7 +4738,6 @@ func TestAmd64Compiler_compile_abs_neg_ceil_floor(t *testing.T) {
 					// Generate and run the code under test.
 					code, _, _, err := compiler.generate()
 					require.NoError(t, err)
-					env := newJITEnvironment()
 					env.exec(code)
 
 					// Check the result.
@@ -4815,7 +4808,8 @@ func TestAmd64Compiler_compile_min_max_copysign(t *testing.T) {
 				{x1: math.NaN(), x2: math.NaN()},
 			} {
 				t.Run(fmt.Sprintf("x1=%f_x2=%f", vs.x1, vs.x2), func(t *testing.T) {
-					compiler := requireNewCompiler(t)
+					env := newJITEnvironment()
+					compiler := env.requireNewCompiler(t)
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
@@ -4884,7 +4878,6 @@ func TestAmd64Compiler_compile_min_max_copysign(t *testing.T) {
 					// Generate and run the code under test.
 					code, _, _, err := compiler.generate()
 					require.NoError(t, err)
-					env := newJITEnvironment()
 					env.exec(code)
 
 					// Check the result.
@@ -4924,7 +4917,10 @@ func TestAmd64Compiler_setupMemoryOffset(t *testing.T) {
 			for _, targetSizeInByte := range targetSizeInBytes {
 				targetSizeInByte := targetSizeInByte
 				t.Run(fmt.Sprintf("base=%d,offset=%d,targetSizeInBytes=%d", base, offset, targetSizeInByte), func(t *testing.T) {
-					compiler := requireNewCompiler(t)
+					env := newJITEnvironment()
+					compiler := env.requireNewCompiler(t)
+					compiler.f.ModuleInstance = env.moduleInstance
+
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
@@ -4944,7 +4940,6 @@ func TestAmd64Compiler_setupMemoryOffset(t *testing.T) {
 					require.NoError(t, err)
 
 					// Run code.
-					env := newJITEnvironment()
 					env.exec(code)
 
 					// If the memory offset exceeds the length of memory, we must exit the function
@@ -4972,9 +4967,12 @@ func TestAmd64Compiler_compileLoad(t *testing.T) {
 		tp := tp
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
+			compiler.f.ModuleInstance = env.moduleInstance
+
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
+
 			// Before load operations, we must push the base offset value.
 			const baseOffset = 100 // For testing. Arbitrary number is fine.
 			base := compiler.locationStack.pushValueOnStack()
@@ -5068,7 +5066,9 @@ func TestAmd64Compiler_compileLoad8(t *testing.T) {
 		tp := tp
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
+			compiler.f.ModuleInstance = env.moduleInstance
+
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -5128,7 +5128,9 @@ func TestAmd64Compiler_compileLoad16(t *testing.T) {
 		tp := tp
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
+			compiler.f.ModuleInstance = env.moduleInstance
+
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -5180,7 +5182,9 @@ func TestAmd64Compiler_compileLoad16(t *testing.T) {
 
 func TestAmd64Compiler_compileLoad32(t *testing.T) {
 	env := newJITEnvironment()
-	compiler := requireNewCompiler(t)
+	compiler := env.requireNewCompiler(t)
+	compiler.f.ModuleInstance = env.moduleInstance
+
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 
@@ -5238,7 +5242,9 @@ func TestAmd64Compiler_compileStore(t *testing.T) {
 		tp := tp
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
+			compiler.f.ModuleInstance = env.moduleInstance
+
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -5296,7 +5302,9 @@ func TestAmd64Compiler_compileStore(t *testing.T) {
 
 func TestAmd64Compiler_compileStore8(t *testing.T) {
 	env := newJITEnvironment()
-	compiler := requireNewCompiler(t)
+	compiler := env.requireNewCompiler(t)
+	compiler.f.ModuleInstance = env.moduleInstance
+
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 
@@ -5339,7 +5347,9 @@ func TestAmd64Compiler_compileStore8(t *testing.T) {
 
 func TestAmd64Compiler_compileStore16(t *testing.T) {
 	env := newJITEnvironment()
-	compiler := requireNewCompiler(t)
+	compiler := env.requireNewCompiler(t)
+	compiler.f.ModuleInstance = env.moduleInstance
+
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 
@@ -5382,7 +5392,9 @@ func TestAmd64Compiler_compileStore16(t *testing.T) {
 
 func TestAmd64Compiler_compileStore32(t *testing.T) {
 	env := newJITEnvironment()
-	compiler := requireNewCompiler(t)
+	compiler := env.requireNewCompiler(t)
+	compiler.f.ModuleInstance = env.moduleInstance
+
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 
@@ -5427,7 +5439,8 @@ func TestAmd64Compiler_compileMemoryGrow(t *testing.T) {
 	for _, currentCallFrameStackPointer := range []uint64{0, 10, 20} {
 		currentCallFrameStackPointer := currentCallFrameStackPointer
 		t.Run(fmt.Sprintf("%d", currentCallFrameStackPointer), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
@@ -5450,7 +5463,6 @@ func TestAmd64Compiler_compileMemoryGrow(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run code.
-			env := newJITEnvironment()
 			env.setCallFrameStackPointer(currentCallFrameStackPointer)
 			env.exec(code)
 
@@ -5468,9 +5480,13 @@ func TestAmd64Compiler_compileMemoryGrow(t *testing.T) {
 }
 
 func TestAmd64Compiler_compileMemorySize(t *testing.T) {
-	compiler := requireNewCompiler(t)
+	env := newJITEnvironment()
+	compiler := env.requireNewCompiler(t)
+	compiler.f.ModuleInstance = env.moduleInstance
+
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
+
 	// Emit memory.size instructions.
 	err = compiler.compileMemorySize()
 	require.NoError(t, err)
@@ -5487,7 +5503,6 @@ func TestAmd64Compiler_compileMemorySize(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run code.
-	env := newJITEnvironment()
 	env.exec(code)
 
 	require.Equal(t, jitCallStatusCodeReturned, env.jitStatus())
@@ -5496,12 +5511,14 @@ func TestAmd64Compiler_compileMemorySize(t *testing.T) {
 
 func TestAmd64Compiler_compileDrop(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		err := compiler.compileDrop(&wazeroir.OperationDrop{})
 		require.NoError(t, err)
 	})
 	t.Run("zero start", func(t *testing.T) {
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		shouldPeek := compiler.locationStack.pushValueOnStack()
 		const numReg = 10
 		for i := int16(0); i < numReg; i++ {
@@ -5522,7 +5539,8 @@ func TestAmd64Compiler_compileDrop(t *testing.T) {
 			numLive = 3
 			dropNum = 5
 		)
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		shouldBottom := compiler.locationStack.pushValueOnStack()
 		for i := int16(0); i < dropNum; i++ {
 			compiler.locationStack.pushValueOnRegister(i)
@@ -5556,7 +5574,8 @@ func TestAmd64Compiler_compileDrop(t *testing.T) {
 				dropNum        = 5
 				liveRegisterID = 10
 			)
-			compiler := requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			bottom := compiler.locationStack.pushValueOnStack()
 			require.Equal(t, uint64(0), compiler.locationStack.stack[0].stackPointer)
 			for i := int16(0); i < dropNum; i++ {
@@ -5597,7 +5616,7 @@ func TestAmd64Compiler_compileDrop(t *testing.T) {
 		})
 		t.Run("real", func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -5635,7 +5654,7 @@ func TestAmd64Compiler_compileDrop(t *testing.T) {
 
 func TestAmd64Compiler_releaseAllRegistersToStack(t *testing.T) {
 	env := newJITEnvironment()
-	compiler := requireNewCompiler(t)
+	compiler := env.requireNewCompiler(t)
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
 
@@ -5677,7 +5696,8 @@ func TestAmd64Compiler_releaseAllRegistersToStack(t *testing.T) {
 func TestAmd64Compiler_generate(t *testing.T) {
 	t.Run("max pointer", func(t *testing.T) {
 		getCompiler := func(t *testing.T) (compiler *amd64Compiler) {
-			compiler = requireNewCompiler(t)
+			env := newJITEnvironment()
+			compiler = env.requireNewCompiler(t)
 			ret := compiler.newProg()
 			ret.As = obj.ARET
 			compiler.addInstruction(ret)
@@ -5712,7 +5732,8 @@ func TestAmd64Compiler_generate(t *testing.T) {
 	})
 
 	t.Run("on generate callback", func(t *testing.T) {
-		compiler := requireNewCompiler(t)
+		env := newJITEnvironment()
+		compiler := env.requireNewCompiler(t)
 		ret := compiler.newProg()
 		ret.As = obj.ARET
 		compiler.addInstruction(ret)
@@ -5730,9 +5751,11 @@ func TestAmd64Compiler_generate(t *testing.T) {
 }
 
 func TestAmd64Compiler_compileUnreachable(t *testing.T) {
-	compiler := requireNewCompiler(t)
+	env := newJITEnvironment()
+	compiler := env.requireNewCompiler(t)
 	err := compiler.emitPreamble()
 	require.NoError(t, err)
+
 	x1Reg := int16(x86.REG_AX)
 	x2Reg := int16(x86.REG_R10)
 	compiler.locationStack.pushValueOnRegister(x1Reg)
@@ -5747,7 +5770,6 @@ func TestAmd64Compiler_compileUnreachable(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run code.
-	env := newJITEnvironment()
 	env.exec(code)
 
 	// Check the jitCallStatus of engine.
@@ -5805,8 +5827,8 @@ func TestAmd64Compiler_compileSelect(t *testing.T) {
 		{x1OnRegister: false, x2OnRegister: false, selectX1: false, condValueOnCondRegister: true},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			compiler := requireNewCompiler(t)
 			env := newJITEnvironment()
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -5900,7 +5922,7 @@ func TestAmd64Compiler_compileSwap(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
 			err := compiler.emitPreamble()
 			require.NoError(t, err)
 
@@ -5963,7 +5985,8 @@ func TestAmd64Compiler_compileGlobalGet(t *testing.T) {
 		tp := tp
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
+			compiler.f.ModuleInstance = env.moduleInstance
 
 			// Setup the globals.
 			globals := []*wasm.GlobalInstance{nil, {Val: globalValue, Type: &wasm.GlobalType{ValType: tp}}, nil}
@@ -6015,7 +6038,8 @@ func TestAmd64Compiler_compileGlobalSet(t *testing.T) {
 		tp := tp
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := requireNewCompiler(t)
+			compiler := env.requireNewCompiler(t)
+			compiler.f.ModuleInstance = env.moduleInstance
 
 			// Setup the globals.
 			env.addGlobals(nil, &wasm.GlobalInstance{Val: 40, Type: &wasm.GlobalType{ValType: tp}}, nil)
@@ -6052,15 +6076,15 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 		isAddressFromRegister := isAddressFromRegister
 		t.Run(fmt.Sprintf("is_address_from_register=%v", isAddressFromRegister), func(t *testing.T) {
 			t.Run("need to grow call frame stack", func(t *testing.T) {
-				t.Skip() // TODO: delete!
 				env := newJITEnvironment()
 				engine := env.engine()
 
 				env.setCallFrameStackPointer(engine.globalContext.callFrameStackLen - 1)
-				compiler := requireNewCompiler(t)
+				compiler := env.requireNewCompiler(t)
+				err := compiler.emitPreamble()
+				require.NoError(t, err)
 
 				require.Empty(t, compiler.locationStack.usedRegisters)
-				var err error
 				if isAddressFromRegister {
 					err = compiler.callFunctionFromRegister(x86.REG_AX, &wasm.FunctionType{})
 				} else {
@@ -6100,13 +6124,18 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 				moduleInstanceToExpectedValueInMemory := map[*wasm.ModuleInstance]uint32{}
 				for i := 0; i < numCalls; i++ {
 					// Each function takes one arguments, adds the value with 100 + i and returns the result.
+					addTargetValue := uint32(100 + i)
+					moduleInstance := &wasm.ModuleInstance{
+						Memory: &wasm.MemoryInstance{Buffer: make([]byte, 1024)},
+					}
+					moduleInstanceToExpectedValueInMemory[moduleInstance] = addTargetValue
 
-					compiler := requireNewCompiler(t)
-					compiler.f = &wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}}
+					compiler := env.requireNewCompiler(t)
+					compiler.f = &wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}, ModuleInstance: moduleInstance}
+
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 
-					addTargetValue := uint32(100 + i)
 					expectedValue += addTargetValue
 					err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: uint32(addTargetValue)})
 					require.NoError(t, err)
@@ -6138,20 +6167,15 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 					code, _, _, err := compiler.generate()
 					require.NoError(t, err)
 
-					moduleInstance := &wasm.ModuleInstance{
-						Memory: &wasm.MemoryInstance{Buffer: make([]byte, 1024)},
-					}
-					moduleInstanceToExpectedValueInMemory[moduleInstance] = addTargetValue
 					compiledFunction := &compiledFunction{
-						codeSegment:           code,
-						codeInitialAddress:    uintptr(unsafe.Pointer(&code[0])),
-						moduleInstanceAddress: uintptr(unsafe.Pointer(moduleInstance)),
+						codeSegment:        code,
+						codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 					}
 					engine.addCompiledFunction(wasm.FunctionAddress(i), compiledFunction)
 				}
 
 				// Now we start building the caller's code.
-				compiler := requireNewCompiler(t)
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 
@@ -6211,8 +6235,8 @@ func TestAmd64Compiler_compileCall(t *testing.T) {
 
 	{
 		// Call target function takes three i32 arguments and does ADD 2 times.
-		compiler := requireNewCompiler(t)
-		compiler.f = &wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}}
+		compiler := env.requireNewCompiler(t)
+		compiler.f = &wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}, ModuleInstance: &wasm.ModuleInstance{}}
 		err := compiler.emitPreamble()
 		require.NoError(t, err)
 		for i := 0; i < 2; i++ {
@@ -6232,7 +6256,7 @@ func TestAmd64Compiler_compileCall(t *testing.T) {
 	}
 
 	// Now we start building the caller's code.
-	compiler := requireNewCompiler(t)
+	compiler := env.requireNewCompiler(t)
 	compiler.f = &wasm.FunctionInstance{ModuleInstance: &wasm.ModuleInstance{
 		Functions: []*wasm.FunctionInstance{
 			{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}, Address: targetFunctionAddress},
@@ -6278,7 +6302,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 	t.Run("out of bounds", func(t *testing.T) {
 		env := newJITEnvironment()
 		env.setTable(make([]wasm.TableElement, 10))
-		compiler := requireNewCompiler(t)
+		compiler := env.requireNewCompiler(t)
 
 		targetOperation := &wazeroir.OperationCallIndirect{}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex.
@@ -6309,7 +6333,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 		table := make([]wasm.TableElement, 10)
 		env.setTable(table)
 
-		compiler := requireNewCompiler(t)
+		compiler := env.requireNewCompiler(t)
 		targetOperation := &wazeroir.OperationCallIndirect{}
 		targetOffset := &wazeroir.OperationConstI32{Value: uint32(0)}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
@@ -6343,21 +6367,22 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 		table := make([]wasm.TableElement, 10)
 		env.setTable(table)
 
-		compiler := requireNewCompiler(t)
+		compiler := env.requireNewCompiler(t)
 		targetOperation := &wazeroir.OperationCallIndirect{}
 		targetOffset := &wazeroir.OperationConstI32{Value: uint32(0)}
+		env.moduleInstance.Types = []*wasm.TypeInstance{{Type: &wasm.FunctionType{}, TypeID: 1000}}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
-		compiler.f = &wasm.FunctionInstance{ModuleInstance: &wasm.ModuleInstance{Types: []*wasm.TypeInstance{{Type: &wasm.FunctionType{}, TypeID: 1000}}}}
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
 		table[0] = wasm.TableElement{FunctionTypeID: 50}
 
+		err := compiler.emitPreamble()
+		require.NoError(t, err)
+
 		// Place the offfset value.
-		err := compiler.compileConstI32(targetOffset)
+		err = compiler.compileConstI32(targetOffset)
 		require.NoError(t, err)
 
 		// Now emit the code.
-		err = compiler.emitPreamble()
-		require.NoError(t, err)
 		require.NoError(t, compiler.compileCallIndirect(targetOperation))
 
 		// Generate the code under test.
@@ -6395,7 +6420,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 				// and it returns one value.
 				expectedReturnValue := uint32(i * 1000)
 				{
-					compiler := requireNewCompiler(t)
+					compiler := env.requireNewCompiler(t)
 					err := compiler.emitPreamble()
 					require.NoError(t, err)
 					err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: expectedReturnValue})
@@ -6412,7 +6437,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 					})
 				}
 
-				compiler := requireNewCompiler(t)
+				compiler := env.requireNewCompiler(t)
 				err := compiler.emitPreamble()
 				require.NoError(t, err)
 


### PR DESCRIPTION
This commit refactors the code around function calls/returns and
reduces the generated instructions. Notably resolves #173 and skips
the module context switch which is supposed to happen on function 
entry and return. Given that, in almost all use cases, users instantiate
single Wasm binary and run the functions from it rather than doing
import/export on multiple binaries, the context switch almost never 
happens. therefore the branch prediction on whether or not 
skipping context switch code should be almost always correct.


As a result, the cost of function calls decreases up to 35% as 
you can see the bench mark result below where the bench case 
is "recursive" fibonacci function which is call heavy.


```
name                       old time/op    new time/op    delta
Engines/jit/fib_for_20-32     105µs ± 3%      70µs ± 3%  -33.55%  (p=0.008 n=5+5)
Engines/jit/fib_for_30-32    13.0ms ± 2%     8.5ms ± 3%  -34.89%  (p=0.008 n=5+5)

name                       old alloc/op   new alloc/op   delta
Engines/jit/fib_for_20-32     16.0B ± 0%     16.0B ± 0%     ~     (all equal)
Engines/jit/fib_for_30-32     16.0B ± 0%     16.0B ± 0%     ~     (all equal)

name                       old allocs/op  new allocs/op  delta
Engines/jit/fib_for_20-32      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Engines/jit/fib_for_30-32      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
```

Overall bench results is as follows:

```
name                                          old time/op    new time/op    delta
Engines/jit/base64_5_per_exec-32                0.00ns ±15%    0.00ns ±44%     ~     (p=0.952 n=5+5)
Engines/jit/base64_100_per_exec-32              0.00ns ± 7%    0.00ns ±21%     ~     (p=0.095 n=5+5)
Engines/jit/base64_10000_per_exec-32            0.02ns ±13%    0.02ns ± 7%     ~     (p=0.421 n=5+5)
Engines/jit/fib_for_5-32                         164ns ± 3%     153ns ± 2%   -6.68%  (p=0.008 n=5+5)
Engines/jit/fib_for_10-32                        966ns ± 3%     687ns ± 1%  -28.86%  (p=0.008 n=5+5)
Engines/jit/fib_for_20-32                        106µs ± 2%      69µs ± 4%  -35.30%  (p=0.008 n=5+5)
Engines/jit/string_manipulation_size_50-32      58.1µs ± 4%    54.2µs ±12%     ~     (p=0.151 n=5+5)
Engines/jit/string_manipulation_size_100-32      177µs ± 2%     152µs ± 2%  -13.93%  (p=0.016 n=5+4)
Engines/jit/string_manipulation_size_1000-32    12.9ms ± 0%    11.1ms ± 5%  -13.44%  (p=0.016 n=4+5)
Engines/jit/reverse_array_size_500-32           12.0µs ± 3%    10.2µs ± 4%  -15.38%  (p=0.008 n=5+5)
Engines/jit/reverse_array_size_1000-32          23.9µs ± 1%    20.7µs ± 3%  -13.60%  (p=0.008 n=5+5)
Engines/jit/reverse_array_size_10000-32          287µs ±14%     251µs ±11%     ~     (p=0.222 n=5+5)
Engines/jit/random_mat_mul_size_5-32            21.2µs ±25%    18.7µs ±10%     ~     (p=0.222 n=5+5)
Engines/jit/random_mat_mul_size_10-32           45.6µs ± 6%    42.1µs ± 3%   -7.71%  (p=0.016 n=5+4)
Engines/jit/random_mat_mul_size_20-32            175µs ± 2%     164µs ± 3%   -6.52%  (p=0.008 n=5+5)

name                                          old alloc/op   new alloc/op   delta
Engines/jit/base64_5_per_exec-32                 0.00B          0.00B          ~     (all equal)
Engines/jit/base64_100_per_exec-32               0.00B          0.00B          ~     (all equal)
Engines/jit/base64_10000_per_exec-32             0.00B          0.00B          ~     (all equal)
Engines/jit/fib_for_5-32                         16.0B ± 0%     16.0B ± 0%     ~     (all equal)
Engines/jit/fib_for_10-32                        16.0B ± 0%     16.0B ± 0%     ~     (all equal)
Engines/jit/fib_for_20-32                        16.0B ± 0%     16.0B ± 0%     ~     (all equal)
Engines/jit/string_manipulation_size_50-32       8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/string_manipulation_size_100-32      8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/string_manipulation_size_1000-32     8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/reverse_array_size_500-32            8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/reverse_array_size_1000-32           8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/reverse_array_size_10000-32          8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/random_mat_mul_size_5-32             8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/random_mat_mul_size_10-32            8.00B ± 0%     8.00B ± 0%     ~     (all equal)
Engines/jit/random_mat_mul_size_20-32            8.00B ± 0%     8.00B ± 0%     ~     (all equal)

name                                          old allocs/op  new allocs/op  delta
Engines/jit/base64_5_per_exec-32                  0.00           0.00          ~     (all equal)
Engines/jit/base64_100_per_exec-32                0.00           0.00          ~     (all equal)
Engines/jit/base64_10000_per_exec-32              0.00           0.00          ~     (all equal)
Engines/jit/fib_for_5-32                          2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Engines/jit/fib_for_10-32                         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Engines/jit/fib_for_20-32                         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Engines/jit/string_manipulation_size_50-32        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/string_manipulation_size_100-32       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/string_manipulation_size_1000-32      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/reverse_array_size_500-32             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/reverse_array_size_1000-32            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/reverse_array_size_10000-32           1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/random_mat_mul_size_5-32              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/random_mat_mul_size_10-32             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Engines/jit/random_mat_mul_size_20-32             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```
