### PR TITLE
Adds Global API and implements for module-defined globals

### DIFF
--- a/internal/wasm/global.go
+++ b/internal/wasm/global.go
@@ -1,0 +1,147 @@
+package internalwasm
+
+import (
+	"fmt"
+
+	publicwasm "github.com/tetratelabs/wazero/wasm"
+)
+
+type mutableGlobal struct {
+	g *GlobalInstance
+}
+
+// compile-time check to ensure mutableGlobal is a wasm.Global
+var _ publicwasm.Global = &mutableGlobal{}
+
+// Type implements wasm.Global Type
+func (g *mutableGlobal) Type() publicwasm.ValueType {
+	return g.g.Type.ValType
+}
+
+// Get implements wasm.Global Get
+func (g *mutableGlobal) Get() uint64 {
+	return g.g.Val
+}
+
+// Set implements wasm.MutableGlobal Set
+func (g *mutableGlobal) Set(v uint64) {
+	g.g.Val = v
+}
+
+// String implements fmt.Stringer
+func (g *mutableGlobal) String() string {
+	switch g.Type() {
+	case ValueTypeI32, ValueTypeI64:
+		return fmt.Sprintf("global(%d)", g.Get())
+	case ValueTypeF32:
+		return fmt.Sprintf("global(%f)", publicwasm.DecodeF32(g.Get()))
+	case ValueTypeF64:
+		return fmt.Sprintf("global(%f)", publicwasm.DecodeF64(g.Get()))
+	default:
+		panic(fmt.Errorf("BUG: unknown value type %X", g.Type()))
+	}
+}
+
+type globalI32 uint64
+
+// compile-time check to ensure globalI32 is a wasm.Global
+var _ publicwasm.Global = globalI32(0)
+
+// Type implements wasm.Global Type
+func (g globalI32) Type() publicwasm.ValueType {
+	return ValueTypeI32
+}
+
+// Get implements wasm.Global Get
+func (g globalI32) Get() uint64 {
+	return uint64(g)
+}
+
+// String implements fmt.Stringer
+func (g globalI32) String() string {
+	return fmt.Sprintf("global(%d)", g)
+}
+
+type globalI64 uint64
+
+// compile-time check to ensure globalI64 is a publicwasm.Global
+var _ publicwasm.Global = globalI64(0)
+
+// Type implements wasm.Global Type
+func (g globalI64) Type() publicwasm.ValueType {
+	return ValueTypeI64
+}
+
+// Get implements wasm.Global Get
+func (g globalI64) Get() uint64 {
+	return uint64(g)
+}
+
+// String implements fmt.Stringer
+func (g globalI64) String() string {
+	return fmt.Sprintf("global(%d)", g)
+}
+
+type globalF32 uint64
+
+// compile-time check to ensure globalF32 is a publicwasm.Global
+var _ publicwasm.Global = globalF32(0)
+
+// Type implements wasm.Global Type
+func (g globalF32) Type() publicwasm.ValueType {
+	return ValueTypeF32
+}
+
+// Get implements wasm.Global Get
+func (g globalF32) Get() uint64 {
+	return uint64(g)
+}
+
+// String implements fmt.Stringer
+func (g globalF32) String() string {
+	return fmt.Sprintf("global(%f)", publicwasm.DecodeF32(g.Get()))
+}
+
+type globalF64 uint64
+
+// compile-time check to ensure globalF64 is a publicwasm.Global
+var _ publicwasm.Global = globalF64(0)
+
+// Type implements wasm.Global Type
+func (g globalF64) Type() publicwasm.ValueType {
+	return ValueTypeF64
+}
+
+// Get implements wasm.Global Get
+func (g globalF64) Get() uint64 {
+	return uint64(g)
+}
+
+// String implements fmt.Stringer
+func (g globalF64) String() string {
+	return fmt.Sprintf("global(%f)", publicwasm.DecodeF64(g.Get()))
+}
+
+// Global implements wasm.Module Global
+func (m *PublicModule) Global(name string) publicwasm.Global {
+	exp, err := m.Context.Module.GetExport(name, ExternTypeGlobal)
+	if err != nil {
+		return nil
+	}
+	if exp.Global.Type.Mutable {
+		return &mutableGlobal{exp.Global}
+	}
+	valType := exp.Global.Type.ValType
+	switch valType {
+	case ValueTypeI32:
+		return globalI32(exp.Global.Val)
+	case ValueTypeI64:
+		return globalI64(exp.Global.Val)
+	case ValueTypeF32:
+		return globalF32(exp.Global.Val)
+	case ValueTypeF64:
+		return globalF64(exp.Global.Val)
+	default:
+		panic(fmt.Errorf("BUG: unknown value type %X", valType))
+	}
+}

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -1,0 +1,279 @@
+package internalwasm
+
+import (
+	"context"
+	gobinary "encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	publicwasm "github.com/tetratelabs/wazero/wasm"
+)
+
+func TestGlobalTypes(t *testing.T) {
+	tests := []struct {
+		name            string
+		global          publicwasm.Global
+		expectedType    publicwasm.ValueType
+		expectedVal     uint64
+		expectedString  string
+		expectedMutable bool
+	}{
+		{
+			name:           "i32 - immutable",
+			global:         globalI32(1),
+			expectedType:   ValueTypeI32,
+			expectedVal:    1,
+			expectedString: "global(1)",
+		},
+		{
+			name:           "i64 - immutable",
+			global:         globalI64(1),
+			expectedType:   ValueTypeI64,
+			expectedVal:    1,
+			expectedString: "global(1)",
+		},
+		{
+			name:           "f32 - immutable",
+			global:         globalF32(publicwasm.EncodeF32(1.0)),
+			expectedType:   ValueTypeF32,
+			expectedVal:    publicwasm.EncodeF32(1.0),
+			expectedString: "global(1.000000)",
+		},
+		{
+			name:           "f64 - immutable",
+			global:         globalF64(publicwasm.EncodeF64(1.0)),
+			expectedType:   ValueTypeF64,
+			expectedVal:    publicwasm.EncodeF64(1.0),
+			expectedString: "global(1.000000)",
+		},
+		{
+			name: "i32 - mutable",
+			global: &mutableGlobal{g: &GlobalInstance{
+				Type: &GlobalType{ValType: ValueTypeI32, Mutable: true},
+				Val:  1,
+			}},
+			expectedType:    ValueTypeI32,
+			expectedVal:     1,
+			expectedString:  "global(1)",
+			expectedMutable: true,
+		},
+		{
+			name: "i64 - mutable",
+			global: &mutableGlobal{g: &GlobalInstance{
+				Type: &GlobalType{ValType: ValueTypeI64, Mutable: true},
+				Val:  1,
+			}},
+			expectedType:    ValueTypeI64,
+			expectedVal:     1,
+			expectedString:  "global(1)",
+			expectedMutable: true,
+		},
+		{
+			name: "f32 - mutable",
+			global: &mutableGlobal{g: &GlobalInstance{
+				Type: &GlobalType{ValType: ValueTypeF32, Mutable: true},
+				Val:  publicwasm.EncodeF32(1.0),
+			}},
+			expectedType:    ValueTypeF32,
+			expectedVal:     publicwasm.EncodeF32(1.0),
+			expectedString:  "global(1.000000)",
+			expectedMutable: true,
+		},
+		{
+			name: "f64 - mutable",
+			global: &mutableGlobal{g: &GlobalInstance{
+				Type: &GlobalType{ValType: ValueTypeF64, Mutable: true},
+				Val:  publicwasm.EncodeF64(1.0),
+			}},
+			expectedType:    ValueTypeF64,
+			expectedVal:     publicwasm.EncodeF64(1.0),
+			expectedString:  "global(1.000000)",
+			expectedMutable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedType, tc.global.Type())
+			require.Equal(t, tc.expectedVal, tc.global.Get())
+			require.Equal(t, tc.expectedString, tc.global.String())
+
+			mutable, ok := tc.global.(publicwasm.MutableGlobal)
+			require.Equal(t, tc.expectedMutable, ok)
+			if ok {
+				mutable.Set(2)
+				require.Equal(t, uint64(2), tc.global.Get())
+			}
+		})
+	}
+}
+
+func TestPublicModule_Global(t *testing.T) {
+	tests := []struct {
+		name     string
+		module   *Module // module as wat doesn't yet support globals
+		expected publicwasm.Global
+	}{
+		{
+			name:   "no global",
+			module: &Module{},
+		},
+		{
+			name: "global not exported",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeI32},
+						Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{1}},
+					},
+				},
+			},
+		},
+		{
+			name: "global exported - immutable I32",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeI32},
+						Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{1}},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: globalI32(1),
+		},
+		{
+			name: "global exported - immutable I64",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeI64},
+						Init: &ConstantExpression{Opcode: OpcodeI64Const, Data: []byte{1}},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: globalI64(1),
+		},
+		{
+			name: "global exported - immutable F32",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeF32},
+						Init: &ConstantExpression{Opcode: OpcodeF32Const,
+							Data: uint64Le(publicwasm.EncodeF32(1.0)),
+						},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: globalF32(publicwasm.EncodeF32(1.0)),
+		},
+		{
+			name: "global exported - immutable F64",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeF64},
+						Init: &ConstantExpression{Opcode: OpcodeF64Const,
+							Data: uint64Le(publicwasm.EncodeF64(1.0)),
+						},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: globalF64(publicwasm.EncodeF64(1.0)),
+		},
+		{
+			name: "global exported - mutable I32",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeI32, Mutable: true},
+						Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{1}},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: &mutableGlobal{
+				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeI32, Mutable: true}, Val: 1},
+			},
+		},
+		{
+			name: "global exported - mutable I64",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeI64, Mutable: true},
+						Init: &ConstantExpression{Opcode: OpcodeI64Const, Data: []byte{1}},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: &mutableGlobal{
+				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeI64, Mutable: true}, Val: 1},
+			},
+		},
+		{
+			name: "global exported - mutable F32",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeF32, Mutable: true},
+						Init: &ConstantExpression{Opcode: OpcodeF32Const,
+							Data: uint64Le(publicwasm.EncodeF32(1.0)),
+						},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: &mutableGlobal{
+				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeF32, Mutable: true}, Val: publicwasm.EncodeF32(1.0)},
+			},
+		},
+		{
+			name: "global exported - mutable F64",
+			module: &Module{
+				GlobalSection: []*Global{
+					{
+						Type: &GlobalType{ValType: ValueTypeF64, Mutable: true},
+						Init: &ConstantExpression{Opcode: OpcodeF64Const,
+							Data: uint64Le(publicwasm.EncodeF64(1.0)),
+						},
+					},
+				},
+				ExportSection: map[string]*Export{"global": {Type: ExternTypeGlobal, Name: "global"}},
+			},
+			expected: &mutableGlobal{
+				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: publicwasm.EncodeF64(1.0)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		s := NewStore(context.Background(), &catchContext{})
+		t.Run(tc.name, func(t *testing.T) {
+			// Instantiate the module and get the export of the above global
+			module, err := s.Instantiate(tc.module, "")
+			require.NoError(t, err)
+
+			if global := module.Global("global"); tc.expected != nil {
+				require.Equal(t, tc.expected, global)
+			} else {
+				require.Nil(t, global)
+			}
+		})
+	}
+}
+
+func uint64Le(v uint64) (ret []byte) {
+	ret = make([]byte, 8)
+	gobinary.LittleEndian.PutUint64(ret, v)
+	return
+}

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -322,11 +322,10 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 							if c.Action.Module != "" {
 								msg += " in module " + c.Action.Module
 							}
