### PR TITLE
Adds ModuleExports.Memory and renames Memory.Len to Memory.Size

### DIFF
--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -187,7 +187,7 @@ type SnapshotPreview1 interface {
 	//
 	// * argv - is the offset to begin writing argument offsets in uint32 little-endian encoding.
 	//   * ArgsSizesGet result argc * 4 bytes are written to this offset
-	// * argvBuf - is the offset to write the null terminated arguments to wasm.MemoryInstance
+	// * argvBuf - is the offset to write the null terminated arguments to ctx.Memory
 	//   * ArgsSizesGet result argv_buf_size bytes are written to this offset
 	//
 	// For example, if ArgsSizesGet wrote argc=2 and argvBufSize=5 for arguments: "a" and "bc"
@@ -215,8 +215,8 @@ type SnapshotPreview1 interface {
 	// corresponding sizes in uint32 little-endian encoding. If either are invalid due to memory constraints, this
 	// returns ErrnoFault.
 	//
-	// * resultArgc - is the offset to write the argument count to wasm.Memory
-	// * resultArgvBufSize - is the offset to write the null-terminated argument length to wasm.Memory
+	// * resultArgc - is the offset to write the argument count to ctx.Memory
+	// * resultArgvBufSize - is the offset to write the null-terminated argument length to ctx.Memory
 	//
 	// For example, if Args are []string{"a","bc"} and
 	//   ArgsSizesGet parameters resultArgc=1 and resultArgvBufSize=6, we expect `ctx.Memory` to contain:
@@ -243,7 +243,7 @@ type SnapshotPreview1 interface {
 	//
 	// * environ - is the offset to begin writing environment variables offsets in uint32 little-endian encoding.
 	//   * EnvironSizesGet result environc * 4 bytes are written to this offset
-	// * environBuf - is the offset to write the environment variables to wasm.Memory
+	// * environBuf - is the offset to write the environment variables to ctx.Memory
 	//   * the format is the same as os.Environ, null terminated "key=val" entries
 	//   * EnvironSizesGet result environBufSize bytes are written to this offset
 	//
@@ -271,8 +271,8 @@ type SnapshotPreview1 interface {
 	// corresponding sizes in uint32 little-endian encoding. If either are invalid due to memory constraints, this
 	// returns ErrnoFault.
 	//
-	// * resultEnvironc - is the offset to write the environment variable count to wasm.Memory
-	// * resultEnvironBufSize - is the offset to write the null-terminated environment variable length to wasm.Memory
+	// * resultEnvironc - is the offset to write the environment variable count to ctx.Memory
+	// * resultEnvironBufSize - is the offset to write the null-terminated environment variable length to ctx.Memory
 	//
 	// For example, if Environ is []string{"a=b","b=cd"} and
 	//   EnvironSizesGet parameters are resultEnvironc=1 and resultEnvironBufSize=6, we expect `ctx.Memory` to contain:
@@ -299,7 +299,7 @@ type SnapshotPreview1 interface {
 	//
 	// * id - The clock id for which to return the time.
 	// * precision - The maximum lag (exclusive) that the returned time value may have, compared to its actual value.
-	// * resultTimestamp - the offset to write the timestamp to wasm.Memory
+	// * resultTimestamp - the offset to write the timestamp to ctx.Memory
 	//   * the timestamp is epoch nanoseconds encoded as a uint64 little-endian encoding.
 	//
 	// For example, if time.Now returned exactly midnight UTC 2022-01-01 (1640995200000000000), and
@@ -481,7 +481,7 @@ type SnapshotPreview1 interface {
 
 	// RandomGet is the WASI function named FunctionRandomGet that write random data in buffer (rand.Read()).
 	//
-	// * buf - is the wasm.Memory offset to write random values
+	// * buf - is the ctx.Memory offset to write random values
 	// * bufLen - size of random data in bytes
 	//
 	// For example, if underlying random source was seeded like `rand.NewSource(42)`, we expect `ctx.Memory` to contain:

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -789,13 +789,17 @@ func instantiateWasmStore(t *testing.T, wasiFunction, wasiImport, moduleName str
 	fn, err := wasm.NewGoFunc(wasiFunction, goFunc)
 	require.NoError(t, err)
 
-	wasiFn, err := store.AddHostFunction(wasi.ModuleSnapshotPreview1, fn)
+	// Add the host module
+	hostModule := &wasm.ModuleInstance{Name: wasi.ModuleSnapshotPreview1, Exports: map[string]*wasm.ExportInstance{}}
+	store.ModuleInstances[hostModule.Name] = hostModule
+
+	wasiFn, err := store.AddHostFunction(hostModule, fn)
 	require.NoError(t, err)
 
-	ctx, err := store.Instantiate(mod, moduleName)
+	instantiated, err := store.Instantiate(mod, moduleName)
 	require.NoError(t, err)
 
-	return store, ctx, wasiFn
+	return store, instantiated.Context, wasiFn
 }
 
 // maskMemory overwrites the first memory in the store with '?', so tests can see what's written.

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -16,19 +16,20 @@ func NewModuleContext(ctx context.Context, engine Engine, instance *ModuleInstan
 	return &ModuleContext{
 		ctx:    ctx,
 		engine: engine,
-		memory: instance.Memory,
+		memory: instance.MemoryInstance,
 		Module: instance,
 	}
 }
 
 // ModuleContext implements wasm.ModuleContext and wasm.Module
 type ModuleContext struct {
-	// ctx is the default context, exposed as wasm.ModuleContext Context
-	ctx    context.Context
+	// ctx is returned by Context and overridden WithContext
+	ctx context.Context
+	// engine is used to implement function.Call
 	engine Engine
-	// Module is exported for spectests.callFunction
+	// Module is exported for spectests
 	Module *ModuleInstance
-	// memory is exposed as wasm.ModuleContext Memory
+	// memory is returned by Memory and overridden WithMemory
 	memory publicwasm.Memory
 }
 
@@ -50,16 +51,17 @@ func (c *ModuleContext) WithMemory(memory *MemoryInstance) *ModuleContext {
 	return c
 }
 
+// Context implements wasm.ModuleContext Context
 func (c *ModuleContext) Context() context.Context {
 	return c.ctx
 }
 
-// Memory implements wasm.ModuleExports Memory
+// Memory implements wasm.ModuleContext Memory
 func (c *ModuleContext) Memory() publicwasm.Memory {
 	return c.memory
 }
 
-// Function implements wasm.ModuleExports Function
+// Function implements wasm.ModuleContext Function
 func (c *ModuleContext) Function(name string) publicwasm.Function {
 	exp, err := c.Module.GetExport(name, ExportKindFunc)
 	if err != nil {
@@ -89,11 +91,15 @@ func (s *Store) ExportHostFunctions(moduleName string, nameToGoFunc map[string]i
 		return nil, err
 	}
 
-	ret := HostExports{NameToFunctionInstance: make(map[string]*FunctionInstance, len(nameToGoFunc))}
+	exportCount := len(nameToGoFunc)
+
+	hostModule := &ModuleInstance{Name: moduleName, Exports: make(map[string]*ExportInstance, exportCount)}
+	s.ModuleInstances[moduleName] = hostModule
+	ret := HostExports{NameToFunctionInstance: make(map[string]*FunctionInstance, exportCount)}
 	for name, goFunc := range nameToGoFunc {
 		if hf, err := NewGoFunc(name, goFunc); err != nil {
 			return nil, err
-		} else if function, err := s.AddHostFunction(moduleName, hf); err != nil {
+		} else if function, err := s.AddHostFunction(hostModule, hf); err != nil {
 			return nil, err
 		} else {
 			ret.NameToFunctionInstance[name] = function
@@ -135,19 +141,19 @@ func (g *HostExports) Function(name string) publicwasm.HostFunction {
 	return f.call
 }
 
-// Len implements wasm.ModuleContext Len
-func (m *MemoryInstance) Len() uint32 {
+// Size implements wasm.ModuleContext Size
+func (m *MemoryInstance) Size() uint32 {
 	return uint32(len(m.Buffer))
 }
 
-// hasLen returns true if Len is sufficient for sizeInBytes at the given offset.
-func (m *MemoryInstance) hasLen(offset uint32, sizeInBytes uint32) bool {
-	return uint64(offset+sizeInBytes) <= uint64(m.Len()) // uint64 prevents overflow on add
+// hasSize returns true if Len is sufficient for sizeInBytes at the given offset.
+func (m *MemoryInstance) hasSize(offset uint32, sizeInBytes uint32) bool {
+	return uint64(offset+sizeInBytes) <= uint64(m.Size()) // uint64 prevents overflow on add
 }
 
 // ReadUint32Le implements wasm.ModuleContext ReadUint32Le
 func (m *MemoryInstance) ReadUint32Le(offset uint32) (uint32, bool) {
-	if !m.hasLen(offset, 4) {
+	if !m.hasSize(offset, 4) {
 		return 0, false
 	}
 	return binary.LittleEndian.Uint32(m.Buffer[offset : offset+4]), true
@@ -164,7 +170,7 @@ func (m *MemoryInstance) ReadFloat32Le(offset uint32) (float32, bool) {
 
 // ReadUint64Le implements wasm.ModuleContext ReadUint64Le
 func (m *MemoryInstance) ReadUint64Le(offset uint32) (uint64, bool) {
-	if !m.hasLen(offset, 8) {
+	if !m.hasSize(offset, 8) {
 		return 0, false
 	}
 	return binary.LittleEndian.Uint64(m.Buffer[offset : offset+8]), true
@@ -181,7 +187,7 @@ func (m *MemoryInstance) ReadFloat64Le(offset uint32) (float64, bool) {
 
 // Read implements wasm.ModuleContext Read
 func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
-	if !m.hasLen(offset, byteCount) {
+	if !m.hasSize(offset, byteCount) {
 		return nil, false
 	}
 	return m.Buffer[offset : offset+byteCount], true
@@ -189,7 +195,7 @@ func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
 
 // WriteUint32Le implements wasm.ModuleContext WriteUint32Le
 func (m *MemoryInstance) WriteUint32Le(offset, v uint32) bool {
-	if !m.hasLen(offset, 4) {
+	if !m.hasSize(offset, 4) {
 		return false
 	}
 	binary.LittleEndian.PutUint32(m.Buffer[offset:], v)
@@ -203,7 +209,7 @@ func (m *MemoryInstance) WriteFloat32Le(offset uint32, v float32) bool {
 
 // WriteUint64Le implements wasm.ModuleContext WriteUint64Le
 func (m *MemoryInstance) WriteUint64Le(offset uint32, v uint64) bool {
-	if !m.hasLen(offset, 8) {
+	if !m.hasSize(offset, 8) {
 		return false
 	}
 	binary.LittleEndian.PutUint64(m.Buffer[offset:], v)
@@ -217,7 +223,7 @@ func (m *MemoryInstance) WriteFloat64Le(offset uint32, v float64) bool {
 
 // Write implements wasm.ModuleContext Write
 func (m *MemoryInstance) Write(offset uint32, val []byte) bool {
-	if !m.hasLen(offset, uint32(len(val))) {
+	if !m.hasSize(offset, uint32(len(val))) {
 		return false
 	}
 	copy(m.Buffer[offset:], val)
@@ -230,8 +236,8 @@ var NoopMemory = &noopMemory{}
 type noopMemory struct {
 }
 
-// Len implements wasm.ModuleContext Len
-func (m *noopMemory) Len() uint32 {
+// Size implements wasm.ModuleContext Size
+func (m *noopMemory) Size() uint32 {
 	return 0
 }
 

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -517,8 +517,9 @@ func (it *interpreter) callHostFunc(ctx *wasm.ModuleContext, f *interpreterFunct
 		in[i] = val
 	}
 
+	// A host function is invoked with the calling frame's memory, which may be different if in another module.
 	if len(it.frames) > 0 {
-		ctx = ctx.WithMemory(it.frames[len(it.frames)-1].f.funcInstance.ModuleInstance.Memory)
+		ctx = ctx.WithMemory(it.frames[len(it.frames)-1].f.funcInstance.ModuleInstance.MemoryInstance)
 	}
 
 	// Handle any special parameter zero
@@ -548,7 +549,7 @@ func (it *interpreter) callHostFunc(ctx *wasm.ModuleContext, f *interpreterFunct
 func (it *interpreter) callNativeFunc(ctx *wasm.ModuleContext, f *interpreterFunction) {
 	frame := &interpreterFrame{f: f}
 	moduleInst := f.funcInstance.ModuleInstance
-	memoryInst := moduleInst.Memory
+	memoryInst := moduleInst.MemoryInstance
 	globals := moduleInst.Globals
 	var table *wasm.TableInstance
 	if len(moduleInst.Tables) > 0 {

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -50,7 +50,7 @@ func TestInterpreter_CallHostFunc(t *testing.T) {
 		hostFn := reflect.ValueOf(func(ctx publicwasm.ModuleContext) {
 			ctxMemory = ctx.Memory()
 		})
-		module := &wasm.ModuleInstance{Memory: memory}
+		module := &wasm.ModuleInstance{MemoryInstance: memory}
 		it := interpreter{functions: map[wasm.FunctionAddress]*interpreterFunction{
 			0: {hostFn: &hostFn, funcInstance: &wasm.FunctionInstance{
 				FunctionKind: wasm.FunctionKindGoModuleContext,

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -19,7 +19,7 @@ func TestVerifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof(eng.callFrameStackElementZeroAddress)), engineGlobalContextCallFrameStackElement0AddressOffset)
 	require.Equal(t, int(unsafe.Offsetof(eng.callFrameStackLen)), engineGlobalContextCallFrameStackLenOffset)
 	require.Equal(t, int(unsafe.Offsetof(eng.callFrameStackPointer)), engineGlobalContextCallFrameStackPointerOffset)
-	require.Equal(t, int(unsafe.Offsetof(eng.previousCallFrameStackPointer)), engineGlobalContextPreviouscallFrameStackPointer)
+	require.Equal(t, int(unsafe.Offsetof(eng.previousCallFrameStackPointer)), engineGlobalContextPreviousCallFrameStackPointer)
 	require.Equal(t, int(unsafe.Offsetof(eng.compiledFunctionsElement0Address)), engineGlobalContextCompiledFunctionsElement0AddressOffset)
 
 	// Offsets for engine.moduleContext.
@@ -61,7 +61,7 @@ func TestVerifyOffsetValue(t *testing.T) {
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Globals)), moduleInstanceGlobalsOffset)
-	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Memory)), moduleInstanceMemoryOffset)
+	require.Equal(t, int(unsafe.Offsetof(moduleInstance.MemoryInstance)), moduleInstanceMemoryOffset)
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Tables)), moduleInstanceTablesOffset)
 
 	// Offsets for wasm.TableInstance.

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -4874,7 +4874,7 @@ func (c *amd64Compiler) returnFunction() error {
 	cmpWithPreviousCallStackPointer.To.Reg = decrementedCallFrameStackPointerRegister
 	cmpWithPreviousCallStackPointer.From.Type = obj.TYPE_MEM
 	cmpWithPreviousCallStackPointer.From.Reg = reservedRegisterForEngine
-	cmpWithPreviousCallStackPointer.From.Offset = engineGlobalContextPreviouscallFrameStackPointer
+	cmpWithPreviousCallStackPointer.From.Offset = engineGlobalContextPreviousCallFrameStackPointer
 	c.addInstruction(cmpWithPreviousCallStackPointer)
 
 	jmpIfNotPreviousCallStackPointer := c.newProg()
@@ -5259,7 +5259,7 @@ func (c *amd64Compiler) initializeReservedStackBasePointer() {
 }
 
 func (c *amd64Compiler) initializeReservedMemoryPointer() {
-	if c.f.ModuleInstance.Memory != nil {
+	if c.f.ModuleInstance.MemoryInstance != nil {
 		setupMemoryRegister := c.newProg()
 		setupMemoryRegister.As = x86.AMOVQ
 		setupMemoryRegister.To.Type = obj.TYPE_REG
@@ -5481,7 +5481,7 @@ func (c *amd64Compiler) initializeModuleContext() error {
 	// Note: if there's memory instruction in the function, memory instance must be non-nil.
 	// That is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's memory instance is nil.
-	if c.f.ModuleInstance.Memory != nil {
+	if c.f.ModuleInstance.MemoryInstance != nil {
 		getMemoryInstanceAddress := c.newProg()
 		getMemoryInstanceAddress.As = x86.AMOVQ
 		getMemoryInstanceAddress.To.Type = obj.TYPE_REG

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -215,9 +215,9 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 		{
 			name: "no nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
@@ -230,47 +230,47 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 		{
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 0)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},
 		{
 			name: "table length zero",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: nil}},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: nil}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table length zero part2",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table nil part2",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables: []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
 			},
 		},
 	} {
@@ -306,8 +306,8 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Globals))
 			require.Equal(t, bufSliceHeader.Data, engine.moduleContext.globalElement0Address)
 
-			if tc.moduleInstance.Memory != nil {
-				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Memory.Buffer))
+			if tc.moduleInstance.MemoryInstance != nil {
+				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.MemoryInstance.Buffer))
 				require.Equal(t, uint64(bufSliceHeader.Len), engine.moduleContext.memorySliceLen)
 				require.Equal(t, bufSliceHeader.Data, engine.moduleContext.memoryElement0Address)
 			}
@@ -5972,7 +5972,7 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 					// Each function takes one argument, adds the value with 100 + i and returns the result.
 					addTargetValue := uint32(100 + i)
 					moduleInstance := &wasm.ModuleInstance{
-						Memory: &wasm.MemoryInstance{Buffer: make([]byte, 1024)},
+						MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 1024)},
 					}
 					moduleInstanceToExpectedValueInMemory[moduleInstance] = addTargetValue
 
@@ -6066,7 +6066,7 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 
 				// Also, in the middle of function call, we write the added value into each memory instance.
 				for mod, expValue := range moduleInstanceToExpectedValueInMemory {
-					require.Equal(t, expValue, binary.LittleEndian.Uint32(mod.Memory.Buffer[0:]))
+					require.Equal(t, expValue, binary.LittleEndian.Uint32(mod.MemoryInstance.Buffer[0:]))
 				}
 			})
 		})

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -517,7 +517,7 @@ func (c *arm64Compiler) compileReturnFunction() error {
 
 	// Next we compare the decremented call frame stack pointer with the engine.precviousCallFrameStackPointer.
 	c.compileMemoryToRegisterInstruction(arm64.AMOVD,
-		reservedRegisterForEngine, engineGlobalContextPreviouscallFrameStackPointer,
+		reservedRegisterForEngine, engineGlobalContextPreviousCallFrameStackPointer,
 		tmpReg,
 	)
 	c.compileTwoRegistersToNoneInstruction(arm64.ACMP, callFramePointerReg, tmpReg)
@@ -3338,7 +3338,7 @@ func (c *arm64Compiler) compileReservedStackBasePointerRegisterInitialization() 
 }
 
 func (c *arm64Compiler) compileReservedMemoryRegisterInitialization() {
-	if c.f.ModuleInstance.Memory != nil {
+	if c.f.ModuleInstance.MemoryInstance != nil {
 		// "reservedRegisterForMemory = engine.MemoryElement0Address"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,
@@ -3404,7 +3404,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// Note: if there's memory instruction in the function, memory instance must be non-nil.
 	// That is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's memory instance is nil.
-	if c.f.ModuleInstance.Memory != nil {
+	if c.f.ModuleInstance.MemoryInstance != nil {
 		// "tmpX = moduleInstance.Memory"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -2107,16 +2107,16 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "no nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables: []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
 			},
 		},
 		{
@@ -2129,25 +2129,25 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: nil}},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: nil}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table empty",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 0)},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},
 		{
@@ -2186,8 +2186,8 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Globals))
 			require.Equal(t, bufSliceHeader.Data, engine.moduleContext.globalElement0Address)
 
-			if tc.moduleInstance.Memory != nil {
-				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Memory.Buffer))
+			if tc.moduleInstance.MemoryInstance != nil {
+				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.MemoryInstance.Buffer))
 				require.Equal(t, uint64(bufSliceHeader.Len), engine.moduleContext.memorySliceLen)
 				require.Equal(t, bufSliceHeader.Data, engine.moduleContext.memoryElement0Address)
 			}

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -47,7 +47,7 @@ func (j *jitEnv) stackTopAsFloat64() float64 {
 }
 
 func (j *jitEnv) memory() []byte {
-	return j.moduleInstance.Memory.Buffer
+	return j.moduleInstance.MemoryInstance.Buffer
 }
 
 func (j *jitEnv) stack() []uint64 {
@@ -133,9 +133,9 @@ func newJITEnvironment() *jitEnv {
 	return &jitEnv{
 		eng: newEngine(),
 		moduleInstance: &wasm.ModuleInstance{
-			Memory:  &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
-			Tables:  []*wasm.TableInstance{{}},
-			Globals: []*wasm.GlobalInstance{},
+			MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
+			Tables:         []*wasm.TableInstance{{}},
+			Globals:        []*wasm.GlobalInstance{},
 		},
 	}
 }

--- a/wasi.go
+++ b/wasi.go
@@ -98,15 +98,15 @@ func StartWASICommand(store wasm.Store, module *Module) (wasm.ModuleExports, err
 		return nil, err
 	}
 
-	ret, err := InstantiateModule(store, module)
+	instantiated, err := internal.Instantiate(module.wasm, module.name)
 	if err != nil {
 		return nil, err
 	}
+	ctx := instantiated.Context
 
-	exports := internal.ModuleContexts[module.name]
-	start := exports.Function(internalwasi.FunctionStart)
-	if _, err = start(exports.Context()); err != nil {
+	start := ctx.Function(internalwasi.FunctionStart)
+	if _, err = start(ctx.Context()); err != nil {
 		return nil, fmt.Errorf("module[%s] function[%s] failed: %w", module.name, internalwasi.FunctionStart, err)
 	}
-	return ret, nil
+	return instantiated, nil
 }


### PR DESCRIPTION
This adds a function to get an exported memory by name, allowing end
users to check ahead of time if memory writes might fail. This also
renames memory.len to size to as that's what the spec calls it.
