### PR TITLE
Adds wazero.MakeWasmFunc and MakeHostFunc

### DIFF
--- a/internal/makefunc/makefunc.go
+++ b/internal/makefunc/makefunc.go
@@ -1,0 +1,148 @@
+package makefunc
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	wasm "github.com/tetratelabs/wazero/internal/wasm"
+	publicwasm "github.com/tetratelabs/wazero/wasm"
+)
+
+var uint64Zero = reflect.Zero(reflect.TypeOf(uint64(0)))
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// MakeWasmFunc implements the goFuncPtr to call the provided wasmFunction.
+//
+// See reflect.MakeFunc
+// TODO: Maybe we can optimize our own variant of reflect.MakeFunc in JIT and add this to the Engine interface.
+func MakeWasmFunc(ctx *wasm.ModuleContext, name string, impl *wasm.FunctionInstance, goFuncPtr interface{}) error {
+	// goFuncPtr should point to nil if used properly, but we don't care as we clobber it.
+	fn := reflect.ValueOf(goFuncPtr).Elem()
+
+	// Ensure the signature is correct and if it has an error result or not.
+	fk, ft, hasErrorResult, err := wasm.GetFunctionType(name, &fn, true)
+	if err != nil {
+		return err
+	}
+
+	cf := &wasmFunc{
+		ctx:                  ctx,
+		impl:                 impl,
+		goFuncKind:           fk,
+		goFuncResultCount:    uint32(len(ft.Results)),
+		goFuncHasErrorResult: hasErrorResult,
+	}
+
+	if cf.goFuncResultCount == 1 {
+		cf.goFuncResultKind = fn.Type().Out(0).Kind()
+	}
+	if cf.goFuncHasErrorResult {
+		cf.goFuncResultCount++
+	}
+
+	// Now that we know the type is compatible with Wasm, make a reflective invoker.
+	v := reflect.MakeFunc(fn.Type(), cf.makeFunc)
+
+	// Set the pointer value to the implementation that calls the Wasm function.
+	fn.Set(v)
+	return nil
+}
+
+type wasmFunc struct {
+	ctx                  *wasm.ModuleContext
+	impl                 *wasm.FunctionInstance
+	goFuncKind           wasm.FunctionKind
+	goFuncResultKind     reflect.Kind
+	goFuncResultCount    uint32
+	goFuncHasErrorResult bool
+}
+
+func (f *wasmFunc) makeFunc(args []reflect.Value) (results []reflect.Value) {
+	wasmParamOffset := 1
+	ctx := f.ctx
+	switch f.goFuncKind {
+	case wasm.FunctionKindGoNoContext: // no special param zero
+		wasmParamOffset = 0
+	case wasm.FunctionKindGoContext:
+		ctx = ctx.WithContext(args[0].Interface().(context.Context))
+	case wasm.FunctionKindGoModuleContext:
+		if ctxImpl, ok := args[0].Interface().(*wasm.ModuleContext); ok {
+			ctx = ctxImpl
+		} else {
+			return f.error(fmt.Errorf("unsupported ModuleContext implementation: %s", args[0].Interface()))
+		}
+	default:
+		panic(fmt.Errorf("BUG: unhandled FunctionKind: %d", f.goFuncKind))
+	}
+
+	wasmParams := make([]uint64, len(args)-wasmParamOffset)
+
+	for i := 0; i < len(wasmParams); i++ {
+		arg := args[i+wasmParamOffset]
+		switch arg.Kind() {
+		case reflect.Float32:
+			wasmParams[i] = publicwasm.EncodeF32(float32(arg.Float()))
+		case reflect.Float64:
+			wasmParams[i] = publicwasm.EncodeF64(arg.Float())
+		case reflect.Uint32, reflect.Uint64:
+			wasmParams[i] = arg.Uint()
+		case reflect.Int32, reflect.Int64:
+			wasmParams[i] = uint64(arg.Int())
+		default:
+			panic(fmt.Errorf("invalid arg[%d]: %s", i+wasmParamOffset, arg))
+		}
+	}
+	wasmResults, err := ctx.Engine.Call(ctx, f.impl, wasmParams...)
+	if err != nil {
+		return f.error(err)
+	}
+
+	// Note: Each result element cannot be nil, though it may be reflect.Zero
+	results = make([]reflect.Value, f.goFuncResultCount)
+
+	// There's no error at this point, so backfill a zero value for it.
+	if f.goFuncHasErrorResult {
+		results[f.goFuncResultCount-1] = reflect.Zero(errorType)
+	}
+
+	// Here, we know there is no error. If the signature expects no result, return early.
+	if f.goFuncResultKind == 0 {
+		return
+	}
+
+	// In wazero, all value types are uint64. Particularly floats need special handling.
+	wasmResult := wasmResults[0]
+	var goResult reflect.Value
+	switch f.goFuncResultKind {
+	case reflect.Invalid: // Void or only-error return
+	case reflect.Float32:
+		goResult = reflect.ValueOf(publicwasm.DecodeF32(wasmResult))
+	case reflect.Float64:
+		goResult = reflect.ValueOf(publicwasm.DecodeF64(wasmResult))
+	case reflect.Uint32:
+		goResult = reflect.ValueOf(uint32(wasmResult))
+	case reflect.Uint64:
+		goResult = reflect.ValueOf(wasmResult)
+	case reflect.Int32, reflect.Int64:
+		goResult = reflect.ValueOf(int64(wasmResult))
+	default:
+		panic(fmt.Errorf("BUG: unsupported result kind: %s", f.goFuncResultKind))
+	}
+	results[0] = goResult
+	return
+}
+
+func (f *wasmFunc) error(err error) []reflect.Value {
+	// If the user didn't define an error return on their goFunc, our only choice is panic.
+	if !f.goFuncHasErrorResult {
+		panic(err)
+	}
+
+	reflectErr := reflect.ValueOf(err)
+	// If there is a Go return type, we have to populate with a zero value it even on error.
+	if f.goFuncResultKind != 0 {
+		return []reflect.Value{uint64Zero, reflectErr}
+	}
+	return []reflect.Value{reflectErr}
+}

