### PR TITLE
Adds host function interfaces

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -1,0 +1,69 @@
+// Package api only includes constants and interfaces. This ensures no package cycles in implementation.
+package api
+
+import "context"
+
+// HostFunctionCallContext is the first argument of all host functions.
+type HostFunctionCallContext interface {
+	// Context returns the host call's context.
+	//
+	// The returned context is always non-nil; it defaults to the background context.
+	Context() context.Context
+
+	// Memory allows restricted access to an importing module's memory during a host function call.
+	Memory() Memory
+}
+
+// Memory allows restricted access to a module's memory. Notably, this does not allow growing.
+//
+// Note: This includes all value types available in WebAssembly 1.0 (MVP) and all are encoded little-endian.
+// See https://www.w3.org/TR/wasm-core-1/#storage%E2%91%A0
+type Memory interface {
+	// Len returns the size in bytes available. Ex. If the underlying memory has 1 page: 65536
+	//
+	// Note: this will not grow during a host function call, even if the underlying memory can.  Ex. If the underlying
+	// memory has min 0 and max 2 pages, this returns zero.
+	Len() uint32
+
+	// ReadUint32Le reads a uint32 in little-endian encoding from the underlying buffer at the offset in or returns
+	// false if out of range.
+	ReadUint32Le(offset uint32) (uint32, bool)
+
+	// ReadFloat32Le reads a float32 from 32 IEEE 754 little-endian encoded bits in the underlying buffer at the offset
+	// or returns false if out of range.
+	// See math.Float32bits
+	ReadFloat32Le(offset uint32) (float32, bool)
+
+	// ReadUint64Le reads a uint64 in little-endian encoding from the underlying buffer at the offset or returns false
+	// if out of range.
+	ReadUint64Le(offset uint32) (uint64, bool)
+
+	// ReadFloat64Le reads a float64 from 64 IEEE 754 little-endian encoded bits in the underlying buffer at the offset
+	// or returns false if out of range.
+	// See math.Float64bits
+	ReadFloat64Le(offset uint32) (float64, bool)
+
+	// Read reads byteCount bytes from the underlying buffer at the offset or returns false if out of range.
+	Read(offset, byteCount uint32) ([]byte, bool)
+
+	// WriteUint32Le writes the value in little-endian encoding to the underlying buffer at the offset in or returns
+	// false if out of range.
+	WriteUint32Le(offset, v uint32) bool
+
+	// WriteFloat32Le writes the value in 32 IEEE 754 little-endian encoded bits to the underlying buffer at the offset
+	// or returns false if out of range.
+	// See math.Float32bits
+	WriteFloat32Le(offset uint32, v float32) bool
+
+	// WriteUint64Le writes the value in little-endian encoding to the underlying buffer at the offset in or returns
+	// false if out of range.
+	WriteUint64Le(offset uint32, v uint64) bool
+
+	// WriteFloat64Le writes the value in 64 IEEE 754 little-endian encoded bits to the underlying buffer at the offset
+	// or returns false if out of range.
+	// See math.Float64bits
+	WriteFloat64Le(offset uint32, v float64) bool
+
+	// Write writes the slice to the underlying buffer at the offset or returns false if out of range.
+	Write(offset uint32, v []byte) bool
+}

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 	binaryFormat "github.com/tetratelabs/wazero/wasm/binary"
@@ -28,7 +27,7 @@ func Test_hostFunc(t *testing.T) {
 	store := wasm.NewStore(interpreter.NewEngine())
 
 	// Host-side implementation of get_random_string on Wasm import.
-	getRandomString := func(ctx api.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
+	getRandomString := func(ctx wasm.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
 		// Assert that context values passed in from CallFunctionContext are accessible.
 		contextValue := ctx.Context().Value(testKey{}).(int64)
 		require.Equal(t, int64(12345), contextValue)

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 	binaryFormat "github.com/tetratelabs/wazero/wasm/binary"
@@ -27,7 +28,7 @@ func Test_hostFunc(t *testing.T) {
 	store := wasm.NewStore(interpreter.NewEngine())
 
 	// Host-side implementation of get_random_string on Wasm import.
-	getRandomString := func(ctx *wasm.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
+	getRandomString := func(ctx api.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
 		// Assert that context values passed in from CallFunctionContext are accessible.
 		contextValue := ctx.Context().Value(testKey{}).(int64)
 		require.Equal(t, int64(12345), contextValue)
@@ -43,11 +44,14 @@ func Test_hostFunc(t *testing.T) {
 		bufAddr := ret[0]
 
 		// Store the address info to the memory.
-		ctx.Memory.PutUint32(retBufPtr, uint32(bufAddr))
-		ctx.Memory.PutUint32(retBufSize, uint32(bufferSize))
+		require.True(t, ctx.Memory().WriteUint32Le(retBufPtr, uint32(bufAddr)))
+		require.True(t, ctx.Memory().WriteUint32Le(retBufSize, uint32(bufferSize)))
 
 		// Now store the random values in the region.
-		n, err := rand.Read(ctx.Memory.Buffer[bufAddr : bufAddr+bufferSize])
+		b, ok := ctx.Memory().Read(uint32(bufAddr), bufferSize)
+		require.True(t, ok)
+
+		n, err := rand.Read(b)
 		require.NoError(t, err)
 		require.Equal(t, bufferSize, n)
 	}
@@ -70,7 +74,7 @@ func Test_hostFunc(t *testing.T) {
 	_, _, err = store.CallFunction(ctx, "test", "_start")
 	require.NoError(t, err)
 
-	// Set a context variable that should be available in HostFunctionCallContext.
+	// Set a context variable that should be available in api.hostFunctionCallContext.
 	ctx = context.WithValue(ctx, testKey{}, int64(12345))
 
 	_, _, err = store.CallFunction(ctx, "test", "base64", 5)

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
 	"github.com/tetratelabs/wazero/wasm/text"
@@ -25,7 +26,7 @@ func Test_Simple(t *testing.T) {
 	store := wasm.NewStore(interpreter.NewEngine())
 
 	stdout := new(bytes.Buffer)
-	hostFunction := func(_ *wasm.HostFunctionCallContext) {
+	hostFunction := func(_ api.HostFunctionCallContext) {
 		_, _ = fmt.Fprintln(stdout, "hello!")
 	}
 

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -26,7 +26,7 @@ func Test_Simple(t *testing.T) {
 	store := wasm.NewStore(interpreter.NewEngine())
 
 	stdout := new(bytes.Buffer)
-	hostFunction := func(_ api.HostFunctionCallContext) {
+	hostFunction := func(api.HostFunctionCallContext) {
 		_, _ = fmt.Fprintln(stdout, "hello!")
 	}
 

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
 	"github.com/tetratelabs/wazero/wasm/text"
@@ -26,7 +25,7 @@ func Test_Simple(t *testing.T) {
 	store := wasm.NewStore(interpreter.NewEngine())
 
 	stdout := new(bytes.Buffer)
-	hostFunction := func(api.HostFunctionCallContext) {
+	hostFunction := func(wasm.HostFunctionCallContext) {
 		_, _ = fmt.Fprintln(stdout, "hello!")
 	}
 

--- a/tests/bench/bench_test.go
+++ b/tests/bench/bench_test.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 	binaryFormat "github.com/tetratelabs/wazero/wasm/binary"
@@ -143,7 +142,7 @@ func runRandomMatMul(b *testing.B, store *wasm.Store) {
 
 func newStore(engine wasm.Engine) *wasm.Store {
 	store := wasm.NewStore(engine)
-	getRandomString := func(ctx api.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
+	getRandomString := func(ctx wasm.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
 		ret, _, _ := store.CallFunction(ctx.Context(), "test", "allocate_buffer", 10)
 		bufAddr := uint32(ret[0])
 		ctx.Memory().WriteUint32Le(retBufPtr, bufAddr)

--- a/tests/bench/bench_test.go
+++ b/tests/bench/bench_test.go
@@ -3,13 +3,13 @@ package bench
 import (
 	"context"
 	_ "embed"
-	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"reflect"
 	"runtime"
 	"testing"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 	binaryFormat "github.com/tetratelabs/wazero/wasm/binary"
@@ -143,12 +143,14 @@ func runRandomMatMul(b *testing.B, store *wasm.Store) {
 
 func newStore(engine wasm.Engine) *wasm.Store {
 	store := wasm.NewStore(engine)
-	getRandomString := func(ctx *wasm.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
+	getRandomString := func(ctx api.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
 		ret, _, _ := store.CallFunction(ctx.Context(), "test", "allocate_buffer", 10)
-		bufAddr := ret[0]
-		binary.LittleEndian.PutUint32(ctx.Memory.Buffer[retBufPtr:], uint32(bufAddr))
-		binary.LittleEndian.PutUint32(ctx.Memory.Buffer[retBufSize:], 10)
-		_, _ = rand.Read(ctx.Memory.Buffer[bufAddr : bufAddr+10])
+		bufAddr := uint32(ret[0])
+		ctx.Memory().WriteUint32Le(retBufPtr, bufAddr)
+		ctx.Memory().WriteUint32Le(retBufSize, 10)
+		b := make([]byte, 10)
+		_, _ = rand.Read(b)
+		ctx.Memory().Write(bufAddr, b)
 	}
 
 	_ = store.AddHostFunction("env", "get_random_string", reflect.ValueOf(getRandomString))

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/binary"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
@@ -130,7 +129,7 @@ func unreachable(t *testing.T, newEngine func() wasm.Engine) {
 
 	const moduleName = "test"
 
-	callUnreachable := func(ctx api.HostFunctionCallContext) {
+	callUnreachable := func(ctx wasm.HostFunctionCallContext) {
 		_, _, err := store.CallFunction(ctx.Context(), moduleName, "unreachable_func")
 		require.NoError(t, err)
 	}
@@ -187,7 +186,7 @@ func recursiveEntry(t *testing.T, newEngine func() wasm.Engine) {
 
 	store := wasm.NewStore(newEngine())
 
-	hostfunc := func(ctx api.HostFunctionCallContext) {
+	hostfunc := func(ctx wasm.HostFunctionCallContext) {
 		_, _, err := store.CallFunction(ctx.Context(), "test", "called_by_host_func")
 		require.NoError(t, err)
 	}
@@ -217,7 +216,7 @@ func importedAndExportedFunc(t *testing.T, newEngine func() wasm.Engine) {
 
 	store := wasm.NewStore(newEngine())
 
-	storeInt := func(ctx api.HostFunctionCallContext, offset uint32, val uint64) uint32 {
+	storeInt := func(ctx wasm.HostFunctionCallContext, offset uint32, val uint64) uint32 {
 		if !ctx.Memory().WriteUint64Le(offset, val) {
 			return 1
 		}
@@ -268,7 +267,7 @@ func hostFuncWithFloatParam(t *testing.T, newEngine func() wasm.Engine) {
 		{
 			testName:  "host function with f32 param",
 			floatType: wasm.ValueTypeF32,
-			identityFloatFunc: reflect.ValueOf(func(ctx api.HostFunctionCallContext, value float32) float32 {
+			identityFloatFunc: reflect.ValueOf(func(ctx wasm.HostFunctionCallContext, value float32) float32 {
 				return value
 			}),
 			floatParam:       uint64(math.Float32bits(math.MaxFloat32)), // float bits as a uint32 value, but casted to uint64 to be passed to CallFunction
@@ -277,7 +276,7 @@ func hostFuncWithFloatParam(t *testing.T, newEngine func() wasm.Engine) {
 		{
 			testName:  "host function with f64 param",
 			floatType: wasm.ValueTypeF64,
-			identityFloatFunc: reflect.ValueOf(func(ctx api.HostFunctionCallContext, value float64) float64 {
+			identityFloatFunc: reflect.ValueOf(func(ctx wasm.HostFunctionCallContext, value float64) float64 {
 				return value
 			}),
 			floatParam:       math.Float64bits(math.MaxFloat64),

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/binary"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
@@ -129,7 +130,7 @@ func unreachable(t *testing.T, newEngine func() wasm.Engine) {
 
 	const moduleName = "test"
 
-	callUnreachable := func(ctx *wasm.HostFunctionCallContext) {
+	callUnreachable := func(ctx api.HostFunctionCallContext) {
 		_, _, err := store.CallFunction(ctx.Context(), moduleName, "unreachable_func")
 		require.NoError(t, err)
 	}
@@ -186,7 +187,7 @@ func recursiveEntry(t *testing.T, newEngine func() wasm.Engine) {
 
 	store := wasm.NewStore(newEngine())
 
-	hostfunc := func(ctx *wasm.HostFunctionCallContext) {
+	hostfunc := func(ctx api.HostFunctionCallContext) {
 		_, _, err := store.CallFunction(ctx.Context(), "test", "called_by_host_func")
 		require.NoError(t, err)
 	}
@@ -201,7 +202,7 @@ func recursiveEntry(t *testing.T, newEngine func() wasm.Engine) {
 }
 
 // importedAndExportedFunc fails if the engine cannot call an "imported-and-then-exported-back" function
-// Notably, this uses memory, which ensures wasm.HostFunctionCallContext is valid in both interpreter and JIT engines.
+// Notably, this uses memory, which ensures api.HostFunctionCallContext is valid in both interpreter and JIT engines.
 func importedAndExportedFunc(t *testing.T, newEngine func() wasm.Engine) {
 	ctx := context.Background()
 	mod, err := text.DecodeModule([]byte(`(module $test
@@ -216,8 +217,8 @@ func importedAndExportedFunc(t *testing.T, newEngine func() wasm.Engine) {
 
 	store := wasm.NewStore(newEngine())
 
-	storeInt := func(ctx *wasm.HostFunctionCallContext, offset uint32, val uint64) uint32 {
-		if !ctx.Memory.PutUint64(offset, val) {
+	storeInt := func(ctx api.HostFunctionCallContext, offset uint32, val uint64) uint32 {
+		if !ctx.Memory().WriteUint64Le(offset, val) {
 			return 1
 		}
 		return 0
@@ -267,7 +268,7 @@ func hostFuncWithFloatParam(t *testing.T, newEngine func() wasm.Engine) {
 		{
 			testName:  "host function with f32 param",
 			floatType: wasm.ValueTypeF32,
-			identityFloatFunc: reflect.ValueOf(func(ctx *wasm.HostFunctionCallContext, value float32) float32 {
+			identityFloatFunc: reflect.ValueOf(func(ctx api.HostFunctionCallContext, value float32) float32 {
 				return value
 			}),
 			floatParam:       uint64(math.Float32bits(math.MaxFloat32)), // float bits as a uint32 value, but casted to uint64 to be passed to CallFunction
@@ -276,7 +277,7 @@ func hostFuncWithFloatParam(t *testing.T, newEngine func() wasm.Engine) {
 		{
 			testName:  "host function with f64 param",
 			floatType: wasm.ValueTypeF64,
-			identityFloatFunc: reflect.ValueOf(func(ctx *wasm.HostFunctionCallContext, value float64) float64 {
+			identityFloatFunc: reflect.ValueOf(func(ctx api.HostFunctionCallContext, value float64) float64 {
 				return value
 			}),
 			floatParam:       math.Float64bits(math.MaxFloat64),

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/binary"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
@@ -188,13 +187,13 @@ func (c command) expectedError() (err error) {
 
 func addSpectestModule(t *testing.T, store *wasm.Store) {
 	for n, v := range map[string]reflect.Value{
-		"print":         reflect.ValueOf(func(api.HostFunctionCallContext) {}),
-		"print_i32":     reflect.ValueOf(func(api.HostFunctionCallContext, uint32) {}),
-		"print_f32":     reflect.ValueOf(func(api.HostFunctionCallContext, float32) {}),
-		"print_i64":     reflect.ValueOf(func(api.HostFunctionCallContext, uint64) {}),
-		"print_f64":     reflect.ValueOf(func(api.HostFunctionCallContext, float64) {}),
-		"print_i32_f32": reflect.ValueOf(func(api.HostFunctionCallContext, uint32, float32) {}),
-		"print_f64_f64": reflect.ValueOf(func(api.HostFunctionCallContext, float64, float64) {}),
+		"print":         reflect.ValueOf(func(wasm.HostFunctionCallContext) {}),
+		"print_i32":     reflect.ValueOf(func(wasm.HostFunctionCallContext, uint32) {}),
+		"print_f32":     reflect.ValueOf(func(wasm.HostFunctionCallContext, float32) {}),
+		"print_i64":     reflect.ValueOf(func(wasm.HostFunctionCallContext, uint64) {}),
+		"print_f64":     reflect.ValueOf(func(wasm.HostFunctionCallContext, float64) {}),
+		"print_i32_f32": reflect.ValueOf(func(wasm.HostFunctionCallContext, uint32, float32) {}),
+		"print_f64_f64": reflect.ValueOf(func(wasm.HostFunctionCallContext, float64, float64) {}),
 	} {
 		require.NoError(t, store.AddHostFunction("spectest", n, v), "AddHostFunction(%s)", n)
 	}

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/binary"
 	"github.com/tetratelabs/wazero/wasm/interpreter"
@@ -187,13 +188,13 @@ func (c command) expectedError() (err error) {
 
 func addSpectestModule(t *testing.T, store *wasm.Store) {
 	for n, v := range map[string]reflect.Value{
-		"print":         reflect.ValueOf(func(*wasm.HostFunctionCallContext) {}),
-		"print_i32":     reflect.ValueOf(func(*wasm.HostFunctionCallContext, uint32) {}),
-		"print_f32":     reflect.ValueOf(func(*wasm.HostFunctionCallContext, float32) {}),
-		"print_i64":     reflect.ValueOf(func(*wasm.HostFunctionCallContext, uint64) {}),
-		"print_f64":     reflect.ValueOf(func(*wasm.HostFunctionCallContext, float64) {}),
-		"print_i32_f32": reflect.ValueOf(func(*wasm.HostFunctionCallContext, uint32, float32) {}),
-		"print_f64_f64": reflect.ValueOf(func(*wasm.HostFunctionCallContext, float64, float64) {}),
+		"print":         reflect.ValueOf(func(api.HostFunctionCallContext) {}),
+		"print_i32":     reflect.ValueOf(func(api.HostFunctionCallContext, uint32) {}),
+		"print_f32":     reflect.ValueOf(func(api.HostFunctionCallContext, float32) {}),
+		"print_i64":     reflect.ValueOf(func(api.HostFunctionCallContext, uint64) {}),
+		"print_f64":     reflect.ValueOf(func(api.HostFunctionCallContext, float64) {}),
+		"print_i32_f32": reflect.ValueOf(func(api.HostFunctionCallContext, uint32, float32) {}),
+		"print_f64_f64": reflect.ValueOf(func(api.HostFunctionCallContext, float64, float64) {}),
 	} {
 		require.NoError(t, store.AddHostFunction("spectest", n, v), "AddHostFunction(%s)", n)
 	}

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -1,7 +1,6 @@
 package wasi
 
 import (
-	"encoding/binary"
 	"errors"
 	"io"
 	"io/fs"
@@ -11,6 +10,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 )
 
@@ -21,15 +21,16 @@ import (
 // parameter is a memory offset to write the result to. As memory offsets are uint32, each parameter representing a
 // result is uint32.
 //
-// Note: In WebAssembly 1.0 (MVP), there may be up to one Memory per store, which means the wasm.HostFunctionCallContext
-// Memory is always the wasm.Store Memories index zero: `store.Memories[0].Buffer`
+// Note: In WebAssembly 1.0 (MVP), there may be up to one Memory per store, which means api.Memory is always the
+// wasm.Store Memories index zero: `store.Memories[0].Buffer`
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
 // See https://wwa.w3.org/TR/wasm-core-1/#memory-instances%E2%91%A0.
 type API interface {
 	// ArgsGet is the WASI function that reads command-line argument data (Args).
 	//
-	// There are two parameters. Both are offsets in the wasm.HostFunctionCallContext Memory Buffer.
+	// There are two parameters. Both are offsets in api.HostFunctionCallContext Memory. If either are invalid due to
+	// memory constraints, this returns ErrnoFault.
 	//
 	// * argv - is the offset to begin writing argument offsets in uint32 little-endian encoding.
 	//   * ArgsSizesGet result argc * 4 bytes are written to this offset
@@ -52,12 +53,13 @@ type API interface {
 	// See ArgsSizesGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_get
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
-	ArgsGet(ctx *wasm.HostFunctionCallContext, argv, argvBuf uint32) Errno
+	ArgsGet(ctx api.HostFunctionCallContext, argv, argvBuf uint32) Errno
 
 	// ArgsSizesGet is a WASI function that reads command-line argument data (Args) sizes.
 	//
-	// There are two result parameters: these are offsets in the wasm.HostFunctionCallContext Memory Buffer to write
-	// corresponding sizes in uint32 little-endian encoding.
+	// There are two result parameters: these are offsets in the api.HostFunctionCallContext Memory to write
+	// corresponding sizes in uint32 little-endian encoding. If either are invalid due to memory constraints, this
+	// returns ErrnoFault.
 	//
 	// * resultArgc - is the offset to write the argument count to wasm.MemoryInstance Buffer
 	// * resultArgvBufSize - is the offset to write the null-terminated argument length to wasm.MemoryInstance Buffer
@@ -78,13 +80,13 @@ type API interface {
 	// See ArgsGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_sizes_get
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
-	ArgsSizesGet(ctx *wasm.HostFunctionCallContext, resultArgc, resultArgvBufSize uint32) Errno
+	ArgsSizesGet(ctx api.HostFunctionCallContext, resultArgc, resultArgvBufSize uint32) Errno
 
-	// TODO: EnvironGet(ctx *wasm.HostFunctionCallContext, environ, environBuf uint32) Errno
+	// TODO: EnvironGet(ctx api.hostFunctionCallContext, environ, environBuf uint32) Errno
 
-	// TODO: EnvironSizesGet(ctx *wasm.HostFunctionCallContext, resulEnvironc, resultEnvironBufSize uint32) Errno
+	// TODO: EnvironSizesGet(ctx api.hostFunctionCallContext, resulEnvironc, resultEnvironBufSize uint32) Errno
 
-	// TODO: ClockResGet(ctx *wasm.HostFunctionCallContext, id, resultResolution uint32) Errno
+	// TODO: ClockResGet(ctx api.hostFunctionCallContext, id, resultResolution uint32) Errno
 
 	// ClockTimeGet is a WASI function that returns the time value of a clock (time.Now).
 	//
@@ -106,7 +108,7 @@ type API interface {
 	// Note: This is similar to `clock_gettime` in POSIX.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_time_getid-clockid-precision-timestamp---errno-timestamp
 	// See https://linux.die.net/man/3/clock_gettime
-	ClockTimeGet(ctx *wasm.HostFunctionCallContext, id uint32, precision uint64, resultTimestamp uint32) Errno
+	ClockTimeGet(ctx api.HostFunctionCallContext, id uint32, precision uint64, resultTimestamp uint32) Errno
 
 	// TODO: FdAdvise
 	// TODO: FdAllocate
@@ -154,7 +156,7 @@ const (
 	wasiSnapshotPreview1Name = "wasi_snapshot_preview1"
 )
 
-type api struct {
+type wasiAPI struct {
 	args  *nullTerminatedStrings
 	stdin io.Reader
 	stdout,
@@ -164,7 +166,7 @@ type api struct {
 	timeNowUnixNano func() uint64
 }
 
-func (a *api) register(store *wasm.Store) (err error) {
+func (a *wasiAPI) register(store *wasm.Store) (err error) {
 	// Note: these are ordered per spec for consistency
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#functions
 	nameToFunction := []struct {
@@ -232,43 +234,43 @@ func (a *api) register(store *wasm.Store) (err error) {
 }
 
 // ArgsGet implements API.ArgsGet
-func (a *api) ArgsGet(ctx *wasm.HostFunctionCallContext, argv, argvBuf uint32) Errno {
-	if !ctx.Memory.ValidateAddrRange(argv, uint64(len(a.args.nullTerminatedValues))*4) /*4 is the size of uint32*/ ||
-		!ctx.Memory.ValidateAddrRange(argvBuf, uint64(a.args.totalBufSize)) {
-		return ErrnoInval
-	}
+func (a *wasiAPI) ArgsGet(ctx api.HostFunctionCallContext, argv, argvBuf uint32) Errno {
 	for _, arg := range a.args.nullTerminatedValues {
-		binary.LittleEndian.PutUint32(ctx.Memory.Buffer[argv:], argvBuf)
+		if !ctx.Memory().WriteUint32Le(argv, argvBuf) {
+			return ErrnoFault
+		}
 		argv += 4 // size of uint32
-		argvBuf += uint32(copy(ctx.Memory.Buffer[argvBuf:], arg))
+		if !ctx.Memory().Write(argvBuf, arg) {
+			return ErrnoFault
+		}
+		argvBuf += uint32(len(arg))
 	}
 
 	return ErrnoSuccess
 }
 
 // ArgsSizesGet implements API.ArgsSizesGet
-func (a *api) ArgsSizesGet(ctx *wasm.HostFunctionCallContext, resultArgc, resultArgvBufSize uint32) Errno {
-	if !ctx.Memory.PutUint32(resultArgc, uint32(len(a.args.nullTerminatedValues))) {
-		return ErrnoInval
+func (a *wasiAPI) ArgsSizesGet(ctx api.HostFunctionCallContext, resultArgc, resultArgvBufSize uint32) Errno {
+	if !ctx.Memory().WriteUint32Le(resultArgc, uint32(len(a.args.nullTerminatedValues))) {
+		return ErrnoFault
 	}
-	if !ctx.Memory.PutUint32(resultArgvBufSize, a.args.totalBufSize) {
-		return ErrnoInval
+	if !ctx.Memory().WriteUint32Le(resultArgvBufSize, a.args.totalBufSize) {
+		return ErrnoFault
 	}
-
 	return ErrnoSuccess
 }
 
-// TODO: func (a *api) EnvironGet
+// TODO: func (a *wasiAPI) EnvironGet
 
-// TODO: func (a *api) EnvironSizesGet
+// TODO: func (a *wasiAPI) EnvironSizesGet
 
-// TODO: func (a *api) FunctionClockResGet
+// TODO: func (a *wasiAPI) FunctionClockResGet
 
 // ClockTimeGet implements API.ClockTimeGet
-func (a *api) ClockTimeGet(ctx *wasm.HostFunctionCallContext, id uint32, precision uint64, resultTimestamp uint32) Errno {
+func (a *wasiAPI) ClockTimeGet(ctx api.HostFunctionCallContext, id uint32, precision uint64, resultTimestamp uint32) Errno {
 	// TODO: id and precision are currently ignored.
-	if !ctx.Memory.PutUint64(resultTimestamp, a.timeNowUnixNano()) {
-		return ErrnoInval
+	if !ctx.Memory().WriteUint64Le(resultTimestamp, a.timeNowUnixNano()) {
+		return ErrnoFault
 	}
 	return ErrnoSuccess
 }
@@ -279,22 +281,22 @@ type fileEntry struct {
 	file    File
 }
 
-type Option func(*api)
+type Option func(*wasiAPI)
 
 func Stdin(reader io.Reader) Option {
-	return func(a *api) {
+	return func(a *wasiAPI) {
 		a.stdin = reader
 	}
 }
 
 func Stdout(writer io.Writer) Option {
-	return func(a *api) {
+	return func(a *wasiAPI) {
 		a.stdout = writer
 	}
 }
 
 func Stderr(writer io.Writer) Option {
-	return func(a *api) {
+	return func(a *wasiAPI) {
 		a.stderr = writer
 	}
 }
@@ -308,13 +310,13 @@ func Args(args ...string) (Option, error) {
 	if err != nil {
 		return nil, err
 	}
-	return func(a *api) {
+	return func(a *wasiAPI) {
 		a.args = wasiStrings
 	}, nil
 }
 
 func Preopen(dir string, fileSys FS) Option {
-	return func(a *api) {
+	return func(a *wasiAPI) {
 		a.opened[uint32(len(a.opened))+3] = fileEntry{
 			path:    dir,
 			fileSys: fileSys,
@@ -328,15 +330,15 @@ func RegisterAPI(store *wasm.Store, opts ...Option) error {
 	return err
 }
 
-// TODO: we can't export a return with API until we figure out how to give users a wasm.HostFunctionCallContext
+// TODO: we can't export a return with API until we figure out how to give users a api.HostFunctionCallContext
 func registerAPI(store *wasm.Store, opts ...Option) (API, error) {
 	ret := newAPI(opts...)
 	err := ret.register(store)
 	return ret, err
 }
 
-func newAPI(opts ...Option) *api {
-	ret := &api{
+func newAPI(opts ...Option) *wasiAPI {
+	ret := &wasiAPI{
 		args:   &nullTerminatedStrings{},
 		stdin:  os.Stdin,
 		stdout: os.Stdout,
@@ -354,7 +356,7 @@ func newAPI(opts ...Option) *api {
 	return ret
 }
 
-func (a *api) randUnusedFD() uint32 {
+func (a *wasiAPI) randUnusedFD() uint32 {
 	fd := uint32(rand.Int31())
 	for {
 		if _, ok := a.opened[fd]; !ok {
@@ -364,14 +366,14 @@ func (a *api) randUnusedFD() uint32 {
 	}
 }
 
-func (a *api) fd_prestat_get(ctx *wasm.HostFunctionCallContext, fd uint32, bufPtr uint32) (err Errno) {
+func (a *wasiAPI) fd_prestat_get(ctx api.HostFunctionCallContext, fd uint32, bufPtr uint32) (err Errno) {
 	if _, ok := a.opened[fd]; !ok {
 		return ErrnoBadf
 	}
 	return ErrnoSuccess
 }
 
-func (a *api) fd_prestat_dir_name(ctx *wasm.HostFunctionCallContext, fd uint32, pathPtr uint32, pathLen uint32) (err Errno) {
+func (a *wasiAPI) fd_prestat_dir_name(ctx api.HostFunctionCallContext, fd uint32, pathPtr uint32, pathLen uint32) (err Errno) {
 	f, ok := a.opened[fd]
 	if !ok {
 		return ErrnoInval
@@ -381,19 +383,23 @@ func (a *api) fd_prestat_dir_name(ctx *wasm.HostFunctionCallContext, fd uint32, 
 		return ErrnoNametoolong
 	}
 
-	copy(ctx.Memory.Buffer[pathPtr:], f.path)
+	if !ctx.Memory().Write(pathPtr, []byte(f.path)) {
+		return ErrnoFault
+	}
 	return ErrnoSuccess
 }
 
-func (a *api) fd_fdstat_get(ctx *wasm.HostFunctionCallContext, fd uint32, bufPtr uint32) (err Errno) {
+func (a *wasiAPI) fd_fdstat_get(ctx api.HostFunctionCallContext, fd uint32, bufPtr uint32) (err Errno) {
 	if _, ok := a.opened[fd]; !ok {
 		return ErrnoBadf
 	}
-	binary.LittleEndian.PutUint64(ctx.Memory.Buffer[bufPtr+16:], R_FD_READ|R_FD_WRITE)
+	if !ctx.Memory().WriteUint64Le(bufPtr+16, R_FD_READ|R_FD_WRITE) {
+		return ErrnoFault
+	}
 	return ErrnoSuccess
 }
 
-func (a *api) path_open(ctx *wasm.HostFunctionCallContext, fd, dirFlags, pathPtr, pathLen, oFlags uint32,
+func (a *wasiAPI) path_open(ctx api.HostFunctionCallContext, fd, dirFlags, pathPtr, pathLen, oFlags uint32,
 	fsRightsBase, fsRightsInheriting uint64,
 	fdFlags, fdPtr uint32) (errno Errno) {
 	dir, ok := a.opened[fd]
@@ -401,7 +407,11 @@ func (a *api) path_open(ctx *wasm.HostFunctionCallContext, fd, dirFlags, pathPtr
 		return ErrnoInval
 	}
 
-	path := string(ctx.Memory.Buffer[pathPtr : pathPtr+pathLen])
+	b, ok := ctx.Memory().Read(pathPtr, pathLen)
+	if !ok {
+		return ErrnoFault
+	}
+	path := string(b)
 	f, err := dir.fileSys.OpenWASI(dirFlags, path, oFlags, fsRightsBase, fsRightsInheriting, fdFlags)
 	if err != nil {
 		switch {
@@ -418,15 +428,17 @@ func (a *api) path_open(ctx *wasm.HostFunctionCallContext, fd, dirFlags, pathPtr
 		file: f,
 	}
 
-	binary.LittleEndian.PutUint32(ctx.Memory.Buffer[fdPtr:], newFD)
+	if !ctx.Memory().WriteUint32Le(fdPtr, newFD) {
+		return ErrnoFault
+	}
 	return ErrnoSuccess
 }
 
-func (a *api) fd_seek(ctx *wasm.HostFunctionCallContext, fd uint32, offset uint64, whence uint32, nwrittenPtr uint32) (err Errno) {
+func (a *wasiAPI) fd_seek(ctx api.HostFunctionCallContext, fd uint32, offset uint64, whence uint32, nwrittenPtr uint32) (err Errno) {
 	return ErrnoNosys // TODO: implement
 }
 
-func (a *api) fd_write(ctx *wasm.HostFunctionCallContext, fd uint32, iovsPtr uint32, iovsLen uint32, nwrittenPtr uint32) (err Errno) {
+func (a *wasiAPI) fd_write(ctx api.HostFunctionCallContext, fd uint32, iovsPtr uint32, iovsLen uint32, nwrittenPtr uint32) (err Errno) {
 	var writer io.Writer
 
 	switch fd {
@@ -445,19 +457,31 @@ func (a *api) fd_write(ctx *wasm.HostFunctionCallContext, fd uint32, iovsPtr uin
 	var nwritten uint32
 	for i := uint32(0); i < iovsLen; i++ {
 		iovPtr := iovsPtr + i*8
-		offset := binary.LittleEndian.Uint32(ctx.Memory.Buffer[iovPtr:])
-		l := binary.LittleEndian.Uint32(ctx.Memory.Buffer[iovPtr+4:])
-		n, err := writer.Write(ctx.Memory.Buffer[offset : offset+l])
+		offset, ok := ctx.Memory().ReadUint32Le(iovPtr)
+		if !ok {
+			return ErrnoFault
+		}
+		l, ok := ctx.Memory().ReadUint32Le(iovPtr + 4)
+		if !ok {
+			return ErrnoFault
+		}
+		b, ok := ctx.Memory().Read(offset, l)
+		if !ok {
+			return ErrnoFault
+		}
+		n, err := writer.Write(b)
 		if err != nil {
 			panic(err)
 		}
 		nwritten += uint32(n)
 	}
-	binary.LittleEndian.PutUint32(ctx.Memory.Buffer[nwrittenPtr:], nwritten)
+	if !ctx.Memory().WriteUint32Le(nwrittenPtr, nwritten) {
+		return ErrnoFault
+	}
 	return ErrnoSuccess
 }
 
-func (a *api) fd_read(ctx *wasm.HostFunctionCallContext, fd uint32, iovsPtr uint32, iovsLen uint32, nreadPtr uint32) (err Errno) {
+func (a *wasiAPI) fd_read(ctx api.HostFunctionCallContext, fd uint32, iovsPtr uint32, iovsLen uint32, nreadPtr uint32) (err Errno) {
 	var reader io.Reader
 
 	switch fd {
@@ -474,9 +498,19 @@ func (a *api) fd_read(ctx *wasm.HostFunctionCallContext, fd uint32, iovsPtr uint
 	var nread uint32
 	for i := uint32(0); i < iovsLen; i++ {
 		iovPtr := iovsPtr + i*8
-		offset := binary.LittleEndian.Uint32(ctx.Memory.Buffer[iovPtr:])
-		l := binary.LittleEndian.Uint32(ctx.Memory.Buffer[iovPtr+4:])
-		n, err := reader.Read(ctx.Memory.Buffer[offset : offset+l])
+		offset, ok := ctx.Memory().ReadUint32Le(iovPtr)
+		if !ok {
+			return ErrnoFault
+		}
+		l, ok := ctx.Memory().ReadUint32Le(iovPtr + 4)
+		if !ok {
+			return ErrnoFault
+		}
+		b, ok := ctx.Memory().Read(offset, l)
+		if !ok {
+			return ErrnoFault
+		}
+		n, err := reader.Read(b)
 		nread += uint32(n)
 		if errors.Is(err, io.EOF) {
 			break
@@ -484,11 +518,13 @@ func (a *api) fd_read(ctx *wasm.HostFunctionCallContext, fd uint32, iovsPtr uint
 			return ErrnoIo
 		}
 	}
-	binary.LittleEndian.PutUint32(ctx.Memory.Buffer[nreadPtr:], nread)
+	if !ctx.Memory().WriteUint32Le(nreadPtr, nread) {
+		return ErrnoFault
+	}
 	return ErrnoSuccess
 }
 
-func (a *api) fd_close(ctx *wasm.HostFunctionCallContext, fd uint32) (err Errno) {
+func (a *wasiAPI) fd_close(ctx api.HostFunctionCallContext, fd uint32) (err Errno) {
 	f, ok := a.opened[fd]
 	if !ok {
 		return ErrnoBadf
@@ -503,14 +539,14 @@ func (a *api) fd_close(ctx *wasm.HostFunctionCallContext, fd uint32) (err Errno)
 	return ErrnoSuccess
 }
 
-func proc_exit(*wasm.HostFunctionCallContext, uint32) {
+func proc_exit(api.HostFunctionCallContext, uint32) {
 	// TODO: implement
 }
 
-func environ_sizes_get(*wasm.HostFunctionCallContext, uint32, uint32) (err Errno) {
+func environ_sizes_get(api.HostFunctionCallContext, uint32, uint32) (err Errno) {
 	return ErrnoNosys // TODO: implement
 }
 
-func environ_get(*wasm.HostFunctionCallContext, uint32, uint32) (err Errno) {
+func environ_get(api.HostFunctionCallContext, uint32, uint32) (err Errno) {
 	return ErrnoNosys // TODO: implement
 }

--- a/wasm/api.go
+++ b/wasm/api.go
@@ -1,5 +1,4 @@
-// Package api only includes constants and interfaces. This ensures no package cycles in implementation.
-package api
+package wasm
 
 import "context"
 

--- a/wasm/engine.go
+++ b/wasm/engine.go
@@ -6,7 +6,7 @@ import "context"
 type Engine interface {
 	// Call invokes a function instance f with given parameters.
 	// Returns the results from the function.
-	// The ctx parameter will be the outer-most ancestor of HostFunctionCallContext.Context.
+	// The ctx parameter will be the outer-most ancestor of api.HostFunctionCallContext Context.
 	Call(ctx context.Context, f *FunctionInstance, params ...uint64) (results []uint64, err error)
 	// Compile compiles down the function instance.
 	Compile(f *FunctionInstance) error

--- a/wasm/host.go
+++ b/wasm/host.go
@@ -1,0 +1,121 @@
+package wasm
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+
+	"github.com/tetratelabs/wazero/api"
+)
+
+// hostFunctionCallContext is the first argument of all host functions.
+type hostFunctionCallContext struct {
+	ctx context.Context
+	// Memory is the currently used memory instance at the time when the host function call is made.
+	memory *MemoryInstance
+	// TODO: Add others if necessary.
+}
+
+// NewHostFunctionCallContext creates a new api.HostFunctionCallContext with a context and memory instance.
+func NewHostFunctionCallContext(ctx context.Context, memory *MemoryInstance) api.HostFunctionCallContext {
+	return &hostFunctionCallContext{ctx: ctx, memory: memory}
+}
+
+// Context implements api.HostFunctionCallContext Context
+func (c *hostFunctionCallContext) Context() context.Context {
+	return c.ctx
+}
+
+// Memory implements api.HostFunctionCallContext Memory
+func (c *hostFunctionCallContext) Memory() api.Memory {
+	return c.memory
+}
+
+// Len implements api.HostFunctionCallContext Len
+func (m *MemoryInstance) Len() uint32 {
+	return uint32(len(m.Buffer))
+}
+
+// hasLen returns true if Len is sufficient for sizeInBytes at the given offset.
+func (m *MemoryInstance) hasLen(offset uint32, sizeInBytes uint32) bool {
+	return uint64(offset+sizeInBytes) <= uint64(m.Len()) // uint64 prevents overflow on add
+}
+
+// ReadUint32Le implements api.HostFunctionCallContext ReadUint32Le
+func (m *MemoryInstance) ReadUint32Le(offset uint32) (uint32, bool) {
+	if !m.hasLen(offset, 4) {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(m.Buffer[offset : offset+4]), true
+}
+
+// ReadFloat32Le implements api.HostFunctionCallContext ReadFloat32Le
+func (m *MemoryInstance) ReadFloat32Le(offset uint32) (float32, bool) {
+	v, ok := m.ReadUint32Le(offset)
+	if !ok {
+		return 0, false
+	}
+	return math.Float32frombits(v), true
+}
+
+// ReadUint64Le implements api.HostFunctionCallContext ReadUint64Le
+func (m *MemoryInstance) ReadUint64Le(offset uint32) (uint64, bool) {
+	if !m.hasLen(offset, 8) {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint64(m.Buffer[offset : offset+8]), true
+}
+
+// ReadFloat64Le implements api.HostFunctionCallContext ReadFloat64Le
+func (m *MemoryInstance) ReadFloat64Le(offset uint32) (float64, bool) {
+	v, ok := m.ReadUint64Le(offset)
+	if !ok {
+		return 0, false
+	}
+	return math.Float64frombits(v), true
+}
+
+// Read implements api.HostFunctionCallContext Read
+func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
+	if !m.hasLen(offset, byteCount) {
+		return nil, false
+	}
+	return m.Buffer[offset : offset+byteCount], true
+}
+
+// WriteUint32Le implements api.HostFunctionCallContext WriteUint32Le
+func (m *MemoryInstance) WriteUint32Le(offset, v uint32) bool {
+	if !m.hasLen(offset, 4) {
+		return false
+	}
+	binary.LittleEndian.PutUint32(m.Buffer[offset:], v)
+	return true
+}
+
+// WriteFloat32Le implements api.HostFunctionCallContext WriteFloat32Le
+func (m *MemoryInstance) WriteFloat32Le(offset uint32, v float32) bool {
+	return m.WriteUint32Le(offset, math.Float32bits(v))
+}
+
+// WriteUint64Le implements api.HostFunctionCallContext WriteUint64Le
+func (m *MemoryInstance) WriteUint64Le(offset uint32, v uint64) bool {
+	if !m.hasLen(offset, 8) {
+		return false
+	}
+	binary.LittleEndian.PutUint64(m.Buffer[offset:], v)
+	return true
+}
+
+// WriteFloat64Le implements api.HostFunctionCallContext WriteFloat64Le
+func (m *MemoryInstance) WriteFloat64Le(offset uint32, v float64) bool {
+	return m.WriteUint64Le(offset, math.Float64bits(v))
+}
+
+// Write implements api.HostFunctionCallContext Write
+func (m *MemoryInstance) Write(offset uint32, val []byte) bool {
+	if !m.hasLen(offset, uint32(len(val))) {
+		return false
+	}
+	copy(m.Buffer[offset:], val)
+	return true
+}

--- a/wasm/host.go
+++ b/wasm/host.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"math"
-
-	"github.com/tetratelabs/wazero/api"
 )
 
 // hostFunctionCallContext is the first argument of all host functions.
@@ -17,7 +15,7 @@ type hostFunctionCallContext struct {
 }
 
 // NewHostFunctionCallContext creates a new api.HostFunctionCallContext with a context and memory instance.
-func NewHostFunctionCallContext(ctx context.Context, memory *MemoryInstance) api.HostFunctionCallContext {
+func NewHostFunctionCallContext(ctx context.Context, memory *MemoryInstance) HostFunctionCallContext {
 	return &hostFunctionCallContext{ctx: ctx, memory: memory}
 }
 
@@ -27,7 +25,7 @@ func (c *hostFunctionCallContext) Context() context.Context {
 }
 
 // Memory implements api.HostFunctionCallContext Memory
-func (c *hostFunctionCallContext) Memory() api.Memory {
+func (c *hostFunctionCallContext) Memory() Memory {
 	return c.memory
 }
 

--- a/wasm/host_test.go
+++ b/wasm/host_test.go
@@ -1,0 +1,450 @@
+package wasm
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryInstance_HasLen(t *testing.T) {
+	memory := &MemoryInstance{Buffer: make([]byte, 100)}
+
+	tests := []struct {
+		name        string
+		offset      uint32
+		sizeInBytes uint64
+		expected    bool
+	}{
+		{
+			name:        "simple valid arguments",
+			offset:      0, // arbitrary valid offset
+			sizeInBytes: 8, // arbitrary valid size
+			expected:    true,
+		},
+		{
+			name:        "maximum valid sizeInBytes",
+			offset:      memory.Len() - 8,
+			sizeInBytes: 8,
+			expected:    true,
+		},
+		{
+			name:        "sizeInBytes exceeds the valid size by 1",
+			offset:      100, // arbitrary valid offset
+			sizeInBytes: uint64(memory.Len() - 99),
+			expected:    false,
+		},
+		{
+			name:        "offset exceeds the memory size",
+			offset:      memory.Len(),
+			sizeInBytes: 1, // arbitrary size
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, memory.hasLen(tc.offset, uint32(tc.sizeInBytes)))
+		})
+	}
+}
+
+func TestMemoryInstance_ReadUint32Le(t *testing.T) {
+	tests := []struct {
+		name       string
+		memory     []byte
+		offset     uint32
+		expected   uint32
+		expectedOk bool
+	}{
+		{
+			name:       "valid offset with an endian-insensitive v",
+			memory:     []byte{0xff, 0xff, 0xff, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.MaxUint32,
+			expectedOk: true,
+		},
+		{
+			name:       "valid offset with an endian-sensitive v",
+			memory:     []byte{0xfe, 0xff, 0xff, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.MaxUint32 - 1,
+			expectedOk: true,
+		},
+		{
+			name:       "maximum boundary valid offset",
+			offset:     1,
+			memory:     []byte{0x00, 0x1, 0x00, 0x00, 0x00},
+			expected:   1, // arbitrary valid v
+			expectedOk: true,
+		},
+		{
+			name:   "offset exceeds the maximum valid offset by 1",
+			memory: []byte{0xff, 0xff, 0xff, 0xff},
+			offset: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			memory := &MemoryInstance{Buffer: tc.memory}
+
+			v, ok := memory.ReadUint32Le(tc.offset)
+			require.Equal(t, tc.expectedOk, ok)
+			require.Equal(t, tc.expected, v)
+		})
+	}
+}
+
+func TestMemoryInstance_ReadUint64Le(t *testing.T) {
+	tests := []struct {
+		name       string
+		memory     []byte
+		offset     uint32
+		expected   uint64
+		expectedOk bool
+	}{
+		{
+			name:       "valid offset with an endian-insensitive v",
+			memory:     []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.MaxUint64,
+			expectedOk: true,
+		},
+		{
+			name:       "valid offset with an endian-sensitive v",
+			memory:     []byte{0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.MaxUint64 - 1,
+			expectedOk: true,
+		},
+		{
+			name:       "maximum boundary valid offset",
+			offset:     1,
+			memory:     []byte{0x00, 0x1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected:   1, // arbitrary valid v
+			expectedOk: true,
+		},
+		{
+			name:   "offset exceeds the maximum valid offset by 1",
+			memory: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			offset: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			memory := &MemoryInstance{Buffer: tc.memory}
+
+			v, ok := memory.ReadUint64Le(tc.offset)
+			require.Equal(t, tc.expectedOk, ok)
+			require.Equal(t, tc.expected, v)
+		})
+	}
+}
+
+func TestMemoryInstance_ReadFloat32Le(t *testing.T) {
+	tests := []struct {
+		name       string
+		memory     []byte
+		offset     uint32
+		expected   float32
+		expectedOk bool
+	}{
+		{
+			name:       "valid offset with an endian-insensitive v",
+			memory:     []byte{0xff, 0x00, 0x00, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.Float32frombits(uint32(0xff0000ff)),
+			expectedOk: true,
+		},
+		{
+			name:       "valid offset with an endian-sensitive v",
+			memory:     []byte{0xfe, 0x00, 0x00, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.Float32frombits(uint32(0xff0000fe)),
+			expectedOk: true,
+		},
+		{
+			name:       "maximum boundary valid offset",
+			offset:     1,
+			memory:     []byte{0x00, 0xcd, 0xcc, 0xcc, 0x3d},
+			expected:   0.1, // arbitrary valid v
+			expectedOk: true,
+		},
+		{
+			name:   "offset exceeds the maximum valid offset by 1",
+			memory: []byte{0xff, 0xff, 0xff, 0xff},
+			offset: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			memory := &MemoryInstance{Buffer: tc.memory}
+
+			v, ok := memory.ReadFloat32Le(tc.offset)
+			require.Equal(t, tc.expectedOk, ok)
+			require.Equal(t, tc.expected, v)
+		})
+	}
+}
+
+func TestMemoryInstance_ReadFloat64Le(t *testing.T) {
+	tests := []struct {
+		name       string
+		memory     []byte
+		offset     uint32
+		expected   float64
+		expectedOk bool
+	}{
+		{
+			name:       "valid offset with an endian-insensitive v",
+			memory:     []byte{0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff},
+			offset:     0, // arbitrary valid offset.
+			expected:   math.Float64frombits(uint64(0xff000000000000ff)),
+			expectedOk: true,
+		},
+		{
+			name:       "valid offset with an endian-sensitive v",
+			memory:     []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xef, 0x7f},
+			offset:     0,               // arbitrary valid offset.
+			expected:   math.MaxFloat64, // arbitrary valid v
+			expectedOk: true,
+		},
+		{
+			name:       "maximum boundary valid offset",
+			offset:     1,
+			memory:     []byte{0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xef, 0x7f},
+			expected:   math.MaxFloat64, // arbitrary valid v
+			expectedOk: true,
+		},
+		{
+			name:   "offset exceeds the maximum valid offset by 1",
+			memory: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			offset: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			memory := &MemoryInstance{Buffer: tc.memory}
+
+			v, ok := memory.ReadFloat64Le(tc.offset)
+			require.Equal(t, tc.expectedOk, ok)
+			require.Equal(t, tc.expected, v)
+		})
+	}
+}
+
+func TestMemoryInstance_WriteUint32Le(t *testing.T) {
+	memory := &MemoryInstance{Buffer: make([]byte, 100)}
+
+	tests := []struct {
+		name          string
+		offset        uint32
+		v             uint32
+		expectedOk    bool
+		expectedBytes []byte
+	}{
+		{
+			name:          "valid offset with an endian-insensitive v",
+			offset:        0, // arbitrary valid offset.
+			v:             math.MaxUint32,
+			expectedOk:    true,
+			expectedBytes: []byte{0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:          "valid offset with an endian-sensitive v",
+			offset:        0, // arbitrary valid offset.
+			v:             math.MaxUint32 - 1,
+			expectedOk:    true,
+			expectedBytes: []byte{0xfe, 0xff, 0xff, 0xff},
+		},
+		{
+			name:          "maximum boundary valid offset",
+			offset:        memory.Len() - 4, // 4 is the size of uint32
+			v:             1,                // arbitrary valid v
+			expectedOk:    true,
+			expectedBytes: []byte{0x1, 0x00, 0x00, 0x00},
+		},
+		{
+			name:          "offset exceeds the maximum valid offset by 1",
+			offset:        memory.Len() - 4 + 1, // 4 is the size of uint32
+			v:             1,                    // arbitrary valid v
+			expectedBytes: []byte{0xff, 0xff, 0xff, 0xff},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedOk, memory.WriteUint32Le(tc.offset, tc.v))
+			if tc.expectedOk {
+				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+4]) // 4 is the size of uint32
+			}
+		})
+	}
+}
+
+func TestMemoryInstance_WriteUint64Le(t *testing.T) {
+	memory := &MemoryInstance{Buffer: make([]byte, 100)}
+	tests := []struct {
+		name          string
+		offset        uint32
+		v             uint64
+		expectedOk    bool
+		expectedBytes []byte
+	}{
+		{
+			name:          "valid offset with an endian-insensitive v",
+			offset:        0, // arbitrary valid offset.
+			v:             math.MaxUint64,
+			expectedOk:    true,
+			expectedBytes: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:          "valid offset with an endian-sensitive v",
+			offset:        0, // arbitrary valid offset.
+			v:             math.MaxUint64 - 1,
+			expectedOk:    true,
+			expectedBytes: []byte{0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:          "maximum boundary valid offset",
+			offset:        memory.Len() - 8, // 8 is the size of uint64
+			v:             1,                // arbitrary valid v
+			expectedOk:    true,
+			expectedBytes: []byte{0x1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:       "offset exceeds the maximum valid offset by 1",
+			offset:     memory.Len() - 8 + 1, // 8 is the size of uint64
+			v:          1,                    // arbitrary valid v
+			expectedOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedOk, memory.WriteUint64Le(tc.offset, tc.v))
+			if tc.expectedOk {
+				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+8]) // 8 is the size of uint64
+			}
+		})
+	}
+}
+
+func TestMemoryInstance_WriteFloat32Le(t *testing.T) {
+	memory := &MemoryInstance{Buffer: make([]byte, 100)}
+
+	tests := []struct {
+		name          string
+		offset        uint32
+		v             float32
+		expectedOk    bool
+		expectedBytes []byte
+	}{
+		{
+			name:          "valid offset with an endian-insensitive v",
+			offset:        0, // arbitrary valid offset.
+			v:             math.Float32frombits(uint32(0xff0000ff)),
+			expectedOk:    true,
+			expectedBytes: []byte{0xff, 0x00, 0x00, 0xff},
+		},
+		{
+			name:          "valid offset with an endian-sensitive v",
+			offset:        0,                                        // arbitrary valid offset.
+			v:             math.Float32frombits(uint32(0xff0000fe)), // arbitrary valid v
+			expectedOk:    true,
+			expectedBytes: []byte{0xfe, 0x00, 0x00, 0xff},
+		},
+		{
+			name:          "maximum boundary valid offset",
+			offset:        memory.Len() - 4, // 4 is the size of float32
+			v:             0.1,              // arbitrary valid v
+			expectedOk:    true,
+			expectedBytes: []byte{0xcd, 0xcc, 0xcc, 0x3d},
+		},
+		{
+			name:          "offset exceeds the maximum valid offset by 1",
+			offset:        memory.Len() - 4 + 1, // 4 is the size of float32
+			v:             math.MaxFloat32,      // arbitrary valid v
+			expectedBytes: []byte{0xff, 0xff, 0xff, 0xff},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedOk, memory.WriteFloat32Le(tc.offset, tc.v))
+			if tc.expectedOk {
+				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+4]) // 4 is the size of float32
+			}
+		})
+	}
+}
+
+func TestMemoryInstance_WriteFloat64Le(t *testing.T) {
+	memory := &MemoryInstance{Buffer: make([]byte, 100)}
+	tests := []struct {
+		name          string
+		offset        uint32
+		v             float64
+		expectedOk    bool
+		expectedBytes []byte
+	}{
+		{
+			name:          "valid offset with an endian-insensitive v",
+			offset:        0, // arbitrary valid offset.
+			v:             math.Float64frombits(uint64(0xff000000000000ff)),
+			expectedOk:    true,
+			expectedBytes: []byte{0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff},
+		},
+		{
+			name:          "valid offset with an endian-sensitive v",
+			offset:        0,               // arbitrary valid offset.
+			v:             math.MaxFloat64, // arbitrary valid v
+			expectedOk:    true,
+			expectedBytes: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xef, 0x7f},
+		},
+		{
+			name:          "maximum boundary valid offset",
+			offset:        memory.Len() - 8, // 8 is the size of float64
+			v:             math.MaxFloat64,  // arbitrary valid v
+			expectedOk:    true,
+			expectedBytes: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xef, 0x7f},
+		},
+		{
+			name:       "offset exceeds the maximum valid offset by 1",
+			offset:     memory.Len() - 8 + 1, // 8 is the size of float64
+			v:          math.MaxFloat64,      // arbitrary valid v
+			expectedOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedOk, memory.WriteFloat64Le(tc.offset, tc.v))
+			if tc.expectedOk {
+				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+8]) // 8 is the size of float64
+			}
+		})
+	}
+}

--- a/wasm/interpreter/interpreter_test.go
+++ b/wasm/interpreter/interpreter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/buildoptions"
 )
@@ -45,9 +46,9 @@ func TestInterpreter_PushFrame_StackOverflow(t *testing.T) {
 func TestInterpreter_CallHostFunc(t *testing.T) {
 	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
 		memory := &wasm.MemoryInstance{}
-		var ctxMemory *wasm.MemoryInstance
-		hostFn := reflect.ValueOf(func(ctx *wasm.HostFunctionCallContext) {
-			ctxMemory = ctx.Memory
+		var ctxMemory api.Memory
+		hostFn := reflect.ValueOf(func(ctx api.HostFunctionCallContext) {
+			ctxMemory = ctx.Memory()
 		})
 		it := interpreter{functions: map[wasm.FunctionAddress]*interpreterFunction{
 			0: {hostFn: &hostFn, funcInstance: &wasm.FunctionInstance{

--- a/wasm/interpreter/interpreter_test.go
+++ b/wasm/interpreter/interpreter_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/buildoptions"
 )
@@ -46,8 +45,8 @@ func TestInterpreter_PushFrame_StackOverflow(t *testing.T) {
 func TestInterpreter_CallHostFunc(t *testing.T) {
 	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
 		memory := &wasm.MemoryInstance{}
-		var ctxMemory api.Memory
-		hostFn := reflect.ValueOf(func(ctx api.HostFunctionCallContext) {
+		var ctxMemory wasm.Memory
+		hostFn := reflect.ValueOf(func(ctx wasm.HostFunctionCallContext) {
 			ctxMemory = ctx.Memory()
 		})
 		it := interpreter{functions: map[wasm.FunctionAddress]*interpreterFunction{

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/buildoptions"
 	"github.com/tetratelabs/wazero/wasm/internal/wazeroir"
@@ -461,7 +460,7 @@ const (
 // After the execution, the result of host function is pushed onto the stack.
 //
 // ctx parameter is passed to the host function as a first argument.
-func (e *engine) execHostFunction(f *reflect.Value, ctx api.HostFunctionCallContext) {
+func (e *engine) execHostFunction(f *reflect.Value, ctx wasm.HostFunctionCallContext) {
 	tp := f.Type()
 	in := make([]reflect.Value, tp.NumIn())
 

--- a/wasm/jit/engine.go
+++ b/wasm/jit/engine.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm"
 	"github.com/tetratelabs/wazero/wasm/buildoptions"
 	"github.com/tetratelabs/wazero/wasm/internal/wazeroir"
@@ -460,7 +461,7 @@ const (
 // After the execution, the result of host function is pushed onto the stack.
 //
 // ctx parameter is passed to the host function as a first argument.
-func (e *engine) execHostFunction(f *reflect.Value, ctx *wasm.HostFunctionCallContext) {
+func (e *engine) execHostFunction(f *reflect.Value, ctx api.HostFunctionCallContext) {
 	tp := f.Type()
 	in := make([]reflect.Value, tp.NumIn())
 
@@ -483,7 +484,7 @@ func (e *engine) execHostFunction(f *reflect.Value, ctx *wasm.HostFunctionCallCo
 		in[i] = val
 	}
 
-	// Host function must receive *wasm.HostFunctionCallContext as a first argument.
+	// Host function must receive api.hostFunctionCallContext as a first argument.
 	val := reflect.New(tp.In(0)).Elem()
 	val.Set(reflect.ValueOf(ctx))
 	in[0] = val

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm/internal/leb128"
 )
 
@@ -81,7 +82,7 @@ func TestStore_CallFunction(t *testing.T) {
 
 func TestStore_AddHostFunction(t *testing.T) {
 	s := NewStore(nopEngineInstance)
-	hostFunction := func(_ *HostFunctionCallContext) {
+	hostFunction := func(_ api.HostFunctionCallContext) {
 	}
 
 	err := s.AddHostFunction("test", "fn", reflect.ValueOf(hostFunction))
@@ -98,8 +99,8 @@ func TestStore_AddHostFunction(t *testing.T) {
 	exp, ok := m.Exports["fn"]
 	require.True(t, ok)
 
-	// Trying to add it again should fail
-	hostFunction2 := func(_ *HostFunctionCallContext) {
+	// Trying to offset it again should fail
+	hostFunction2 := func(_ api.HostFunctionCallContext) {
 	}
 	err = s.AddHostFunction("test", "fn", reflect.ValueOf(hostFunction2))
 	require.EqualError(t, err, `"fn" is already exported in module "test"`)
@@ -111,7 +112,7 @@ func TestStore_AddHostFunction(t *testing.T) {
 
 func TestStore_ExportImportedHostFunction(t *testing.T) {
 	s := NewStore(nopEngineInstance)
-	hostFunction := func(_ *HostFunctionCallContext) {
+	hostFunction := func(_ api.HostFunctionCallContext) {
 	}
 
 	err := s.AddHostFunction("", "host_fn", reflect.ValueOf(hostFunction))
@@ -184,7 +185,7 @@ func (e *nopEngine) Compile(_ *FunctionInstance) error {
 	return nil
 }
 
-func TestStore_addFunctionInstance(t *testing.T) {
+func TestStore_addHostFunction(t *testing.T) {
 	t.Run("too many functions", func(t *testing.T) {
 		s := NewStore(nopEngineInstance)
 		const max = 10
@@ -205,7 +206,7 @@ func TestStore_addFunctionInstance(t *testing.T) {
 			// After the addition, one instance is added.
 			require.Len(t, s.Functions, i+1)
 
-			// The added function instance must have i for its funcaddr.
+			// The added function instance must have i for its address.
 			require.Equal(t, FunctionAddress(i), f.Address)
 		}
 	})
@@ -243,164 +244,6 @@ func TestStore_getTypeInstance(t *testing.T) {
 			})
 		}
 	})
-}
-
-func TestMemoryInstance_ValidateAddrRange(t *testing.T) {
-	memory := &MemoryInstance{
-		Buffer: make([]byte, 100),
-	}
-
-	tests := []struct {
-		name      string
-		addr      uint32
-		rangeSize uint64
-		expected  bool
-	}{
-		{
-			name:      "simple valid arguments",
-			addr:      0,   // arbitrary valid address
-			rangeSize: 100, // arbitrary valid size
-			expected:  true,
-		},
-		{
-			name:      "maximum valid rangeSize",
-			addr:      0, // arbitrary valid address
-			rangeSize: uint64(len(memory.Buffer)),
-			expected:  true,
-		},
-		{
-			name:      "rangeSize exceeds the valid size by 1",
-			addr:      100, // arbitrary valid address
-			rangeSize: uint64(len(memory.Buffer)) - 99,
-			expected:  false,
-		},
-		{
-			name:      "rangeSize exceeds the valid size and the memory size by 1",
-			addr:      0, // arbitrary valid address
-			rangeSize: uint64(len(memory.Buffer)) + 1,
-			expected:  false,
-		},
-		{
-			name:      "addr exceeds the memory size",
-			addr:      uint32(len(memory.Buffer)),
-			rangeSize: 0, // arbitrary size
-			expected:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, memory.ValidateAddrRange(tc.addr, tc.rangeSize))
-		})
-	}
-}
-
-func TestMemoryInstance_PutUint32(t *testing.T) {
-	memory := &MemoryInstance{
-		Buffer: make([]byte, 100),
-	}
-
-	tests := []struct {
-		name               string
-		addr               uint32
-		val                uint32
-		shouldSuceed       bool
-		expectedWrittenVal uint32
-	}{
-		{
-			name:               "valid addr with an endian-insensitive val",
-			addr:               0, // arbitrary valid address.
-			val:                math.MaxUint32,
-			shouldSuceed:       true,
-			expectedWrittenVal: math.MaxUint32,
-		},
-		{
-			name:               "valid addr with an endian-sensitive val",
-			addr:               0, // arbitrary valid address.
-			val:                math.MaxUint32 - 1,
-			shouldSuceed:       true,
-			expectedWrittenVal: math.MaxUint32 - 1,
-		},
-		{
-			name:               "maximum boundary valid addr",
-			addr:               uint32(len(memory.Buffer)) - 4, // 4 is the size of uint32
-			val:                1,                              // arbitrary valid val
-			shouldSuceed:       true,
-			expectedWrittenVal: 1,
-		},
-		{
-			name:         "addr exceeds the maximum valid addr by 1",
-			addr:         uint32(len(memory.Buffer)) - 4 + 1, // 4 is the size of uint32
-			val:          1,                                  // arbitrary valid val
-			shouldSuceed: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.shouldSuceed, memory.PutUint32(tc.addr, tc.val))
-			if tc.shouldSuceed {
-				require.Equal(t, tc.expectedWrittenVal, binary.LittleEndian.Uint32(memory.Buffer[tc.addr:tc.addr+4])) // 4 is the size of uint32
-			}
-		})
-	}
-}
-
-func TestMemoryInstance_PutUint64(t *testing.T) {
-	memory := &MemoryInstance{
-		Buffer: make([]byte, 100),
-	}
-
-	tests := []struct {
-		name               string
-		addr               uint32
-		val                uint64
-		shouldSuceed       bool
-		expectedWrittenVal uint64
-	}{
-		{
-			name:               "valid addr with an endian-insensitive val",
-			addr:               0, // arbitrary valid address.
-			val:                math.MaxUint64,
-			shouldSuceed:       true,
-			expectedWrittenVal: math.MaxUint64,
-		},
-		{
-			name:               "valid addr with an endian-sensitive val",
-			addr:               0, // arbitrary valid address.
-			val:                math.MaxUint64 - 1,
-			shouldSuceed:       true,
-			expectedWrittenVal: math.MaxUint64 - 1,
-		},
-		{
-			name:               "maximum boundary valid addr",
-			addr:               uint32(len(memory.Buffer)) - 8, // 8 is the size of uint64
-			val:                1,                              // arbitrary valid val
-			shouldSuceed:       true,
-			expectedWrittenVal: 1,
-		},
-		{
-			name:         "addr exceeds the maximum valid addr by 1",
-			addr:         uint32(len(memory.Buffer)) - 8 + 1, // 8 is the size of uint64
-			val:          1,                                  // arbitrary valid val
-			shouldSuceed: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.shouldSuceed, memory.PutUint64(tc.addr, tc.val))
-			if tc.shouldSuceed {
-				require.Equal(t, tc.expectedWrittenVal, binary.LittleEndian.Uint64(memory.Buffer[tc.addr:tc.addr+8])) // 8 is the size of uint64
-			}
-		})
-	}
 }
 
 func TestStore_buildGlobalInstances(t *testing.T) {

--- a/wasm/store_test.go
+++ b/wasm/store_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/wasm/internal/leb128"
 )
 
@@ -82,7 +81,7 @@ func TestStore_CallFunction(t *testing.T) {
 
 func TestStore_AddHostFunction(t *testing.T) {
 	s := NewStore(nopEngineInstance)
-	hostFunction := func(_ api.HostFunctionCallContext) {
+	hostFunction := func(_ HostFunctionCallContext) {
 	}
 
 	err := s.AddHostFunction("test", "fn", reflect.ValueOf(hostFunction))
@@ -100,7 +99,7 @@ func TestStore_AddHostFunction(t *testing.T) {
 	require.True(t, ok)
 
 	// Trying to offset it again should fail
-	hostFunction2 := func(_ api.HostFunctionCallContext) {
+	hostFunction2 := func(_ HostFunctionCallContext) {
 	}
 	err = s.AddHostFunction("test", "fn", reflect.ValueOf(hostFunction2))
 	require.EqualError(t, err, `"fn" is already exported in module "test"`)
@@ -112,7 +111,7 @@ func TestStore_AddHostFunction(t *testing.T) {
 
 func TestStore_ExportImportedHostFunction(t *testing.T) {
 	s := NewStore(nopEngineInstance)
-	hostFunction := func(_ api.HostFunctionCallContext) {
+	hostFunction := func(_ HostFunctionCallContext) {
 	}
 
 	err := s.AddHostFunction("", "host_fn", reflect.ValueOf(hostFunction))


### PR DESCRIPTION
This adds two interfaces with only one implementation each, used to
decouple end-user code from internals.

* wasm.HostFunctionCallContext - allows access to go Context and Memory
* wasm.Memory - read/write standard types and arbitrary data

This currently ports existing code to use the interfaces. It is true
that over time we can use structs instead of interfaces internally to
save a pointer reference in WASI call sites. However, I'm choosing not
to do this right now, as it is more important to see the interfaces
work. We should defer optimizing towards structs until after we
repackage implementations under the "internal" directory.

Fixes #204