### PR TITLE
Add struct vs interface access bench

### DIFF
--- a/tests/bench/interface_bench_test.go
+++ b/tests/bench/interface_bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkInterfaceVSUnexport(b *testing.B) {
 	})
 }
 
-type MemoryInstanceInteface interface {
+type MemoryInstanceInterface interface {
 	PutUint32(addr uint32, val uint32) bool
 }
 

--- a/tests/bench/interface_bench_test.go
+++ b/tests/bench/interface_bench_test.go
@@ -1,0 +1,50 @@
+package bench
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func BenchmarkInterfaceVSUnexport(b *testing.B) {
+	const size = 100
+	const val = 55
+	var memInterface MemoryInstanceInteface = &memoryInstance{buffer: make([]byte, size)}
+	var memStruct = &memoryInstance{buffer: make([]byte, size)}
+
+	b.Run("interface", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for addr := uint32(0); addr < size+1000; addr++ {
+				memInterface.PutUint32(addr, val)
+			}
+		}
+	})
+	b.Run("struct", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for addr := uint32(0); addr < size+1000; addr++ {
+				memStruct.PutUint32(addr, val)
+			}
+		}
+	})
+}
+
+type MemoryInstanceInteface interface {
+	PutUint32(addr uint32, val uint32) bool
+}
+
+type memoryInstance struct {
+	buffer []byte // inexpert only this
+	Min    uint32 // PS especially below would make sense to also not export as export makes it mutable
+	Max    *uint32
+}
+
+func (m *memoryInstance) validateAddrRange(addr uint32, rangeSize uint64) bool {
+	return uint64(addr) < uint64(len(m.buffer)) && rangeSize <= uint64(len(m.buffer))-uint64(addr)
+}
+
+func (m *memoryInstance) PutUint32(addr uint32, val uint32) bool {
+	if !m.validateAddrRange(addr, uint64(4)) {
+		return false
+	}
+	binary.LittleEndian.PutUint32(m.buffer[addr:], val)
+	return true
+}

--- a/tests/bench/interface_bench_test.go
+++ b/tests/bench/interface_bench_test.go
@@ -8,7 +8,7 @@ import (
 func BenchmarkInterfaceVSUnexport(b *testing.B) {
 	const size = 100
 	const val = 55
-	var memInterface MemoryInstanceInteface = &memoryInstance{buffer: make([]byte, size)}
+	var memInterface MemoryInstanceInterface = &memoryInstance{buffer: make([]byte, size)}
 	var memStruct = &memoryInstance{buffer: make([]byte, size)}
 
 	b.Run("interface", func(b *testing.B) {


### PR DESCRIPTION
as a reference to #204 

Here's the result (for 5 times), and this shows that there's certain overhead in the interface usage

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 3950X 16-Core Processor            
BenchmarkInterfaceVSUnexport/interface-32         	  533025	      2370 ns/op	       0 B/op	       0 allocs/op
BenchmarkInterfaceVSUnexport/struct-32            	 1485394	       819.6 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	4.205s
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 3950X 16-Core Processor            
BenchmarkInterfaceVSUnexport/interface-32         	  452220	      2328 ns/op	       0 B/op	       0 allocs/op
BenchmarkInterfaceVSUnexport/struct-32            	 1499652	       798.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	3.006s
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 3950X 16-Core Processor            
BenchmarkInterfaceVSUnexport/interface-32         	  536872	      2216 ns/op	       0 B/op	       0 allocs/op
BenchmarkInterfaceVSUnexport/struct-32            	 1446681	       827.6 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	4.209s
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 3950X 16-Core Processor            
BenchmarkInterfaceVSUnexport/interface-32         	  532909	      2235 ns/op	       0 B/op	       0 allocs/op
BenchmarkInterfaceVSUnexport/struct-32            	 1448143	       790.8 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	4.011s
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 3950X 16-Core Processor            
BenchmarkInterfaceVSUnexport/interface-32         	  537165	      2320 ns/op	       0 B/op	       0 allocs/op
BenchmarkInterfaceVSUnexport/struct-32            	 1530110	       828.5 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	4.236s

```