### PR TITLE
Adds ModuleConfig.Validate() to allow pre-flight checks on source

### DIFF
--- a/wasm.go
+++ b/wasm.go
@@ -67,6 +67,12 @@ type ModuleConfig struct {
 	Source []byte
 }
 
+// Validate errs if the source is invalid. This is used to pre-flight check the Source when instantiation is deferred.
+func (m *ModuleConfig) Validate() error {
+	_, _, err := decodeModule(m)
+	return err
+}
+
 // InstantiateModule instantiates the module namespace or errs if the configuration was invalid.
 //
 // Ex.

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -47,6 +47,30 @@ func TestDecodeModule(t *testing.T) {
 			require.NoError(t, config.Validate())
 		})
 	}
+
+	t.Run("caches repetitive decodes", func(t *testing.T) {
+		config := &ModuleConfig{Source: wat}
+		m, _, err := decodeModule(config)
+		require.NoError(t, err)
+
+		again, _, err := decodeModule(config)
+		require.NoError(t, err)
+
+		require.Same(t, m, again)
+	})
+
+	t.Run("changing source invalidates decode cache", func(t *testing.T) {
+		config := &ModuleConfig{Source: wat}
+		m, _, err := decodeModule(config)
+		require.NoError(t, err)
+
+		config.Source = wasm
+		again, _, err := decodeModule(config)
+		require.NoError(t, err)
+
+		require.Equal(t, m, again)
+		require.NotSame(t, m, again)
+	})
 }
 
 func TestDecodeModule_Errors(t *testing.T) {

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -34,13 +34,17 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, name, err := decodeModule(&ModuleConfig{Name: tc.moduleName, Source: tc.source})
+			config := &ModuleConfig{Name: tc.moduleName, Source: tc.source}
+			_, name, err := decodeModule(config)
 			require.NoError(t, err)
 			if tc.moduleName == "" {
 				require.Equal(t, "test" /* from the text format */, name)
 			} else {
 				require.Equal(t, tc.moduleName, name)
 			}
+
+			// Avoid adding another test just to check Validate works
+			require.NoError(t, config.Validate())
 		})
 	}
 }
@@ -71,8 +75,12 @@ func TestDecodeModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := decodeModule(&ModuleConfig{Source: tc.source})
+			config := &ModuleConfig{Source: tc.source}
+			_, _, err := decodeModule(config)
 			require.EqualError(t, err, tc.expectedErr)
+
+			// Avoid adding another test just to check Validate works
+			require.EqualError(t, config.Validate(), tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
This adds `ModuleConfig.Validate()` as needed by wapc-go to ensure a
module instantiated many times later is checked first. This is a method
of config in case we later add the ability to force a format. For now,
it relies on detection and the call-site only use binary anyway.