-							inst, ok := store.ModuleInstances[moduleName]
-							require.True(t, ok, msg)
-							addr, err := inst.GetExport(c.Action.Field, wasm.ExternTypeGlobal)
-							require.NoError(t, err)
-							actual := addr.Global
+							module := store.Module(moduleName)
+							require.NotNil(t, module)
+							global := module.Global(c.Action.Field)
+							require.NotNil(t, global)
 							var expType wasm.ValueType
 							switch c.Exps[0].ValType {
 							case "i32":
@@ -338,9 +337,8 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 							case "f64":
 								expType = wasm.ValueTypeF64
 							}
-							require.NotNil(t, actual, msg)
-							require.Equal(t, expType, actual.Type.ValType, msg)
-							require.Equal(t, exps[0], actual.Val, expType, msg)
+							require.Equal(t, expType, global.Type(), msg)
+							require.Equal(t, exps[0], global.Get(), msg)
 						default:
 							t.Fatalf("unsupported action type type: %v", c)
 						}


### PR DESCRIPTION
Global is a WebAssembly 1.0 (20191205) global exported from an
instantiated module (wazero.Runtime NewModule).

Ex. If the value is not mutable, you can read it once:
```go
offset := module.Global("memory.offset").Get()
```

Globals are allowed by specification to be mutable. However, this can
be disabled by configuration. When in doubt, safe cast to find out if
the value can change.

Ex.
```go
offset := module.Global("memory.offset")
if _, ok := offset.(wasm.MutableGlobal); ok {
	value can change
} else {
	value is constant
}
```

See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#globals%E2%91%A0