### PR TITLE
Stops proliferation of MVP jargon

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -77,20 +77,20 @@ https://github.com/bytecodealliance/wasmtime/blob/v0.29.0/crates/lightbeam/src/m
 
 ## Implementation limitations
 
-WebAssembly 1.0 (MVP) specification allows runtimes to [limit certain aspects of Wasm module or execution](https://www.w3.org/TR/wasm-core-1/#a2-implementation-limitations).
+WebAssembly 1.0 (20191205) specification allows runtimes to [limit certain aspects of Wasm module or execution](https://www.w3.org/TR/2019/REC-2019/REC-wasm-core-1-20191205/#a2-implementation-limitations).
 
 wazero limitations are imposed pragmatically and described below.
 
 ### Number of functions in a store
 
-The possible number of function instances in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) is not specified in the WebAssembly specifications since [`funcaddr`](https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr) corresponding to a function instance can be arbitrary number.
+The possible number of function instances in [a store](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#store%E2%91%A0) is not specified in the WebAssembly specifications since [`funcaddr`](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr) corresponding to a function instance can be arbitrary number.
 wazero limits the maximum function instances to 2^27 as even that number would occupy 1GB in function pointers.
 
 That is because not only we _believe_ that all use cases are fine with the limitation, but also we have no way to test wazero runtimes under these unusual circumstances.
 
 ### Number of function types in a store
 
-There's no limitation on the number of function types in [a store](https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0) according to the spec. In wazero implementation, we assign each function type to a unique ID, and choose to use `uint32` to represent the IDs.
+There's no limitation on the number of function types in [a store](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#store%E2%91%A0) according to the spec. In wazero implementation, we assign each function type to a unique ID, and choose to use `uint32` to represent the IDs.
 Therefore the maximum number of function types a store can have is limited to 2^27 as even that number would occupy 512MB just to reference the function types.
 
 This is due to the same reason for the limitation on the number of functions above.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ language!
 
 Here's an example of using wazero to invoke a factorial included in a Wasm binary.
 
-While our [source for this](tests/engine/testdata/fac.wat) is the WebAssembly 1.0 (MVP) Text Format,
+While our [source for this](tests/engine/testdata/fac.wat) is the WebAssembly 1.0 (20191205) Text Format,
 it could have been written in another language that targets Wasm, such as AssemblyScript/C/C++/Rust/TinyGo/Zig.
 
 ```golang

--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -34,7 +34,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-args_getargv-pointerpointeru8-argv_buf-pointeru8---errno
 	FunctionArgsGet = "args_get"
 
-	// ImportArgsGet is the WebAssembly 1.0 (MVP) Text format import of FunctionArgsGet
+	// ImportArgsGet is the WebAssembly 1.0 (20191205) Text format import of FunctionArgsGet
 	ImportArgsGet = `(import "wasi_snapshot_preview1" "args_get"
     (func $wasi.args_get (param $argv i32) (param $argv_buf i32) (result (;errno;) i32)))`
 
@@ -42,7 +42,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-args_sizes_get---errno-size-size
 	FunctionArgsSizesGet = "args_sizes_get"
 
-	// ImportArgsSizesGet is the WebAssembly 1.0 (MVP) Text format import of FunctionArgsSizesGet
+	// ImportArgsSizesGet is the WebAssembly 1.0 (20191205) Text format import of FunctionArgsSizesGet
 	ImportArgsSizesGet = `(import "wasi_snapshot_preview1" "args_sizes_get"
     (func $wasi.args_sizes_get (param $result.argc i32) (param $result.argv_buf_size i32) (result (;errno;) i32)))`
 
@@ -50,7 +50,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-environ_getenviron-pointerpointeru8-environ_buf-pointeru8---errno
 	FunctionEnvironGet = "environ_get"
 
-	// ImportEnvironGet is the WebAssembly 1.0 (MVP) Text format import of FunctionEnvironGet
+	// ImportEnvironGet is the WebAssembly 1.0 (20191205) Text format import of FunctionEnvironGet
 	ImportEnvironGet = `(import "wasi_snapshot_preview1" "environ_get"
     (func $wasi.environ_get (param $environ i32) (param $environ_buf i32) (result (;errno;) i32)))`
 
@@ -58,7 +58,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-environ_sizes_get---errno-size-size
 	FunctionEnvironSizesGet = "environ_sizes_get"
 
-	// ImportEnvironSizesGet is the WebAssembly 1.0 (MVP) Text format import of FunctionEnvironSizesGet
+	// ImportEnvironSizesGet is the WebAssembly 1.0 (20191205) Text format import of FunctionEnvironSizesGet
 	ImportEnvironSizesGet = `
 (import "wasi_snapshot_preview1" "environ_sizes_get"
     (func $wasi.environ_sizes_get (param $result.environc i32) (param $result.environBufSize i32) (result (;errno;) i32)))`
@@ -67,7 +67,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_res_getid-clockid---errno-timestamp
 	FunctionClockResGet = "clock_res_get"
 
-	// ImportClockResGet is the WebAssembly 1.0 (MVP) Text format import of FunctionClockResGet
+	// ImportClockResGet is the WebAssembly 1.0 (20191205) Text format import of FunctionClockResGet
 	ImportClockResGet = `
 (import "wasi_snapshot_preview1" "clock_res_get"
     (func $wasi.clock_res_get (param $id i32) (param $result.resolution i32) (result (;errno;) i32)))`
@@ -76,7 +76,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_time_getid-clockid-precision-timestamp---errno-timestamp
 	FunctionClockTimeGet = "clock_time_get"
 
-	// ImportClockTimeGet is the WebAssembly 1.0 (MVP) Text format import of FunctionClockTimeGet
+	// ImportClockTimeGet is the WebAssembly 1.0 (20191205) Text format import of FunctionClockTimeGet
 	ImportClockTimeGet = `(import "wasi_snapshot_preview1" "clock_time_get"
     (func $wasi.clock_time_get (param $id i32) (param $precision i64) (param $result.timestamp i32) (result (;errno;) i32)))`
 
@@ -86,7 +86,7 @@ const (
 	// FunctionFdClose closes a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_close
 	FunctionFdClose = "fd_close"
-	// ImportFdClose is the WebAssembly 1.0 (MVP) Text format import of FunctionFdClose
+	// ImportFdClose is the WebAssembly 1.0 (20191205) Text format import of FunctionFdClose
 	ImportFdClose = `(import "wasi_snapshot_preview1" "fd_close"
     (func $wasi.fd_close (param $fd i32) (result (;errno;) i32)))`
 
@@ -102,14 +102,14 @@ const (
 	// FunctionFdPrestatGet returns the prestat data of a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_get
 	FunctionFdPrestatGet = "fd_prestat_get"
-	// ImportFdPrestatGet is the WebAssembly 1.0 (MVP) Text format import of FunctionFdPrestatGet
+	// ImportFdPrestatGet is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
 	ImportFdPrestatGet = `(import "wasi_snapshot_preview1" "fd_prestat_get"
     (func $wasi.fd_prestat_get (param $fd i32) (param $result.prestat i32) (result (;errno;) i32)))`
 
 	// FunctionFdPrestatDirName returns the path of the pre-opened directory of a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_dir_name
 	FunctionFdPrestatDirName = "fd_prestat_dir_name"
-	// ImportFdPrestatDirName is the WebAssembly 1.0 (MVP) Text format import of FunctionFdPrestatGet
+	// ImportFdPrestatDirName is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
 	ImportFdPrestatDirName = `(import "wasi_snapshot_preview1" "fd_prestat_dir_name"
     (func $wasi.fd_prestat_dir_name (param $fd i32) (param $path i32) (param $path_len i32) (result (;errno;) i32)))`
 
@@ -118,7 +118,7 @@ const (
 	// FunctionFdRead read bytes from a file descriptor
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
 	FunctionFdRead = "fd_read"
-	// ImportFdRead is the WebAssembly 1.0 (MVP) Text format import of FunctionFdPrestatGet
+	// ImportFdRead is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
 	ImportFdRead = `(import "wasi_snapshot_preview1" "fd_read"
     (func $wasi.fd_read (param $fd i32) (param $iovs i32) (param $iovs_len i32) (param $result.size i32) (result (;errno;) i32)))`
 
@@ -131,7 +131,7 @@ const (
 	// FunctionFdWrite write bytes to a file descriptor
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_write
 	FunctionFdWrite = "fd_write"
-	// ImportFdWrite is the WebAssembly 1.0 (MVP) Text format import of FunctionFdPrestatGet
+	// ImportFdWrite is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
 	ImportFdWrite = `(import "wasi_snapshot_preview1" "fd_write"
     (func $wasi.fd_write (param $fd i32) (param $iovs i32) (param $iovs_len i32) (param $result.size i32) (result (;errno;) i32)))`
 
@@ -151,7 +151,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 	FunctionProcExit = "proc_exit"
 
-	// ImportProcExit is the WebAssembly 1.0 (MVP) Text format import of ProcExit
+	// ImportProcExit is the WebAssembly 1.0 (20191205) Text format import of ProcExit
 	//
 	// See ImportProcExit
 	// See API.ProcExit
@@ -167,7 +167,7 @@ const (
 	// See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-random_getbuf-pointeru8-buf_len-size---errno
 	FunctionRandomGet = "random_get"
 
-	// ImportRandomGet is the WebAssembly 1.0 (MVP) Text format import of FunctionRandomGet
+	// ImportRandomGet is the WebAssembly 1.0 (20191205) Text format import of FunctionRandomGet
 	ImportRandomGet = `(import "wasi_snapshot_preview1" "random_get"
     (func $wasi.random_get (param $buf i32) (param $buf_len i32) (result (;errno;) i32)))`
 
@@ -178,7 +178,7 @@ const (
 
 // SnapshotPreview1 includes all host functions to export for WASI version wasi.ModuleSnapshotPreview1.
 //
-// Note: When translating WASI functions, each result besides Errno is always an uint32 parameter. WebAssembly 1.0 (MVP)
+// Note: When translating WASI functions, each result besides Errno is always an uint32 parameter. WebAssembly 1.0 (20191205)
 // can have up to one result, which is already used by Errno. This forces other results to be parameters. A result
 // parameter is a memory offset to write the result to. As memory offsets are uint32, each parameter representing a
 // result is uint32.
@@ -188,12 +188,12 @@ const (
 // doubt about portability, first look at internal/wasi/RATIONALE.md and if needed an issue on
 // https://github.com/WebAssembly/WASI/issues
 //
-// Note: In WebAssembly 1.0 (MVP), there may be up to one Memory per store, which means wasm.Memory is always the
+// Note: In WebAssembly 1.0 (20191205), there may be up to one Memory per store, which means wasm.Memory is always the
 // wasm.Store Memories index zero: `store.Memories[0].Buffer`
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
 // See https://github.com/WebAssembly/WASI/issues/215
-// See https://wwa.w3.org/TR/wasm-core-1/#memory-instances%E2%91%A0.
+// See https://wwa.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0.
 type SnapshotPreview1 interface {
 	// ArgsGet is the WASI function that reads command-line argument data (Args).
 	//
@@ -217,7 +217,7 @@ type SnapshotPreview1 interface {
 	//          offset that begins "a" --+           |
 	//                     offset that begins "bc" --+
 	//
-	// Note: ImportArgsGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportArgsGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See ArgsSizesGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_get
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
@@ -245,7 +245,7 @@ type SnapshotPreview1 interface {
 	//             resultArgvBufSize --|
 	//   len([]byte{'a',0,'b',c',0}) --+
 	//
-	// Note: ImportArgsSizesGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportArgsSizesGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See ArgsGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_sizes_get
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
@@ -273,7 +273,7 @@ type SnapshotPreview1 interface {
 	//                              environ offset for "a=b" --+           |
 	//                                         environ offset for "b=cd" --+
 	//
-	// Note: ImportEnvironGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportEnvironGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See EnvironSizesGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#environ_get
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
@@ -302,7 +302,7 @@ type SnapshotPreview1 interface {
 	//    len([]byte{'a','=','b',0,    |
 	//           'b','=','c','d',0}) --+
 	//
-	// Note: ImportEnvironGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportEnvironGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See EnvironGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#environ_sizes_get
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
@@ -326,7 +326,7 @@ type SnapshotPreview1 interface {
 	//          []byte{?, 0x0, 0x0, 0x1f, 0xa6, 0x70, 0xfc, 0xc5, 0x16, ?}
 	//  resultTimestamp --^
 	//
-	// Note: ImportClockTimeGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportClockTimeGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// Note: This is similar to `clock_gettime` in POSIX.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_time_getid-clockid-precision-timestamp---errno-timestamp
 	// See https://linux.die.net/man/3/clock_gettime
@@ -339,7 +339,7 @@ type SnapshotPreview1 interface {
 	//
 	// * fd - the file descriptor to close
 	//
-	// Note: ImportFdClose shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportFdClose shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// Note: This is similar to `close` in POSIX.
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#fd_close
 	// See https://linux.die.net/man/3/close
@@ -374,7 +374,7 @@ type SnapshotPreview1 interface {
 	//            tag --+           |
 	//                              +-- size in bytes of the string "/tmp"
 	//
-	// Note: ImportFdPrestatGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportFdPrestatGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See FdPrestatDirName
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#prestat
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#fd_prestat_get
@@ -401,7 +401,7 @@ type SnapshotPreview1 interface {
 	//   []byte{?, '/', 't', 'm', 'p', ?}
 	//       path --^
 	//
-	// Note: ImportFdPrestatDirName shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportFdPrestatDirName shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See FdPrestatGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_dir_name
 	FdPrestatDirName(ctx wasm.ModuleContext, fd uint32, path uint32, pathLen uint32) wasi.Errno
@@ -446,7 +446,7 @@ type SnapshotPreview1 interface {
 	//                            iovs[1].offset --+           |
 	//                                            resultSize --+
 	//
-	// Note: ImportFdRead shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportFdRead shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// Note: This is similar to `readv` in POSIX.
 	// See FdWrite
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
@@ -503,7 +503,7 @@ type SnapshotPreview1 interface {
 	//   []byte{ 0..24, ?, 6, 0, 0, 0', ? }
 	//        resultSize --^
 	//
-	// Note: ImportFdWrite shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportFdWrite shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// Note: This is similar to `writev` in POSIX.
 	// See FdRead
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#ciovec
@@ -532,7 +532,7 @@ type SnapshotPreview1 interface {
 	// You can get the exit code by casting the error to wasi.ExitCode.
 	// See wasi.ExitCode
 	//
-	// Note: ImportProcExit shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportProcExit shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 	ProcExit(rval uint32)
 
@@ -552,7 +552,7 @@ type SnapshotPreview1 interface {
 	//          []byte{?, 0x53, 0x8c, 0x7f, 0x96, 0xb1, ?}
 	//              buf --^
 	//
-	// Note: ImportRandomGet shows this signature in the WebAssembly 1.0 (MVP) Text Format.
+	// Note: ImportRandomGet shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-random_getbuf-pointeru8-bufLen-size---errno
 	RandomGet(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno
 

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -1124,7 +1124,7 @@ func instantiateWasmStore(t *testing.T, wasiFunction, wasiImport, moduleName str
 
 // maskMemory sets the first memory in the store to '?' * size, so tests can see what's written.
 //
-// Note: WebAssembly 1.0 (MVP) can have only up to one memory, so index zero is unambiguous.
+// Note: WebAssembly 1.0 (20191205) can have only up to one memory, so index zero is unambiguous.
 func maskMemory(store *wasm.Store, size int) {
 	store.Memories[0].Buffer = make([]byte, size)
 	for i := 0; i < size; i++ {

--- a/internal/wasm/binary/code.go
+++ b/internal/wasm/binary/code.go
@@ -71,12 +71,12 @@ func decodeCode(r io.Reader) (*wasm.Code, error) {
 	return &wasm.Code{Body: body, LocalTypes: localTypes}, nil
 }
 
-// encodeCode returns the wasm.Code encoded in WebAssembly 1.0 (MVP) Binary Format.
+// encodeCode returns the wasm.Code encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-code
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-code
 func encodeCode(c *wasm.Code) []byte {
 	// local blocks compress locals while preserving index order by grouping locals of the same type.
-	// https://www.w3.org/TR/wasm-core-1/#code-section%E2%91%A0
+	// https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#code-section%E2%91%A0
 	localBlockCount := uint32(0) // how many blocks of locals with the same type (types can repeat!)
 	var localBlocks []byte
 	localTypeLen := len(c.LocalTypes)

--- a/internal/wasm/binary/decoder.go
+++ b/internal/wasm/binary/decoder.go
@@ -9,8 +9,8 @@ import (
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (MVP) Binary Format
-// See https://www.w3.org/TR/wasm-core-1/#binary-format%E2%91%A0
+// DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (20191205) Binary Format
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-format%E2%91%A0
 func DecodeModule(binary []byte) (*wasm.Module, error) {
 	r := bytes.NewReader(binary)
 
@@ -28,7 +28,7 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 	m := &wasm.Module{}
 	for {
 		// TODO: except custom sections, all others are required to be in order, but we aren't checking yet.
-		// See https://www.w3.org/TR/wasm-core-1/#modules%E2%91%A0%E2%93%AA
+		// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#modules%E2%91%A0%E2%93%AA
 		sectionID, err := r.ReadByte()
 		if err == io.EOF {
 			break

--- a/internal/wasm/binary/encoder.go
+++ b/internal/wasm/binary/encoder.go
@@ -6,9 +6,9 @@ import (
 
 var sizePrefixedName = []byte{4, 'n', 'a', 'm', 'e'}
 
-// EncodeModule implements wasm.EncodeModule for the WebAssembly 1.0 (MVP) Binary Format.
+// EncodeModule implements wasm.EncodeModule for the WebAssembly 1.0 (20191205) Binary Format.
 // Note: If saving to a file, the conventional extension is wasm
-// See https://www.w3.org/TR/wasm-core-1/#binary-format%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-format%E2%91%A0
 func EncodeModule(m *wasm.Module) (bytes []byte) {
 	bytes = append(Magic, version...)
 	if m.SectionElementCount(wasm.SectionIDType) > 0 {
@@ -46,7 +46,7 @@ func EncodeModule(m *wasm.Module) (bytes []byte) {
 	}
 	if m.SectionElementCount(wasm.SectionIDCustom) > 0 {
 		// >> The name section should appear only once in a module, and only after the data section.
-		// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
+		// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-namesec
 		if m.NameSection != nil {
 			nameSection := append(sizePrefixedName, encodeNameSectionData(m.NameSection)...)
 			bytes = append(bytes, encodeSection(wasm.SectionIDCustom, nameSection)...)

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -33,9 +33,9 @@ func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
 	return
 }
 
-// encodeExport returns the wasm.Export encoded in WebAssembly 1.0 (MVP) Binary Format.
+// encodeExport returns the wasm.Export encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#export-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
 func encodeExport(i *wasm.Export) []byte {
 	data := encodeSizePrefixed([]byte(i.Name))
 	data = append(data, i.Kind)

--- a/internal/wasm/binary/header.go
+++ b/internal/wasm/binary/header.go
@@ -1,9 +1,9 @@
 package binary
 
 // Magic is the 4 byte preamble (literally "\0asm") of the binary format
-// See https://www.w3.org/TR/wasm-core-1/#binary-magic
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-magic
 var Magic = []byte{0x00, 0x61, 0x73, 0x6D}
 
 // version is format version and doesn't change between known specification versions
-// See https://www.w3.org/TR/wasm-core-1/#binary-version
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-version
 var version = []byte{0x01, 0x00, 0x00, 0x00}

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -48,9 +48,9 @@ func decodeImport(r *bytes.Reader) (i *wasm.Import, err error) {
 	return
 }
 
-// encodeImport returns the wasm.Import encoded in WebAssembly 1.0 (MVP) Binary Format.
+// encodeImport returns the wasm.Import encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-import
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-import
 func encodeImport(i *wasm.Import) []byte {
 	data := encodeSizePrefixed([]byte(i.Module))
 	data = append(data, encodeSizePrefixed([]byte(i.Name))...)

--- a/internal/wasm/binary/limits.go
+++ b/internal/wasm/binary/limits.go
@@ -8,9 +8,9 @@ import (
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// decodeLimitsType returns the wasm.LimitsType decoded with the WebAssembly 1.0 (MVP) Binary Format.
+// decodeLimitsType returns the wasm.LimitsType decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#limits%E2%91%A6
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#limits%E2%91%A6
 func decodeLimitsType(r io.Reader) (*wasm.LimitsType, error) {
 	b := make([]byte, 1)
 	_, err := io.ReadFull(r, b)
@@ -41,9 +41,9 @@ func decodeLimitsType(r io.Reader) (*wasm.LimitsType, error) {
 	return ret, nil
 }
 
-// encodeLimitsType returns the wasm.LimitsType encoded in WebAssembly 1.0 (MVP) Binary Format.
+// encodeLimitsType returns the wasm.LimitsType encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#limits%E2%91%A6
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#limits%E2%91%A6
 func encodeLimitsType(l *wasm.LimitsType) []byte {
 	if l.Max == nil {
 		return append(leb128.EncodeUint32(0x00), leb128.EncodeUint32(l.Min)...)

--- a/internal/wasm/binary/memory.go
+++ b/internal/wasm/binary/memory.go
@@ -7,9 +7,9 @@ import (
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// decodeMemoryType returns the wasm.MemoryType decoded with the WebAssembly 1.0 (MVP) Binary Format.
+// decodeMemoryType returns the wasm.MemoryType decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-memory
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
 func decodeMemoryType(r io.Reader) (*wasm.MemoryType, error) {
 	ret, err := decodeLimitsType(r)
 	if err != nil {
@@ -28,9 +28,9 @@ func decodeMemoryType(r io.Reader) (*wasm.MemoryType, error) {
 	return ret, nil
 }
 
-// encodeMemoryType returns the wasm.MemoryType encoded in WebAssembly 1.0 (MVP) Binary Format.
+// encodeMemoryType returns the wasm.MemoryType encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-memory
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
 func encodeMemoryType(i *wasm.MemoryType) []byte {
 	return encodeLimitsType(i)
 }

--- a/internal/wasm/binary/names.go
+++ b/internal/wasm/binary/names.go
@@ -26,7 +26,7 @@ const (
 // * FunctionNames decode from subsection 1
 // * LocalNames decode from subsection 2
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-namesec
 func decodeNameSection(r *bytes.Reader, limit uint64) (result *wasm.NameSection, err error) {
 	// TODO: add leb128 functions that work on []byte and offset. While using a reader allows us to reuse reader-based
 	// leb128 functions, it is less efficient, causes untestable code and in some cases more complex vs plain []byte.
@@ -154,7 +154,7 @@ func decodeFunctionCount(r *bytes.Reader, subsectionID uint8) (uint32, error) {
 //
 // Note: The result can be nil because this does not encode empty subsections
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-namesec
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-namesec
 func encodeNameSectionData(n *wasm.NameSection) (data []byte) {
 	if n.ModuleName != "" {
 		data = append(data, encodeNameSubsection(subsectionIDModuleName, encodeSizePrefixed([]byte(n.ModuleName)))...)
@@ -169,7 +169,7 @@ func encodeNameSectionData(n *wasm.NameSection) (data []byte) {
 }
 
 // encodeFunctionNameData encodes the data for the function name subsection.
-// See https://www.w3.org/TR/wasm-core-1/#binary-funcnamesec
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-funcnamesec
 func encodeFunctionNameData(n *wasm.NameSection) []byte {
 	if len(n.FunctionNames) == 0 {
 		return nil
@@ -188,7 +188,7 @@ func encodeNameMap(m wasm.NameMap) []byte {
 }
 
 // encodeLocalNameData encodes the data for the local name subsection.
-// See https://www.w3.org/TR/wasm-core-1/#binary-localnamesec
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-localnamesec
 func encodeLocalNameData(n *wasm.NameSection) []byte {
 	if len(n.LocalNames) == 0 {
 		return nil
@@ -205,7 +205,7 @@ func encodeLocalNameData(n *wasm.NameSection) []byte {
 }
 
 // encodeNameSubsection returns a buffer encoding the given subsection
-// See https://www.w3.org/TR/wasm-core-1/#subsections%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#subsections%E2%91%A0
 func encodeNameSubsection(subsectionID uint8, content []byte) []byte {
 	contentSizeInBytes := leb128.EncodeUint32(uint32(len(content)))
 	result := []byte{subsectionID}
@@ -215,7 +215,7 @@ func encodeNameSubsection(subsectionID uint8, content []byte) []byte {
 }
 
 // encodeNameAssoc encodes the index and data prefixed by their size.
-// See https://www.w3.org/TR/wasm-core-1/#binary-namemap
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-namemap
 func encodeNameAssoc(na *wasm.NameAssoc) []byte {
 	return append(leb128.EncodeUint32(na.Index), encodeSizePrefixed([]byte(na.Name))...)
 }

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -211,15 +211,15 @@ func decodeDataSection(r *bytes.Reader) ([]*wasm.DataSegment, error) {
 }
 
 // encodeSection encodes the sectionID, the size of its contents in bytes, followed by the contents.
-// See https://www.w3.org/TR/wasm-core-1/#sections%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#sections%E2%91%A0
 func encodeSection(sectionID wasm.SectionID, contents []byte) []byte {
 	return append([]byte{sectionID}, encodeSizePrefixed(contents)...)
 }
 
-// encodeTypeSection encodes a SectionIDType for the given imports in WebAssembly 1.0 (MVP) Binary Format.
+// encodeTypeSection encodes a SectionIDType for the given imports in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See encodeFunctionType
-// See https://www.w3.org/TR/wasm-core-1/#type-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#type-section%E2%91%A0
 func encodeTypeSection(types []*wasm.FunctionType) []byte {
 	contents := leb128.EncodeUint32(uint32(len(types)))
 	for _, t := range types {
@@ -228,10 +228,10 @@ func encodeTypeSection(types []*wasm.FunctionType) []byte {
 	return encodeSection(wasm.SectionIDType, contents)
 }
 
-// encodeImportSection encodes a SectionIDImport for the given imports in WebAssembly 1.0 (MVP) Binary Format.
+// encodeImportSection encodes a SectionIDImport for the given imports in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See encodeImport
-// See https://www.w3.org/TR/wasm-core-1/#import-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#import-section%E2%91%A0
 func encodeImportSection(imports []*wasm.Import) []byte {
 	contents := leb128.EncodeUint32(uint32(len(imports)))
 	for _, i := range imports {
@@ -241,9 +241,9 @@ func encodeImportSection(imports []*wasm.Import) []byte {
 }
 
 // encodeFunctionSection encodes a SectionIDFunction for the type indices associated with module-defined functions in
-// WebAssembly 1.0 (MVP) Binary Format.
+// WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#function-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-section%E2%91%A0
 func encodeFunctionSection(typeIndices []wasm.Index) []byte {
 	contents := leb128.EncodeUint32(uint32(len(typeIndices)))
 	for _, index := range typeIndices {
@@ -252,10 +252,10 @@ func encodeFunctionSection(typeIndices []wasm.Index) []byte {
 	return encodeSection(wasm.SectionIDFunction, contents)
 }
 
-// encodeCodeSection encodes a SectionIDCode for the module-defined function in WebAssembly 1.0 (MVP) Binary Format.
+// encodeCodeSection encodes a SectionIDCode for the module-defined function in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See encodeCode
-// See https://www.w3.org/TR/wasm-core-1/#code-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#code-section%E2%91%A0
 func encodeCodeSection(code []*wasm.Code) []byte {
 	contents := leb128.EncodeUint32(uint32(len(code)))
 	for _, i := range code {
@@ -264,10 +264,10 @@ func encodeCodeSection(code []*wasm.Code) []byte {
 	return encodeSection(wasm.SectionIDCode, contents)
 }
 
-// encodeMemorySection encodes a SectionIDMemory for the module-defined function in WebAssembly 1.0 (MVP) Binary Format.
+// encodeMemorySection encodes a SectionIDMemory for the module-defined function in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See encodeMemoryType
-// See https://www.w3.org/TR/wasm-core-1/#memory-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-section%E2%91%A0
 func encodeMemorySection(memories []*wasm.MemoryType) []byte {
 	contents := leb128.EncodeUint32(uint32(len(memories)))
 	for _, i := range memories {
@@ -276,10 +276,10 @@ func encodeMemorySection(memories []*wasm.MemoryType) []byte {
 	return encodeSection(wasm.SectionIDMemory, contents)
 }
 
-// encodeExportSection encodes a SectionIDExport for the given exports in WebAssembly 1.0 (MVP) Binary Format.
+// encodeExportSection encodes a SectionIDExport for the given exports in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See encodeExport
-// See https://www.w3.org/TR/wasm-core-1/#export-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
 func encodeExportSection(exports map[string]*wasm.Export) []byte {
 	contents := leb128.EncodeUint32(uint32(len(exports)))
 	for _, e := range exports {
@@ -288,9 +288,9 @@ func encodeExportSection(exports map[string]*wasm.Export) []byte {
 	return encodeSection(wasm.SectionIDExport, contents)
 }
 
-// encodeStartSection encodes a SectionIDStart for the given function index in WebAssembly 1.0 (MVP) Binary Format.
+// encodeStartSection encodes a SectionIDStart for the given function index in WebAssembly 1.0 (20191205) Binary Format.
 //
-// See https://www.w3.org/TR/wasm-core-1/#start-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#start-section%E2%91%A0
 func encodeStartSection(funcidx wasm.Index) []byte {
 	return encodeSection(wasm.SectionIDStart, leb128.EncodeUint32(funcidx))
 }

--- a/internal/wasm/binary/types.go
+++ b/internal/wasm/binary/types.go
@@ -71,10 +71,10 @@ var encodedOneResult = map[wasm.ValueType][]byte{
 	wasm.ValueTypeF64: {0x60, 0, 1, wasm.ValueTypeF64},
 }
 
-// encodeFunctionType returns the wasm.FunctionType encoded in WebAssembly 1.0 (MVP) Binary Format.
+// encodeFunctionType returns the wasm.FunctionType encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // Note: Function types are encoded by the byte 0x60 followed by the respective vectors of parameter and result types.
-// See https://www.w3.org/TR/wasm-core-1/#function-types%E2%91%A4
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-types%E2%91%A4
 func encodeFunctionType(t *wasm.FunctionType) []byte {
 	paramCount, resultCount := len(t.Params), len(t.Results)
 	if paramCount == 0 && resultCount == 0 {
@@ -95,7 +95,7 @@ func encodeFunctionType(t *wasm.FunctionType) []byte {
 		}
 		return append(append([]byte{0x60}, encodeValTypes(t.Params)...), 1, t.Results[0])
 	}
-	// This branch should never be reaches as WebAssembly 1.0 (MVP) supports at most 1 result
+	// This branch should never be reaches as WebAssembly 1.0 (20191205) supports at most 1 result
 	data := append([]byte{0x60}, encodeValTypes(t.Params)...)
 	return append(data, encodeValTypes(t.Results)...)
 }

--- a/internal/wasm/binary/types_test.go
+++ b/internal/wasm/binary/types_test.go
@@ -56,12 +56,12 @@ func TestEncodeFunctionType(t *testing.T) {
 			expected: []byte{0x60, 2, i32, i64, 0},
 		},
 		{
-			name:     "no param two results", // this is just for coverage as WebAssembly 1.0 (MVP) does not allow it!
+			name:     "no param two results", // this is just for coverage as WebAssembly 1.0 (20191205) does not allow it!
 			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 0, 2, i32, i64},
 		},
 		{
-			name:     "one param two results", // this is just for coverage as WebAssembly 1.0 (MVP) does not allow it!
+			name:     "one param two results", // this is just for coverage as WebAssembly 1.0 (20191205) does not allow it!
 			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 1, i64, 2, i32, i64},
 		},
@@ -71,7 +71,7 @@ func TestEncodeFunctionType(t *testing.T) {
 			expected: []byte{0x60, 2, i32, i64, 1, i32},
 		},
 		{
-			name:     "two param two results", // this is just for coverage as WebAssembly 1.0 (MVP) does not allow it!
+			name:     "two param two results", // this is just for coverage as WebAssembly 1.0 (20191205) does not allow it!
 			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 2, i32, i64, 2, i32, i64},
 		},

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -9,7 +9,7 @@ import (
 )
 
 // validateFunctionInstance validates the instruction sequence of a function instance.
-// following the specification https://www.w3.org/TR/wasm-core-1/#instructions%E2%91%A2.
+// following the specification https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#instructions%E2%91%A2.
 //
 // f is the validation target function instance.
 // functions is the list of function indexes which are declared on a module from which the target is instantiated.
@@ -30,9 +30,9 @@ func validateFunctionInstance(
 	types []*FunctionType,
 	maxStackValues int,
 ) error {
-	// Note: In WebAssembly 1.0 (MVP), multiple memories are not allowed.
+	// Note: In WebAssembly 1.0 (20191205), multiple memories are not allowed.
 	hasMemory := len(memories) > 0
-	// Note: In WebAssembly 1.0 (MVP), multiple tables are not allowed.
+	// Note: In WebAssembly 1.0 (20191205), multiple tables are not allowed.
 	hasTable := len(tables) > 0
 
 	// We start with the outermost control block which is for function return if the code branches into it.

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -24,7 +24,7 @@ const (
 	FunctionKindGoModuleContext
 )
 
-// GoFunc binds a WebAssembly 1.0 (MVP) Type Use to a Go func signature.
+// GoFunc binds a WebAssembly 1.0 (20191205) Type Use to a Go func signature.
 type GoFunc struct {
 	wasmFunctionName string
 	// functionKind is never FunctionKindWasm

--- a/internal/wasm/instruction.go
+++ b/internal/wasm/instruction.go
@@ -392,7 +392,7 @@ var instructionNames = [256]string{
 }
 
 // InstructionName returns the instruction corresponding to this binary Opcode.
-// See https://www.w3.org/TR/wasm-core-1/#a7-index-of-instructions
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#a7-index-of-instructions
 func InstructionName(oc Opcode) string {
 	return instructionNames[oc]
 }

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -559,7 +559,7 @@ func (vm *callEngine) callNativeFunc(ctx *wasm.ModuleContext, f *compiledFunctio
 	globals := moduleInst.Globals
 	var table *wasm.TableInstance
 	if len(moduleInst.Tables) > 0 {
-		table = moduleInst.Tables[0] // WebAssembly 1.0 (MVP) defines at most one table
+		table = moduleInst.Tables[0] // WebAssembly 1.0 (20191205) defines at most one table
 	}
 	vm.pushFrame(frame)
 	bodyLen := uint64(len(frame.f.body))

--- a/internal/wasm/jit/compiler.go
+++ b/internal/wasm/jit/compiler.go
@@ -70,7 +70,7 @@ type compiler interface {
 	// 2) If the type of the function table[offset] doesn't match the specified function type, the function exits with jitCallStatusCodeTypeMismatchOnIndirectCall.
 	// Otherwise, we successfully enter the target function.
 	//
-	// Note: WebAssembly 1.0 (MVP) supports at most one table, so this doesn't support multiple tables.
+	// Note: WebAssembly 1.0 (20191205) supports at most one table, so this doesn't support multiple tables.
 	// See wasm.CallIndirect
 	compileCallIndirect(o *wazeroir.OperationCallIndirect) error
 	// compileDrop adds instructions to drop values within the given inclusive range from the value stack.
@@ -206,8 +206,8 @@ type compiler interface {
 	// To summarize, if the source float value is NaN or doesn't fit in the destination range of integers (incl. +=Inf),
 	// then the runtime behavior is undefined. In wazero, we exit the function in these undefined cases with
 	// jitCallStatusCodeInvalidFloatToIntConversion or jitCallStatusIntegerOverflow status code.
-	// [1] https://www.w3.org/TR/wasm-core-1/#-hrefop-trunc-umathrmtruncmathsfu_m-n-z for unsigned integers.
-	// [2] https://www.w3.org/TR/wasm-core-1/#-hrefop-trunc-smathrmtruncmathsfs_m-n-z for signed integers.
+	// [1] https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefop-trunc-umathrmtruncmathsfu_m-n-z for unsigned integers.
+	// [2] https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefop-trunc-smathrmtruncmathsfs_m-n-z for signed integers.
 	// See OpcodeI32TruncF32S OpcodeI32TruncF32U OpcodeI32TruncF64S OpcodeI32TruncF64U
 	// See OpcodeI64TruncF32S OpcodeI64TruncF32U OpcodeI64TruncF64S OpcodeI64TruncF64U
 	compileITruncFromF(o *wazeroir.OperationITruncFromF) error

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -8,10 +8,10 @@ import (
 const (
 	// MemoryPageSize is the unit of memory length in WebAssembly,
 	// and is defined as 2^16 = 65536.
-	// See https://www.w3.org/TR/wasm-core-1/#memory-instances%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0
 	MemoryPageSize = uint32(65536)
 	// MemoryMaxPages is maximum number of pages defined (2^16).
-	// See https://www.w3.org/TR/wasm-core-1/#grow-mem
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem
 	MemoryMaxPages = MemoryPageSize
 	// MemoryPageSizeInBits satisfies the relation: "1 << MemoryPageSizeInBits == MemoryPageSize".
 	MemoryPageSizeInBits = 16
@@ -134,7 +134,7 @@ func memoryBytesNumToPages(bytesNum uint64) (pages uint32) {
 }
 
 // Grow extends the memory buffer by "newPages" * memoryPageSize.
-// The logic here is described in https://www.w3.org/TR/wasm-core-1/#grow-mem.
+// The logic here is described in https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem.
 //
 // Returns -1 if the operation resulted in excedding the maximum memory pages.
 // Otherwise, returns the prior memory size after growing the memory buffer.

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -20,7 +20,7 @@ type DecodeModule func(source []byte) (result *Module, err error)
 type EncodeModule func(m *Module) (bytes []byte)
 
 // Module is a WebAssembly binary representation.
-// See https://www.w3.org/TR/wasm-core-1/#modules%E2%91%A8
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#modules%E2%91%A8
 //
 // Differences from the specification:
 // * The NameSection is decoded, so not present as a key "name" in CustomSections.
@@ -33,7 +33,7 @@ type Module struct {
 	//
 	// Note: In the Binary Format, this is SectionIDType.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#types%E2%91%A0%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#types%E2%91%A0%E2%91%A0
 	TypeSection []*FunctionType
 
 	// ImportSection contains imported functions, tables, memories or globals required for instantiation
@@ -43,7 +43,7 @@ type Module struct {
 	//
 	// Note: In the Binary Format, this is SectionIDImport.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#import-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#import-section%E2%91%A0
 	ImportSection []*Import
 
 	// FunctionSection contains the index in TypeSection of each function defined in this module.
@@ -57,7 +57,7 @@ type Module struct {
 	//
 	// Note: In the Binary Format, this is SectionIDFunction.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#function-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-section%E2%91%A0
 	FunctionSection []Index
 
 	// TableSection contains each table defined in this module.
@@ -66,12 +66,12 @@ type Module struct {
 	// For example, if there are two imported tables and one defined in this module, the table Index 3 is defined in
 	// this module at TableSection[0].
 	//
-	// Note: Version 1.0 (MVP) of the WebAssembly spec allows at most one table definition per module, so the length of
+	// Note: Version 1.0 (20191205) of the WebAssembly spec allows at most one table definition per module, so the length of
 	// the TableSection can be zero or one, and can only be one if there is no ImportKindTable.
 	//
 	// Note: In the Binary Format, this is SectionIDTable.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#table-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#table-section%E2%91%A0
 	TableSection []*TableType
 
 	// MemorySection contains each memory defined in this module.
@@ -80,12 +80,12 @@ type Module struct {
 	// For example, if there are two imported memories and one defined in this module, the memory Index 3 is defined in
 	// this module at TableSection[0].
 	//
-	// Note: Version 1.0 (MVP) of the WebAssembly spec allows at most one memory definition per module, so the length of
+	// Note: Version 1.0 (20191205) of the WebAssembly spec allows at most one memory definition per module, so the length of
 	// the MemorySection can be zero or one, and can only be one if there is no ImportKindMemory.
 	//
 	// Note: In the Binary Format, this is SectionIDMemory.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#memory-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-section%E2%91%A0
 	MemorySection []*MemoryType
 
 	// GlobalSection contains each global defined in this module.
@@ -96,14 +96,14 @@ type Module struct {
 	//
 	// Note: In the Binary Format, this is SectionIDGlobal.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#global-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-section%E2%91%A0
 	GlobalSection []*Global
 
 	// ExportSection contains each export defined in this module.
 	//
 	// Note: In the Binary Format, this is SectionIDExport.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#exports%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#exports%E2%91%A0
 	ExportSection map[string]*Export
 
 	// StartSection is the index of a function to call before returning from Store.Instantiate.
@@ -113,7 +113,7 @@ type Module struct {
 	//
 	// Note: In the Binary Format, this is SectionIDStart.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#start-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#start-section%E2%91%A0
 	StartSection *Index
 
 	// Note: In the Binary Format, this is SectionIDElement.
@@ -123,7 +123,7 @@ type Module struct {
 	//
 	// Note: In the Binary Format, this is SectionIDCode.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#code-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#code-section%E2%91%A0
 	CodeSection []*Code
 
 	// Note: In the Binary Format, this is SectionIDData.
@@ -131,11 +131,11 @@ type Module struct {
 
 	// NameSection is set when the SectionIDCustom "name" was successfully decoded from the binary format.
 	//
-	// Note: This is the only SectionIDCustom defined in the WebAssembly 1.0 (MVP) Binary Format.
+	// Note: This is the only SectionIDCustom defined in the WebAssembly 1.0 (20191205) Binary Format.
 	// Others are skipped as they are not used in wazero.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#name-section%E2%91%A0
-	// See https://www.w3.org/TR/wasm-core-1/#custom-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#name-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#custom-section%E2%91%A0
 	NameSection *NameSection
 }
 
@@ -175,20 +175,20 @@ func (m *Module) TypeOfFunction(funcIdx Index) *FunctionType {
 // For example, the function index namespace starts with any ImportKindFunc in the Module.TypeSection followed by the
 // Module.FunctionSection
 //
-// See https://www.w3.org/TR/wasm-core-1/#binary-index
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-index
 type Index = uint32
 
 // FunctionType is a possibly empty function signature.
 //
-// See https://www.w3.org/TR/wasm-core-1/#function-types%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-types%E2%91%A0
 type FunctionType struct {
 	// Params are the possibly empty sequence of value types accepted by a function with this signature.
 	Params []ValueType
 
 	// Results are the possibly empty sequence of value types returned by a function with this signature.
 	//
-	// Note: In WebAssembly 1.0 (MVP), there can be at most one result.
-	// See https://www.w3.org/TR/wasm-core-1/#result-types%E2%91%A0
+	// Note: In WebAssembly 1.0 (20191205), there can be at most one result.
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#result-types%E2%91%A0
 	Results []ValueType
 }
 
@@ -210,7 +210,7 @@ func (t *FunctionType) String() (ret string) {
 }
 
 // Import is the binary representation of an import indicated by Kind
-// See https://www.w3.org/TR/wasm-core-1/#binary-import
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-import
 type Import struct {
 	Kind ImportKind
 	// Module is the possibly empty primary namespace of this import
@@ -255,7 +255,7 @@ type ConstantExpression struct {
 }
 
 // Export is the binary representation of an export indicated by Kind
-// See https://www.w3.org/TR/wasm-core-1/#binary-export
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-export
 type Export struct {
 	Kind ExportKind
 	// Name is what the host refers to this definition as.
@@ -272,13 +272,13 @@ type ElementSegment struct {
 }
 
 // Code is an entry in the Module.CodeSection containing the locals and body of the function.
-// See https://www.w3.org/TR/wasm-core-1/#binary-code
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-code
 type Code struct {
 	// LocalTypes are any function-scoped variables in insertion order.
-	// See https://www.w3.org/TR/wasm-core-1/#binary-local
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-local
 	LocalTypes []ValueType
 	// Body is a sequence of expressions ending in OpcodeEnd
-	// See https://www.w3.org/TR/wasm-core-1/#binary-expr
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-expr
 	Body []byte
 }
 
@@ -291,7 +291,7 @@ type DataSegment struct {
 // NameSection represent the known custom name subsections defined in the WebAssembly Binary Format
 //
 // Note: This can be nil if no names were decoded for any reason including configuration.
-// See https://www.w3.org/TR/wasm-core-1/#name-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#name-section%E2%91%A0
 type NameSection struct {
 	// ModuleName is the symbolic identifier for a module. Ex. math
 	//
@@ -301,7 +301,7 @@ type NameSection struct {
 	// FunctionNames is an association of a function index to its symbolic identifier. Ex. add
 	//
 	// * the key (idx) is in the function namespace, where module defined functions are preceded by imported ones.
-	// See https://www.w3.org/TR/wasm-core-1/#functions%E2%91%A7
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#functions%E2%91%A7
 	//
 	// Ex. Assuming the below text format is the second import, you would expect FunctionNames[1] = "mul"
 	//	(import "Math" "Mul" (func $mul (param $x f32) (param $y f32) (result f32)))
@@ -329,7 +329,7 @@ type NameSection struct {
 //
 // Note: NameMap is unique by NameAssoc.Index, but NameAssoc.Name needn't be unique.
 // Note: When encoding in the Binary format, this must be ordered by NameAssoc.Index
-// See https://www.w3.org/TR/wasm-core-1/#binary-namemap
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-namemap
 type NameMap []*NameAssoc
 
 type NameAssoc struct {
@@ -341,7 +341,7 @@ type NameAssoc struct {
 //
 // Note: IndirectNameMap is unique by NameMapAssoc.Index, but NameMapAssoc.NameMap needn't be unique.
 // Note: When encoding in the Binary format, this must be ordered by NameMapAssoc.Index
-// https://www.w3.org/TR/wasm-core-1/#binary-indirectnamemap
+// https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-indirectnamemap
 type IndirectNameMap []*NameMapAssoc
 
 type NameMapAssoc struct {
@@ -416,17 +416,17 @@ func (m *Module) SectionElementCount(sectionID SectionID) uint32 { // element as
 	}
 }
 
-// SectionID identifies the sections of a Module in the WebAssembly 1.0 (MVP) Binary Format.
+// SectionID identifies the sections of a Module in the WebAssembly 1.0 (20191205) Binary Format.
 //
 // Note: these are defined in the wasm package, instead of the binary package, as a key per section is needed regardless
 // of format, and deferring to the binary type avoids confusion.
 //
-// See https://www.w3.org/TR/wasm-core-1/#sections%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#sections%E2%91%A0
 type SectionID = byte
 
 const (
 	// SectionIDCustom includes the standard defined NameSection and possibly others not defined in the standard.
-	SectionIDCustom SectionID = iota // don't add anything not in https://www.w3.org/TR/wasm-core-1/#sections%E2%91%A0
+	SectionIDCustom SectionID = iota // don't add anything not in https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#sections%E2%91%A0
 	SectionIDType
 	SectionIDImport
 	SectionIDFunction
@@ -441,7 +441,7 @@ const (
 )
 
 // SectionIDName returns the canonical name of a module section.
-// https://www.w3.org/TR/wasm-core-1/#sections%E2%91%A0
+// https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#sections%E2%91%A0
 func SectionIDName(sectionID SectionID) string {
 	switch sectionID {
 	case SectionIDCustom:
@@ -488,7 +488,7 @@ func ValueTypeName(t ValueType) string {
 }
 
 // ImportKind indicates which import description is present
-// See https://www.w3.org/TR/wasm-core-1/#import-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#import-section%E2%91%A0
 type ImportKind = byte
 
 const (
@@ -499,7 +499,7 @@ const (
 )
 
 // ExportKind indicates which index Export.Index points to
-// See https://www.w3.org/TR/wasm-core-1/#export-section%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
 type ExportKind = byte
 
 const (
@@ -510,7 +510,7 @@ const (
 )
 
 // ExportKindName returns the canonical name of the exportdesc.
-// https://www.w3.org/TR/wasm-core-1/#syntax-exportdesc
+// https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-exportdesc
 func ExportKindName(ek ExportKind) string {
 	switch ek {
 	case ExportKindFunc:

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -24,7 +24,7 @@ type (
 	// via multiple goroutines might result in race conditions. In that case, the invocation
 	// and access to any methods and field of Store must be guarded by mutex.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#store%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#store%E2%91%A0
 	Store struct {
 		// The following fields are wazero-specific fields of Store.
 
@@ -59,21 +59,21 @@ type (
 
 		// The followings fields match the definition of Store in the specification.
 
-		// Functions holds function instances (https://www.w3.org/TR/wasm-core-1/#function-instances%E2%91%A0),
+		// Functions holds function instances (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-instances%E2%91%A0),
 		// in this store.
-		// The slice index is to be interpreted as funcaddr (https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr).
+		// The slice index is to be interpreted as funcaddr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr).
 		Functions []*FunctionInstance
-		// Globals holds global instances (https://www.w3.org/TR/wasm-core-1/#global-instances%E2%91%A0),
+		// Globals holds global instances (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-instances%E2%91%A0),
 		// in this store.
-		// The slice index is to be interpreted as globaladdr (https://www.w3.org/TR/wasm-core-1/#syntax-globaladdr).
+		// The slice index is to be interpreted as globaladdr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaladdr).
 		Globals []*GlobalInstance
-		// Memories holds memory instances (https://www.w3.org/TR/wasm-core-1/#memory-instances%E2%91%A0),
+		// Memories holds memory instances (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0),
 		// in this store.
-		// The slice index is to be interpreted as memaddr (https://www.w3.org/TR/wasm-core-1/#syntax-memaddr).
+		// The slice index is to be interpreted as memaddr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-memaddr).
 		Memories []*MemoryInstance
-		// Tables holds table instances (https://www.w3.org/TR/wasm-core-1/#table-instances%E2%91%A0),
+		// Tables holds table instances (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#table-instances%E2%91%A0),
 		// in this store.
-		// The slice index is to be interpreted as tableaddr (https://www.w3.org/TR/wasm-core-1/#syntax-tableaddr).
+		// The slice index is to be interpreted as tableaddr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-tableaddr).
 		Tables []*TableInstance
 	}
 
@@ -81,7 +81,7 @@ type (
 	// The difference from the spec is that in wazero, a ModuleInstance holds pointers
 	// to the instances, rather than "addresses" (i.e. index to Store.Functions, Globals, etc) for convenience.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#syntax-moduleinst
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-moduleinst
 	ModuleInstance struct {
 		Name      string
 		Exports   map[string]*ExportInstance
@@ -98,7 +98,7 @@ type (
 	// The difference from the spec is that in wazero, a ExportInstance holds pointers
 	// to the instances, rather than "addresses" (i.e. index to Store.Functions, Globals, etc) for convenience.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#syntax-exportinst
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-exportinst
 	ExportInstance struct {
 		Kind     ExportKind
 		Function *FunctionInstance
@@ -108,7 +108,7 @@ type (
 	}
 
 	// FunctionInstance represents a function instance in a Store.
-	// See https://www.w3.org/TR/wasm-core-1/#function-instances%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-instances%E2%91%A0
 	FunctionInstance struct {
 		// ModuleInstance holds the pointer to the module instance to which this function belongs.
 		ModuleInstance *ModuleInstance
@@ -124,7 +124,7 @@ type (
 		// This is nil when FunctionKind == FunctionKindWasm. Otherwise, all the above fields are ignored as they are
 		// specific to Wasm functions.
 		HostFunction *reflect.Value
-		// Address is the funcaddr(https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr) of this function instance.
+		// Address is the funcaddr(https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr) of this function instance.
 		// More precisely, this equals the index of this function instance in store.FunctionInstances.
 		// All function calls are made via funcaddr at runtime, not the index (scoped to a module).
 		//
@@ -148,7 +148,7 @@ type (
 	}
 
 	// GlobalInstance represents a global instance in a store.
-	// See https://www.w3.org/TR/wasm-core-1/#global-instances%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-instances%E2%91%A0
 	GlobalInstance struct {
 		Type *GlobalType
 		// Val holds a 64-bit representation of the actual value.
@@ -156,9 +156,9 @@ type (
 	}
 
 	// TableInstance represents a table instance in a store.
-	// See https://www.w3.org/TR/wasm-core-1/#table-instances%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#table-instances%E2%91%A0
 	//
-	// Note this is fixed to function type until post MVP reference type is implemented.
+	// Note this is fixed to function type until post 20191205 reference type is implemented.
 	TableInstance struct {
 		// Table holds the table elements managed by this table instance.
 		//
@@ -176,9 +176,9 @@ type (
 
 	// TableElement represents an item in a table instance.
 	//
-	// Note: this is fixed to function type as it is the only supported type in WebAssembly 1.0 (MVP)
+	// Note: this is fixed to function type as it is the only supported type in WebAssembly 1.0 (20191205)
 	TableElement struct {
-		// FunctionAddress is funcaddr (https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr)
+		// FunctionAddress is funcaddr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr)
 		// of the target function instance. More precisely, this equals the index of
 		// the target function instance in Store.FunctionInstances.
 		FunctionAddress FunctionAddress
@@ -189,16 +189,16 @@ type (
 
 	// MemoryInstance represents a memory instance in a store, and implements wasm.Memory.
 	//
-	// Note: In WebAssembly 1.0 (MVP), there may be up to one Memory per store, which means the precise memory is always
+	// Note: In WebAssembly 1.0 (20191205), there may be up to one Memory per store, which means the precise memory is always
 	// wasm.Store Memories index zero: `store.Memories[0]`
-	// See https://www.w3.org/TR/wasm-core-1/#memory-instances%E2%91%A0.
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0.
 	MemoryInstance struct {
 		Buffer []byte
 		Min    uint32
 		Max    *uint32
 	}
 
-	// FunctionAddress is funcaddr (https://www.w3.org/TR/wasm-core-1/#syntax-funcaddr),
+	// FunctionAddress is funcaddr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr),
 	// and the index to Store.Functions.
 	FunctionAddress uint64
 

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -38,12 +38,12 @@ const (
 	callbackPositionEndField
 )
 
-// moduleParser parses a single wasm.Module from WebAssembly 1.0 (MVP) Text format.
+// moduleParser parses a single wasm.Module from WebAssembly 1.0 (20191205) Text format.
 //
 // Note: The indexNamespace of wasm.SectionIDMemory and wasm.SectionIDTable allow up-to-one item. For example, you
 // cannot define both one import and one module-defined memory, rather one or the other (or none). Even if these rules
 // are also enforced in module instantiation, they are also enforced here, to allow relevant source line/col in errors.
-// See https://www.w3.org/TR/wasm-core-1/#modules%E2%91%A3
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#modules%E2%91%A3
 type moduleParser struct {
 	// source is the entire WebAssembly text format source code being parsed.
 	source []byte
@@ -89,8 +89,8 @@ type moduleParser struct {
 	unresolvedExports map[wasm.Index]*wasm.Export
 }
 
-// DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (MVP) Text Format
-// See https://www.w3.org/TR/wasm-core-1/#text-format%E2%91%A0
+// DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (20191205) Text Format
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-format%E2%91%A0
 func DecodeModule(source []byte) (result *wasm.Module, err error) {
 	// names are the wasm.Module NameSection
 	//

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -205,7 +205,7 @@ func TestDecodeModule(t *testing.T) {
 		},
 		{
 			// Spec says expand abbreviations first. It doesn't explicitly say you can't mix forms.
-			// See https://www.w3.org/TR/wasm-core-1/#abbreviations%E2%91%A0
+			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A0
 			name: "import func inlined type - mixed abbreviated",
 			input: `(module
 	(import "wasi_snapshot_preview1" "fd_write" (func $wasi.fd_write (param i32) (param i32 i32) (param i32) (result i32)))
@@ -704,7 +704,7 @@ func TestDecodeModule(t *testing.T) {
 		},
 		{
 			// Spec says expand abbreviations first. It doesn't explicitly say you can't mix forms.
-			// See https://www.w3.org/TR/wasm-core-1/#abbreviations%E2%91%A0
+			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A0
 			name: "func inlined type - mixed abbreviated",
 			input: `(module
 			(func $wasi.fd_write (param i32) (param i32 i32) (param i32) (result i32) local.get 0)

--- a/internal/wasm/text/errors.go
+++ b/internal/wasm/text/errors.go
@@ -51,7 +51,7 @@ func unexpectedToken(tok tokenType, tokenBytes []byte) error {
 // Ex. Both of these fail because an import can only be declared when SectionIDFunction is empty.
 // `(func) (import "" "" (func))` which is the same as  `(func) (import "" "" (func))`
 //
-// See https://www.w3.org/TR/wasm-core-1/#modules%E2%91%A0%E2%91%A2
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#modules%E2%91%A0%E2%91%A2
 func importAfterModuleDefined(section wasm.SectionID) error {
 	return fmt.Errorf("import after module-defined %s", wasm.SectionIDName(section))
 }
@@ -64,8 +64,8 @@ func importAfterModuleDefined(section wasm.SectionID) error {
 //   * Note the latter expands to the same as the former: `(import "" "" (memory 1))`
 // * `(module (import "" "" (memory 1)) (import "" "" (memory 1)))`
 //
-// See https://www.w3.org/TR/wasm-core-1/#tables%E2%91%A0
-// See https://www.w3.org/TR/wasm-core-1/#memories%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#tables%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memories%E2%91%A0
 func moreThanOneInvalidInSection(section wasm.SectionID) error {
 	return moreThanOneInvalid(wasm.SectionIDName(section))
 }

--- a/internal/wasm/text/func_parser.go
+++ b/internal/wasm/text/func_parser.go
@@ -36,12 +36,12 @@ type funcParser struct {
 	currentTypeIdx    wasm.Index
 	currentParamNames wasm.NameMap
 
-	// currentBody is the current function body encoded in WebAssembly 1.0 (MVP) binary format
+	// currentBody is the current function body encoded in WebAssembly 1.0 (20191205) binary format
 	currentBody []byte
 }
 
 // end indicates the end of instructions in this function body
-// See https://www.w3.org/TR/wasm-core-1/#expressions%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#expressions%E2%91%A0
 var end = []byte{wasm.OpcodeEnd}
 var codeEnd = &wasm.Code{Body: end}
 
@@ -143,13 +143,13 @@ func (p *funcParser) beginFieldOrInstruction(tok tokenType, tokenBytes []byte, l
 func (p *funcParser) beginInstruction(tokenBytes []byte) (next tokenParser, err error) {
 	var opCode wasm.Opcode
 	switch string(tokenBytes) {
-	case "local.get": // See https://www.w3.org/TR/wasm-core-1/#-hrefsyntax-instr-variablemathsflocalgetx%E2%91%A0
+	case "local.get": // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-variablemathsflocalgetx%E2%91%A0
 		opCode = wasm.OpcodeLocalGet
 		next = p.parseLocalIndex
-	case "i32.add": // See https://www.w3.org/TR/wasm-core-1/#syntax-instr-numeric
+	case "i32.add": // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-instr-numeric
 		opCode = wasm.OpcodeI32Add
 		next = p.beginFieldOrInstruction
-	case "call": // See https://www.w3.org/TR/wasm-core-1/#-hrefsyntax-instr-controlmathsfcallx
+	case "call": // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-controlmathsfcallx
 		opCode = wasm.OpcodeCall
 		next = p.parseFuncIndex
 	default:

--- a/internal/wasm/text/index_namespace.go
+++ b/internal/wasm/text/index_namespace.go
@@ -19,7 +19,7 @@ func newIndexNamespace() *indexNamespace {
 // features, uniqueness and lookup, as implemented with a map. The key is stripped of the leading '$' to match other
 // tools, as described in stripDollar
 //
-// See https://www.w3.org/TR/wasm-core-1/#text-context
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-context
 type indexNamespace struct {
 	unresolvedIndices []*unresolvedIndex
 
@@ -29,9 +29,9 @@ type indexNamespace struct {
 	// idToIdx resolves symbolic identifiers, such as "v_v" to a numeric index in the appropriate section, such
 	// as '2'. Duplicate identifiers are not allowed by specification.
 	//
-	// Note: This is not encoded in the wasm.NameSection as there is no type name section in WebAssembly 1.0 (MVP)
+	// Note: This is not encoded in the wasm.NameSection as there is no type name section in WebAssembly 1.0 (20191205)
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#text-context
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-context
 	idToIdx map[string]wasm.Index
 }
 
@@ -104,7 +104,7 @@ func (i *indexNamespace) recordOutOfRange(section wasm.SectionID, idx wasm.Index
 // Note: section, idx, line and col used for lazy validation of index. These are attached to an error if later parsed to
 // be invalid (ex an unknown function or out-of-bound index).
 //
-// See https://www.w3.org/TR/wasm-core-1/#indices%E2%91%A4
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#indices%E2%91%A4
 type unresolvedIndex struct {
 	// section is the primary index of what's targeting this index (in the wasm.Module)
 	section wasm.SectionID

--- a/internal/wasm/text/lexer.go
+++ b/internal/wasm/text/lexer.go
@@ -56,7 +56,7 @@ func lex(parser tokenParser, source []byte) (line, col uint32, err error) {
 		b1 := source[i]
 
 		// The spec does not consider newlines apart from '\n'. Notably, a bare '\r' is not a newline here.
-		// See https://www.w3.org/TR/wasm-core-1/#text-comment
+		// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-comment
 		if b1 == '\n' {
 			line++
 			col = 0  // for loop will + 1
@@ -150,7 +150,7 @@ func lex(parser tokenParser, source []byte) (line, col uint32, err error) {
 		//
 		// Note: Even though string allows unicode contents it is enclosed by ASCII double-quotes (").
 		//
-		// See https://www.w3.org/TR/wasm-core-1/#characters%E2%91%A0
+		// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#characters%E2%91%A0
 
 		tok := firstTokenByte[b1]
 		// Track positions passed to the parser
@@ -228,7 +228,7 @@ func lex(parser tokenParser, source []byte) (line, col uint32, err error) {
 
 		// Unsigned floating-point constants for infinity or canonical NaN (not a number) clash with keyword
 		// representation. For example, "nan" and "inf" are floating-point constants, while "nano" and "info" are
-		// possible keywords. See https://www.w3.org/TR/wasm-core-1/#floating-point%E2%91%A6
+		// possible keywords. See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#floating-point%E2%91%A6
 		//
 		// TODO: Ex. inf nan nan:0xfffffffffffff or nan:0x400000
 

--- a/internal/wasm/text/memory_parser.go
+++ b/internal/wasm/text/memory_parser.go
@@ -20,7 +20,7 @@ type onMemory func(min uint32, max *uint32) tokenParser
 //    onMemory resumes here --+
 //
 // Note: memoryParser is reusable. The caller resets via begin.
-// See https://www.w3.org/TR/wasm-core-1/#memories%E2%91%A7
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memories%E2%91%A7
 type memoryParser struct {
 	memoryNamespace *indexNamespace
 

--- a/internal/wasm/text/numbers.go
+++ b/internal/wasm/text/numbers.go
@@ -6,7 +6,7 @@ package text
 // length known at the parsing layer.
 //
 // Note: This is similar to, but cannot use strconv.Atoi because WebAssembly allows underscore characters in numeric
-// representation. See https://www.w3.org/TR/wasm-core-1/#integers%E2%91%A6
+// representation. See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#integers%E2%91%A6
 func decodeUint32(tokenBytes []byte) (uint32, bool) { // TODO: hex
 	// The max ASCII length of a uint32 is 10 (length of 4294967295). If we are at that length we can overflow.
 	//

--- a/internal/wasm/text/token.go
+++ b/internal/wasm/text/token.go
@@ -1,7 +1,7 @@
 package text
 
 // token is the set of tokens defined by the WebAssembly Text Format 1.0
-// See https://www.w3.org/TR/wasm-core-1/#tokens%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#tokens%E2%91%A0
 type tokenType byte
 
 const (
@@ -13,7 +13,7 @@ const (
 	//		i32.const 6
 	//		i32.lt_s
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#text-keyword
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-keyword
 	tokenKeyword
 
 	// tokenUN is an unsigned integer in decimal or hexadecimal notation, optionally separated by underscores.
@@ -24,7 +24,7 @@ const (
 	//		(i32.const 0x0a)
 	//		(i32.const 0x0_A)
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#text-int
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-int
 	tokenUN
 
 	// tokenSN is a signed integer in decimal or hexadecimal notation, optionally separated by underscores.
@@ -35,7 +35,7 @@ const (
 	//		(i32.const +0x0a)
 	//		(i32.const +0x0_A)
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#text-int
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-int
 	tokenSN
 
 	// tokenFN represents an IEEE-754 floating point number in decimal or hexadecimal notation, optionally separated by
@@ -63,7 +63,7 @@ const (
 	//		(data (i32.const 0) "\u{263a}\u{0a}")
 	//		(data (i32.const 0) "\e2\98\ba\0a")
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#strings%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#strings%E2%91%A0
 	tokenString
 
 	// tokenID is a sequence of idChar characters prefixed by a '$':
@@ -73,7 +73,7 @@ const (
 	//		i32.const 6
 	//		i32.lt_s
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#text-id
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-id
 	tokenID
 
 	// tokenLParen is a left paren: '('
@@ -86,12 +86,12 @@ const (
 	//
 	// For example, '0$y' is a tokenReserved, because it doesn't start with a letter or '$'.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#text-reserved
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-reserved
 	tokenReserved
 )
 
 // tokenNames is index-coordinated with tokenType
-// See https://www.w3.org/TR/wasm-core-1/#tokens%E2%91%A0 for the naming choices.
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#tokens%E2%91%A0 for the naming choices.
 var tokenNames = [...]string{
 	"invalid",
 	"keyword",
@@ -147,7 +147,7 @@ var firstTokenByte = [256]tokenType{
 }
 
 // idChar is a printable ASCII character that does not contain a space, quotation mark, comma, semicolon, or bracket.
-// See https://www.w3.org/TR/wasm-core-1/#text-idchar
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-idchar
 var idChar = buildIdChars()
 
 func buildIdChars() (result [256]bool) {
@@ -176,7 +176,7 @@ func _idChar(ch byte) bool {
 // stripDollar returns the input without a leading '$'
 //
 // The WebAssembly 1.0 specification includes support for naming modules, functions, locals and tables via the custom
-// 'name' section: https://www.w3.org/TR/wasm-core-1/#binary-namesec However, how this round-trips between the text and
+// 'name' section: https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-namesec However, how this round-trips between the text and
 // binary format is not discussed.
 //
 // We know that in the text format names must be dollar-sign prefixed to conform with tokenID conventions. However, we

--- a/internal/wasm/text/typeuse_parser.go
+++ b/internal/wasm/text/typeuse_parser.go
@@ -62,7 +62,7 @@ type typeUseParser struct {
 	parsedTypeField bool
 
 	// currentTypeIndex should be read when parsedTypeField is true
-	// See https://www.w3.org/TR/wasm-core-1/#type-uses%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#type-uses%E2%91%A0
 	currentTypeIndex wasm.Index
 
 	// currentTypeIndexUnresolved is set when the currentTypeIndex was not in the wasm.Module TypeSection
@@ -450,7 +450,7 @@ func (p *typeUseParser) recordInlinedType(inlinedIdx wasm.Index) {
 
 // requireInlinedMatchesReferencedType satisfies the following rule:
 //	>> If inline declarations are given, then their types must match the referenced function type.
-// See https://www.w3.org/TR/wasm-core-1/#type-uses%E2%91%A0
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#type-uses%E2%91%A0
 func requireInlinedMatchesReferencedType(typeSection []*wasm.FunctionType, index wasm.Index, params, results []wasm.ValueType) error {
 	if !funcTypeEquals(typeSection[index], params, results) {
 		return fmt.Errorf("inlined type doesn't match module.type[%d].func", index)

--- a/wasm.go
+++ b/wasm.go
@@ -35,7 +35,7 @@ type StoreConfig struct {
 	// * This is the outer-most ancestor of wasm.ModuleContext Context() during wasm.HostFunction invocations.
 	// * This is the default context of wasm.Function when callers pass nil.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#start-function%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#start-function%E2%91%A0
 	Context context.Context
 	// Engine defaults to NewEngineInterpreter
 	Engine *Engine
@@ -58,12 +58,12 @@ func NewStoreWithConfig(config *StoreConfig) wasm.Store {
 	return internalwasm.NewStore(ctx, engine.e)
 }
 
-// ModuleConfig defines the WebAssembly 1.0 (MVP) module to instantiate.
+// ModuleConfig defines the WebAssembly 1.0 (20191205) module to instantiate.
 type ModuleConfig struct {
 	// Name defaults to what's decoded from the custom name section and can be overridden WithName.
-	// See https://www.w3.org/TR/wasm-core-1/#name-section%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#name-section%E2%91%A0
 	Name string
-	// Source is the WebAssembly 1.0 (MVP) text or binary encoding of the module.
+	// Source is the WebAssembly 1.0 (20191205) text or binary encoding of the module.
 	Source []byte
 
 	validatedSource []byte
@@ -93,7 +93,7 @@ func (m *ModuleConfig) WithName(moduleName string) *ModuleConfig {
 // Ex.
 //	exports, _ := wazero.InstantiateModule(wazero.NewStore(), &wazero.ModuleConfig{Source: wasm})
 //
-// Note: StoreConfig.Context is used for any WebAssembly 1.0 (MVP) Start Function.
+// Note: StoreConfig.Context is used for any WebAssembly 1.0 (20191205) Start Function.
 func InstantiateModule(store wasm.Store, module *ModuleConfig) (wasm.ModuleExports, error) {
 	internal, ok := store.(*internalwasm.Store)
 	if !ok {
@@ -147,7 +147,7 @@ func decodeModule(module *ModuleConfig) (m *internalwasm.Module, err error) {
 	return
 }
 
-// HostModuleConfig are WebAssembly 1.0 (MVP) exports from the host bound to a module name used by InstantiateHostModule.
+// HostModuleConfig are WebAssembly 1.0 (20191205) exports from the host bound to a module name used by InstantiateHostModule.
 type HostModuleConfig struct {
 	// Name is the module name that these exports can be imported with. Ex. wasi.ModuleSnapshotPreview1
 	Name string
@@ -156,7 +156,7 @@ type HostModuleConfig struct {
 	//
 	// The key is the name to export and the value is the func. Ex. WASISnapshotPreview1
 	//
-	// Noting a context exception described later, all parameters or result types must match WebAssembly 1.0 (MVP) value
+	// Noting a context exception described later, all parameters or result types must match WebAssembly 1.0 (20191205) value
 	// types. This means uint32, uint64, float32 or float64. Up to one result can be returned.
 	//
 	// Ex. This is a valid host function:
@@ -186,7 +186,7 @@ type HostModuleConfig struct {
 	//		return x + y
 	//	}
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#host-functions%E2%91%A2
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#host-functions%E2%91%A2
 	Functions map[string]interface{}
 }
 

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -6,7 +6,7 @@ import (
 	"math"
 )
 
-// ValueType describes a numeric type used in Web Assembly 1.0 (MVP). For example, Function parameters and results are
+// ValueType describes a numeric type used in Web Assembly 1.0 (20191205). For example, Function parameters and results are
 // only definable as a value type.
 //
 // The following describes how to convert between Wasm and Golang types:
@@ -26,7 +26,7 @@ import (
 //	result := wasm.DecodeF64(result[0])
 //
 // Note: This is a type alias as it is easier to encode and decode in the binary format.
-// See https://www.w3.org/TR/wasm-core-1/#binary-valtype
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-valtype
 type ValueType = byte
 
 const (
@@ -78,8 +78,8 @@ type ModuleExports interface {
 	Function(name string) Function
 }
 
-// Function is a WebAssembly 1.0 (MVP) function exported from an instantiated module (wazero.InstantiateModule).
-// See https://www.w3.org/TR/wasm-core-1/#syntax-func
+// Function is a WebAssembly 1.0 (20191205) function exported from an instantiated module (wazero.InstantiateModule).
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-func
 type Function interface {
 	// ParamTypes are the possibly empty sequence of value types accepted by a function with this signature.
 	// See ValueType documentation for encoding rules.
@@ -87,8 +87,8 @@ type Function interface {
 
 	// ResultTypes are the possibly empty sequence of value types returned by a function with this signature.
 	//
-	// Note: In WebAssembly 1.0 (MVP), there can be at most one result.
-	// See https://www.w3.org/TR/wasm-core-1/#result-types%E2%91%A0
+	// Note: In WebAssembly 1.0 (20191205), there can be at most one result.
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#result-types%E2%91%A0
 	// See ValueType documentation for decoding rules.
 	ResultTypes() []ValueType
 
@@ -107,18 +107,18 @@ type Function interface {
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
 }
 
-// HostExports return functions defined in Go, a.k.a. "Host Functions" in WebAssembly 1.0 (MVP).
+// HostExports return functions defined in Go, a.k.a. "Host Functions" in WebAssembly 1.0 (20191205).
 //
 // Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
-// See https://www.w3.org/TR/wasm-core-1/#syntax-hostfunc
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-hostfunc
 type HostExports interface {
 	// Function returns a host function exported under this module name or nil if it wasn't.
 	Function(name string) HostFunction
 }
 
-// HostFunction is like a Function, except it is implemented in Go. This is a "Host Function" in WebAssembly 1.0 (MVP).
+// HostFunction is like a Function, except it is implemented in Go. This is a "Host Function" in WebAssembly 1.0 (20191205).
 //
-// See https://www.w3.org/TR/wasm-core-1/#syntax-hostfunc
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-hostfunc
 type HostFunction interface {
 	// ParamTypes are documented as Function.ParamTypes
 	ParamTypes() []ValueType
@@ -150,15 +150,15 @@ type ModuleContext interface {
 // Memory allows restricted access to a module's memory. Notably, this does not allow growing.
 //
 // Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
-// Note: This includes all value types available in WebAssembly 1.0 (MVP) and all are encoded little-endian.
-// See https://www.w3.org/TR/wasm-core-1/#storage%E2%91%A0
+// Note: This includes all value types available in WebAssembly 1.0 (20191205) and all are encoded little-endian.
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#storage%E2%91%A0
 type Memory interface {
 	// Size returns the size in bytes available. Ex. If the underlying memory has 1 page: 65536
 	//
 	// Note: this will not grow during a host function call, even if the underlying memory can.  Ex. If the underlying
 	// memory has min 0 and max 2 pages, this returns zero.
 	//
-	// See https://www.w3.org/TR/wasm-core-1/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
 	Size() uint32
 
 	// ReadByte reads a single byte from the underlying buffer at the offset in or returns false if out of range.


### PR DESCRIPTION
MVP was a term used by WebAssembly insiders when ramping up to the 1.0
spec. While these folks still use that term it is confusing and
unnecessary way to qualify a W3C version. Here are some of the problems:

* MVP does not match a W3C published URL
* MVP does not match a git tag on the spec repo
* MVP was a work in progress, so there are text that say "not in MVP"
  which ended up in 1.0 (as MVP became more than it was).
* MVP is jargon to people who don't know that stands for Minimum Viable Product.

This stops this practice and instead uses the W3C 1.0 Draft version
instead: 20191205