### PR TITLE
Adds wasm.Store API to get exported module and host functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ it could have been written in another language that targets Wasm, such as Assemb
 ```golang
 func main() {
 	// Read WebAssembly binary containing an exported "fac" function.
+	// * Ex. (func (export "fac") (param i64) (result i64) ...
 	source, _ := os.ReadFile("./tests/engine/testdata/fac.wasm")
 
 	// Decode the binary as WebAssembly module.
 	mod, _ := wazero.DecodeModuleBinary(source)
 
 	// Instantiate the module with a Wasm Interpreter, to return its exported functions
-	functions, _ := wazero.NewStore().Instantiate(mod)
+	exports, _ := wazero.InstantiateModule(wazero.NewStore(), mod)
 
 	// Get the factorial function
-	fac, _ := functions.GetFunctionI64Return("fac")
+	fac, _ := exports.Function("fac")
 
 	// Discover 7! is 5040
 	fmt.Println(fac(context.Background(), 7))

--- a/examples/add_test.go
+++ b/examples/add_test.go
@@ -27,21 +27,20 @@ func Test_AddInt(t *testing.T) {
 	store := wazero.NewStore()
 	require.NoError(t, err)
 
-	m, err := store.Instantiate(mod)
+	exports, err := wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
 
-	addInt, ok := m.GetFunctionI32Return("AddInt")
+	addInt, ok := exports.Function("AddInt")
 	require.True(t, ok)
 
 	for _, c := range []struct {
-		value1, value2 uint64
-		result         uint32
+		value1, value2, expected uint64 // i32i32_i32 sig, but wasm.Function params and results are uint64
 	}{
-		{value1: 1, value2: 2, result: 3},
-		{value1: 5, value2: 5, result: 10},
+		{value1: 1, value2: 2, expected: 3},
+		{value1: 5, value2: 5, expected: 10},
 	} {
-		ret, err := addInt(context.Background(), c.value1, c.value2)
+		results, err := addInt(context.Background(), c.value1, c.value2)
 		require.NoError(t, err)
-		require.Equal(t, c.result, ret)
+		require.Equal(t, c.expected, results[0])
 	}
 }

--- a/examples/file_system_test.go
+++ b/examples/file_system_test.go
@@ -48,18 +48,15 @@ func Test_file_system(t *testing.T) {
 	mod, err := wazero.DecodeModuleBinary(filesystemWasm)
 	require.NoError(t, err)
 
+	store := wazero.NewStore()
+
 	memFS := wazero.WASIMemFS()
 	err = writeFile(memFS, "input.txt", []byte("Hello, file system!"))
 	require.NoError(t, err)
 
-	// Configure WASI host functions with the memory filesystem
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{
-			wasi.ModuleSnapshotPreview1: wazero.WASISnapshotPreview1WithConfig(
-				&wazero.WASIConfig{Preopens: map[string]wasi.FS{".": memFS}},
-			),
-		},
-	})
+	_, err = wazero.ExportHostFunctions(store, wasi.ModuleSnapshotPreview1, wazero.WASISnapshotPreview1WithConfig(
+		&wazero.WASIConfig{Preopens: map[string]wasi.FS{".": memFS}},
+	))
 	require.NoError(t, err)
 
 	// Note: TinyGo binaries must be treated as WASI Commands to initialize memory.

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -20,11 +20,12 @@ type testKey struct{}
 var hostFuncWasm []byte
 
 func Test_hostFunc(t *testing.T) {
-	mod, err := wazero.DecodeModuleBinary(hostFuncWasm)
-	require.NoError(t, err)
+	allocateBuffer := func(context.Context, uint32) uint32 {
+		panic("unimplemented")
+	}
 
 	// Host-side implementation of get_random_string on Wasm import.
-	getRandomString := func(ctx wasm.HostFunctionCallContext, retBufPtr uint32, retBufSize uint32) {
+	getRandomString := func(ctx wasm.ModuleContext, retBufPtr uint32, retBufSize uint32) {
 		// Assert that context values passed in from CallFunctionContext are accessible.
 		contextValue := ctx.Context().Value(testKey{}).(int64)
 		require.Equal(t, int64(12345), contextValue)
@@ -34,11 +35,7 @@ func Test_hostFunc(t *testing.T) {
 		// Note that this is recursive call. That means that this is the VM function call during the VM function call.
 		// More precisely, we call test.base64 (in Wasm), and the function in turn calls this get_random_string function,
 		// and we call test.allocate_buffer (in Wasm) here: host->vm->host->vm.
-		allocateBuffer, ok := ctx.Functions().GetFunctionI32Return("allocate_buffer")
-		require.True(t, ok)
-
-		offset, err := allocateBuffer(ctx.Context(), bufferSize)
-		require.NoError(t, err)
+		offset := allocateBuffer(ctx.Context(), bufferSize)
 
 		// Store the address info to the memory.
 		require.True(t, ctx.Memory().WriteUint32Le(retBufPtr, offset))
@@ -53,26 +50,37 @@ func Test_hostFunc(t *testing.T) {
 		require.Equal(t, bufferSize, n)
 	}
 
-	hfs, err := wazero.NewHostFunctions(map[string]interface{}{"get_random_string": getRandomString})
+	mod, err := wazero.DecodeModuleBinary(hostFuncWasm)
 	require.NoError(t, err)
 
-	// Note: neither the host function above nor the TinyGo source testdata/host_func.go directly use WASI.
-	// However, all TinyGo binaries must be treated as WASI Commands to initialize memory.
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{
-			wasi.ModuleSnapshotPreview1: wazero.WASISnapshotPreview1(),
-			"env":                       hfs,
-		},
-	})
+	store := wazero.NewStore()
+
+	_, err = wazero.ExportHostFunctions(store, "env", map[string]interface{}{"get_random_string": getRandomString})
 	require.NoError(t, err)
 
-	m, err := wazero.StartWASICommand(store, mod)
+	// Note: host_func.go doesn't directly use WASI, but TinyGo needs to be initialized as a WASI Command.
+	_, err = wazero.ExportHostFunctions(store, wasi.ModuleSnapshotPreview1, wazero.WASISnapshotPreview1())
 	require.NoError(t, err)
 
-	// Set a context variable that should be available in wasm.HostFunctionCallContext.
-	ctx := context.WithValue(context.Background(), testKey{}, int64(12345))
-	base64, ok := m.GetFunctionVoidReturn("base64")
+	exports, err := wazero.StartWASICommand(store, mod)
+	require.NoError(t, err)
+
+	allocateBufferFn, ok := exports.Function("allocate_buffer")
 	require.True(t, ok)
-	err = base64(ctx, 5)
+
+	// Implement the function pointer. This mainly shows how you can decouple a module function dependency.
+	allocateBuffer = func(ctx context.Context, size uint32) uint32 {
+		res, err := allocateBufferFn(ctx, uint64(size))
+		require.NoError(t, err)
+		return uint32(res[0])
+	}
+
+	// Set a context variable that should be available in wasm.ModuleContext.
+	ctx := context.WithValue(context.Background(), testKey{}, int64(12345))
+
+	// Invoke a module-defined function that depends on a host function import
+	base64, ok := exports.Function("base64")
+	require.True(t, ok)
+	_, err = base64(ctx, uint64(5))
 	require.NoError(t, err)
 }

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -12,30 +12,25 @@ import (
 
 // Test_Simple implements a basic function in go: hello. This is imported as the Wasm name "$hello" and run on start.
 func Test_Simple(t *testing.T) {
-	mod, err := wazero.DecodeModuleText([]byte(`(module $test
-	(import "" "hello" (func $hello))
-	(start $hello)
-)`))
-	require.NoError(t, err)
-
 	stdout := new(bytes.Buffer)
 	goFunc := func() {
 		_, _ = fmt.Fprintln(stdout, "hello!")
 	}
 
-	// Assign the Go function as a host function. This could error if the signature was invalid for Wasm.
-	hostFuncs, err := wazero.NewHostFunctions(map[string]interface{}{"hello": goFunc})
+	mod, err := wazero.DecodeModuleText([]byte(`(module $test
+	(import "" "hello" (func $hello))
+	(start $hello)
+)`))
 	require.NoError(t, err)
+	store := wazero.NewStore()
 
 	// Host functions can be exported as any module name, including the empty string.
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{"": hostFuncs},
-	})
+	_, err = wazero.ExportHostFunctions(store, "", map[string]interface{}{"hello": goFunc})
 	require.NoError(t, err)
 
 	// The "hello" function was imported as $hello in Wasm. Since it was marked as the start
 	// function, it is invoked on instantiation. Ensure that worked: "hello" was called!
-	_, err = store.Instantiate(mod)
+	_, err = wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
 	require.Equal(t, "hello!\n", stdout.String())
 }

--- a/examples/stdio_test.go
+++ b/examples/stdio_test.go
@@ -19,6 +19,7 @@ var stdioWasm []byte
 func Test_stdio(t *testing.T) {
 	mod, err := wazero.DecodeModuleBinary(stdioWasm)
 	require.NoError(t, err)
+	store := wazero.NewStore()
 
 	stdinBuf := bytes.NewBuffer([]byte("WASI\n"))
 	stdoutBuf := bytes.NewBuffer(nil)
@@ -26,11 +27,7 @@ func Test_stdio(t *testing.T) {
 
 	// Configure WASI host functions with the IO buffers
 	wasiConfig := &wazero.WASIConfig{Stdin: stdinBuf, Stdout: stdoutBuf, Stderr: stderrBuf}
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{
-			wasi.ModuleSnapshotPreview1: wazero.WASISnapshotPreview1WithConfig(wasiConfig),
-		},
-	})
+	_, err = wazero.ExportHostFunctions(store, wasi.ModuleSnapshotPreview1, wazero.WASISnapshotPreview1WithConfig(wasiConfig))
 	require.NoError(t, err)
 
 	// StartWASICommand runs the "_start" function which is what TinyGo compiles "main" to

--- a/examples/wasi_test.go
+++ b/examples/wasi_test.go
@@ -1,0 +1,65 @@
+package examples
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/wasi"
+	"github.com/tetratelabs/wazero/wasm"
+)
+
+func Test_WASI(t *testing.T) {
+	// built-in WASI function to write a random value to memory
+	randomGet := func(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno {
+		panic("unimplemented")
+	}
+
+	stdout := new(bytes.Buffer)
+	goFunc := func(ctx wasm.ModuleContext) {
+		// Write 8 random bytes to memory using WASI.
+		errno := randomGet(ctx, 0, 8)
+		require.Equal(t, wasi.ErrnoSuccess, errno)
+
+		// Read them back and print it in hex!
+		random, ok := ctx.Memory().ReadUint64Le(0)
+		require.True(t, ok)
+		_, _ = fmt.Fprintf(stdout, "random: %x\n", random)
+	}
+
+	mod, err := wazero.DecodeModuleText([]byte(`(module $wasi
+	(import "wasi_snapshot_preview1" "random_get"
+		(func $wasi.random_get (param $buf i32) (param $buf_len i32) (result (;errno;) i32)))
+	(import "" "random" (func $random))
+	(memory 1)
+	(start $random)
+)`))
+	require.NoError(t, err)
+	store := wazero.NewStore()
+
+	// Host functions can be exported as any module name, including the empty string.
+	_, err = wazero.ExportHostFunctions(store, "", map[string]interface{}{"random": goFunc})
+	require.NoError(t, err)
+
+	// Configure WASI and implement the function to use it
+	we, err := wazero.ExportHostFunctions(store, wasi.ModuleSnapshotPreview1, wazero.WASISnapshotPreview1())
+	require.NoError(t, err)
+	randomGetFn, ok := we.Function("random_get")
+	require.True(t, ok)
+
+	// Implement the function pointer. This mainly shows how you can decouple a host function dependency.
+	randomGet = func(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno {
+		res, err := randomGetFn(ctx, uint64(buf), uint64(bufLen))
+		require.NoError(t, err)
+		return wasi.Errno(res[0])
+	}
+
+	// The "random" function was imported as $random in Wasm. Since it was marked as the start
+	// function, it is invoked on instantiation. Ensure that worked: "random" was called!
+	_, err = wazero.InstantiateModule(store, mod)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "random: ")
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 
 require (
 	// only used in benchmarks
-	github.com/bytecodealliance/wasmtime-go v0.32.0
+	github.com/bytecodealliance/wasmtime-go v0.34.0
 	github.com/stretchr/testify v1.7.0
 	// Once we reach some maturity, remove this dep and implement our own assembler.
 	github.com/twitchyliquid64/golang-asm v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bytecodealliance/wasmtime-go v0.32.0 h1:/GsrnJz2bfULAIZygN4vUElLYliQrx/o/1opP9X7Gck=
-github.com/bytecodealliance/wasmtime-go v0.32.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.34.0 h1:PaWS0DUusaXaU3aNoSYjag6WmuxjyPYBHgkrC4EXips=
+github.com/bytecodealliance/wasmtime-go v0.34.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/moremath/moremath.go
+++ b/internal/moremath/moremath.go
@@ -2,12 +2,14 @@ package moremath
 
 import "math"
 
-// math.Min doen't comply with the Wasm spec, so we borrow from the original
-// with a change that either one of NaN results in NaN even if another is -Inf.
-// https://github.com/golang/go/blob/1d20a362d0ca4898d77865e314ef6f73582daef0/src/math/dim.go#L74-L91
+// WasmCompatMin is the Wasm spec compatible variant of math.Min
+//
+// This returns math.NaN if either parameter is math.NaN, even if the other is -math.Inf.
+//
+// See https://github.com/golang/go/blob/1d20a362d0ca4898d77865e314ef6f73582daef0/src/math/dim.go#L74-L91
 func WasmCompatMin(x, y float64) float64 {
 	switch {
-	case math.IsNaN(x) || math.IsNaN(y):
+	case math.IsNaN(x) || math.IsNaN(y): // NaN cannot be compared with themselves, so we have to use IsNaN
 		return math.NaN()
 	case math.IsInf(x, -1) || math.IsInf(y, -1):
 		return math.Inf(-1)
@@ -23,12 +25,14 @@ func WasmCompatMin(x, y float64) float64 {
 	return y
 }
 
-// math.Max doen't comply with the Wasm spec, so we borrow from the original
-// with a change that either one of NaN results in NaN even if another is Inf.
-// https://github.com/golang/go/blob/1d20a362d0ca4898d77865e314ef6f73582daef0/src/math/dim.go#L42-L59
+// WasmCompatMax is the Wasm spec compatible variant of math.Max
+//
+// This returns math.NaN if either parameter is math.NaN, even if the other is math.Inf.
+//
+// See https://github.com/golang/go/blob/1d20a362d0ca4898d77865e314ef6f73582daef0/src/math/dim.go#L42-L59
 func WasmCompatMax(x, y float64) float64 {
 	switch {
-	case math.IsNaN(x) || math.IsNaN(y):
+	case math.IsNaN(x) || math.IsNaN(y): // NaN cannot be compared with themselves, so we have to use IsNaN
 		return math.NaN()
 	case math.IsInf(x, 1) || math.IsInf(y, 1):
 		return math.Inf(1)
@@ -45,9 +49,12 @@ func WasmCompatMax(x, y float64) float64 {
 	return y
 }
 
-// WasmCompatNearestF32 is the Wasm spec compatible variant of math.Round, which is used for Nearest instruction.
-// For example, this converts 1.9 to 2.0, and this has the semantics of LLVM's rint instrinsic: https://llvm.org/docs/LangRef.html#llvm-rint-intrinsic.
-// For the difference from math.Round, math.Round(-4.5) results in -5 while this produces -4.
+// WasmCompatNearestF32 is the Wasm spec compatible variant of math.Round, used for Nearest instruction.
+// For example, this converts 1.9 to 2.0, and this has the semantics of LLVM's rint intrinsic.
+//
+// Ex. math.Round(-4.5) results in -5 while this results in -4.
+//
+// See https://llvm.org/docs/LangRef.html#llvm-rint-intrinsic.
 func WasmCompatNearestF32(f float32) float32 {
 	// TODO: look at https://github.com/bytecodealliance/wasmtime/pull/2171 and reconsider this algorithm
 	if f != -0 && f != 0 {
@@ -67,9 +74,12 @@ func WasmCompatNearestF32(f float32) float32 {
 	return f
 }
 
-// WasmCompatNearestF64 is the Wasm spec compatible variant of math.Round, which is used for Nearest instruction.
-// For example, this converts 1.9 to 2.0, and this has the semantics of LLVM's rint instrinsic: https://llvm.org/docs/LangRef.html#llvm-rint-intrinsic.
-// For the difference from math.Round, math.Round(-4.5) results in -5 while this produces -4.
+// WasmCompatNearestF64 is the Wasm spec compatible variant of math.Round, used for Nearest instruction.
+// For example, this converts 1.9 to 2.0, and this has the semantics of LLVM's rint intrinsic.
+//
+// Ex. math.Round(-4.5) results in -5 while this results in -4.
+//
+// See https://llvm.org/docs/LangRef.html#llvm-rint-intrinsic.
 func WasmCompatNearestF64(f float64) float64 {
 	// TODO: look at https://github.com/bytecodealliance/wasmtime/pull/2171 and reconsider this algorithm
 	if f != -0 && f != 0 {

--- a/internal/moremath/moremath_test.go
+++ b/internal/moremath/moremath_test.go
@@ -11,6 +11,8 @@ func TestWasmCompatMin(t *testing.T) {
 	require.Equal(t, WasmCompatMin(-1.1, 123), -1.1)
 	require.Equal(t, WasmCompatMin(-1.1, math.Inf(1)), -1.1)
 	require.Equal(t, WasmCompatMin(math.Inf(-1), 123), math.Inf(-1))
+
+	// NaN cannot be compared with themselves, so we have to use IsNaN
 	require.True(t, math.IsNaN(WasmCompatMin(math.NaN(), 1.0)))
 	require.True(t, math.IsNaN(WasmCompatMin(1.0, math.NaN())))
 	require.True(t, math.IsNaN(WasmCompatMin(math.Inf(-1), math.NaN())))
@@ -22,6 +24,8 @@ func TestWasmCompatMax(t *testing.T) {
 	require.Equal(t, WasmCompatMax(-1.1, 123.1), 123.1)
 	require.Equal(t, WasmCompatMax(-1.1, math.Inf(1)), math.Inf(1))
 	require.Equal(t, WasmCompatMax(math.Inf(-1), 123.1), 123.1)
+
+	// NaN cannot be compared with themselves, so we have to use IsNaN
 	require.True(t, math.IsNaN(WasmCompatMax(math.NaN(), 1.0)))
 	require.True(t, math.IsNaN(WasmCompatMax(1.0, math.NaN())))
 	require.True(t, math.IsNaN(WasmCompatMax(math.Inf(-1), math.NaN())))

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -5,7 +5,7 @@ type Engine interface {
 	// Call invokes a function instance f with given parameters.
 	// Returns the results from the function.
 	// The ctx's context.Context will be the outer-most ancestor of the argument to wasm.FunctionVoidReturn, etc.
-	Call(ctx *HostFunctionCallContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
+	Call(ctx *ModuleContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
 
 	// Compile compiles down the function instance.
 	Compile(f *FunctionInstance) error

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -1,0 +1,160 @@
+package internalwasm
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	publicwasm "github.com/tetratelabs/wazero/wasm"
+)
+
+// FunctionKind identifies the type of function that can be called.
+type FunctionKind byte
+
+const (
+	// FunctionKindWasm is not a Go function: it is implemented in Wasm.
+	FunctionKindWasm FunctionKind = iota
+	// FunctionKindGoNoContext is a function implemented in Go, with a signature matching FunctionType.
+	FunctionKindGoNoContext
+	// FunctionKindGoContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
+	// a context.Context.
+	FunctionKindGoContext
+	// FunctionKindGoModuleContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
+	// a ModuleContext.
+	FunctionKindGoModuleContext
+)
+
+// GoFunc binds a WebAssembly 1.0 (MVP) Type Use to a Go func signature.
+type GoFunc struct {
+	wasmFunctionName string
+	// functionKind is never FunctionKindWasm
+	functionKind FunctionKind
+	functionType *FunctionType
+	goFunc       *reflect.Value
+}
+
+func NewGoFunc(wasmFunctionName string, goFunc interface{}) (hf *GoFunc, err error) {
+	hf = &GoFunc{wasmFunctionName: wasmFunctionName}
+	fn := reflect.ValueOf(goFunc)
+	hf.goFunc = &fn
+	hf.functionKind, hf.functionType, _, err = GetFunctionType(hf.wasmFunctionName, hf.goFunc, false)
+	return
+}
+
+// Below are reflection code to get the interface type used to parse functions and set values.
+
+var moduleContextType = reflect.TypeOf((*publicwasm.ModuleContext)(nil)).Elem()
+var goContextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// GetHostFunctionCallContextValue returns a reflect.Value for a context param[0], or nil if there isn't one.
+func GetHostFunctionCallContextValue(fk FunctionKind, ctx *ModuleContext) *reflect.Value {
+	switch fk {
+	case FunctionKindGoNoContext: // no special param zero
+	case FunctionKindGoContext:
+		val := reflect.New(goContextType).Elem()
+		val.Set(reflect.ValueOf(ctx.Context()))
+		return &val
+	case FunctionKindGoModuleContext:
+		val := reflect.New(moduleContextType).Elem()
+		val.Set(reflect.ValueOf(ctx))
+		return &val
+	}
+	return nil
+}
+
+// GetFunctionType returns the function type corresponding to the function signature or errs if invalid.
+func GetFunctionType(name string, fn *reflect.Value, allowErrorResult bool) (fk FunctionKind, ft *FunctionType, hasErrorResult bool, err error) {
+	if fn.Kind() != reflect.Func {
+		err = fmt.Errorf("%s is a %s, but should be a Func", name, fn.Kind().String())
+		return
+	}
+	p := fn.Type()
+
+	pOffset := 0
+	pCount := p.NumIn()
+	fk = FunctionKindGoNoContext
+	if pCount > 0 && p.In(0).Kind() == reflect.Interface {
+		p0 := p.In(0)
+		if p0.Implements(moduleContextType) {
+			fk = FunctionKindGoModuleContext
+			pOffset = 1
+			pCount--
+		} else if p0.Implements(goContextType) {
+			fk = FunctionKindGoContext
+			pOffset = 1
+			pCount--
+		}
+	}
+
+	rCount := p.NumOut()
+	if (allowErrorResult && rCount > 2) || (!allowErrorResult && rCount > 1) {
+		err = fmt.Errorf("%s has more than one result", name)
+		return
+	}
+
+	if allowErrorResult && rCount > 0 {
+		maybeErrIdx := rCount - 1
+		if p.Out(maybeErrIdx).Implements(errorType) {
+			hasErrorResult = true
+			rCount--
+		}
+	}
+
+	ft = &FunctionType{Params: make([]ValueType, pCount), Results: make([]ValueType, rCount)}
+
+	for i := 0; i < len(ft.Params); i++ {
+		pI := p.In(i + pOffset)
+		if t, ok := getTypeOf(pI.Kind()); ok {
+			ft.Params[i] = t
+			continue
+		}
+
+		// Now, we will definitely err, decide which message is best
+		var arg0Type reflect.Type
+		if hc := pI.Implements(moduleContextType); hc {
+			arg0Type = moduleContextType
+		} else if gc := pI.Implements(goContextType); gc {
+			arg0Type = goContextType
+		}
+
+		if arg0Type != nil {
+			err = fmt.Errorf("%s param[%d] is a %s, which may be defined only once as param[0]", name, i+pOffset, arg0Type)
+		} else {
+			err = fmt.Errorf("%s param[%d] is unsupported: %s", name, i+pOffset, pI.Kind())
+		}
+		return
+	}
+
+	if rCount == 0 {
+		return
+	}
+
+	result := p.Out(0)
+	if t, ok := getTypeOf(result.Kind()); ok {
+		ft.Results[0] = t
+		return
+	}
+
+	if result.Implements(errorType) {
+		err = fmt.Errorf("%s result[0] is an error, which is unsupported", name)
+	} else {
+		err = fmt.Errorf("%s result[0] is unsupported: %s", name, result.Kind())
+	}
+	return
+}
+
+func getTypeOf(kind reflect.Kind) (ValueType, bool) {
+	switch kind {
+	case reflect.Float64:
+		return ValueTypeF64, true
+	case reflect.Float32:
+		return ValueTypeF32, true
+	case reflect.Int32, reflect.Uint32:
+		return ValueTypeI32, true
+	case reflect.Int64, reflect.Uint64:
+		return ValueTypeI64, true
+	default:
+		return 0x00, false
+	}
+}

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -1,0 +1,173 @@
+package internalwasm
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	publicwasm "github.com/tetratelabs/wazero/wasm"
+)
+
+type errno uint32
+
+func TestGetFunctionType(t *testing.T) {
+	i32, i64, f32, f64 := ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64
+
+	tests := []struct {
+		name              string
+		inputFunc         interface{}
+		allowErrorResult  bool
+		expectedKind      FunctionKind
+		expectedType      *FunctionType
+		expectErrorResult bool
+	}{
+		{
+			name:         "nullary",
+			inputFunc:    func() {},
+			expectedKind: FunctionKindGoNoContext,
+			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:             "nullary allowErrorResult",
+			inputFunc:        func() {},
+			allowErrorResult: true,
+			expectedKind:     FunctionKindGoNoContext,
+			expectedType:     &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:              "void error result",
+			inputFunc:         func() error { return nil },
+			allowErrorResult:  true,
+			expectedKind:      FunctionKindGoNoContext,
+			expectErrorResult: true,
+			expectedType:      &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:             "void uint32 allowErrorResult",
+			inputFunc:        func() uint32 { return 0 },
+			allowErrorResult: true,
+			expectedKind:     FunctionKindGoNoContext,
+			expectedType:     &FunctionType{Params: []ValueType{}, Results: []ValueType{i32}},
+		},
+		{
+			name:             "void type uint32 allowErrorResult",
+			inputFunc:        func() errno { return 0 },
+			allowErrorResult: true,
+			expectedKind:     FunctionKindGoNoContext,
+			expectedType:     &FunctionType{Params: []ValueType{}, Results: []ValueType{i32}},
+		},
+		{
+			name:              "void (uint32,error) results",
+			inputFunc:         func() (uint32, error) { return 0, nil },
+			allowErrorResult:  true,
+			expectedKind:      FunctionKindGoNoContext,
+			expectErrorResult: true,
+			expectedType:      &FunctionType{Params: []ValueType{}, Results: []ValueType{i32}},
+		},
+		{
+			name:         "wasm.ModuleContext void return",
+			inputFunc:    func(publicwasm.ModuleContext) {},
+			expectedKind: FunctionKindGoModuleContext,
+			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:         "context.Context void return",
+			inputFunc:    func(context.Context) {},
+			expectedKind: FunctionKindGoContext,
+			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
+		},
+		{
+			name:         "all supported params and i32 result",
+			inputFunc:    func(uint32, uint64, float32, float64) uint32 { return 0 },
+			expectedKind: FunctionKindGoNoContext,
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+		},
+		{
+			name:         "all supported params and i32 result - wasm.ModuleContext",
+			inputFunc:    func(publicwasm.ModuleContext, uint32, uint64, float32, float64) uint32 { return 0 },
+			expectedKind: FunctionKindGoModuleContext,
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+		},
+		{
+			name:         "all supported params and i32 result - context.Context",
+			inputFunc:    func(context.Context, uint32, uint64, float32, float64) uint32 { return 0 },
+			expectedKind: FunctionKindGoContext,
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			rVal := reflect.ValueOf(tc.inputFunc)
+			fk, ft, hasErrorResult, err := GetFunctionType("fn", &rVal, tc.allowErrorResult)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedKind, fk)
+			require.Equal(t, tc.expectedType, ft)
+			require.Equal(t, tc.expectErrorResult, hasErrorResult)
+		})
+	}
+}
+
+func TestGetFunctionTypeErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            interface{}
+		allowErrorResult bool
+		expectedErr      string
+	}{
+		{
+			name:        "not a func",
+			input:       struct{}{},
+			expectedErr: "fn is a struct, but should be a Func",
+		},
+		{
+			name:        "unsupported param",
+			input:       func(uint32, string) {},
+			expectedErr: "fn param[1] is unsupported: string",
+		},
+		{
+			name:        "unsupported result",
+			input:       func() string { return "" },
+			expectedErr: "fn result[0] is unsupported: string",
+		},
+		{
+			name:        "error result",
+			input:       func() error { return nil },
+			expectedErr: "fn result[0] is an error, which is unsupported",
+		},
+		{
+			name:        "multiple results",
+			input:       func() (uint64, uint32) { return 0, 0 },
+			expectedErr: "fn has more than one result",
+		},
+		{
+			name:        "multiple context types",
+			input:       func(publicwasm.ModuleContext, context.Context) error { return nil },
+			expectedErr: "fn param[1] is a context.Context, which may be defined only once as param[0]",
+		},
+		{
+			name:        "multiple context.Context",
+			input:       func(context.Context, uint64, context.Context) error { return nil },
+			expectedErr: "fn param[2] is a context.Context, which may be defined only once as param[0]",
+		},
+		{
+			name:        "multiple wasm.ModuleContext",
+			input:       func(publicwasm.ModuleContext, uint64, publicwasm.ModuleContext) error { return nil },
+			expectedErr: "fn param[2] is a wasm.ModuleContext, which may be defined only once as param[0]",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			rVal := reflect.ValueOf(tc.input)
+			_, _, _, err := GetFunctionType("fn", &rVal, tc.allowErrorResult)
+			require.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -5,330 +5,135 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"reflect"
 
 	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
-// FunctionKind identifies the type of function that can be called.
-type FunctionKind byte
+// compile time check to ensure ModuleContext implements publicwasm.ModuleContext
+var _ publicwasm.ModuleContext = &ModuleContext{}
 
-const (
-	// FunctionKindWasm is not a host function: it is implemented in Wasm.
-	FunctionKindWasm FunctionKind = iota
-	// FunctionKindHostNoContext is a function implemented in Go, with a signature matching FunctionType.
-	FunctionKindHostNoContext
-	// FunctionKindHostGoContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
-	// a context.Context.
-	FunctionKindHostGoContext
-	// FunctionKindHostFunctionCallContext is a function implemented in Go, with a signature matching FunctionType, except arg zero is
-	// a HostFunctionCallContext.
-	FunctionKindHostFunctionCallContext
-)
-
-type HostFunction struct {
-	name string
-	// functionKind is never FunctionKindWasm
-	functionKind FunctionKind
-	functionType *FunctionType
-	goFunc       *reflect.Value
-}
-
-func NewHostFunction(funcName string, goFunc interface{}) (hf *HostFunction, err error) {
-	hf = &HostFunction{name: funcName}
-	fn := reflect.ValueOf(goFunc)
-	hf.goFunc = &fn
-	hf.functionKind, hf.functionType, err = GetFunctionType(hf.name, hf.goFunc)
-	return
-}
-
-// Below are reflection code to get the interface type used to parse functions and set values.
-
-var hostFunctionCallContextType = reflect.TypeOf((*publicwasm.HostFunctionCallContext)(nil)).Elem()
-var goContextType = reflect.TypeOf((*context.Context)(nil)).Elem()
-var errorType = reflect.TypeOf((*error)(nil)).Elem()
-
-// GetHostFunctionCallContextValue returns a reflect.Value for a context param[0], or nil if there isn't one.
-func GetHostFunctionCallContextValue(fk FunctionKind, ctx *HostFunctionCallContext) *reflect.Value {
-	switch fk {
-	case FunctionKindHostNoContext: // no special param zero
-	case FunctionKindHostGoContext:
-		val := reflect.New(goContextType).Elem()
-		val.Set(reflect.ValueOf(ctx.Context()))
-		return &val
-	case FunctionKindHostFunctionCallContext:
-		val := reflect.New(hostFunctionCallContextType).Elem()
-		val.Set(reflect.ValueOf(ctx))
-		return &val
-	}
-	return nil
-}
-
-// GetFunctionType returns the function type corresponding to the function signature or errs if invalid.
-func GetFunctionType(name string, fn *reflect.Value) (fk FunctionKind, ft *FunctionType, err error) {
-	if fn.Kind() != reflect.Func {
-		err = fmt.Errorf("%s is a %s, but should be a Func", name, fn.Kind().String())
-		return
-	}
-	p := fn.Type()
-
-	pOffset := 0
-	pCount := p.NumIn()
-	fk = FunctionKindHostNoContext
-	if pCount > 0 && p.In(0).Kind() == reflect.Interface {
-		p0 := p.In(0)
-		if p0.Implements(hostFunctionCallContextType) {
-			fk = FunctionKindHostFunctionCallContext
-			pOffset = 1
-			pCount--
-		} else if p0.Implements(goContextType) {
-			fk = FunctionKindHostGoContext
-			pOffset = 1
-			pCount--
-		}
-	}
-	rCount := p.NumOut()
-	switch rCount {
-	case 0, 1: // ok
-	default:
-		err = fmt.Errorf("%s has more than one result", name)
-		return
-	}
-
-	ft = &FunctionType{Params: make([]ValueType, pCount), Results: make([]ValueType, rCount)}
-
-	for i := 0; i < len(ft.Params); i++ {
-		pI := p.In(i + pOffset)
-		if t, ok := getTypeOf(pI.Kind()); ok {
-			ft.Params[i] = t
-			continue
-		}
-
-		// Now, we will definitely err, decide which message is best
-		var arg0Type reflect.Type
-		if hc := pI.Implements(hostFunctionCallContextType); hc {
-			arg0Type = hostFunctionCallContextType
-		} else if gc := pI.Implements(goContextType); gc {
-			arg0Type = goContextType
-		}
-
-		if arg0Type != nil {
-			err = fmt.Errorf("%s param[%d] is a %s, which may be defined only once as param[0]", name, i+pOffset, arg0Type)
-		} else {
-			err = fmt.Errorf("%s param[%d] is unsupported: %s", name, i+pOffset, pI.Kind())
-		}
-		return
-	}
-
-	if rCount == 0 {
-		return
-	}
-	result := p.Out(0)
-	if t, ok := getTypeOf(result.Kind()); ok {
-		ft.Results[0] = t
-		return
-	}
-
-	if e := result.Implements(errorType); e {
-		err = fmt.Errorf("%s result[0] is an error, which is unsupported", name)
-	} else {
-		err = fmt.Errorf("%s result[0] is unsupported: %s", name, result.Kind())
-	}
-	return
-}
-
-func getTypeOf(kind reflect.Kind) (ValueType, bool) {
-	switch kind {
-	case reflect.Float64:
-		return ValueTypeF64, true
-	case reflect.Float32:
-		return ValueTypeF32, true
-	case reflect.Int32, reflect.Uint32:
-		return ValueTypeI32, true
-	case reflect.Int64, reflect.Uint64:
-		return ValueTypeI64, true
-	default:
-		return 0x00, false
-	}
-}
-
-// compile time check to ensure HostFunctionCallContext implements publicwasm.HostFunctionCallContext
-var _ publicwasm.HostFunctionCallContext = &HostFunctionCallContext{}
-
-func NewHostFunctionCallContext(s *Store, instance *ModuleInstance) *HostFunctionCallContext {
-	return &HostFunctionCallContext{
+func NewModuleContext(s *Store, instance *ModuleInstance) *ModuleContext {
+	return &ModuleContext{
+		Engine: s.Engine,
 		ctx:    context.Background(),
 		memory: instance.Memory,
-		module: instance,
-		store:  s,
+		Module: instance,
 	}
 }
 
-// HostFunctionCallContext implements wasm.HostFunctionCallContext and wasm.Module
-type HostFunctionCallContext struct {
-	// ctx is exposed as wasm.HostFunctionCallContext Context
-	ctx context.Context
-	// memory is exposed as wasm.HostFunctionCallContext Memory
+// ModuleContext implements wasm.ModuleContext and wasm.Module
+type ModuleContext struct {
+	// Engine is exported for wazero.MakeWasmFunc
+	Engine Engine
+	// Module is exported for wazero.MakeWasmFunc
+	Module *ModuleInstance
+	// memory is exposed as wasm.ModuleContext Memory
 	memory publicwasm.Memory
-	// module is the current module
-	module *ModuleInstance
-	// store is a reference to Store.Engine and Store.HostFunctionCallContexts
-	store *Store
+	// ctx is exposed as wasm.ModuleContext Context
+	ctx context.Context
 }
 
 // WithContext allows overriding context without re-allocation when the result would be the same.
-func (c *HostFunctionCallContext) WithContext(ctx context.Context) *HostFunctionCallContext {
+func (c *ModuleContext) WithContext(ctx context.Context) *ModuleContext {
 	// only re-allocate if it will change the effective context
 	if ctx != nil && ctx != c.ctx {
-		return &HostFunctionCallContext{ctx: ctx, memory: c.memory, module: c.module, store: c.store}
+		return &ModuleContext{Engine: c.Engine, Module: c.Module, memory: c.memory, ctx: ctx}
 	}
 	return c
 }
 
 // WithMemory allows overriding memory without re-allocation when the result would be the same.
-func (c *HostFunctionCallContext) WithMemory(memory *MemoryInstance) *HostFunctionCallContext {
+func (c *ModuleContext) WithMemory(memory *MemoryInstance) *ModuleContext {
 	// only re-allocate if it will change the effective memory
 	if memory != nil && memory.Max != nil && *memory.Max > 0 && memory != c.memory {
-		return &HostFunctionCallContext{ctx: c.ctx, memory: memory, module: c.module, store: c.store}
+		return &ModuleContext{Engine: c.Engine, Module: c.Module, memory: memory, ctx: c.ctx}
 	}
 	return c
 }
 
-func (c *HostFunctionCallContext) Context() context.Context {
+func (c *ModuleContext) Context() context.Context {
 	return c.ctx
 }
 
 // Memory implements wasm.Module Memory
-func (c *HostFunctionCallContext) Memory() publicwasm.Memory {
+func (c *ModuleContext) Memory() publicwasm.Memory {
 	return c.memory
 }
 
-// Functions implements wasm.HostFunctionCallContext Functions
-func (c *HostFunctionCallContext) Functions() publicwasm.ModuleFunctions {
-	return c
-}
-
-// FunctionsForModule implements wasm.HostFunctionCallContext FunctionsForModule
-func (c *HostFunctionCallContext) FunctionsForModule(moduleName string) (publicwasm.ModuleFunctions, bool) {
-	c, ok := c.store.HostFunctionCallContexts[moduleName]
-	if !ok {
-		return nil, false
-	}
-	return c, true
-}
-
-func (c *HostFunctionCallContext) GetFunctionVoidReturn(name string) (publicwasm.FunctionVoidReturn, bool) {
-	f, err := c.module.GetFunctionVoidReturn(name)
+// Function implements wasm.Functions Function
+func (c *ModuleContext) Function(name string) (publicwasm.Function, bool) {
+	exp, err := c.Module.GetExport(name, ExportKindFunc)
 	if err != nil {
 		return nil, false
 	}
-	return (&functionVoidReturn{c: c, f: f}).Call, true
+	return (&function{c: c, f: exp.Function}).Call, true
 }
 
-func (c *HostFunctionCallContext) GetFunctionI32Return(name string) (publicwasm.FunctionI32Return, bool) {
-	f, err := c.module.GetFunction(name, ValueTypeI32)
-	if err != nil {
-		return nil, false
-	}
-	return (&functionI32Return{c: c, f: f}).Call, true
-}
-
-func (c *HostFunctionCallContext) GetFunctionI64Return(name string) (publicwasm.FunctionI64Return, bool) {
-	f, err := c.module.GetFunction(name, ValueTypeI64)
-	if err != nil {
-		return nil, false
-	}
-	return (&functionI64Return{c: c, f: f}).Call, true
-}
-
-func (c *HostFunctionCallContext) GetFunctionF32Return(name string) (publicwasm.FunctionF32Return, bool) {
-	f, err := c.module.GetFunction(name, ValueTypeF32)
-	if err != nil {
-		return nil, false
-	}
-	return (&functionF32Return{c: c, f: f}).Call, true
-}
-
-func (c *HostFunctionCallContext) GetFunctionF64Return(name string) (publicwasm.FunctionF64Return, bool) {
-	f, err := c.module.GetFunction(name, ValueTypeF64)
-	if err != nil {
-		return nil, false
-	}
-	return (&functionF64Return{c: c, f: f}).Call, true
-}
-
-type functionVoidReturn struct {
-	c *HostFunctionCallContext
+type function struct {
+	c *ModuleContext
 	f *FunctionInstance
 }
 
-func (f *functionVoidReturn) Call(ctx context.Context, params ...uint64) error {
-	_, err := call(f.c.WithContext(ctx), f.f, params...)
-	return err
-}
-
-type functionI32Return struct {
-	c *HostFunctionCallContext
-	f *FunctionInstance
-}
-
-func (f *functionI32Return) Call(ctx context.Context, params ...uint64) (uint32, error) {
-	results, err := call(f.c.WithContext(ctx), f.f, params...)
-	if err != nil {
-		return 0, err
-	}
-	return uint32(results[0]), nil
-}
-
-type functionI64Return struct {
-	c *HostFunctionCallContext
-	f *FunctionInstance
-}
-
-func (f *functionI64Return) Call(ctx context.Context, params ...uint64) (uint64, error) {
-	results, err := call(f.c.WithContext(ctx), f.f, params...)
-	if err != nil {
-		return 0, err
-	}
-	return results[0], nil
-}
-
-type functionF32Return struct {
-	c *HostFunctionCallContext
-	f *FunctionInstance
-}
-
-func (f *functionF32Return) Call(ctx context.Context, params ...uint64) (float32, error) {
-	results, err := call(f.c.WithContext(ctx), f.f, params...)
-	if err != nil {
-		return 0, err
-	}
-	return float32(math.Float64frombits(results[0])), nil
-}
-
-type functionF64Return struct {
-	c *HostFunctionCallContext
-	f *FunctionInstance
-}
-
-func (f *functionF64Return) Call(ctx context.Context, params ...uint64) (float64, error) {
-	results, err := call(f.c.WithContext(ctx), f.f, params...)
-	if err != nil {
-		return 0, err
-	}
-	return math.Float64frombits(results[0]), nil
-}
-
-func call(ctx *HostFunctionCallContext, f *FunctionInstance, params ...uint64) ([]uint64, error) {
-	paramSignature := f.FunctionType.Type.Params
+func (f *function) Call(ctx context.Context, params ...uint64) ([]uint64, error) {
+	paramSignature := f.f.FunctionType.Type.Params
 	paramCount := len(params)
 	if len(paramSignature) != paramCount {
 		return nil, fmt.Errorf("expected %d params, but passed %d", len(paramSignature), paramCount)
 	}
-	return ctx.store.Engine.Call(ctx, f, params...)
+	hc := f.c.WithContext(ctx)
+	return hc.Engine.Call(hc, f.f, params...)
 }
 
-// Len implements wasm.HostFunctionCallContext Len
+// ExportHostFunctions is defined internally for use in WASI tests and to keep the code size in the root directory small.
+func (s *Store) ExportHostFunctions(moduleName string, nameToGoFunc map[string]interface{}) (publicwasm.HostExports, error) {
+	if err := s.requireModuleUnused(moduleName); err != nil {
+		return nil, err
+	}
+
+	ret := HostExports{NameToFunctionInstance: make(map[string]*FunctionInstance, len(nameToGoFunc))}
+	for name, goFunc := range nameToGoFunc {
+		if hf, err := NewGoFunc(name, goFunc); err != nil {
+			return nil, err
+		} else if function, err := s.AddHostFunction(moduleName, hf); err != nil {
+			return nil, err
+		} else {
+			ret.NameToFunctionInstance[name] = function
+		}
+	}
+	return &ret, nil
+}
+
+func (s *Store) requireModuleUnused(moduleName string) error {
+	if _, ok := s.hostExports[moduleName]; ok {
+		return fmt.Errorf("module %s has already been exported by this host", moduleName)
+	}
+	if _, ok := s.ModuleContexts[moduleName]; ok {
+		return fmt.Errorf("module %s has already been instantiated", moduleName)
+	}
+	return nil
+}
+
+// HostExports implements wasm.HostExports
+type HostExports struct {
+	NameToFunctionInstance map[string]*FunctionInstance
+}
+
+// call implements wasm.HostFunction
+func (f *FunctionInstance) call(ctx publicwasm.ModuleContext, params ...uint64) ([]uint64, error) {
+	hCtx, ok := ctx.(*ModuleContext)
+	if !ok { // TODO: guard that hCtx.Module actually imported this!
+		return nil, fmt.Errorf("this function was not imported by %s", ctx)
+	}
+	return hCtx.Engine.Call(hCtx, f, params...)
+}
+
+// Function implements wasm.HostExports Function
+func (g *HostExports) Function(name string) (publicwasm.HostFunction, bool) {
+	f, ok := g.NameToFunctionInstance[name]
+	return f.call, ok
+}
+
+// Len implements wasm.ModuleContext Len
 func (m *MemoryInstance) Len() uint32 {
 	return uint32(len(m.Buffer))
 }
@@ -338,7 +143,7 @@ func (m *MemoryInstance) hasLen(offset uint32, sizeInBytes uint32) bool {
 	return uint64(offset+sizeInBytes) <= uint64(m.Len()) // uint64 prevents overflow on add
 }
 
-// ReadUint32Le implements wasm.HostFunctionCallContext ReadUint32Le
+// ReadUint32Le implements wasm.ModuleContext ReadUint32Le
 func (m *MemoryInstance) ReadUint32Le(offset uint32) (uint32, bool) {
 	if !m.hasLen(offset, 4) {
 		return 0, false
@@ -346,7 +151,7 @@ func (m *MemoryInstance) ReadUint32Le(offset uint32) (uint32, bool) {
 	return binary.LittleEndian.Uint32(m.Buffer[offset : offset+4]), true
 }
 
-// ReadFloat32Le implements wasm.HostFunctionCallContext ReadFloat32Le
+// ReadFloat32Le implements wasm.ModuleContext ReadFloat32Le
 func (m *MemoryInstance) ReadFloat32Le(offset uint32) (float32, bool) {
 	v, ok := m.ReadUint32Le(offset)
 	if !ok {
@@ -355,7 +160,7 @@ func (m *MemoryInstance) ReadFloat32Le(offset uint32) (float32, bool) {
 	return math.Float32frombits(v), true
 }
 
-// ReadUint64Le implements wasm.HostFunctionCallContext ReadUint64Le
+// ReadUint64Le implements wasm.ModuleContext ReadUint64Le
 func (m *MemoryInstance) ReadUint64Le(offset uint32) (uint64, bool) {
 	if !m.hasLen(offset, 8) {
 		return 0, false
@@ -363,7 +168,7 @@ func (m *MemoryInstance) ReadUint64Le(offset uint32) (uint64, bool) {
 	return binary.LittleEndian.Uint64(m.Buffer[offset : offset+8]), true
 }
 
-// ReadFloat64Le implements wasm.HostFunctionCallContext ReadFloat64Le
+// ReadFloat64Le implements wasm.ModuleContext ReadFloat64Le
 func (m *MemoryInstance) ReadFloat64Le(offset uint32) (float64, bool) {
 	v, ok := m.ReadUint64Le(offset)
 	if !ok {
@@ -372,7 +177,7 @@ func (m *MemoryInstance) ReadFloat64Le(offset uint32) (float64, bool) {
 	return math.Float64frombits(v), true
 }
 
-// Read implements wasm.HostFunctionCallContext Read
+// Read implements wasm.ModuleContext Read
 func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
 	if !m.hasLen(offset, byteCount) {
 		return nil, false
@@ -380,7 +185,7 @@ func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
 	return m.Buffer[offset : offset+byteCount], true
 }
 
-// WriteUint32Le implements wasm.HostFunctionCallContext WriteUint32Le
+// WriteUint32Le implements wasm.ModuleContext WriteUint32Le
 func (m *MemoryInstance) WriteUint32Le(offset, v uint32) bool {
 	if !m.hasLen(offset, 4) {
 		return false
@@ -389,12 +194,12 @@ func (m *MemoryInstance) WriteUint32Le(offset, v uint32) bool {
 	return true
 }
 
-// WriteFloat32Le implements wasm.HostFunctionCallContext WriteFloat32Le
+// WriteFloat32Le implements wasm.ModuleContext WriteFloat32Le
 func (m *MemoryInstance) WriteFloat32Le(offset uint32, v float32) bool {
 	return m.WriteUint32Le(offset, math.Float32bits(v))
 }
 
-// WriteUint64Le implements wasm.HostFunctionCallContext WriteUint64Le
+// WriteUint64Le implements wasm.ModuleContext WriteUint64Le
 func (m *MemoryInstance) WriteUint64Le(offset uint32, v uint64) bool {
 	if !m.hasLen(offset, 8) {
 		return false
@@ -403,12 +208,12 @@ func (m *MemoryInstance) WriteUint64Le(offset uint32, v uint64) bool {
 	return true
 }
 
-// WriteFloat64Le implements wasm.HostFunctionCallContext WriteFloat64Le
+// WriteFloat64Le implements wasm.ModuleContext WriteFloat64Le
 func (m *MemoryInstance) WriteFloat64Le(offset uint32, v float64) bool {
 	return m.WriteUint64Le(offset, math.Float64bits(v))
 }
 
-// Write implements wasm.HostFunctionCallContext Write
+// Write implements wasm.ModuleContext Write
 func (m *MemoryInstance) Write(offset uint32, val []byte) bool {
 	if !m.hasLen(offset, uint32(len(val))) {
 		return false
@@ -423,57 +228,57 @@ var NoopMemory = &noopMemory{}
 type noopMemory struct {
 }
 
-// Len implements wasm.HostFunctionCallContext Len
+// Len implements wasm.ModuleContext Len
 func (m *noopMemory) Len() uint32 {
 	return 0
 }
 
-// ReadUint32Le implements wasm.HostFunctionCallContext ReadUint32Le
+// ReadUint32Le implements wasm.ModuleContext ReadUint32Le
 func (m *noopMemory) ReadUint32Le(_ uint32) (uint32, bool) {
 	return 0, false
 }
 
-// ReadFloat32Le implements wasm.HostFunctionCallContext ReadFloat32Le
+// ReadFloat32Le implements wasm.ModuleContext ReadFloat32Le
 func (m *noopMemory) ReadFloat32Le(_ uint32) (float32, bool) {
 	return 0, false
 }
 
-// ReadUint64Le implements wasm.HostFunctionCallContext ReadUint64Le
+// ReadUint64Le implements wasm.ModuleContext ReadUint64Le
 func (m *noopMemory) ReadUint64Le(_ uint32) (uint64, bool) {
 	return 0, false
 }
 
-// ReadFloat64Le implements wasm.HostFunctionCallContext ReadFloat64Le
+// ReadFloat64Le implements wasm.ModuleContext ReadFloat64Le
 func (m *noopMemory) ReadFloat64Le(_ uint32) (float64, bool) {
 	return 0, false
 }
 
-// Read implements wasm.HostFunctionCallContext Read
+// Read implements wasm.ModuleContext Read
 func (m *noopMemory) Read(_, _ uint32) ([]byte, bool) {
 	return nil, false
 }
 
-// WriteUint32Le implements wasm.HostFunctionCallContext WriteUint32Le
+// WriteUint32Le implements wasm.ModuleContext WriteUint32Le
 func (m *noopMemory) WriteUint32Le(_, _ uint32) bool {
 	return false
 }
 
-// WriteFloat32Le implements wasm.HostFunctionCallContext WriteFloat32Le
+// WriteFloat32Le implements wasm.ModuleContext WriteFloat32Le
 func (m *noopMemory) WriteFloat32Le(_ uint32, _ float32) bool {
 	return false
 }
 
-// WriteUint64Le implements wasm.HostFunctionCallContext WriteUint64Le
+// WriteUint64Le implements wasm.ModuleContext WriteUint64Le
 func (m *noopMemory) WriteUint64Le(_ uint32, _ uint64) bool {
 	return false
 }
 
-// WriteFloat64Le implements wasm.HostFunctionCallContext WriteFloat64Le
+// WriteFloat64Le implements wasm.ModuleContext WriteFloat64Le
 func (m *noopMemory) WriteFloat64Le(_ uint32, _ float64) bool {
 	return false
 }
 
-// Write implements wasm.HostFunctionCallContext Write
+// Write implements wasm.ModuleContext Write
 func (m *noopMemory) Write(_ uint32, _ []byte) bool {
 	return false
 }

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -3,12 +3,9 @@ package internalwasm
 import (
 	"context"
 	"math"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
 func TestMemoryInstance_HasLen(t *testing.T) {
@@ -453,121 +450,61 @@ func TestMemoryInstance_WriteFloat64Le(t *testing.T) {
 	}
 }
 
-func TestGetFunctionType(t *testing.T) {
-	i32, i64, f32, f64 := ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64
-
-	tests := []struct {
-		name         string
-		inputFunc    interface{}
-		expectedKind FunctionKind
-		expectedType *FunctionType
-	}{
-		{
-			name:         "nullary",
-			inputFunc:    func() {},
-			expectedKind: FunctionKindHostNoContext,
-			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
-		},
-		{
-			name:         "wasm.HostFunctionCallContext void return",
-			inputFunc:    func(publicwasm.HostFunctionCallContext) {},
-			expectedKind: FunctionKindHostFunctionCallContext,
-			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
-		},
-		{
-			name:         "context.Context void return",
-			inputFunc:    func(context.Context) {},
-			expectedKind: FunctionKindHostGoContext,
-			expectedType: &FunctionType{Params: []ValueType{}, Results: []ValueType{}},
-		},
-		{
-			name:         "all supported params and i32 result",
-			inputFunc:    func(uint32, uint64, float32, float64) uint32 { return 0 },
-			expectedKind: FunctionKindHostNoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
-		},
-		{
-			name:         "all supported params and i32 result - wasm.HostFunctionCallContext",
-			inputFunc:    func(publicwasm.HostFunctionCallContext, uint32, uint64, float32, float64) uint32 { return 0 },
-			expectedKind: FunctionKindHostFunctionCallContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
-		},
-		{
-			name:         "all supported params and i32 result - context.Context",
-			inputFunc:    func(context.Context, uint32, uint64, float32, float64) uint32 { return 0 },
-			expectedKind: FunctionKindHostGoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64}, Results: []ValueType{i32}},
+func TestFunction_Call(t *testing.T) {
+	name := "test"
+	fn := "fn"
+	engine := &nopEngine{}
+	s := NewStore(engine)
+	m := &ModuleInstance{
+		Name: name,
+		Exports: map[string]*ExportInstance{
+			fn: {
+				Kind: ExportKindFunc,
+				Function: &FunctionInstance{
+					FunctionKind: FunctionKindWasm,
+					FunctionType: &TypeInstance{
+						Type: &FunctionType{
+							Params:  []ValueType{},
+							Results: []ValueType{},
+						},
+					},
+				},
+			},
 		},
 	}
+	ctx := NewModuleContext(s, m)
+	s.ModuleInstances[name] = m
+	s.ModuleContexts[name] = ctx
 
+	type testKey struct{}
+	ctxVal := context.WithValue(context.Background(), testKey{}, "test")
+
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		actualCtx context.Context
+	}{
+		{
+			name:      "nil context",
+			ctx:       nil,
+			actualCtx: context.Background(),
+		},
+		{
+			name:      "background context",
+			ctx:       context.Background(),
+			actualCtx: context.Background(),
+		},
+		{
+			name:      "context with value",
+			ctx:       ctxVal,
+			actualCtx: ctxVal,
+		},
+	}
 	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			rVal := reflect.ValueOf(tc.inputFunc)
-			fk, ft, err := GetFunctionType("fn", &rVal)
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := (&function{ctx, m.Exports[fn].Function}).Call(tt.ctx)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedKind, fk)
-			require.Equal(t, tc.expectedType, ft)
-		})
-	}
-}
-
-func TestGetFunctionTypeErrors(t *testing.T) {
-	tests := []struct {
-		name        string
-		input       interface{}
-		expectedErr string
-	}{
-		{
-			name:        "not a func",
-			input:       struct{}{},
-			expectedErr: "fn is a struct, but should be a Func",
-		},
-		{
-			name:        "unsupported param",
-			input:       func(uint32, string) {},
-			expectedErr: "fn param[1] is unsupported: string",
-		},
-		{
-			name:        "unsupported result",
-			input:       func() string { return "" },
-			expectedErr: "fn result[0] is unsupported: string",
-		},
-		{
-			name:        "error result",
-			input:       func() error { return nil },
-			expectedErr: "fn result[0] is an error, which is unsupported",
-		},
-		{
-			name:        "multiple results",
-			input:       func() (uint64, uint32) { return 0, 0 },
-			expectedErr: "fn has more than one result",
-		},
-		{
-			name:        "multiple context types",
-			input:       func(publicwasm.HostFunctionCallContext, context.Context) error { return nil },
-			expectedErr: "fn param[1] is a context.Context, which may be defined only once as param[0]",
-		},
-		{
-			name:        "multiple context.Context",
-			input:       func(context.Context, uint64, context.Context) error { return nil },
-			expectedErr: "fn param[2] is a context.Context, which may be defined only once as param[0]",
-		},
-		{
-			name:        "multiple wasm.HostFunctionCallContext",
-			input:       func(publicwasm.HostFunctionCallContext, uint64, publicwasm.HostFunctionCallContext) error { return nil },
-			expectedErr: "fn param[2] is a wasm.HostFunctionCallContext, which may be defined only once as param[0]",
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			rVal := reflect.ValueOf(tc.input)
-			_, _, err := GetFunctionType("fn", &rVal)
-			require.EqualError(t, err, tc.expectedErr)
+			require.Equal(t, tt.actualCtx, engine.ctx.ctx)
 		})
 	}
 }

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -425,7 +425,7 @@ func (it *interpreter) lowerIROps(f *wasm.FunctionInstance,
 }
 
 // Call implements an interpreted wasm.Engine.
-func (it *interpreter) Call(ctx *wasm.HostFunctionCallContext, f *wasm.FunctionInstance, params ...uint64) (results []uint64, err error) {
+func (it *interpreter) Call(ctx *wasm.ModuleContext, f *wasm.FunctionInstance, params ...uint64) (results []uint64, err error) {
 	prevFrameLen := len(it.frames)
 
 	// shouldRecover is true when a panic at the origin of callstack should be recovered
@@ -492,12 +492,12 @@ func (it *interpreter) Call(ctx *wasm.HostFunctionCallContext, f *wasm.FunctionI
 	return
 }
 
-func (it *interpreter) callHostFunc(ctx *wasm.HostFunctionCallContext, f *interpreterFunction) {
+func (it *interpreter) callHostFunc(ctx *wasm.ModuleContext, f *interpreterFunction) {
 	tp := f.hostFn.Type()
 	in := make([]reflect.Value, tp.NumIn())
 
 	wasmParamOffset := 0
-	if f.funcInstance.FunctionKind != wasm.FunctionKindHostNoContext {
+	if f.funcInstance.FunctionKind != wasm.FunctionKindGoNoContext {
 		wasmParamOffset = 1
 	}
 	for i := len(in) - 1; i >= wasmParamOffset; i-- {
@@ -543,7 +543,7 @@ func (it *interpreter) callHostFunc(ctx *wasm.HostFunctionCallContext, f *interp
 	it.popFrame()
 }
 
-func (it *interpreter) callNativeFunc(ctx *wasm.HostFunctionCallContext, f *interpreterFunction) {
+func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFunction) {
 	frame := &interpreterFrame{f: f}
 	moduleInst := f.funcInstance.ModuleInstance
 	memoryInst := moduleInst.Memory

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -1325,7 +1325,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 					switch wazeroir.SignedInt(op.b2) {
 					case wazeroir.SignedInt32:
 						v := math.Trunc(float64(math.Float32frombits(uint32(it.pop()))))
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < math.MinInt32 || v > math.MaxInt32 {
 							panic(wasm.ErrRuntimeIntegerOverflow)
@@ -1334,7 +1334,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 					case wazeroir.SignedInt64:
 						v := math.Trunc(float64(math.Float32frombits(uint32(it.pop()))))
 						res := int64(v)
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < math.MinInt64 || v >= math.MaxInt64 {
 							// Note: math.MaxInt64 is rounded up to math.MaxInt64+1 in 64-bit float representation,
@@ -1344,7 +1344,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 						it.push(uint64(res))
 					case wazeroir.SignedUint32:
 						v := math.Trunc(float64(math.Float32frombits(uint32(it.pop()))))
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < 0 || v > math.MaxUint32 {
 							panic(wasm.ErrRuntimeIntegerOverflow)
@@ -1353,7 +1353,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 					case wazeroir.SignedUint64:
 						v := math.Trunc(float64(math.Float32frombits(uint32(it.pop()))))
 						res := uint64(v)
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < 0 || v >= math.MaxUint64 {
 							// Note: math.MaxUint64 is rounded up to math.MaxUint64+1 in 64-bit float representation,
@@ -1367,7 +1367,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 					switch wazeroir.SignedInt(op.b2) {
 					case wazeroir.SignedInt32:
 						v := math.Trunc(math.Float64frombits(it.pop()))
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < math.MinInt32 || v > math.MaxInt32 {
 							panic(wasm.ErrRuntimeIntegerOverflow)
@@ -1376,7 +1376,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 					case wazeroir.SignedInt64:
 						v := math.Trunc(math.Float64frombits(it.pop()))
 						res := int64(v)
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < math.MinInt64 || v >= math.MaxInt64 {
 							// Note: math.MaxInt64 is rounded up to math.MaxInt64+1 in 64-bit float representation,
@@ -1386,7 +1386,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 						it.push(uint64(res))
 					case wazeroir.SignedUint32:
 						v := math.Trunc(math.Float64frombits(it.pop()))
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < 0 || v > math.MaxUint32 {
 							panic(wasm.ErrRuntimeIntegerOverflow)
@@ -1395,7 +1395,7 @@ func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFun
 					case wazeroir.SignedUint64:
 						v := math.Trunc(math.Float64frombits(it.pop()))
 						res := uint64(v)
-						if math.IsNaN(v) {
+						if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							panic(wasm.ErrRuntimeInvalidConversionToInteger)
 						} else if v < 0 || v >= math.MaxUint64 {
 							// Note: math.MaxUint64 is rounded up to math.MaxUint64+1 in 64-bit float representation,

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -530,7 +530,9 @@ func (it *interpreter) callHostFunc(ctx *wasm.ModuleContext, f *interpreterFunct
 	it.pushFrame(frame)
 	for _, ret := range f.hostFn.Call(in) {
 		switch ret.Kind() {
-		case reflect.Float64, reflect.Float32:
+		case reflect.Float32:
+			it.push(uint64(math.Float32bits(float32(ret.Float()))))
+		case reflect.Float64:
 			it.push(math.Float64bits(ret.Float()))
 		case reflect.Uint32, reflect.Uint64:
 			it.push(ret.Uint())

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -46,13 +46,13 @@ func TestInterpreter_CallHostFunc(t *testing.T) {
 	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
 		memory := &wasm.MemoryInstance{}
 		var ctxMemory publicwasm.Memory
-		hostFn := reflect.ValueOf(func(ctx publicwasm.HostFunctionCallContext) {
+		hostFn := reflect.ValueOf(func(ctx publicwasm.ModuleContext) {
 			ctxMemory = ctx.Memory()
 		})
 		module := &wasm.ModuleInstance{Memory: memory}
 		it := interpreter{functions: map[wasm.FunctionAddress]*interpreterFunction{
 			0: {hostFn: &hostFn, funcInstance: &wasm.FunctionInstance{
-				FunctionKind: wasm.FunctionKindHostFunctionCallContext,
+				FunctionKind: wasm.FunctionKindGoModuleContext,
 				FunctionType: &wasm.TypeInstance{
 					Type: &wasm.FunctionType{
 						Params:  []wasm.ValueType{},
@@ -65,13 +65,13 @@ func TestInterpreter_CallHostFunc(t *testing.T) {
 		}}
 
 		// When calling a host func directly, there may be no stack. This ensures the module's memory is used.
-		it.callHostFunc(newHostFunctionCallContext(&it, module), it.functions[0])
+		it.callHostFunc(newModuleContext(&it, module), it.functions[0])
 		require.Same(t, memory, ctxMemory)
 	})
 }
 
-func newHostFunctionCallContext(engine wasm.Engine, module *wasm.ModuleInstance) *wasm.HostFunctionCallContext {
-	ctx := wasm.NewHostFunctionCallContext(&wasm.Store{
+func newModuleContext(engine wasm.Engine, module *wasm.ModuleInstance) *wasm.ModuleContext {
+	ctx := wasm.NewModuleContext(&wasm.Store{
 		Engine:          engine,
 		ModuleInstances: map[string]*wasm.ModuleInstance{"test": module},
 	}, module)

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -333,7 +333,7 @@ func (c *callFrame) String() string {
 	)
 }
 
-func (e *engine) Call(ctx *wasm.HostFunctionCallContext, f *wasm.FunctionInstance, params ...uint64) (results []uint64, err error) {
+func (e *engine) Call(ctx *wasm.ModuleContext, f *wasm.FunctionInstance, params ...uint64) (results []uint64, err error) {
 	// We ensure that this Call method never panics as
 	// this Call method is indirectly invoked by embedders via store.CallFunction,
 	// and we have to make sure that all the runtime errors, including the one happening inside
@@ -458,7 +458,7 @@ const (
 // After the execution, the result of host function is pushed onto the stack.
 //
 // ctx parameter is passed to the host function as a first argument.
-func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *wasm.HostFunctionCallContext) {
+func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *wasm.ModuleContext) {
 	// TODO: the signature won't ever change for a host function once instantiated. For this reason, we should be able
 	// to optimize below based on known possible outcomes. This includes knowledge about if it has a context param[0]
 	// and which type (if any) it returns.
@@ -468,7 +468,7 @@ func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *w
 	// We pop the value and pass them as arguments in a reverse order according to the
 	// stack machine convention.
 	wasmParamOffset := 0
-	if fk != wasm.FunctionKindHostNoContext {
+	if fk != wasm.FunctionKindGoNoContext {
 		wasmParamOffset = 1
 	}
 	for i := len(in) - 1; i >= wasmParamOffset; i-- {
@@ -508,7 +508,7 @@ func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *w
 	}
 }
 
-func (e *engine) execWasmFunction(ctx *wasm.HostFunctionCallContext, f *compiledFunction) {
+func (e *engine) execWasmFunction(ctx *wasm.ModuleContext, f *compiledFunction) {
 	// We continuously execute functions until we reach the previous top frame
 	// to support recursive Wasm function executions.
 	e.globalContext.previousCallFrameStackPointer = e.globalContext.callFrameStackPointer

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -496,7 +496,9 @@ func (e *engine) execHostFunction(fk wasm.FunctionKind, f *reflect.Value, ctx *w
 	// Execute the host function and push back the call result onto the stack.
 	for _, ret := range f.Call(in) {
 		switch ret.Kind() {
-		case reflect.Float64, reflect.Float32:
+		case reflect.Float32:
+			e.pushValue(uint64(math.Float32bits(float32(ret.Float()))))
+		case reflect.Float64:
 			e.pushValue(math.Float64bits(ret.Float()))
 		case reflect.Uint32, reflect.Uint64:
 			e.pushValue(ret.Uint())

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -3539,7 +3539,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 				require.Equal(t, uint64(1), env.stackPointer())
 				exp := tc.x1 / tc.x2
 				actual := env.stackTopAsFloat32()
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, tc.x1/tc.x2, actual)
@@ -3614,7 +3614,7 @@ func TestAmd64Compiler_compileDiv(t *testing.T) {
 				require.Equal(t, uint64(1), env.stackPointer())
 				exp := tc.x1 / tc.x2
 				actual := env.stackTopAsFloat64()
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, tc.x1/tc.x2, actual)
@@ -3976,7 +3976,7 @@ func TestAmd64Compiler_compileF32DemoteFromF64(t *testing.T) {
 
 			// Check the result.
 			require.Equal(t, uint64(1), env.stackPointer())
-			if math.IsNaN(v) {
+			if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 				require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 			} else {
 				exp := float32(v)
@@ -4021,7 +4021,7 @@ func TestAmd64Compiler_compileF64PromoteFromF32(t *testing.T) {
 
 			// Check the result.
 			require.Equal(t, uint64(1), env.stackPointer())
-			if math.IsNaN(float64(v)) {
+			if math.IsNaN(float64(v)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 				require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 			} else {
 				exp := float64(v)
@@ -4253,7 +4253,7 @@ func TestAmd64Compiler_compileITruncFromF(t *testing.T) {
 
 					// Check the result.
 					expStatus := jitCallStatusCodeReturned
-					if math.IsNaN(v) {
+					if math.IsNaN(v) { // NaN cannot be compared with themselves, so we have to use IsNaN
 						expStatus = jitCallStatusCodeInvalidFloatToIntConversion
 					}
 					if tc.inputType == wazeroir.Float32 && tc.outputType == wazeroir.SignedInt32 {
@@ -4585,6 +4585,7 @@ func TestAmd64Compiler_compile_abs_neg_ceil_floor(t *testing.T) {
 					require.Equal(t, uint64(1), env.stackPointer())
 					if is32Bit {
 						actual := env.stackTopAsFloat32()
+						// NaN cannot be compared with themselves, so we have to use IsNaN
 						if math.IsNaN(float64(expFloat32)) {
 							require.True(t, math.IsNaN(float64(actual)))
 						} else {
@@ -4592,7 +4593,7 @@ func TestAmd64Compiler_compile_abs_neg_ceil_floor(t *testing.T) {
 						}
 					} else {
 						actual := env.stackTopAsFloat64()
-						if math.IsNaN(expFloat64) {
+						if math.IsNaN(expFloat64) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							require.True(t, math.IsNaN(actual))
 						} else {
 							require.Equal(t, expFloat64, actual)
@@ -4725,6 +4726,7 @@ func TestAmd64Compiler_compile_min_max_copysign(t *testing.T) {
 					require.Equal(t, uint64(1), env.stackPointer())
 					if is32Bit {
 						actual := env.stackTopAsFloat32()
+						// NaN cannot be compared with themselves, so we have to use IsNaN
 						if math.IsNaN(float64(expFloat32)) {
 							require.True(t, math.IsNaN(float64(actual)), actual)
 						} else {
@@ -4732,7 +4734,7 @@ func TestAmd64Compiler_compile_min_max_copysign(t *testing.T) {
 						}
 					} else {
 						actual := env.stackTopAsFloat64()
-						if math.IsNaN(expFloat64) {
+						if math.IsNaN(expFloat64) { // NaN cannot be compared with themselves, so we have to use IsNaN
 							require.True(t, math.IsNaN(actual), actual)
 						} else {
 							require.Equal(t, expFloat64, actual)

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -738,6 +738,7 @@ func TestArm64Compiler_compile_Add_Sub_Mul(t *testing.T) {
 									require.Equal(t, x1+x2, env.stackTopAsUint64())
 								case wazeroir.UnsignedTypeF32:
 									exp := math.Float32frombits(uint32(x1)) + math.Float32frombits(uint32(x2))
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(float64(exp)) {
 										require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 									} else {
@@ -745,6 +746,7 @@ func TestArm64Compiler_compile_Add_Sub_Mul(t *testing.T) {
 									}
 								case wazeroir.UnsignedTypeF64:
 									exp := math.Float64frombits(x1) + math.Float64frombits(x2)
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(exp) {
 										require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 									} else {
@@ -759,6 +761,7 @@ func TestArm64Compiler_compile_Add_Sub_Mul(t *testing.T) {
 									require.Equal(t, x1-x2, env.stackTopAsUint64())
 								case wazeroir.UnsignedTypeF32:
 									exp := math.Float32frombits(uint32(x1)) - math.Float32frombits(uint32(x2))
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(float64(exp)) {
 										require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 									} else {
@@ -766,6 +769,7 @@ func TestArm64Compiler_compile_Add_Sub_Mul(t *testing.T) {
 									}
 								case wazeroir.UnsignedTypeF64:
 									exp := math.Float64frombits(x1) - math.Float64frombits(x2)
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(exp) {
 										require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 									} else {
@@ -780,6 +784,7 @@ func TestArm64Compiler_compile_Add_Sub_Mul(t *testing.T) {
 									require.Equal(t, x1*x2, env.stackTopAsUint64())
 								case wazeroir.UnsignedTypeF32:
 									exp := math.Float32frombits(uint32(x1)) * math.Float32frombits(uint32(x2))
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(float64(exp)) {
 										require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 									} else {
@@ -787,6 +792,7 @@ func TestArm64Compiler_compile_Add_Sub_Mul(t *testing.T) {
 									}
 								case wazeroir.UnsignedTypeF64:
 									exp := math.Float64frombits(x1) * math.Float64frombits(x2)
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(exp) {
 										require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 									} else {
@@ -2847,6 +2853,7 @@ func TestArm64Compiler_compile_Div_Rem(t *testing.T) {
 									}
 								case wazeroir.SignedTypeFloat32:
 									exp := math.Float32frombits(uint32(x1)) / math.Float32frombits(uint32(x2))
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(float64(exp)) {
 										require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 									} else {
@@ -2854,6 +2861,7 @@ func TestArm64Compiler_compile_Div_Rem(t *testing.T) {
 									}
 								case wazeroir.SignedTypeFloat64:
 									exp := math.Float64frombits(x1) / math.Float64frombits(x2)
+									// NaN cannot be compared with themselves, so we have to use IsNaN
 									if math.IsNaN(exp) {
 										require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 									} else {
@@ -2917,7 +2925,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := float32(math.Abs(float64(v)))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -2934,7 +2942,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := math.Abs(v)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -2951,7 +2959,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := -float32(v)
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -2968,7 +2976,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := -v
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -2985,7 +2993,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := float32(math.Ceil(float64(v)))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3002,7 +3010,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := math.Ceil(v)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3019,7 +3027,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := float32(math.Floor(float64(v)))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3036,7 +3044,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := math.Floor(v)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3053,7 +3061,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := float32(math.Trunc(float64(v)))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3070,7 +3078,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := math.Trunc(v)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3087,7 +3095,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := moremath.WasmCompatNearestF32(float32(v))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3104,7 +3112,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := moremath.WasmCompatNearestF64(v)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3121,7 +3129,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := float32(math.Sqrt(float64(v)))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3138,7 +3146,7 @@ func TestArm64Compiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.
 			verifyFunc: func(t *testing.T, v float64, raw uint64) {
 				exp := math.Sqrt(v)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3218,7 +3226,7 @@ func TestArm64Compiler_compile_Min_Max_Copysign(t *testing.T) {
 			verifyFunc: func(t *testing.T, x1, x2 float64, raw uint64) {
 				exp := float32(moremath.WasmCompatMin(float64(float32(x1)), float64(float32(x2))))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3235,7 +3243,7 @@ func TestArm64Compiler_compile_Min_Max_Copysign(t *testing.T) {
 			verifyFunc: func(t *testing.T, x1, x2 float64, raw uint64) {
 				exp := moremath.WasmCompatMin(x1, x2)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3252,7 +3260,7 @@ func TestArm64Compiler_compile_Min_Max_Copysign(t *testing.T) {
 			verifyFunc: func(t *testing.T, x1, x2 float64, raw uint64) {
 				exp := float32(moremath.WasmCompatMax(float64(float32(x1)), float64(float32(x2))))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3269,7 +3277,7 @@ func TestArm64Compiler_compile_Min_Max_Copysign(t *testing.T) {
 			verifyFunc: func(t *testing.T, x1, x2 float64, raw uint64) {
 				exp := moremath.WasmCompatMax(x1, x2)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3286,7 +3294,7 @@ func TestArm64Compiler_compile_Min_Max_Copysign(t *testing.T) {
 			verifyFunc: func(t *testing.T, x1, x2 float64, raw uint64) {
 				exp := float32(math.Copysign(float64(float32(x1)), float64(float32(x2))))
 				actual := math.Float32frombits(uint32(raw))
-				if math.IsNaN(float64(exp)) {
+				if math.IsNaN(float64(exp)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(float64(actual)))
 				} else {
 					require.Equal(t, exp, actual)
@@ -3303,7 +3311,7 @@ func TestArm64Compiler_compile_Min_Max_Copysign(t *testing.T) {
 			verifyFunc: func(t *testing.T, x1, x2 float64, raw uint64) {
 				exp := math.Copysign(x1, x2)
 				actual := math.Float64frombits(raw)
-				if math.IsNaN(exp) {
+				if math.IsNaN(exp) { // NaN cannot be compared with themselves, so we have to use IsNaN
 					require.True(t, math.IsNaN(actual))
 				} else {
 					require.Equal(t, exp, actual)

--- a/store.go
+++ b/store.go
@@ -1,6 +1,8 @@
 package wazero
 
 import (
+	"fmt"
+
 	internalwasm "github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/interpreter"
 	"github.com/tetratelabs/wazero/internal/wasm/jit"
@@ -19,7 +21,39 @@ func NewEngineJIT() *Engine { // TODO: compiler?
 	return &Engine{e: jit.NewEngine()}
 }
 
-// HostFunctions are functions written in Go, which a WebAssembly Module can import.
+// StoreConfig allows customization of a Store via NewStoreWithConfig
+type StoreConfig struct {
+	// Engine defaults to NewEngineInterpreter
+	Engine *Engine
+}
+
+func NewStore() wasm.Store {
+	return internalwasm.NewStore(interpreter.NewEngine())
+}
+
+// NewStoreWithConfig returns a store with the given configuration.
+func NewStoreWithConfig(config *StoreConfig) wasm.Store {
+	engine := config.Engine
+	if engine == nil {
+		engine = NewEngineInterpreter()
+	}
+	return internalwasm.NewStore(engine.e)
+}
+
+// InstantiateModule instantiates the module namespace or errs if the configuration was invalid.
+func InstantiateModule(store wasm.Store, module *Module) (wasm.ModuleExports, error) {
+	internal, ok := store.(*internalwasm.Store)
+	if !ok {
+		return nil, fmt.Errorf("unsupported Store implementation: %s", store)
+	}
+	return internal.Instantiate(module.wasm, module.name)
+}
+
+// ExportHostFunctions adds functions written in Go, which a WebAssembly Module can import.
+//
+// Here is a description of parameters:
+// * moduleName is the module name that these functions are imported with. Ex. wasi.ModuleSnapshotPreview1
+// * nameToGoFunc map key is the name to export and the value is the func. Ex. WASISnapshotPreview1
 //
 // Noting a context exception described later, all parameters or result types must match WebAssembly 1.0 (MVP) value
 // types. This means uint32, uint64, float32 or float64. Up to one result can be returned.
@@ -30,7 +64,7 @@ func NewEngineJIT() *Engine { // TODO: compiler?
 //		return x + y
 //	}
 //
-// Host functions may also have an initial parameter (param[0]) of type context.Context or wasm.HostFunctionCallContext.
+// Host functions may also have an initial parameter (param[0]) of type context.Context or wasm.ModuleContext.
 //
 // Ex. This uses a Go Context:
 //
@@ -39,71 +73,23 @@ func NewEngineJIT() *Engine { // TODO: compiler?
 //		return x + y + ctx.Value(extraKey).(uint32)
 //	}
 //
-// The most sophisticated context is wasm.HostFunctionCallContext, which allows access to the Go context, but also
+// The most sophisticated context is wasm.ModuleContext, which allows access to the Go context, but also
 // allows writing to memory. This is important because there are only numeric types in Wasm. The only way to share other
 // data is via writing memory and sharing offsets.
 //
 // Ex. This reads the parameters from!
 //
-//	addInts := func(ctx wasm.HostFunctionCallContext, offset uint32) uint32 {
+//	addInts := func(ctx wasm.ModuleContext, offset uint32) uint32 {
 //		x, _ := ctx.Memory().ReadUint32Le(offset)
 //		y, _ := ctx.Memory().ReadUint32Le(offset + 4) // 32 bits == 4 bytes!
 //		return x + y
 //	}
 //
-// See https://www.w3.org/TR/wasm-core-1/#value-types%E2%91%A0
-type HostFunctions struct {
-	nameToHostFunction map[string]*internalwasm.HostFunction
-}
-
-// NewHostFunctions returns host functions to export. The map key is the name to export and the value is the function.
-// See HostFunctions documentation for notes on writing host functions.
-func NewHostFunctions(nameToGoFunc map[string]interface{}) (ret *HostFunctions, err error) {
-	ret = &HostFunctions{make(map[string]*internalwasm.HostFunction, len(nameToGoFunc))}
-	for name, goFunc := range nameToGoFunc {
-		if ret.nameToHostFunction[name], err = internalwasm.NewHostFunction(name, goFunc); err != nil {
-			return nil, err
-		}
+// See https://www.w3.org/TR/wasm-core-1/#host-functions%E2%91%A2
+func ExportHostFunctions(store wasm.Store, moduleName string, nameToGoFunc map[string]interface{}) (wasm.HostExports, error) {
+	internal, ok := store.(*internalwasm.Store)
+	if !ok {
+		return nil, fmt.Errorf("unsupported Store implementation: %s", store)
 	}
-	return
-}
-
-// StoreConfig allows customization of a Store via NewStoreWithConfig
-type StoreConfig struct {
-	// Engine defaults to NewEngineInterpreter
-	Engine *Engine
-	// ModuleToHostFunctions include any module to host function exports
-	ModuleToHostFunctions map[string]*HostFunctions
-}
-
-func NewStore() *Store {
-	return &Store{s: internalwasm.NewStore(interpreter.NewEngine())}
-}
-
-// NewStoreWithConfig returns a store with the given configuration or errs if there was a problem registering a host
-// function (such as WASI).
-func NewStoreWithConfig(config *StoreConfig) (*Store, error) {
-	engine := config.Engine
-	if engine == nil {
-		engine = NewEngineInterpreter()
-	}
-	s := internalwasm.NewStore(engine.e)
-	if config.ModuleToHostFunctions != nil {
-		for m, hfs := range config.ModuleToHostFunctions {
-			for _, hf := range hfs.nameToHostFunction {
-				if err := s.AddHostFunction(m, hf); err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
-	return &Store{s: s}, nil
-}
-
-type Store struct {
-	s *internalwasm.Store
-}
-
-func (s *Store) Instantiate(module *Module) (wasm.ModuleFunctions, error) {
-	return s.s.Instantiate(module.m, module.name)
+	return internal.ExportHostFunctions(moduleName, nameToGoFunc)
 }

--- a/tests/bench/testdata/case.go
+++ b/tests/bench/testdata/case.go
@@ -22,7 +22,7 @@ func allocateBuffer(size uint32) *byte {
 //export get_random_string
 func getRandomStringRaw(retBufPtr **byte, retBufSize *int)
 
-// Get randm string from the hosts.
+// Get random string from the hosts.
 func getRandmString() string {
 	var bufPtr *byte
 	var bufSize int

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -268,10 +268,6 @@ func testImportedAndExportedFunc(t *testing.T, newEngine func() *wazero.Engine) 
 	require.Equal(t, []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0}, memory.Buffer[0:10])
 }
 
-func TestHostFunctions(t *testing.T) {
-	testHostFunctions(t, wazero.NewEngineInterpreter)
-}
-
 //  testHostFunctions ensures arg0 is optionally a context, and fails if a float parameter corrupts a host function value
 func testHostFunctions(t *testing.T, newEngine func() *wazero.Engine) {
 	ctx := context.Background()

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -42,30 +42,29 @@ var (
 
 func runTests(t *testing.T, newEngine func() *wazero.Engine) {
 	t.Run("fibonacci", func(t *testing.T) {
-		fibonacci(t, newEngine)
+		testFibonacci(t, newEngine)
 	})
 	t.Run("fac", func(t *testing.T) {
-		fac(t, newEngine)
+		testFac(t, newEngine)
 	})
 	t.Run("unreachable", func(t *testing.T) {
-		unreachable(t, newEngine)
+		testUnreachable(t, newEngine)
 	})
 	t.Run("memory", func(t *testing.T) {
-		memory(t, newEngine)
+		testMemory(t, newEngine)
 	})
 	t.Run("recursive entry", func(t *testing.T) {
-		recursiveEntry(t, newEngine)
+		testRecursiveEntry(t, newEngine)
 	})
 	t.Run("imported-and-exported func", func(t *testing.T) {
-		importedAndExportedFunc(t, newEngine)
+		testImportedAndExportedFunc(t, newEngine)
 	})
-	t.Run("host function with float32 type", func(t *testing.T) {
-		hostFunctions(t, newEngine)
+	t.Run("host function with float type", func(t *testing.T) {
+		testHostFunctions(t, newEngine)
 	})
 }
 
-func fibonacci(t *testing.T, newEngine func() *wazero.Engine) {
-	ctx := context.Background()
+func testFibonacci(t *testing.T, newEngine func() *wazero.Engine) {
 	mod, err := wazero.DecodeModuleBinary(fibWasm)
 	require.NoError(t, err)
 
@@ -77,27 +76,27 @@ func fibonacci(t *testing.T, newEngine func() *wazero.Engine) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+			store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+			exports, err := wazero.InstantiateModule(store, mod)
 			require.NoError(t, err)
-			m, err := store.Instantiate(mod)
-			require.NoError(t, err)
-			fib, ok := m.GetFunctionI64Return("fib")
+
+			fib, ok := exports.Function("fib")
 			require.True(t, ok)
-			out, err := fib(ctx, 20)
+
+			results, err := fib(context.Background(), 20)
 			require.NoError(t, err)
-			require.Equal(t, uint64(10946), out)
+
+			require.Equal(t, uint64(10946), results[0])
 		}()
 	}
 	wg.Wait()
 }
 
-func fac(t *testing.T, newEngine func() *wazero.Engine) {
-	ctx := context.Background()
+func testFac(t *testing.T, newEngine func() *wazero.Engine) {
 	mod, err := wazero.DecodeModuleBinary(facWasm)
 	require.NoError(t, err)
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
-	require.NoError(t, err)
-	m, err := store.Instantiate(mod)
+	store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+	exports, err := wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
 	for _, name := range []string{
 		"fac-rec",
@@ -107,46 +106,50 @@ func fac(t *testing.T, newEngine func() *wazero.Engine) {
 		"fac-opt",
 	} {
 		name := name
-		fac, ok := m.GetFunctionI64Return(name)
+
+		fac, ok := exports.Function("fac")
 		require.True(t, ok)
+
 		t.Run(name, func(t *testing.T) {
-			out, err := fac(ctx, 25)
+			results, err := fac(context.Background(), 25)
 			require.NoError(t, err)
-			require.Equal(t, uint64(7034535277573963776), out)
+			require.Equal(t, uint64(7034535277573963776), results[0])
 		})
 	}
-	fac, ok := m.GetFunctionI64Return("fac-rec")
-	require.True(t, ok)
-	_, err = fac(ctx, 1073741824)
-	require.ErrorIs(t, err, wasm.ErrRuntimeCallStackOverflow)
+
+	t.Run("fac-rec - stack overflow", func(t *testing.T) {
+		fac, ok := exports.Function("fac-rec")
+		require.True(t, ok)
+
+		_, err := fac(context.Background(), 1073741824)
+		require.ErrorIs(t, err, wasm.ErrRuntimeCallStackOverflow)
+	})
 }
 
-func unreachable(t *testing.T, newEngine func() *wazero.Engine) {
-	ctx := context.Background()
+func testUnreachable(t *testing.T, newEngine func() *wazero.Engine) {
 	mod, err := wazero.DecodeModuleBinary(unreachableWasm)
 	require.NoError(t, err)
 
-	callUnreachable := func(ctx publicwasm.HostFunctionCallContext) {
-		fn, ok := ctx.Functions().GetFunctionVoidReturn("unreachable_func")
+	callUnreachable := func(ctx publicwasm.ModuleContext) {
+		unreachable, ok := ctx.Function("unreachable_func")
 		require.True(t, ok)
-		require.NoError(t, fn(ctx.Context()))
+
+		_, err := unreachable(ctx.Context())
+		require.NoError(t, err)
 	}
-	hostFuncs, err := wazero.NewHostFunctions(map[string]interface{}{"cause_unreachable": callUnreachable})
+
+	store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+
+	_, err = wazero.ExportHostFunctions(store, "host", map[string]interface{}{"cause_unreachable": callUnreachable})
 	require.NoError(t, err)
 
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		Engine:                newEngine(),
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{"host": hostFuncs},
-	})
+	exports, err := wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
 
-	m, err := store.Instantiate(mod)
-	require.NoError(t, err)
-
-	main, ok := m.GetFunctionVoidReturn("main")
+	main, ok := exports.Function("main")
 	require.True(t, ok)
 
-	err = main(ctx)
+	_, err = main(context.Background())
 	exp := `wasm runtime error: unreachable
 wasm backtrace:
 	0: unreachable_func
