### PR TITLE
Complete JIT compilation engine for arm64 target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ wazero is an early project, so APIs are subject to change until version 1.0.
 There's the concept called "engine" in wazero (which is a word commonly used in Wasm runtimes). Engines are responsible for compiling and executing WebAssembly modules.
 There are two types of engines are available for wazero:
 
-1. _Interpreter_: a naive interpreter-based implementation of Wasm virtual machine. Its implementation doesn't have any platform (GOARCH, GOOS) specific code, therefore _interpreter_ engine can be used for any compilation target available for Go (such as `arm64`).
-2. _JIT engine_: compiles WebAssembly modules, generates the machine code, and executing it all at runtime. Currently wazero only implements the JIT compiler for `amd64` target. Generally speaking, _JIT engine_ is faster than _Interpreter_ by order of magnitude. However, the implementation is immature and has a bunch of aspects that could be improved (for example, it just does a singlepass compilation and doesn't do any optimizations, etc.). Please refer to [internal/wasm/jit/RATIONALE.md](internal/wasm/jit/RATIONALE.md) for the design choices and considerations in our JIT engine.
+1. _Interpreter_: a naive interpreter-based implementation of Wasm virtual machine. Its implementation doesn't have any platform (GOARCH, GOOS) specific code, therefore _interpreter_ engine can be used for any compilation target available for Go (such as `riscv64`).
+2. _JIT engine_: compiles WebAssembly modules, generates the machine code, and executing it all at runtime. Currently wazero implements the JIT compiler for `amd64` and `arm64` target. Generally speaking, _JIT engine_ is faster than _Interpreter_ by order of magnitude. However, the implementation is immature and has a bunch of aspects that could be improved (for example, it just does a singlepass compilation and doesn't do any optimizations, etc.). Please refer to [internal/wasm/jit/RATIONALE.md](internal/wasm/jit/RATIONALE.md) for the design choices and considerations in our JIT engine.
 
 Both of engines passes 100% of [WebAssembly spec test suites]((https://github.com/WebAssembly/spec/tree/wg-1.0/test/core)) (on supported platforms).
 
-| Engine     | Usage|GOARCH=amd64 | GOARCH=others |
-|:----------:|:---:|:-------------:|:------:|
-| Interpreter|`wazero.NewEngineInterpreter()`| ✅    | ✅ |
-| JIT engine |`wazero.NewEngineJIT()`|   ✅   | ❌  |
+| Engine     | Usage|GOARCH=amd64 | GOARCH=arm64 |GOARCH=others |
+|:---|:---:|:---:|:---:|:---:|
+| Interpreter|`wazero.NewEngineInterpreter()`| ✅    |✅    | ✅ |
+| JIT engine |`wazero.NewEngineJIT()`|   ✅   |✅    |  ❌  |
 
 If you choose no configuration, ex `wazero.NewStore()`, the interpreter is used. You can also choose explicitly like so:
 ```go
@@ -58,9 +58,5 @@ First, why do you want to write host environments in Go? You might want to have 
 write plugins in their favorite languages. That's where Wasm comes into play. You write your own Wasm host environments and embed Wasm runtime in your projects, and now users are able to write plugins in their own favorite lanugages (AssembyScript, C, C++, Rust, Zig, etc.). As a specific example, you maybe write proxy severs in Go and want to allow users to extend the proxy via [Proxy-Wasm ABI](https://github.com/proxy-wasm/spec). Maybe you are writing server-side rendering applications via Wasm, or [OpenPolicyAgent](https://www.openpolicyagent.org/docs/latest/wasm/) is using Wasm for plugin system.
 
 However, experienced Golang developers often avoid using CGO because [_CGO is not Go_](https://dave.cheney.net/2016/01/18/cgo-is-not-go)[ -- _Rob_ _Pike_](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=757s), and it introduces another complexity into your projects. But unfortunately, as I mentioned there's no pure Go Wasm runtime out there, so you have to resort to CGO.
-
-Currently, any performance optimization hasn't been done to this runtime yet, and the runtime is just a simple interpreter of Wasm binary. That means in terms of performance, the runtime here is inferior to any aforementioned runtimes (e.g. Wasmtime) for now.
-
-However, _theoretically speaking_, this project has the potential to compete with these state-of-the-art JIT-style runtimes. The rationale for that is it is well-know that [CGO is slow](https://github.com/golang/go/issues/19574). More specifically, if you make large amount of CGO calls which cross the boundary between Go and C (stack) space, then the usage of CGO could be a bottleneck.
 
 Since we can do JIT compilation purely in Go, this runtime could be the fastest one for some use cases where we have to make large amount of CGO calls (e.g. Proxy-Wasm host environment, or request-based plugin systems).

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ There are two types of engines are available for wazero:
 
 Both of engines passes 100% of [WebAssembly spec test suites]((https://github.com/WebAssembly/spec/tree/wg-1.0/test/core)) (on supported platforms).
 
-| Engine     | Usage|GOARCH=amd64 | GOARCH=arm64 |GOARCH=others |
-|:---|:---:|:---:|:---:|:---:|
-| Interpreter|`wazero.NewEngineInterpreter()`| ✅    |✅    | ✅ |
-| JIT engine |`wazero.NewEngineJIT()`|   ✅   |✅    |  ❌  |
+| Engine     | Usage| amd64 | arm64 | others |
+|:---:|:---:|:---:|:---:|:---:|
+| Interpreter|`wazero.NewEngineInterpreter()`|✅ |✅|✅|
+| JIT engine |`wazero.NewEngineJIT()`|✅|✅ |❌|
 
 If you choose no configuration, ex `wazero.NewStore()`, the interpreter is used. You can also choose explicitly like so:
 ```go
@@ -58,5 +58,9 @@ First, why do you want to write host environments in Go? You might want to have 
 write plugins in their favorite languages. That's where Wasm comes into play. You write your own Wasm host environments and embed Wasm runtime in your projects, and now users are able to write plugins in their own favorite lanugages (AssembyScript, C, C++, Rust, Zig, etc.). As a specific example, you maybe write proxy severs in Go and want to allow users to extend the proxy via [Proxy-Wasm ABI](https://github.com/proxy-wasm/spec). Maybe you are writing server-side rendering applications via Wasm, or [OpenPolicyAgent](https://www.openpolicyagent.org/docs/latest/wasm/) is using Wasm for plugin system.
 
 However, experienced Golang developers often avoid using CGO because [_CGO is not Go_](https://dave.cheney.net/2016/01/18/cgo-is-not-go)[ -- _Rob_ _Pike_](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=757s), and it introduces another complexity into your projects. But unfortunately, as I mentioned there's no pure Go Wasm runtime out there, so you have to resort to CGO.
+
+Currently, any performance optimization hasn't been done to this runtime yet, and the runtime is just a simple interpreter of Wasm binary. That means in terms of performance, the runtime here is inferior to any aforementioned runtimes (e.g. Wasmtime) for now.
+
+However, _theoretically speaking_, this project has the potential to compete with these state-of-the-art JIT-style runtimes. The rationale for that is it is well-know that [CGO is slow](https://github.com/golang/go/issues/19574). More specifically, if you make large amount of CGO calls which cross the boundary between Go and C (stack) space, then the usage of CGO could be a bottleneck.
 
 Since we can do JIT compilation purely in Go, this runtime could be the fastest one for some use cases where we have to make large amount of CGO calls (e.g. Proxy-Wasm host environment, or request-based plugin systems).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Both of engines passes 100% of [WebAssembly spec test suites]((https://github.co
 | Interpreter|`wazero.NewEngineInterpreter()`|✅ |✅|✅|
 | JIT engine |`wazero.NewEngineJIT()`|✅|✅ |❌|
 
+*Note:* JIT does not yet work on Windows. Please use the interpreter and track [this issue](https://github.com/tetratelabs/wazero/issues/270) if interested.
+
 If you choose no configuration, ex `wazero.NewStore()`, the interpreter is used. You can also choose explicitly like so:
 ```go
 store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: wazero.NewEngineJIT()})

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -662,12 +662,10 @@ func (e *engine) addCompiledFunction(addr wasm.FunctionAddress, compiled *compil
 
 func compileHostFunction(f *wasm.FunctionInstance) (*compiledFunction, error) {
 	compiler, done, err := newCompiler(f, nil)
+	defer done()
+
 	if err != nil {
 		return nil, err
-	}
-
-	if done != nil {
-		defer done()
 	}
 
 	if err = compiler.compileHostFunction(f.Address); err != nil {
@@ -707,12 +705,9 @@ func compileWasmFunction(f *wasm.FunctionInstance) (*compiledFunction, error) {
 	}
 
 	compiler, done, err := newCompiler(f, ir)
+	defer done()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize assembly builder: %w", err)
-	}
-
-	if done != nil {
-		defer done()
 	}
 
 	if err := compiler.compilePreamble(); err != nil {

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -1,7 +1,6 @@
 package jit
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math"
 	"reflect"
@@ -682,10 +681,6 @@ func compileHostFunction(f *wasm.FunctionInstance) (*compiledFunction, error) {
 		stackPointerCeil = res
 	}
 
-	if buildoptions.IsDebugMode {
-		fmt.Printf("compiled code in hex: %s\n", hex.EncodeToString(code))
-	}
-
 	return &compiledFunction{
 		source:             f,
 		codeSegment:        code,
@@ -876,10 +871,6 @@ func compileWasmFunction(f *wasm.FunctionInstance) (*compiledFunction, error) {
 	code, staticData, stackPointerCeil, err := compiler.compile()
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile: %w", err)
-	}
-
-	if buildoptions.IsDebugMode {
-		fmt.Printf("compiled code in hex: %s\n", hex.EncodeToString(code))
 	}
 
 	return &compiledFunction{

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -90,12 +90,12 @@ func newArchContext() (ret archContext) { return }
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.
 // Note: ir param can be nil for host functions.
-func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, error) {
+func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, func(), error) {
 	// We can choose arbitrary number instead of 1024 which indicates the cache size in the compiler.
 	// TODO: optimize the number.
 	b, err := asm.NewBuilder("amd64", 1024)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create a new assembly builder: %w", err)
+		return nil, nil, fmt.Errorf("failed to create a new assembly builder: %w", err)
 	}
 
 	compiler := &amd64Compiler{
@@ -106,7 +106,7 @@ func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (comp
 		ir:            ir,
 		labels:        map[string]*labelInfo{},
 	}
-	return compiler, nil
+	return compiler, nil, nil
 }
 
 func (c *amd64Compiler) String() string {

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -89,6 +89,7 @@ type archContext struct{}
 func newArchContext() (ret archContext) { return }
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.
+// The function returned must be invoked when finished compiling, so use `defer` to ensure this.
 // Note: ir param can be nil for host functions.
 func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, func(), error) {
 	// We can choose arbitrary number instead of 1024 which indicates the cache size in the compiler.

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -95,7 +95,7 @@ func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (comp
 	// TODO: optimize the number.
 	b, err := asm.NewBuilder("amd64", 1024)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create a new assembly builder: %w", err)
+		return nil, func() {}, fmt.Errorf("failed to create a new assembly builder: %w", err)
 	}
 
 	compiler := &amd64Compiler{
@@ -106,7 +106,7 @@ func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (comp
 		ir:            ir,
 		labels:        map[string]*labelInfo{},
 	}
-	return compiler, nil, nil
+	return compiler, func() {}, nil
 }
 
 func (c *amd64Compiler) String() string {

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -79,6 +79,7 @@ func unlockAssembler() {
 }
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.
+// The function returned must be invoked when finished compiling, so use `defer` to ensure this.
 // Note: ir param can be nil for host functions.
 func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (c compiler, done func(), err error) {
 	// golang-asm is not goroutine-safe so we take lock until we complete the compilation.

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -2369,26 +2369,22 @@ func (c *arm64Compiler) compileITruncFromF(o *wazeroir.OperationITruncFromF) err
 	c.compileRegisterToRegisterInstruction(arm64.AMSR, zeroRegister, arm64.REG_FPSR)
 
 	var convinst obj.As
-	var is32bitFloat bool
-	if o.InputType == wazeroir.Float32 && o.OutputType == wazeroir.SignedInt32 {
+	var is32bitFloat = o.InputType == wazeroir.Float32
+	if is32bitFloat && o.OutputType == wazeroir.SignedInt32 {
 		convinst = arm64.AFCVTZSSW
-		is32bitFloat = true
-	} else if o.InputType == wazeroir.Float32 && o.OutputType == wazeroir.SignedInt64 {
+	} else if is32bitFloat && o.OutputType == wazeroir.SignedInt64 {
 		convinst = arm64.AFCVTZSS
-		is32bitFloat = true
-	} else if o.InputType == wazeroir.Float64 && o.OutputType == wazeroir.SignedInt32 {
+	} else if !is32bitFloat && o.OutputType == wazeroir.SignedInt32 {
 		convinst = arm64.AFCVTZSDW
-	} else if o.InputType == wazeroir.Float64 && o.OutputType == wazeroir.SignedInt64 {
+	} else if !is32bitFloat && o.OutputType == wazeroir.SignedInt64 {
 		convinst = arm64.AFCVTZSD
-	} else if o.InputType == wazeroir.Float32 && o.OutputType == wazeroir.SignedUint32 {
+	} else if is32bitFloat && o.OutputType == wazeroir.SignedUint32 {
 		convinst = arm64.AFCVTZUSW
-		is32bitFloat = true
-	} else if o.InputType == wazeroir.Float32 && o.OutputType == wazeroir.SignedUint64 {
+	} else if is32bitFloat && o.OutputType == wazeroir.SignedUint64 {
 		convinst = arm64.AFCVTZUS
-		is32bitFloat = true
-	} else if o.InputType == wazeroir.Float64 && o.OutputType == wazeroir.SignedUint32 {
+	} else if !is32bitFloat && o.OutputType == wazeroir.SignedUint32 {
 		convinst = arm64.AFCVTZUDW
-	} else if o.InputType == wazeroir.Float64 && o.OutputType == wazeroir.SignedUint64 {
+	} else if !is32bitFloat && o.OutputType == wazeroir.SignedUint64 {
 		convinst = arm64.AFCVTZUD
 	}
 

--- a/internal/wasm/jit/jit_other.go
+++ b/internal/wasm/jit/jit_other.go
@@ -16,6 +16,6 @@ func jitcall(codeSegment, engine uintptr) {
 	panic("unsupported GOARCH")
 }
 
-func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, error) {
+func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, func(), error) {
 	panic("unsupported GOARCH")
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -138,8 +138,7 @@ func TestStore_addHostFunction(t *testing.T) {
 		s := NewStore(context.Background(), nopEngineInstance)
 		const max = 10
 		s.maximumFunctionAddress = max
-		s.Functions = make([]*FunctionInstance, max)
-		err := s.addFunctionInstance(nil)
+		err := s.addFunctionInstance(&FunctionInstance{Address: max + 1})
 		require.Error(t, err)
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -153,9 +152,6 @@ func TestStore_addHostFunction(t *testing.T) {
 
 			// After the addition, one instance is added.
 			require.Len(t, s.Functions, i+1)
-
-			// The added function instance must have i for its address.
-			require.Equal(t, FunctionAddress(i), f.Address)
 		}
 	})
 }

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestJIT(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Skip()
 	}
 	runTests(t, wazero.NewEngineJIT)

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -230,7 +230,7 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 }
 
 func TestJIT(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Skip()
 	}
 	runTest(t, jit.NewEngine)


### PR DESCRIPTION
This commit completes the baseline single pass JIT engine for arm64 target.
The implementation passes 100% of specification tests and all the e2e tests
that have been used for amd64. Notably, the engine is stable under high
concurrency where multiple gorutines are holding stores and each of them
has Wasm execution environment.


One thing to note is that  the assembler (golang-asm) is not goroutine-safe,
so we have to take a lock on the assembler usage, therefore the compilation 
cannot scale to multiple CPU cores. This will be resolved once we build our
homemade assembler in #233.

resolves #187 
