### PR TITLE
text: fixes code section ID parsing a function

### DIFF
--- a/wasm/text/decoder_test.go
+++ b/wasm/text/decoder_test.go
@@ -1830,9 +1830,9 @@ func TestParseModule_Errors(t *testing.T) {
 			expectedErr: "1:34: unknown type: f65 in module.func[0].param[1]",
 		},
 		{
-			name:        "func double result",
+			name:        "func duplicate result",
 			input:       "(module (func (param i32) (result i32) (result i32)))",
-			expectedErr: "1:41: result declared out of order in module.func[0]",
+			expectedErr: "1:41: duplicate result in module.func[0]",
 		},
 		{
 			name:        "func double result type",
@@ -1922,7 +1922,7 @@ func TestParseModule_Errors(t *testing.T) {
 		{
 			name:        "func param after result",
 			input:       "(module (func (result i32) (param i32)))",
-			expectedErr: "1:29: param declared out of order in module.func[0]",
+			expectedErr: "1:29: param after result in module.func[0]",
 		},
 		{
 			name:        "func points nowhere",

--- a/wasm/text/func_parser.go
+++ b/wasm/text/func_parser.go
@@ -117,8 +117,12 @@ func sExpressionsUnsupported(tok tokenType, tokenBytes []byte, _, _ uint32) (tok
 		return nil, unexpectedToken(tok, tokenBytes)
 	}
 	switch string(tokenBytes) {
-	case "result", "param": // TODO: local
-		return nil, fmt.Errorf("%s declared out of order", tokenBytes)
+	case "param":
+		return nil, errors.New("param after result")
+	case "result":
+		return nil, errors.New("duplicate result")
+	case "local":
+		return nil, errors.New("TODO: local")
 	}
 	return nil, fmt.Errorf("TODO: s-expressions are not yet supported: %s", tokenBytes)
 }

--- a/wasm/text/func_parser.go
+++ b/wasm/text/func_parser.go
@@ -96,7 +96,7 @@ func (p *funcParser) parseFunc(tok tokenType, tokenBytes []byte, line, col uint3
 // The onFunc field is invoked once any instructions are written into currentBody.
 //
 // Ex. Given the source `(module (func nop))`
-//                 begin starts here --^  ^
+//          afterTypeUse starts here --^  ^
 //                    calls onFunc here --+
 func (p *funcParser) afterTypeUse(typeIdx wasm.Index, paramNames wasm.NameMap, pos onTypeUsePosition, tok tokenType, tokenBytes []byte, line, col uint32) (tokenParser, error) {
 	switch pos {

--- a/wasm/text/func_parser_test.go
+++ b/wasm/text/func_parser_test.go
@@ -46,12 +46,12 @@ func TestFuncParser(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			var parsedCode *wasm.Code
-			var setFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, localNames wasm.NameMap) (tokenParser, error) {
+			var setFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, name string, localNames wasm.NameMap) (tokenParser, error) {
 				parsedCode = code
 				return parseErr, nil
 			}
 
-			require.NoError(t, parseFunc(newFuncParser(newIndexNamespace(), setFunc), tc.source))
+			require.NoError(t, parseFunc(newFuncParser(&typeUseParser{module: &wasm.Module{}}, newIndexNamespace(), setFunc), tc.source))
 			require.Equal(t, tc.expected, parsedCode)
 		})
 	}
@@ -102,12 +102,12 @@ func TestFuncParser_Call_Unresolved(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			var parsedCode *wasm.Code
-			var setFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, localNames wasm.NameMap) (tokenParser, error) {
+			var setFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, name string, localNames wasm.NameMap) (tokenParser, error) {
 				parsedCode = code
 				return parseErr, nil
 			}
 
-			fp := newFuncParser(newIndexNamespace(), setFunc)
+			fp := newFuncParser(&typeUseParser{module: &wasm.Module{}}, newIndexNamespace(), setFunc)
 			require.NoError(t, parseFunc(fp, tc.source))
 			require.Equal(t, tc.expectedCode, parsedCode)
 			require.Equal(t, []*unresolvedIndex{tc.expectedUnresolvedIndex}, fp.funcNamespace.unresolvedIndices)
@@ -159,12 +159,12 @@ func TestFuncParser_Call_Resolved(t *testing.T) {
 			funcNamespace.count++
 
 			var parsedCode *wasm.Code
-			var setFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, localNames wasm.NameMap) (tokenParser, error) {
+			var setFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, name string, localNames wasm.NameMap) (tokenParser, error) {
 				parsedCode = code
 				return parseErr, nil
 			}
 
-			fp := newFuncParser(funcNamespace, setFunc)
+			fp := newFuncParser(&typeUseParser{module: &wasm.Module{}}, funcNamespace, setFunc)
 			require.NoError(t, parseFunc(fp, tc.source))
 			require.Equal(t, tc.expected, parsedCode)
 		})
