### PR TITLE
Pushes param length validation to engine

### DIFF
--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -508,7 +508,7 @@ func TestSnapshotPreview1_FdClose(t *testing.T) {
 	})
 	t.Run(FunctionFdClose, func(t *testing.T) {
 		store, ctx, fn, api := setupFD()
-		ret, err := store.Engine.Call(ctx, fn, uint64(fdToClose), uint64(fdToClose))
+		ret, err := store.Engine.Call(ctx, fn, uint64(fdToClose))
 		require.NoError(t, err)
 		require.Equal(t, wasi.ErrnoSuccess, wasi.Errno(ret[0])) // cast because results are always uint64
 		require.NotContains(t, api.opened, fdToClose)           // Fd is closed and removed from the opened FDs.

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -142,11 +142,11 @@ func (f *FunctionInstance) ResultTypes() []publicwasm.ValueType {
 
 // Call implements wasm.HostFunction Call
 func (f *FunctionInstance) Call(ctx publicwasm.ModuleContext, params ...uint64) ([]uint64, error) {
-	hCtx, ok := ctx.(*ModuleContext)
-	if !ok { // TODO: guard that hCtx.Module actually imported this!
+	modCtx, ok := ctx.(*ModuleContext)
+	if !ok { // TODO: guard that modCtx.Module actually imported this!
 		return nil, fmt.Errorf("this function was not imported by %s", ctx)
 	}
-	return hCtx.engine.Call(hCtx, f, params...)
+	return modCtx.engine.Call(modCtx, f, params...)
 }
 
 // Function implements wasm.HostExports Function

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -16,7 +16,7 @@ func TestInterpreter_PushFrame(t *testing.T) {
 	f1 := &interpreterFrame{}
 	f2 := &interpreterFrame{}
 
-	it := interpreter{}
+	it := engine{}
 	require.Empty(t, it.frames)
 
 	it.pushFrame(f1)
@@ -36,37 +36,82 @@ func TestInterpreter_PushFrame_StackOverflow(t *testing.T) {
 	f3 := &interpreterFrame{}
 	f4 := &interpreterFrame{}
 
-	it := interpreter{}
+	it := engine{}
 	it.pushFrame(f1)
 	it.pushFrame(f2)
 	it.pushFrame(f3)
 	require.Panics(t, func() { it.pushFrame(f4) })
 }
 
-func TestInterpreter_CallHostFunc(t *testing.T) {
-	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
-		memory := &wasm.MemoryInstance{}
-		var ctxMemory publicwasm.Memory
-		hostFn := reflect.ValueOf(func(ctx publicwasm.ModuleContext) {
-			ctxMemory = ctx.Memory()
-		})
-		module := &wasm.ModuleInstance{MemoryInstance: memory}
-		it := interpreter{functions: map[wasm.FunctionAddress]*interpreterFunction{
-			0: {hostFn: &hostFn, funcInstance: &wasm.FunctionInstance{
-				FunctionKind: wasm.FunctionKindGoModuleContext,
-				FunctionType: &wasm.TypeInstance{
-					Type: &wasm.FunctionType{
-						Params:  []wasm.ValueType{},
-						Results: []wasm.ValueType{},
-					},
-				},
-				ModuleInstance: module,
-			},
-			},
-		}}
+func TestEngine_Call(t *testing.T) {
+	i64 := wasm.ValueTypeI64
+	m := &wasm.Module{
+		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}},
+		FunctionSection: []wasm.Index{wasm.Index(0)},
+		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
+	}
 
+	// Use exported functions to simplify instantiation of a Wasm function
+	e := NewEngine()
+	store := wasm.NewStore(context.Background(), e)
+	_, err := store.Instantiate(m, "")
+	require.NoError(t, err)
+
+	// ensure base case doesn't fail
+	results, err := e.Call(store.ModuleContexts[""], store.Functions[0], 3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), results[0])
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		_, err := e.Call(store.ModuleContexts[""], store.Functions[0])
+		require.EqualError(t, err, "expected 1 params, but passed 0")
+	})
+
+	t.Run("errs when too many parameters", func(t *testing.T) {
+		_, err := e.Call(store.ModuleContexts[""], store.Functions[0], 1, 2)
+		require.EqualError(t, err, "expected 1 params, but passed 2")
+	})
+}
+
+func TestEngine_Call_HostFn(t *testing.T) {
+	memory := &wasm.MemoryInstance{}
+	var ctxMemory publicwasm.Memory
+	hostFn := reflect.ValueOf(func(ctx publicwasm.ModuleContext, v uint64) uint64 {
+		ctxMemory = ctx.Memory()
+		return v
+	})
+
+	e := NewEngine()
+	module := &wasm.ModuleInstance{MemoryInstance: memory}
+	modCtx := wasm.NewModuleContext(context.Background(), e, module)
+	f := &wasm.FunctionInstance{
+		HostFunction: &hostFn,
+		FunctionKind: wasm.FunctionKindGoModuleContext,
+		FunctionType: &wasm.TypeInstance{
+			Type: &wasm.FunctionType{
+				Params:  []wasm.ValueType{wasm.ValueTypeI64},
+				Results: []wasm.ValueType{wasm.ValueTypeI64},
+			},
+		},
+		ModuleInstance: module,
+	}
+	require.NoError(t, e.Compile(f))
+
+	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
 		// When calling a host func directly, there may be no stack. This ensures the module's memory is used.
-		it.callHostFunc(wasm.NewModuleContext(context.Background(), &it, module), it.functions[0])
+		results, err := e.Call(modCtx, f, 3)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), results[0])
 		require.Same(t, memory, ctxMemory)
