### PR TITLE
Combines Store+Engine into Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are two runtime configurations supported in wazero, where _JIT_ is default
 1. _Interpreter_: a naive interpreter-based implementation of Wasm virtual machine. Its implementation doesn't have any platform (GOARCH, GOOS) specific code, therefore _interpreter_ engine can be used for any compilation target available for Go (such as `riscv64`).
 2. _JIT_: compiles WebAssembly modules, generates the machine code, and executing it all at runtime. Currently wazero implements the JIT compiler for `amd64` and `arm64` target. Generally speaking, _JIT engine_ is faster than _Interpreter_ by order of magnitude. However, the implementation is immature and has a bunch of aspects that could be improved (for example, it just does a singlepass compilation and doesn't do any optimizations, etc.). Please refer to [internal/wasm/jit/RATIONALE.md](internal/wasm/jit/RATIONALE.md) for the design choices and considerations in our JIT engine.
 
-Both of configurations passes 100% of [WebAssembly spec test suites]((https://github.com/WebAssembly/spec/tree/wg-1.0/test/core)) (on supported platforms).
+Both configurations pass 100% of [WebAssembly spec test suites]((https://github.com/WebAssembly/spec/tree/wg-1.0/test/core)) (on supported platforms).
 
 | Engine     | Usage| amd64 | arm64 | others |
 |:---:|:---:|:---:|:---:|:---:|

--- a/config_supported.go
+++ b/config_supported.go
@@ -3,7 +3,8 @@
 
 package wazero
 
-// NewRuntimeConfig returns NewRuntimeConfigJIT
+// NewRuntimeConfig returns NewRuntimeConfigInterpreter
+// TODO: switch back to NewRuntimeConfigJIT https://github.com/tetratelabs/wazero/issues/308
 func NewRuntimeConfig() *RuntimeConfig {
-	return NewRuntimeConfigJIT()
+	return NewRuntimeConfigInterpreter()
 }


### PR DESCRIPTION
This simplifies state management and the amount of terminology end-users
need to learn by using one concept `Runtime` instead of two: `Engine`
and `Store`. This bridges the concepts to the specification by still
having `wazero.Runtime` implement `wasm.Store`.

The net result is that we can know for sure which "engine" is used when
decoding. This allows us a lot of flexibility especially pre-compilation
when JIT is possible.

This also changes the default to JIT based on compiler flags so that
downstream projects like wapc-go don't have to do this individually
(including tracking of which OS+Arch have JIT).

Finally, this uses more go-idiomatic terms like `New` instead of
`Instantiate`.

```go
// before: to force a specific compilation strategy
store, err := wazero.NewStoreWithConfig(&wazero.StoreConfig{Engine: wazero.NewEngineJIT()})
// now
r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfigJIT())

// before: to instantiate a module from source
exports, _ := wazero.InstantiateModule(wazero.NewStore(), &wazero.ModuleConfig{Source: source})
// now
module, _ := wazero.NewRuntime().NewModuleFromSource(source)

// before: to instantiate a host module
_, err := wazero.InstantiateHostModule(store, wazero.WASISnapshotPreview1WithConfig(wasiConfig))
// now
_, err := r.NewHostModule(wazero.WASISnapshotPreview1WithConfig(wasiConfig))

// before: to start a WASI command
_, err = wazero.StartWASICommand(store, &wazero.ModuleConfig{Source: stdioWasm})
// now
_, err = wazero.StartWASICommandFromSource(r, stdioWasm)
```

Note: this is a follow-up PR from 76c0bfc33f721b8e2de1b41b0f50ae4a27621349 which was accidentally merged without review.