### PR TITLE
Removes CustomSection except NameSection

### DIFF
--- a/wasm/binary/encoder.go
+++ b/wasm/binary/encoder.go
@@ -11,44 +11,40 @@ var sizePrefixedName = []byte{4, 'n', 'a', 'm', 'e'}
 // See https://www.w3.org/TR/wasm-core-1/#binary-format%E2%91%A0
 func EncodeModule(m *wasm.Module) (bytes []byte) {
 	bytes = append(magic, version...)
-	if m.SectionSize(wasm.SectionIDType) > 0 {
+	if m.SectionElementCount(wasm.SectionIDType) > 0 {
 		bytes = append(bytes, encodeTypeSection(m.TypeSection)...)
 	}
-	if m.SectionSize(wasm.SectionIDImport) > 0 {
+	if m.SectionElementCount(wasm.SectionIDImport) > 0 {
 		bytes = append(bytes, encodeImportSection(m.ImportSection)...)
 	}
-	if m.SectionSize(wasm.SectionIDFunction) > 0 {
+	if m.SectionElementCount(wasm.SectionIDFunction) > 0 {
 		bytes = append(bytes, encodeFunctionSection(m.FunctionSection)...)
 	}
-	if m.SectionSize(wasm.SectionIDTable) > 0 {
+	if m.SectionElementCount(wasm.SectionIDTable) > 0 {
 		panic("TODO: TableSection")
 	}
-	if m.SectionSize(wasm.SectionIDMemory) > 0 {
+	if m.SectionElementCount(wasm.SectionIDMemory) > 0 {
 		bytes = append(bytes, encodeMemorySection(m.MemorySection)...)
 	}
-	if m.SectionSize(wasm.SectionIDGlobal) > 0 {
+	if m.SectionElementCount(wasm.SectionIDGlobal) > 0 {
 		panic("TODO: GlobalSection")
 	}
-	if m.SectionSize(wasm.SectionIDExport) > 0 {
+	if m.SectionElementCount(wasm.SectionIDExport) > 0 {
 		bytes = append(bytes, encodeExportSection(m.ExportSection)...)
 	}
-	if m.SectionSize(wasm.SectionIDStart) > 0 {
+	if m.SectionElementCount(wasm.SectionIDStart) > 0 {
 		bytes = append(bytes, encodeStartSection(*m.StartSection)...)
 	}
-	if m.SectionSize(wasm.SectionIDElement) > 0 {
+	if m.SectionElementCount(wasm.SectionIDElement) > 0 {
 		panic("TODO: ElementSection")
 	}
-	if m.SectionSize(wasm.SectionIDCode) > 0 {
+	if m.SectionElementCount(wasm.SectionIDCode) > 0 {
 		bytes = append(bytes, encodeCodeSection(m.CodeSection)...)
 	}
-	if m.SectionSize(wasm.SectionIDData) > 0 {
+	if m.SectionElementCount(wasm.SectionIDData) > 0 {
 		panic("TODO: DataSection")
 	}
-	if m.SectionSize(wasm.SectionIDCustom) > 0 {
-		for name, data := range m.CustomSections {
-			bytes = append(bytes, encodeCustomSection(name, data)...)
-		}
-
+	if m.SectionElementCount(wasm.SectionIDCustom) > 0 {
 		// >> The name section should appear only once in a module, and only after the data section.
 		// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
 		if m.NameSection != nil {

--- a/wasm/binary/encoder_test.go
+++ b/wasm/binary/encoder_test.go
@@ -33,34 +33,6 @@ func TestModule_Encode(t *testing.T) {
 				's', 'i', 'm', 'p', 'l', 'e'),
 		},
 		{
-			name: "only custom section",
-			input: &wasm.Module{CustomSections: map[string][]byte{
-				"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
-			}},
-			expected: append(append(magic, version...),
-				wasm.SectionIDCustom, 0xf, // 15 bytes in this section
-				0x04, 'm', 'e', 'm', 'e',
-				1, 2, 3, 4, 5, 6, 7, 8, 9, 0),
-		},
-		{
-			name: "name section and a custom section", // name should encode last
-			input: &wasm.Module{
-				NameSection: &wasm.NameSection{ModuleName: "simple"},
-				CustomSections: map[string][]byte{
-					"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
-				},
-			},
-			expected: append(append(magic, version...),
-				wasm.SectionIDCustom, 0xf, // 15 bytes in this section
-				0x04, 'm', 'e', 'm', 'e',
-				1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
-				wasm.SectionIDCustom, 0x0e, // 14 bytes in this section
-				0x04, 'n', 'a', 'm', 'e',
-				subsectionIDModuleName, 0x07, // 7 bytes in this subsection
-				0x06, // the Module name simple is 6 bytes long
-				's', 'i', 'm', 'p', 'l', 'e'),
-		},
-		{
 			name: "type section",
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{

--- a/wasm/binary/names_test.go
+++ b/wasm/binary/names_test.go
@@ -1,6 +1,7 @@
 package binary
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -201,7 +202,8 @@ func TestDecodeNameSection(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			ns, err := decodeNameSection(encodeNameSectionData(tc.input))
+			data := encodeNameSectionData(tc.input)
+			ns, err := decodeNameSection(bytes.NewReader(data), uint64(len(data)))
 			require.NoError(t, err)
 			require.Equal(t, tc.input, ns)
 		})
@@ -302,7 +304,7 @@ func TestDecodeNameSection_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeNameSection(tc.input)
+			_, err := decodeNameSection(bytes.NewReader(tc.input), uint64(len(tc.input)))
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/wasm/binary/section.go
+++ b/wasm/binary/section.go
@@ -9,14 +9,6 @@ import (
 	"github.com/tetratelabs/wazero/wasm/internal/leb128"
 )
 
-func readCustomSectionData(r *bytes.Reader, dataSize uint32) ([]byte, error) {
-	data := make([]byte, dataSize)
-	if _, err := io.ReadFull(r, data); err != nil {
-		return nil, fmt.Errorf("cannot read custom section data: %w", err)
-	}
-	return data, nil
-}
-
 func decodeTypeSection(r io.Reader) ([]*wasm.FunctionType, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
@@ -216,14 +208,6 @@ func decodeDataSection(r *bytes.Reader) ([]*wasm.DataSegment, error) {
 		}
 	}
 	return result, nil
-}
-
-// encodeCustomSection encodes the opaque bytes for the given name as a SectionIDCustom
-// See https://www.w3.org/TR/wasm-core-1/#binary-customsec
-func encodeCustomSection(name string, data []byte) []byte {
-	// The contents of a custom section is the non-empty name followed by potentially empty opaque data
-	contents := append(encodeSizePrefixed([]byte(name)), data...)
-	return encodeSection(wasm.SectionIDCustom, contents)
 }
 
 // encodeSection encodes the sectionID, the size of its contents in bytes, followed by the contents.

--- a/wasm/module_test.go
+++ b/wasm/module_test.go
@@ -225,23 +225,6 @@ func TestModule_SectionSize(t *testing.T) {
 			expected: map[string]uint32{"custom": 1},
 		},
 		{
-			name: "only custom section",
-			input: &Module{CustomSections: map[string][]byte{
-				"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
-			}},
-			expected: map[string]uint32{"custom": 1},
-		},
-		{
-			name: "name section and a custom section",
-			input: &Module{
-				NameSection: &NameSection{ModuleName: "simple"},
-				CustomSections: map[string][]byte{
-					"meme": {1, 2, 3, 4, 5, 6, 7, 8, 9, 0},
-				},
-			},
-			expected: map[string]uint32{"custom": 2},
-		},
-		{
 			name: "type section",
 			input: &Module{
 				TypeSection: []*FunctionType{
@@ -312,7 +295,7 @@ func TestModule_SectionSize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := map[string]uint32{}
 			for i := SectionID(0); i <= SectionIDData; i++ {
-				if size := tc.input.SectionSize(i); size > 0 {
+				if size := tc.input.SectionElementCount(i); size > 0 {
 					actual[SectionIDName(i)] = size
 				}
 			}

--- a/wasm/store.go
+++ b/wasm/store.go
@@ -288,7 +288,7 @@ func (s *Store) Instantiate(module *Module, name string) error {
 
 	for i, f := range instance.Functions {
 		if err := s.engine.Compile(f); err != nil {
-			idx := module.SectionSize(SectionIDFunction) - 1
+			idx := module.SectionElementCount(SectionIDFunction) - 1
 			return fmt.Errorf("compilation failed at index %d/%d: %v", i, idx, err)
 		}
 	}
@@ -598,9 +598,9 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 	n, nLen := 0, len(functionNames)
 
 	for codeIndex, typeIndex := range module.FunctionSection {
-		if typeIndex >= module.SectionSize(SectionIDType) {
+		if typeIndex >= module.SectionElementCount(SectionIDType) {
 			return rollbackFuncs, fmt.Errorf("function type index out of range")
-		} else if uint32(codeIndex) >= module.SectionSize(SectionIDCode) {
+		} else if uint32(codeIndex) >= module.SectionElementCount(SectionIDCode) {
 			return rollbackFuncs, fmt.Errorf("code index out of range")
 		}
 
@@ -631,7 +631,7 @@ func (s *Store) buildFunctionInstances(module *Module, target *ModuleInstance) (
 		}
 
 		if err := validateFunctionInstance(f, funcs, globals, mems, tables, module.TypeSection, maximumValuesOnStack); err != nil {
-			idx := module.SectionSize(SectionIDFunction) - 1
+			idx := module.SectionElementCount(SectionIDFunction) - 1
 			return rollbackFuncs, fmt.Errorf("invalid function '%s' (%d/%d): %v", f.Name, codeIndex, idx, err)
 		}
 
@@ -684,7 +684,7 @@ func (s *Store) buildMemoryInstances(module *Module, target *ModuleInstance) (ro
 
 		size := uint64(offset) + uint64(len(d.Init))
 		maxPage := MemoryMaxPages
-		if d.MemoryIndex < module.SectionSize(SectionIDMemory) && module.MemorySection[d.MemoryIndex].Max != nil {
+		if d.MemoryIndex < module.SectionElementCount(SectionIDMemory) && module.MemorySection[d.MemoryIndex].Max != nil {
 			maxPage = *module.MemorySection[d.MemoryIndex].Max
 		}
 		if size > memoryPagesToBytesNum(maxPage) {
@@ -737,7 +737,7 @@ func (s *Store) buildTableInstances(module *Module, target *ModuleInstance) (rol
 		size := offset + len(elem.Init)
 
 		max := uint32(math.MaxUint32)
-		if elem.TableIndex < module.SectionSize(SectionIDTable) && module.TableSection[elem.TableIndex].Limit.Max != nil {
+		if elem.TableIndex < module.SectionElementCount(SectionIDTable) && module.TableSection[elem.TableIndex].Limit.Max != nil {
 			max = *module.TableSection[elem.TableIndex].Limit.Max
 		}
 
@@ -775,7 +775,7 @@ func (s *Store) buildTableInstances(module *Module, target *ModuleInstance) (rol
 }
 
 func (s *Store) buildExportInstances(module *Module, target *ModuleInstance) (rollbackFuncs []func(), err error) {
-	target.Exports = make(map[string]*ExportInstance, module.SectionSize(SectionIDExport))
+	target.Exports = make(map[string]*ExportInstance, module.SectionElementCount(SectionIDExport))
 	for name, exp := range module.ExportSection {
 		index := exp.Index
 		var ei *ExportInstance

--- a/wasm/text/decoder.go
+++ b/wasm/text/decoder.go
@@ -175,7 +175,7 @@ func (p *moduleParser) beginModuleField(tok tokenType, tokenBytes []byte, _, _ u
 			return p.parseImportModule, nil
 		case "func":
 			p.pos = positionFunc
-			p.funcParser.currentIdx = p.module.SectionSize(wasm.SectionIDFunction)
+			p.funcParser.currentIdx = p.module.SectionElementCount(wasm.SectionIDFunction)
 			return p.funcParser.begin, nil
 		case "table":
 			return nil, errors.New("TODO: table")
@@ -191,7 +191,7 @@ func (p *moduleParser) beginModuleField(tok tokenType, tokenBytes []byte, _, _ u
 			p.pos = positionExport
 			return p.parseExportName, nil
 		case "start":
-			if p.module.SectionSize(wasm.SectionIDStart) > 0 {
+			if p.module.SectionElementCount(wasm.SectionIDStart) > 0 {
 				return nil, moreThanOneInvalid("start")
 			}
 			p.pos = positionStart
@@ -310,7 +310,7 @@ func (p *moduleParser) beginImportDesc(tok tokenType, tokenBytes []byte, _, _ ui
 
 	switch string(tokenBytes) {
 	case "func":
-		if p.module.SectionSize(wasm.SectionIDFunction) > 0 {
+		if p.module.SectionElementCount(wasm.SectionIDFunction) > 0 {
 			return nil, importAfterModuleDefined(wasm.SectionIDFunction)
 		}
 		p.pos = positionImportFunc
@@ -361,7 +361,7 @@ func (p *moduleParser) addFunctionName(name string) {
 // Ex. If there is no signature `(import "" "main" (func))`
 //                     calls onImportFunc here ---^
 func (p *moduleParser) parseImportFunc(tok tokenType, tokenBytes []byte, line, col uint32) (tokenParser, error) {
-	idx := p.module.SectionSize(wasm.SectionIDImport)
+	idx := p.module.SectionElementCount(wasm.SectionIDImport)
 	if tok == tokenID { // Ex. (func $main $main)
 		return nil, fmt.Errorf("redundant ID %s", tokenBytes)
 	}
@@ -520,7 +520,7 @@ func (p *moduleParser) parseExportDesc(tok tokenType, tokenBytes []byte, line, c
 	default:
 		panic(fmt.Errorf("BUG: unhandled parsing state on parseExportDesc: %v", p.pos))
 	}
-	eIdx := p.module.SectionSize(wasm.SectionIDExport)
+	eIdx := p.module.SectionElementCount(wasm.SectionIDExport)
 	typeIdx, resolved, err := namespace.parseIndex(wasm.SectionIDExport, eIdx, 0, tok, tokenBytes, line, col)
 	if err != nil {
 		return nil, err
@@ -730,22 +730,22 @@ func (p *moduleParser) errorContext() string {
 	case positionModule:
 		return "module"
 	case positionType:
-		idx := p.module.SectionSize(wasm.SectionIDType)
+		idx := p.module.SectionElementCount(wasm.SectionIDType)
 		return fmt.Sprintf("module.type[%d]%s", idx, p.typeParser.errorContext())
 	case positionImport, positionImportFunc: // TODO: table, memory or global
-		idx := p.module.SectionSize(wasm.SectionIDImport)
+		idx := p.module.SectionElementCount(wasm.SectionIDImport)
 		if p.pos == positionImport {
 			return fmt.Sprintf("module.import[%d]", idx)
 		}
 		return fmt.Sprintf("module.import[%d].func%s", idx, p.typeUseParser.errorContext())
 	case positionFunc:
-		idx := p.module.SectionSize(wasm.SectionIDFunction)
+		idx := p.module.SectionElementCount(wasm.SectionIDFunction)
 		return fmt.Sprintf("module.func[%d]%s", idx, p.typeUseParser.errorContext())
 	case positionMemory:
-		idx := p.module.SectionSize(wasm.SectionIDMemory)
+		idx := p.module.SectionElementCount(wasm.SectionIDMemory)
 		return fmt.Sprintf("module.memory[%d]", idx)
 	case positionExport, positionExportFunc: // TODO: table, memory or global
-		idx := p.module.SectionSize(wasm.SectionIDExport)
+		idx := p.module.SectionElementCount(wasm.SectionIDExport)
 		if p.pos == positionExport {
 			return fmt.Sprintf("module.export[%d]", idx)
 		}


### PR DESCRIPTION
Per #232, we will be unexporting fields only used during instantiate. Any
additional custom sections are unusable otherwise, so this skips them.
In doing so, this eliminates a length check bug, some TODO and some
logic that enforced strict name uniqueness even though that only rule
only applied to the name section.

Note: this doesn't restrict future use of custom sections, ex for DWARF,
just we don't buffer sections we don't use anymore.

See https://www.w3.org/TR/wasm-core-1/#custom-section%E2%91%A0
