### PR TITLE
Removes requirement to pass a HostFunctionCallContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,8 @@ func main() {
 	// Decode the binary as WebAssembly module.
 	mod, _ := wazero.DecodeModuleBinary(source)
 
-	// Initialize the execution environment called "store" with Interpreter-based engine.
-	store := wazero.NewStore()
-
-	// Instantiate the module, which returns its exported functions
-	functions, _ := store.Instantiate(mod)
+	// Instantiate the module with a Wasm Interpreter, to return its exported functions
+	functions, _ := wazero.NewStore().Instantiate(mod)
 
 	// Get the factorial function
 	fac, _ := functions.GetFunctionI64Return("fac")

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -2,13 +2,14 @@ package examples
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"github.com/tetratelabs/wazero/wasm"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/wasm"
 )
 
 // Test_Simple implements a basic function in go: hello. This is imported as the Wasm name "$hello" and run on start.
@@ -20,9 +21,12 @@ func Test_Simple(t *testing.T) {
 	require.NoError(t, err)
 
 	stdout := new(bytes.Buffer)
-	goFunc := func(wasm.HostFunctionCallContext) {
-		_, _ = fmt.Fprintln(stdout, "hello!")
-	}
+		addInts := func(ctx wasm.HostFunctionCallContext, offset uint32) uint32 {
+			x, _ := ctx.Memory().ReadUint32Le(offset)
+			, _ := ctx.Memory().ReadUint32Le(offset + 4) // 32 bits == 4 bytes!
+			// add a little extra if we put some in the context!
+			return x + y + ctx.Value(extraKey).(uint32)
+		}
 
 	// Assign the Go function as a host function. This could error if the signature was invalid for Wasm.
 	hostFuncs, err := wazero.NewHostFunctions(map[string]interface{}{"hello": goFunc})

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -2,9 +2,7 @@ package examples
 
 import (
 	"bytes"
-	"context"
 	"fmt"
-	"github.com/tetratelabs/wazero/wasm"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,12 +19,9 @@ func Test_Simple(t *testing.T) {
 	require.NoError(t, err)
 
 	stdout := new(bytes.Buffer)
-		addInts := func(ctx wasm.HostFunctionCallContext, offset uint32) uint32 {
-			x, _ := ctx.Memory().ReadUint32Le(offset)
-			, _ := ctx.Memory().ReadUint32Le(offset + 4) // 32 bits == 4 bytes!
-			// add a little extra if we put some in the context!
-			return x + y + ctx.Value(extraKey).(uint32)
-		}
+	goFunc := func() {
+		_, _ = fmt.Fprintln(stdout, "hello!")
+	}
 
 	// Assign the Go function as a host function. This could error if the signature was invalid for Wasm.
 	hostFuncs, err := wazero.NewHostFunctions(map[string]interface{}{"hello": goFunc})

--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -113,7 +113,7 @@ const (
 	FunctionPathUnlinkFile       = "path_unlink_file"
 	FunctionPollOneoff           = "poll_oneoff"
 
-	// ProcExit terminates the execution of the module with an exit code.
+	// FunctionProcExit terminates the execution of the module with an exit code.
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 	FunctionProcExit = "proc_exit"
 
@@ -339,7 +339,7 @@ type SnapshotPreview1 interface {
 	//
 	// Note: ImportProcExit shows this signature in the WebAssembly 1.0 (MVP) Text Format.
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
-	ProcExit(ctx wasm.HostFunctionCallContext, rval uint32)
+	ProcExit(rval uint32)
 
 	// TODO: ProcRaise
 	// TODO: SchedYield
@@ -505,8 +505,8 @@ func (a *wasiAPI) ClockTimeGet(ctx wasm.HostFunctionCallContext, id uint32, prec
 	return wasi.ErrnoSuccess
 }
 
-// ProcExit implements API.ProcExit
-func (a *wasiAPI) ProcExit(ctx wasm.HostFunctionCallContext, exitCode uint32) {
+// ProcExit implements SnapshotPreview1.ProcExit
+func (a *wasiAPI) ProcExit(exitCode uint32) {
 	// Panic in a host function is caught by the engines, and the value of the panic is returned as the error of the CallFunction.
 	// See the document of API.ProcExit.
 	panic(wasi.ExitCode(exitCode))

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -16,8 +16,8 @@ type FunctionKind byte
 const (
 	// FunctionKindWasm is not a host function: it is implemented in Wasm.
 	FunctionKindWasm FunctionKind = iota
-	// FunctionKindHost is a function implemented in Go, with a signature matching FunctionType.
-	FunctionKindHost
+	// FunctionKindHostNoContext is a function implemented in Go, with a signature matching FunctionType.
+	FunctionKindHostNoContext
 	// FunctionKindHostGoContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
 	// a context.Context.
 	FunctionKindHostGoContext
@@ -51,7 +51,7 @@ var errorType = reflect.TypeOf((*error)(nil)).Elem()
 // GetHostFunctionCallContextValue returns a reflect.Value for a context param[0], or nil if there isn't one.
 func GetHostFunctionCallContextValue(fk FunctionKind, ctx *HostFunctionCallContext) *reflect.Value {
 	switch fk {
-	case FunctionKindHost: // no special param zero
+	case FunctionKindHostNoContext: // no special param zero
 	case FunctionKindHostGoContext:
 		val := reflect.New(goContextType).Elem()
 		val.Set(reflect.ValueOf(ctx.Context()))
@@ -74,7 +74,7 @@ func GetFunctionType(name string, fn *reflect.Value) (fk FunctionKind, ft *Funct
 
 	pOffset := 0
 	pCount := p.NumIn()
-	fk = FunctionKindHost
+	fk = FunctionKindHostNoContext
 	if pCount > 0 && p.In(0).Kind() == reflect.Interface {
 		p0 := p.In(0)
 		if p0.Implements(hostFunctionCallContextType) {

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -10,42 +10,131 @@ import (
 	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
+// FunctionKind identifies the type of function that can be called.
+type FunctionKind byte
+
+const (
+	// FunctionKindWasm is not a host function: it is implemented in Wasm.
+	FunctionKindWasm FunctionKind = iota
+	// FunctionKindHost is a function implemented in Go, with a signature matching FunctionType.
+	FunctionKindHost
+	// FunctionKindHostGoContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
+	// a context.Context.
+	FunctionKindHostGoContext
+	// FunctionKindHostFunctionCallContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
+	// a HostFunctionCallContext.
+	FunctionKindHostFunctionCallContext
+)
+
 type HostFunction struct {
-	name         string
+	name string
+	// functionKind is never FunctionKindWasm
+	functionKind FunctionKind
 	functionType *FunctionType
 	goFunc       *reflect.Value
 }
 
+func NewHostFunction(funcName string, goFunc interface{}) (hf *HostFunction, err error) {
+	hf = &HostFunction{name: funcName}
+	fn := reflect.ValueOf(goFunc)
+	hf.goFunc = &fn
+	hf.functionKind, hf.functionType, err = GetFunctionType(hf.name, hf.goFunc)
+	return
+}
+
+// Below are reflection code to get the interface type used to parse functions and set values.
+
+var hostFunctionCallContextType = reflect.TypeOf((*publicwasm.HostFunctionCallContext)(nil)).Elem()
+var goContextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// GetHostFunctionCallContextValue returns a reflect.Value for a context param[0], or nil if there isn't one.
+func GetHostFunctionCallContextValue(fk FunctionKind, ctx *HostFunctionCallContext) *reflect.Value {
+	switch fk {
+	case FunctionKindHost: // no special param zero
+	case FunctionKindHostGoContext:
+		val := reflect.New(goContextType).Elem()
+		val.Set(reflect.ValueOf(ctx.Context()))
+		return &val
+	case FunctionKindHostFunctionCallContext:
+		val := reflect.New(hostFunctionCallContextType).Elem()
+		val.Set(reflect.ValueOf(ctx))
+		return &val
+	}
+	return nil
+}
+
 // GetFunctionType returns the function type corresponding to the function signature or errs if invalid.
-func GetFunctionType(name string, fn *reflect.Value) (*FunctionType, error) {
+func GetFunctionType(name string, fn *reflect.Value) (fk FunctionKind, ft *FunctionType, err error) {
 	if fn.Kind() != reflect.Func {
-		return nil, fmt.Errorf("%s value is not a reflect.Func: %s", name, fn.String())
+		err = fmt.Errorf("%s is a %s, but should be a Func", name, fn.Kind().String())
+		return
 	}
 	p := fn.Type()
-	if p.NumIn() == 0 { // TODO: actually check the type
-		return nil, fmt.Errorf("%s must accept wasm.HostFunctionCallContext as the first param", name)
-	}
 
-	paramTypes := make([]ValueType, p.NumIn()-1)
-	for i := range paramTypes {
-		kind := p.In(i + 1).Kind()
-		if t, ok := getTypeOf(kind); !ok {
-			return nil, fmt.Errorf("%s param[%d] is unsupported: %s", name, i, kind.String())
-		} else {
-			paramTypes[i] = t
+	pOffset := 0
+	pCount := p.NumIn()
+	fk = FunctionKindHost
+	if pCount > 0 && p.In(0).Kind() == reflect.Interface {
+		p0 := p.In(0)
+		if hc := p0.Implements(hostFunctionCallContextType); hc {
+			fk = FunctionKindHostFunctionCallContext
+			pOffset = 1
+			pCount--
+		} else if gc := p0.Implements(goContextType); gc {
+			fk = FunctionKindHostGoContext
+			pOffset = 1
+			pCount--
 		}
 	}
-
-	resultTypes := make([]ValueType, p.NumOut())
-	for i := range resultTypes {
-		kind := p.Out(i).Kind()
-		if t, ok := getTypeOf(kind); !ok {
-			return nil, fmt.Errorf("%s result[%d] is unsupported: %s", name, i, kind.String())
-		} else {
-			resultTypes[i] = t
-		}
+	rCount := p.NumOut()
+	switch rCount {
+	case 0, 1: // ok
+	default:
+		err = fmt.Errorf("%s has more than one result", name)
+		return
 	}
-	return &FunctionType{Params: paramTypes, Results: resultTypes}, nil
+
+	ft = &FunctionType{Params: make([]ValueType, pCount), Results: make([]ValueType, rCount)}
+
+	for i := 0; i < len(ft.Params); i++ {
+		pI := p.In(i + pOffset)
+		if t, ok := getTypeOf(pI.Kind()); ok {
+			ft.Params[i] = t
+			continue
+		}
+
+		// Now, we will definitely err, decide which message is best
+		var arg0Type reflect.Type
+		if hc := pI.Implements(hostFunctionCallContextType); hc {
+			arg0Type = hostFunctionCallContextType
+		} else if gc := pI.Implements(goContextType); gc {
+			arg0Type = goContextType
+		}
+
+		if arg0Type != nil {
+			err = fmt.Errorf("%s param[%d] is a %s, which may be defined only once as param[0]", name, i+pOffset, arg0Type)
+		} else {
+			err = fmt.Errorf("%s param[%d] is unsupported: %s", name, i+pOffset, pI.Kind())
+		}
+		return
+	}
+
+	if rCount == 0 {
+		return
+	}
+	result := p.Out(0)
+	if t, ok := getTypeOf(result.Kind()); ok {
+		ft.Results[0] = t
+		return
+	}
+
+	if e := result.Implements(errorType); e {
+		err = fmt.Errorf("%s result[0] is an error, which is unsupported", name)
+	} else {
+		err = fmt.Errorf("%s result[0] is unsupported: %s", name, result.Kind())
+	}
+	return
 }
 
 func getTypeOf(kind reflect.Kind) (ValueType, bool) {

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -77,11 +77,11 @@ func GetFunctionType(name string, fn *reflect.Value) (fk FunctionKind, ft *Funct
 	fk = FunctionKindHost
 	if pCount > 0 && p.In(0).Kind() == reflect.Interface {
 		p0 := p.In(0)
-		if hc := p0.Implements(hostFunctionCallContextType); hc {
+		if p0.Implements(hostFunctionCallContextType) {
 			fk = FunctionKindHostFunctionCallContext
 			pOffset = 1
 			pCount--
-		} else if gc := p0.Implements(goContextType); gc {
+		} else if p0.Implements(goContextType) {
 			fk = FunctionKindHostGoContext
 			pOffset = 1
 			pCount--

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -1,10 +1,14 @@
 package internalwasm
 
 import (
+	"context"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
 func TestMemoryInstance_HasLen(t *testing.T) {
@@ -445,6 +449,125 @@ func TestMemoryInstance_WriteFloat64Le(t *testing.T) {
 			if tc.expectedOk {
 				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+8]) // 8 is the size of float64
 			}
+		})
+	}
+}
+
+func TestGetFunctionType(t *testing.T) {
+	i32, i64, f32, f64 := ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64
+
+	tests := []struct {
+		name         string
+		inputFunc    interface{}
+		expectedKind FunctionKind
+		expectedType *FunctionType
+	}{
+		{
+			name:         "nullary",
+			inputFunc:    func() {},
+			expectedKind: FunctionKindHost,
+			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:         "wasm.HostFunctionCallContext void return",
+			inputFunc:    func(publicwasm.HostFunctionCallContext) {},
+			expectedKind: FunctionKindHostFunctionCallContext,
+			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:         "context.Context void return",
+			inputFunc:    func(context.Context) {},
+			expectedKind: FunctionKindHostGoContext,
+			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:         "all supported params and i32 result",
+			inputFunc:    func(uint32, uint64, float32, float64) uint32 { return 0 },
+			expectedKind: FunctionKindHost,
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+		},
+		{
+			name:         "all supported params and i32 result - wasm.HostFunctionCallContext",
+			inputFunc:    func(publicwasm.HostFunctionCallContext, uint32, uint64, float32, float64) uint32 { return 0 },
+			expectedKind: FunctionKindHostFunctionCallContext,
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+		},
+		{
+			name:         "all supported params and i32 result - context.Context",
+			inputFunc:    func(context.Context, uint32, uint64, float32, float64) uint32 { return 0 },
+			expectedKind: FunctionKindHostGoContext,
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			rVal := reflect.ValueOf(tc.inputFunc)
+			fk, ft, err := GetFunctionType("fn", &rVal)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedKind, fk)
+			require.Equal(t, tc.expectedType, ft)
+		})
+	}
+}
+
+func TestGetFunctionTypeErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       interface{}
+		expectedErr string
+	}{
+		{
+			name:        "not a func",
+			input:       struct{}{},
+			expectedErr: "fn is a struct, but should be a Func",
+		},
+		{
+			name:        "unsupported param",
+			input:       func(uint32, string) {},
+			expectedErr: "fn param[1] is unsupported: string",
+		},
+		{
+			name:        "unsupported result",
+			input:       func() string { return "" },
+			expectedErr: "fn result[0] is unsupported: string",
+		},
+		{
+			name:        "error result",
+			input:       func() error { return nil },
+			expectedErr: "fn result[0] is an error, which is unsupported",
+		},
+		{
+			name:        "multiple results",
+			input:       func() (uint64, uint32) { return 0, 0 },
+			expectedErr: "fn has more than one result",
+		},
+		{
+			name:        "multiple context types",
+			input:       func(publicwasm.HostFunctionCallContext, context.Context) error { return nil },
+			expectedErr: "fn param[1] is a context.Context, which may be defined only once as param[0]",
+		},
+		{
+			name:        "multiple context.Context",
+			input:       func(context.Context, uint64, context.Context) error { return nil },
+			expectedErr: "fn param[2] is a context.Context, which may be defined only once as param[0]",
+		},
+		{
+			name:        "multiple wasm.HostFunctionCallContext",
+			input:       func(publicwasm.HostFunctionCallContext, uint64, publicwasm.HostFunctionCallContext) error { return nil },
+			expectedErr: "fn param[2] is a wasm.HostFunctionCallContext, which may be defined only once as param[0]",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			rVal := reflect.ValueOf(tc.input)
+			_, _, err := GetFunctionType("fn", &rVal)
+			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -465,7 +465,7 @@ func TestGetFunctionType(t *testing.T) {
 		{
 			name:         "nullary",
 			inputFunc:    func() {},
-			expectedKind: FunctionKindHost,
+			expectedKind: FunctionKindHostNoContext,
 			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
 		},
 		{
@@ -483,7 +483,7 @@ func TestGetFunctionType(t *testing.T) {
 		{
 			name:         "all supported params and i32 result",
 			inputFunc:    func(uint32, uint64, float32, float64) uint32 { return 0 },
-			expectedKind: FunctionKindHost,
+			expectedKind: FunctionKindHostNoContext,
 			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
 		},
 		{

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -497,7 +497,7 @@ func (it *interpreter) callHostFunc(ctx *wasm.HostFunctionCallContext, f *interp
 	in := make([]reflect.Value, tp.NumIn())
 
 	wasmParamOffset := 0
-	if f.funcInstance.FunctionKind != wasm.FunctionKindHost {
+	if f.funcInstance.FunctionKind != wasm.FunctionKindHostNoContext {
 		wasmParamOffset = 1
 	}
 	for i := len(in) - 1; i >= wasmParamOffset; i-- {

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -117,13 +117,7 @@ type interpreterOp struct {
 func (it *interpreter) Compile(f *wasm.FunctionInstance) error {
 	funcaddr := f.Address
 
-	if f.IsHostFunction() {
-		ret := &interpreterFunction{
-			hostFn: f.HostFunction, funcInstance: f,
-		}
-		it.functions[funcaddr] = ret
-		return nil
-	} else {
+	if f.FunctionKind == wasm.FunctionKindWasm {
 		ir, err := wazeroir.Compile(f)
 		if err != nil {
 			return fmt.Errorf("failed to compile Wasm to wazeroir: %w", err)
@@ -138,6 +132,12 @@ func (it *interpreter) Compile(f *wasm.FunctionInstance) error {
 			cb(fn)
 		}
 		delete(it.onCompilationDoneCallbacks, funcaddr)
+	} else {
+		ret := &interpreterFunction{
+			hostFn: f.HostFunction, funcInstance: f,
+		}
+		it.functions[funcaddr] = ret
+		return nil
 	}
 	return nil
 }
@@ -495,7 +495,12 @@ func (it *interpreter) Call(ctx *wasm.HostFunctionCallContext, f *wasm.FunctionI
 func (it *interpreter) callHostFunc(ctx *wasm.HostFunctionCallContext, f *interpreterFunction) {
 	tp := f.hostFn.Type()
 	in := make([]reflect.Value, tp.NumIn())
-	for i := len(in) - 1; i >= 1; i-- {
+
+	wasmParamOffset := 0
+	if f.funcInstance.FunctionKind != wasm.FunctionKindHost {
+		wasmParamOffset = 1
+	}
+	for i := len(in) - 1; i >= wasmParamOffset; i-- {
 		val := reflect.New(tp.In(i)).Elem()
 		raw := it.pop()
 		kind := tp.In(i).Kind()
@@ -512,12 +517,14 @@ func (it *interpreter) callHostFunc(ctx *wasm.HostFunctionCallContext, f *interp
 		in[i] = val
 	}
 
-	val := reflect.New(tp.In(0)).Elem()
 	if len(it.frames) > 0 {
 		ctx = ctx.WithMemory(it.frames[len(it.frames)-1].f.funcInstance.ModuleInstance.Memory)
 	}
-	val.Set(reflect.ValueOf(ctx))
-	in[0] = val
+
+	// Handle any special parameter zero
+	if val := wasm.GetHostFunctionCallContextValue(f.funcInstance.FunctionKind, ctx); val != nil {
+		in[0] = *val
+	}
 
 	frame := &interpreterFrame{f: f}
 	it.pushFrame(frame)

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -52,6 +52,7 @@ func TestInterpreter_CallHostFunc(t *testing.T) {
 		module := &wasm.ModuleInstance{Memory: memory}
 		it := interpreter{functions: map[wasm.FunctionAddress]*interpreterFunction{
 			0: {hostFn: &hostFn, funcInstance: &wasm.FunctionInstance{
+				FunctionKind: wasm.FunctionKindHostFunctionCallContext,
 				FunctionType: &wasm.TypeInstance{
 					Type: &wasm.FunctionType{
 						Params:  []wasm.ValueType{},

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -459,6 +459,9 @@ const (
 //
 // ctx parameter is passed to the host function as a first argument.
 func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *wasm.HostFunctionCallContext) {
+	// TODO: the signature won't ever change for a host function once instantiated. For this reason, we should be able
+	// to optimize below based on known possible outcomes. This includes knowledge about if it has a context param[0]
+	// and which type (if any) it returns.
 	tp := f.Type()
 	in := make([]reflect.Value, tp.NumIn())
 

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -468,7 +468,7 @@ func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *w
 	// We pop the value and pass them as arguments in a reverse order according to the
 	// stack machine convention.
 	wasmParamOffset := 0
-	if fk != wasm.FunctionKindHost {
+	if fk != wasm.FunctionKindHostNoContext {
 		wasmParamOffset = 1
 	}
 	for i := len(in) - 1; i >= wasmParamOffset; i-- {

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -66,7 +66,7 @@ type (
 		// when making function calls or returning from them.
 		callFrameStackPointer uint64
 		// previousCallFrameStackPointer is to support re-entrant execution.
-		// This is updated whenever exntering engine.execFunction.
+		// This is updated whenever exntering engine.execWasmFunction.
 		// If this is the initial call into Wasm, the value equals zero,
 		// but if this is the recursive function call from the host function, the value becomes non-zero.
 		previousCallFrameStackPointer uint64
@@ -138,7 +138,7 @@ type (
 	// That is, callFrameTop().returnAddress or returnStackBasePointer are not set
 	// until it makes a function call.
 	callFrame struct {
-		// Set when making function call from this function frame, or for the initial function frame to call from engine.execFunction.
+		// Set when making function call from this function frame, or for the initial function frame to call from engine.execWasmFunction.
 		returnAddress uintptr
 		// Set when making function call from this function frame.
 		returnStackBasePointer uint64
@@ -388,10 +388,10 @@ func (e *engine) Call(ctx *wasm.HostFunctionCallContext, f *wasm.FunctionInstanc
 		return
 	}
 
-	if compiled.source.IsHostFunction() {
-		e.execHostFunction(compiled.source.HostFunction, ctx)
+	if f.FunctionKind == wasm.FunctionKindWasm {
+		e.execWasmFunction(ctx, compiled)
 	} else {
-		e.execFunction(ctx, compiled)
+		e.execHostFunction(f.FunctionKind, compiled.source.HostFunction, ctx)
 	}
 
 	// Note the top value is the tail of the results,
@@ -450,8 +450,7 @@ const (
 
 // execHostFunction executes the given host function represented as *reflect.Value.
 //
-// The arguments to the function are popped from the stack stack following the convension of
-// Wasm stack machine.
+// The arguments to the function are popped from the stack following the convention of the Wasm stack machine.
 // For example, if the host function F requires the (x1 uint32, x2 float32) parameters, and
 // the stack is [..., A, B], then the function is called as F(A, B) where A and B are interpreted
 // as uint32 and float32 respectively.
@@ -459,13 +458,17 @@ const (
 // After the execution, the result of host function is pushed onto the stack.
 //
 // ctx parameter is passed to the host function as a first argument.
-func (e *engine) execHostFunction(f *reflect.Value, ctx *wasm.HostFunctionCallContext) {
+func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *wasm.HostFunctionCallContext) {
 	tp := f.Type()
 	in := make([]reflect.Value, tp.NumIn())
 
 	// We pop the value and pass them as arguments in a reverse order according to the
 	// stack machine convention.
-	for i := len(in) - 1; i >= 1; i-- {
+	wasmParamOffset := 0
+	if fk != wasm.FunctionKindHost {
+		wasmParamOffset = 1
+	}
+	for i := len(in) - 1; i >= wasmParamOffset; i-- {
 		val := reflect.New(tp.In(i)).Elem()
 		raw := e.popValue()
 		kind := tp.In(i).Kind()
@@ -482,12 +485,12 @@ func (e *engine) execHostFunction(f *reflect.Value, ctx *wasm.HostFunctionCallCo
 		in[i] = val
 	}
 
-	// Host function must receive wasm.HostFunctionCallContext as a first argument.
-	val := reflect.New(tp.In(0)).Elem()
-	val.Set(reflect.ValueOf(ctx))
-	in[0] = val
+	// Handle any special parameter zero
+	if val := wasm.GetHostFunctionCallContextValue(fk, ctx); val != nil {
+		in[0] = *val
+	}
 
-	// Excute the host function and push back the call result onto the stack.
+	// Execute the host function and push back the call result onto the stack.
 	for _, ret := range f.Call(in) {
 		switch ret.Kind() {
 		case reflect.Float64, reflect.Float32:
@@ -502,7 +505,7 @@ func (e *engine) execHostFunction(f *reflect.Value, ctx *wasm.HostFunctionCallCo
 	}
 }
 
-func (e *engine) execFunction(ctx *wasm.HostFunctionCallContext, f *compiledFunction) {
+func (e *engine) execWasmFunction(ctx *wasm.HostFunctionCallContext, f *compiledFunction) {
 	// We continuously execute functions until we reach the previous top frame
 	// to support recursive Wasm function executions.
 	e.globalContext.previousCallFrameStackPointer = e.globalContext.callFrameStackPointer
@@ -533,12 +536,12 @@ jitentry:
 			fn := e.compiledFunctions[e.exitContext.functionCallAddress]
 			callerCompiledFunction := e.callFrameAt(1).compiledFunction
 			if buildoptions.IsDebugMode {
-				if !fn.source.IsHostFunction() {
+				if fn.source.FunctionKind == wasm.FunctionKindWasm {
 					panic("jitCallStatusCodeCallHostFunction is only for host functions")
 				}
 			}
 			saved := e.globalContext.previousCallFrameStackPointer
-			e.execHostFunction(fn.source.HostFunction,
+			e.execHostFunction(fn.source.FunctionKind, fn.source.HostFunction,
 				ctx.WithMemory(callerCompiledFunction.source.ModuleInstance.Memory),
 			)
 			e.globalContext.previousCallFrameStackPointer = saved
@@ -636,10 +639,10 @@ func (e *engine) builtinFunctionMemoryGrow(mem *wasm.MemoryInstance) {
 
 func (e *engine) Compile(f *wasm.FunctionInstance) (err error) {
 	var compiled *compiledFunction
-	if f.IsHostFunction() {
-		compiled, err = compileHostFunction(f)
-	} else {
+	if f.FunctionKind == wasm.FunctionKindWasm {
 		compiled, err = compileWasmFunction(f)
+	} else {
+		compiled, err = compileHostFunction(f)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to compile function: %w", err)

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -4829,7 +4829,7 @@ func (c *amd64Compiler) callFunction(addr wasm.FunctionAddress, addrReg int16, f
 }
 
 // returnFunction adds instructions to return from the current callframe back to the caller's frame.
-// If this is the current one is the origin, we return back to the engine.execFunction with the Returned status.
+// If this is the current one is the origin, we return back to the engine.execWasmFunction with the Returned status.
 // Otherwise, we jump into the callers' return address stored in callFrame.returnAddress while setting
 // up all the necessary change on the engine's state.
 //

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -43,7 +43,10 @@ func requirePushTwoFloat32Consts(t *testing.T, x1, x2 float32, compiler *arm64Co
 }
 
 func (j *jitEnv) requireNewCompiler(t *testing.T) *arm64Compiler {
-	cmp, err := newCompiler(&wasm.FunctionInstance{ModuleInstance: j.moduleInstance}, nil)
+	cmp, err := newCompiler(&wasm.FunctionInstance{
+		ModuleInstance: j.moduleInstance,
+		FunctionKind:   wasm.FunctionKindWasm,
+	}, nil)
 	require.NoError(t, err)
 	ret, ok := cmp.(*arm64Compiler)
 	require.True(t, ok)
@@ -1692,8 +1695,11 @@ func TestArm64Compiler_compileCall(t *testing.T) {
 				expectedValue += addTargetValue
 
 				compiler := env.requireNewCompiler(t)
-				compiler.f = &wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType},
-					ModuleInstance: &wasm.ModuleInstance{}}
+				compiler.f = &wasm.FunctionInstance{
+					FunctionKind:   wasm.FunctionKindWasm,
+					FunctionType:   &wasm.TypeInstance{Type: targetFunctionType},
+					ModuleInstance: &wasm.ModuleInstance{},
+				}
 
 				err := compiler.compilePreamble()
 				require.NoError(t, err)

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -115,6 +115,7 @@ func (j *jitEnv) exec(code []byte) {
 		codeSegment:        code,
 		codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 		source: &wasm.FunctionInstance{
+			FunctionKind: wasm.FunctionKindWasm,
 			FunctionType: &wasm.TypeInstance{Type: &wasm.FunctionType{}},
 		},
 	}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -204,7 +204,7 @@ func TestStore_addHostFunction(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		s := NewStore(nopEngineInstance)
 		for i := 0; i < 10; i++ {
-			f := &FunctionInstance{FunctionKind: FunctionKindHost}
+			f := &FunctionInstance{FunctionKind: FunctionKindHostNoContext}
 			require.Len(t, s.Functions, i)
 
 			err := s.addFunctionInstance(f)


### PR DESCRIPTION
This allows users to decouple from wazero code when authoring host
functions. Notably, this allows them to opt out of using a context, or
only using a Go context instead of HostFunctionCallContext.

This backfills docs on how to write host functions (in simple terms).

Finally, this does not optimize engines to avoid propagating context or
looking up memory if it would never be used. That could be done later.