--- a/tests/bench/makewasmfunc_test.go
+++ b/tests/bench/makewasmfunc_test.go
@@ -1,0 +1,51 @@
+//go:build amd64
+// +build amd64
+
+// Wasmtime cannot be used non-amd64 platform.
+package bench
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+)
+
+// BenchmarkMakeWasmFunc tracks the time spent calling internalwasm.MakeWasmFunc
+func BenchmarkMakeWasmFunc(b *testing.B) {
+	benches := []struct {
+		name   string
+		engine func() *wazero.Engine
+	}{
+		{name: "Interpreter", engine: wazero.NewEngineInterpreter},
+		{name: "JIT", engine: wazero.NewEngineJIT},
+	}
+
+	for _, bb := range benches {
+		bc := bb
+
+		mod, err := wazero.DecodeModuleBinary(facWasm)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: bc.engine()})
+
+		exports, err := wazero.InstantiateModule(store, mod)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(bc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+
+				var fn func(uint64) uint64
+				if err := wazero.MakeWasmFunc(exports, "fac-iter", &fn); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds `wazero.MakeWasmFunc` and `MakeHostFunc` which allow
users to avoid knowing how to encode parameters or results.

```
var addFloat func(float64, float64) float64
_ = wazero.MakeWasmFunc(exports, name, &addFloat)
res := addFloat(1.5, 1.5) // 3.0!
```

This should help avoid problems and make the API easier to deal with.
Someone can also use the export API to make a codegen alternative to
MakeWasmFunc!

Note: the name `MakeWasmFunc` is similar to `reflect.MakeFunc` and
that's how it is currently implemented.

`MakeHostFunc` is also available for the same reason in host functions.