@@ -207,13 +207,13 @@ func TestFuncParser_Errors(t *testing.T) {
 		},
 		{
 			name:        "param out of order", // because this parser is after the type use, so it must be wrong
-			source:      "(func (param i32))",
-			expectedErr: "1:8: param declared out of order",
+			source:      "(func (result i32) (param i32))",
+			expectedErr: "1:21: param declared out of order",
 		},
 		{
 			name:        "result out of order", // because this parser is after the type use, so it must be wrong
-			source:      "(func (result i32))",
-			expectedErr: "1:8: result declared out of order",
+			source:      "(func (result i32) (result i32))",
+			expectedErr: "1:21: result declared out of order",
 		},
 	}
 
@@ -221,23 +221,18 @@ func TestFuncParser_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			fp := newFuncParser(newIndexNamespace(), failOnFunc)
+			fp := newFuncParser(&typeUseParser{module: &wasm.Module{}}, newIndexNamespace(), failOnFunc)
 			require.EqualError(t, parseFunc(fp, tc.source), tc.expectedErr)
 		})
 	}
 }
 
-var failOnFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, localNames wasm.NameMap) (tokenParser, error) {
+var failOnFunc onFunc = func(typeIdx wasm.Index, code *wasm.Code, name string, localNames wasm.NameMap) (tokenParser, error) {
 	return nil, errors.New("unexpected to call onFunc on error")
 }
 
 func parseFunc(fp *funcParser, source string) error {
-	// TODO: all func hooks into func_parser.go, so that we don't have to fake the onTypeUse position
-	var parser tokenParser = func(tok tokenType, tokenBytes []byte, line, col uint32) (tokenParser, error) {
-		return fp.begin(0, nil, onTypeUseUnhandledToken, tok, tokenBytes, line, col)
-	}
-
-	line, col, err := lex(skipTokens(2, parser), []byte(source)) // skip the leading (func
+	line, col, err := lex(skipTokens(2, fp.begin), []byte(source)) // skip the leading (func
 	if err != nil {
 		err = &FormatError{Line: line, Col: col, cause: err}
 	}

--- a/wasm/text/func_parser_test.go
+++ b/wasm/text/func_parser_test.go
@@ -206,14 +206,14 @@ func TestFuncParser_Errors(t *testing.T) {
 			expectedErr: "1:8: TODO: s-expressions are not yet supported: f32.const",
 		},
 		{
-			name:        "param out of order", // because this parser is after the type use, so it must be wrong
+			name:        "param after result",
 			source:      "(func (result i32) (param i32))",
-			expectedErr: "1:21: param declared out of order",
+			expectedErr: "1:21: param after result",
 		},
 		{
-			name:        "result out of order", // because this parser is after the type use, so it must be wrong
+			name:        "duplicate result",
 			source:      "(func (result i32) (result i32))",
-			expectedErr: "1:21: result declared out of order",
+			expectedErr: "1:21: duplicate result",
 		},
 	}
 

--- a/wasm/text/memory_parser.go
+++ b/wasm/text/memory_parser.go
@@ -33,7 +33,7 @@ type memoryParser struct {
 	currentMax *uint32
 }
 
-// begin should be called after reaching the "memory" keyword in a memory field. Parsing continues until onMemory or
+// begin should be called after reaching the "memory" keyword in a module field. Parsing continues until onMemory or
 // error.
 //
 // This stage records the ID of the current memory, if present, and resumes with beginMin.

--- a/wasm/text/type_parser.go
+++ b/wasm/text/type_parser.go
@@ -50,7 +50,7 @@ type typeParser struct {
 	parsedParamID bool
 }
 
-// begin should be called after reaching the "type" keyword in a type field. Parsing continues until onType or error.
+// begin should be called after reaching the "type" keyword in a module field. Parsing continues until onType or error.
 //
 // This stage records the ID of the current type, if present, and resumes with tryBeginFunc.
 //


### PR DESCRIPTION
This moves logic to func_parser.go, which allows us to keep a coherent
function index when parsing code.