@@ -158,78 +161,73 @@ wasm backtrace:
 	require.Equal(t, exp, err.Error())
 }
 
-func memory(t *testing.T, newEngine func() *wazero.Engine) {
-	ctx := context.Background()
+func testMemory(t *testing.T, newEngine func() *wazero.Engine) {
 	mod, err := wazero.DecodeModuleBinary(memoryWasm)
 	require.NoError(t, err)
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+	store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+	exports, err := wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
-	m, err := store.Instantiate(mod)
-	require.NoError(t, err)
+
+	size, ok := exports.Function("size")
+	require.True(t, ok)
 
 	// First, we have zero-length memory instance.
-	size, ok := m.GetFunctionI32Return("size")
-	require.True(t, ok)
-	out, err := size(ctx)
+	results, err := size(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), out)
+	require.Equal(t, uint64(0), results[0])
+
+	grow, ok := exports.Function("grow")
+	require.True(t, ok)
 
 	// Then grow the memory.
-	grow, ok := m.GetFunctionI32Return("grow")
-	require.True(t, ok)
-	newPages := uint32(10)
-
-	out, err = grow(ctx, uint64(newPages))
+	newPages := uint64(10)
+	results, err = grow(context.Background(), newPages)
 	require.NoError(t, err)
+
 	// Grow returns the previous number of memory pages, namely zero.
-	require.Equal(t, uint32(0), out)
+	require.Equal(t, uint64(0), results[0])
 
 	// Now size should return the new pages -- 10.
-	out, err = size(ctx)
+	results, err = size(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, newPages, out)
+	require.Equal(t, newPages, results[0])
 
 	// Growing memory with zero pages is valid but should be noop.
-	out, err = grow(ctx, 0)
+	results, err = grow(context.Background(), 0)
 	require.NoError(t, err)
-	require.Equal(t, newPages, out)
+	require.Equal(t, newPages, results[0])
 }
 