+	})
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		_, err := e.Call(modCtx, f)
+		require.EqualError(t, err, "expected 1 params, but passed 0")
+	})
+
+	t.Run("errs when too many parameters", func(t *testing.T) {
+		_, err := e.Call(modCtx, f, 1, 2)
+		require.EqualError(t, err, "expected 1 params, but passed 2")
 	})
 }

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -1,13 +1,16 @@
 package jit
 
 import (
+	"context"
 	"math"
+	"reflect"
 	"testing"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
+	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
 // Ensures that the offset consts do not drift when we manipulate the target structs.
@@ -80,4 +83,77 @@ func TestVerifyOffsetValue(t *testing.T) {
 	// Offsets for wasm.GlobalInstance
 	var globalInstance wasm.GlobalInstance
 	require.Equal(t, int(unsafe.Offsetof(globalInstance.Val)), globalInstanceValueOffset)
+}
+
+func TestEngine_Call(t *testing.T) {
+	i64 := wasm.ValueTypeI64
+	m := &wasm.Module{
+		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}},
+		FunctionSection: []wasm.Index{wasm.Index(0)},
+		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
+	}
+
+	// Use exported functions to simplify instantiation of a Wasm function
+	e := NewEngine()
+	store := wasm.NewStore(context.Background(), e)
+	_, err := store.Instantiate(m, "")
+	require.NoError(t, err)
+
+	// ensure base case doesn't fail
+	results, err := e.Call(store.ModuleContexts[""], store.Functions[0], 3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), results[0])
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		_, err := e.Call(store.ModuleContexts[""], store.Functions[0])
+		require.EqualError(t, err, "expected 1 params, but passed 0")
+	})
+
+	t.Run("errs when too many parameters", func(t *testing.T) {
+		_, err := e.Call(store.ModuleContexts[""], store.Functions[0], 1, 2)
+		require.EqualError(t, err, "expected 1 params, but passed 2")
+	})
+}
+
+func TestEngine_Call_HostFn(t *testing.T) {
+	memory := &wasm.MemoryInstance{}
+	var ctxMemory publicwasm.Memory
+	hostFn := reflect.ValueOf(func(ctx publicwasm.ModuleContext, v uint64) uint64 {
+		ctxMemory = ctx.Memory()
+		return v
+	})
+
+	e := NewEngine()
+	module := &wasm.ModuleInstance{MemoryInstance: memory}
+	modCtx := wasm.NewModuleContext(context.Background(), e, module)
+	f := &wasm.FunctionInstance{
+		HostFunction: &hostFn,
+		FunctionKind: wasm.FunctionKindGoModuleContext,
+		FunctionType: &wasm.TypeInstance{
+			Type: &wasm.FunctionType{
+				Params:  []wasm.ValueType{wasm.ValueTypeI64},
+				Results: []wasm.ValueType{wasm.ValueTypeI64},
+			},
+		},
+		ModuleInstance: module,
+	}
+	require.NoError(t, e.Compile(f))
+
+	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
+		// When calling a host func directly, there may be no stack. This ensures the module's memory is used.
+		results, err := e.Call(modCtx, f, 3)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), results[0])
+		require.Same(t, memory, ctxMemory)
+	})
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		_, err := e.Call(modCtx, f)
+		require.EqualError(t, err, "expected 1 params, but passed 0")
+	})
+
+	t.Run("errs when too many parameters", func(t *testing.T) {
+		_, err := e.Call(modCtx, f, 1, 2)
+		require.EqualError(t, err, "expected 1 params, but passed 2")
+	})
 }

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -363,7 +363,7 @@ func (m *ModuleExports) Function(name string) publicwasm.Function {
 	if err != nil {
 		return nil
 	}
-	return &function{c: m.Context, f: exp.Function}
+	return &exportedFunction{module: m.Context, function: exp.Function}
 }
 
 // Memory implements wasm.ModuleExports Memory


### PR DESCRIPTION
This pushes parameter length validation to inside the engine to avoid bugs. Formerly, we were inconsistent checking this depending on whether the function was Wasm or not.

This also replicates the tests for interpreter to JIT and renames `interpreter.interpreter` to `interpreter.engine` for consistency