### PR TITLE
Add `Name` and `Data` (for custom data) fields to `HostFunctionCallContext`

### DIFF
--- a/wasm/interpreter/interpreter.go
+++ b/wasm/interpreter/interpreter.go
@@ -511,11 +511,15 @@ func (it *interpreter) callHostFunc(f *interpreterFunction) {
 	}
 
 	val := reflect.New(tp.In(0)).Elem()
-	var memory *wasm.MemoryInstance
+	module := f.funcInstance.ModuleInstance
 	if len(it.frames) > 0 {
-		memory = it.frames[len(it.frames)-1].f.funcInstance.ModuleInstance.Memory
+		module = it.frames[len(it.frames)-1].f.funcInstance.ModuleInstance
 	}
-	val.Set(reflect.ValueOf(&wasm.HostFunctionCallContext{Memory: memory}))
+	val.Set(reflect.ValueOf(&wasm.HostFunctionCallContext{
+		Name:   module.Name,
+		Memory: module.Memory,
+		Data:   module.Data,
+	}))
 	in[0] = val
 
 	frame := &interpreterFrame{f: f}

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -387,7 +387,11 @@ func (e *engine) Call(f *wasm.FunctionInstance, params ...uint64) (results []uin
 	}
 
 	if compiled.source.IsHostFunction() {
-		e.execHostFunction(compiled.source.HostFunction, &wasm.HostFunctionCallContext{Memory: f.ModuleInstance.Memory})
+		e.execHostFunction(compiled.source.HostFunction, &wasm.HostFunctionCallContext{
+			Name:   f.ModuleInstance.Name,
+			Memory: f.ModuleInstance.Memory,
+			Data:   f.ModuleInstance.Data,
+		})
 	} else {
 		e.execFunction(compiled)
 	}
@@ -533,7 +537,11 @@ jitentry:
 				}
 			}
 			saved := e.globalContext.previousCallFrameStackPointer
-			e.execHostFunction(fn.source.HostFunction, &wasm.HostFunctionCallContext{Memory: callerCompiledFunction.source.ModuleInstance.Memory})
+			e.execHostFunction(fn.source.HostFunction, &wasm.HostFunctionCallContext{
+				Name:   callerCompiledFunction.source.ModuleInstance.Name,
+				Memory: callerCompiledFunction.source.ModuleInstance.Memory,
+				Data:   callerCompiledFunction.source.ModuleInstance.Data,
+			})
 			e.globalContext.previousCallFrameStackPointer = saved
 			goto jitentry
 		case jitCallStatusCodeCallBuiltInFunction:

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -78,6 +78,7 @@ type (
 		Memory    *MemoryInstance
 		Tables    []*TableInstance
 		Types     []*TypeInstance
+		Data      interface{}
 	}
 
 	// ExportInstance represents an exported instance in a Store.
@@ -310,6 +311,15 @@ func (s *Store) Instantiate(module *Module, name string) error {
 			return fmt.Errorf("calling start function failed: %v", err)
 		}
 	}
+	return nil
+}
+
+func (s *Store) SetInstanceData(moduleName string, data interface{}) error {
+	m, ok := s.ModuleInstances[moduleName]
+	if !ok {
+		return fmt.Errorf("module %s not instantiated", moduleName)
+	}
+	m.Data = data
 	return nil
 }
 
@@ -844,8 +854,13 @@ func DecodeBlockType(types []*TypeInstance, r io.Reader) (*FunctionType, uint64,
 
 // HostFunctionCallContext is the first argument of all host functions.
 type HostFunctionCallContext struct {
+	// Name is the name of the module instance so that host calls can be correlated with the instance
+	// that called them.
+	Name string
 	// Memory is the currently used memory instance at the time when the host function call is made.
 	Memory *MemoryInstance
+	// Data is custom module instance data set by the host application and passed back in host calls.
+	Data interface{}
 	// TODO: Add others if necessary.
 }
 


### PR DESCRIPTION
This PR adds the name of the module instance and custom/user-defined data to HostFunctionCallContext so state can exist for the duration of the call. This can be used to pass higher level data structures can be passed (e.g. via `[]byte`) to and from the module. See RPC/ABI example [here](https://github.com/wapc/wapc-go/blob/multi_engine/engines/wazero/wazero.go).

I also added a few more WASI host calls to support TinyGo 0.22.0 which should allow #167 tests to pass. /cc @mathetake

Tested with both JIT and interpreter.

Closes #183 