### PR TITLE
Adds Module.SectionSize and constrains text parsing rules

### DIFF
--- a/wasm/binary/decoder.go
+++ b/wasm/binary/decoder.go
@@ -27,6 +27,8 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 
 	m := &wasm.Module{}
 	for {
+		// TODO: except custom sections, all others are required to be in order, but we aren't checking yet.
+		// See https://www.w3.org/TR/wasm-core-1/#modules%E2%91%A0%E2%93%AA
 		sectionID := make([]byte, 1)
 		if _, err := io.ReadFull(r, sectionID); err == io.EOF {
 			break
@@ -36,7 +38,7 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 
 		sectionSize, _, err := leb128.DecodeUint32(r)
 		if err != nil {
-			return nil, fmt.Errorf("get size of section for id=%d: %v", sectionID[0], err)
+			return nil, fmt.Errorf("get size of section %s: %v", wasm.SectionIDName(sectionID[0]), err)
 		}
 
 		sectionContentStart := r.Len()
@@ -104,11 +106,11 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("section ID %d: %v", sectionID[0], err)
+			return nil, fmt.Errorf("%s section: %v", wasm.SectionIDName(sectionID[0]), err)
 		}
 	}
 
-	functionCount, codeCount := len(m.FunctionSection), len(m.CodeSection)
+	functionCount, codeCount := m.SectionSize(wasm.SectionIDFunction), m.SectionSize(wasm.SectionIDCode)
 	if functionCount != codeCount {
 		return nil, fmt.Errorf("function and code section have inconsistent lengths: %d != %d", functionCount, codeCount)
 	}

--- a/wasm/binary/decoder.go
+++ b/wasm/binary/decoder.go
@@ -106,7 +106,7 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("%s section: %v", wasm.SectionIDName(sectionID[0]), err)
+			return nil, fmt.Errorf("section %s: %v", wasm.SectionIDName(sectionID[0]), err)
 		}
 	}
 

--- a/wasm/binary/decoder_test.go
+++ b/wasm/binary/decoder_test.go
@@ -134,7 +134,7 @@ func TestDecodeModule_Errors(t *testing.T) {
 				wasm.SectionIDCustom, 0x09, // 9 bytes in this section
 				0x04, 'm', 'e', 'm', 'e',
 				subsectionIDModuleName, 0x03, 0x01, 'y'),
-			expectedErr: "custom section: redundant custom section meme",
+			expectedErr: "section custom: redundant custom section meme",
 		},
 		{
 			name: "redundant name section",
@@ -145,7 +145,7 @@ func TestDecodeModule_Errors(t *testing.T) {
 				wasm.SectionIDCustom, 0x09, // 9 bytes in this section
 				0x04, 'n', 'a', 'm', 'e',
 				subsectionIDModuleName, 0x03, 0x01, 'x'),
-			expectedErr: "custom section: redundant custom section name",
+			expectedErr: "section custom: redundant custom section name",
 		},
 	}
 

--- a/wasm/binary/decoder_test.go
+++ b/wasm/binary/decoder_test.go
@@ -134,7 +134,7 @@ func TestDecodeModule_Errors(t *testing.T) {
 				wasm.SectionIDCustom, 0x09, // 9 bytes in this section
 				0x04, 'm', 'e', 'm', 'e',
 				subsectionIDModuleName, 0x03, 0x01, 'y'),
-			expectedErr: "section ID 0: redundant custom section meme",
+			expectedErr: "custom section: redundant custom section meme",
 		},
 		{
 			name: "redundant name section",
@@ -145,7 +145,7 @@ func TestDecodeModule_Errors(t *testing.T) {
 				wasm.SectionIDCustom, 0x09, // 9 bytes in this section
 				0x04, 'n', 'a', 'm', 'e',
 				subsectionIDModuleName, 0x03, 0x01, 'x'),
-			expectedErr: "section ID 0: redundant custom section name",
+			expectedErr: "custom section: redundant custom section name",
 		},
 	}
 

