### PR TITLE
Fix interpreter cannot call "imported-and-exported-back" function

### DIFF
--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tetratelabs/wazero/wasm/binary"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
 	"github.com/tetratelabs/wazero/wasm/jit"
+	"github.com/tetratelabs/wazero/wasm/text"
 )
 
 func TestJIT(t *testing.T) {
@@ -173,9 +174,9 @@ func recursiveEntry(t *testing.T, newEngine func() wasm.Engine) {
 }
 
 func importedAndExportedFunc(t *testing.T, newEngine func() wasm.Engine) {
-	buf, err := os.ReadFile("testdata/imported_and_exported_func.wasm")
+	buf, err := os.ReadFile("testdata/imported_and_exported_func.wat")
 	require.NoError(t, err)
-	mod, err := binary.DecodeModule(buf)
+	mod, err := text.DecodeModule(buf)
 	require.NoError(t, err)
 
 	store := wasm.NewStore(newEngine())

--- a/tests/engine/testdata/imported_and_exported_func.wat
+++ b/tests/engine/testdata/imported_and_exported_func.wat
@@ -1,0 +1,7 @@
+;; This is a module to test that the engine can call "imported-and-then-exported-back" function correctly
+(module
+  ;; arbitrary function with params
+  (import "env" "add_int" (func $add_int (param i32 i32) (result i32)))
+  ;; add_int is imported from the environment, but it's also exported back to the environment
+  (export "add_int" (func $add_int))
+  )

--- a/tests/engine/testdata/imported_and_exported_func.wat
+++ b/tests/engine/testdata/imported_and_exported_func.wat
@@ -1,7 +1,0 @@
-;; This is a module to test that the engine can call "imported-and-then-exported-back" function correctly
-(module
-  ;; arbitrary function with params
-  (import "env" "add_int" (func $add_int (param i32 i32) (result i32)))
-  ;; add_int is imported from the environment, but it's also exported back to the environment
-  (export "add_int" (func $add_int))
-  )

--- a/wasm/interpreter/interpreter.go
+++ b/wasm/interpreter/interpreter.go
@@ -481,7 +481,7 @@ func (it *interpreter) Call(f *wasm.FunctionInstance, params ...uint64) (results
 		it.push(param)
 	}
 	if g.hostFn != nil {
-		it.callHostFunc(g, params...)
+		it.callHostFunc(g)
 	} else {
 		it.callNativeFunc(g)
 	}
@@ -492,7 +492,7 @@ func (it *interpreter) Call(f *wasm.FunctionInstance, params ...uint64) (results
 	return
 }
 
-func (it *interpreter) callHostFunc(f *interpreterFunction, _ ...uint64) {
+func (it *interpreter) callHostFunc(f *interpreterFunction) {
 	tp := f.hostFn.Type()
 	in := make([]reflect.Value, tp.NumIn())
 	for i := len(in) - 1; i >= 1; i-- {
@@ -582,7 +582,7 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 		case wazeroir.OperationKindCall:
 			{
 				if op.f.hostFn != nil {
-					it.callHostFunc(op.f, it.stack[len(it.stack)-len(op.f.funcInstance.FunctionType.Type.Params):]...)
+					it.callHostFunc(op.f)
 				} else {
 					it.callNativeFunc(op.f)
 				}
@@ -605,7 +605,7 @@ func (it *interpreter) callNativeFunc(f *interpreterFunction) {
 				target := it.functions[table.Table[offset].FunctionAddress]
 				// Call in.
 				if target.hostFn != nil {
-					it.callHostFunc(target, it.stack[len(it.stack)-len(target.funcInstance.FunctionType.Type.Params):]...)
+					it.callHostFunc(target)
 				} else {
 					it.callNativeFunc(target)
 				}

--- a/wasm/interpreter/interpreter.go
+++ b/wasm/interpreter/interpreter.go
@@ -477,12 +477,12 @@ func (it *interpreter) Call(f *wasm.FunctionInstance, params ...uint64) (results
 		return
 	}
 
+	for _, param := range params {
+		it.push(param)
+	}
 	if g.hostFn != nil {
 		it.callHostFunc(g, params...)
 	} else {
-		for _, param := range params {
-			it.push(param)
-		}
 		it.callNativeFunc(g)
 	}
 	results = make([]uint64, len(f.FunctionType.Type.Results))


### PR DESCRIPTION
This PR fixes a bug that interpreter crashes when it calls such a guest function that was imported from the host into a wasm module, but was exported to the host again. This is an interpreter-only bug and JIT has been correctly handling this without problem.

Please note that this PR alone will not allow us to test the WASI APIs by calling such "imported and exported back" WASI API functions. It turned out that there is another issue. See #195 