### PR TITLE
Folds ImportKind and ExportKind into ExternType

### DIFF
--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -1011,7 +1011,7 @@ func (a *wasiAPI) randUnusedFD() uint32 {
 }
 
 func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
-	if start, err := requireExport(module, moduleName, FunctionStart, internalwasm.ExternalKindFunc); err != nil {
+	if start, err := requireExport(module, moduleName, FunctionStart, internalwasm.ExternTypeFunc); err != nil {
 		return err
 	} else {
 		// TODO: this should be verified during decode so that errors have the correct source positions
@@ -1023,10 +1023,10 @@ func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
 			return fmt.Errorf("module[%s] function[%s] must have an empty (nullary) signature: %s", moduleName, FunctionStart, ft.String())
 		}
 	}
-	if _, err := requireExport(module, moduleName, FunctionInitialize, internalwasm.ExternalKindFunc); err == nil {
+	if _, err := requireExport(module, moduleName, FunctionInitialize, internalwasm.ExternTypeFunc); err == nil {
 		return fmt.Errorf("module[%s] must not export func[%s]", moduleName, FunctionInitialize)
 	}
-	if _, err := requireExport(module, moduleName, "memory", internalwasm.ExternalKindMemory); err != nil {
+	if _, err := requireExport(module, moduleName, "memory", internalwasm.ExternTypeMemory); err != nil {
 		return err
 	}
 	// TODO: the spec also requires export of "__indirect_function_table", but we aren't enforcing it, and doing so
@@ -1034,10 +1034,10 @@ func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
 	return nil
 }
 
-func requireExport(module *internalwasm.Module, moduleName string, exportName string, kind internalwasm.ExternalKind) (*internalwasm.Export, error) {
+func requireExport(module *internalwasm.Module, moduleName string, exportName string, kind internalwasm.ExternType) (*internalwasm.Export, error) {
 	exp, ok := module.ExportSection[exportName]
-	if !ok || exp.Kind != kind {
-		return nil, fmt.Errorf("module[%s] does not export %s[%s]", moduleName, internalwasm.ExternalKindName(kind), exportName)
+	if !ok || exp.Type != kind {
+		return nil, fmt.Errorf("module[%s] does not export %s[%s]", moduleName, internalwasm.ExternTypeName(kind), exportName)
 	}
 	return exp, nil
 }

--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -1011,7 +1011,7 @@ func (a *wasiAPI) randUnusedFD() uint32 {
 }
 
 func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
-	if start, err := requireExport(module, moduleName, FunctionStart, internalwasm.ExportKindFunc); err != nil {
+	if start, err := requireExport(module, moduleName, FunctionStart, internalwasm.ExternalKindFunc); err != nil {
 		return err
 	} else {
 		// TODO: this should be verified during decode so that errors have the correct source positions
@@ -1023,10 +1023,10 @@ func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
 			return fmt.Errorf("module[%s] function[%s] must have an empty (nullary) signature: %s", moduleName, FunctionStart, ft.String())
 		}
 	}
-	if _, err := requireExport(module, moduleName, FunctionInitialize, internalwasm.ExportKindFunc); err == nil {
+	if _, err := requireExport(module, moduleName, FunctionInitialize, internalwasm.ExternalKindFunc); err == nil {
 		return fmt.Errorf("module[%s] must not export func[%s]", moduleName, FunctionInitialize)
 	}
-	if _, err := requireExport(module, moduleName, "memory", internalwasm.ExportKindMemory); err != nil {
+	if _, err := requireExport(module, moduleName, "memory", internalwasm.ExternalKindMemory); err != nil {
 		return err
 	}
 	// TODO: the spec also requires export of "__indirect_function_table", but we aren't enforcing it, and doing so
@@ -1034,10 +1034,10 @@ func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
 	return nil
 }
 
-func requireExport(module *internalwasm.Module, moduleName string, exportName string, kind internalwasm.ExportKind) (*internalwasm.Export, error) {
+func requireExport(module *internalwasm.Module, moduleName string, exportName string, kind internalwasm.ExternalKind) (*internalwasm.Export, error) {
 	exp, ok := module.ExportSection[exportName]
 	if !ok || exp.Kind != kind {
-		return nil, fmt.Errorf("module[%s] does not export %s[%s]", moduleName, internalwasm.ExportKindName(kind), exportName)
+		return nil, fmt.Errorf("module[%s] does not export %s[%s]", moduleName, internalwasm.ExternalKindName(kind), exportName)
 	}
 	return exp, nil
 }

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -46,11 +46,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "Math", Name: "Add",
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 0,
 					},
 				},
@@ -63,7 +63,7 @@ func TestDecodeModule(t *testing.T) {
 				ExportSection: map[string]*wasm.Export{
 					"mem": {
 						Name:  "mem",
-						Kind:  wasm.ExternalKindMemory,
+						Type:  wasm.ExternTypeMemory,
 						Index: 0,
 					},
 				},
@@ -75,7 +75,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{}},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -46,11 +46,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "Math", Name: "Add",
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 0,
 					},
 				},
@@ -63,7 +63,7 @@ func TestDecodeModule(t *testing.T) {
 				ExportSection: map[string]*wasm.Export{
 					"mem": {
 						Name:  "mem",
-						Kind:  wasm.ExportKindMemory,
+						Kind:  wasm.ExternalKindMemory,
 						Index: 0,
 					},
 				},
@@ -75,7 +75,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{}},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -59,11 +59,11 @@ func TestModule_Encode(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "Math", Name: "Add",
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 0,
 					},
 				},
@@ -75,9 +75,9 @@ func TestModule_Encode(t *testing.T) {
 				0x60, 0x02, f32, f32, 0x01, f32, // func=0x60 2 params and 1 result
 				wasm.SectionIDImport, 0x17, // 23 bytes in this section
 				0x02, // 2 imports
-				0x04, 'M', 'a', 't', 'h', 0x03, 'M', 'u', 'l', wasm.ImportKindFunc,
+				0x04, 'M', 'a', 't', 'h', 0x03, 'M', 'u', 'l', wasm.ExternalKindFunc,
 				0x01, // type index
-				0x04, 'M', 'a', 't', 'h', 0x03, 'A', 'd', 'd', wasm.ImportKindFunc,
+				0x04, 'M', 'a', 't', 'h', 0x03, 'A', 'd', 'd', wasm.ExternalKindFunc,
 				0x00, // type index
 			),
 		},
