### PR TITLE
Exports wasm.ValueType and makes Functions interfaces for signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ func main() {
 	exports, _ := wazero.InstantiateModule(wazero.NewStore(), &wazero.ModuleConfig{Source: source})
 
 	// Discover 7! is 5040
-	fmt.Println(exports.Function("fac")(context.Background(), 7))
+	fmt.Println(exports.Function("fac").Call(context.Background(), 7))
 }
 ```
 

--- a/examples/add_test.go
+++ b/examples/add_test.go
@@ -32,7 +32,7 @@ func Test_AddInt(t *testing.T) {
 		{value1: 1, value2: 2, expected: 3},
 		{value1: 5, value2: 5, expected: 10},
 	} {
-		results, err := addInt(context.Background(), c.value1, c.value2)
+		results, err := addInt.Call(context.Background(), c.value1, c.value2)
 		require.NoError(t, err)
 		require.Equal(t, c.expected, results[0])
 	}

--- a/examples/fibonacci_test.go
+++ b/examples/fibonacci_test.go
@@ -33,7 +33,7 @@ func Test_fibonacci(t *testing.T) {
 		{input: 10, expected: 55},
 		{input: 5, expected: 5},
 	} {
-		results, err := fibonacci(context.Background(), c.input)
+		results, err := fibonacci.Call(context.Background(), c.input)
 		require.NoError(t, err)
 		require.Equal(t, c.expected, results[0])
 	}

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -66,7 +66,7 @@ func Test_hostFunc(t *testing.T) {
 
 	// Implement the function pointer. This mainly shows how you can decouple a module function dependency.
 	allocateBuffer = func(ctx context.Context, size uint32) uint32 {
-		res, err := allocateBufferFn(ctx, uint64(size))
+		res, err := allocateBufferFn.Call(ctx, uint64(size))
 		require.NoError(t, err)
 		return uint32(res[0])
 	}
@@ -75,6 +75,6 @@ func Test_hostFunc(t *testing.T) {
 	ctx := context.WithValue(context.Background(), testKey{}, int64(12345))
 
 	// Invoke a module-defined function that depends on a host function import
-	_, err = exports.Function("base64")(ctx, uint64(5))
+	_, err = exports.Function("base64").Call(ctx, uint64(5))
 	require.NoError(t, err)
 }

--- a/examples/wasi_test.go
+++ b/examples/wasi_test.go
@@ -43,7 +43,7 @@ func Test_WASI(t *testing.T) {
 
 	// Implement the function pointer. This mainly shows how you can decouple a host function dependency.
 	randomGet = func(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno {
-		res, err := randomGetFn(ctx, uint64(buf), uint64(bufLen))
+		res, err := randomGetFn.Call(ctx, uint64(buf), uint64(bufLen))
 		require.NoError(t, err)
 		return wasi.Errno(res[0])
 	}

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -2,6 +2,8 @@ package internalwasm
 
 import (
 	"fmt"
+
+	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
 // DecodeModule parses the configured source into a Module. This function returns when the source is exhausted or
@@ -470,34 +472,19 @@ func SectionIDName(sectionID SectionID) string {
 	return "unknown"
 }
 
-// ValueType is the binary encoding of a type such as i32
-// See https://www.w3.org/TR/wasm-core-1/#binary-valtype
-//
-// Note: This is a type alias as it is easier to encode and decode in the binary format.
-type ValueType = byte
+// ValueType is an alias of wasm.ValueType defined to simplify imports.
+type ValueType = publicwasm.ValueType
 
 const (
-	ValueTypeI32 ValueType = 0x7f
-	ValueTypeI64 ValueType = 0x7e
-	ValueTypeF32 ValueType = 0x7d
-	ValueTypeF64 ValueType = 0x7c
+	ValueTypeI32 = publicwasm.ValueTypeI32
+	ValueTypeI64 = publicwasm.ValueTypeI64
+	ValueTypeF32 = publicwasm.ValueTypeF32
+	ValueTypeF64 = publicwasm.ValueTypeF64
 )
 
-// ValueTypeName returns the type name of the given ValueType as a string.
-// These type names match the names used in the WebAssembly text format.
-// Note that ValueTypeName returns "unknown", if an undefined ValueType value is passed.
+// ValueTypeName is an alias of wasm.ValueTypeName defined to simplify imports.
 func ValueTypeName(t ValueType) string {
-	switch t {
-	case ValueTypeI32:
-		return "i32"
-	case ValueTypeI64:
-		return "i64"
-	case ValueTypeF32:
-		return "f32"
-	case ValueTypeF64:
-		return "f64"
-	}
-	return "unknown"
+	return publicwasm.ValueTypeName(t)
 }
 
 // ImportKind indicates which import description is present

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -82,28 +82,6 @@ func TestExportKindName(t *testing.T) {
 	}
 }
 
-func TestValueTypeName(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    ValueType
-		expected string
-	}{
-		{"i32", ValueTypeI32, "i32"},
-		{"i64", ValueTypeI64, "i64"},
-		{"f32", ValueTypeF32, "f32"},
-		{"f64", ValueTypeF64, "f64"},
-		{"unknown", 100, "unknown"},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, ValueTypeName(tc.input))
-		})
-	}
-}
-
 func TestModule_allDeclarations(t *testing.T) {
 	for i, tc := range []struct {
 		module            *Module

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -363,7 +363,7 @@ func (m *ModuleExports) Function(name string) publicwasm.Function {
 	if err != nil {
 		return nil
 	}
-	return (&function{c: m.Context, f: exp.Function}).Call
+	return &function{c: m.Context, f: exp.Function}
 }
 
 // Memory implements wasm.ModuleExports Memory

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -153,7 +153,7 @@ func TestStore_ExportImportedHostFunction(t *testing.T) {
 	})
 }
 
-func TestFunctionInstance_call(t *testing.T) {
+func TestFunctionInstance_Call(t *testing.T) {
 	type key string
 	storeCtx := context.WithValue(context.Background(), key("wa"), "zero")
 
@@ -211,7 +211,7 @@ func TestFunctionInstance_call(t *testing.T) {
 			require.NoError(t, err)
 
 			// This fails if the function wasn't invoked, or had an unexpected context.
-			_, err = instantiated.Function(functionName)(tc.ctx)
+			_, err = instantiated.Function(functionName).Call(tc.ctx)
 			require.NoError(t, err)
 			if tc.expected == nil {
 				require.Nil(t, engine.ctx)

--- a/tests/bench/bench_fac_iter_test.go
+++ b/tests/bench/bench_fac_iter_test.go
@@ -33,7 +33,7 @@ func TestFacIter(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := 0; i < 10000; i++ {
-			res, err := fn(ctx, in)
+			res, err := fn.Call(ctx, in)
 			require.NoError(t, err)
 			require.Equal(t, expValue, res[0])
 		}
@@ -44,7 +44,7 @@ func TestFacIter(t *testing.T) {
 		require.NoError(t, err)
 
 		for i := 0; i < 10000; i++ {
-			res, err := fn(ctx, in)
+			res, err := fn.Call(ctx, in)
 			require.NoError(t, err)
 			require.Equal(t, expValue, res[0])
 		}
@@ -129,7 +129,7 @@ func BenchmarkFacIter_Invoke(b *testing.B) {
 		}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, err = fn(ctx, in); err != nil {
+			if _, err = fn.Call(ctx, in); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -141,7 +141,7 @@ func BenchmarkFacIter_Invoke(b *testing.B) {
 		}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if _, err = fn(ctx, in); err != nil {
+			if _, err = fn.Call(ctx, in); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/tests/codec/codec_test.go
+++ b/tests/codec/codec_test.go
@@ -113,7 +113,7 @@ func TestExampleUpToDate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call the add function as a smoke test
-		results, err := exports.Function("AddInt")(context.Background(), uint64(1), uint64(2))
+		results, err := exports.Function("AddInt").Call(context.Background(), 1, 2)
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), results[0])
 	})

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -463,20 +463,8 @@ func requireValueEq(t *testing.T, actual, expected uint64, valType wasm.ValueTyp
 
 // callFunction is inlined here as the spectest needs to validate the signature was correct
 // TODO: This is likely already covered with unit tests!
-func callFunction(s *wasm.Store, moduleName, funcName string, params ...uint64) (results []uint64, resultTypes []wasm.ValueType, err error) {
-	ctx := s.ModuleContexts[moduleName]
-	var exp *wasm.ExportInstance
-	if exp, err = ctx.Module.GetExport(funcName, wasm.ExportKindFunc); err != nil {
-		return
-	}
-
-	f := exp.Function
-	if len(f.FunctionType.Type.Params) != len(params) {
-		err = fmt.Errorf("invalid number of parameters")
-		return
-	}
-
-	results, err = s.Engine.Call(ctx, f, params...)
-	resultTypes = f.FunctionType.Type.Results
-	return
+func callFunction(s *wasm.Store, moduleName, funcName string, params ...uint64) ([]uint64, []wasm.ValueType, error) {
+	fn := s.ModuleExports(moduleName).Function(funcName)
+	results, err := fn.Call(context.Background(), params...)
+	return results, fn.ResultTypes(), err
 }

--- a/wasi.go
+++ b/wasi.go
@@ -112,7 +112,7 @@ func StartWASICommand(store wasm.Store, module *ModuleConfig) (wasm.ModuleExport
 	ctx := instantiated.Context
 
 	start := ctx.Function(internalwasi.FunctionStart)
-	if _, err = start(ctx.Context()); err != nil {
+	if _, err = start.Call(ctx.Context()); err != nil {
 		return nil, fmt.Errorf("module[%s] function[%s] failed: %w", moduleName, internalwasi.FunctionStart, err)
 	}
 	return instantiated, nil

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -6,6 +6,53 @@ import (
 	"math"
 )
 
+// ValueType describes a numeric type used in Web Assembly 1.0 (MVP). For example, Function parameters and results are
+// only definable as a value type.
+//
+// The following describes how to convert between Wasm and Golang types:
+//  * ValueTypeI32 - uint64(uint32,int32,int64)
+//  * ValueTypeI64 - uint64
+//  * ValueTypeF32 - EncodeF32 DecodeF32 from float32
+//  * ValueTypeF64 - EncodeF64 DecodeF64 from float64
+//
+// Ex. Given a Text Format type use (param i64) (result i64), no conversion is necessary.
+//
+//	results, _ := fn(ctx, input)
+//	result := result[0]
+//
+// Ex. Given a Text Format type use (param f64) (result f64), conversion is necessary.
+//
+//	results, _ := fn(ctx, wasm.EncodeF64(input))
+//	result := wasm.DecodeF64(result[0])
+//
+// Note: This is a type alias as it is easier to encode and decode in the binary format.
+// See https://www.w3.org/TR/wasm-core-1/#binary-valtype
+type ValueType = byte
+
+const (
+	ValueTypeI32 ValueType = 0x7f
+	ValueTypeI64 ValueType = 0x7e
+	ValueTypeF32 ValueType = 0x7d
+	ValueTypeF64 ValueType = 0x7c
+)
+
+// ValueTypeName returns the type name of the given ValueType as a string.
+// These type names match the names used in the WebAssembly text format.
+// Note that ValueTypeName returns "unknown", if an undefined ValueType value is passed.
+func ValueTypeName(t ValueType) string {
+	switch t {
+	case ValueTypeI32:
+		return "i32"
+	case ValueTypeI64:
+		return "i64"
+	case ValueTypeF32:
+		return "f32"
+	case ValueTypeF64:
+		return "f64"
+	}
+	return "unknown"
+}
+
 // Store allows access to instantiated modules and host functions
 type Store interface {
 	// ModuleExports returns exports from an instantiated module or nil if there aren't any.
@@ -43,23 +90,7 @@ type ModuleExports interface {
 //		results, err := fn(ctx.Context(), offset, byteCount)
 //	--snip--
 //
-// The following describes how remaining parameters map to Web Assembly 1.0 (MVP) Value Types:
-//  * I32 - uint64(uint32,int32,int64)
-//  * I64 - uint64
-//  * F32 - EncodeF32 DecodeF32 from float32
-//  * F64 - EncodeF64 DecodeF64 from float64
-//
-// Ex. Given a Text Format type use (param i64) (result i64)
-//
-//	results, _ := fn(ctx, input)
-//	result := result[0]
-//
-// Ex. Given a Text Format type use (param f64) (result f64)
-//
-//	results, _ := fn(ctx, wasm.EncodeF64(input))
-//	result := wasm.DecodeF64(result[0])
-//
-// See https://www.w3.org/TR/wasm-core-1/#binary-valtype
+// Parameters and results are encoded according to documentation on ValueType.
 type Function func(ctx context.Context, params ...uint64) ([]uint64, error)
 
 // HostExports return functions defined in Go, a.k.a. "Host Functions" in WebAssembly 1.0 (MVP).
@@ -151,25 +182,25 @@ type Memory interface {
 	Write(offset uint32, v []byte) bool
 }
 
-// EncodeF32 converts the input so that it can be used as a Function F32 parameter or result.
+// EncodeF32 encodes the input as a ValueTypeF32.
 // See DecodeF32
 func EncodeF32(input float32) uint64 {
 	return uint64(math.Float32bits(input))
 }
 
-// DecodeF32 converts the Function F32 parameter or result to a float32.
+// DecodeF32 decodes the input as a ValueTypeF32.
 // See DecodeF32
 func DecodeF32(input uint64) float32 {
 	return math.Float32frombits(uint32(input))
 }
 
-// EncodeF64 converts the input so that it can be used as a Function F64 parameter or result.
+// EncodeF64 encodes the input as a ValueTypeF64.
 // See DecodeF64
 func EncodeF64(input float64) uint64 {
 	return math.Float64bits(input)
 }
 
-// DecodeF64 converts the Function F64 parameter or result to a float64.
+// DecodeF64 decodes the input as a ValueTypeF64.
 // See EncodeF64
 func DecodeF64(input uint64) float64 {
 	return math.Float64frombits(input)

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -92,7 +92,7 @@ type Function interface {
 	// See ValueType documentation for decoding rules.
 	ResultTypes() []ValueType
 
-	// Call is invokes the function with parameters encoded according to ParamTypes. Up to one result is returned,
+	// Call invokes the function with parameters encoded according to ParamTypes. Up to one result is returned,
 	// encoded according to ResultTypes. An error is returned for any failure looking up or invoking the function
 	// including signature mismatch.
 	//

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -38,7 +38,8 @@ const (
 
 // ValueTypeName returns the type name of the given ValueType as a string.
 // These type names match the names used in the WebAssembly text format.
-// Note that ValueTypeName returns "unknown", if an undefined ValueType value is passed.
+//
+// Note: This returns "unknown", if an undefined ValueType value is passed.
 func ValueTypeName(t ValueType) string {
 	switch t {
 	case ValueTypeI32:

--- a/wasm/wasm_test.go
+++ b/wasm/wasm_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValueTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    ValueType
+		expected string
+	}{
+		{"i32", ValueTypeI32, "i32"},
+		{"i64", ValueTypeI64, "i64"},
+		{"f32", ValueTypeF32, "f32"},
+		{"f64", ValueTypeF64, "f64"},
+		{"unknown", 100, "unknown"},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, ValueTypeName(tc.input))
+		})
+	}
+}
+
 func TestEncodeDecodeF32(t *testing.T) {
 	for _, v := range []float32{
 		0, 100, -100, 1, -1,

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -214,7 +214,7 @@ func TestFunction_Context(t *testing.T) {
 			require.NoError(t, err)
 
 			// This fails if the function wasn't invoked, or had an unexpected context.
-			results, err := exports.Function(functionName)(tc.ctx)
+			results, err := exports.Function(functionName).Call(tc.ctx)
 			require.NoError(t, err)
 			require.Equal(t, expectedResult, results[0])
 		})


### PR DESCRIPTION
This moves code for `ValueType` constants public, so that we can
verify function signatures. To achieve this without complicating
function calls this makes `Function` and `HostFunction` `interface`
instead of `func` types.

Note: We'll also need `ValueType` when re-introducing a Globals API.

To keep complexity down in consideration that there are only 4 types, I
copied the constants into the internalwasm package. This reduces the
import complexity otherwise would have caused.