### PR TITLE
jit(amd64): less instructions for memory bounds check: part 2

### DIFF
--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -3944,6 +3944,7 @@ func (c *amd64Compiler) compileLoad(o *wazeroir.OperationLoad) error {
 		moveFromMemory.To.Reg = reg
 		moveFromMemory.From.Type = obj.TYPE_MEM
 		moveFromMemory.From.Reg = reservedRegisterForMemory
+		// because this is accessed as memory.Buffer[ceil-targetSizeInBytes: ceil]
 		moveFromMemory.From.Offset = -targetSizeInBytes
 		moveFromMemory.From.Index = reg
 		moveFromMemory.From.Scale = 1
@@ -3961,6 +3962,7 @@ func (c *amd64Compiler) compileLoad(o *wazeroir.OperationLoad) error {
 		moveFromMemory.To.Type = obj.TYPE_REG
 		moveFromMemory.To.Reg = floatReg
 		moveFromMemory.From.Type = obj.TYPE_MEM
+		// because this is accessed as memory.Buffer[ceil-targetSizeInBytes: ceil]
 		moveFromMemory.From.Offset = -targetSizeInBytes
 		moveFromMemory.From.Reg = reservedRegisterForMemory
 		moveFromMemory.From.Index = reg
@@ -3999,6 +4001,7 @@ func (c *amd64Compiler) compileLoad8(o *wazeroir.OperationLoad8) error {
 	moveFromMemory.To.Reg = reg
 	moveFromMemory.From.Type = obj.TYPE_MEM
 	moveFromMemory.From.Reg = reservedRegisterForMemory
+	// because this is accessed as memory.Buffer[ceil-targetSizeInBytes: ceil]
 	moveFromMemory.From.Offset = -targetSizeInBytes
 	moveFromMemory.From.Index = reg
 	moveFromMemory.From.Scale = 1
@@ -4035,6 +4038,7 @@ func (c *amd64Compiler) compileLoad16(o *wazeroir.OperationLoad16) error {
 	moveFromMemory.To.Reg = reg
 	moveFromMemory.From.Type = obj.TYPE_MEM
 	moveFromMemory.From.Reg = reservedRegisterForMemory
+	// because this is accessed as memory.Buffer[ceil-targetSizeInBytes: ceil]
 	moveFromMemory.From.Offset = -targetSizeInBytes
 	moveFromMemory.From.Index = reg
 	moveFromMemory.From.Scale = 1
@@ -4065,6 +4069,7 @@ func (c *amd64Compiler) compileLoad32(o *wazeroir.OperationLoad32) error {
 	moveFromMemory.To.Reg = reg
 	moveFromMemory.From.Type = obj.TYPE_MEM
 	moveFromMemory.From.Reg = reservedRegisterForMemory
+	// because this is accessed as memory.Buffer[ceil-targetSizeInBytes: ceil]
 	moveFromMemory.From.Offset = -targetSizeInBytes
 	moveFromMemory.From.Index = reg
 	moveFromMemory.From.Scale = 1
@@ -4175,6 +4180,7 @@ func (c *amd64Compiler) moveToMemory(offsetConst uint32, moveInstruction obj.As,
 	moveToMemory.From.Reg = val.register
 	moveToMemory.To.Type = obj.TYPE_MEM
 	moveToMemory.To.Reg = reservedRegisterForMemory
+	// because this is accessed as memory.Buffer[ceil-targetSizeInBytes: ceil]
 	moveToMemory.To.Offset = -targetSizeInByte
 	moveToMemory.To.Index = reg
 	moveToMemory.To.Scale = 1

--- a/wasm/jit/jit_amd64.go
+++ b/wasm/jit/jit_amd64.go
@@ -4081,7 +4081,7 @@ func (c *amd64Compiler) compileLoad32(o *wazeroir.OperationLoad32) error {
 // as memory.Buffer[ceil-targetSizeInBytes: ceil].
 //
 // Note: this also emits the instructions to check the out of bounds memory access.
-// In other words, the ceil exceeds the memory size, the code exits with jitCallStatusCodeMemoryOutOfBounds status.
+// In other words, if the ceil exceeds the memory size, the code exits with jitCallStatusCodeMemoryOutOfBounds status.
 func (c *amd64Compiler) setupMemoryAccessCeil(offsetArg uint32, targetSizeInBytes int64) (int16, error) {
 	base := c.locationStack.pop()
 	if err := c.ensureOnGeneralPurposeRegister(base); err != nil {

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -4813,15 +4813,14 @@ func TestAmd64Compiler_setupMemoryOffset(t *testing.T) {
 					env.exec(code)
 
 					mem := env.memory()
-					baseOffset := int64(base) + int64(offset)
-					if ceil := baseOffset + int64(targetSizeInByte); int64(len(mem)) < ceil {
+					if ceil := int64(base) + int64(offset) + int64(targetSizeInByte); int64(len(mem)) < ceil {
 						// If the targe memory region's ceil exceeds the length of memory, we must exit the function
 						// with jitCallStatusCodeMemoryOutOfBounds status code.
 						require.Equal(t, jitCallStatusCodeMemoryOutOfBounds, env.jitStatus())
 					} else {
 						require.Equal(t, jitCallStatusCodeReturned, env.jitStatus())
 						require.Equal(t, uint64(1), env.stackPointer())
-						require.Equal(t, uint64(baseOffset), env.stackTopAsUint64())
+						require.Equal(t, uint64(ceil), env.stackTopAsUint64())
 					}
 				})
 			}

--- a/wasm/jit/jit_amd64_test.go
+++ b/wasm/jit/jit_amd64_test.go
@@ -4774,7 +4774,7 @@ func TestAmd64Compiler_compile_min_max_copysign(t *testing.T) {
 	}
 }
 
-func TestAmd64Compiler_setupMemoryOffset(t *testing.T) {
+func TestAmd64Compiler_setupMemoryAccessCeil(t *testing.T) {
 	bases := []uint32{0, 1 << 5, 1 << 9, 1 << 10, 1 << 15, math.MaxUint32 - 1, math.MaxUint32}
 	offsets := []uint32{0,
 		1 << 10, 1 << 31, math.MaxInt32 - 1, math.MaxInt32 - 2, math.MaxInt32 - 3, math.MaxInt32 - 4,
@@ -4798,7 +4798,7 @@ func TestAmd64Compiler_setupMemoryOffset(t *testing.T) {
 					err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: base})
 					require.NoError(t, err)
 
-					reg, err := compiler.setupMemoryOffset(offset, targetSizeInByte)
+					reg, err := compiler.setupMemoryAccessCeil(offset, targetSizeInByte)
 					require.NoError(t, err)
 
 					compiler.locationStack.pushValueLocationOnRegister(reg)


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>