### PR TITLE
Fix float32-type parameter not working for host function

### DIFF
--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -230,37 +230,37 @@ func importedAndExportedFunc(t *testing.T, newEngine func() wasm.Engine) {
 func hostFuncWithFloat32Param(t *testing.T, newEngine func() wasm.Engine) {
 	ctx := context.Background()
 	mod, err := text.DecodeModule([]byte(`(module
-		;; 'test_f32param' is a host function which accepts a f32 param
-		;; and tests if it is an expected value.
-		(import "test" "f32param" (func $test.f32param (param f32)))
+		;; 'identity_f32' is a host function which accepts a float32 param.
+		;; It should just return the given value without breaking it.
+		(import "test" "identity_f32" (func $identity_f32 (param f32) (result f32)))
 
-		;; 'call_test_f32' is an exported guest function to call
-		;; the host function, 'test_f32param', from the guest.
-		;; call->test.f32param proxies test.f32param via call in order to test floats aren't corrupted.
-		(func $call->test.f32param (param f32)
+		;; 'call_identity_f32' proxies test.identity_f32 via call in order to test floats aren't corrupted
+		(func $call_identity_f32 (param f32) (result f32)
 			local.get 0
-			call $test_f32param
+			call $identity_f32
 		)
-		(export "call_test_f32param" (func $call_test_f32param))
+		(export "call_identity_f32" (func $call_identity_f32))
 		)`))
 	require.NoError(t, err)
 
 	store := wasm.NewStore(newEngine())
 
-	expectedFloat32Val := float32(math.MaxFloat32) // arbitrary float32 value.
-	// testF32Param is called from the guest function, call_test_f32param.
-	// This function expects the guest to pass expectedF32Val.
-	testF32Param := func(ctx *wasm.HostFunctionCallContext, value float32) {
-		require.Equal(t, expectedFloat32Val, value)
+	// identityF32 is a host function that just returns the given float32 parameter to the guest.
+	identityF32 := func(ctx *wasm.HostFunctionCallContext, value float32) float32 {
+		return value
 	}
-	err = store.AddHostFunction("env", "test_f32param", reflect.ValueOf(testF32Param))
+	err = store.AddHostFunction("env", "identity_f32", reflect.ValueOf(identityF32))
 	require.NoError(t, err)
 
 	err = store.Instantiate(mod, "test")
 	require.NoError(t, err)
 
-	// `call_test_f32param` calls the host function `testF32Param` with `expectedF32Val` as its parameter,
-	// and `testF32Param` asserts that it gets `expectedFloat32Val` without the value being corrupted.
-	_, _, err = store.CallFunction(ctx, "test", "call_test_f32param", uint64(math.Float32bits(expectedFloat32Val)))
+	expectedF32Val := float32(math.MaxFloat32) // arbitrary f32 value
+	// This call should return the given `expectedF32Val` without corrupting the value.
+	results, resultTypes, err := store.CallFunction(ctx, "test", "call_identity_f32", uint64(math.Float32bits(expectedF32Val)))
 	require.NoError(t, err)
+	require.Len(t, results, len(resultTypes))
+	require.Equal(t, wasm.ValueTypeF32, resultTypes[0])
+	// Note that the f32 result is returned as a float64 bits value in wazero.
+	require.Equal(t, float64(expectedF32Val), math.Float64frombits(results[0]))
 }

--- a/wasm/interpreter/interpreter.go
+++ b/wasm/interpreter/interpreter.go
@@ -501,7 +501,9 @@ func (it *interpreter) callHostFunc(ctx context.Context, f *interpreterFunction)
 		raw := it.pop()
 		kind := tp.In(i).Kind()
 		switch kind {
-		case reflect.Float64, reflect.Float32:
+		case reflect.Float32:
+			val.SetFloat(float64(math.Float32frombits(uint32(raw))))
+		case reflect.Float64:
 			val.SetFloat(math.Float64frombits(raw))
 		case reflect.Uint32, reflect.Uint64:
 			val.SetUint(raw)

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -471,7 +471,9 @@ func (e *engine) execHostFunction(f *reflect.Value, ctx *wasm.HostFunctionCallCo
 		raw := e.popValue()
 		kind := tp.In(i).Kind()
 		switch kind {
-		case reflect.Float64, reflect.Float32:
+		case reflect.Float32:
+			val.SetFloat(float64(math.Float32frombits(uint32(raw))))
+		case reflect.Float64:
 			val.SetFloat(math.Float64frombits(raw))
 		case reflect.Uint32, reflect.Uint64:
 			val.SetUint(raw)

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -226,7 +226,10 @@ const (
 	ValueTypeF64 ValueType = 0x7c
 )
 
-func valueTypeName(t ValueType) string {
+// ValuTypeName returns the type name of the given ValueType as a string.
+// These type names match the names used in the WebAssembly text format.
+// Note that ValueTypeName returns "unknown", if an undefined ValueType value is passed.
+func ValueTypeName(t ValueType) string {
 	switch t {
 	case ValueTypeI32:
 		return "i32"
@@ -242,14 +245,14 @@ func valueTypeName(t ValueType) string {
 
 func (t *FunctionType) String() (ret string) {
 	for _, b := range t.Params {
-		ret += valueTypeName(b)
+		ret += ValueTypeName(b)
 	}
 	if len(t.Params) == 0 {
 		ret += "null"
 	}
 	ret += "_"
 	for _, b := range t.Results {
-		ret += valueTypeName(b)
+		ret += ValueTypeName(b)
 	}
 	if len(t.Results) == 0 {
 		ret += "null"

--- a/wasm/module_test.go
+++ b/wasm/module_test.go
@@ -99,7 +99,7 @@ func TestValueTypeName(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, valueTypeName(tc.input))
+			require.Equal(t, tc.expected, ValueTypeName(tc.input))
 		})
 	}
 }

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -439,7 +439,7 @@ func TestStore_executeConstExpression(t *testing.T) {
 	})
 	t.Run("non global expr", func(t *testing.T) {
 		for _, vt := range []ValueType{ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64} {
-			t.Run(valueTypeName(vt), func(t *testing.T) {
+			t.Run(ValueTypeName(vt), func(t *testing.T) {
 				t.Run("valid", func(t *testing.T) {
 					// Allocate bytes with enough size for all types.
 					expr := &ConstantExpression{Data: make([]byte, 8)}
@@ -526,7 +526,7 @@ func TestStore_executeConstExpression(t *testing.T) {
 				{valueType: ValueTypeF32, val: uint64(math.Float32bits(634634432.12311))},
 				{valueType: ValueTypeF64, val: math.Float64bits(1.12312311)},
 			} {
-				t.Run(valueTypeName(tc.valueType), func(t *testing.T) {
+				t.Run(ValueTypeName(tc.valueType), func(t *testing.T) {
 					// The index specified in Data equals zero.
 					expr := &ConstantExpression{Data: []byte{0}, Opcode: OpcodeGlobalGet}
 					globals := []*GlobalInstance{{Val: tc.val, Type: &GlobalType{ValType: tc.valueType}}}


### PR DESCRIPTION
This PR fixes that `float32` parameters were not correctly passed to the host function.