-func recursiveEntry(t *testing.T, newEngine func() *wazero.Engine) {
-	ctx := context.Background()
+func testRecursiveEntry(t *testing.T, newEngine func() *wazero.Engine) {
 	mod, err := wazero.DecodeModuleBinary(recursiveWasm)
 	require.NoError(t, err)
 
-	hostfunc := func(ctx publicwasm.HostFunctionCallContext) {
-		fn, ok := ctx.Functions().GetFunctionI32Return("called_by_host_func")
+	hostfunc := func(ctx publicwasm.ModuleContext) {
+		fn, ok := ctx.Function("called_by_host_func")
 		require.True(t, ok)
-		_, err := fn(ctx.Context())
+
+		_, err = fn(ctx.Context())
 		require.NoError(t, err)
 	}
 
-	hostFuncs, err := wazero.NewHostFunctions(map[string]interface{}{"host_func": hostfunc})
+	store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+
+	_, err = wazero.ExportHostFunctions(store, "env", map[string]interface{}{"host_func": hostfunc})
 	require.NoError(t, err)
 
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		Engine:                newEngine(),
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{"env": hostFuncs},
-	})
+	exports, err := wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
 
-	m, err := store.Instantiate(mod)
-	require.NoError(t, err)
-
-	main, ok := m.GetFunctionVoidReturn("main")
+	main, ok := exports.Function("main")
 	require.True(t, ok)
 
-	err = main(ctx, 1)
+	_, err = main(context.Background(), 1)
 	require.NoError(t, err)
 }
 
