### PR TITLE
Refactors store and adds ReleaseModuleInstance.

### DIFF
--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -9,4 +9,10 @@ type Engine interface {
 
 	// Compile compiles down the function instance.
 	Compile(f *FunctionInstance) error
+
+	// Release releases the resources allocated by a function instance.
+	// Note: this is only called after ensuring that no existing function will call the release target.
+	// Therefore, it is safe to reuse the resource, for example reallocate the new compiled function
+	// for the same FunctionIndex.
+	Release(f *FunctionInstance) error
 }

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -3,12 +3,13 @@ package internalwasm
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/tetratelabs/wazero/internal/leb128"
 )
 
-// validateFunctionInstance validates the instruction sequence of a function instance.
+// validateFunction validates the instruction sequence of a function.
 // following the specification https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#instructions%E2%91%A2.
 //
 // f is the validation target function instance.
@@ -21,8 +22,10 @@ import (
 //
 // Returns an error if the instruction sequence is not valid,
 // or potentially it can exceed the maximum number of values on the stack.
-func validateFunctionInstance(
-	f *FunctionInstance,
+func validateFunction(
+	functionType *FunctionType,
+	body []byte,
+	localTypes []ValueType,
 	functions []Index,
 	globals []*GlobalType,
 	memories []*MemoryType,
@@ -36,20 +39,20 @@ func validateFunctionInstance(
 	hasTable := len(tables) > 0
 
 	// We start with the outermost control block which is for function return if the code branches into it.
-	controlBloclStack := []*controlBlock{{blockType: f.FunctionType.Type}}
+	controlBloclStack := []*controlBlock{{blockType: functionType}}
 	// Create the valueTypeStack to track the state of Wasm value stacks at anypoint of execution.
 	valueTypeStack := &valueTypeStack{}
 
 	// Now start walking through all the instructions in the body while tracking
 	// control blocks and value types to check the validity of all instructions.
-	for pc := uint64(0); pc < uint64(len(f.Body)); pc++ {
-		op := f.Body[pc]
+	for pc := uint64(0); pc < uint64(len(body)); pc++ {
+		op := body[pc]
 		if OpcodeI32Load <= op && op <= OpcodeI64Store32 {
 			if !hasMemory {
 				return fmt.Errorf("unknown memory access")
 			}
 			pc++
-			align, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			align, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read memory align: %v", err)
 			}
@@ -227,7 +230,7 @@ func validateFunctionInstance(
 			}
 			pc += num
 			// offset
-			_, num, err = leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			_, num, err = leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read memory offset: %v", err)
 			}
@@ -237,7 +240,7 @@ func validateFunctionInstance(
 				return fmt.Errorf("unknown memory access")
 			}
 			pc++
-			val, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			val, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read immediate: %v", err)
 			}
@@ -258,14 +261,14 @@ func validateFunctionInstance(
 			pc++
 			switch Opcode(op) {
 			case OpcodeI32Const:
-				_, num, err := leb128.DecodeInt32(bytes.NewBuffer(f.Body[pc:]))
+				_, num, err := leb128.DecodeInt32(bytes.NewBuffer(body[pc:]))
 				if err != nil {
 					return fmt.Errorf("read i32 immediate: %s", err)
 				}
 				pc += num - 1
 				valueTypeStack.push(ValueTypeI32)
 			case OpcodeI64Const:
-				_, num, err := leb128.DecodeInt64(bytes.NewBuffer(f.Body[pc:]))
+				_, num, err := leb128.DecodeInt64(bytes.NewBuffer(body[pc:]))
 				if err != nil {
 					return fmt.Errorf("read i64 immediate: %v", err)
 				}
@@ -280,46 +283,46 @@ func validateFunctionInstance(
 			}
 		} else if OpcodeLocalGet <= op && op <= OpcodeGlobalSet {
 			pc++
-			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read immediate: %v", err)
 			}
 			pc += num - 1
 			switch op {
 			case OpcodeLocalGet:
-				inputLen := uint32(len(f.FunctionType.Type.Params))
-				if l := uint32(len(f.LocalTypes)) + inputLen; index >= l {
+				inputLen := uint32(len(functionType.Params))
+				if l := uint32(len(localTypes)) + inputLen; index >= l {
 					return fmt.Errorf("invalid local index for local.get %d >= %d(=len(locals)+len(parameters))", index, l)
 				}
 				if index < inputLen {
-					valueTypeStack.push(f.FunctionType.Type.Params[index])
+					valueTypeStack.push(functionType.Params[index])
 				} else {
-					valueTypeStack.push(f.LocalTypes[index-inputLen])
+					valueTypeStack.push(localTypes[index-inputLen])
 				}
 			case OpcodeLocalSet:
-				inputLen := uint32(len(f.FunctionType.Type.Params))
-				if l := uint32(len(f.LocalTypes)) + inputLen; index >= l {
+				inputLen := uint32(len(functionType.Params))
+				if l := uint32(len(localTypes)) + inputLen; index >= l {
 					return fmt.Errorf("invalid local index for local.set %d >= %d(=len(locals)+len(parameters))", index, l)
 				}
 				var expType ValueType
 				if index < inputLen {
-					expType = f.FunctionType.Type.Params[index]
+					expType = functionType.Params[index]
 				} else {
-					expType = f.LocalTypes[index-inputLen]
+					expType = localTypes[index-inputLen]
 				}
 				if err := valueTypeStack.popAndVerifyType(expType); err != nil {
 					return err
 				}
 			case OpcodeLocalTee:
-				inputLen := uint32(len(f.FunctionType.Type.Params))
-				if l := uint32(len(f.LocalTypes)) + inputLen; index >= l {
+				inputLen := uint32(len(functionType.Params))
+				if l := uint32(len(localTypes)) + inputLen; index >= l {
 					return fmt.Errorf("invalid local index for local.tee %d >= %d(=len(locals)+len(parameters))", index, l)
 				}
 				var expType ValueType
 				if index < inputLen {
-					expType = f.FunctionType.Type.Params[index]
+					expType = functionType.Params[index]
 				} else {
-					expType = f.LocalTypes[index-inputLen]
+					expType = localTypes[index-inputLen]
 				}
 				if err := valueTypeStack.popAndVerifyType(expType); err != nil {
 					return err
@@ -342,7 +345,7 @@ func validateFunctionInstance(
 			}
 		} else if op == OpcodeBr {
 			pc++
-			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read immediate: %v", err)
 			} else if int(index) >= len(controlBloclStack) {
@@ -364,7 +367,7 @@ func validateFunctionInstance(
 			valueTypeStack.unreachable()
 		} else if op == OpcodeBrIf {
 			pc++
-			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read immediate: %v", err)
 			} else if int(index) >= len(controlBloclStack) {
@@ -393,7 +396,7 @@ func validateFunctionInstance(
 			}
 		} else if op == OpcodeBrTable {
 			pc++
-			r := bytes.NewBuffer(f.Body[pc:])
+			r := bytes.NewBuffer(body[pc:])
 			nl, num, err := leb128.DecodeUint32(r)
 			if err != nil {
 				return fmt.Errorf("read immediate: %w", err)
@@ -455,7 +458,7 @@ func validateFunctionInstance(
 			valueTypeStack.unreachable()
 		} else if op == OpcodeCall {
 			pc++
-			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			index, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read immediate: %v", err)
 			}
@@ -474,14 +477,14 @@ func validateFunctionInstance(
 			}
 		} else if op == OpcodeCallIndirect {
 			pc++
-			typeIndex, num, err := leb128.DecodeUint32(bytes.NewBuffer(f.Body[pc:]))
+			typeIndex, num, err := leb128.DecodeUint32(bytes.NewBuffer(body[pc:]))
 			if err != nil {
 				return fmt.Errorf("read immediate: %v", err)
 			}
 			pc += num - 1
 			pc++
-			if f.Body[pc] != 0x00 {
-				return fmt.Errorf("call_indirect reserved bytes not zero but got %d", f.Body[pc])
+			if body[pc] != 0x00 {
+				return fmt.Errorf("call_indirect reserved bytes not zero but got %d", body[pc])
 			}
 			if !hasTable {
 				return fmt.Errorf("table not given while having call_indirect")
@@ -699,7 +702,7 @@ func validateFunctionInstance(
 				return fmt.Errorf("invalid numeric instruction 0x%x", op)
 			}
 		} else if op == OpcodeBlock {
-			bt, num, err := DecodeBlockType(f.ModuleInstance.Types, bytes.NewBuffer(f.Body[pc+1:]))
+			bt, num, err := decodeBlockType(types, bytes.NewBuffer(body[pc+1:]))
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -711,7 +714,7 @@ func validateFunctionInstance(
 			valueTypeStack.pushStackLimit()
 			pc += num
 		} else if op == OpcodeLoop {
-			bt, num, err := DecodeBlockType(f.ModuleInstance.Types, bytes.NewBuffer(f.Body[pc+1:]))
+			bt, num, err := decodeBlockType(types, bytes.NewBuffer(body[pc+1:]))
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -724,7 +727,7 @@ func validateFunctionInstance(
 			valueTypeStack.pushStackLimit()
 			pc += num
 		} else if op == OpcodeIf {
-			bt, num, err := DecodeBlockType(f.ModuleInstance.Types, bytes.NewBuffer(f.Body[pc+1:]))
+			bt, num, err := decodeBlockType(types, bytes.NewBuffer(body[pc+1:]))
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -775,7 +778,7 @@ func validateFunctionInstance(
 			// on values previously pushed by outer blocks.
 			valueTypeStack.popStackLimit()
 		} else if op == OpcodeReturn {
-			expTypes := f.FunctionType.Type.Results
+			expTypes := functionType.Results
 			for i := 0; i < len(expTypes); i++ {
 				if err := valueTypeStack.popAndVerifyType(expTypes[len(expTypes)-1-i]); err != nil {
 					return fmt.Errorf("return type mismatch on return: %v; want %v", err, expTypes)
@@ -943,4 +946,47 @@ type controlBlock struct {
 	blockTypeBytes         uint64
 	isLoop                 bool
 	isIf                   bool
+}
+
+func decodeBlockType(types []*FunctionType, r io.Reader) (*FunctionType, uint64, error) {
+	return decodeBlockTypeImpl(func(index int64) (*FunctionType, error) {
+		if index < 0 || (index >= int64(len(types))) {
+			return nil, fmt.Errorf("type index out of range: %d", index)
+		}
+		return types[index], nil
+	}, r)
+}
+
+// DecodeBlockType is exported for use in the compiler
+func DecodeBlockType(types []*TypeInstance, r io.Reader) (*FunctionType, uint64, error) {
+	return decodeBlockTypeImpl(func(index int64) (*FunctionType, error) {
+		if index < 0 || (index >= int64(len(types))) {
+			return nil, fmt.Errorf("type index out of range: %d", index)
+		}
+		return types[index].Type, nil
+	}, r)
+}
+
+func decodeBlockTypeImpl(functionTypeResolver func(index int64) (*FunctionType, error), r io.Reader) (*FunctionType, uint64, error) {
+	raw, num, err := leb128.DecodeInt33AsInt64(r)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decode int33: %w", err)
+	}
+
+	var ret *FunctionType
+	switch raw {
+	case -64: // 0x40 in original byte = nil
+		ret = &FunctionType{}
+	case -1: // 0x7f in original byte = i32
+		ret = &FunctionType{Results: []ValueType{ValueTypeI32}}
+	case -2: // 0x7e in original byte = i64
+		ret = &FunctionType{Results: []ValueType{ValueTypeI64}}
+	case -3: // 0x7d in original byte = f32
+		ret = &FunctionType{Results: []ValueType{ValueTypeF32}}
+	case -4: // 0x7c in original byte = f64
+		ret = &FunctionType{Results: []ValueType{ValueTypeF64}}
+	default:
+		ret, err = functionTypeResolver(raw)
+	}
+	return ret, num, err
 }

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -12,25 +12,25 @@ func TestValidateFunction_valueStackLimit(t *testing.T) {
 	const valuesNum = max + 1
 
 	// Build a function which has max+1 const instructions.
-	f := &FunctionInstance{Body: []byte{}, FunctionType: &TypeInstance{Type: &FunctionType{}}}
+	var body []byte
 	for i := 0; i < valuesNum; i++ {
-		f.Body = append(f.Body, OpcodeI32Const, 1)
+		body = append(body, OpcodeI32Const, 1)
 	}
 
 	// Drop all the consts so that if the max is higher, this function body would be sound.
 	for i := 0; i < valuesNum; i++ {
-		f.Body = append(f.Body, OpcodeDrop)
+		body = append(body, OpcodeDrop)
 	}
 
 	// Plus all functions must end with End opcode.
-	f.Body = append(f.Body, OpcodeEnd)
+	body = append(body, OpcodeEnd)
 
 	t.Run("not exceed", func(t *testing.T) {
-		err := validateFunctionInstance(f, nil, nil, nil, nil, nil, max+1)
+		err := validateFunction(&FunctionType{}, body, nil, nil, nil, nil, nil, nil, max+1)
 		require.NoError(t, err)
 	})
 	t.Run("exceed", func(t *testing.T) {
-		err := validateFunctionInstance(f, nil, nil, nil, nil, nil, max)
+		err := validateFunction(&FunctionType{}, body, nil, nil, nil, nil, nil, nil, max)
 		require.Error(t, err)
 		expMsg := fmt.Sprintf("function may have %d stack values, which exceeds limit %d", valuesNum, max)
 		require.Equal(t, expMsg, err.Error())

--- a/internal/wasm/jit/compiler.go
+++ b/internal/wasm/jit/compiler.go
@@ -19,7 +19,7 @@ type compiler interface {
 	compile() (code []byte, staticData compiledFunctionStaticData, stackPointerCeil uint64, err error)
 	// compileHostFunction emits the trampoline code from which native code can jump into the host function.
 	// TODO: maybe we wouldn't need to have trampoline for host functions.
-	compileHostFunction(address wasm.FunctionAddress) error
+	compileHostFunction(address wasm.FunctionIndex) error
 	// compileLabel notify compilers of the beginning of a label.
 	// Return true if the compiler decided to skip the entire label.
 	// See wazeroir.OperationLabel

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -58,14 +58,14 @@ func TestVerifyOffsetValue(t *testing.T) {
 
 	// Offsets for wasm.TableElement.
 	var tableElement wasm.TableElement
-	require.Equal(t, int(unsafe.Offsetof(tableElement.FunctionAddress)), tableElementFunctionAddressOffset)
+	require.Equal(t, int(unsafe.Offsetof(tableElement.FunctionIndex)), tableElementFunctionIndexOffset)
 	require.Equal(t, int(unsafe.Offsetof(tableElement.FunctionTypeID)), tableElementFunctionTypeIDOffset)
 
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Globals)), moduleInstanceGlobalsOffset)
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.MemoryInstance)), moduleInstanceMemoryOffset)
-	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Tables)), moduleInstanceTablesOffset)
+	require.Equal(t, int(unsafe.Offsetof(moduleInstance.TableInstance)), moduleInstanceTableOffset)
 
 	// Offsets for wasm.TableInstance.
 	var tableInstance wasm.TableInstance

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -93,7 +93,7 @@ func TestArm64Compiler_returnFunction(t *testing.T) {
 		// Push the call frames.
 		const callFrameNums = 10
 		stackPointerToExpectedValue := map[uint64]uint32{}
-		for funcaddr := wasm.FunctionAddress(0); funcaddr < callFrameNums; funcaddr++ {
+		for funcaddr := wasm.FunctionIndex(0); funcaddr < callFrameNums; funcaddr++ {
 			// We have to do compilation in a separate subtest since each compilation takes
 			// the mutext lock and must release on the cleanup of each subtest.
 			// TODO: delete after https://github.com/tetratelabs/wazero/issues/233
@@ -1764,13 +1764,13 @@ func TestArm64Compiler_compileCall(t *testing.T) {
 
 					code, _, _, err := compiler.compile()
 					require.NoError(t, err)
-					addr := wasm.FunctionAddress(i)
-					eng.addCompiledFunction(addr, &compiledFunction{
+					index := wasm.FunctionIndex(i)
+					eng.addCompiledFunction(index, &compiledFunction{
 						codeSegment:        code,
 						codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 					})
 					env.module().Functions = append(env.module().Functions,
-						&wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}, Address: addr})
+						&wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}, Index: index})
 				})
 			}
 
@@ -1803,7 +1803,7 @@ func TestArm64Compiler_compileCall(t *testing.T) {
 				// If the call frame stack pointer equals the length of call frame stack length,
 				// we have to call the builtin function to grow the slice.
 				require.Equal(t, jitCallStatusCodeCallBuiltInFunction, env.jitStatus())
-				require.Equal(t, builtinFunctionAddressGrowCallFrameStack, env.functionCallAddress(), env.functionCallAddress())
+				require.Equal(t, builtinFunctionIndexGrowCallFrameStack, env.functionCallAddress(), env.functionCallAddress())
 
 				// Grow the callFrame stack, and exec again from the return address.
 				vm := env.callEngine()
@@ -1942,7 +1942,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 
 				table := make([]wasm.TableElement, 10)
 				for i := 0; i < len(table); i++ {
-					table[i] = wasm.TableElement{FunctionAddress: wasm.FunctionAddress(i), FunctionTypeID: targetTypeID}
+					table[i] = wasm.TableElement{FunctionIndex: wasm.FunctionIndex(i), FunctionTypeID: targetTypeID}
 				}
 
 				for i := 0; i < len(table); i++ {
@@ -1973,7 +1973,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 							codeSegment:        code,
 							codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 						}
-						eng.addCompiledFunction(table[i].FunctionAddress, cf)
+						eng.addCompiledFunction(table[i].FunctionIndex, cf)
 					})
 
 					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -1987,7 +1987,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 
 						compiler.f = &wasm.FunctionInstance{ModuleInstance: moduleInstance, FunctionKind: wasm.FunctionKindWasm}
 
-						// Place the offfset value. Here we try calling a function of functionaddr == table[i].FunctionAddress.
+						// Place the offfset value. Here we try calling a function of functionaddr == table[i].FunctionIndex.
 						err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: uint32(i)})
 						require.NoError(t, err)
 
@@ -2012,7 +2012,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 							// If the call frame stack pointer equals the length of call frame stack length,
 							// we have to call the builtin function to grow the slice.
 							require.Equal(t, jitCallStatusCodeCallBuiltInFunction, env.jitStatus())
-							require.Equal(t, builtinFunctionAddressGrowCallFrameStack, env.functionCallAddress(), env.functionCallAddress())
+							require.Equal(t, builtinFunctionIndexGrowCallFrameStack, env.functionCallAddress(), env.functionCallAddress())
 
 							// Grow the callFrame stack, and exec again from the return address.
 							vm := env.callEngine()
@@ -2145,28 +2145,28 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
 				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 		{
 			name: "memory nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Tables:  []*wasm.TableInstance{{Table: make([]wasm.TableElement, 20)}},
+				Globals:       []*wasm.GlobalInstance{{Val: 100}},
+				TableInstance: &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
 				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:         []*wasm.TableInstance{{Table: nil}},
+				TableInstance:  &wasm.TableInstance{Table: nil},
 				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
@@ -2174,7 +2174,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			name: "table empty",
 			moduleInstance: &wasm.ModuleInstance{
 				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
+				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
 				Globals:        []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
@@ -2182,7 +2182,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
 				Globals:        []*wasm.GlobalInstance{{Val: 100}},
-				Tables:         []*wasm.TableInstance{{Table: make([]wasm.TableElement, 0)}},
+				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
 				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},
@@ -2229,8 +2229,8 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 				require.Equal(t, bufSliceHeader.Data, vm.moduleContext.memoryElement0Address)
 			}
 
-			if len(tc.moduleInstance.Tables) > 0 {
-				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Tables[0].Table))
+			if tc.moduleInstance.TableInstance != nil {
+				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.TableInstance.Table))
 				require.Equal(t, uint64(tableHeader.Len), vm.moduleContext.tableSliceLen)
 				require.Equal(t, tableHeader.Data, vm.moduleContext.tableElement0Address)
 			}
@@ -2755,7 +2755,7 @@ func TestArm64Compiler_compileMemoryGrow(t *testing.T) {
 
 	// After the initial exec, the code must exit with builtin function call status and funcaddress for memory grow.
 	require.Equal(t, jitCallStatusCodeCallBuiltInFunction, env.jitStatus())
-	require.Equal(t, builtinFunctionAddressMemoryGrow, env.functionCallAddress())
+	require.Equal(t, builtinFunctionIndexMemoryGrow, env.functionCallAddress())
 
 	// Reenter from the return address.
 	jitcall(env.callFrameStackPeek().returnAddress, uintptr(unsafe.Pointer(env.callEngine())))
@@ -2873,7 +2873,7 @@ func TestArm64Compiler_compileHostFunction(t *testing.T) {
 	// TODO: delete after #233
 	compiler.compileNOP()
 
-	addr := wasm.FunctionAddress(100)
+	addr := wasm.FunctionIndex(100)
 	err := compiler.compileHostFunction(addr)
 	require.NoError(t, err)
 

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -51,7 +51,7 @@ func (j *jitEnv) jitStatus() jitCallStatusCode {
 	return j.vm.exitContext.statusCode
 }
 
-func (j *jitEnv) functionCallAddress() wasm.FunctionAddress {
+func (j *jitEnv) functionCallAddress() wasm.FunctionIndex {
 	return j.vm.exitContext.functionCallAddress
 }
 
@@ -76,7 +76,7 @@ func (j *jitEnv) getGlobal(index uint32) uint64 {
 }
 
 func (j *jitEnv) setTable(table []wasm.TableElement) {
-	j.moduleInstance.Tables[0] = &wasm.TableInstance{Table: table}
+	j.moduleInstance.TableInstance = &wasm.TableInstance{Table: table}
 }
 
 func (j *jitEnv) callFrameStackPeek() *callFrame {
@@ -133,7 +133,7 @@ func newJITEnvironment() *jitEnv {
 		eng: eng,
 		moduleInstance: &wasm.ModuleInstance{
 			MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
-			Tables:         []*wasm.TableInstance{{}},
+			TableInstance:  &wasm.TableInstance{},
 			Globals:        []*wasm.GlobalInstance{},
 		},
 		vm: eng.newCallEngine(),

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -1,8 +1,11 @@
 package internalwasm
 
 import (
+	"bytes"
 	"fmt"
 
+	"github.com/tetratelabs/wazero/internal/ieee754"
+	"github.com/tetratelabs/wazero/internal/leb128"
 	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
@@ -168,6 +171,274 @@ func (m *Module) TypeOfFunction(funcIdx Index) *FunctionType {
 		return nil
 	}
 	return m.TypeSection[typeIdx]
+}
+
+func (m *Module) Validate() error {
+	if err := m.validateStartSection(); err != nil {
+		return err
+	}
+
+	functions, globals, memories, tables := m.allDeclarations()
+
+	// The wazero specific limitation described at RATIONALE.md.
+	const maximumGlobals = 1 << 27
+	if err := m.validateGlobals(globals, maximumGlobals); err != nil {
+		return err
+	}
+
+	if err := m.validateTables(tables, globals); err != nil {
+		return err
+	}
+
+	if err := m.validateMemories(memories, globals); err != nil {
+		return err
+	}
+
+	if err := m.validateFunctions(functions, globals, memories, tables); err != nil {
+		return err
+	}
+
+	if err := m.validateExports(functions, globals, memories, tables); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Module) validateStartSection() error {
+	// Check the start function is valid.
+	// TODO: this should be verified during decode so that errors have the correct source positions
+	if m.StartSection != nil {
+		startIndex := *m.StartSection
+		ft := m.TypeOfFunction(startIndex)
+		if ft == nil { // TODO: move this check to decoder so that a module can never be decoded invalidly
+			return fmt.Errorf("start function has an invalid type")
+		}
+		if len(ft.Params) > 0 || len(ft.Results) > 0 {
+			return fmt.Errorf("start function must have an empty (nullary) signature: %s", ft.String())
+		}
+	}
+	return nil
+}
+
+func (m *Module) validateGlobals(globals []*GlobalType, maxGlobals int) error {
+	if len(globals) > maxGlobals {
+		return fmt.Errorf("too many globals in a module")
+	}
+
+	// Global's initialization constant expression can only reference the imported globals.
+	// See the note on https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#constant-expressions%E2%91%A0
+	importedGlobals := globals[:m.ImportGlobalCount()]
+	for _, g := range m.GlobalSection {
+		if err := validateConstExpression(importedGlobals, g.Init, g.Type.ValType); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Module) validateFunctions(functions []Index, globals []*GlobalType, memories []*MemoryType, tables []*TableType) error {
+	// The wazero specific limitation described at RATIONALE.md.
+	const maximumValuesOnStack = 1 << 27
+
+	for codeIndex, typeIndex := range m.FunctionSection {
+		if typeIndex >= m.SectionElementCount(SectionIDType) {
+			return fmt.Errorf("function type index out of range")
+		} else if uint32(codeIndex) >= m.SectionElementCount(SectionIDCode) {
+			return fmt.Errorf("code index out of range")
+		}
+
+		if err := validateFunction(
+			m.TypeSection[typeIndex],
+			m.CodeSection[codeIndex].Body,
+			m.CodeSection[codeIndex].LocalTypes,
+			functions, globals, memories, tables, m.TypeSection, maximumValuesOnStack); err != nil {
+			idx := m.SectionElementCount(SectionIDFunction) - 1
+			return fmt.Errorf("invalid function (%d/%d): %v", codeIndex, idx, err)
+		}
+	}
+	return nil
+}
+
+func (m *Module) validateTables(tables []*TableType, globals []*GlobalType) error {
+	if len(tables) > 1 {
+		return fmt.Errorf("multiple tables are not supported")
+	}
+
+	for _, elem := range m.ElementSection {
+		if int(elem.TableIndex) >= len(tables) {
+			return fmt.Errorf("table index out of range")
+		}
+		err := validateConstExpression(globals, elem.OffsetExpr, ValueTypeI32)
+		if err != nil {
+			return fmt.Errorf("invalid const expression for element: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Module) validateMemories(memories []*MemoryType, globals []*GlobalType) error {
+	if len(memories) > 1 {
+		return fmt.Errorf("multiple memories are not supported")
+	} else if len(m.DataSection) > 0 && len(memories) == 0 {
+		return fmt.Errorf("unknown memory")
+	}
+
+	for _, d := range m.DataSection {
+		if d.MemoryIndex != 0 {
+			return fmt.Errorf("memory index must be zero")
+		}
+		if err := validateConstExpression(globals, d.OffsetExpression, ValueTypeI32); err != nil {
+			return fmt.Errorf("calculate offset: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Module) validateExports(functions []Index, globals []*GlobalType, memories []*MemoryType, tables []*TableType) error {
+	for name, exp := range m.ExportSection {
+		index := exp.Index
+		switch exp.Type {
+		case ExternTypeFunc:
+			if index >= uint32(len(functions)) {
+				return fmt.Errorf("unknown function for export[%s]", name)
+			}
+		case ExternTypeGlobal:
+			if index >= uint32(len(globals)) {
+				return fmt.Errorf("unknown global for export[%s]", name)
+			}
+		case ExternTypeMemory:
+			if index != 0 || len(memories) == 0 {
+				return fmt.Errorf("unknown memory for export[%s]", name)
+			}
+		case ExternTypeTable:
+			if index >= uint32(len(tables)) {
+				return fmt.Errorf("unknown table for export[%s]", name)
+			}
+		}
+	}
+	return nil
+}
+
+func validateConstExpression(globals []*GlobalType, expr *ConstantExpression, expectedType ValueType) (err error) {
+	var actualType ValueType
+	r := bytes.NewBuffer(expr.Data)
+	switch expr.Opcode {
+	case OpcodeI32Const:
+		_, _, err = leb128.DecodeInt32(r)
+		if err != nil {
+			return fmt.Errorf("read i32: %w", err)
+		}
+		actualType = ValueTypeI32
+	case OpcodeI64Const:
+		_, _, err = leb128.DecodeInt64(r)
+		if err != nil {
+			return fmt.Errorf("read i64: %w", err)
+		}
+		actualType = ValueTypeI64
+	case OpcodeF32Const:
+		_, err = ieee754.DecodeFloat32(r)
+		if err != nil {
+			return fmt.Errorf("read f32: %w", err)
+		}
+		actualType = ValueTypeF32
+	case OpcodeF64Const:
+		_, err = ieee754.DecodeFloat64(r)
+		if err != nil {
+			return fmt.Errorf("read f64: %w", err)
+		}
+		actualType = ValueTypeF64
+	case OpcodeGlobalGet:
+		id, _, err := leb128.DecodeUint32(r)
+		if err != nil {
+			return fmt.Errorf("read index of global: %w", err)
+		}
+		if uint32(len(globals)) <= id {
+			return fmt.Errorf("global index out of range")
+		}
+		actualType = globals[id].ValType
+	default:
+		return fmt.Errorf("invalid opcode for const expression: 0x%x", expr.Opcode)
+	}
+
+	if actualType != expectedType {
+		return fmt.Errorf("const expression type mismatch")
+	}
+	return nil
+}
+
+func (m *Module) buildGlobalInstances(importedGlobals []*GlobalInstance) (globals []*GlobalInstance) {
+	for _, gs := range m.GlobalSection {
+		var gv uint64
+		// Global's initialization constant expression can only reference the imported globals.
+		// See the note on https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#constant-expressions%E2%91%A0
+		switch v := executeConstExpression(importedGlobals, gs.Init).(type) {
+		case int32:
+			gv = uint64(v)
+		case int64:
+			gv = uint64(v)
+		case float32:
+			gv = publicwasm.EncodeF32(v)
+		case float64:
+			gv = publicwasm.EncodeF64(v)
+		}
+		globals = append(globals, &GlobalInstance{
+			Type: gs.Type,
+			Val:  gv,
+		})
+	}
+	return
+}
+
+func (m *Module) buildFunctionInstances() (functions []*FunctionInstance) {
+	var functionNames NameMap
+	if m.NameSection != nil {
+		functionNames = m.NameSection.FunctionNames
+	}
+
+	importCount := m.ImportFuncCount()
+	n, nLen := 0, len(functionNames)
+	for codeIndex := range m.FunctionSection {
+		funcIdx := Index(importCount + uint32(len(functions)))
+		// Seek to see if there's a better name than "unknown"
+		name := "unknown"
+		for ; n < nLen; n++ {
+			next := functionNames[n]
+			if next.Index > funcIdx {
+				break // we have function names, but starting at a later index
+			} else if next.Index == funcIdx {
+				name = next.Name
+				break
+			}
+		}
+
+		f := &FunctionInstance{
+			Name:         name,
+			FunctionKind: FunctionKindWasm,
+			Body:         m.CodeSection[codeIndex].Body,
+			LocalTypes:   m.CodeSection[codeIndex].LocalTypes,
+		}
+		functions = append(functions, f)
+	}
+	return
+}
+
+func (module *Module) buildMemoryInstance() (mem *MemoryInstance) {
+	for _, memSec := range module.MemorySection {
+		mem = &MemoryInstance{
+			Buffer: make([]byte, memoryPagesToBytesNum(memSec.Min)),
+			Min:    memSec.Min,
+			Max:    memSec.Max,
+		}
+	}
+	return
+}
+
+func (module *Module) buildTableInstance() (table *TableInstance) {
+	for _, tableSeg := range module.TableSection {
+		table = newTableInstance(tableSeg.Limit.Min, tableSeg.Limit.Max)
+	}
+	return
 }
 
 // Index is the offset in an index namespace, not necessarily an absolute position in a Module section. This is because

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -1,7 +1,9 @@
 package internalwasm
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -280,4 +282,449 @@ func TestModule_SectionSize(t *testing.T) {
 			require.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestValidateConstExpression(t *testing.T) {
+	t.Run("invalid opcode", func(t *testing.T) {
+		expr := &ConstantExpression{Opcode: OpcodeNop}
+		err := validateConstExpression(nil, expr, valueTypeUnknown)
+		require.Error(t, err)
+	})
+	for _, vt := range []ValueType{ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64} {
+		t.Run(ValueTypeName(vt), func(t *testing.T) {
+			t.Run("valid", func(t *testing.T) {
+				// Allocate bytes with enough size for all types.
+				expr := &ConstantExpression{Data: make([]byte, 8)}
+				switch vt {
+				case ValueTypeI32:
+					expr.Data[0] = 1
+					expr.Opcode = OpcodeI32Const
+				case ValueTypeI64:
+					expr.Data[0] = 2
+					expr.Opcode = OpcodeI64Const
+				case ValueTypeF32:
+					binary.LittleEndian.PutUint32(expr.Data, math.Float32bits(math.MaxFloat32))
+					expr.Opcode = OpcodeF32Const
+				case ValueTypeF64:
+					binary.LittleEndian.PutUint64(expr.Data, math.Float64bits(math.MaxFloat64))
+					expr.Opcode = OpcodeF64Const
+				}
+
+				err := validateConstExpression(nil, expr, vt)
+				require.NoError(t, err)
+			})
+			t.Run("invalid", func(t *testing.T) {
+				// Empty data must be failure.
+				expr := &ConstantExpression{Data: make([]byte, 0)}
+				switch vt {
+				case ValueTypeI32:
+					expr.Opcode = OpcodeI32Const
+				case ValueTypeI64:
+					expr.Opcode = OpcodeI64Const
+				case ValueTypeF32:
+					expr.Opcode = OpcodeF32Const
+				case ValueTypeF64:
+					expr.Opcode = OpcodeF64Const
+				}
+				err := validateConstExpression(nil, expr, vt)
+				require.Error(t, err)
+			})
+		})
+	}
+	t.Run("global expr", func(t *testing.T) {
+		t.Run("failed to read global index", func(t *testing.T) {
+			// Empty data for global index is invalid.
+			expr := &ConstantExpression{Data: make([]byte, 0), Opcode: OpcodeGlobalGet}
+			err := validateConstExpression(nil, expr, valueTypeUnknown)
+			require.Error(t, err)
+		})
+		t.Run("global index out of range", func(t *testing.T) {
+			// Data holds the index in leb128 and this time the value exceeds len(globals) (=0).
+			expr := &ConstantExpression{Data: []byte{1}, Opcode: OpcodeGlobalGet}
+			var globals []*GlobalType
+			err := validateConstExpression(globals, expr, valueTypeUnknown)
+			require.Error(t, err)
+		})
+
+		t.Run("type mismatch", func(t *testing.T) {
+			for _, vt := range []ValueType{
+				ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64,
+			} {
+				t.Run(ValueTypeName(vt), func(t *testing.T) {
+					// The index specified in Data equals zero.
+					expr := &ConstantExpression{Data: []byte{0}, Opcode: OpcodeGlobalGet}
+					globals := []*GlobalType{{ValType: valueTypeUnknown}}
+
+					err := validateConstExpression(globals, expr, vt)
+					require.Error(t, err)
+				})
+			}
+		})
+		t.Run("ok", func(t *testing.T) {
+			for _, vt := range []ValueType{
+				ValueTypeI32, ValueTypeI64, ValueTypeF32, ValueTypeF64,
+			} {
+				t.Run(ValueTypeName(vt), func(t *testing.T) {
+					// The index specified in Data equals zero.
+					expr := &ConstantExpression{Data: []byte{0}, Opcode: OpcodeGlobalGet}
+					globals := []*GlobalType{{ValType: vt}}
+
+					err := validateConstExpression(globals, expr, vt)
+					require.NoError(t, err)
+				})
+			}
+		})
+	})
+}
+
+func TestModule_validateStartSection(t *testing.T) {
+	t.Run("no start section", func(t *testing.T) {
+		m := Module{}
+		err := m.validateStartSection()
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		for _, ft := range []*FunctionType{
+			{Params: []ValueType{ValueTypeI32}},
+			{Results: []ValueType{ValueTypeI32}},
+			{Params: []ValueType{ValueTypeI32}, Results: []ValueType{ValueTypeI32}},
+		} {
+			t.Run(ft.String(), func(t *testing.T) {
+				index := uint32(0)
+				m := Module{StartSection: &index, FunctionSection: []uint32{0}, TypeSection: []*FunctionType{ft}}
+				err := m.validateStartSection()
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+func TestModule_validateGlobals(t *testing.T) {
+	t.Run("too many globals", func(t *testing.T) {
+		m := Module{}
+		err := m.validateGlobals(make([]*GlobalType, 10), 9)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "too many globals")
+	})
+	t.Run("global index out of range", func(t *testing.T) {
+		m := Module{GlobalSection: []*Global{
+			{
+				Type: &GlobalType{ValType: ValueTypeI32},
+				// Trying to reference globals[1] which is not imported.
+				Init: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{1}},
+			},
+		}}
+		err := m.validateGlobals(nil, 9)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "global index out of range")
+	})
+	t.Run("invalid const expression", func(t *testing.T) {
+		m := Module{GlobalSection: []*Global{
+			{
+				Type: &GlobalType{ValType: valueTypeUnknown},
+				Init: &ConstantExpression{Opcode: OpcodeUnreachable},
+			},
+		}}
+		err := m.validateGlobals(nil, 9)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid opcode for const expression")
+	})
+	t.Run("ok", func(t *testing.T) {
+		m := Module{GlobalSection: []*Global{
+			{
+				Type: &GlobalType{ValType: ValueTypeI32},
+				Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{0}},
+			},
+		}}
+		err := m.validateGlobals(nil, 9)
+		require.NoError(t, err)
+	})
+	t.Run("ok with imported global", func(t *testing.T) {
+		m := Module{
+			GlobalSection: []*Global{
+				{
+					Type: &GlobalType{ValType: ValueTypeI32},
+					// Trying to reference globals[1] which is imported.
+					Init: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0}},
+				},
+			},
+			ImportSection: []*Import{{Type: ExternTypeGlobal}},
+		}
+		globalDeclarations := []*GlobalType{
+			{ValType: ValueTypeI32}, // Imported one.
+			nil,                     // the local one trying to validate.
+		}
+		err := m.validateGlobals(globalDeclarations, 9)
+		require.NoError(t, err)
+	})
+}
+
+func TestModule_validateFunctions(t *testing.T) {
+	t.Run("type index out of range", func(t *testing.T) {
+		m := Module{FunctionSection: []uint32{1000 /* arbitrary large */}}
+		err := m.validateFunctions(nil, nil, nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "function type index out of range")
+	})
+	t.Run("insufficient code section", func(t *testing.T) {
+		m := Module{
+			FunctionSection: []uint32{0},
+			TypeSection:     []*FunctionType{{}},
+			// Code section not exists.
+		}
+		err := m.validateFunctions(nil, nil, nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "code index out of range")
+	})
+	t.Run("invalid function", func(t *testing.T) {
+		m := Module{
+			FunctionSection: []uint32{0},
+			TypeSection:     []*FunctionType{{}},
+			CodeSection: []*Code{
+				{Body: []byte{OpcodeF32Abs}},
+			},
+		}
+		err := m.validateFunctions(nil, nil, nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid function (0/0): cannot pop the 1st f32 operand")
+	})
+	t.Run("ok", func(t *testing.T) {
+		m := Module{
+			FunctionSection: []uint32{0},
+			TypeSection:     []*FunctionType{{}},
+			CodeSection: []*Code{
+				{Body: []byte{OpcodeI32Const, 0, OpcodeDrop, OpcodeEnd}},
+			},
+		}
+		err := m.validateFunctions(nil, nil, nil, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestModule_validateTables(t *testing.T) {
+	t.Run("multiple tables", func(t *testing.T) {
+		m := Module{}
+		err := m.validateTables(make([]*TableType, 10), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple tables are not supported")
+	})
+	t.Run("table index out of range", func(t *testing.T) {
+		m := Module{ElementSection: []*ElementSegment{{TableIndex: 1000}}}
+		err := m.validateTables(make([]*TableType, 1), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "table index out of range")
+	})
+	t.Run("invalid const expr", func(t *testing.T) {
+		m := Module{ElementSection: []*ElementSegment{{
+			TableIndex: 0,
+			OffsetExpr: &ConstantExpression{
+				Opcode: OpcodeUnreachable, // Invalid!
+			},
+		}}}
+		err := m.validateTables(make([]*TableType, 1), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid opcode for const expression: 0x0")
+	})
+	t.Run("ok", func(t *testing.T) {
+		m := Module{ElementSection: []*ElementSegment{{
+			TableIndex: 0,
+			OffsetExpr: &ConstantExpression{
+				Opcode: OpcodeI32Const,
+				Data:   []byte{0x1},
+			},
+		}}}
+		err := m.validateTables(make([]*TableType, 1), nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestModule_validateMemories(t *testing.T) {
+	t.Run("multiple memory", func(t *testing.T) {
+		m := Module{}
+		err := m.validateMemories(make([]*LimitsType, 10), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple memories are not supported")
+	})
+	t.Run("data section exits but memory not declared", func(t *testing.T) {
+		m := Module{DataSection: make([]*DataSegment, 1)}
+		err := m.validateMemories(nil, nil)
+		require.Error(t, err)
+		require.Contains(t, "unknown memory", err.Error())
+	})
+	t.Run("non zero memory index data", func(t *testing.T) {
+		m := Module{DataSection: []*DataSegment{{MemoryIndex: 1}}}
+		err := m.validateMemories(make([]*LimitsType, 1), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "memory index must be zero")
+	})
+	t.Run("invalid const expr", func(t *testing.T) {
+		m := Module{DataSection: []*DataSegment{{
+			MemoryIndex: 0,
+			OffsetExpression: &ConstantExpression{
+				Opcode: OpcodeUnreachable, // Invalid!
+			},
+		}}}
+		err := m.validateMemories(make([]*LimitsType, 1), nil)
+		require.Contains(t, err.Error(), "invalid opcode for const expression: 0x0")
+	})
+	t.Run("ok", func(t *testing.T) {
+		m := Module{DataSection: []*DataSegment{{
+			MemoryIndex: 0, Init: []byte{0x1},
+			OffsetExpression: &ConstantExpression{
+				Opcode: OpcodeI32Const,
+				Data:   []byte{0x1},
+			},
+		}}}
+		err := m.validateMemories(make([]*LimitsType, 1), nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestModule_validateExports(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		exportSection map[string]*Export
+		functions     []Index
+		globals       []*GlobalType
+		memories      []*MemoryType
+		tables        []*TableType
+		expErr        bool
+	}{
+		{name: "empty export section", exportSection: map[string]*Export{}},
+		{
+			name:          "valid func",
+			exportSection: map[string]*Export{"": {Type: ExternTypeFunc, Index: 0}},
+			functions:     []Index{100 /* arbitrary type id*/},
+		},
+		{
+			name:          "invalid func",
+			exportSection: map[string]*Export{"": {Type: ExternTypeFunc, Index: 1}},
+			functions:     []Index{100 /* arbitrary type id*/},
+			expErr:        true,
+		},
+		{
+			name:          "valid global",
+			exportSection: map[string]*Export{"": {Type: ExternTypeGlobal, Index: 0}},
+			globals:       []*GlobalType{{}},
+		},
+		{
+			name:          "invalid global",
+			exportSection: map[string]*Export{"": {Type: ExternTypeFunc, Index: 1}},
+			globals:       []*GlobalType{{}},
+			expErr:        true,
+		},
+		{
+			name:          "valid table",
+			exportSection: map[string]*Export{"": {Type: ExternTypeTable, Index: 0}},
+			tables:        []*TableType{{}},
+		},
+		{
+			name:          "invalid table",
+			exportSection: map[string]*Export{"": {Type: ExternTypeTable, Index: 1}},
+			tables:        []*TableType{{}},
+			expErr:        true,
+		},
+		{
+			name:          "valid memory",
+			exportSection: map[string]*Export{"": {Type: ExternTypeMemory, Index: 0}},
+			memories:      []*MemoryType{&LimitsType{}},
+		},
+		{
+			name:          "invalid memory index",
+			exportSection: map[string]*Export{"": {Type: ExternTypeMemory, Index: 1}},
+			expErr:        true,
+		},
+		{
+			name:          "invalid memory index",
+			exportSection: map[string]*Export{"": {Type: ExternTypeMemory, Index: 1}},
+			// Multiple memories are not valid.
+			memories: []*MemoryType{&LimitsType{}, &LimitsType{}},
+			expErr:   true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := Module{ExportSection: tc.exportSection}
+			err := m.validateExports(tc.functions, tc.globals, tc.memories, tc.tables)
+			if tc.expErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestModule_buildGlobalInstances(t *testing.T) {
+	data := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	binary.LittleEndian.PutUint64(data, math.Float64bits(1.0))
+	m := Module{GlobalSection: []*Global{
+		{
+			Type: &GlobalType{Mutable: true, ValType: ValueTypeF64},
+			Init: &ConstantExpression{Opcode: OpcodeF64Const,
+				Data: []byte{0, 0, 0, 0, 0, 0, 0xf0, 0x3f}}, // == float64(1.0)
+		},
+		{
+			Type: &GlobalType{Mutable: false, ValType: ValueTypeI32},
+			Init: &ConstantExpression{Opcode: OpcodeI32Const,
+				Data: []byte{1}},
+		},
+	}}
+
+	globals := m.buildGlobalInstances(nil)
+	expectedGlobals := []*GlobalInstance{
+		{Type: &GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: math.Float64bits(1.0)},
+		{Type: &GlobalType{ValType: ValueTypeI32, Mutable: false}, Val: uint64(1)},
+	}
+
+	require.Len(t, globals, len(expectedGlobals))
+	for i := range globals {
+		actual, expected := globals[i], expectedGlobals[i]
+		require.Equal(t, expected, actual)
+	}
+}
+
+func TestModule_buildFunctionInstances(t *testing.T) {
+	nopCode := &Code{nil, []byte{OpcodeEnd}}
+	m := Module{
+		ImportSection: []*Import{{Type: ExternTypeFunc}},
+		NameSection: &NameSection{
+			FunctionNames: NameMap{
+				{Index: Index(2), Name: "two"},
+				{Index: Index(4), Name: "four"},
+				{Index: Index(5), Name: "five"},
+			},
+		},
+		CodeSection: []*Code{nopCode, nopCode, nopCode, nopCode, nopCode},
+	}
+
+	actual := m.buildFunctionInstances()
+	expectedNames := []string{"unknown", "two", "unknown", "four", "five"}
+	for i, f := range actual {
+		require.Equal(t, expectedNames[i], f.Name)
+		require.Equal(t, nopCode.Body, f.Body)
+	}
+}
+
+func TestModule_buildMemoryInstance(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		m := Module{MemorySection: []*MemoryType{}}
+		mem := m.buildMemoryInstance()
+		require.Nil(t, mem)
+	})
+	t.Run("non-nil", func(t *testing.T) {
+		min := uint32(1)
+		max := uint32(10)
+		m := Module{MemorySection: []*MemoryType{&LimitsType{Min: min, Max: &max}}}
+		mem := m.buildMemoryInstance()
+		require.Equal(t, min, mem.Min)
+		require.Equal(t, max, *mem.Max)
+	})
+}
+
+func TestModule_buildTableInstance(t *testing.T) {
+	m := Module{TableSection: []*TableType{{Limit: &LimitsType{Min: 1}}}}
+	table := m.buildTableInstance()
+	require.Equal(t, uint32(1), table.Min)
 }

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -354,11 +354,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 						}
 						buf, err := testcases.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-						mod, err := binary.DecodeModule(buf)
-						if err == nil {
-							_, err = store.Instantiate(mod, "")
-						}
-						require.Error(t, err, msg)
+						requireInstantiationError(t, store, buf, msg)
 					case "assert_trap":
 						moduleName := lastInstanceName
 						if c.Action.Module != "" {
@@ -383,11 +379,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 						}
 						buf, err := testcases.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-						mod, err := binary.DecodeModule(buf)
-						if err == nil {
-							_, err = store.Instantiate(mod, "")
-						}
-						require.Error(t, err, msg)
+						requireInstantiationError(t, store, buf, msg)
 					case "assert_exhaustion":
 						moduleName := lastInstanceName
 						if c.Action.Module != "" {
@@ -412,20 +404,11 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 						}
 						buf, err := testcases.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-						mod, err := binary.DecodeModule(buf)
-						if err == nil {
-							_, err = store.Instantiate(mod, "")
-						}
-						require.Error(t, err, msg)
+						requireInstantiationError(t, store, buf, msg)
 					case "assert_uninstantiable":
 						buf, err := testcases.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-
-						mod, err := binary.DecodeModule(buf)
-						require.NoError(t, err, msg)
-
-						_, err = store.Instantiate(mod, "")
-						require.Error(t, err, msg)
+						requireInstantiationError(t, store, buf, msg)
 					default:
 						t.Fatalf("unsupported command type: %s", c)
 					}
@@ -433,6 +416,21 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 			}
 		})
 	}
+}
+
+func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg string) {
+	mod, err := binary.DecodeModule(buf)
+	if err != nil {
+		return
+	}
+
+	err = mod.Validate()
+	if err != nil {
+		return
+	}
+
+	_, err = store.Instantiate(mod, "")
+	require.Error(t, err, msg)
 }
 
 // basename avoids filepath.Base to ensure a forward slash is used even in Windows.


### PR DESCRIPTION
This PR refactors store.go and adds store.ReleaseModuleInstance.
Notably, this removes the "rollback" functions in InstantiateModule
which we had used to rollback the mutated state when we encounter
the initialization failure. Instead, we separate out the validation from
initialization and migrate most of the validation logics into module.go

As for ReleaseModuleInstance, that is necessary to complete #293,
will be leveraged to make it possible for store to be used for long-running
processes and environment.