--- a/wasm/binary/encoder.go
+++ b/wasm/binary/encoder.go
@@ -11,47 +11,50 @@ var sizePrefixedName = []byte{4, 'n', 'a', 'm', 'e'}
 // See https://www.w3.org/TR/wasm-core-1/#binary-format%E2%91%A0
 func EncodeModule(m *wasm.Module) (bytes []byte) {
 	bytes = append(magic, version...)
-	for name, data := range m.CustomSections {
-		bytes = append(bytes, encodeCustomSection(name, data)...)
-	}
-	if len(m.TypeSection) > 0 {
+	if m.SectionSize(wasm.SectionIDType) > 0 {
 		bytes = append(bytes, encodeTypeSection(m.TypeSection)...)
 	}
-	if len(m.ImportSection) > 0 {
+	if m.SectionSize(wasm.SectionIDImport) > 0 {
 		bytes = append(bytes, encodeImportSection(m.ImportSection)...)
 	}
-	if len(m.FunctionSection) > 0 {
+	if m.SectionSize(wasm.SectionIDFunction) > 0 {
 		bytes = append(bytes, encodeFunctionSection(m.FunctionSection)...)
 	}
-	if len(m.TableSection) > 0 {
+	if m.SectionSize(wasm.SectionIDTable) > 0 {
 		panic("TODO: TableSection")
 	}
-	if len(m.MemorySection) > 0 {
+	if m.SectionSize(wasm.SectionIDMemory) > 0 {
 		bytes = append(bytes, encodeMemorySection(m.MemorySection)...)
 	}
-	if len(m.GlobalSection) > 0 {
+	if m.SectionSize(wasm.SectionIDGlobal) > 0 {
 		panic("TODO: GlobalSection")
 	}
-	if len(m.ExportSection) > 0 {
+	if m.SectionSize(wasm.SectionIDExport) > 0 {
 		bytes = append(bytes, encodeExportSection(m.ExportSection)...)
 	}
-	if m.StartSection != nil {
+	if m.SectionSize(wasm.SectionIDStart) > 0 {
 		bytes = append(bytes, encodeStartSection(*m.StartSection)...)
 	}
-	if len(m.ElementSection) > 0 {
+	if m.SectionSize(wasm.SectionIDElement) > 0 {
 		panic("TODO: ElementSection")
 	}
-	if len(m.CodeSection) > 0 {
+	if m.SectionSize(wasm.SectionIDCode) > 0 {
 		bytes = append(bytes, encodeCodeSection(m.CodeSection)...)
 	}
-	if len(m.DataSection) > 0 {
+	if m.SectionSize(wasm.SectionIDData) > 0 {
 		panic("TODO: DataSection")
 	}
-	// >> The name section should appear only once in a module, and only after the data section.
-	// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
-	if m.NameSection != nil {
-		nameSection := append(sizePrefixedName, encodeNameSectionData(m.NameSection)...)
-		bytes = append(bytes, encodeSection(wasm.SectionIDCustom, nameSection)...)
+	if m.SectionSize(wasm.SectionIDCustom) > 0 {
+		for name, data := range m.CustomSections {
+			bytes = append(bytes, encodeCustomSection(name, data)...)
+		}
+
+		// >> The name section should appear only once in a module, and only after the data section.
+		// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
+		if m.NameSection != nil {
+			nameSection := append(sizePrefixedName, encodeNameSectionData(m.NameSection)...)
+			bytes = append(bytes, encodeSection(wasm.SectionIDCustom, nameSection)...)
+		}
 	}
 	return
 }

--- a/wasm/binary/section.go
+++ b/wasm/binary/section.go
@@ -165,7 +165,7 @@ func decodeExportSection(r *bytes.Reader) (map[string]*wasm.Export, error) {
 	return exportSection, nil
 }
 
-func decodeStartSection(r *bytes.Reader) (*uint32, error) {
+func decodeStartSection(r *bytes.Reader) (*wasm.Index, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
@@ -260,10 +260,10 @@ func encodeImportSection(imports []*wasm.Import) []byte {
 // WebAssembly 1.0 (MVP) Binary Format.
 //
 // See https://www.w3.org/TR/wasm-core-1/#function-section%E2%91%A0
-func encodeFunctionSection(functions []wasm.Index) []byte {
-	contents := leb128.EncodeUint32(uint32(len(functions)))
-	for _, typeIndex := range functions {
-		contents = append(contents, leb128.EncodeUint32(typeIndex)...)
+func encodeFunctionSection(typeIndices []wasm.Index) []byte {
+	contents := leb128.EncodeUint32(uint32(len(typeIndices)))
+	for _, index := range typeIndices {
+		contents = append(contents, leb128.EncodeUint32(index)...)
 	}
 	return encodeSection(wasm.SectionIDFunction, contents)
 }
@@ -307,6 +307,6 @@ func encodeExportSection(exports map[string]*wasm.Export) []byte {
 // encodeStartSection encodes a SectionIDStart for the given function index in WebAssembly 1.0 (MVP) Binary Format.
 //
 // See https://www.w3.org/TR/wasm-core-1/#start-section%E2%91%A0
-func encodeStartSection(funcidx uint32) []byte {
+func encodeStartSection(funcidx wasm.Index) []byte {
 	return encodeSection(wasm.SectionIDStart, leb128.EncodeUint32(funcidx))
 }

--- a/wasm/binary/section_test.go
+++ b/wasm/binary/section_test.go
@@ -111,6 +111,11 @@ func TestDecodeExportSection_Errors(t *testing.T) {
 	}
 }
 
+func TestEncodeFunctionSection(t *testing.T) {
+	require.Equal(t, []byte{wasm.SectionIDFunction, 0x2, 0x01, 0x05}, encodeFunctionSection([]wasm.Index{5}))
+}
+
+// TestEncodeStartSection uses the same index as TestEncodeFunctionSection to highlight the encoding is different.
 func TestEncodeStartSection(t *testing.T) {
 	require.Equal(t, []byte{wasm.SectionIDStart, 0x01, 0x05}, encodeStartSection(5))
 }

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -467,7 +467,12 @@ func (m *Module) allDeclarations() (functions []Index, globals []*GlobalType, me
 	return
 }
 
-// SectionSize returns the count of items in a given section
+// SectionSize returns the count of items for a given section ID
+//
+// For example, given...
+// * SectionIDType this returns the count of FunctionType
+// * SectionIDCustom this returns the count of unique section names
+// * SectionIDExport this returns the count of unique export names
 func (m *Module) SectionSize(sectionID SectionID) uint32 {
 	switch sectionID {
 	case SectionIDCustom:

--- a/wasm/text/func_parser_test.go
+++ b/wasm/text/func_parser_test.go
@@ -213,7 +213,7 @@ func TestFuncParser_Errors(t *testing.T) {
 		{
 			name:        "duplicate result",
 			source:      "(func (result i32) (result i32))",
-			expectedErr: "1:21: duplicate result",
+			expectedErr: "1:21: at most one result allowed",
 		},
 	}
 

--- a/wasm/text/index_namespace.go
+++ b/wasm/text/index_namespace.go
@@ -38,12 +38,22 @@ type indexNamespace struct {
 // setID ensures the given tokenID is unique within this context and raises an error if not. The resulting mapping is
 // stripped of the leading '$' to match other tools, as described in stripDollar.
 func (i *indexNamespace) setID(idToken []byte) (string, error) {
-	id := string(stripDollar(idToken))
-	if _, ok := i.idToIdx[id]; ok {
-		return id, fmt.Errorf("duplicate ID %s", idToken)
+	name, err := i.requireNoID(idToken)
+	if err != nil {
+		return name, err
 	}
-	i.idToIdx[id] = i.count
-	return id, nil
+	i.idToIdx[name] = i.count
+	return name, nil
+}
+
+// hasID checks to see if this tokenID is unique within this context and returns an error. The result string is
+// stripped of the leading '$' to match other tools, as described in stripDollar.
+func (i *indexNamespace) requireNoID(idToken []byte) (string, error) {
+	name := string(stripDollar(idToken))
+	if _, ok := i.idToIdx[name]; ok {
+		return name, fmt.Errorf("duplicate ID %s", idToken)
+	}
+	return name, nil
 }
 
 // parseIndex is a tokenParser called in a field that can only contain a symbolic identifier or raw numeric index.

--- a/wasm/text/memory_parser_test.go
+++ b/wasm/text/memory_parser_test.go
@@ -60,8 +60,8 @@ func TestMemoryParser(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			namespace := newIndexNamespace()
-			parsed, tp, err := parseMemoryType(namespace, tc.input)
+			memoryNamespace := newIndexNamespace()
+			parsed, tp, err := parseMemoryType(memoryNamespace, tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, parsed)
 			require.Equal(t, uint32(1), tp.memoryNamespace.count)
@@ -151,13 +151,13 @@ func TestMemoryParser_Errors(t *testing.T) {
 	})
 }
 
-func parseMemoryType(namespace *indexNamespace, input string) (*wasm.MemoryType, *memoryParser, error) {
+func parseMemoryType(memoryNamespace *indexNamespace, input string) (*wasm.MemoryType, *memoryParser, error) {
 	var parsed *wasm.MemoryType
 	var setFunc onMemory = func(min uint32, max *uint32) tokenParser {
 		parsed = &wasm.MemoryType{Min: min, Max: max}
 		return parseErr
 	}
-	tp := newMemoryParser(namespace, setFunc)
+	tp := newMemoryParser(memoryNamespace, setFunc)
 	// memoryParser starts after the '(memory', so we need to eat it first!
 	_, _, err := lex(skipTokens(2, tp.begin), []byte(input))
 	return parsed, tp, err

--- a/wasm/text/type_parser_test.go
+++ b/wasm/text/type_parser_test.go
@@ -100,8 +100,8 @@ func TestTypeParser(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			namespace := newIndexNamespace()
-			parsed, tp, err := parseFunctionType(namespace, tc.input)
+			typeNamespace := newIndexNamespace()
+			parsed, tp, err := parseFunctionType(typeNamespace, tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, parsed)
 			require.Equal(t, uint32(1), tp.typeNamespace.count)
@@ -246,13 +246,13 @@ func TestTypeParser_Errors(t *testing.T) {
 	})
 }
 
-func parseFunctionType(namespace *indexNamespace, input string) (*wasm.FunctionType, *typeParser, error) {
+func parseFunctionType(typeNamespace *indexNamespace, input string) (*wasm.FunctionType, *typeParser, error) {
 	var parsed *wasm.FunctionType
 	var setFunc onType = func(ft *wasm.FunctionType) tokenParser {
 		parsed = ft
 		return parseErr
 	}
-	tp := newTypeParser(namespace, setFunc)
+	tp := newTypeParser(typeNamespace, setFunc)
 	// typeParser starts after the '(type', so we need to eat it first!
 	_, _, err := lex(skipTokens(2, tp.begin), []byte(input))
 	return parsed, tp, err


### PR DESCRIPTION
This consolidates more code around SectionID, notably consistently
getting and using section ID length. This also enforces rules in text
parsing such as up to one memory, and imported functions can't be
defined after regular ones.