### PR TITLE
Add wazero specific limitations

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -38,7 +38,7 @@ This is due to the same reason for the limitation on the number of functions abo
 
 According to the spec, there's no limitation on the number of values we a function can retain in the Wasm values stack. We limit the maximum number to 2^27 = 134,217,728.
 The reason is that we internally represent all the values as 64-bit integes regardless of its types (including f32, f64), and 2^27 values means 
-1 GiB = (2^30). 1 GiB is the reasonable for most applications [as we see a Goroutine has a stack size limit with that number on 64-bit arch](https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/runtime/proc.go#L120), considering that WebAssembly is (currently) 32-bit environment.
+1 GiB = (2^30). 1 GiB is the reasonable for most applications [as we see a Goroutine has 250 MB as a limit on the stack for 32-bit arch](https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/runtime/proc.go#L120), considering that WebAssembly is (currently) 32-bit environment.
 
 All the functions are statically analyzed at module insntantiation phase, and if a function can potentially reach this limit, an error is returend.
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -29,7 +29,7 @@ That is because not only we _believe_ that all use cases are fine with the limit
 ### Number of function types in a store
 
 There's no limitation on the number of function types in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) according to the spec. In wazero implementation, we assign each function type to a unique ID, and choose to use `uint32` to represent the IDs.
-Therefore the maximum number of function types a store can have is limited to 2^27 as that would result in occupying 2^29 = (512 MiB) bytes in memory for function types alone.
+Therefore the maximum number of function types a store can have is limited to 2^27 as even that number would occupy 512MB just to reference the function types.
 
 This is due to the same reason for the limitation on the number of functions above.
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -13,20 +13,40 @@ Note: `microwasm` was never specified formally, and only exists in a historical 
 https://github.com/bytecodealliance/wasmtime/blob/v0.29.0/crates/lightbeam/src/microwasm.rs
 
 
-## Size limitations
-### Number of functions
+## Implementation limitations
+
+[WebAssembly specification states that](https://www.w3.org/TR/wasm-core-1/#a2-implementation-limitations)
+runtime implementors can impose their own limits on a number of aspects of a Wasm module or execution.
+
+The followings are the limitations we explicitly impose and handle as errors during module instantiation in wazero:
+
+### Number of functions in a store
 
 The possible number of function instances in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) is not specified in the WebAssembly specifications since [`funcaddr`](https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr) corresponding to a function instance can be arbitrary number. 
-In wazero, we choose to use `uint32` to represent `funcaddr`. Therefore the maximum number of function instances a store can instantiate is limited to 2^32. 
+In wazero, we choose to use `uint32` to represent `funcaddr`. Therefore the maximum number of function instances a store can instantiate is limited to 2^27. 
 
 That is because not only we _believe_ that all use cases are fine with the limitation, but also we have no way to test wazero runtimes under these unusual circumstances.
 
-### Number of function types
+### Number of function types in a store
 
 There's no limitation on the number of function types in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) according to the spec. In wazero implementation, we assign each function type to a unique ID, and choose to use `uint32` to represent the IDs.
-Therefore the maximum number of function types a store can have is limited to 2^32. 
+Therefore the maximum number of function types a store can have is limited to 2^27. 
 
 This is due to the same reason for the limitation on the number of functions above.
+
+### Number of values on the stack in a function
+
+According to the spec, there's no limitation on the number of values we a function can retain in the Wasm values stack. We limit the maximum number to 2^27 = 134,217,728.
+The reason is that we internally represent all the values as 64-bit integes regardless of its types (including f32, f64), and 2^27 values means 
+1 GiB = (2^30). 1 GiB is the reasonable for most applications [as we see a Goroutine has a stack size limit with that number on 64-bit arch](https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/runtime/proc.go#L120), considering that WebAssembly is (currently) 32-bit environment.
+
+All the functions are statically analyzed at module insntantiation phase, and if a function can potentially reach this limit, an error is returend.
+
+### Number of globals in a module
+
+Theoretically, a module can declare globals (inclding imported ones) up to 2^32 times. However, we limit the number of available globals in a module to 2^27 = 134,217,728.
+That is because internally we store globals in a slice with pointer types (meaning 8 bytes on 64-bit platforms), and thefore 2^27 globals
+means that we have 1 GiB size of slice which seems large enough for most applications.
 
 ## JIT engine implementation
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -15,15 +15,14 @@ https://github.com/bytecodealliance/wasmtime/blob/v0.29.0/crates/lightbeam/src/m
 
 ## Implementation limitations
 
-[WebAssembly specification states that](https://www.w3.org/TR/wasm-core-1/#a2-implementation-limitations)
-runtime implementors can impose their own limits on a number of aspects of a Wasm module or execution.
+WebAssembly 1.0 (MVP) specification allows runtimes to [limit certain aspects of Wasm module or execution](https://www.w3.org/TR/wasm-core-1/#a2-implementation-limitations).
 
-The followings are the limitations we explicitly impose and handle as errors during module instantiation in wazero:
+wazero limitations are imposed pragmatically and described below.
 
 ### Number of functions in a store
 
 The possible number of function instances in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) is not specified in the WebAssembly specifications since [`funcaddr`](https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr) corresponding to a function instance can be arbitrary number. 
-In wazero, we choose to set the maximum number of function instances a store can instantiate is limited to 2^27 as that would result in occupying 2^20 (= 1 GiB) bytes in memory for function pointers alone.
+wazero limits the maximum function instances to 2^27 as even that number would occupy 1GB in function pointers.
 
 That is because not only we _believe_ that all use cases are fine with the limitation, but also we have no way to test wazero runtimes under these unusual circumstances.
 
@@ -36,7 +35,7 @@ This is due to the same reason for the limitation on the number of functions abo
 
 ### Number of values on the stack in a function
 
-According to the spec, there's no limitation on the number of values we a function can retain in the Wasm values stack. We limit the maximum number to 2^27 = 134,217,728.
+While the the spec does not clarify a limitation of function stack values, wazero limits this to 2^27 = 134,217,728.
 The reason is that we internally represent all the values as 64-bit integes regardless of its types (including f32, f64), and 2^27 values means 
 1 GiB = (2^30). 1 GiB is the reasonable for most applications [as we see a Goroutine has 250 MB as a limit on the stack for 32-bit arch](https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/runtime/proc.go#L120), considering that WebAssembly is (currently) 32-bit environment.
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -23,14 +23,14 @@ The followings are the limitations we explicitly impose and handle as errors dur
 ### Number of functions in a store
 
 The possible number of function instances in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) is not specified in the WebAssembly specifications since [`funcaddr`](https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr) corresponding to a function instance can be arbitrary number. 
-In wazero, we choose to use `uint32` to represent `funcaddr`. Therefore the maximum number of function instances a store can instantiate is limited to 2^27. 
+In wazero, we choose to set the maximum number of function instances a store can instantiate is limited to 2^27 as that would result in occupying 2^20 (= 1 GiB) bytes in memory for function pointers alone.
 
 That is because not only we _believe_ that all use cases are fine with the limitation, but also we have no way to test wazero runtimes under these unusual circumstances.
 
 ### Number of function types in a store
 
 There's no limitation on the number of function types in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) according to the spec. In wazero implementation, we assign each function type to a unique ID, and choose to use `uint32` to represent the IDs.
-Therefore the maximum number of function types a store can have is limited to 2^27. 
+Therefore the maximum number of function types a store can have is limited to 2^27 as that would result in occupying 2^29 = (512 MiB) bytes in memory for function types alone.
 
 This is due to the same reason for the limitation on the number of functions above.
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -36,14 +36,14 @@ This is due to the same reason for the limitation on the number of functions abo
 ### Number of values on the stack in a function
 
 While the the spec does not clarify a limitation of function stack values, wazero limits this to 2^27 = 134,217,728.
-The reason is that we internally represent all the values as 64-bit integes regardless of its types (including f32, f64), and 2^27 values means 
+The reason is that we internally represent all the values as 64-bit integers regardless of its types (including f32, f64), and 2^27 values means 
 1 GiB = (2^30). 1 GiB is the reasonable for most applications [as we see a Goroutine has 250 MB as a limit on the stack for 32-bit arch](https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/runtime/proc.go#L120), considering that WebAssembly is (currently) 32-bit environment.
 
-All the functions are statically analyzed at module insntantiation phase, and if a function can potentially reach this limit, an error is returend.
+All the functions are statically analyzed at module instantiation phase, and if a function can potentially reach this limit, an error is returned.
 
 ### Number of globals in a module
 
-Theoretically, a module can declare globals (inclding imported ones) up to 2^32 times. However, we limit the number of available globals in a module to 2^27 = 134,217,728.
+Theoretically, a module can declare globals (including imports) up to 2^32 times. However, wazero limits this to  2^27(134,217,728) per module.
 That is because internally we store globals in a slice with pointer types (meaning 8 bytes on 64-bit platforms), and thefore 2^27 globals
 means that we have 1 GiB size of slice which seems large enough for most applications.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,5 +5,3 @@ This directory contains tests which use multiple packages. For example:
 - `engine` contains variety of e2e tests, mainly to ensure the consistency in the behavior between engines.
 - `spectest` contains end-to-end tests with the [WebAssembly specification tests](https://github.com/WebAssembly/spec/tree/wg-1.0/test/core).
 - `wasi` contains end-to-end tests on the interoperability of our WASI implementation with language runtimes. This also substitutes for WASI spec tests until we have another option.
-
-Note: tests that use raw Wasm text or binary files must live inside of this directory except `examples`.

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -402,6 +402,7 @@ func (c *amd64Compiler) compileGlobalGet(o *wazeroir.OperationGlobalGet) error {
 	getGlobalInstanceLocation.To.Type = obj.TYPE_REG
 	getGlobalInstanceLocation.To.Reg = intReg
 	getGlobalInstanceLocation.From.Type = obj.TYPE_CONST
+	// Note: globals are limited to 2^27 in a module, so this offset never exceeds 32-bit.
 	getGlobalInstanceLocation.From.Offset = 8 * int64(o.Index)
 	c.addInstruction(getGlobalInstanceLocation)
 
@@ -475,6 +476,7 @@ func (c *amd64Compiler) compileGlobalSet(o *wazeroir.OperationGlobalSet) error {
 	getGlobalInstanceLocation.To.Type = obj.TYPE_REG
 	getGlobalInstanceLocation.To.Reg = intReg
 	getGlobalInstanceLocation.From.Type = obj.TYPE_CONST
+	// Note: globals are limited to 2^27 in a module, so this offset never exceeds 32-bit.
 	getGlobalInstanceLocation.From.Offset = 8 * int64(o.Index)
 	c.addInstruction(getGlobalInstanceLocation)
 
@@ -1259,6 +1261,7 @@ func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
 		prog.As = x86.AMOVQ
 		prog.From.Type = obj.TYPE_MEM
 		prog.From.Reg = reservedRegisterForStackBasePointerAddress
+		// Note: stack pointers are ensured not to exceed 2^27 so this offset never exceeds 32-bit range.
 		prog.From.Offset = int64(pickTarget.stackPointer) * 8
 		prog.To.Type = obj.TYPE_REG
 		prog.To.Reg = reg
@@ -2200,6 +2203,7 @@ func (c *amd64Compiler) emitShiftOp(instruction obj.As, is32Bit bool) error {
 		// Shift target can be placed on a memory location.
 		inst.To.Type = obj.TYPE_MEM
 		inst.To.Reg = reservedRegisterForStackBasePointerAddress
+		// Note: stack pointers are ensured not to exceed 2^27 so this offset never exceeds 32-bit range.
 		inst.To.Offset = int64(x1.stackPointer) * 8
 	}
 	c.addInstruction(inst)
@@ -4466,6 +4470,7 @@ func (c *amd64Compiler) moveStackToRegister(loc *valueLocation) {
 	prog.As = x86.AMOVQ
 	prog.From.Type = obj.TYPE_MEM
 	prog.From.Reg = reservedRegisterForStackBasePointerAddress
+	// Note: stack pointers are ensured not to exceed 2^27 so this offset never exceeds 32-bit range.
 	prog.From.Offset = int64(loc.stackPointer) * 8
 	prog.To.Type = obj.TYPE_REG
 	prog.To.Reg = loc.register
@@ -4823,7 +4828,7 @@ func (c *amd64Compiler) callFunction(addr wasm.FunctionAddress, addrReg int16, f
 			readCompiledFunctionAddressAddress.From.Index = addrReg
 			readCompiledFunctionAddressAddress.From.Scale = 8 // because the size of *compiledFunction equals 8 bytes.
 		} else {
-			// TODO: rethink on this since if addr*8 >= math.MaxUint32, then this instruction is invalid.
+			// Note: Funcaddr is limited up to 2^27 so this offset never exceeds 32-bit integer.
 			readCompiledFunctionAddressAddress.From.Offset = int64(addr) * 8 // because the size of *compiledFunction equals 8 bytes.
 		}
 		c.addInstruction(readCompiledFunctionAddressAddress)
@@ -5236,6 +5241,7 @@ func (c *amd64Compiler) releaseRegisterToStack(loc *valueLocation) {
 	prog.As = x86.AMOVQ
 	prog.To.Type = obj.TYPE_MEM
 	prog.To.Reg = reservedRegisterForStackBasePointerAddress
+	// Note: stack pointers are ensured not to exceed 2^27 so this offset never exceeds 32-bit range.
 	prog.To.Offset = int64(loc.stackPointer) * 8
 	prog.From.Type = obj.TYPE_REG
 	prog.From.Reg = loc.register

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -6088,7 +6088,7 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 				if isAddressFromRegister {
 					err = compiler.callFunctionFromRegister(x86.REG_AX, &wasm.FunctionType{})
 				} else {
-					err = compiler.callFunctionFromAddress(0xdeadbeaf, &wasm.FunctionType{})
+					err = compiler.callFunctionFromAddress(11111 /* can be arbitrary*/, &wasm.FunctionType{})
 				}
 				require.NoError(t, err)
 				require.Empty(t, compiler.locationStack.usedRegisters)

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -463,13 +463,13 @@ func executeConstExpression(globals []*GlobalInstance, expr *ConstantExpression)
 	case OpcodeI32Const:
 		v, _, err = leb128.DecodeInt32(r)
 		if err != nil {
-			return nil, 0, fmt.Errorf("read uint32: %w", err)
+			return nil, 0, fmt.Errorf("read i32: %w", err)
 		}
 		return v, ValueTypeI32, nil
 	case OpcodeI64Const:
-		v, _, err = leb128.DecodeInt32(r)
+		v, _, err = leb128.DecodeInt64(r)
 		if err != nil {
-			return nil, 0, fmt.Errorf("read uint64: %w", err)
+			return nil, 0, fmt.Errorf("read i64: %w", err)
 		}
 		return v, ValueTypeI64, nil
 	case OpcodeF32Const:

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -36,8 +36,10 @@ type (
 		// do type-checks on indirect function calls.
 		TypeIDs map[string]FunctionTypeID
 
-		// maximumFunctionAddress and maximumFunctionTypes represent the limit on the number of each instance type in a store.
-		maximumFunctionAddress, maximumFunctionTypes int
+		// maximumFunctionAddress represents the limit on the number of function addresses (= function instances) in a store.
+		maximumFunctionAddress int
+		//  maximumFunctionTypes represents the limit on the number of function types in a store.
+		maximumFunctionTypes int
 		// maximumGlobals is the maximum number of globals that can be declared in a module.
 		maximumGlobals int
 

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -37,10 +37,13 @@ type (
 		TypeIDs map[string]FunctionTypeID
 
 		// maximumFunctionAddress represents the limit on the number of function addresses (= function instances) in a store.
+		// Note: this is fixed to 2^27 but have this a field for testability.
 		maximumFunctionAddress int
 		//  maximumFunctionTypes represents the limit on the number of function types in a store.
+		// Note: this is fixed to 2^27 but have this a field for testability.
 		maximumFunctionTypes int
 		// maximumGlobals is the maximum number of globals that can be declared in a module.
+		// Note: this is fixed to 2^27 but have this a field for testability.
 		maximumGlobals int
 
 		// The followings fields match the definition of Store in the specification.
@@ -186,6 +189,7 @@ type (
 	FunctionTypeID uint32
 )
 
+// The wazero specific limitations described at RATIONALE.md.
 const (
 	maximumFunctionAddress = 1 << 27
 	maximumFunctionTypes   = 1 << 27

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/wazero/wasm/internal/leb128"
 )
 

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -263,3 +263,15 @@ func TestMemoryInstance_PutUint32(t *testing.T) {
 		})
 	}
 }
+
+func TestStore_buildGlobalInstances(t *testing.T) {
+	t.Run("too many globals", func(t *testing.T) {
+		// Setup a store to have the reasonably low max on globals for testing.
+		s := NewStore(nopEngineInstance)
+		const max = 10
+		s.maximumGlobals = max
+
+		_, err := s.buildGlobalInstances(&Module{GlobalSection: make([]*Global, max+1)}, nil)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
This PR add more documentations on wazero specific limits,
and impose the limitation in the module instantiation phase.

Also, this backfills tests for executeConstantExpression and buildGlobalInstances
and fixed a bug in the former.

The implementation on the function value stack height limit will be in a followup PR
as it would be rather large change.

