### PR TITLE
text: changes string value of externtype "mem" to "memory"

### DIFF
--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -459,20 +459,32 @@ const (
 	ExternTypeGlobal ExternType = 0x03
 )
 
-// ExternTypeName returns the canonical name of the import or export description.
+// The below are exported to consolidate parsing behavior for external types.
+const (
+	// ExternTypeFuncName is the name of the WebAssembly 1.0 (20191205) Text Format field for ExternTypeFunc.
+	ExternTypeFuncName = "func"
+	// ExternTypeTableName is the name of the WebAssembly 1.0 (20191205) Text Format field for ExternTypeTable.
+	ExternTypeTableName = "table"
+	// ExternTypeMemoryName is the name of the WebAssembly 1.0 (20191205) Text Format field for ExternTypeMemory.
+	ExternTypeMemoryName = "memory"
+	// ExternTypeGlobalName is the name of the WebAssembly 1.0 (20191205) Text Format field for ExternTypeGlobal.
+	ExternTypeGlobalName = "global"
+)
+
+// ExternTypeName returns the name of the WebAssembly 1.0 (20191205) Text Format field of the given type.
 //
-// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-importdesc
-// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-exportdesc
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#imports⑤
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#exports%E2%91%A4
 func ExternTypeName(et ExternType) string {
 	switch et {
 	case ExternTypeFunc:
-		return "func"
+		return ExternTypeFuncName
 	case ExternTypeTable:
-		return "table"
+		return ExternTypeTableName
 	case ExternTypeMemory:
-		return "mem"
+		return ExternTypeMemoryName
 	case ExternTypeGlobal:
-		return "global"
+		return ExternTypeGlobalName
 	}
 	return fmt.Sprintf("%#x", et)
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -68,7 +68,7 @@ func TestExternTypeName(t *testing.T) {
 	}{
 		{"func", ExternTypeFunc, "func"},
 		{"table", ExternTypeTable, "table"},
-		{"mem", ExternTypeMemory, "mem"},
+		{"mem", ExternTypeMemory, "memory"},
 		{"global", ExternTypeGlobal, "global"},
 		{"unknown", 100, "0x64"},
 	}

--- a/internal/wasm/text/func_parser.go
+++ b/internal/wasm/text/func_parser.go
@@ -45,8 +45,8 @@ type funcParser struct {
 var end = []byte{wasm.OpcodeEnd}
 var codeEnd = &wasm.Code{Body: end}
 
-// begin should be called after reaching the "func" keyword in a module field. Parsing continues until onFunc or
-// error.
+// begin should be called after reaching the internalwasm.ExternTypeFuncName keyword in a module field. Parsing
+// continues until onFunc or error.
 //
 // This stage records the ID of the current function, if present, and resumes with onFunc.
 //

--- a/internal/wasm/text/memory_parser.go
+++ b/internal/wasm/text/memory_parser.go
@@ -33,8 +33,8 @@ type memoryParser struct {
 	currentMax *uint32
 }
 
-// begin should be called after reaching the "memory" keyword in a module field. Parsing continues until onMemory or
-// error.
+// begin should be called after reaching the internalwasm.ExternTypeMemoryName keyword in a module field. Parsing
+// continues until onMemory or error.
 //
 // This stage records the ID of the current memory, if present, and resumes with beginMin.
 //

--- a/internal/wasm/text/type_parser.go
+++ b/internal/wasm/text/type_parser.go
@@ -91,7 +91,7 @@ func (p *typeParser) beginFunc(tok tokenType, tokenBytes []byte, _, _ uint32) (t
 		return nil, expectedField(tok)
 	}
 
-	if string(tokenBytes) != "func" {
+	if string(tokenBytes) != wasm.ExternTypeFuncName {
 		return nil, unexpectedFieldName(tokenBytes)
 	}
 
@@ -118,7 +118,7 @@ func (p *typeParser) parseFunc(tok tokenType, tokenBytes []byte, line, col uint3
 	}
 }
 
-// parseFuncEnd completes the "func" field and returns end
+// parseFuncEnd completes the internalwasm.ExternTypeFuncName field and returns end
 func (p *typeParser) parseFuncEnd(tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	if tok != tokenRParen {
 		return nil, unexpectedToken(tok, tokenBytes)

--- a/internal/wasm/text/typeuse_parser.go
+++ b/internal/wasm/text/typeuse_parser.go
@@ -22,7 +22,7 @@ func newTypeUseParser(module *wasm.Module, typeNamespace *indexNamespace) *typeU
 // that is not a "result": pos clarifies this.
 type onTypeUse func(typeIdx wasm.Index, paramNames wasm.NameMap, pos callbackPosition, tok tokenType, tokenBytes []byte, line, col uint32) (tokenParser, error)
 
-// typeUseParser parses an inlined type from a field such "func" and calls onTypeUse.
+// typeUseParser parses an inlined type from a field such internalwasm.ExternTypeFuncName and calls onTypeUse.
 //
 // Ex. `(import "Math" "PI" (func $math.pi (result f32)))`
 //                           starts here --^           ^


### PR DESCRIPTION
This changes the string value of "mem" to "memory" so that the same
constants currently used for error context can also be used for field
parsing dispatch.
