### PR TITLE
ci: add arm64 test job

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -108,10 +108,6 @@ jobs:
           image: tonistiigi/binfmt:latest
           platforms: arm64
 
-      # Reference: https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
-      - name: Setup the multiarch docker settings
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # This step will execute the registering scripts
-
       - name: Run built test binaries inside the qemu
         run: docker run -w /tmp/wazero -v $(pwd):/tmp/wazero --rm -t arm64v8/ubuntu /bin/bash -c 'find . -name "*.test" | xargs -Ibin bash -c "bin test.v"'
 

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -105,7 +105,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          image: tonistiigi/binfmt:latest
           platforms: arm64
 
       - name: Run built test binaries inside the qemu

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -71,7 +71,7 @@ jobs:
       - run: make test
 
   test_arm64:
-    name: Test (${{ matrix.os }}, Go-${{ matrix.go-version }}) / arm64
+    name: Test (ubuntu, Go-${{ matrix.go-version }}) / arm64
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -97,7 +97,7 @@ jobs:
             ~/go/pkg/mod
           key: test-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}-arm64
 
-      - name: build test binaries
+      - name: Build test binaries
         run: go list ./... | xargs -Ipkg go test pkg -c
         env:
           GOARCH: arm64

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -41,7 +41,7 @@ jobs:
       - run: make check
 
   test_amd64:
-    name: Test (${{ matrix.os }}, Go-${{ matrix.go-version }}) / amd64
+    name: (amd64, ${{ matrix.os }}, Go-${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -71,7 +71,13 @@ jobs:
       - run: make test
 
   test_arm64:
-    name: Test (ubuntu, Go-${{ matrix.go-version }}) / arm64
+    # Here we cannot use "make test" to test on arm64. We have to run tests inside the emulation, but running all tests in the emulation
+    # comes with costs as we have to install all the build dependency there and build time itself can be a bottleneck.
+    # Therefore, we choose to build arm64 test binaries on usual amd64 environment so we can leverage Go's cross compilation
+    # functionality and reduce the maintenance cost of build dependencies outside of amd64 platform, and just we run the 
+    # built test binaries inside of the emulation. This way, the overhead of emulation becomes ignorable.
+    # Note: this can be generalized to any GOARCH.
+    name: (arm64, ubuntu, Go-${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -71,8 +71,9 @@ jobs:
       - run: make test
 
   test_arm64:
-    # Here we cannot use "make test" to test on arm64. We have to run tests inside the emulation, but running all tests in the emulation
-    # comes with costs as we have to install all the build dependency there and build time itself can be a bottleneck.
+    # Here we cannot use "make test" to test on arm64. We have to run tests inside the emulation, but running all tests 
+    # from scratch including build phase in the emulation comes with costs since we have to install all the build dependency
+    # and build time itself can be a bottleneck.
     # Therefore, we choose to build arm64 test binaries on usual amd64 environment so we can leverage Go's cross compilation
     # functionality and reduce the maintenance cost of build dependencies outside of amd64 platform, and just we run the 
     # built test binaries inside of the emulation. This way, the overhead of emulation becomes ignorable.

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -40,8 +40,8 @@ jobs:
 
       - run: make check
 
-  test:
-    name: Test (${{ matrix.os }}, go-${{ matrix.go-version }})
+  test_amd64:
+    name: Test (${{ matrix.os }}, Go-${{ matrix.go-version }}) / amd64
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -69,6 +69,51 @@ jobs:
           key: test-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
 
       - run: make test
+
+  test_arm64:
+    name: Test (${{ matrix.os }}, Go-${{ matrix.go-version }}) / arm64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [
+          "ubuntu-latest",
+        ]
+        go-version: [
+          "1.17",  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+          "1.16",  # temporarily support go 1.16 per #37
+        ]
+
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: test-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}-arm64
+
+      - name: build test binaries
+        run: go list ./... | xargs -Ipkg go test pkg -c
+        env:
+          GOARCH: arm64
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: arm64
+
+      # Reference: https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
+      - name: Setup the multiarch docker settings
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes # This step will execute the registering scripts
+
+      - name: Run built test binaries inside the qemu
+        run: docker run -w /tmp/wazero -v $(pwd):/tmp/wazero --rm -t arm64v8/ubuntu /bin/bash -c 'find . -name "*.test" | xargs -Ibin bash -c "bin test.v"'
 
   bench:
     name: Benchmark

--- a/examples/stdio_test.go
+++ b/examples/stdio_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	_ "embed"
+
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/binary"

--- a/examples/stdio_test.go
+++ b/examples/stdio_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	_ "embed"
-
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/binary"


### PR DESCRIPTION
This commit adds a CI job for running test on arm64 arch with qemu. The idea 
is just building test binaries with `go test -c` on amd64, not arm64 and 
running  these built test binaries inside the emulation.  This would reduce
the cost of build time in emulation. 