### PR TITLE
Adds note clarifying status of WASI tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,9 @@
 This directory contains tests which use multiple packages. For example:
 
-- `bench` contains benchmark tests.
-- `codec` contains a test and benchmark on text and binary decoders.
-- `engine` contains variety of e2e tests, mainly to ensure the consistency in the behavior between engines.
-- `spectest` contains end-to-end tests with the [WebAssembly specification tests](https://github.com/WebAssembly/spec/tree/wg-1.0/test/core).
+* `bench` contains benchmark tests.
+* `codec` contains a test and benchmark on text and binary decoders.
+* `engine` contains variety of e2e tests, mainly to ensure the consistency in the behavior between engines.
+* `spectest` contains end-to-end tests with the [WebAssembly specification tests](https://github.com/WebAssembly/spec/tree/wg-1.0/test/core).
+
+*Note*: this doesn't contain WASI tests, as there's not yet an [official testsuite](https://github.com/WebAssembly/WASI/issues/9).
+Meanwhile, WASI functions are unit tested including via Text Format imports [here](../wasi/wasi_test.go)


### PR DESCRIPTION
This adds a link to status we didn't have (thanks to @mbovel)