### PR TITLE
text: defers evaluation of current section index

### DIFF
--- a/internal/wasm/text/func_parser.go
+++ b/internal/wasm/text/func_parser.go
@@ -31,7 +31,6 @@ type funcParser struct {
 	// funcNamespace is described by moduleParser.funcNamespace
 	funcNamespace *indexNamespace
 
-	currentIdx        wasm.Index
 	currentName       string
 	currentTypeIdx    wasm.Index
 	currentParamNames wasm.NameMap
@@ -88,7 +87,7 @@ func (p *funcParser) parseFunc(tok tokenType, tokenBytes []byte, line, col uint3
 		return nil, fmt.Errorf("redundant ID %s", tokenBytes)
 	}
 
-	return p.typeUseParser.begin(wasm.SectionIDFunction, p.currentIdx, p.afterTypeUse, tok, tokenBytes, line, col)
+	return p.typeUseParser.begin(wasm.SectionIDFunction, p.afterTypeUse, tok, tokenBytes, line, col)
 }
 
 // afterTypeUse is a tokenParser that starts after a type use.
@@ -127,7 +126,7 @@ func sExpressionsUnsupported(tok tokenType, tokenBytes []byte, _, _ uint32) (tok
 	return nil, fmt.Errorf("TODO: s-expressions are not yet supported: %s", tokenBytes)
 }
 
-func (p *funcParser) beginFieldOrInstruction(tok tokenType, tokenBytes []byte, line, col uint32) (tokenParser, error) {
+func (p *funcParser) beginFieldOrInstruction(tok tokenType, tokenBytes []byte, _, _ uint32) (tokenParser, error) {
 	switch tok {
 	case tokenLParen:
 		return sExpressionsUnsupported, nil
@@ -174,7 +173,7 @@ func (p *funcParser) end() (tokenParser, error) {
 // placeholder byte(0) is added instead and will be resolved later.
 func (p *funcParser) parseFuncIndex(tok tokenType, tokenBytes []byte, line, col uint32) (tokenParser, error) {
 	bodyOffset := uint32(len(p.currentBody))
-	idx, resolved, err := p.funcNamespace.parseIndex(wasm.SectionIDCode, p.currentIdx, bodyOffset, tok, tokenBytes, line, col)
+	idx, resolved, err := p.funcNamespace.parseIndex(wasm.SectionIDCode, bodyOffset, tok, tokenBytes, line, col)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wasm/text/index_namespace_test.go
+++ b/internal/wasm/text/index_namespace_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 func TestIndexNamespace_SetId(t *testing.T) {
-	in := newIndexNamespace()
+	in := newIndexNamespace(func(_ wasm.SectionID) uint32 {
+		t.Fail()
+		return 0
+	})
 	t.Run("set when empty", func(t *testing.T) {
 		id, err := in.setID([]byte("$x"))
 		require.NoError(t, err)

--- a/internal/wasm/text/memory_parser_test.go
+++ b/internal/wasm/text/memory_parser_test.go
@@ -60,7 +60,10 @@ func TestMemoryParser(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			memoryNamespace := newIndexNamespace()
+			memoryNamespace := newIndexNamespace(func(sectionID wasm.SectionID) uint32 {
+				require.Equal(t, wasm.SectionIDMemory, sectionID)
+				return 0
+			})
 			parsed, tp, err := parseMemoryType(memoryNamespace, tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, parsed)
@@ -133,14 +136,21 @@ func TestMemoryParser_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			parsed, _, err := parseMemoryType(newIndexNamespace(), tc.input)
+			memoryNamespace := newIndexNamespace(func(sectionID wasm.SectionID) uint32 {
+				require.Equal(t, wasm.SectionIDMemory, sectionID)
+				return 0
+			})
+			parsed, _, err := parseMemoryType(memoryNamespace, tc.input)
 			require.EqualError(t, err, tc.expectedErr)
 			require.Nil(t, parsed)
 		})
 	}
 
 	t.Run("duplicate ID", func(t *testing.T) {
-		memoryNamespace := newIndexNamespace()
+		memoryNamespace := newIndexNamespace(func(sectionID wasm.SectionID) uint32 {
+			require.Equal(t, wasm.SectionIDMemory, sectionID)
+			return 0
+		})
 		_, err := memoryNamespace.setID([]byte("$mem"))
 		require.NoError(t, err)
 		memoryNamespace.count++

--- a/internal/wasm/text/type_parser_test.go
+++ b/internal/wasm/text/type_parser_test.go
@@ -100,7 +100,10 @@ func TestTypeParser(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			typeNamespace := newIndexNamespace()
+			typeNamespace := newIndexNamespace(func(sectionID wasm.SectionID) uint32 {
+				require.Equal(t, wasm.SectionIDType, sectionID)
+				return 0
+			})
 			parsed, tp, err := parseFunctionType(typeNamespace, tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, parsed)
@@ -228,14 +231,21 @@ func TestTypeParser_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			parsed, _, err := parseFunctionType(newIndexNamespace(), tc.input)
+			typeNamespace := newIndexNamespace(func(sectionID wasm.SectionID) uint32 {
+				require.Equal(t, wasm.SectionIDType, sectionID)
+				return 0
+			})
+			parsed, _, err := parseFunctionType(typeNamespace, tc.input)
 			require.EqualError(t, err, tc.expectedErr)
 			require.Nil(t, parsed)
 		})
 	}
 
 	t.Run("duplicate ID", func(t *testing.T) {
-		typeNamespace := newIndexNamespace()
+		typeNamespace := newIndexNamespace(func(sectionID wasm.SectionID) uint32 {
+			require.Equal(t, wasm.SectionIDType, sectionID)
+			return 0
+		})
 		_, err := typeNamespace.setID([]byte("$v_v"))
 		require.NoError(t, err)
 		typeNamespace.count++


### PR DESCRIPTION
The current section index is typically only read when there is an
unresolved reference. This pushes evaluation until when it is needed,
which simpilifies tracking and reduces arity of callbacks.
