### PR TITLE
wasi: backfill docs and tests of fd_read and fd_write

### DIFF
--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -436,15 +436,15 @@ type SnapshotPreview1 interface {
 	//     offset --+   length --+   offset --+  length --+
 	//
 	// If the contents of the `fd` parameter was "wazero" (6 bytes) and
-	//    parameter resultSize=30, this function writes the below to `ctx.Memory`:
+	//    parameter resultSize=26, this function writes the below to `ctx.Memory`:
 	//
-	//                       iovs[0].length        iovs[1].length           uint32le
-	//                      +--------------+       +----+                  +--------+
-	//                      |              |       |    |                  |        |
-	//   []byte{ 0..16, ?, 'w', 'a', 'z', 'e', ?, 'r', 'o', ?, ?, ?, ?, ?, 6, 0, 0, 0 }
-	//     iovs[0].offset --^                      ^                       ^
-	//                            iovs[1].offset --+                       |
-	//                                                        resultSize --+
+	//                       iovs[0].length        iovs[1].length
+	//                      +--------------+       +----+       uint32le
+	//                      |              |       |    |      +--------+
+	//   []byte{ 0..16, ?, 'w', 'a', 'z', 'e', ?, 'r', 'o', ?, 6, 0, 0, 0 }
+	//     iovs[0].offset --^                      ^           ^
+	//                            iovs[1].offset --+           |
+	//                                            resultSize --+
 	//
 	// Note: ImportFdRead shows this signature in the WebAssembly 1.0 (MVP) Text Format.
 	// Note: This is similar to `readv` in POSIX.
@@ -495,12 +495,12 @@ type SnapshotPreview1 interface {
 	//     iovs[0].offset --^                      ^
 	//                            iovs[1].offset --+
 	//
-	// Since "wazero" was written, if parameter resultSize=30, this function writes the below to `ctx.Memory`:
+	// Since "wazero" was written, if parameter resultSize=26, this function writes the below to `ctx.Memory`:
 	//
 	//                      uint32le
 	//                     +--------+
 	//                     |        |
-	//   []byte{ 0..28, ?, 6, 0, 0, 0', ? }
+	//   []byte{ 0..24, ?, 6, 0, 0, 0', ? }
 	//        resultSize --^
 	//
 	// Note: ImportFdWrite shows this signature in the WebAssembly 1.0 (MVP) Text Format.
@@ -801,7 +801,7 @@ func (a *wasiAPI) fd_seek(ctx wasm.ModuleContext, fd uint32, offset uint64, when
 	return wasi.ErrnoNosys // TODO: implement
 }
 
-// FdWrite implements SnahpshotPreview1.FdWrite
+// FdWrite implements SnapshotPreview1.FdWrite
 func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
 	var writer io.Writer
 

--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -183,9 +183,10 @@ const (
 // parameter is a memory offset to write the result to. As memory offsets are uint32, each parameter representing a
 // result is uint32.
 //
-// Note: The WASI specification is sometimes ambiguous. Please see internal/wasi/RATIONALE.md for rationale on decisions that impact portability.
-//
-// Note: Errno mappings are not defined in WASI, yet, so these mappings are best efforts by maintainers.
+// Note: The WASI specification is sometimes ambiguous resulting in some runtimes interpreting the same function
+// ways. wasi.Errno mappings are not defined in WASI, yet, so these mappings are best efforts by maintainers. When in
+// doubt about portability, first look at internal/wasi/RATIONALE.md and if needed an issue on
+// https://github.com/WebAssembly/WASI/issues
 //
 // Note: In WebAssembly 1.0 (MVP), there may be up to one Memory per store, which means wasm.Memory is always the
 // wasm.Store Memories index zero: `store.Memories[0].Buffer`
@@ -205,7 +206,7 @@ type SnapshotPreview1 interface {
 	//   * ArgsSizesGet result argv_buf_size bytes are written to this offset
 	//
 	// For example, if ArgsSizesGet wrote argc=2 and argvBufSize=5 for arguments: "a" and "bc"
-	//   and ArgsGet results argv=7 and argvBuf=1, we expect `ctx.Memory` to contain:
+	//    parameters argv=7 and argvBuf=1, this function writes the below to `ctx.Memory`:
 	//
 	//               argvBufSize          uint32le    uint32le
 	//            +----------------+     +--------+  +--------+
@@ -233,7 +234,7 @@ type SnapshotPreview1 interface {
 	// * resultArgvBufSize - is the offset to write the null-terminated argument length to ctx.Memory
 	//
 	// For example, if Args are []string{"a","bc"} and
-	//   ArgsSizesGet parameters resultArgc=1 and resultArgvBufSize=6, we expect `ctx.Memory` to contain:
+	//    parameters resultArgc=1 and resultArgvBufSize=6, this function writes the below to `ctx.Memory`:
 	//
 	//                   uint32le       uint32le
 	//                  +--------+     +--------+
@@ -262,7 +263,7 @@ type SnapshotPreview1 interface {
 	//   * EnvironSizesGet result environBufSize bytes are written to this offset
 	//
 	// For example, if EnvironSizesGet wrote environc=2 and environBufSize=9 for environment variables: "a=b", "b=cd"
-	//   and EnvironGet parameters environ=11 and environBuf=1, we expect `ctx.Memory` to contain:
+	//   and parameters environ=11 and environBuf=1, this function writes the below to `ctx.Memory`:
 	//
 	//                           environBufSize                 uint32le    uint32le
 	//              +------------------------------------+     +--------+  +--------+
@@ -289,7 +290,7 @@ type SnapshotPreview1 interface {
 	// * resultEnvironBufSize - is the offset to write the null-terminated environment variable length to ctx.Memory
 	//
 	// For example, if Environ is []string{"a=b","b=cd"} and
-	//   EnvironSizesGet parameters are resultEnvironc=1 and resultEnvironBufSize=6, we expect `ctx.Memory` to contain:
+	//    parameters resultEnvironc=1 and resultEnvironBufSize=6, this function writes the below to `ctx.Memory`:
 	//
 	//                   uint32le       uint32le
 	//                  +--------+     +--------+
@@ -317,7 +318,7 @@ type SnapshotPreview1 interface {
 	//   * the timestamp is epoch nanoseconds encoded as a uint64 little-endian encoding.
 	//
 	// For example, if time.Now returned exactly midnight UTC 2022-01-01 (1640995200000000000), and
-	//   ClockTimeGet resultTimestamp=1, we expect `ctx.Memory` to contain:
+	//   parameters resultTimestamp=1, this function writes the below to `ctx.Memory`:
 	//
 	//                                      uint64le
 	//                    +------------------------------------------+
@@ -336,7 +337,7 @@ type SnapshotPreview1 interface {
 
 	// FdClose is the WASI function to close a file descriptor. This returns ErrnoBadf if the fd is invalid.
 	//
-	// * fd - the file decriptor to close
+	// * fd - the file descriptor to close
 	//
 	// Note: ImportFdClose shows this signature in the WebAssembly 1.0 (MVP) Text Format.
 	// Note: This is similar to `close` in POSIX.
@@ -354,109 +355,104 @@ type SnapshotPreview1 interface {
 	// TODO: wasi.FdPread
 
 	// FdPrestatGet is the WASI function to return the prestat data of a file descriptor.
-	// This returns ErrnoBadf if the fd is invalid.
+	// This returns wasi.ErrnoBadf if the fd is invalid.
 	//
-	// * fd - the file decriptor to get the prestat
+	// * fd - the file descriptor to get the prestat
 	// * resultPrestat - the offset to write the result prestat data
 	//
-	// A prestat is a union data which consists of two fields, uint8 `tag` indicating the type of the prestat data,
-	// and uint32 contents data that varies according to `tag`. They have the following memory layout.
-	// * tag - uint8. offset 0
-	// * contents - uint32. offset 4
-	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#prestat
+	// prestat byte layout is 8 bytes, beginning with an 8-bit tag and 3 pad bytes. The only valid tag is `prestat_dir`,
+	// which is tag zero. This simplifies the byte layout to 4 empty bytes followed by the uint32le encoded path length.
 	//
-	// For example, suppose fd 3 is a file descriptor with a prestat data of tag = `prestat_dir` (value: 0).
-	// For this tag, the contents is prNameLen. Suppose it has value 3 in this example.
-	// Now, if FdPrestatGet parameters fd = 3 and resultPrestat = 1, we expect `ctx.Memory` to contain:
+	// For example, the directory name corresponding with `fd` was "/tmp" and
+	//    parameter resultPrestat=1, this function writes the below to `ctx.Memory`:
 	//
 	//                     padding   uint32le
 	//          uint8 --+  +-----+  +--------+
 	//                  |  |     |  |        |
-	//        []byte{?, 0, 0, 0, 0, 3, 0, 0, 0, ?}
+	//        []byte{?, 0, 0, 0, 0, 4, 0, 0, 0, ?}
 	//  resultPrestat --^           ^
 	//            tag --+           |
-	//                              +-- prNameLen
+	//                              +-- size in bytes of the string "/tmp"
 	//
 	// Note: ImportFdPrestatGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// See FdPrestatDirName
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#prestat
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#fd_prestat_get
 	FdPrestatGet(ctx wasm.ModuleContext, fd uint32, resultPrestat uint32) wasi.Errno
 
 	// FdPrestatDirName is the WASI function to return the path of the pre-opened directory of a file descriptor.
 	//
-	// * fd - the file decriptor to get the path of the pre-opened directory
+	// * fd - the file descriptor to get the path of the pre-opened directory
 	// * path - the offset in `ctx.Memory` to write the result path
-	// * pathLen - FdPrestatDirName writes the result path string to `path` offset for the length of `pathLen`.
+	// * pathLen - the count of bytes to write to `path`
+	//   * This should match the uint32le FdPrestatGet writes to offset `resultPrestat`+4
 	//
-	// FdPrestatDirName returns the following errors.
-	// * ErrnoBadf - if `fd` is invalid
-	// * ErrnoFault - if `path` is an invalid offset due to the memory constraint
-	// * ErrnoNametoolong - if `pathLen` is longer than the actual length of the result path
-	// TODO: FdPrestatDirName may have to return ErrnoNotdir if the type of the prestat data of `fd` is not a PrestatDir.
+	// The wasi.Errno returned is wasi.ErrnoSuccess except the following error conditions:
+	// * wasi.ErrnoBadf - if `fd` is invalid
+	// * wasi.ErrnoFault - if `path` is an invalid offset due to the memory constraint
+	// * wasi.ErrnoNametoolong - if `pathLen` is longer than the actual length of the result path
 	//
-	// For example, if fd 3 is a file with path = "test",
-	// and FdPrestatDirName parameters fd = 3, path = 1, and pathLen = 3, we expect `ctx.Memory` to contain:
+	// For example, the directory name corresponding with `fd` was "/tmp" and
+	//    parameters path=1 pathLen=4 (correct), this function will write the below to `ctx.Memory`:
 	//
-	//                pathLen
-	//              +---------+
-	//              |         |
-	//   []byte{?, 't', 'e', 's', ?, ?, ?}
+	//                  pathLen
+	//              +--------------+
+	//              |              |
+	//   []byte{?, '/', 't', 'm', 'p', ?}
 	//       path --^
 	//
-	// Note: `prNameLen` field of the result of FdPrestatGet has the exact length of the actual path.
-	// See FdPrestatGet
-	// Note: Some runtimes may have another semantics. See internal/wasi/RATIONALE.md#FdPrestatDirName
 	// Note: ImportFdPrestatDirName shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// See FdPrestatGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_dir_name
 	FdPrestatDirName(ctx wasm.ModuleContext, fd uint32, path uint32, pathLen uint32) wasi.Errno
+	// TODO: FdPrestatDirName may have to return ErrnoNotdir if the type of the prestat data of `fd` is not a PrestatDir.
 
 	// TODO: wasi.FdPwrite
 
 	// FdRead is the WASI function to read from a file descriptor.
 	//
-	// * fd - the file decriptor to read from
-	// * iovs - the offset in `ctx.Memory` that contains a series of `iovec`, which indicates where to write the bytes read.
-	// * iovsLen - the number of `iovec`s in `iovs`
+	// * fd - an opened file descriptor to read data from
+	// * iovs - the offset in `ctx.Memory` to read offset, size pairs representing where to write file data.
+	//   * Both offset and length are encoded as uint32le.
+	// * iovsLen - the count of memory offset, size pairs to read sequentially starting at iovs.
 	// * resultSize - the offset in `ctx.Memory` to write the number of bytes read
-	// `iovec` is a memory offset / length pair, which are named buf/bufLen, encoded sequentially as uint32le.
-	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#iovec
 	//
-	// FdRead returns the following errors.
-	// * ErrnoBadf - if `fd` is invalid
-	// * ErrnoFault - if `iovs` or `resultSize` contain an invalid offset due to the memory constraint
-	// * ErrnoIo - if an IO related error happens during the operation
+	// The wasi.Errno returned is wasi.ErrnoSuccess except the following error conditions:
+	// * wasi.ErrnoBadf - if `fd` is invalid
+	// * wasi.ErrnoFault - if `iovs` or `resultSize` contain an invalid offset due to the memory constraint
+	// * wasi.ErrnoIo - if an IO related error happens during the operation
 	//
-	// For example, suppose fd 3 is a file with the contents "test",
-	// and FdRead parameters fd = 3, iovs = 1, and iovsLen = 2, resultSize = 24
-	// and two `iovec`s are {buf: 18, bufLen: 2} and {buf: 21, bufLen: 2}.
-	// Now, `ctx.Memory` contains
+	// For example, this function needs to first read `iovs` to determine where to write contents. If
+	//    parameters iovs=1 iovsLen=2, this function reads two offset/length pairs from `ctx.Memory`:
 	//
 	//                      iovs[0]                  iovs[1]
-	//              +--------------------+   +--------------------+
-	//              |uint32le    uint32le|   |uint32le    uint32le|
-	//              +--------+  +--------+   +--------+  +--------+
-	//              |        |  |        |   |        |  |        |
-	//   []byte{?, 18, 0, 0, 0, 2, 0, 0, 0, 21, 0, 0, 0, 2, 0, 0, 0, ?... }
-	//       iovs --^           ^            ^           ^    17th --^
-	//              |           |            |           |
-	//        buf --+  bufLen --+      buf --+  bufLen --+
+	//              +---------------------+   +--------------------+
+	//              | uint32le    uint32le|   |uint32le    uint32le|
+	//              +---------+  +--------+   +--------+  +--------+
+	//              |         |  |        |   |        |  |        |
+	//    []byte{?, 18, 0, 0, 0, 4, 0, 0, 0, 23, 0, 0, 0, 2, 0, 0, 0, ?... }
+	//       iovs --^            ^            ^           ^
+	//              |            |            |           |
+	//     offset --+   length --+   offset --+  length --+
 	//
-	// After FdRead completes, we expect `ctx.Memory` to contain:
+	// If the contents of the `fd` parameter was "wazero" (6 bytes) and
+	//    parameter resultSize=30, this function writes the below to `ctx.Memory`:
 	//
-	//                             iovs[0]      iovs[1]
-	//                             bufLen       bufLen       uint32le
-	//                             +----+       +----+      +--------+
-	//                             |    |       |    |      |        |
-	//   []byte{ same as above.., 't', 'e', ?, 's', 't', ?, 4, 0, 0, 0 }
-	//               iovs[0] buf --^            ^           ^
-	//                  (= 18th)  iovs[1] buf --+           |
-	//                               (= 21st)  resultSize --+
-	//                                           (= 24th)
+	//                       iovs[0].length        iovs[1].length           uint32le
+	//                      +--------------+       +----+                  +--------+
+	//                      |              |       |    |                  |        |
+	//   []byte{ 0..16, ?, 'w', 'a', 'z', 'e', ?, 'r', 'o', ?, ?, ?, ?, ?, 6, 0, 0, 0 }
+	//     iovs[0].offset --^                      ^                       ^
+	//                            iovs[1].offset --+                       |
+	//                                                        resultSize --+
 	//
 	// Note: ImportFdRead shows this signature in the WebAssembly 1.0 (MVP) Text Format.
-	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
 	// Note: This is similar to `readv` in POSIX.
+	// See FdWrite
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#iovec
 	// See https://linux.die.net/man/3/readv
-	FdRead(ctx wasm.ModuleContext, fd uint32, iovs uint32, iovsLen uint32, resultSize uint32) wasi.Errno
+	FdRead(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno
 
 	// TODO: wasi.FdReaddir
 	// TODO: wasi.FdRenumber
@@ -464,50 +460,56 @@ type SnapshotPreview1 interface {
 	// TODO: wasi.FdSync
 	// TODO: wasi.FdTell
 
-	// TODO: wasi.FdWrite
 	// FdWrite is the WASI function to write to a file descriptor.
 	//
-	// * fd - the file decriptor to write to
-	// * iovs - the offset in `ctx.Memory` that contains a series of `ciovec`, which indicates ranges of the bytes to write.
-	// * iovsLen - the number of `ciovec`s in `iovs`
+	// * fd - an opened file descriptor to write data to
+	// * iovs - the offset in `ctx.Memory` to read offset, size pairs representing the data to write to `fd`
+	//   * Both offset and length are encoded as uint32le.
+	// * iovsLen - the count of memory offset, size pairs to read sequentially starting at iovs.
 	// * resultSize - the offset in `ctx.Memory` to write the number of bytes written
-	// `ciovec` is a memory offset / length pair, which are named buf/bufLen, encoded sequentially as uint32le.
-	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#ciovec
-	// Note: ciovec` is an equivalent structure to `iovec` for `fd_read` with no difference other than the name.
 	//
-	// FdWrite returns the following errors.
-	// * ErrnoBadf - if `fd` is invalid
-	// * ErrnoFault - if `iovs` or `resultSize` contain an invalid offset due to the memory constraint
-	// * ErrnoIo - if an IO related error happens during the operation
+	// The wasi.Errno returned is wasi.ErrnoSuccess except the following error conditions:
+	// * wasi.ErrnoBadf - if `fd` is invalid
+	// * wasi.ErrnoFault - if `iovs` or `resultSize` contain an invalid offset due to the memory constraint
+	// * wasi.ErrnoIo - if an IO related error happens during the operation
 	//
-	// For example, suppose fd 3 is an empty opened file,
-	// and FdWrite parameters fd = 3, iovs = 1, and iovsLen = 2, resultSize = 22,
-	// and two `ciovec`s are {buf: 17, bufLen: 2} and {buf: 20, bufLen: 2}.
-	// Now, suppose `ctx.Memory` contains
+	// For example, this function needs to first read `iovs` to determine what to write to `fd`. If
+	//    parameters iovs=1 iovsLen=2, this function reads two offset/length pairs from `ctx.Memory`:
 	//
-	//                     ciovs[0]                 ciovs[1]
-	//              +--------------------+   +--------------------+  ciovs[0]     ciovs[1]
-	//              |uint32le    uint32le|   |uint32le    uint32le|   bufLen       bufLen
-	//              +--------+  +--------+   +--------+  +--------+   +----+       +----+
-	//              |        |  |        |   |        |  |        |   |    |       |    |
-	//   []byte{?, 17, 0, 0, 0, 2, 0, 0, 0, 20, 0, 0, 0, 2, 0, 0, 0, 't', 'e', ?, 's', 't', ... }
-	//       iovs --^           ^            ^           ^            ^            ^
-	//              |           |            |           |   ciovs[0] |   ciovs[1] |
-	//        buf --+  bufLen --+      buf --+  bufLen --+     buf  --+     buf  --+
+	//                      iovs[0]                  iovs[1]
+	//              +---------------------+   +--------------------+
+	//              | uint32le    uint32le|   |uint32le    uint32le|
+	//              +---------+  +--------+   +--------+  +--------+
+	//              |         |  |        |   |        |  |        |
+	//    []byte{?, 18, 0, 0, 0, 4, 0, 0, 0, 23, 0, 0, 0, 2, 0, 0, 0, ?... }
+	//       iovs --^            ^            ^           ^
+	//              |            |            |           |
+	//     offset --+   length --+   offset --+  length --+
 	//
-	// After FdWrite completes, we expect `ctx.Memory` to contain:
+	// This function reads those chunks `ctx.Memory` into the `fd` sequentially.
 	//
-	//                              uint32le
-	//                             +--------+
-	//                             |        |
-	//   []byte{ same as above..., 4, 0, 0, 0, ? }
-	//                resultSize --^
+	//                       iovs[0].length        iovs[1].length
+	//                      +--------------+       +----+
+	//                      |              |       |    |
+	//   []byte{ 0..16, ?, 'w', 'a', 'z', 'e', ?, 'r', 'o', ? }
+	//     iovs[0].offset --^                      ^
+	//                            iovs[1].offset --+
+	//
+	// Since "wazero" was written, if parameter resultSize=30, this function writes the below to `ctx.Memory`:
+	//
+	//                      uint32le
+	//                     +--------+
+	//                     |        |
+	//   []byte{ 0..28, ?, 6, 0, 0, 0', ? }
+	//        resultSize --^
 	//
 	// Note: ImportFdWrite shows this signature in the WebAssembly 1.0 (MVP) Text Format.
-	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_write
 	// Note: This is similar to `writev` in POSIX.
+	// See FdRead
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#ciovec
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_write
 	// See https://linux.die.net/man/3/writev
-	FdWrite(ctx wasm.ModuleContext, fd uint32, iovs uint32, iovsLen uint32, resultSize uint32) wasi.Errno
+	FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno
 
 	// TODO: PathCreateDirectory
 	// TODO: PathFilestatGet
@@ -752,7 +754,7 @@ func (a *wasiAPI) FdPrestatDirName(ctx wasm.ModuleContext, fd uint32, pathPtr ui
 }
 
 // FdRead implements SnahpshotPreview1.FdRead
-func (a *wasiAPI) FdRead(ctx wasm.ModuleContext, fd uint32, iovs uint32, iovsLen uint32, resultSize uint32) wasi.Errno {
+func (a *wasiAPI) FdRead(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
 	var reader io.Reader
 
 	switch fd {
@@ -800,7 +802,7 @@ func (a *wasiAPI) fd_seek(ctx wasm.ModuleContext, fd uint32, offset uint64, when
 }
 
 // FdWrite implements SnahpshotPreview1.FdWrite
-func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd uint32, iovs uint32, iovsLen uint32, resultSize uint32) wasi.Errno {
+func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
 	var writer io.Writer
 
 	switch fd {

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -188,7 +188,7 @@ func TestSnapshotPreview1_ArgsSizesGet_Errors(t *testing.T) {
 		{
 			name:        "argvBufSize exceeds the maximum valid size by 1",
 			argc:        validAddress,
-			argvBufSize: memorySize - 4 + 1, // 4 is the size of uint32, the type of the length
+			argvBufSize: memorySize - 4 + 1, // 4 the encoded size of uint32le
 		},
 	}
 

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -188,7 +188,7 @@ func TestSnapshotPreview1_ArgsSizesGet_Errors(t *testing.T) {
 		{
 			name:        "argvBufSize exceeds the maximum valid size by 1",
 			argc:        validAddress,
-			argvBufSize: memorySize - 4 + 1, // 4 the encoded size of uint32le
+			argvBufSize: memorySize - 4 + 1, // 4 is count of bytes to encode uint32le
 		},
 	}
 
@@ -388,7 +388,7 @@ func TestSnapshotPreview1_EnvironSizesGet_Errors(t *testing.T) {
 		{
 			name:           "environBufSizePtr exceeds the maximum valid size by 1",
 			environc:       validAddress,
-			environBufSize: memorySize - 4 + 1, // 4 is the size of uint32, the type of the length
+			environBufSize: memorySize - 4 + 1, // 4 is count of bytes to encode uint32le
 		},
 	}
 
@@ -574,9 +574,8 @@ func TestSnapshotPreview1_FdPrestatDirName_Errors(t *testing.T) {
 	store, ctx, fn := instantiateWasmStore(t, FunctionFdPrestatDirName, ImportFdPrestatDirName, moduleName, opt)
 
 	memorySize := uint32(len(store.Memories[0].Buffer))
-	validAddress := uint32(0)     // Arbitrary valid address as arguments to fd_prestat_dir_name. We chose 0 here.
-	actualPathLen := len(dirName) // Actual length of the dirName as a valid pathLen.
-	fd := uint32(3)               // fd 3 will be opened for the "/tmp" directory after 0, 1, and 2, that are stdin/out/err
+	validAddress := uint32(0) // Arbitrary valid address as arguments to fd_prestat_dir_name. We chose 0 here.
+	fd := uint32(3)           // fd 3 will be opened for the "/tmp" directory after 0, 1, and 2, that are stdin/out/err
 
 	tests := []struct {
 		name          string
@@ -589,28 +588,28 @@ func TestSnapshotPreview1_FdPrestatDirName_Errors(t *testing.T) {
 			name:          "out-of-memory path",
 			fd:            fd,
 			path:          memorySize,
-			pathLen:       uint32(actualPathLen),
+			pathLen:       uint32(len(dirName)),
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "path exceeds the maximum valid address by 1",
 			fd:            fd,
-			path:          memorySize - uint32(actualPathLen) + 1,
-			pathLen:       uint32(actualPathLen),
+			path:          memorySize - uint32(len(dirName)) + 1,
+			pathLen:       uint32(len(dirName)),
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
-			name:          "pathLen exceeds the actual length of the dir name",
+			name:          "pathLen exceeds the length of the dir name",
 			fd:            fd,
 			path:          validAddress,
-			pathLen:       uint32(actualPathLen) + 1,
+			pathLen:       uint32(len(dirName)) + 1,
 			expectedErrno: wasi.ErrnoNametoolong,
 		},
 		{
 			name:          "invalid fd",
 			fd:            42, // arbitrary invalid fd
 			path:          validAddress,
-			pathLen:       uint32(actualPathLen) + 1,
+			pathLen:       uint32(len(dirName)) + 1,
 			expectedErrno: wasi.ErrnoBadf,
 		},
 	}

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -698,10 +698,11 @@ func TestAPI_FdRead_Errors(t *testing.T) {
 	})
 
 	memorySize := uint32(len(store.Memories[0].Buffer))
-	validIovs := uint32(0)            // arbitrary valid offset for iovec. tc.iovec will be placed at this offset.
+	validIovs := uint32(1)            // arbitrary valid offset for iovec. tc.iovec will be placed at this offset.
 	validIov := iovecInBytes(0x10, 4) // arbitrary valid iovec
 	validResultSize := uint32(0x100)  // arbitrary valid offset for resultSize
 
+	// Test parameters are filled with the valid values if they're not defined.
 	tests := []struct {
 		name          string
 		fd            uint32
@@ -712,48 +713,47 @@ func TestAPI_FdRead_Errors(t *testing.T) {
 	}{
 		{
 			name:          "out-of-memory iovs",
-			fd:            validFD,
 			iovs:          memorySize,
-			iovec:         validIov,
-			resultSize:    validResultSize,
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "out-of-memory iovs[0].buf",
-			fd:            validFD,
-			iovs:          validIovs, // offset to the iovec below
 			iovec:         iovecInBytes(memorySize, 4),
-			resultSize:    validResultSize,
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
-			name:          "too long iovs[0].bufLen",
-			fd:            validFD,
-			iovs:          validIovs,                     // offset to the iovec below
-			iovec:         iovecInBytes(memorySize-3, 4), // last 1 byte exceeds the memory
-			resultSize:    validResultSize,
+			name:          "bytes to read exceeds the memory by 1",
+			iovec:         iovecInBytes(memorySize-1, 2),
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "out-of-memory resultSize",
-			fd:            validFD,
-			iovs:          validIovs,          // offset to the iovec below
-			iovec:         iovecInBytes(0, 4), // arbitrary valid iovec
 			resultSize:    memorySize,
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "invalid fd",
-			fd:            42,                 // arbitrary invalid fd
-			iovs:          validIovs,          // offset to the iovec below
-			iovec:         iovecInBytes(0, 4), // arbitrary valid iovec
-			resultSize:    validResultSize,
+			fd:            42, // arbitrary invalid fd
 			expectedErrno: wasi.ErrnoBadf,
 		},
 	}
 
 	for _, tt := range tests {
 		tc := tt
+
+		// Fill the parameters with the default valid values if they're not defined.
+		if tc.fd == 0 {
+			tc.fd = validFD
+		}
+		if tc.iovs == 0 {
+			tc.iovs = validIovs
+		}
+		if tc.iovec == nil {
+			tc.iovec = validIov
+		}
+		if tc.resultSize == 0 {
+			tc.resultSize = validResultSize
+		}
 
 		t.Run(tc.name, func(t *testing.T) {
 			copy(store.Memories[0].Buffer[0:], tc.iovec)
@@ -843,10 +843,11 @@ func TestAPI_FdWrite_Errors(t *testing.T) {
 	})
 
 	memorySize := uint32(len(store.Memories[0].Buffer))
-	validIovs := uint32(0)           // arbitrary valid offset for iovec. tc.iovec will be placed at this offset.
-	validIov := iovecInBytes(0, 4)   // arbitrary valid iovec. We don't care the contents of the memory as long as the range is valid.
-	validResultSize := uint32(0x100) // arbitrary valid offset for resultSize
+	validIovs := uint32(1)            // arbitrary valid offset for iovec. tc.iovec will be placed at this offset.
+	validIov := iovecInBytes(0x10, 4) // arbitrary valid iovec. We don't care the contents of the memory as long as the range is valid.
+	validResultSize := uint32(0x100)  // arbitrary valid offset for resultSize
 
+	// Test parameters are filled with the valid values if they're not defined.
 	tests := []struct {
 		name          string
 		fd            uint32
@@ -857,47 +858,47 @@ func TestAPI_FdWrite_Errors(t *testing.T) {
 	}{
 		{
 			name:          "out-of-memory iovs",
-			fd:            validFD,
 			iovs:          memorySize,
-			iovec:         validIov,
-			resultSize:    validResultSize,
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "out-of-memory iovs[0].buf",
-			fd:            validFD,
-			iovs:          validIovs, // offset to the iovec below
 			iovec:         iovecInBytes(memorySize, 4),
-			resultSize:    validResultSize,
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
-			name:          "bytes to write exceeds the memory",
-			fd:            validFD,
-			iovs:          validIovs,                     // offset to the iovec below
-			iovec:         iovecInBytes(memorySize-1, 2), // last 1 byte will exceed the memory by 1
-			resultSize:    validResultSize,
+			name:          "bytes to write exceeds the memory by 1",
+			iovec:         iovecInBytes(memorySize-1, 2),
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "out-of-memory resultSize",
-			fd:            validFD,
-			iovs:          validIovs, // offset to the iovec below
-			iovec:         validIov,
 			resultSize:    memorySize,
 			expectedErrno: wasi.ErrnoFault,
 		},
 		{
 			name:          "invalid fd",
-			fd:            42,        // arbitrary invalid fd
-			iovs:          validIovs, // offset to the iovec below
-			iovec:         validIov,
+			fd:            42, // arbitrary invalid fd
 			expectedErrno: wasi.ErrnoBadf,
 		},
 	}
 
 	for _, tt := range tests {
 		tc := tt
+
+		// Fill the parameters with the default valid values if they're not defined.
+		if tc.fd == 0 {
+			tc.fd = validFD
+		}
+		if tc.iovs == 0 {
+			tc.iovs = validIovs
+		}
+		if tc.iovec == nil {
+			tc.iovec = validIov
+		}
+		if tc.resultSize == 0 {
+			tc.resultSize = validResultSize
+		}
 
 		t.Run(tc.name, func(t *testing.T) {
 			copy(store.Memories[0].Buffer[validIovs:], tc.iovec) // put the given iovec to a valid address for iovs


### PR DESCRIPTION
This PR backfills the docs and tests of `fd_write`, and backfills the tests of `fd_read`.