@@ -87,7 +87,7 @@ func TestModule_Encode(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{}},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,
@@ -98,7 +98,7 @@ func TestModule_Encode(t *testing.T) {
 				0x60, 0x0, 0x0, // func=0x60 0 params and 0 result
 				wasm.SectionIDImport, 0x0a, // 10 bytes in this section
 				0x01, // 1 import
-				0x00, 0x05, 'h', 'e', 'l', 'l', 'o', wasm.ImportKindFunc,
+				0x00, 0x05, 'h', 'e', 'l', 'l', 'o', wasm.ExternalKindFunc,
 				0x00, // type index
 				wasm.SectionIDStart, 0x01,
 				0x00, // start function index
@@ -115,7 +115,7 @@ func TestModule_Encode(t *testing.T) {
 					{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"AddInt": {Name: "AddInt", Kind: wasm.ExportKindFunc, Index: wasm.Index(0)},
+					"AddInt": {Name: "AddInt", Kind: wasm.ExternalKindFunc, Index: wasm.Index(0)},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{{Index: wasm.Index(0), Name: "addInt"}},
@@ -137,7 +137,7 @@ func TestModule_Encode(t *testing.T) {
 				wasm.SectionIDExport, 0x0a, // 10 bytes in this section
 				0x01,                               // 1 export
 				0x06, 'A', 'd', 'd', 'I', 'n', 't', // size of "AddInt", "AddInt"
-				wasm.ExportKindFunc, 0x00, // func[0]
+				wasm.ExternalKindFunc, 0x00, // func[0]
 				wasm.SectionIDCode, 0x09, // 9 bytes in this section
 				01,                     // one code section
 				07,                     // length of the body + locals

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -59,11 +59,11 @@ func TestModule_Encode(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "Math", Name: "Add",
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 0,
 					},
 				},
@@ -75,9 +75,9 @@ func TestModule_Encode(t *testing.T) {
 				0x60, 0x02, f32, f32, 0x01, f32, // func=0x60 2 params and 1 result
 				wasm.SectionIDImport, 0x17, // 23 bytes in this section
 				0x02, // 2 imports
-				0x04, 'M', 'a', 't', 'h', 0x03, 'M', 'u', 'l', wasm.ExternalKindFunc,
+				0x04, 'M', 'a', 't', 'h', 0x03, 'M', 'u', 'l', wasm.ExternTypeFunc,
 				0x01, // type index
-				0x04, 'M', 'a', 't', 'h', 0x03, 'A', 'd', 'd', wasm.ExternalKindFunc,
+				0x04, 'M', 'a', 't', 'h', 0x03, 'A', 'd', 'd', wasm.ExternTypeFunc,
 				0x00, // type index
 			),
 		},
@@ -87,7 +87,7 @@ func TestModule_Encode(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{}},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,
@@ -98,7 +98,7 @@ func TestModule_Encode(t *testing.T) {
 				0x60, 0x0, 0x0, // func=0x60 0 params and 0 result
 				wasm.SectionIDImport, 0x0a, // 10 bytes in this section
 				0x01, // 1 import
-				0x00, 0x05, 'h', 'e', 'l', 'l', 'o', wasm.ExternalKindFunc,
+				0x00, 0x05, 'h', 'e', 'l', 'l', 'o', wasm.ExternTypeFunc,
 				0x00, // type index
 				wasm.SectionIDStart, 0x01,
 				0x00, // start function index
@@ -115,7 +115,7 @@ func TestModule_Encode(t *testing.T) {
 					{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"AddInt": {Name: "AddInt", Kind: wasm.ExternalKindFunc, Index: wasm.Index(0)},
+					"AddInt": {Name: "AddInt", Type: wasm.ExternTypeFunc, Index: wasm.Index(0)},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{{Index: wasm.Index(0), Name: "addInt"}},
@@ -137,7 +137,7 @@ func TestModule_Encode(t *testing.T) {
 				wasm.SectionIDExport, 0x0a, // 10 bytes in this section
 				0x01,                               // 1 export
 				0x06, 'A', 'd', 'd', 'I', 'n', 't', // size of "AddInt", "AddInt"
-				wasm.ExternalKindFunc, 0x00, // func[0]
+				wasm.ExternTypeFunc, 0x00, // func[0]
 				wasm.SectionIDCode, 0x09, // 9 bytes in this section
 				01,                     // one code section
 				07,                     // length of the body + locals

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -23,7 +23,7 @@ func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
 
 	i.Kind = b[0]
 	switch i.Kind {
-	case wasm.ExportKindFunc, wasm.ExportKindTable, wasm.ExportKindMemory, wasm.ExportKindGlobal:
+	case wasm.ExternalKindFunc, wasm.ExternalKindTable, wasm.ExternalKindMemory, wasm.ExternalKindGlobal:
 		if i.Index, _, err = leb128.DecodeUint32(r); err != nil {
 			return nil, fmt.Errorf("error decoding export index: %w", err)
 		}

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -21,9 +21,9 @@ func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
 		return nil, fmt.Errorf("error decoding export kind: %w", err)
 	}
 
-	i.Kind = b[0]
-	switch i.Kind {
-	case wasm.ExternalKindFunc, wasm.ExternalKindTable, wasm.ExternalKindMemory, wasm.ExternalKindGlobal:
+	i.Type = b[0]
+	switch i.Type {
+	case wasm.ExternTypeFunc, wasm.ExternTypeTable, wasm.ExternTypeMemory, wasm.ExternTypeGlobal:
 		if i.Index, _, err = leb128.DecodeUint32(r); err != nil {
 			return nil, fmt.Errorf("error decoding export index: %w", err)
 		}
@@ -38,7 +38,7 @@ func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
 func encodeExport(i *wasm.Export) []byte {
 	data := encodeSizePrefixed([]byte(i.Name))
-	data = append(data, i.Kind)
+	data = append(data, i.Type)
 	data = append(data, leb128.EncodeUint32(i.Index)...)
 	return data
 }

--- a/internal/wasm/binary/export_test.go
+++ b/internal/wasm/binary/export_test.go
@@ -17,70 +17,70 @@ func TestEncodeExport(t *testing.T) {
 		{
 			name: "func no name, index 0",
 			input: &wasm.Export{ // Ex. (export "" (func 0)))
-				Kind:  wasm.ExternalKindFunc,
+				Type:  wasm.ExternTypeFunc,
 				Name:  "",
 				Index: 0,
 			},
-			expected: []byte{wasm.ExternalKindFunc, 0x00, 0x00},
+			expected: []byte{wasm.ExternTypeFunc, 0x00, 0x00},
 		},
 		{
 			name: "func name, func index 0",
 			input: &wasm.Export{ // Ex. (export "pi" (func 0))
-				Kind:  wasm.ExternalKindFunc,
+				Type:  wasm.ExternTypeFunc,
 				Name:  "pi",
 				Index: 0,
 			},
 			expected: []byte{
 				0x02, 'p', 'i',
-				wasm.ExternalKindFunc,
+				wasm.ExternTypeFunc,
 				0x00,
 			},
 		},
 		{
 			name: "func name, index 10",
 			input: &wasm.Export{ // Ex. (export "pi" (func 10))
-				Kind:  wasm.ExternalKindFunc,
+				Type:  wasm.ExternTypeFunc,
 				Name:  "pi",
 				Index: 10,
 			},
 			expected: []byte{
 				0x02, 'p', 'i',
-				wasm.ExternalKindFunc,
+				wasm.ExternTypeFunc,
 				0x0a,
 			},
 		},
 		{
 			name: "memory no name, index 0",
 			input: &wasm.Export{ // Ex. (export "" (memory 0)))
-				Kind:  wasm.ExternalKindMemory,
+				Type:  wasm.ExternTypeMemory,
 				Name:  "",
 				Index: 0,
 			},
-			expected: []byte{0x00, wasm.ExternalKindMemory, 0x00},
+			expected: []byte{0x00, wasm.ExternTypeMemory, 0x00},
 		},
 		{
 			name: "memory name, memory index 0",
 			input: &wasm.Export{ // Ex. (export "mem" (memory 0))
-				Kind:  wasm.ExternalKindMemory,
+				Type:  wasm.ExternTypeMemory,
 				Name:  "mem",
 				Index: 0,
 			},
 			expected: []byte{
 				0x03, 'm', 'e', 'm',
-				wasm.ExternalKindMemory,
+				wasm.ExternTypeMemory,
 				0x00,
 			},
 		},
 		{
 			name: "memory name, index 10",
 			input: &wasm.Export{ // Ex. (export "mem" (memory 10))
-				Kind:  wasm.ExternalKindMemory,
+				Type:  wasm.ExternTypeMemory,
 				Name:  "mem",
 				Index: 10,
 			},
 			expected: []byte{
 				0x03, 'm', 'e', 'm',
-				wasm.ExternalKindMemory,
+				wasm.ExternTypeMemory,
 				0x0a,
 			},
 		},

--- a/internal/wasm/binary/export_test.go
+++ b/internal/wasm/binary/export_test.go
@@ -17,70 +17,70 @@ func TestEncodeExport(t *testing.T) {
 		{
 			name: "func no name, index 0",
 			input: &wasm.Export{ // Ex. (export "" (func 0)))
-				Kind:  wasm.ExportKindFunc,
+				Kind:  wasm.ExternalKindFunc,
 				Name:  "",
 				Index: 0,
 			},
-			expected: []byte{wasm.ExportKindFunc, 0x00, 0x00},
+			expected: []byte{wasm.ExternalKindFunc, 0x00, 0x00},
 		},
 		{
 			name: "func name, func index 0",
 			input: &wasm.Export{ // Ex. (export "pi" (func 0))
-				Kind:  wasm.ExportKindFunc,
+				Kind:  wasm.ExternalKindFunc,
 				Name:  "pi",
 				Index: 0,
 			},
 			expected: []byte{
 				0x02, 'p', 'i',
-				wasm.ExportKindFunc,
+				wasm.ExternalKindFunc,
 				0x00,
 			},
 		},
 		{
 			name: "func name, index 10",
 			input: &wasm.Export{ // Ex. (export "pi" (func 10))
-				Kind:  wasm.ExportKindFunc,
+				Kind:  wasm.ExternalKindFunc,
 				Name:  "pi",
 				Index: 10,
 			},
 			expected: []byte{
 				0x02, 'p', 'i',
-				wasm.ExportKindFunc,
+				wasm.ExternalKindFunc,
 				0x0a,
 			},
 		},
 		{
 			name: "memory no name, index 0",
 			input: &wasm.Export{ // Ex. (export "" (memory 0)))
-				Kind:  wasm.ExportKindMemory,
+				Kind:  wasm.ExternalKindMemory,
 				Name:  "",
 				Index: 0,
 			},
-			expected: []byte{0x00, wasm.ExportKindMemory, 0x00},
+			expected: []byte{0x00, wasm.ExternalKindMemory, 0x00},
 		},
 		{
 			name: "memory name, memory index 0",
 			input: &wasm.Export{ // Ex. (export "mem" (memory 0))
-				Kind:  wasm.ExportKindMemory,
+				Kind:  wasm.ExternalKindMemory,
 				Name:  "mem",
 				Index: 0,
 			},
 			expected: []byte{
 				0x03, 'm', 'e', 'm',
-				wasm.ExportKindMemory,
+				wasm.ExternalKindMemory,
 				0x00,
 			},
 		},
 		{
 			name: "memory name, index 10",
 			input: &wasm.Export{ // Ex. (export "mem" (memory 10))
-				Kind:  wasm.ExportKindMemory,
+				Kind:  wasm.ExternalKindMemory,
 				Name:  "mem",
 				Index: 10,
 			},
 			expected: []byte{
 				0x03, 'm', 'e', 'm',
-				wasm.ExportKindMemory,
+				wasm.ExternalKindMemory,
 				0x0a,
 			},
 		},

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -26,19 +26,19 @@ func decodeImport(r *bytes.Reader) (i *wasm.Import, err error) {
 
 	i.Kind = b[0]
 	switch i.Kind {
-	case wasm.ImportKindFunc:
+	case wasm.ExternalKindFunc:
 		if i.DescFunc, _, err = leb128.DecodeUint32(r); err != nil {
 			return nil, fmt.Errorf("error decoding import func typeindex: %w", err)
 		}
-	case wasm.ImportKindTable:
+	case wasm.ExternalKindTable:
 		if i.DescTable, err = decodeTableType(r); err != nil {
 			return nil, fmt.Errorf("error decoding import table desc: %w", err)
 		}
-	case wasm.ImportKindMemory:
+	case wasm.ExternalKindMemory:
 		if i.DescMem, err = decodeMemoryType(r); err != nil {
 			return nil, fmt.Errorf("error decoding import mem desc: %w", err)
 		}
-	case wasm.ImportKindGlobal:
+	case wasm.ExternalKindGlobal:
 		if i.DescGlobal, err = decodeGlobalType(r); err != nil {
 			return nil, fmt.Errorf("error decoding import global desc: %w", err)
 		}
@@ -56,14 +56,14 @@ func encodeImport(i *wasm.Import) []byte {
 	data = append(data, encodeSizePrefixed([]byte(i.Name))...)
 	data = append(data, i.Kind)
 	switch i.Kind {
-	case wasm.ImportKindFunc:
+	case wasm.ExternalKindFunc:
 		data = append(data, leb128.EncodeUint32(i.DescFunc)...)
-	case wasm.ImportKindTable:
-		panic("TODO: encodeImportKindTable")
-	case wasm.ImportKindMemory:
-		panic("TODO: encodeImportKindMemory")
-	case wasm.ImportKindGlobal:
-		panic("TODO: encodeImportKindGlobal")
+	case wasm.ExternalKindTable:
+		panic("TODO: encodeExternalKindTable")
+	case wasm.ExternalKindMemory:
+		panic("TODO: encodeExternalKindMemory")
+	case wasm.ExternalKindGlobal:
+		panic("TODO: encodeExternalKindGlobal")
 	default:
 		panic(fmt.Errorf("invalid kind: %#x", i.Kind))
 	}

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -24,21 +24,21 @@ func decodeImport(r *bytes.Reader) (i *wasm.Import, err error) {
 		return nil, fmt.Errorf("error decoding import kind: %w", err)
 	}
 
-	i.Kind = b[0]
-	switch i.Kind {
-	case wasm.ExternalKindFunc:
+	i.Type = b[0]
+	switch i.Type {
+	case wasm.ExternTypeFunc:
 		if i.DescFunc, _, err = leb128.DecodeUint32(r); err != nil {
 			return nil, fmt.Errorf("error decoding import func typeindex: %w", err)
 		}
-	case wasm.ExternalKindTable:
+	case wasm.ExternTypeTable:
 		if i.DescTable, err = decodeTableType(r); err != nil {
 			return nil, fmt.Errorf("error decoding import table desc: %w", err)
 		}
-	case wasm.ExternalKindMemory:
+	case wasm.ExternTypeMemory:
 		if i.DescMem, err = decodeMemoryType(r); err != nil {
 			return nil, fmt.Errorf("error decoding import mem desc: %w", err)
 		}
-	case wasm.ExternalKindGlobal:
+	case wasm.ExternTypeGlobal:
 		if i.DescGlobal, err = decodeGlobalType(r); err != nil {
 			return nil, fmt.Errorf("error decoding import global desc: %w", err)
 		}
@@ -54,18 +54,18 @@ func decodeImport(r *bytes.Reader) (i *wasm.Import, err error) {
 func encodeImport(i *wasm.Import) []byte {
 	data := encodeSizePrefixed([]byte(i.Module))
 	data = append(data, encodeSizePrefixed([]byte(i.Name))...)
-	data = append(data, i.Kind)
-	switch i.Kind {
-	case wasm.ExternalKindFunc:
+	data = append(data, i.Type)
+	switch i.Type {
+	case wasm.ExternTypeFunc:
 		data = append(data, leb128.EncodeUint32(i.DescFunc)...)
-	case wasm.ExternalKindTable:
-		panic("TODO: encodeExternalKindTable")
-	case wasm.ExternalKindMemory:
-		panic("TODO: encodeExternalKindMemory")
-	case wasm.ExternalKindGlobal:
-		panic("TODO: encodeExternalKindGlobal")
+	case wasm.ExternTypeTable:
+		panic("TODO: encodeExternTypeTable")
+	case wasm.ExternTypeMemory:
+		panic("TODO: encodeExternTypeMemory")
+	case wasm.ExternTypeGlobal:
+		panic("TODO: encodeExternTypeGlobal")
 	default:
-		panic(fmt.Errorf("invalid kind: %#x", i.Kind))
+		panic(fmt.Errorf("invalid externtype: %s", wasm.ExternTypeName(i.Type)))
 	}
 	return data
 }

--- a/internal/wasm/binary/import_test.go
+++ b/internal/wasm/binary/import_test.go
@@ -17,17 +17,17 @@ func TestEncodeImport(t *testing.T) {
 		{
 			name: "func no module, no name, type index 0",
 			input: &wasm.Import{ // Ex. (import "" "" (func (type 0)))
-				Kind:     wasm.ExternalKindFunc,
+				Type:     wasm.ExternTypeFunc,
 				Module:   "",
 				Name:     "",
 				DescFunc: 0,
 			},
-			expected: []byte{wasm.ExternalKindFunc, 0x00, 0x00, 0x00},
+			expected: []byte{wasm.ExternTypeFunc, 0x00, 0x00, 0x00},
 		},
 		{
 			name: "func module, no name, type index 0",
 			input: &wasm.Import{ // Ex. (import "$test" "" (func (type 0)))
-				Kind:     wasm.ExternalKindFunc,
+				Type:     wasm.ExternTypeFunc,
 				Module:   "test",
 				Name:     "",
 				DescFunc: 0,
@@ -35,14 +35,14 @@ func TestEncodeImport(t *testing.T) {
 			expected: []byte{
 				0x04, 't', 'e', 's', 't',
 				0x00,
-				wasm.ExternalKindFunc,
+				wasm.ExternTypeFunc,
 				0x00,
 			},
 		},
 		{
 			name: "func module, name, type index 0",
 			input: &wasm.Import{ // Ex. (import "$math" "$pi" (func (type 0)))
-				Kind:     wasm.ExternalKindFunc,
+				Type:     wasm.ExternTypeFunc,
 				Module:   "math",
 				Name:     "pi",
 				DescFunc: 0,
@@ -50,14 +50,14 @@ func TestEncodeImport(t *testing.T) {
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
 				0x02, 'p', 'i',
-				wasm.ExternalKindFunc,
+				wasm.ExternTypeFunc,
 				0x00,
 			},
 		},
 		{
 			name: "func module, name, type index 10",
 			input: &wasm.Import{ // Ex. (import "$math" "$pi" (func (type 10)))
-				Kind:     wasm.ExternalKindFunc,
+				Type:     wasm.ExternTypeFunc,
 				Module:   "math",
 				Name:     "pi",
 				DescFunc: 10,
@@ -65,7 +65,7 @@ func TestEncodeImport(t *testing.T) {
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
 				0x02, 'p', 'i',
-				wasm.ExternalKindFunc,
+				wasm.ExternTypeFunc,
 				0x0a,
 			},
 		},

--- a/internal/wasm/binary/import_test.go
+++ b/internal/wasm/binary/import_test.go
@@ -17,17 +17,17 @@ func TestEncodeImport(t *testing.T) {
 		{
 			name: "func no module, no name, type index 0",
 			input: &wasm.Import{ // Ex. (import "" "" (func (type 0)))
-				Kind:     wasm.ImportKindFunc,
+				Kind:     wasm.ExternalKindFunc,
 				Module:   "",
 				Name:     "",
 				DescFunc: 0,
 			},
-			expected: []byte{wasm.ImportKindFunc, 0x00, 0x00, 0x00},
+			expected: []byte{wasm.ExternalKindFunc, 0x00, 0x00, 0x00},
 		},
 		{
 			name: "func module, no name, type index 0",
 			input: &wasm.Import{ // Ex. (import "$test" "" (func (type 0)))
-				Kind:     wasm.ImportKindFunc,
+				Kind:     wasm.ExternalKindFunc,
 				Module:   "test",
 				Name:     "",
 				DescFunc: 0,
@@ -35,14 +35,14 @@ func TestEncodeImport(t *testing.T) {
 			expected: []byte{
 				0x04, 't', 'e', 's', 't',
 				0x00,
-				wasm.ImportKindFunc,
+				wasm.ExternalKindFunc,
 				0x00,
 			},
 		},
 		{
 			name: "func module, name, type index 0",
 			input: &wasm.Import{ // Ex. (import "$math" "$pi" (func (type 0)))
-				Kind:     wasm.ImportKindFunc,
+				Kind:     wasm.ExternalKindFunc,
 				Module:   "math",
 				Name:     "pi",
 				DescFunc: 0,
@@ -50,14 +50,14 @@ func TestEncodeImport(t *testing.T) {
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
 				0x02, 'p', 'i',
-				wasm.ImportKindFunc,
+				wasm.ExternalKindFunc,
 				0x00,
 			},
 		},
 		{
 			name: "func module, name, type index 10",
 			input: &wasm.Import{ // Ex. (import "$math" "$pi" (func (type 10)))
-				Kind:     wasm.ImportKindFunc,
+				Kind:     wasm.ExternalKindFunc,
 				Module:   "math",
 				Name:     "pi",
 				DescFunc: 10,
@@ -65,7 +65,7 @@ func TestEncodeImport(t *testing.T) {
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
 				0x02, 'p', 'i',
-				wasm.ImportKindFunc,
+				wasm.ExternalKindFunc,
 				0x0a,
 			},
 		},

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -47,15 +47,15 @@ func TestDecodeExportSection(t *testing.T) {
 		{
 			name: "empty and non-empty name",
 			input: []byte{
-				0x02,                        // 2 exports
-				0x00,                        // Size of empty name
-				wasm.ExternalKindFunc, 0x02, // func[2]
+				0x02,                      // 2 exports
+				0x00,                      // Size of empty name
+				wasm.ExternTypeFunc, 0x02, // func[2]
 				0x01, 'a', // Size of name, name
-				wasm.ExternalKindFunc, 0x01, // func[1]
+				wasm.ExternTypeFunc, 0x01, // func[1]
 			},
 			expected: map[string]*wasm.Export{
-				"":  {Name: "", Kind: wasm.ExternalKindFunc, Index: wasm.Index(2)},
-				"a": {Name: "a", Kind: wasm.ExternalKindFunc, Index: wasm.Index(1)},
+				"":  {Name: "", Type: wasm.ExternTypeFunc, Index: wasm.Index(2)},
+				"a": {Name: "a", Type: wasm.ExternTypeFunc, Index: wasm.Index(1)},
 			},
 		},
 	}
@@ -80,11 +80,11 @@ func TestDecodeExportSection_Errors(t *testing.T) {
 		{
 			name: "duplicates empty name",
 			input: []byte{
-				0x02,                        // 2 exports
-				0x00,                        // Size of empty name
-				wasm.ExternalKindFunc, 0x00, // func[0]
-				0x00,                        // Size of empty name
-				wasm.ExternalKindFunc, 0x00, // func[0]
+				0x02,                      // 2 exports
+				0x00,                      // Size of empty name
+				wasm.ExternTypeFunc, 0x00, // func[0]
+				0x00,                      // Size of empty name
+				wasm.ExternTypeFunc, 0x00, // func[0]
 			},
 			expectedErr: "export[1] duplicates name \"\"",
 		},
@@ -93,9 +93,9 @@ func TestDecodeExportSection_Errors(t *testing.T) {
 			input: []byte{
 				0x02,      // 2 exports
 				0x01, 'a', // Size of name, name
-				wasm.ExternalKindFunc, 0x00, // func[0]
+				wasm.ExternTypeFunc, 0x00, // func[0]
 				0x01, 'a', // Size of name, name
-				wasm.ExternalKindFunc, 0x00, // func[0]
+				wasm.ExternTypeFunc, 0x00, // func[0]
 			},
 			expectedErr: "export[1] duplicates name \"a\"",
 		},

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -47,15 +47,15 @@ func TestDecodeExportSection(t *testing.T) {
 		{
 			name: "empty and non-empty name",
 			input: []byte{
-				0x02,                      // 2 exports
-				0x00,                      // Size of empty name
-				wasm.ExportKindFunc, 0x02, // func[2]
+				0x02,                        // 2 exports
+				0x00,                        // Size of empty name
+				wasm.ExternalKindFunc, 0x02, // func[2]
 				0x01, 'a', // Size of name, name
-				wasm.ExportKindFunc, 0x01, // func[1]
+				wasm.ExternalKindFunc, 0x01, // func[1]
 			},
 			expected: map[string]*wasm.Export{
-				"":  {Name: "", Kind: wasm.ExportKindFunc, Index: wasm.Index(2)},
-				"a": {Name: "a", Kind: wasm.ExportKindFunc, Index: wasm.Index(1)},
+				"":  {Name: "", Kind: wasm.ExternalKindFunc, Index: wasm.Index(2)},
+				"a": {Name: "a", Kind: wasm.ExternalKindFunc, Index: wasm.Index(1)},
 			},
 		},
 	}
@@ -80,11 +80,11 @@ func TestDecodeExportSection_Errors(t *testing.T) {
 		{
 			name: "duplicates empty name",
 			input: []byte{
-				0x02,                      // 2 exports
-				0x00,                      // Size of empty name
-				wasm.ExportKindFunc, 0x00, // func[0]
-				0x00,                      // Size of empty name
-				wasm.ExportKindFunc, 0x00, // func[0]
+				0x02,                        // 2 exports
+				0x00,                        // Size of empty name
+				wasm.ExternalKindFunc, 0x00, // func[0]
+				0x00,                        // Size of empty name
+				wasm.ExternalKindFunc, 0x00, // func[0]
 			},
 			expectedErr: "export[1] duplicates name \"\"",
 		},
@@ -93,9 +93,9 @@ func TestDecodeExportSection_Errors(t *testing.T) {
 			input: []byte{
 				0x02,      // 2 exports
 				0x01, 'a', // Size of name, name
-				wasm.ExportKindFunc, 0x00, // func[0]
+				wasm.ExternalKindFunc, 0x00, // func[0]
 				0x01, 'a', // Size of name, name
-				wasm.ExportKindFunc, 0x00, // func[0]
+				wasm.ExternalKindFunc, 0x00, // func[0]
 			},
 			expectedErr: "export[1] duplicates name \"a\"",
 		},

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -61,7 +61,7 @@ func (c *ModuleContext) Memory() publicwasm.Memory {
 
 // Function implements wasm.ModuleContext Function
 func (c *ModuleContext) Function(name string) publicwasm.Function {
-	exp, err := c.Module.GetExport(name, ExternalKindFunc)
+	exp, err := c.Module.GetExport(name, ExternTypeFunc)
 	if err != nil {
 		return nil
 	}

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -61,7 +61,7 @@ func (c *ModuleContext) Memory() publicwasm.Memory {
 
 // Function implements wasm.ModuleContext Function
 func (c *ModuleContext) Function(name string) publicwasm.Function {
-	exp, err := c.Module.GetExport(name, ExportKindFunc)
+	exp, err := c.Module.GetExport(name, ExternalKindFunc)
 	if err != nil {
 		return nil
 	}

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -261,7 +261,7 @@ type Export struct {
 	// Name is what the host refers to this definition as.
 	Name string
 	// Index is the index of the definition to export, the index namespace is by Kind
-	// Ex. If ExternalKindFunc, this is an index in the function index namespace.
+	// Ex. If ExternalKindFunc, this is an position in the function index namespace.
 	Index Index
 }
 

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -60,24 +60,24 @@ func TestSectionIDName(t *testing.T) {
 	}
 }
 
-func TestExternalKindName(t *testing.T) {
+func TestExternTypeName(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    ExternalKind
+		input    ExternType
 		expected string
 	}{
-		{"func", ExternalKindFunc, "func"},
-		{"table", ExternalKindTable, "table"},
-		{"mem", ExternalKindMemory, "mem"},
-		{"global", ExternalKindGlobal, "global"},
-		{"unknown", 100, "unknown"},
+		{"func", ExternTypeFunc, "func"},
+		{"table", ExternTypeTable, "table"},
+		{"mem", ExternTypeMemory, "mem"},
+		{"global", ExternTypeGlobal, "global"},
+		{"unknown", 100, "0x64"},
 	}
 
 	for _, tt := range tests {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, ExternalKindName(tc.input))
+			require.Equal(t, tc.expected, ExternTypeName(tc.input))
 		})
 	}
 }
@@ -93,7 +93,7 @@ func TestModule_allDeclarations(t *testing.T) {
 		// Functions.
 		{
 			module: &Module{
-				ImportSection:   []*Import{{Kind: ExternalKindFunc, DescFunc: 10000}},
+				ImportSection:   []*Import{{Type: ExternTypeFunc, DescFunc: 10000}},
 				FunctionSection: []Index{10, 20, 30},
 			},
 			expectedFunctions: []Index{10000, 10, 20, 30},
@@ -106,14 +106,14 @@ func TestModule_allDeclarations(t *testing.T) {
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindFunc, DescFunc: 10000}},
+				ImportSection: []*Import{{Type: ExternTypeFunc, DescFunc: 10000}},
 			},
 			expectedFunctions: []Index{10000},
 		},
 		// Globals.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindGlobal, DescGlobal: &GlobalType{Mutable: false}}},
+				ImportSection: []*Import{{Type: ExternTypeGlobal, DescGlobal: &GlobalType{Mutable: false}}},
 				GlobalSection: []*Global{{Type: &GlobalType{Mutable: true}}},
 			},
 			expectedGlobals: []*GlobalType{{Mutable: false}, {Mutable: true}},
@@ -126,21 +126,21 @@ func TestModule_allDeclarations(t *testing.T) {
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindGlobal, DescGlobal: &GlobalType{Mutable: false}}},
+				ImportSection: []*Import{{Type: ExternTypeGlobal, DescGlobal: &GlobalType{Mutable: false}}},
 			},
 			expectedGlobals: []*GlobalType{{Mutable: false}},
 		},
 		// Memories.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindMemory, DescMem: &LimitsType{Min: 1}}},
+				ImportSection: []*Import{{Type: ExternTypeMemory, DescMem: &LimitsType{Min: 1}}},
 				MemorySection: []*MemoryType{{Min: 100}},
 			},
 			expectedMemories: []*MemoryType{{Min: 1}, {Min: 100}},
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindMemory, DescMem: &LimitsType{Min: 1}}},
+				ImportSection: []*Import{{Type: ExternTypeMemory, DescMem: &LimitsType{Min: 1}}},
 			},
 			expectedMemories: []*MemoryType{{Min: 1}},
 		},
@@ -153,14 +153,14 @@ func TestModule_allDeclarations(t *testing.T) {
 		// Tables.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
+				ImportSection: []*Import{{Type: ExternTypeTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
 				TableSection:  []*TableType{{Limit: &LimitsType{Min: 10}}},
 			},
 			expectedTables: []*TableType{{Limit: &LimitsType{Min: 1}}, {Limit: &LimitsType{Min: 10}}},
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ExternalKindTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
+				ImportSection: []*Import{{Type: ExternTypeTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
 			},
 			expectedTables: []*TableType{{Limit: &LimitsType{Min: 1}}},
 		},
@@ -223,11 +223,11 @@ func TestModule_SectionSize(t *testing.T) {
 				ImportSection: []*Import{
 					{
 						Module: "Math", Name: "Mul",
-						Kind:     ExternalKindFunc,
+						Type:     ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "Math", Name: "Add",
-						Kind:     ExternalKindFunc,
+						Type:     ExternTypeFunc,
 						DescFunc: 0,
 					},
 				},
@@ -243,7 +243,7 @@ func TestModule_SectionSize(t *testing.T) {
 					{Body: []byte{OpcodeLocalGet, 0, OpcodeLocalGet, 1, OpcodeI32Add, OpcodeEnd}},
 				},
 				ExportSection: map[string]*Export{
-					"AddInt": {Name: "AddInt", Kind: ExternalKindFunc, Index: Index(0)},
+					"AddInt": {Name: "AddInt", Type: ExternTypeFunc, Index: Index(0)},
 				},
 				StartSection: &zero,
 			},

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -60,16 +60,16 @@ func TestSectionIDName(t *testing.T) {
 	}
 }
 
-func TestExportKindName(t *testing.T) {
+func TestExternalKindName(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    ExportKind
+		input    ExternalKind
 		expected string
 	}{
-		{"func", ExportKindFunc, "func"},
-		{"table", ExportKindTable, "table"},
-		{"mem", ExportKindMemory, "mem"},
-		{"global", ExportKindGlobal, "global"},
+		{"func", ExternalKindFunc, "func"},
+		{"table", ExternalKindTable, "table"},
+		{"mem", ExternalKindMemory, "mem"},
+		{"global", ExternalKindGlobal, "global"},
 		{"unknown", 100, "unknown"},
 	}
 
@@ -77,7 +77,7 @@ func TestExportKindName(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, ExportKindName(tc.input))
+			require.Equal(t, tc.expected, ExternalKindName(tc.input))
 		})
 	}
 }
@@ -93,7 +93,7 @@ func TestModule_allDeclarations(t *testing.T) {
 		// Functions.
 		{
 			module: &Module{
-				ImportSection:   []*Import{{Kind: ImportKindFunc, DescFunc: 10000}},
+				ImportSection:   []*Import{{Kind: ExternalKindFunc, DescFunc: 10000}},
 				FunctionSection: []Index{10, 20, 30},
 			},
 			expectedFunctions: []Index{10000, 10, 20, 30},
@@ -106,14 +106,14 @@ func TestModule_allDeclarations(t *testing.T) {
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindFunc, DescFunc: 10000}},
+				ImportSection: []*Import{{Kind: ExternalKindFunc, DescFunc: 10000}},
 			},
 			expectedFunctions: []Index{10000},
 		},
 		// Globals.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindGlobal, DescGlobal: &GlobalType{Mutable: false}}},
+				ImportSection: []*Import{{Kind: ExternalKindGlobal, DescGlobal: &GlobalType{Mutable: false}}},
 				GlobalSection: []*Global{{Type: &GlobalType{Mutable: true}}},
 			},
 			expectedGlobals: []*GlobalType{{Mutable: false}, {Mutable: true}},
@@ -126,21 +126,21 @@ func TestModule_allDeclarations(t *testing.T) {
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindGlobal, DescGlobal: &GlobalType{Mutable: false}}},
+				ImportSection: []*Import{{Kind: ExternalKindGlobal, DescGlobal: &GlobalType{Mutable: false}}},
 			},
 			expectedGlobals: []*GlobalType{{Mutable: false}},
 		},
 		// Memories.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindMemory, DescMem: &LimitsType{Min: 1}}},
+				ImportSection: []*Import{{Kind: ExternalKindMemory, DescMem: &LimitsType{Min: 1}}},
 				MemorySection: []*MemoryType{{Min: 100}},
 			},
 			expectedMemories: []*MemoryType{{Min: 1}, {Min: 100}},
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindMemory, DescMem: &LimitsType{Min: 1}}},
+				ImportSection: []*Import{{Kind: ExternalKindMemory, DescMem: &LimitsType{Min: 1}}},
 			},
 			expectedMemories: []*MemoryType{{Min: 1}},
 		},
@@ -153,14 +153,14 @@ func TestModule_allDeclarations(t *testing.T) {
 		// Tables.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
+				ImportSection: []*Import{{Kind: ExternalKindTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
 				TableSection:  []*TableType{{Limit: &LimitsType{Min: 10}}},
 			},
 			expectedTables: []*TableType{{Limit: &LimitsType{Min: 1}}, {Limit: &LimitsType{Min: 10}}},
 		},
 		{
 			module: &Module{
-				ImportSection: []*Import{{Kind: ImportKindTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
+				ImportSection: []*Import{{Kind: ExternalKindTable, DescTable: &TableType{Limit: &LimitsType{Min: 1}}}},
 			},
 			expectedTables: []*TableType{{Limit: &LimitsType{Min: 1}}},
 		},
@@ -223,11 +223,11 @@ func TestModule_SectionSize(t *testing.T) {
 				ImportSection: []*Import{
 					{
 						Module: "Math", Name: "Mul",
-						Kind:     ImportKindFunc,
+						Kind:     ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "Math", Name: "Add",
-						Kind:     ImportKindFunc,
+						Kind:     ExternalKindFunc,
 						DescFunc: 0,
 					},
 				},
@@ -243,7 +243,7 @@ func TestModule_SectionSize(t *testing.T) {
 					{Body: []byte{OpcodeLocalGet, 0, OpcodeLocalGet, 1, OpcodeI32Add, OpcodeEnd}},
 				},
 				ExportSection: map[string]*Export{
-					"AddInt": {Name: "AddInt", Kind: ExportKindFunc, Index: Index(0)},
+					"AddInt": {Name: "AddInt", Kind: ExternalKindFunc, Index: Index(0)},
 				},
 				StartSection: &zero,
 			},

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -38,14 +38,14 @@ func TestModuleInstance_Memory(t *testing.T) {
 			name: "memory exported, different name",
 			input: &Module{
 				MemorySection: []*MemoryType{{1, nil}},
-				ExportSection: map[string]*Export{"momory": {Kind: ExportKindMemory, Name: "momory", Index: 0}},
+				ExportSection: map[string]*Export{"momory": {Kind: ExternalKindMemory, Name: "momory", Index: 0}},
 			},
 		},
 		{
 			name: "memory exported, but zero length",
 			input: &Module{
 				MemorySection: []*MemoryType{{0, nil}},
-				ExportSection: map[string]*Export{"memory": {Kind: ExportKindMemory, Name: "memory", Index: 0}},
+				ExportSection: map[string]*Export{"memory": {Kind: ExternalKindMemory, Name: "memory", Index: 0}},
 			},
 			expected: true,
 		},
@@ -53,7 +53,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			name: "memory exported, one page",
 			input: &Module{
 				MemorySection: []*MemoryType{{1, nil}},
-				ExportSection: map[string]*Export{"memory": {Kind: ExportKindMemory, Name: "memory", Index: 0}},
+				ExportSection: map[string]*Export{"memory": {Kind: ExternalKindMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
 			expectedLen: 65536,
@@ -62,7 +62,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			name: "memory exported, two pages",
 			input: &Module{
 				MemorySection: []*MemoryType{{2, nil}},
-				ExportSection: map[string]*Export{"memory": {Kind: ExportKindMemory, Name: "memory", Index: 0}},
+				ExportSection: map[string]*Export{"memory": {Kind: ExternalKindMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
 			expectedLen: 65536 * 2,
@@ -137,13 +137,13 @@ func TestStore_ExportImportedHostFunction(t *testing.T) {
 	t.Run("ModuleInstance is the importing module", func(t *testing.T) {
 		_, err = s.Instantiate(&Module{
 			TypeSection:   []*FunctionType{{}},
-			ImportSection: []*Import{{Kind: ImportKindFunc, Name: "host_fn", DescFunc: 0}},
+			ImportSection: []*Import{{Kind: ExternalKindFunc, Name: "host_fn", DescFunc: 0}},
 			MemorySection: []*MemoryType{{1, nil}},
-			ExportSection: map[string]*Export{"host.fn": {Kind: ExportKindFunc, Name: "host.fn", Index: 0}},
+			ExportSection: map[string]*Export{"host.fn": {Kind: ExternalKindFunc, Name: "host.fn", Index: 0}},
 		}, "test")
 		require.NoError(t, err)
 
-		ei, err := s.getExport("test", "host.fn", ExportKindFunc)
+		ei, err := s.getExport("test", "host.fn", ExternalKindFunc)
 		require.NoError(t, err)
 		os.Environ()
 		// We expect the host function to be called in context of the importing module.
@@ -200,13 +200,13 @@ func TestFunctionInstance_Call(t *testing.T) {
 			instantiated, err := store.Instantiate(&Module{
 				TypeSection: []*FunctionType{{}},
 				ImportSection: []*Import{{
-					Kind:     ImportKindFunc,
+					Kind:     ExternalKindFunc,
 					Module:   hostModule.Name,
 					Name:     functionName,
 					DescFunc: 0,
 				}},
 				MemorySection: []*MemoryType{{1, nil}},
-				ExportSection: map[string]*Export{functionName: {Kind: ExportKindFunc, Name: functionName, Index: 0}},
+				ExportSection: map[string]*Export{functionName: {Kind: ExternalKindFunc, Name: functionName, Index: 0}},
 			}, "test")
 			require.NoError(t, err)
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -38,14 +38,14 @@ func TestModuleInstance_Memory(t *testing.T) {
 			name: "memory exported, different name",
 			input: &Module{
 				MemorySection: []*MemoryType{{1, nil}},
-				ExportSection: map[string]*Export{"momory": {Kind: ExternalKindMemory, Name: "momory", Index: 0}},
+				ExportSection: map[string]*Export{"momory": {Type: ExternTypeMemory, Name: "momory", Index: 0}},
 			},
 		},
 		{
 			name: "memory exported, but zero length",
 			input: &Module{
 				MemorySection: []*MemoryType{{0, nil}},
-				ExportSection: map[string]*Export{"memory": {Kind: ExternalKindMemory, Name: "memory", Index: 0}},
+				ExportSection: map[string]*Export{"memory": {Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected: true,
 		},
@@ -53,7 +53,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			name: "memory exported, one page",
 			input: &Module{
 				MemorySection: []*MemoryType{{1, nil}},
-				ExportSection: map[string]*Export{"memory": {Kind: ExternalKindMemory, Name: "memory", Index: 0}},
+				ExportSection: map[string]*Export{"memory": {Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
 			expectedLen: 65536,
@@ -62,7 +62,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			name: "memory exported, two pages",
 			input: &Module{
 				MemorySection: []*MemoryType{{2, nil}},
-				ExportSection: map[string]*Export{"memory": {Kind: ExternalKindMemory, Name: "memory", Index: 0}},
+				ExportSection: map[string]*Export{"memory": {Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
 			expectedLen: 65536 * 2,
@@ -137,13 +137,13 @@ func TestStore_ExportImportedHostFunction(t *testing.T) {
 	t.Run("ModuleInstance is the importing module", func(t *testing.T) {
 		_, err = s.Instantiate(&Module{
 			TypeSection:   []*FunctionType{{}},
-			ImportSection: []*Import{{Kind: ExternalKindFunc, Name: "host_fn", DescFunc: 0}},
+			ImportSection: []*Import{{Type: ExternTypeFunc, Name: "host_fn", DescFunc: 0}},
 			MemorySection: []*MemoryType{{1, nil}},
-			ExportSection: map[string]*Export{"host.fn": {Kind: ExternalKindFunc, Name: "host.fn", Index: 0}},
+			ExportSection: map[string]*Export{"host.fn": {Type: ExternTypeFunc, Name: "host.fn", Index: 0}},
 		}, "test")
 		require.NoError(t, err)
 
-		ei, err := s.getExport("test", "host.fn", ExternalKindFunc)
+		ei, err := s.getExport("test", "host.fn", ExternTypeFunc)
 		require.NoError(t, err)
 		os.Environ()
 		// We expect the host function to be called in context of the importing module.
@@ -200,13 +200,13 @@ func TestFunctionInstance_Call(t *testing.T) {
 			instantiated, err := store.Instantiate(&Module{
 				TypeSection: []*FunctionType{{}},
 				ImportSection: []*Import{{
-					Kind:     ExternalKindFunc,
+					Type:     ExternTypeFunc,
 					Module:   hostModule.Name,
 					Name:     functionName,
 					DescFunc: 0,
 				}},
 				MemorySection: []*MemoryType{{1, nil}},
-				ExportSection: map[string]*Export{functionName: {Kind: ExternalKindFunc, Name: functionName, Index: 0}},
+				ExportSection: map[string]*Export{functionName: {Type: ExternTypeFunc, Name: functionName, Index: 0}},
 			}, "test")
 			require.NoError(t, err)
 

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -69,7 +69,9 @@ type moduleParser struct {
 	// functions.
 	typeUseParser *typeUseParser
 
-	// funcNamespace represents the function index namespace, where any wasm.ImportKindFunc precede the FunctionSection.
+	// funcNamespace represents the function index namespace, which begins with any internalwasm.ExternalKindFunc in the
+	// internalwasm.SectionIDImport followed by the internalwasm.SectionIDFunction.
+	//
 	// Non-abbreviated imported and module-defined functions can declare symbolic IDs, such as "$main", which are
 	// resolved here (without the '$' prefix).
 	funcNamespace *indexNamespace
@@ -77,7 +79,9 @@ type moduleParser struct {
 	// funcParser parses the CodeSection for a given module-defined function.
 	funcParser *funcParser
 
-	// memoryNamespace represents the memory index namespace, where any wasm.ImportKindMemory precede the MemorySection.
+	// memoryNamespace represents the memory index namespace, which begins with any internalwasm.ExternalKindMemory in
+	// the internalwasm.SectionIDImport followed by the internalwasm.SectionIDMemory.
+	//
 	// Non-abbreviated imported and module-defined memories can declare symbolic IDs, such as "$mem", which are resolved
 	// here (without the '$' prefix).
 	memoryNamespace *indexNamespace
@@ -288,7 +292,7 @@ func (p *moduleParser) parseImportName(tok tokenType, tokenBytes []byte, _, _ ui
 	}
 }
 
-// parseImport returns beginImportDesc to determine the wasm.ImportKind and dispatch accordingly.
+// parseImport returns beginImportDesc to determine the wasm.ExternalKind and dispatch accordingly.
 func (p *moduleParser) parseImport(tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	switch tok {
 	case tokenString: // Ex. (import "Math" "PI" "PI"
@@ -374,7 +378,7 @@ func (p *moduleParser) parseImportFunc(tok tokenType, tokenBytes []byte, line, c
 // the current import into the ImportSection.
 func (p *moduleParser) onImportFunc(typeIdx wasm.Index, paramNames wasm.NameMap, pos callbackPosition, tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	i := p.currentModuleField.(*wasm.Import)
-	i.Kind = wasm.ImportKindFunc
+	i.Kind = wasm.ExternalKindFunc
 	i.DescFunc = typeIdx
 	p.addLocalNames(paramNames)
 
@@ -472,7 +476,7 @@ func (p *moduleParser) parseExportName(tok tokenType, tokenBytes []byte, _, _ ui
 	}
 }
 
-// parseExport returns beginExportDesc to determine the wasm.ExportKind and dispatch accordingly.
+// parseExport returns beginExportDesc to determine the wasm.ExternalKind and dispatch accordingly.
 func (p *moduleParser) parseExport(tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	switch tok {
 	case tokenString: // Ex. (export "PI" "PI"
@@ -512,10 +516,10 @@ func (p *moduleParser) parseExportDesc(tok tokenType, tokenBytes []byte, line, c
 	e := p.currentModuleField.(*wasm.Export)
 	switch p.pos {
 	case positionExportFunc:
-		e.Kind = wasm.ExportKindFunc
+		e.Kind = wasm.ExternalKindFunc
 		namespace = p.funcNamespace
 	case positionExportMemory:
-		e.Kind = wasm.ExportKindMemory
+		e.Kind = wasm.ExternalKindMemory
 		namespace = p.memoryNamespace
 	default:
 		panic(fmt.Errorf("BUG: unhandled parsing state on parseExportDesc: %v", p.pos))

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -69,7 +69,7 @@ type moduleParser struct {
 	// functions.
 	typeUseParser *typeUseParser
 
-	// funcNamespace represents the function index namespace, which begins with any internalwasm.ExternalKindFunc in the
+	// funcNamespace represents the function index namespace, which begins with any internalwasm.ExternTypeFunc in the
 	// internalwasm.SectionIDImport followed by the internalwasm.SectionIDFunction.
 	//
 	// Non-abbreviated imported and module-defined functions can declare symbolic IDs, such as "$main", which are
@@ -79,7 +79,7 @@ type moduleParser struct {
 	// funcParser parses the CodeSection for a given module-defined function.
 	funcParser *funcParser
 
-	// memoryNamespace represents the memory index namespace, which begins with any internalwasm.ExternalKindMemory in
+	// memoryNamespace represents the memory index namespace, which begins with any internalwasm.ExternTypeMemory in
 	// the internalwasm.SectionIDImport followed by the internalwasm.SectionIDMemory.
 	//
 	// Non-abbreviated imported and module-defined memories can declare symbolic IDs, such as "$mem", which are resolved
@@ -292,7 +292,7 @@ func (p *moduleParser) parseImportName(tok tokenType, tokenBytes []byte, _, _ ui
 	}
 }
 
-// parseImport returns beginImportDesc to determine the wasm.ExternalKind and dispatch accordingly.
+// parseImport returns beginImportDesc to determine the wasm.ExternType and dispatch accordingly.
 func (p *moduleParser) parseImport(tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	switch tok {
 	case tokenString: // Ex. (import "Math" "PI" "PI"
@@ -378,7 +378,7 @@ func (p *moduleParser) parseImportFunc(tok tokenType, tokenBytes []byte, line, c
 // the current import into the ImportSection.
 func (p *moduleParser) onImportFunc(typeIdx wasm.Index, paramNames wasm.NameMap, pos callbackPosition, tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	i := p.currentModuleField.(*wasm.Import)
-	i.Kind = wasm.ExternalKindFunc
+	i.Type = wasm.ExternTypeFunc
 	i.DescFunc = typeIdx
 	p.addLocalNames(paramNames)
 
@@ -476,7 +476,7 @@ func (p *moduleParser) parseExportName(tok tokenType, tokenBytes []byte, _, _ ui
 	}
 }
 
-// parseExport returns beginExportDesc to determine the wasm.ExternalKind and dispatch accordingly.
+// parseExport returns beginExportDesc to determine the wasm.ExternType and dispatch accordingly.
 func (p *moduleParser) parseExport(tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	switch tok {
 	case tokenString: // Ex. (export "PI" "PI"
@@ -516,10 +516,10 @@ func (p *moduleParser) parseExportDesc(tok tokenType, tokenBytes []byte, line, c
 	e := p.currentModuleField.(*wasm.Export)
 	switch p.pos {
 	case positionExportFunc:
-		e.Kind = wasm.ExternalKindFunc
+		e.Type = wasm.ExternTypeFunc
 		namespace = p.funcNamespace
 	case positionExportMemory:
-		e.Kind = wasm.ExternalKindMemory
+		e.Type = wasm.ExternTypeMemory
 		namespace = p.memoryNamespace
 	default:
 		panic(fmt.Errorf("BUG: unhandled parsing state on parseExportDesc: %v", p.pos))

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -52,7 +52,7 @@ func TestDecodeModule(t *testing.T) {
 				},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 1,
 				}},
 				NameSection: &wasm.NameSection{
@@ -67,7 +67,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -82,7 +82,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -97,7 +97,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -113,11 +113,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}, {
 					Module: "baz", Name: "qux",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -132,7 +132,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32, {}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 1,
 				}},
 			},
@@ -144,11 +144,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}, {
 					Module: "baz", Name: "qux",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -162,7 +162,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -179,7 +179,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -196,7 +196,7 @@ func TestDecodeModule(t *testing.T) {
 		)`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0, 0},
 				CodeSection: []*wasm.Code{
 					{Body: end}, {Body: []byte{wasm.OpcodeCall, 0x01, wasm.OpcodeEnd}},
@@ -214,7 +214,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -231,7 +231,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32_v},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionProcExit,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -244,7 +244,7 @@ func TestDecodeModule(t *testing.T) {
 			input: `(module (import "" "" (func (result i32))))`,
 			expected: &wasm.Module{
 				TypeSection:   []*wasm.FunctionType{v_i32},
-				ImportSection: []*wasm.Import{{Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection: []*wasm.Import{{Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 			},
 		},
 		{
@@ -256,7 +256,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32i32i64i64i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionPathOpen,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -273,7 +273,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32i32i64i64i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionPathOpen,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -291,11 +291,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32_i32, i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}, {
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 1,
 				}},
 				NameSection: &wasm.NameSection{
@@ -324,11 +324,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 2,
 					},
 				},
@@ -354,11 +354,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 2,
 					},
 				},
@@ -382,11 +382,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionEnvironGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -411,11 +411,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionEnvironGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -440,11 +440,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionEnvironGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -463,7 +463,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i64_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "Math", Name: "Mul",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -484,11 +484,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i64_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "Math", Name: "Mul",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}, {
 					Module: "Math", Name: "Add",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -507,7 +507,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{
 					{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
 				},
-				ImportSection: []*wasm.Import{{Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection: []*wasm.Import{{Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 				NameSection: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
 						{Index: 0, NameMap: wasm.NameMap{{Index: wasm.Index(2), Name: "v"}, {Index: wasm.Index(4), Name: "t"}}},
@@ -531,11 +531,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionPathOpen,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 2,
 					},
 				},
@@ -557,7 +557,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -572,7 +572,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -587,7 +587,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -602,7 +602,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -916,7 +916,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -943,7 +943,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -970,7 +970,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -997,7 +997,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -1024,7 +1024,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ImportKindFunc,
+						Kind:     wasm.ExternalKindFunc,
 						DescFunc: 1,
 					},
 				},
@@ -1174,10 +1174,10 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{
-					{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0},
+					{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{FunctionNames: wasm.NameMap{{Index: 0, Name: "bar"}}},
 			},
@@ -1191,10 +1191,10 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{
-					{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0},
+					{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 0},
 				},
 			},
 		},
@@ -1208,11 +1208,11 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{
-					{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0},
+					{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 0},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{&wasm.NameAssoc{Index: 0, Name: "bar"}},
@@ -1229,12 +1229,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 1},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{
@@ -1254,12 +1254,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 1},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{
@@ -1279,12 +1279,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 1},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
 				},
 			},
 		},
@@ -1298,12 +1298,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ImportKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExportKindFunc, Index: 1},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
 				},
 			},
 		},
@@ -1329,7 +1329,7 @@ func TestDecodeModule(t *testing.T) {
 					{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"AddInt": {Name: "AddInt", Kind: wasm.ExportKindFunc, Index: 0},
+					"AddInt": {Name: "AddInt", Kind: wasm.ExternalKindFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{{Index: 0, Name: "addInt"}},
@@ -1351,7 +1351,7 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				MemorySection: []*wasm.MemoryType{{Min: 0}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindMemory, Index: 0},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindMemory, Index: 0},
 				},
 			},
 		},
@@ -1364,7 +1364,7 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				MemorySection: []*wasm.MemoryType{{Min: 0}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExportKindMemory, Index: 0},
+					"foo": {Name: "foo", Kind: wasm.ExternalKindMemory, Index: 0},
 				},
 			},
 		},
@@ -1382,8 +1382,8 @@ func TestDecodeModule(t *testing.T) {
 				FunctionSection: []wasm.Index{0, 0, 0},
 				CodeSection:     []*wasm.Code{{Body: end}, {Body: end}, {Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"":  {Name: "", Kind: wasm.ExportKindFunc, Index: wasm.Index(2)},
-					"a": {Name: "a", Kind: wasm.ExportKindFunc, Index: 1},
+					"":  {Name: "", Kind: wasm.ExternalKindFunc, Index: wasm.Index(2)},
+					"a": {Name: "a", Kind: wasm.ExternalKindFunc, Index: 1},
 				},
 			},
 		},
@@ -1396,7 +1396,7 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				MemorySection: []*wasm.MemoryType{{Min: 1}},
 				ExportSection: map[string]*wasm.Export{
-					"memory": {Name: "memory", Kind: wasm.ExportKindMemory, Index: 0},
+					"memory": {Name: "memory", Kind: wasm.ExternalKindMemory, Index: 0},
 				},
 			},
 		},
@@ -1410,7 +1410,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,
@@ -1427,7 +1427,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ImportKindFunc,
+					Kind:     wasm.ExternalKindFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -52,7 +52,7 @@ func TestDecodeModule(t *testing.T) {
 				},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 1,
 				}},
 				NameSection: &wasm.NameSection{
@@ -67,7 +67,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -82,7 +82,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -97,7 +97,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -113,11 +113,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}, {
 					Module: "baz", Name: "qux",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -132,7 +132,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32, {}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 1,
 				}},
 			},
@@ -144,11 +144,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}, {
 					Module: "baz", Name: "qux",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -162,7 +162,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -179,7 +179,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -196,7 +196,7 @@ func TestDecodeModule(t *testing.T) {
 		)`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0, 0},
 				CodeSection: []*wasm.Code{
 					{Body: end}, {Body: []byte{wasm.OpcodeCall, 0x01, wasm.OpcodeEnd}},
@@ -214,7 +214,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -231,7 +231,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32_v},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionProcExit,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -244,7 +244,7 @@ func TestDecodeModule(t *testing.T) {
 			input: `(module (import "" "" (func (result i32))))`,
 			expected: &wasm.Module{
 				TypeSection:   []*wasm.FunctionType{v_i32},
-				ImportSection: []*wasm.Import{{Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection: []*wasm.Import{{Type: wasm.ExternTypeFunc, DescFunc: 0}},
 			},
 		},
 		{
@@ -256,7 +256,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32i32i64i64i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionPathOpen,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -273,7 +273,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32i32i32i32i64i64i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionPathOpen,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -291,11 +291,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i32_i32, i32i32i32i32_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}, {
 					Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 1,
 				}},
 				NameSection: &wasm.NameSection{
@@ -324,11 +324,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 2,
 					},
 				},
@@ -354,11 +354,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 2,
 					},
 				},
@@ -382,11 +382,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionEnvironGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -411,11 +411,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionEnvironGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -440,11 +440,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionEnvironGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -463,7 +463,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i64_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "Math", Name: "Mul",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -484,11 +484,11 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{i32i64_i32},
 				ImportSection: []*wasm.Import{{
 					Module: "Math", Name: "Mul",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}, {
 					Module: "Math", Name: "Add",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				NameSection: &wasm.NameSection{
@@ -507,7 +507,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{
 					{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
 				},
-				ImportSection: []*wasm.Import{{Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection: []*wasm.Import{{Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				NameSection: &wasm.NameSection{
 					LocalNames: wasm.IndirectNameMap{
 						{Index: 0, NameMap: wasm.NameMap{{Index: wasm.Index(2), Name: "v"}, {Index: wasm.Index(4), Name: "t"}}},
@@ -531,11 +531,11 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionPathOpen,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					}, {
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 2,
 					},
 				},
@@ -557,7 +557,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -572,7 +572,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -587,7 +587,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -602,7 +602,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 			},
@@ -916,7 +916,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -943,7 +943,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -970,7 +970,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -997,7 +997,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -1024,7 +1024,7 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []*wasm.Import{
 					{
 						Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsGet,
-						Kind:     wasm.ExternalKindFunc,
+						Type:     wasm.ExternTypeFunc,
 						DescFunc: 1,
 					},
 				},
@@ -1174,10 +1174,10 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{
-					{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0},
+					{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{FunctionNames: wasm.NameMap{{Index: 0, Name: "bar"}}},
 			},
@@ -1191,10 +1191,10 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{
-					{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0},
+					{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 			},
 		},
@@ -1208,11 +1208,11 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{
-					{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0},
+					{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 0},
+					"foo": {Name: "foo", Type: wasm.ExternTypeFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{&wasm.NameAssoc{Index: 0, Name: "bar"}},
@@ -1229,12 +1229,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
+					"foo": {Name: "foo", Type: wasm.ExternTypeFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 1},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{
@@ -1254,12 +1254,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
+					"foo": {Name: "foo", Type: wasm.ExternTypeFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 1},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{
@@ -1279,12 +1279,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
+					"foo": {Name: "foo", Type: wasm.ExternTypeFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 1},
 				},
 			},
 		},
@@ -1298,12 +1298,12 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
-				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Kind: wasm.ExternalKindFunc, DescFunc: 0}},
+				ImportSection:   []*wasm.Import{{Module: "foo", Name: "bar", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindFunc, Index: 0},
-					"bar": {Name: "bar", Kind: wasm.ExternalKindFunc, Index: 1},
+					"foo": {Name: "foo", Type: wasm.ExternTypeFunc, Index: 0},
+					"bar": {Name: "bar", Type: wasm.ExternTypeFunc, Index: 1},
 				},
 			},
 		},
@@ -1329,7 +1329,7 @@ func TestDecodeModule(t *testing.T) {
 					{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 				},
 				ExportSection: map[string]*wasm.Export{
-					"AddInt": {Name: "AddInt", Kind: wasm.ExternalKindFunc, Index: 0},
+					"AddInt": {Name: "AddInt", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
 					FunctionNames: wasm.NameMap{{Index: 0, Name: "addInt"}},
@@ -1351,7 +1351,7 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				MemorySection: []*wasm.MemoryType{{Min: 0}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindMemory, Index: 0},
+					"foo": {Name: "foo", Type: wasm.ExternTypeMemory, Index: 0},
 				},
 			},
 		},
@@ -1364,7 +1364,7 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				MemorySection: []*wasm.MemoryType{{Min: 0}},
 				ExportSection: map[string]*wasm.Export{
-					"foo": {Name: "foo", Kind: wasm.ExternalKindMemory, Index: 0},
+					"foo": {Name: "foo", Type: wasm.ExternTypeMemory, Index: 0},
 				},
 			},
 		},
@@ -1382,8 +1382,8 @@ func TestDecodeModule(t *testing.T) {
 				FunctionSection: []wasm.Index{0, 0, 0},
 				CodeSection:     []*wasm.Code{{Body: end}, {Body: end}, {Body: end}},
 				ExportSection: map[string]*wasm.Export{
-					"":  {Name: "", Kind: wasm.ExternalKindFunc, Index: wasm.Index(2)},
-					"a": {Name: "a", Kind: wasm.ExternalKindFunc, Index: 1},
+					"":  {Name: "", Type: wasm.ExternTypeFunc, Index: wasm.Index(2)},
+					"a": {Name: "a", Type: wasm.ExternTypeFunc, Index: 1},
 				},
 			},
 		},
@@ -1396,7 +1396,7 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				MemorySection: []*wasm.MemoryType{{Min: 1}},
 				ExportSection: map[string]*wasm.Export{
-					"memory": {Name: "memory", Kind: wasm.ExternalKindMemory, Index: 0},
+					"memory": {Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},
 			},
 		},
@@ -1410,7 +1410,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,
@@ -1427,7 +1427,7 @@ func TestDecodeModule(t *testing.T) {
 				TypeSection: []*wasm.FunctionType{v_v},
 				ImportSection: []*wasm.Import{{
 					Module: "", Name: "hello",
-					Kind:     wasm.ExternalKindFunc,
+					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
 				}},
 				StartSection: &zero,

--- a/tests/codec/codec_test.go
+++ b/tests/codec/codec_test.go
@@ -43,11 +43,11 @@ func newExample() *wasm.Module {
 		ImportSection: []*wasm.Import{
 			{
 				Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-				Kind:     wasm.ImportKindFunc,
+				Kind:     wasm.ExternalKindFunc,
 				DescFunc: 0,
 			}, {
 				Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-				Kind:     wasm.ImportKindFunc,
+				Kind:     wasm.ExternalKindFunc,
 				DescFunc: 2,
 			},
 		},
@@ -59,9 +59,9 @@ func newExample() *wasm.Module {
 		},
 		MemorySection: []*wasm.MemoryType{{Min: 1, Max: &three}},
 		ExportSection: map[string]*wasm.Export{
-			"AddInt": {Name: "AddInt", Kind: wasm.ExportKindFunc, Index: wasm.Index(4)},
-			"":       {Name: "", Kind: wasm.ExportKindFunc, Index: wasm.Index(3)},
-			"mem":    {Name: "mem", Kind: wasm.ExportKindMemory, Index: wasm.Index(0)},
+			"AddInt": {Name: "AddInt", Kind: wasm.ExternalKindFunc, Index: wasm.Index(4)},
+			"":       {Name: "", Kind: wasm.ExternalKindFunc, Index: wasm.Index(3)},
+			"mem":    {Name: "mem", Kind: wasm.ExternalKindMemory, Index: wasm.Index(0)},
 		},
 		StartSection: &three,
 		NameSection: &wasm.NameSection{

--- a/tests/codec/codec_test.go
+++ b/tests/codec/codec_test.go
@@ -43,11 +43,11 @@ func newExample() *wasm.Module {
 		ImportSection: []*wasm.Import{
 			{
 				Module: "wasi_snapshot_preview1", Name: wasi.FunctionArgsSizesGet,
-				Kind:     wasm.ExternalKindFunc,
+				Type:     wasm.ExternTypeFunc,
 				DescFunc: 0,
 			}, {
 				Module: "wasi_snapshot_preview1", Name: wasi.FunctionFdWrite,
-				Kind:     wasm.ExternalKindFunc,
+				Type:     wasm.ExternTypeFunc,
 				DescFunc: 2,
 			},
 		},
@@ -59,9 +59,9 @@ func newExample() *wasm.Module {
 		},
 		MemorySection: []*wasm.MemoryType{{Min: 1, Max: &three}},
 		ExportSection: map[string]*wasm.Export{
-			"AddInt": {Name: "AddInt", Kind: wasm.ExternalKindFunc, Index: wasm.Index(4)},
-			"":       {Name: "", Kind: wasm.ExternalKindFunc, Index: wasm.Index(3)},
-			"mem":    {Name: "mem", Kind: wasm.ExternalKindMemory, Index: wasm.Index(0)},
+			"AddInt": {Name: "AddInt", Type: wasm.ExternTypeFunc, Index: wasm.Index(4)},
+			"":       {Name: "", Type: wasm.ExternTypeFunc, Index: wasm.Index(3)},
+			"mem":    {Name: "mem", Type: wasm.ExternTypeMemory, Index: wasm.Index(0)},
 		},
 		StartSection: &three,
 		NameSection: &wasm.NameSection{

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -327,7 +327,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 							}
 							inst, ok := store.ModuleInstances[moduleName]
 							require.True(t, ok, msg)
-							addr, err := inst.GetExport(c.Action.Field, wasm.ExportKindGlobal)
+							addr, err := inst.GetExport(c.Action.Field, wasm.ExternalKindGlobal)
 							require.NoError(t, err)
 							actual := addr.Global
 							var expType wasm.ValueType

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -327,7 +327,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 							}
 							inst, ok := store.ModuleInstances[moduleName]
 							require.True(t, ok, msg)
-							addr, err := inst.GetExport(c.Action.Field, wasm.ExternalKindGlobal)
+							addr, err := inst.GetExport(c.Action.Field, wasm.ExternTypeGlobal)
 							require.NoError(t, err)
 							actual := addr.Global
 							var expType wasm.ValueType


### PR DESCRIPTION
This centralizes our management of external types by choosing the word
"external" also used in the spec instead of defining the same constants
for imports vs exports. One advantage is more coherent reference
searching as constants are no longer split. Another is future work can
use a single "kind" type to manage namespace length checks.