-// importedAndExportedFunc fails if the engine cannot call an "imported-and-then-exported-back" function
-// Notably, this uses memory, which ensures wasm.HostFunctionCallContext is valid in both interpreter and JIT engines.
-func importedAndExportedFunc(t *testing.T, newEngine func() *wazero.Engine) {
-	ctx := context.Background()
+// testImportedAndExportedFunc fails if the engine cannot call an "imported-and-then-exported-back" function
+// Notably, this uses memory, which ensures wasm.ModuleContext is valid in both interpreter and JIT engines.
+func testImportedAndExportedFunc(t *testing.T, newEngine func() *wazero.Engine) {
 	mod, err := wazero.DecodeModuleText([]byte(`(module $test
 		(import "" "store_int"
 			(func $store_int (param $offset i32) (param $val i64) (result (;errno;) i32)))
@@ -241,41 +239,41 @@ func importedAndExportedFunc(t *testing.T, newEngine func() *wazero.Engine) {
 	require.NoError(t, err)
 
 	var memory *wasm.MemoryInstance
-	storeInt := func(ctx publicwasm.HostFunctionCallContext, offset uint32, val uint64) uint32 {
+	storeInt := func(ctx publicwasm.ModuleContext, offset uint32, val uint64) uint32 {
 		if !ctx.Memory().WriteUint64Le(offset, val) {
 			return 1
 		}
-		// sneak a reference to the memory so we can check it later
+		// sneak a reference to the memory, so we can check it later
 		memory = ctx.Memory().(*wasm.MemoryInstance)
 		return 0
 	}
 
-	hostFuncs, err := wazero.NewHostFunctions(map[string]interface{}{"store_int": storeInt})
+	store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+
+	_, err = wazero.ExportHostFunctions(store, "", map[string]interface{}{"store_int": storeInt})
 	require.NoError(t, err)
 
-	store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-		Engine:                newEngine(),
-		ModuleToHostFunctions: map[string]*wazero.HostFunctions{"": hostFuncs},
-	})
-	require.NoError(t, err)
-
-	m, err := store.Instantiate(mod)
+	exports, err := wazero.InstantiateModule(store, mod)
 	require.NoError(t, err)
 
 	// Call store_int and ensure it didn't return an error code.
-	storeIntFn, ok := m.GetFunctionI32Return("store_int")
+	storeIntFn, ok := exports.Function("store_int")
 	require.True(t, ok)
 
-	result, err := storeIntFn(ctx, 1, math.MaxUint64)
+	results, err := storeIntFn(context.Background(), 1, math.MaxUint64)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), result)
+	require.Equal(t, uint64(0), results[0])
 
 	// Since offset=1 and val=math.MaxUint64, we expect to have written exactly 8 bytes, with all bits set, at index 1.
 	require.Equal(t, []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0}, memory.Buffer[0:10])
 }
 
-//  hostFunctions ensures arg0 is optionally a context, and fails if a float parameter corrupts a host function value
-func hostFunctions(t *testing.T, newEngine func() *wazero.Engine) {
+func TestHostFunctions(t *testing.T) {
+	testHostFunctions(t, wazero.NewEngineInterpreter)
+}
+
+//  testHostFunctions ensures arg0 is optionally a context, and fails if a float parameter corrupts a host function value
+func testHostFunctions(t *testing.T, newEngine func() *wazero.Engine) {
 	ctx := context.Background()
 	mod, err := wazero.DecodeModuleText([]byte(`(module $test
 	;; these imports return the input param
@@ -296,16 +294,15 @@ func hostFunctions(t *testing.T, newEngine func() *wazero.Engine) {
 )`))
 	require.NoError(t, err)
 
-	floatFuncs, err := wazero.NewHostFunctions(map[string]interface{}{
+	floatFuncs := map[string]interface{}{
 		"identity_f32": func(value float32) float32 {
 			return value
 		},
 		"identity_f64": func(value float64) float64 {
 			return value
-		}})
-	require.NoError(t, err)
+		}}
 
-	floatFuncsGoContext, err := wazero.NewHostFunctions(map[string]interface{}{
+	floatFuncsGoContext := map[string]interface{}{
 		"identity_f32": func(funcCtx context.Context, value float32) float32 {
 			require.Equal(t, ctx, funcCtx)
 			return value
@@ -313,52 +310,52 @@ func hostFunctions(t *testing.T, newEngine func() *wazero.Engine) {
 		"identity_f64": func(funcCtx context.Context, value float64) float64 {
 			require.Equal(t, ctx, funcCtx)
 			return value
-		}})
-	require.NoError(t, err)
+		}}
 
-	floatFuncsHostFunctionCallContext, err := wazero.NewHostFunctions(map[string]interface{}{
-		"identity_f32": func(funcCtx publicwasm.HostFunctionCallContext, value float32) float32 {
+	floatFuncsModuleContext := map[string]interface{}{
+		"identity_f32": func(funcCtx publicwasm.ModuleContext, value float32) float32 {
 			require.Equal(t, ctx, funcCtx.Context())
 			return value
 		},
-		"identity_f64": func(funcCtx publicwasm.HostFunctionCallContext, value float64) float64 {
+		"identity_f64": func(funcCtx publicwasm.ModuleContext, value float64) float64 {
 			require.Equal(t, ctx, funcCtx.Context())
 			return value
-		}})
-	require.NoError(t, err)
+		}}
 
-	for k, v := range map[string]*wazero.HostFunctions{
-		"":                                floatFuncs,
-		" - context.Context":              floatFuncsGoContext,
-		" - wasm.HostFunctionCallContext": floatFuncsHostFunctionCallContext,
+	for k, v := range map[string]map[string]interface{}{
+		"":                      floatFuncs,
+		" - context.Context":    floatFuncsGoContext,
+		" - wasm.ModuleContext": floatFuncsModuleContext,
 	} {
-		store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{
-			Engine:                newEngine(),
-			ModuleToHostFunctions: map[string]*wazero.HostFunctions{"host": v},
-		})
+		store := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: newEngine()})
+
+		_, err = wazero.ExportHostFunctions(store, "host", v)
 		require.NoError(t, err)
 
-		m, err := store.Instantiate(mod)
+		m, err := wazero.InstantiateModule(store, mod)
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("host function with f32 param%s", k), func(t *testing.T) {
-			fn, ok := m.GetFunctionF32Return("call->test.identity_f32")
+			name := "call->test.identity_f32"
+			input := float32(math.MaxFloat32)
+
+			fn, ok := m.Function(name)
 			require.True(t, ok)
 
-			f32 := float32(math.MaxFloat32)
-			result, err := fn(ctx, uint64(math.Float32bits(f32))) // float bits are a uint32 value, call requires uint64
+			results, err := fn(ctx, publicwasm.EncodeF32(input)) // float bits are a uint32 value, call requires uint64
 			require.NoError(t, err)
-			require.Equal(t, f32, result)
+			require.Equal(t, input, publicwasm.DecodeF32(results[0]))
 		})
 
 		t.Run(fmt.Sprintf("host function with f64 param%s", k), func(t *testing.T) {
-			fn, ok := m.GetFunctionF64Return("call->test.identity_f64")
+			name := "call->test.identity_f64"
+			input := math.MaxFloat64
+			fn, ok := m.Function(name)
 			require.True(t, ok)
 
-			f64 := math.MaxFloat64
-			result, err := fn(ctx, math.Float64bits(f64))
+			results, err := fn(ctx, publicwasm.EncodeF64(input))
 			require.NoError(t, err)
-			require.Equal(t, f64, result)
+			require.Equal(t, input, publicwasm.DecodeF64(results[0]))
 		})
 	}
 }

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -440,7 +440,7 @@ func requireValueEq(t *testing.T, actual, expected uint64, valType wasm.ValueTyp
 	case wasm.ValueTypeF32:
 		expF := math.Float32frombits(uint32(expected))
 		actualF := math.Float32frombits(uint32(actual))
-		if math.IsNaN(float64(expF)) {
+		if math.IsNaN(float64(expF)) { // NaN cannot be compared with themselves, so we have to use IsNaN
 			require.True(t, math.IsNaN(float64(actualF)), msg)
 		} else {
 			require.Equal(t, expF, actualF, msg)
@@ -448,7 +448,7 @@ func requireValueEq(t *testing.T, actual, expected uint64, valType wasm.ValueTyp
 	case wasm.ValueTypeF64:
 		expF := math.Float64frombits(expected)
 		actualF := math.Float64frombits(actual)
-		if math.IsNaN(expF) {
+		if math.IsNaN(expF) { // NaN cannot be compared with themselves, so we have to use IsNaN
 			require.True(t, math.IsNaN(actualF), msg)
 		} else {
 			require.Equal(t, expF, actualF, msg)

--- a/wasi.go
+++ b/wasi.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	internalwasi "github.com/tetratelabs/wazero/internal/wasi"
+	internalwasm "github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/wasi"
 	"github.com/tetratelabs/wazero/wasm"
 )
@@ -32,12 +33,12 @@ type WASIConfig struct {
 }
 
 // WASISnapshotPreview1 are functions to export as wasi.ModuleSnapshotPreview1
-func WASISnapshotPreview1() *HostFunctions {
+func WASISnapshotPreview1() map[string]interface{} {
 	return WASISnapshotPreview1WithConfig(&WASIConfig{})
 }
 
 // WASISnapshotPreview1WithConfig are functions to export as wasi.ModuleSnapshotPreview1
-func WASISnapshotPreview1WithConfig(c *WASIConfig) *HostFunctions {
+func WASISnapshotPreview1WithConfig(c *WASIConfig) map[string]interface{} {
 	// TODO: delete the internalwasi.Option types as they are not accessible as they are internal!
 	var opts []internalwasi.Option
 	if c.Stdin != nil {
@@ -57,7 +58,7 @@ func WASISnapshotPreview1WithConfig(c *WASIConfig) *HostFunctions {
 		opts = append(opts, opt)
 	}
 	if len(c.Environ) > 0 {
-		environ := make([]string, len(c.Environ))
+		environ := make([]string, 0, len(c.Environ))
 		for k, v := range c.Environ {
 			environ = append(environ, fmt.Sprintf("%s=%s", k, v))
 		}
@@ -72,12 +73,7 @@ func WASISnapshotPreview1WithConfig(c *WASIConfig) *HostFunctions {
 			opts = append(opts, internalwasi.Preopen(k, v))
 		}
 	}
-	_, nameToGoFunc := internalwasi.SnapshotPreview1Functions(opts...)
-	hostFunctions, err := NewHostFunctions(nameToGoFunc)
-	if err != nil {
-		panic(fmt.Errorf("BUG: %w", err)) // panic for ease of API as SnapshotPreview1Functions are tested
-	}
-	return hostFunctions
+	return internalwasi.SnapshotPreview1Functions(opts...)
 }
 
 // StartWASICommand instantiates the module and starts its WASI Command function ("_start"). The return value are all
@@ -89,22 +85,26 @@ func WASISnapshotPreview1WithConfig(c *WASIConfig) *HostFunctions {
 // * "memory" is an exported memory.
 //
 // Note: Exporting "__indirect_function_table" is mentioned as required, but not enforced here.
-// Note: The wasm.ModuleFunctions return value does not restrict exports after "_start" as allowed in the specification.
+// Note: The wasm.Functions return value does not restrict exports after "_start" as allowed in the specification.
 // Note: All TinyGo Wasm are WASI commands. They initialize memory on "_start" and import "fd_write" to implement panic.
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/design/application-abi.md#current-unstable-abi
-func StartWASICommand(store *Store, module *Module) (wasm.ModuleFunctions, error) {
-	if err := internalwasi.ValidateWASICommand(module.m, module.name); err != nil {
+func StartWASICommand(store wasm.Store, module *Module) (wasm.ModuleExports, error) {
+	internal, ok := store.(*internalwasm.Store)
+	if !ok {
+		return nil, fmt.Errorf("unsupported Store implementation: %s", store)
+	}
+	if err := internalwasi.ValidateWASICommand(module.wasm, module.name); err != nil {
 		return nil, err
 	}
 
-	ret, err := store.Instantiate(module)
+	ret, err := InstantiateModule(store, module)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx := store.s.HostFunctionCallContexts[module.name]
-	start, _ := ctx.GetFunctionVoidReturn(internalwasi.FunctionStart)
-	if err = start(ctx.Context()); err != nil {
+	ctx := internal.ModuleContexts[module.name]
+	start, _ := ctx.Function(internalwasi.FunctionStart)
+	if _, err = start(ctx.Context()); err != nil {
 		return nil, fmt.Errorf("module[%s] function[%s] failed: %w", module.name, internalwasi.FunctionStart, err)
 	}
 	return ret, nil

--- a/wasm.go
+++ b/wasm.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DecodeModule parses the configured source into a Module. This function returns when the source is exhausted or
-// an error occurs. The result can be initialized for use via Store.Instantiate.
+// an error occurs. The result can be initialized for use via InstantiateModule.
 //
 // Here's a description of the return values:
 // * result is the module parsed or nil on error
@@ -32,7 +32,7 @@ func decodeModule(decoder internalwasm.DecodeModule, source []byte) (*Module, er
 	if m.NameSection != nil {
 		name = m.NameSection.ModuleName
 	}
-	return &Module{m: m, name: name}, nil
+	return &Module{wasm: m, name: name}, nil
 }
 
 // EncodeModule encodes the given module into a byte slice depending on the format of the implementation.
@@ -44,12 +44,13 @@ var EncodeModuleBinary EncodeModule = func(m *Module) []byte {
 }
 
 func encodeModule(encoder internalwasm.EncodeModule, m *Module) []byte {
-	return encoder(m.m)
+	return encoder(m.wasm)
 }
 
+// Module is a WebAssembly 1.0 (MVP) module decoded (DecodeModule) from a valid source.
 type Module struct {
-	m    *internalwasm.Module
 	name string
+	wasm *internalwasm.Module
 }
 
 // Name defaults to what's decoded from the custom name section and can be overridden WithName.

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -3,56 +3,81 @@ package wasm
 
 import (
 	"context"
+	"math"
 )
 
-// ModuleFunctions return functions available in a module, post-instantiation.
-//
-// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
-// Note: This includes all return types available in WebAssembly 1.0 (MVP).
-type ModuleFunctions interface {
-	// GetFunctionVoidReturn returns a void-return function for this module or false if it isn't available under that
-	// name or has a different return.
-	GetFunctionVoidReturn(name string) (FunctionVoidReturn, bool)
+// Store allows access to instantiated modules and host functions
+type Store interface {
+	// ModuleExports returns exports from an instantiated module or false if it wasn't.
+	ModuleExports(moduleName string) (ModuleExports, bool)
 
-	// GetFunctionI32Return returns a ValueTypeI32-return function for this module or false if it isn't available under
-	// that name or has a different return.
-	GetFunctionI32Return(name string) (FunctionI32Return, bool)
-
-	// GetFunctionI64Return returns a ValueTypeI64-return function for this module or false if it isn't available under
-	// that name or has a different return.
-	GetFunctionI64Return(name string) (FunctionI64Return, bool)
-
-	// GetFunctionF32Return returns a ValueTypeF32-return function for this module or false if it isn't available under
-	// that name or has a different return.
-	GetFunctionF32Return(name string) (FunctionF32Return, bool)
-
-	// GetFunctionF64Return returns a ValueTypeF64-return function for this module or false if it isn't available under
-	// that name or has a different return.
-	GetFunctionF64Return(name string) (FunctionF64Return, bool)
+	// HostExports returns exported host functions for the moduleName or false there are none.
+	HostExports(moduleName string) (HostExports, bool)
 }
 
-type FunctionVoidReturn func(ctx context.Context, params ...uint64) error
-type FunctionI32Return func(ctx context.Context, params ...uint64) (uint32, error)
-type FunctionI64Return func(ctx context.Context, params ...uint64) (uint64, error)
-type FunctionF32Return func(ctx context.Context, params ...uint64) (float32, error)
-type FunctionF64Return func(ctx context.Context, params ...uint64) (float64, error)
-
-// HostFunctionCallContext is the first argument of all host functions.
+// ModuleExports return functions exported in a module, post-instantiation.
 //
 // Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
-type HostFunctionCallContext interface {
+type ModuleExports interface {
+	// Function returns a function exported from this module or false if it wasn't.
+	Function(name string) (Function, bool)
+}
+
+// Function is an advanced API allowing efficient invocation of WebAssembly 1.0 (MVP) functions, given predefined
+// knowledge about the function signature. An error is returned for any failure looking up or invoking the function including
+// signature mismatch.
+//
+// Web Assembly 1.0 (MVP) Value Type Conversion:
+//  * I32 - uint64(uint32,int32,int64)
+//  * I64 - uint64
+//  * F32 - EncodeF32 DecodeF32 from float32
+//  * F64 - EncodeF64 DecodeF64 from float64
+//
+// Ex. Given a Text Format type use (param i64) (result i64)
+//
+//	results, _ := fn(ctx, input)
+//	result := result[0]
+//
+// Ex. Given a Text Format type use (param f64) (result f64)
+//
+//	results, _ := fn(ctx, wasm.EncodeF64(input))
+//	result := wasm.DecodeF64(result[0])
+//
+// Note: The ctx parameter will be the outer-most ancestor of ModuleContext.Context
+// ctx will default to context.Background() is nil is passed.
+// See https://www.w3.org/TR/wasm-core-1/#binary-valtype
+type Function func(ctx context.Context, params ...uint64) ([]uint64, error)
+
+// HostExports return functions defined in Go, a.k.a. "Host Functions" in WebAssembly 1.0 (MVP).
+//
+// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
+// See https://www.w3.org/TR/wasm-core-1/#syntax-hostfunc
+type HostExports interface {
+	// Function returns a function in this module or false if it isn't available under that name.
+	Function(name string) (HostFunction, bool)
+}
+
+// HostFunction is like a Function, except it is implemented in Go. This is a "Host Function" in WebAssembly 1.0 (MVP).
+//
+// Note: The usage is the same as Function, except it must be called from an importing module (ctx). The errs if the
+// module did not import this function!
+// See https://www.w3.org/TR/wasm-core-1/#syntax-hostfunc
+type HostFunction func(ctx ModuleContext, params ...uint64) ([]uint64, error)
+
+// ModuleContext is the first argument of a HostFunction.
+//
+// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
+type ModuleContext interface {
 	// Context returns the host call's context.
 	//
 	// The returned context is always non-nil; it defaults to the background context.
 	Context() context.Context
 
-	// Memory returns a potentially zero memory for the importing module
+	// Memory returns a potentially zero memory of the importing module
 	Memory() Memory
 
-	// Functions returns the importing module's functions.
-	//
-	// Note: The main use case for this is callbacks.
-	Functions() ModuleFunctions
+	// Function returns a function exported from this module or false if it wasn't.
+	Function(name string) (Function, bool)
 }
 
 // Memory allows restricted access to a module's memory. Notably, this does not allow growing.
@@ -108,4 +133,28 @@ type Memory interface {
 
 	// Write writes the slice to the underlying buffer at the offset or returns false if out of range.
 	Write(offset uint32, v []byte) bool
+}
+
+// EncodeF32 converts the input so that it can be used as a Function F32 parameter or result.
+// See DecodeF32
+func EncodeF32(input float32) uint64 {
+	return uint64(math.Float32bits(input))
+}
+
+// DecodeF32 converts the Function F32 parameter or result to a float32.
+// See DecodeF32
+func DecodeF32(input uint64) float32 {
+	return float32(math.Float64frombits(input))
+}
+
+// EncodeF64 converts the input so that it can be used as a Function F64 parameter or result.
+// See DecodeF64
+func EncodeF64(input float64) uint64 {
+	return math.Float64bits(input)
+}
+
+// DecodeF64 converts the Function F64 parameter or result to a float64.
+// See DecodeF64
+func DecodeF64(res uint64) float64 {
+	return math.Float64frombits(res)
 }

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -144,7 +144,7 @@ func EncodeF32(input float32) uint64 {
 // DecodeF32 converts the Function F32 parameter or result to a float32.
 // See DecodeF32
 func DecodeF32(input uint64) float32 {
-	return float32(math.Float64frombits(input))
+	return math.Float32frombits(uint32(input))
 }
 
 // EncodeF64 converts the input so that it can be used as a Function F64 parameter or result.

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -154,7 +154,7 @@ func EncodeF64(input float64) uint64 {
 }
 
 // DecodeF64 converts the Function F64 parameter or result to a float64.
-// See DecodeF64
-func DecodeF64(res uint64) float64 {
-	return math.Float64frombits(res)
+// See EncodeF64
+func DecodeF64(input uint64) float64 {
+	return math.Float64frombits(input)
 }

--- a/wasm/wasm_test.go
+++ b/wasm/wasm_test.go
@@ -1,0 +1,53 @@
+package wasm
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecodeF32(t *testing.T) {
+	for _, v := range []float32{
+		0, 100, -100, 1, -1,
+		100.01234124, -100.01234124, 200.12315,
+		math.MaxFloat32,
+		math.SmallestNonzeroFloat32,
+		float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN()),
+	} {
+		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
+			encoded := EncodeF32(v)
+			decoded := DecodeF32(encoded)
+			if math.IsNaN(float64(decoded)) { // NaN cannot be compared with themselves, so we have to use IsNaN
+				require.True(t, math.IsNaN(float64(decoded)))
+			} else {
+				require.Equal(t, v, decoded)
+			}
+		})
+	}
+}
+
+func TestEncodeDecodeF64(t *testing.T) {
+	for _, v := range []float64{
+		0, 100, -100, 1, -1,
+		100.01234124, -100.01234124, 200.12315,
+		math.MaxFloat32,
+		math.SmallestNonzeroFloat32,
+		math.MaxFloat64,
+		math.SmallestNonzeroFloat64,
+		6.8719476736e+10,  /* = 1 << 36 */
+		1.37438953472e+11, /* = 1 << 37 */
+		math.Inf(1), math.Inf(-1), math.NaN(),
+	} {
+		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
+			encoded := EncodeF64(v)
+			decoded := DecodeF64(encoded)
+			if math.IsNaN(decoded) { // cannot use require.Equal as NaN by definition doesn't equal itself
+				require.True(t, math.IsNaN(decoded))
+			} else {
+				require.Equal(t, v, decoded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds this interface `wasm.Store` which gives access to functions in
a store without leaking an API to change the store. This is primarily to
support configuration use cases where post-initialization, there's no
need or desire to mutate the store. This also backfills codecs needed to
handle float results.

```go
// Store allows access to instantiated modules and host functions
type Store interface {
	// ModuleExports returns exports from an instantiated module or false if it wasn't.
	ModuleExports(moduleName string) (ModuleExports, bool)

	// HostExports returns exported host functions for the moduleName or false there are none.
	HostExports(moduleName string) (HostExports, bool)
}
```

While `ModuleExports` are returned on `wazero.InstantiateModule`, they can also be accessed by module name later. Here's an example of decoupling where central configuration configures the store and plugins use it:
```go
// Config wiring can instantiate the store and locate the name of the function desired
exports, _ := store.ModuleExports("math")
addFloat, _ := exports.Function("AddFloat")

// That function could be used directly or implement a friendlier interface.
results, _ := addFloat(context.Background(), wasm.EncodeF64(1.5),
wasm.EncodeF64(1.5))
res := wasm.DecodeF64(result[0])) // 3.0!
```

This design also allows unwinding of function dependencies, ex where a host function needs to use another host function:
```go
	// built-in WASI function to write a random value to memory
	randomGet := func(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno {
		panic("unimplemented")
	}

	goFunc := func(ctx wasm.ModuleContext) {
		// Write 8 random bytes to memory using WASI.
		errno := randomGet(ctx, 0, 8)
	--snip--

	// Configure WASI and implement the function to use it
	we, err := wazero.ExportHostFunctions(store, wasi.ModuleSnapshotPreview1, wazero.WASISnapshotPreview1())
	require.NoError(t, err)
	randomGetFn, ok := we.Function("random_get")
	require.True(t, ok)

	// Implement the function pointer. This mainly shows how you can decouple a host function dependency.
	randomGet = func(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno {
		res, err := randomGetFn(ctx, uint64(buf), uint64(bufLen))
		require.NoError(t, err)
		return wasi.Errno(res[0])
	}
```

Ancillary changes:
* `NewStoreWithConfig()` no longer returns an error or takes host function config
* `HostFunctionCallContext` has been renamed to `ModuleContext`
* `wasi.Errno` was converted back to a uint32 alias to match mapped types