### PR TITLE
Stubs WASI functions for GrainLang

### DIFF
--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -34,7 +34,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-args_getargv-pointerpointeru8-argv_buf-pointeru8---errno
 	FunctionArgsGet = "args_get"
 
-	// ImportArgsGet is the WebAssembly 1.0 (20191205) Text format import of FunctionArgsGet
+	// ImportArgsGet is the WebAssembly 1.0 (20191205) Text format import of FunctionArgsGet.
 	ImportArgsGet = `(import "wasi_snapshot_preview1" "args_get"
     (func $wasi.args_get (param $argv i32) (param $argv_buf i32) (result (;errno;) i32)))`
 
@@ -42,7 +42,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-args_sizes_get---errno-size-size
 	FunctionArgsSizesGet = "args_sizes_get"
 
-	// ImportArgsSizesGet is the WebAssembly 1.0 (20191205) Text format import of FunctionArgsSizesGet
+	// ImportArgsSizesGet is the WebAssembly 1.0 (20191205) Text format import of FunctionArgsSizesGet.
 	ImportArgsSizesGet = `(import "wasi_snapshot_preview1" "args_sizes_get"
     (func $wasi.args_sizes_get (param $result.argc i32) (param $result.argv_buf_size i32) (result (;errno;) i32)))`
 
@@ -50,7 +50,7 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-environ_getenviron-pointerpointeru8-environ_buf-pointeru8---errno
 	FunctionEnvironGet = "environ_get"
 
-	// ImportEnvironGet is the WebAssembly 1.0 (20191205) Text format import of FunctionEnvironGet
+	// ImportEnvironGet is the WebAssembly 1.0 (20191205) Text format import of FunctionEnvironGet.
 	ImportEnvironGet = `(import "wasi_snapshot_preview1" "environ_get"
     (func $wasi.environ_get (param $environ i32) (param $environ_buf i32) (result (;errno;) i32)))`
 
@@ -58,137 +58,367 @@ const (
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-environ_sizes_get---errno-size-size
 	FunctionEnvironSizesGet = "environ_sizes_get"
 
-	// ImportEnvironSizesGet is the WebAssembly 1.0 (20191205) Text format import of FunctionEnvironSizesGet
-	ImportEnvironSizesGet = `
-(import "wasi_snapshot_preview1" "environ_sizes_get"
+	// ImportEnvironSizesGet is the WebAssembly 1.0 (20191205) Text format import of FunctionEnvironSizesGet.
+	ImportEnvironSizesGet = `(import "wasi_snapshot_preview1" "environ_sizes_get"
     (func $wasi.environ_sizes_get (param $result.environc i32) (param $result.environBufSize i32) (result (;errno;) i32)))`
 
 	// FunctionClockResGet returns the resolution of a clock.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_res_getid-clockid---errno-timestamp
 	FunctionClockResGet = "clock_res_get"
 
-	// ImportClockResGet is the WebAssembly 1.0 (20191205) Text format import of FunctionClockResGet
-	ImportClockResGet = `
-(import "wasi_snapshot_preview1" "clock_res_get"
+	// ImportClockResGet is the WebAssembly 1.0 (20191205) Text format import of FunctionClockResGet.
+	ImportClockResGet = `(import "wasi_snapshot_preview1" "clock_res_get"
     (func $wasi.clock_res_get (param $id i32) (param $result.resolution i32) (result (;errno;) i32)))`
 
 	// FunctionClockTimeGet returns the time value of a clock.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_time_getid-clockid-precision-timestamp---errno-timestamp
 	FunctionClockTimeGet = "clock_time_get"
 
-	// ImportClockTimeGet is the WebAssembly 1.0 (20191205) Text format import of FunctionClockTimeGet
+	// ImportClockTimeGet is the WebAssembly 1.0 (20191205) Text format import of FunctionClockTimeGet.
 	ImportClockTimeGet = `(import "wasi_snapshot_preview1" "clock_time_get"
     (func $wasi.clock_time_get (param $id i32) (param $precision i64) (param $result.timestamp i32) (result (;errno;) i32)))`
 
-	FunctionFdAdvise   = "fd_advise"
+	// FunctionFdAdvise provides file advisory information on a file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_advisefd-fd-offset-filesize-len-filesize-advice-advice---errno
+	FunctionFdAdvise = "fd_advise"
+
+	// ImportFdAdvise is the WebAssembly 1.0 (20191205) Text format import of FunctionFdAdvise.
+	ImportFdAdvise = `(import "wasi_snapshot_preview1" "fd_advise"
+    (func $wasi.fd_advise (param $fd i32) (param $offset i64) (param $len i64) (param $result.advice i32) (result (;errno;) i32)))`
+
+	// FunctionFdAllocate forces the allocation of space in a file.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_allocatefd-fd-offset-filesize-len-filesize---errno
 	FunctionFdAllocate = "fd_allocate"
+
+	// ImportFdAllocate is the WebAssembly 1.0 (20191205) Text format import of FunctionFdAllocate.
+	ImportFdAllocate = `(import "wasi_snapshot_preview1" "fd_allocate"
+    (func $wasi.fd_allocate (param $fd i32) (param $offset i64) (param $len i64) (result (;errno;) i32)))`
 
 	// FunctionFdClose closes a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_close
 	FunctionFdClose = "fd_close"
-	// ImportFdClose is the WebAssembly 1.0 (20191205) Text format import of FunctionFdClose
+
+	// ImportFdClose is the WebAssembly 1.0 (20191205) Text format import of FunctionFdClose.
 	ImportFdClose = `(import "wasi_snapshot_preview1" "fd_close"
     (func $wasi.fd_close (param $fd i32) (result (;errno;) i32)))`
 
-	FunctionFdDataSync         = "fd_datasync"
-	FunctionFdFdstatGet        = "fd_fdstat_get"
-	FunctionFdFdstatSetFlags   = "fd_fdstat_set_flags"
-	FunctionFdFdstatSetRights  = "fd_fdstat_set_rights"
-	FunctionFdFilestatGet      = "fd_filestat_get"
-	FunctionFdFilestatSetSize  = "fd_filestat_set_size"
+	// FunctionFdDatasync synchronizes the data of a file to disk.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_close
+	FunctionFdDatasync = "fd_datasync"
+
+	// ImportFdDatasync is the WebAssembly 1.0 (20191205) Text format import of FunctionFdDatasync.
+	ImportFdDatasync = `(import "wasi_snapshot_preview1" "fd_datasync"
+    (func $wasi.fd_datasync (param $fd i32) (result (;errno;) i32)))`
+
+	// FunctionFdFdstatGet gets the attributes of a file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_getfd-fd---errno-fdstat
+	FunctionFdFdstatGet = "fd_fdstat_get"
+
+	// ImportFdFdstatGet is the WebAssembly 1.0 (20191205) Text format import of FunctionFdFdstatGet.
+	ImportFdFdstatGet = `(import "wasi_snapshot_preview1" "fd_fdstat_get"
+    (func $wasi.fd_fdstat_get (param $fd i32) (param $result.stat i32) (result (;errno;) i32)))`
+
+	// FunctionFdFdstatSetFlags adjusts the flags associated with a file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_flagsfd-fd-flags-fdflags---errno
+	FunctionFdFdstatSetFlags = "fd_fdstat_set_flags"
+
+	// ImportFdFdstatSetFlags is the WebAssembly 1.0 (20191205) Text format import of FunctionFdFdstatSetFlags.
+	ImportFdFdstatSetFlags = `(import "wasi_snapshot_preview1" "fd_fdstat_set_flags"
+    (func $wasi.fd_fdstat_set_flags (param $fd i32) (param $flags i32) (result (;errno;) i32)))`
+
+	// FunctionFdFdstatSetRights adjusts the rights associated with a file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_rightsfd-fd-fs_rights_base-rights-fs_rights_inheriting-rights---errno
+	FunctionFdFdstatSetRights = "fd_fdstat_set_rights"
+
+	// ImportFdFdstatSetRights is the WebAssembly 1.0 (20191205) Text format import of FunctionFdFdstatSetRights.
+	ImportFdFdstatSetRights = `(import "wasi_snapshot_preview1" "fd_fdstat_set_rights"
+    (func $wasi.fd_fdstat_set_rights (param $fd i32) (param $fs_rights_base i64) (param $fs_rights_inheriting i64) (result (;errno;) i32)))`
+
+	// FunctionFdFilestatGet returns the attributes of an open file.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_filestat_getfd-fd---errno-filestat
+	FunctionFdFilestatGet = "fd_filestat_get"
+
+	// ImportFdFilestatGet is the WebAssembly 1.0 (20191205) Text format import of FunctionFdFilestatGet.
+	ImportFdFilestatGet = `(import "wasi_snapshot_preview1" "fd_filestat_get"
+    (func $wasi.fd_filestat_get (param $fd i32) (param $result.buf i32) (result (;errno;) i32)))`
+
+	// FunctionFdFilestatSetSize adjusts the size of an open file.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_filestat_set_sizefd-fd-size-filesize---errno
+	FunctionFdFilestatSetSize = "fd_filestat_set_size"
+
+	// ImportFdFilestatSetSize is the WebAssembly 1.0 (20191205) Text format import of FunctionFdFilestatSetSize.
+	ImportFdFilestatSetSize = `(import "wasi_snapshot_preview1" "fd_filestat_set_size"
+    (func $wasi.fd_filestat_set_size (param $fd i32) (param $size i64) (result (;errno;) i32)))`
+
+	// FunctionFdFilestatSetTimes adjusts the times of an open file.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_filestat_set_timesfd-fd-atim-timestamp-mtim-timestamp-fst_flags-fstflags---errno
 	FunctionFdFilestatSetTimes = "fd_filestat_set_times"
-	FunctionFdPread            = "fd_pread"
+
+	// ImportFdFilestatSetTimes is the WebAssembly 1.0 (20191205) Text format import of FunctionFdFilestatSetTimes.
+	ImportFdFilestatSetTimes = `(import "wasi_snapshot_preview1" "fd_filestat_set_times"
+    (func $wasi.fd_filestat_set_times (param $fd i32) (param $atim i64) (param $mtim i64) (param $fst_flags i32) (result (;errno;) i32)))`
+
+	// FunctionFdPread reads from a file descriptor, without using and updating the file descriptor's offset.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_preadfd-fd-iovs-iovec_array-offset-filesize---errno-size
+	FunctionFdPread = "fd_pread"
+
+	// ImportFdPread is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPread.
+	ImportFdPread = `(import "wasi_snapshot_preview1" "fd_pread"
+    (func $wasi.fd_pread (param $fd i32) (param $iovs i32) (param $offset i64) (param $result.nread i32) (result (;errno;) i32)))`
 
 	// FunctionFdPrestatGet returns the prestat data of a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_get
 	FunctionFdPrestatGet = "fd_prestat_get"
-	// ImportFdPrestatGet is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
+
+	// ImportFdPrestatGet is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet.
 	ImportFdPrestatGet = `(import "wasi_snapshot_preview1" "fd_prestat_get"
     (func $wasi.fd_prestat_get (param $fd i32) (param $result.prestat i32) (result (;errno;) i32)))`
 
 	// FunctionFdPrestatDirName returns the path of the pre-opened directory of a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_dir_name
 	FunctionFdPrestatDirName = "fd_prestat_dir_name"
-	// ImportFdPrestatDirName is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
+
+	// ImportFdPrestatDirName is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatDirName.
 	ImportFdPrestatDirName = `(import "wasi_snapshot_preview1" "fd_prestat_dir_name"
     (func $wasi.fd_prestat_dir_name (param $fd i32) (param $path i32) (param $path_len i32) (result (;errno;) i32)))`
 
+	// FunctionFdPwrite writes to a file descriptor, without using and updating the file descriptor's offset.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_pwritefd-fd-iovs-ciovec_array-offset-filesize---errno-size
 	FunctionFdPwrite = "fd_pwrite"
 
-	// FunctionFdRead read bytes from a file descriptor
+	// ImportFdPwrite is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPwrite.
+	ImportFdPwrite = `(import "wasi_snapshot_preview1" "fd_pwrite"
+    (func $wasi.fd_pwrite (param $fd i32) (param $iovs i32) (param $offset i64) (param $result.nwritten i32) (result (;errno;) i32)))`
+
+	// FunctionFdRead read bytes from a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
 	FunctionFdRead = "fd_read"
-	// ImportFdRead is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
+
+	// ImportFdRead is the WebAssembly 1.0 (20191205) Text format import of FunctionFdRead.
 	ImportFdRead = `(import "wasi_snapshot_preview1" "fd_read"
     (func $wasi.fd_read (param $fd i32) (param $iovs i32) (param $iovs_len i32) (param $result.size i32) (result (;errno;) i32)))`
 
-	FunctionFdReaddir  = "fd_readdir"
-	FunctionFdRenumber = "fd_renumber"
-	FunctionFdSeek     = "fd_seek"
-	FunctionFdSync     = "fd_sync"
-	FunctionFdTell     = "fd_tell"
+	// FunctionFdReaddir reads directory entries from a directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_readdirfd-fd-buf-pointeru8-buf_len-size-cookie-dircookie---errno-size
+	FunctionFdReaddir = "fd_readdir"
 
-	// FunctionFdWrite write bytes to a file descriptor
+	// ImportFdReaddir is the WebAssembly 1.0 (20191205) Text format import of FunctionFdReaddir.
+	ImportFdReaddir = `(import "wasi_snapshot_preview1" "fd_readdir"
+    (func $wasi.fd_readdir (param $fd i32) (param $buf i32) (param $buf_len i32) (param $cookie i64) (param $result.bufused i32) (result (;errno;) i32)))`
+
+	// FunctionFdRenumber atomically replaces a file descriptor by renumbering another file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_renumberfd-fd-to-fd---errno
+	FunctionFdRenumber = "fd_renumber"
+
+	// ImportFdRenumber is the WebAssembly 1.0 (20191205) Text format import of FunctionFdRenumber.
+	ImportFdRenumber = `(import "wasi_snapshot_preview1" "fd_renumber"
+    (func $wasi.fd_renumber (param $fd i32) (param $to i32) (result (;errno;) i32)))`
+
+	// FunctionFdSeek moves the offset of a file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_seekfd-fd-offset-filedelta-whence-whence---errno-filesize
+	FunctionFdSeek = "fd_seek"
+
+	// ImportFdSeek is the WebAssembly 1.0 (20191205) Text format import of FunctionFdSeek.
+	ImportFdSeek = `(import "wasi_snapshot_preview1" "fd_seek"
+    (func $wasi.fd_seek (param $fd i32) (param $offset i64) (param $whence i32) (param $result.newoffset i32) (result (;errno;) i32)))`
+
+	// FunctionFdSync synchronizes the data and metadata of a file to disk.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_syncfd-fd---errno
+	FunctionFdSync = "fd_sync"
+
+	// ImportFdSync is the WebAssembly 1.0 (20191205) Text format import of FunctionFdSync.
+	ImportFdSync = `(import "wasi_snapshot_preview1" "fd_sync"
+    (func $wasi.fd_sync (param $fd i32) (result (;errno;) i32)))`
+
+	// FunctionFdTell returns the current offset of a file descriptor.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_tellfd-fd---errno-filesize
+	FunctionFdTell = "fd_tell"
+
+	// ImportFdTell is the WebAssembly 1.0 (20191205) Text format import of FunctionFdTell.
+	ImportFdTell = `(import "wasi_snapshot_preview1" "fd_tell"
+    (func $wasi.fd_tell (param $fd i32) (param $result.offset i32) (result (;errno;) i32)))`
+
+	// FunctionFdWrite write bytes to a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_write
 	FunctionFdWrite = "fd_write"
-	// ImportFdWrite is the WebAssembly 1.0 (20191205) Text format import of FunctionFdPrestatGet
+
+	// ImportFdWrite is the WebAssembly 1.0 (20191205) Text format import of FunctionFdWrite.
 	ImportFdWrite = `(import "wasi_snapshot_preview1" "fd_write"
     (func $wasi.fd_write (param $fd i32) (param $iovs i32) (param $iovs_len i32) (param $result.size i32) (result (;errno;) i32)))`
 
-	FunctionPathCreateDirectory  = "path_create_directory"
-	FunctionPathFilestatGet      = "path_filestat_get"
+	// FunctionPathCreateDirectory creates a directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_create_directoryfd-fd-path-string---errno
+	FunctionPathCreateDirectory = "path_create_directory"
+
+	// ImportPathCreateDirectory is the WebAssembly 1.0 (20191205) Text format import of FunctionPathCreateDirectory.
+	ImportPathCreateDirectory = `(import "wasi_snapshot_preview1" "path_create_directory"
+    (func $wasi.path_create_directory (param $fd i32) (param $path i32) (param $path_len i32) (result (;errno;) i32)))`
+
+	// FunctionPathFilestatGet returns the attributes of a file or directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_filestat_getfd-fd-flags-lookupflags-path-string---errno-filestat
+	FunctionPathFilestatGet = "path_filestat_get"
+
+	// ImportPathFilestatGet is the WebAssembly 1.0 (20191205) Text format import of FunctionPathFilestatGet.
+	ImportPathFilestatGet = `(import "wasi_snapshot_preview1" "path_filestat_get"
+    (func $wasi.path_filestat_get (param $fd i32) (param $flags i32) (param $path i32) (param $path_len i32) (param $result.buf i32) (result (;errno;) i32)))`
+
+	// FunctionPathFilestatSetTimes adjusts the timestamps of a file or directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_filestat_set_timesfd-fd-flags-lookupflags-path-string-atim-timestamp-mtim-timestamp-fst_flags-fstflags---errno
 	FunctionPathFilestatSetTimes = "path_filestat_set_times"
-	FunctionPathLink             = "path_link"
-	FunctionPathOpen             = "path_open"
-	FunctionPathReadlink         = "path_readlink"
-	FunctionPathRemoveDirectory  = "path_remove_directory"
-	FunctionPathRename           = "path_rename"
-	FunctionPathSymlink          = "path_symlink"
-	FunctionPathUnlinkFile       = "path_unlink_file"
-	FunctionPollOneoff           = "poll_oneoff"
+
+	// ImportPathFilestatSetTimes is the WebAssembly 1.0 (20191205) Text format import of FunctionPathFilestatSetTimes.
+	ImportPathFilestatSetTimes = `(import "wasi_snapshot_preview1" "path_filestat_set_times"
+    (func $wasi.path_filestat_set_times (param $fd i32) (param $flags i32) (param $path i32) (param $path_len i32) (param $atim i64) (param $mtim i64) (param $fst_flags i32) (result (;errno;) i32)))`
+
+	// FunctionPathLink adjusts the timestamps of a file or directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#path_link
+	FunctionPathLink = "path_link"
+
+	// ImportPathLink is the WebAssembly 1.0 (20191205) Text format import of FunctionPathLink.
+	ImportPathLink = `(import "wasi_snapshot_preview1" "path_link"
+    (func $wasi.path_link (param $old_fd i32) (param $old_flags i32) (param $old_path i32) (param $old_path_len i32) (param $new_fd i32) (param $new_path i32) (param $new_path_len i32) (result (;errno;) i32)))`
+
+	// FunctionPathOpen opens a file or directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_openfd-fd-dirflags-lookupflags-path-string-oflags-oflags-fs_rights_base-rights-fs_rights_inheriting-rights-fdflags-fdflags---errno-fd
+	FunctionPathOpen = "path_open"
+
+	// ImportPathOpen is the WebAssembly 1.0 (20191205) Text format import of FunctionPathOpen.
+	ImportPathOpen = `(import "wasi_snapshot_preview1" "path_open"
+    (func $wasi.path_open (param $fd i32) (param $dirflags i32) (param $path i32) (param $path_len i32) (param $oflags i32) (param $fs_rights_base i64) (param $fs_rights_inheriting i64) (param $fdflags i32) (param $result.opened_fd i32) (result (;errno;) i32)))`
+
+	// FunctionPathReadlink reads the contents of a symbolic link.
+	// See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_readlinkfd-fd-path-string-buf-pointeru8-buf_len-size---errno-size
+	FunctionPathReadlink = "path_readlink"
+
+	// ImportPathReadlink is the WebAssembly 1.0 (20191205) Text format import of FunctionPathReadlink.
+	ImportPathReadlink = `(import "wasi_snapshot_preview1" "path_readlink"
+    (func $wasi.path_readlink (param $fd i32) (param $path i32) (param $path_len i32) (param $buf i32) (param $buf_len i32) (param $result.bufused i32) (result (;errno;) i32)))`
+
+	// FunctionPathRemoveDirectory removes a directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_remove_directoryfd-fd-path-string---errno
+	FunctionPathRemoveDirectory = "path_remove_directory"
+
+	// ImportPathRemoveDirectory is the WebAssembly 1.0 (20191205) Text format import of FunctionPathRemoveDirectory.
+	ImportPathRemoveDirectory = `(import "wasi_snapshot_preview1" "path_remove_directory"
+    (func $wasi.path_remove_directory (param $fd i32) (param $path i32) (param $path_len i32) (result (;errno;) i32)))`
+
+	// FunctionPathRename renames a file or directory.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_renamefd-fd-old_path-string-new_fd-fd-new_path-string---errno
+	FunctionPathRename = "path_rename"
+
+	// ImportPathRename is the WebAssembly 1.0 (20191205) Text format import of FunctionPathRename.
+	ImportPathRename = `(import "wasi_snapshot_preview1" "path_rename"
+    (func $wasi.path_rename (param $fd i32) (param $old_path i32) (param $old_path_len i32) (param $new_fd i32) (param $new_path i32) (param $new_path_len i32) (result (;errno;) i32)))`
+
+	// FunctionPathSymlink creates a symbolic link.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#path_symlink
+	FunctionPathSymlink = "path_symlink"
+
+	// ImportPathSymlink is the WebAssembly 1.0 (20191205) Text format import of FunctionPathSymlink.
+	ImportPathSymlink = `(import "wasi_snapshot_preview1" "path_symlink"
+    (func $wasi.path_symlink (param $old_path i32) (param $old_path_len i32) (param $new_fd i32) (param $fd i32) (param $new_path i32) (param $new_path_len i32) (result (;errno;) i32)))`
+
+	// FunctionPathUnlinkFile unlinks a file.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_unlink_filefd-fd-path-string---errno
+	FunctionPathUnlinkFile = "path_unlink_file"
+
+	// ImportPathUnlinkFile is the WebAssembly 1.0 (20191205) Text format import of FunctionPathUnlinkFile.
+	ImportPathUnlinkFile = `(import "wasi_snapshot_preview1" "path_unlink_file"
+    (func $wasi.path_unlink_file (param $fd i32) (param $path i32) (param $path_len i32) (result (;errno;) i32)))`
+
+	// FunctionPollOneoff unlinks a file.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-poll_oneoffin-constpointersubscription-out-pointerevent-nsubscriptions-size---errno-size
+	FunctionPollOneoff = "poll_oneoff"
+
+	// ImportPollOneoff is the WebAssembly 1.0 (20191205) Text format import of FunctionPollOneoff.
+	ImportPollOneoff = `(import "wasi_snapshot_preview1" "poll_oneoff"
+    (func $wasi.poll_oneoff (param $in i32) (param $out i32) (param $nsubscriptions i32) (param $result.nevents i32) (result (;errno;) i32)))`
 
 	// FunctionProcExit terminates the execution of the module with an exit code.
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 	FunctionProcExit = "proc_exit"
 
-	// ImportProcExit is the WebAssembly 1.0 (20191205) Text format import of ProcExit
+	// ImportProcExit is the WebAssembly 1.0 (20191205) Text format import of FunctionProcExit.
 	//
 	// See ImportProcExit
-	// See API.ProcExit
+	// See SnapshotPreview1.ProcExit
 	// See FunctionProcExit
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#proc_exit
 	ImportProcExit = `(import "wasi_snapshot_preview1" "proc_exit"
     (func $wasi.proc_exit (param $rval i32)))`
 
-	FunctionProcRaise  = "proc_raise"
+	// FunctionProcRaise sends a signal to the process of the calling thread.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-proc_raisesig-signal---errno
+	FunctionProcRaise = "proc_raise"
+
+	// ImportProcRaise is the WebAssembly 1.0 (20191205) Text format import of FunctionProcRaise.
+	ImportProcRaise = `(import "wasi_snapshot_preview1" "proc_raise"
+    (func $wasi.proc_raise (param $sig i32) (result (;errno;) i32)))`
+
+	// FunctionSchedYield temporarily yields execution of the calling thread.
+	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sched_yield---errno
 	FunctionSchedYield = "sched_yield"
 
-	// FunctionRandomGet write random data in buffer
+	// ImportSchedYield is the WebAssembly 1.0 (20191205) Text format import of FunctionSchedYield.
+	ImportSchedYield = `(import "wasi_snapshot_preview1" "sched_yield"
+    (func $wasi.sched_yield (result (;errno;) i32)))`
+
+	// FunctionRandomGet writes random data in buffer.
 	// See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-random_getbuf-pointeru8-buf_len-size---errno
 	FunctionRandomGet = "random_get"
 
-	// ImportRandomGet is the WebAssembly 1.0 (20191205) Text format import of FunctionRandomGet
+	// ImportRandomGet is the WebAssembly 1.0 (20191205) Text format import of FunctionRandomGet.
 	ImportRandomGet = `(import "wasi_snapshot_preview1" "random_get"
     (func $wasi.random_get (param $buf i32) (param $buf_len i32) (result (;errno;) i32)))`
 
-	FunctionSockRecv     = "sock_recv"
-	FunctionSockSend     = "sock_send"
+	// FunctionSockRecv receives a message from a socket.
+	// See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_recvfd-fd-ri_data-iovec_array-ri_flags-riflags---errno-size-roflags
+	FunctionSockRecv = "sock_recv"
+
+	// ImportSockRecv is the WebAssembly 1.0 (20191205) Text format import of FunctionSockRecv.
+	ImportSockRecv = `(import "wasi_snapshot_preview1" "sock_recv"
+    (func $wasi.sock_recv (param $fd i32) (param $ri_data i32) (param $ri_data_count i32) (param $ri_flags i32) (param $result.ro_datalen i32) (param $result.ro_flags i32) (result (;errno;) i32)))`
+
+	// FunctionSockSend sends a message on a socket.
+	// See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_sendfd-fd-si_data-ciovec_array-si_flags-siflags---errno-size
+	FunctionSockSend = "sock_send"
+
+	// ImportSockSend is the WebAssembly 1.0 (20191205) Text format import of FunctionSockSend.
+	ImportSockSend = `(import "wasi_snapshot_preview1" "sock_send"
+    (func $wasi.sock_send (param $fd i32) (param $si_data i32) (param $si_data_count i32) (param $si_flags i32) (param $result.so_datalen i32) (result (;errno;) i32)))`
+
+	// FunctionSockShutdown shuts down socket send and receive channels.
+	// See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_shutdownfd-fd-how-sdflags---errno
 	FunctionSockShutdown = "sock_shutdown"
+
+	// ImportSockShutdown is the WebAssembly 1.0 (20191205) Text format import of FunctionSockShutdown.
+	ImportSockShutdown = `(import "wasi_snapshot_preview1" "sock_shutdown"
+    (func $wasi.sock_shutdown (param $fd i32) (param $how i32) (result (;errno;) i32)))`
 )
 
 // SnapshotPreview1 includes all host functions to export for WASI version wasi.ModuleSnapshotPreview1.
 //
-// Note: When translating WASI functions, each result besides Errno is always an uint32 parameter. WebAssembly 1.0 (20191205)
-// can have up to one result, which is already used by Errno. This forces other results to be parameters. A result
-// parameter is a memory offset to write the result to. As memory offsets are uint32, each parameter representing a
-// result is uint32.
+// ## Translation notes
+// ### String
+// WebAssembly 1.0 (20191205) has no string type, so any string input parameter expands to two uint32 parameters: offset
+// and length.
 //
-// Note: The WASI specification is sometimes ambiguous resulting in some runtimes interpreting the same function
-// ways. wasi.Errno mappings are not defined in WASI, yet, so these mappings are best efforts by maintainers. When in
-// doubt about portability, first look at internal/wasi/RATIONALE.md and if needed an issue on
+// ### iovec_array
+// `iovec_array` is encoded as two uin32le values (i32): offset and count.
+//
+// ### Result
+// Each result besides wasi.Errno is always an uint32 parameter. WebAssembly 1.0 (20191205) can have up to one result,
+// which is already used by wasi.Errno. This forces other results to be parameters. A result parameter is a memory
+// offset to write the result to. As memory offsets are uint32, each parameter representing a result is uint32.
+//
+// ### Errno
+// The WASI specification is sometimes ambiguous resulting in some runtimes interpreting the same function ways.
+// wasi.Errno mappings are not defined in WASI, yet, so these mappings are best efforts by maintainers. When in doubt
+// about portability, first look at internal/wasi/RATIONALE.md and if needed an issue on
 // https://github.com/WebAssembly/WASI/issues
 //
-// Note: In WebAssembly 1.0 (20191205), there may be up to one Memory per store, which means wasm.Memory is always the
+// ## Memory
+// In WebAssembly 1.0 (20191205), there may be up to one Memory per store, which means wasm.Memory is always the
 // wasm.Store Memories index zero: `store.Memories[0].Buffer`
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
@@ -308,7 +538,8 @@ type SnapshotPreview1 interface {
 	// See https://en.wikipedia.org/wiki/Null-terminated_string
 	EnvironSizesGet(ctx wasm.ModuleContext, resultEnvironc, resultEnvironBufSize uint32) wasi.Errno
 
-	// TODO: ClockResGet(ctx wasm.ModuleContext, id, resultResolution uint32) wasi.Errno
+	// ClockResGet is the WASI function named FunctionClockResGet and is stubbed for GrainLang per #271
+	ClockResGet(ctx wasm.ModuleContext, id uint32, resultResolution uint32) wasi.Errno
 
 	// ClockTimeGet is the WASI function named FunctionClockTimeGet that returns the time value of a clock (time.Now).
 	//
@@ -332,8 +563,11 @@ type SnapshotPreview1 interface {
 	// See https://linux.die.net/man/3/clock_gettime
 	ClockTimeGet(ctx wasm.ModuleContext, id uint32, precision uint64, resultTimestamp uint32) wasi.Errno
 
-	// TODO: wasi.FdAdvise
-	// TODO: wasi.FdAllocate
+	// FdAdvise is the WASI function named FunctionFdAdvise and is stubbed for GrainLang per #271
+	FdAdvise(ctx wasm.ModuleContext, fd uint32, offset, len uint64, resultAdvice uint32) wasi.Errno
+
+	// FdAllocate is the WASI function named FunctionFdAllocate and is stubbed for GrainLang per #271
+	FdAllocate(ctx wasm.ModuleContext, fd uint32, offset, len uint64, resultAdvice uint32) wasi.Errno
 
 	// FdClose is the WASI function to close a file descriptor. This returns ErrnoBadf if the fd is invalid.
 	//
@@ -345,14 +579,30 @@ type SnapshotPreview1 interface {
 	// See https://linux.die.net/man/3/close
 	FdClose(ctx wasm.ModuleContext, fd uint32) wasi.Errno
 
-	// TODO: wasi.FdDataSync
-	// TODO: wasi.FdFdstatGet
-	// TODO: wasi.FdFdstatSetFlags
-	// TODO: wasi.FdFdstatSetRights
-	// TODO: wasi.FdFilestatGet
-	// TODO: wasi.FdFilestatSetSize
-	// TODO: wasi.FdFilestatSetTimes
-	// TODO: wasi.FdPread
+	// FdDatasync is the WASI function named FunctionFdDatasync and is stubbed for GrainLang per #271
+	FdDatasync(ctx wasm.ModuleContext, fd uint32) wasi.Errno
+
+	// FdFdstatGet is the WASI function named FunctionFdFdstatGet
+	// TODO: complete documentation and tests
+	FdFdstatGet(ctx wasm.ModuleContext, fd uint32, resultStat uint32) wasi.Errno
+
+	// FdFdstatSetFlags is the WASI function named FunctionFdFdstatSetFlags and is stubbed for GrainLang per #271
+	FdFdstatSetFlags(ctx wasm.ModuleContext, fd uint32, flags uint32) wasi.Errno
+
+	// FdFdstatSetRights is the WASI function named FunctionFdFdstatSetRights and is stubbed for GrainLang per #271
+	FdFdstatSetRights(ctx wasm.ModuleContext, fd uint32, fsRightsBase, fsRightsInheriting uint64) wasi.Errno
+
+	// FdFilestatGet is the WASI function named FunctionFdFilestatGet
+	FdFilestatGet(ctx wasm.ModuleContext, fd uint32, resultBuf uint32) wasi.Errno
+
+	// FdFilestatSetSize is the WASI function named FunctionFdFilestatSetSize
+	FdFilestatSetSize(ctx wasm.ModuleContext, fd uint32, size uint64) wasi.Errno
+
+	// FdFilestatSetTimes is the WASI function named FunctionFdFilestatSetTimes
+	FdFilestatSetTimes(ctx wasm.ModuleContext, fd uint32, atim, mtim uint64, fstFlags uint32) wasi.Errno
+
+	// FdPread is the WASI function named FunctionFdPread
+	FdPread(ctx wasm.ModuleContext, fd, iovs uint32, offset uint64, resultNread uint32) wasi.Errno
 
 	// FdPrestatGet is the WASI function to return the prestat data of a file descriptor.
 	// This returns wasi.ErrnoBadf if the fd is invalid.
@@ -404,17 +654,18 @@ type SnapshotPreview1 interface {
 	// Note: ImportFdPrestatDirName shows this signature in the WebAssembly 1.0 (20191205) Text Format.
 	// See FdPrestatGet
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_dir_name
-	FdPrestatDirName(ctx wasm.ModuleContext, fd uint32, path uint32, pathLen uint32) wasi.Errno
+	FdPrestatDirName(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno
 	// TODO: FdPrestatDirName may have to return ErrnoNotdir if the type of the prestat data of `fd` is not a PrestatDir.
 
-	// TODO: wasi.FdPwrite
+	// FdPwrite is the WASI function named FunctionFdPwrite
+	FdPwrite(ctx wasm.ModuleContext, fd, iovs uint32, offset uint64, resultNwritten uint32) wasi.Errno
 
 	// FdRead is the WASI function to read from a file descriptor.
 	//
 	// * fd - an opened file descriptor to read data from
 	// * iovs - the offset in `ctx.Memory` to read offset, size pairs representing where to write file data.
 	//   * Both offset and length are encoded as uint32le.
-	// * iovsLen - the count of memory offset, size pairs to read sequentially starting at iovs.
+	// * iovsCount - the count of memory offset, size pairs to read sequentially starting at iovs.
 	// * resultSize - the offset in `ctx.Memory` to write the number of bytes read
 	//
 	// The wasi.Errno returned is wasi.ErrnoSuccess except the following error conditions:
@@ -423,7 +674,7 @@ type SnapshotPreview1 interface {
 	// * wasi.ErrnoIo - if an IO related error happens during the operation
 	//
 	// For example, this function needs to first read `iovs` to determine where to write contents. If
-	//    parameters iovs=1 iovsLen=2, this function reads two offset/length pairs from `ctx.Memory`:
+	//    parameters iovs=1 iovsCount=2, this function reads two offset/length pairs from `ctx.Memory`:
 	//
 	//                      iovs[0]                  iovs[1]
 	//              +---------------------+   +--------------------+
@@ -452,20 +703,29 @@ type SnapshotPreview1 interface {
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#iovec
 	// See https://linux.die.net/man/3/readv
-	FdRead(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno
+	FdRead(ctx wasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno
 
-	// TODO: wasi.FdReaddir
-	// TODO: wasi.FdRenumber
-	// TODO: wasi.FdSeek
-	// TODO: wasi.FdSync
-	// TODO: wasi.FdTell
+	// FdReaddir is the WASI function named FunctionFdReaddir
+	FdReaddir(ctx wasm.ModuleContext, fd, buf, bufLen uint32, cookie uint64, resultBufused uint32) wasi.Errno
+
+	// FdRenumber is the WASI function named FunctionFdRenumber
+	FdRenumber(ctx wasm.ModuleContext, fd, to uint32) wasi.Errno
+
+	// FdSeek is the WASI function named FunctionFdSeek
+	FdSeek(ctx wasm.ModuleContext, fd uint32, offset uint64, whence uint32, resultNewoffset uint32) wasi.Errno
+
+	// FdSync is the WASI function named FunctionFdSync
+	FdSync(ctx wasm.ModuleContext, fd uint32) wasi.Errno
+
+	// FdTell is the WASI function named FunctionFdTell
+	FdTell(ctx wasm.ModuleContext, fd, resultOffset uint32) wasi.Errno
 
 	// FdWrite is the WASI function to write to a file descriptor.
 	//
 	// * fd - an opened file descriptor to write data to
 	// * iovs - the offset in `ctx.Memory` to read offset, size pairs representing the data to write to `fd`
 	//   * Both offset and length are encoded as uint32le.
-	// * iovsLen - the count of memory offset, size pairs to read sequentially starting at iovs.
+	// * iovsCount - the count of memory offset, size pairs to read sequentially starting at iovs.
 	// * resultSize - the offset in `ctx.Memory` to write the number of bytes written
 	//
 	// The wasi.Errno returned is wasi.ErrnoSuccess except the following error conditions:
@@ -474,7 +734,7 @@ type SnapshotPreview1 interface {
 	// * wasi.ErrnoIo - if an IO related error happens during the operation
 	//
 	// For example, this function needs to first read `iovs` to determine what to write to `fd`. If
-	//    parameters iovs=1 iovsLen=2, this function reads two offset/length pairs from `ctx.Memory`:
+	//    parameters iovs=1 iovsCount=2, this function reads two offset/length pairs from `ctx.Memory`:
 	//
 	//                      iovs[0]                  iovs[1]
 	//              +---------------------+   +--------------------+
@@ -509,19 +769,40 @@ type SnapshotPreview1 interface {
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#ciovec
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_write
 	// See https://linux.die.net/man/3/writev
-	FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno
+	FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno
 
-	// TODO: PathCreateDirectory
-	// TODO: PathFilestatGet
-	// TODO: PathFilestatSetTimes
-	// TODO: PathLink
-	// TODO: PathOpen
-	// TODO: PathReadlink
-	// TODO: PathRemoveDirectory
-	// TODO: PathRename
-	// TODO: PathSymlink
-	// TODO: PathUnlinkFile
-	// TODO: PollOneoff
+	// PathCreateDirectory is the WASI function named FunctionPathCreateDirectory
+	PathCreateDirectory(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno
+
+	// PathFilestatGet is the WASI function named FunctionPathFilestatGet
+	PathFilestatGet(ctx wasm.ModuleContext, fd, flags, path, pathLen, resultBuf uint32) wasi.Errno
+
+	// PathFilestatSetTimes is the WASI function named FunctionPathFilestatSetTimes
+	PathFilestatSetTimes(ctx wasm.ModuleContext, fd, flags, path, pathLen uint32, atim, mtime uint64, fstFlags uint32) wasi.Errno
+
+	// PathLink is the WASI function named FunctionPathLink
+	PathLink(ctx wasm.ModuleContext, oldFd, oldFlags, oldPath, oldPathLen, newFd, newPath, newPathLen uint32) wasi.Errno
+
+	// PathOpen is the WASI function named FunctionPathOpen
+	PathOpen(ctx wasm.ModuleContext, fd, dirflags, path, pathLen, oflags uint32, fsRightsBase, fsRightsInheriting uint32, fdflags, resultOpenedFd uint32) wasi.Errno
+
+	// PathReadlink is the WASI function named FunctionPathReadlink
+	PathReadlink(ctx wasm.ModuleContext, fd, path, pathLen, buf, bufLen, resultBufused uint32) wasi.Errno
+
+	// PathRemoveDirectory is the WASI function named FunctionPathRemoveDirectory
+	PathRemoveDirectory(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno
+
+	// PathRename is the WASI function named FunctionPathRename
+	PathRename(ctx wasm.ModuleContext, fd, oldPath, oldPathLen, newFd, newPath, newPathLen uint32) wasi.Errno
+
+	// PathSymlink is the WASI function named FunctionPathSymlink
+	PathSymlink(ctx wasm.ModuleContext, oldPath, oldPathLen, fd, newFd, newPath, newPathLen uint32) wasi.Errno
+
+	// PathUnlinkFile is the WASI function named FunctionPathUnlinkFile
+	PathUnlinkFile(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno
+
+	// PollOneoff is the WASI function named FunctionPollOneoff
+	PollOneoff(ctx wasm.ModuleContext, in, out, nsubscriptions, resultNevents uint32) wasi.Errno
 
 	// ProcExit is the WASI function that terminates the execution of the module with an exit code.
 	// An exit code of 0 indicates successful termination. The meanings of other values are not defined by WASI.
@@ -536,8 +817,11 @@ type SnapshotPreview1 interface {
 	// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 	ProcExit(rval uint32)
 
-	// TODO: ProcRaise
-	// TODO: SchedYield
+	// ProcRaise is the WASI function named FunctionProcRaise
+	ProcRaise(ctx wasm.ModuleContext, sig uint32) wasi.Errno
+
+	// SchedYield is the WASI function named FunctionSchedYield
+	SchedYield(ctx wasm.ModuleContext) wasi.Errno
 
 	// RandomGet is the WASI function named FunctionRandomGet that write random data in buffer (rand.Read()).
 	//
@@ -556,9 +840,14 @@ type SnapshotPreview1 interface {
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-random_getbuf-pointeru8-bufLen-size---errno
 	RandomGet(ctx wasm.ModuleContext, buf, bufLen uint32) wasi.Errno
 
-	// TODO: SockRecv
-	// TODO: SockSend
-	// TODO: SockShutdown
+	// SockRecv is the WASI function named FunctionSockRecv
+	SockRecv(ctx wasm.ModuleContext, fd, riData, riDataCount, riFlags, resultRoDataLen, resultRoFlags uint32) wasi.Errno
+
+	// SockSend is the WASI function named FunctionSockSend
+	SockSend(ctx wasm.ModuleContext, fd, siData, siDataCount, siFlags, resultSoDataLen uint32) wasi.Errno
+
+	// SockShutdown is the WASI function named FunctionSockShutdown
+	SockShutdown(ctx wasm.ModuleContext, fd, how uint32) wasi.Errno
 }
 
 type wasiAPI struct {
@@ -583,51 +872,51 @@ func SnapshotPreview1Functions(opts ...Option) (nameToGoFunc map[string]interfac
 	// Note: these are ordered per spec for consistency even if the resulting map can't guarantee that.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#functions
 	nameToGoFunc = map[string]interface{}{
-		FunctionArgsGet:         a.ArgsGet,
-		FunctionArgsSizesGet:    a.ArgsSizesGet,
-		FunctionEnvironGet:      a.EnvironGet,
-		FunctionEnvironSizesGet: a.EnvironSizesGet,
-		// TODO: FunctionClockResGet
-		FunctionClockTimeGet: a.ClockTimeGet,
-		// TODO: FunctionFdAdvise
-		// TODO: FunctionFdAllocate
-		FunctionFdClose: a.FdClose,
-		// TODO: FunctionFdDataSync
-		FunctionFdFdstatGet: a.fd_fdstat_get,
-		// TODO: FunctionFdFdstatSetFlags
-		// TODO: FunctionFdFdstatSetRights
-		// TODO: FunctionFdFilestatGet
-		// TODO: FunctionFdFilestatSetSize
-		// TODO: FunctionFdFilestatSetTimes
-		// TODO: FunctionFdPread
-		FunctionFdPrestatGet:     a.FdPrestatGet,
-		FunctionFdPrestatDirName: a.FdPrestatDirName,
-		// TODO: FunctionFdPwrite
-		FunctionFdRead: a.FdRead,
-		// TODO: FunctionFdReaddir
-		// TODO: FunctionFdRenumber
-		FunctionFdSeek: a.fd_seek,
-		// TODO: FunctionFdSync
-		// TODO: FunctionFdTell
-		FunctionFdWrite: a.FdWrite,
-		// TODO: FunctionPathCreateDirectory
-		// TODO: FunctionPathFilestatGet
-		// TODO: FunctionPathFilestatSetTimes
-		// TODO: FunctionPathLink
-		FunctionPathOpen: a.path_open,
-		// TODO: FunctionPathReadlink
-		// TODO: FunctionPathRemoveDirectory
-		// TODO: FunctionPathRename
-		// TODO: FunctionPathSymlink
-		// TODO: FunctionPathUnlinkFile
-		// TODO: FunctionPollOneoff
-		FunctionProcExit: a.ProcExit,
-		// TODO: FunctionProcRaise
-		// TODO: FunctionSchedYield
-		FunctionRandomGet: a.RandomGet,
-		// TODO: FunctionSockRecv
-		// TODO: FunctionSockSend
-		// TODO: FunctionSockShutdown
+		FunctionArgsGet:              a.ArgsGet,
+		FunctionArgsSizesGet:         a.ArgsSizesGet,
+		FunctionEnvironGet:           a.EnvironGet,
+		FunctionEnvironSizesGet:      a.EnvironSizesGet,
+		FunctionClockResGet:          a.ClockResGet,
+		FunctionClockTimeGet:         a.ClockTimeGet,
+		FunctionFdAdvise:             a.FdAdvise,
+		FunctionFdAllocate:           a.FdAllocate,
+		FunctionFdClose:              a.FdClose,
+		FunctionFdDatasync:           a.FdDatasync,
+		FunctionFdFdstatGet:          a.FdFdstatGet,
+		FunctionFdFdstatSetFlags:     a.FdFdstatSetFlags,
+		FunctionFdFdstatSetRights:    a.FdFdstatSetRights,
+		FunctionFdFilestatGet:        a.FdFilestatGet,
+		FunctionFdFilestatSetSize:    a.FdFilestatSetSize,
+		FunctionFdFilestatSetTimes:   a.FdFilestatSetTimes,
+		FunctionFdPread:              a.FdPread,
+		FunctionFdPrestatGet:         a.FdPrestatGet,
+		FunctionFdPrestatDirName:     a.FdPrestatDirName,
+		FunctionFdPwrite:             a.FdPwrite,
+		FunctionFdRead:               a.FdRead,
+		FunctionFdReaddir:            a.FdReaddir,
+		FunctionFdRenumber:           a.FdRenumber,
+		FunctionFdSeek:               a.FdSeek,
+		FunctionFdSync:               a.FdSync,
+		FunctionFdTell:               a.FdTell,
+		FunctionFdWrite:              a.FdWrite,
+		FunctionPathCreateDirectory:  a.PathCreateDirectory,
+		FunctionPathFilestatGet:      a.PathFilestatGet,
+		FunctionPathFilestatSetTimes: a.PathFilestatSetTimes,
+		FunctionPathLink:             a.PathLink,
+		FunctionPathOpen:             a.PathOpen,
+		FunctionPathReadlink:         a.PathReadlink,
+		FunctionPathRemoveDirectory:  a.PathRemoveDirectory,
+		FunctionPathRename:           a.PathRename,
+		FunctionPathSymlink:          a.PathSymlink,
+		FunctionPathUnlinkFile:       a.PathUnlinkFile,
+		FunctionPollOneoff:           a.PollOneoff,
+		FunctionProcExit:             a.ProcExit,
+		FunctionProcRaise:            a.ProcRaise,
+		FunctionSchedYield:           a.SchedYield,
+		FunctionRandomGet:            a.RandomGet,
+		FunctionSockRecv:             a.SockRecv,
+		FunctionSockSend:             a.SockSend,
+		FunctionSockShutdown:         a.SockShutdown,
 	}
 	return
 }
@@ -688,7 +977,10 @@ func (a *wasiAPI) EnvironSizesGet(ctx wasm.ModuleContext, resultEnvironc uint32,
 	return wasi.ErrnoSuccess
 }
 
-// TODO: Func (a *wasiAPI) FunctionClockResGet
+// ClockResGet implements SnapshotPreview1.ClockResGet
+func (a *wasiAPI) ClockResGet(ctx wasm.ModuleContext, id uint32, resultResolution uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
 
 // ClockTimeGet implements SnapshotPreview1.ClockTimeGet
 func (a *wasiAPI) ClockTimeGet(ctx wasm.ModuleContext, id uint32, precision uint64, resultTimestamp uint32) wasi.Errno {
@@ -699,7 +991,17 @@ func (a *wasiAPI) ClockTimeGet(ctx wasm.ModuleContext, id uint32, precision uint
 	return wasi.ErrnoSuccess
 }
 
-// FdClose implements SnaphotPreview1.FdClose
+// FdAdvise implements SnapshotPreview1.FdAdvise
+func (a *wasiAPI) FdAdvise(ctx wasm.ModuleContext, fd uint32, offset, len uint64, resultAdvice uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdAllocate implements SnapshotPreview1.FdAllocate
+func (a *wasiAPI) FdAllocate(ctx wasm.ModuleContext, fd uint32, offset, len uint64) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdClose implements SnapshotPreview1.FdClose
 func (a *wasiAPI) FdClose(ctx wasm.ModuleContext, fd uint32) wasi.Errno {
 	f, ok := a.opened[fd]
 	if !ok {
@@ -715,17 +1017,23 @@ func (a *wasiAPI) FdClose(ctx wasm.ModuleContext, fd uint32) wasi.Errno {
 	return wasi.ErrnoSuccess
 }
 
-func (a *wasiAPI) fd_fdstat_get(ctx wasm.ModuleContext, fd uint32, bufPtr uint32) wasi.Errno {
+// FdDatasync implements SnapshotPreview1.FdDatasync
+func (a *wasiAPI) FdDatasync(ctx wasm.ModuleContext, fd uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdFdstatGet implements SnapshotPreview1.FdFdstatGet
+func (a *wasiAPI) FdFdstatGet(ctx wasm.ModuleContext, fd uint32, resultStat uint32) wasi.Errno {
 	if _, ok := a.opened[fd]; !ok {
 		return wasi.ErrnoBadf
 	}
-	if !ctx.Memory().WriteUint64Le(bufPtr+16, wasi.R_FD_READ|wasi.R_FD_WRITE) {
+	if !ctx.Memory().WriteUint64Le(resultStat+16, wasi.R_FD_READ|wasi.R_FD_WRITE) {
 		return wasi.ErrnoFault
 	}
 	return wasi.ErrnoSuccess
 }
 
-// FdPrestatGet implements SnahpshotPreview1.FdPrestatGet
+// FdPrestatGet implements SnapshotPreview1.FdPrestatGet
 // TODO: Currently FdPrestatGet implements nothing except returning ErrnoBadf
 func (a *wasiAPI) FdPrestatGet(ctx wasm.ModuleContext, fd uint32, bufPtr uint32) wasi.Errno {
 	if _, ok := a.opened[fd]; !ok {
@@ -734,7 +1042,37 @@ func (a *wasiAPI) FdPrestatGet(ctx wasm.ModuleContext, fd uint32, bufPtr uint32)
 	return wasi.ErrnoSuccess
 }
 
-// FdPrestatDirName implements SnahpshotPreview1.FdPrestatDirName
+// FdFdstatSetFlags implements SnapshotPreview1.FdFdstatSetFlags
+func (a *wasiAPI) FdFdstatSetFlags(ctx wasm.ModuleContext, fd uint32, flags uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdFdstatSetRights implements SnapshotPreview1.FdFdstatSetRights
+func (a *wasiAPI) FdFdstatSetRights(ctx wasm.ModuleContext, fd uint32, fsRightsBase, fsRightsInheriting uint64) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdFilestatGet implements SnapshotPreview1.FdFilestatGet
+func (a *wasiAPI) FdFilestatGet(ctx wasm.ModuleContext, fd uint32, resultBuf uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdFilestatSetSize implements SnapshotPreview1.FdFilestatSetSize
+func (a *wasiAPI) FdFilestatSetSize(ctx wasm.ModuleContext, fd uint32, size uint64) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdFilestatSetTimes implements SnapshotPreview1.FdFilestatSetTimes
+func (a *wasiAPI) FdFilestatSetTimes(ctx wasm.ModuleContext, fd uint32, atim, mtim uint64, fstFlags uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdPread implements SnapshotPreview1.FdPread
+func (a *wasiAPI) FdPread(ctx wasm.ModuleContext, fd, iovs uint32, offset uint64, resultNread uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdPrestatDirName implements SnapshotPreview1.FdPrestatDirName
 func (a *wasiAPI) FdPrestatDirName(ctx wasm.ModuleContext, fd uint32, pathPtr uint32, pathLen uint32) wasi.Errno {
 	f, ok := a.opened[fd]
 	if !ok {
@@ -753,8 +1091,13 @@ func (a *wasiAPI) FdPrestatDirName(ctx wasm.ModuleContext, fd uint32, pathPtr ui
 	return wasi.ErrnoSuccess
 }
 
-// FdRead implements SnahpshotPreview1.FdRead
-func (a *wasiAPI) FdRead(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
+// FdPwrite implements SnapshotPreview1.FdPwrite
+func (a *wasiAPI) FdPwrite(ctx wasm.ModuleContext, fd, iovs uint32, offset uint64, resultNwritten uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdRead implements SnapshotPreview1.FdRead
+func (a *wasiAPI) FdRead(ctx wasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno {
 	var reader io.Reader
 
 	switch fd {
@@ -769,7 +1112,7 @@ func (a *wasiAPI) FdRead(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize u
 	}
 
 	var nread uint32
-	for i := uint32(0); i < iovsLen; i++ {
+	for i := uint32(0); i < iovsCount; i++ {
 		iovPtr := iovs + i*8
 		offset, ok := ctx.Memory().ReadUint32Le(iovPtr)
 		if !ok {
@@ -797,12 +1140,33 @@ func (a *wasiAPI) FdRead(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize u
 	return wasi.ErrnoSuccess
 }
 
-func (a *wasiAPI) fd_seek(ctx wasm.ModuleContext, fd uint32, offset uint64, whence uint32, nwrittenPtr uint32) wasi.Errno {
-	return wasi.ErrnoNosys // TODO: implement
+// FdReaddir implements SnapshotPreview1.FdReaddir
+func (a *wasiAPI) FdReaddir(ctx wasm.ModuleContext, fd, buf, bufLen uint32, cookie uint64, resultBufused uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdRenumber implements SnapshotPreview1.FdRenumber
+func (a *wasiAPI) FdRenumber(ctx wasm.ModuleContext, fd, to uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdSeek implements SnapshotPreview1.FdSeek
+func (a *wasiAPI) FdSeek(ctx wasm.ModuleContext, fd uint32, offset uint64, whence uint32, resultNewoffset uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdSync implements SnapshotPreview1.FdSync
+func (a *wasiAPI) FdSync(ctx wasm.ModuleContext, fd uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// FdTell implements SnapshotPreview1.FdTell
+func (a *wasiAPI) FdTell(ctx wasm.ModuleContext, fd, resultOffset uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
 }
 
 // FdWrite implements SnapshotPreview1.FdWrite
-func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
+func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno {
 	var writer io.Writer
 
 	switch fd {
@@ -819,7 +1183,7 @@ func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize 
 	}
 
 	var nwritten uint32
-	for i := uint32(0); i < iovsLen; i++ {
+	for i := uint32(0); i < iovsCount; i++ {
 		iovPtr := iovs + i*8
 		offset, ok := ctx.Memory().ReadUint32Le(iovPtr)
 		if !ok {
@@ -845,20 +1209,40 @@ func (a *wasiAPI) FdWrite(ctx wasm.ModuleContext, fd, iovs, iovsLen, resultSize 
 	return wasi.ErrnoSuccess
 }
 
-func (a *wasiAPI) path_open(ctx wasm.ModuleContext, fd, dirFlags, pathPtr, pathLen, oFlags uint32,
-	fsRightsBase, fsRightsInheriting uint64,
-	fdFlags, fdPtr uint32) (errno wasi.Errno) {
+// PathCreateDirectory implements SnapshotPreview1.PathCreateDirectory
+func (a *wasiAPI) PathCreateDirectory(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathFilestatGet implements SnapshotPreview1.PathFilestatGet
+func (a *wasiAPI) PathFilestatGet(ctx wasm.ModuleContext, fd, flags, path, pathLen, resultBuf uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathFilestatSetTimes implements SnapshotPreview1.PathFilestatSetTimes
+func (a *wasiAPI) PathFilestatSetTimes(ctx wasm.ModuleContext, fd, flags, path, pathLen uint32, atim, mtime uint64, fstFlags uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathLink implements SnapshotPreview1.PathLink
+func (a *wasiAPI) PathLink(ctx wasm.ModuleContext, oldFd, oldFlags, oldPath, oldPathLen, newFd, newPath, newPathLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathOpen implements SnapshotPreview1.PathOpen
+func (a *wasiAPI) PathOpen(ctx wasm.ModuleContext, fd, dirflags, path, pathLen, oflags uint32, fsRightsBase,
+	fsRightsInheriting uint64, fdflags, resultOpenedFd uint32) (errno wasi.Errno) {
 	dir, ok := a.opened[fd]
 	if !ok || dir.fileSys == nil {
 		return wasi.ErrnoInval
 	}
 
-	b, ok := ctx.Memory().Read(pathPtr, pathLen)
+	b, ok := ctx.Memory().Read(path, pathLen)
 	if !ok {
 		return wasi.ErrnoFault
 	}
-	path := string(b)
-	f, err := dir.fileSys.OpenWASI(dirFlags, path, oFlags, fsRightsBase, fsRightsInheriting, fdFlags)
+	pathName := string(b)
+	f, err := dir.fileSys.OpenWASI(dirflags, pathName, oflags, fsRightsBase, fsRightsInheriting, fdflags)
 	if err != nil {
 		switch {
 		case errors.Is(err, fs.ErrNotExist):
@@ -874,17 +1258,57 @@ func (a *wasiAPI) path_open(ctx wasm.ModuleContext, fd, dirFlags, pathPtr, pathL
 		file: f,
 	}
 
-	if !ctx.Memory().WriteUint32Le(fdPtr, newFD) {
+	if !ctx.Memory().WriteUint32Le(resultOpenedFd, newFD) {
 		return wasi.ErrnoFault
 	}
 	return wasi.ErrnoSuccess
 }
 
+// PathReadlink implements SnapshotPreview1.PathReadlink
+func (a *wasiAPI) PathReadlink(ctx wasm.ModuleContext, fd, path, pathLen, buf, bufLen, resultBufused uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathRemoveDirectory implements SnapshotPreview1.PathRemoveDirectory
+func (a *wasiAPI) PathRemoveDirectory(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathRename implements SnapshotPreview1.PathRename
+func (a *wasiAPI) PathRename(ctx wasm.ModuleContext, fd, oldPath, oldPathLen, newFd, newPath, newPathLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathSymlink implements SnapshotPreview1.PathSymlink
+func (a *wasiAPI) PathSymlink(ctx wasm.ModuleContext, oldPath, oldPathLen, fd, newFd, newPath, newPathLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PathUnlinkFile implements SnapshotPreview1.PathUnlinkFile
+func (a *wasiAPI) PathUnlinkFile(ctx wasm.ModuleContext, fd, path, pathLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// PollOneoff implements SnapshotPreview1.PollOneoff
+func (a *wasiAPI) PollOneoff(ctx wasm.ModuleContext, in, out, nsubscriptions, resultNevents uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
 // ProcExit implements SnapshotPreview1.ProcExit
 func (a *wasiAPI) ProcExit(exitCode uint32) {
 	// Panic in a host function is caught by the engines, and the value of the panic is returned as the error of the CallFunction.
-	// See the document of API.ProcExit.
+	// See the document of SnapshotPreview1.ProcExit.
 	panic(wasi.ExitCode(exitCode))
+}
+
+// ProcRaise implements SnapshotPreview1.ProcRaise
+func (a *wasiAPI) ProcRaise(ctx wasm.ModuleContext, sig uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// SchedYield implements SnapshotPreview1.SchedYield
+func (a *wasiAPI) SchedYield(ctx wasm.ModuleContext) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
 }
 
 // RandomGet implements SnapshotPreview1.RandomGet
@@ -901,6 +1325,21 @@ func (a *wasiAPI) RandomGet(ctx wasm.ModuleContext, buf uint32, bufLen uint32) (
 	}
 
 	return wasi.ErrnoSuccess
+}
+
+// SockRecv implements SnapshotPreview1.SockRecv
+func (a *wasiAPI) SockRecv(ctx wasm.ModuleContext, fd, riData, riDataCount, riFlags, resultRoDataLen, resultRoFlags uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// SockSend implements SnapshotPreview1.SockSend
+func (a *wasiAPI) SockSend(ctx wasm.ModuleContext, fd, siData, siDataCount, siFlags, resultSoDataLen uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
+}
+
+// SockShutdown implements SnapshotPreview1.SockShutdown
+func (a *wasiAPI) SockShutdown(ctx wasm.ModuleContext, fd, how uint32) wasi.Errno {
+	return wasi.ErrnoNosys // stubbed for GrainLang per #271
 }
 
 type fileEntry struct {

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -435,7 +435,20 @@ func TestSnapshotPreview1_EnvironSizesGet_Errors(t *testing.T) {
 	}
 }
 
-// TODO TestSnapshotPreview1_ClockResGet TestSnapshotPreview1_ClockResGet_Errors
+// TestSnapshotPreview1_ClockResGet only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_ClockResGet(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionClockResGet, ImportClockResGet, moduleName)
+
+	t.Run("SnapshotPreview1.ClockResGet", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().ClockResGet(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionClockResGet, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
 
 func TestSnapshotPreview1_ClockTimeGet(t *testing.T) {
 	epochNanos := uint64(1640995200000000000) // midnight UTC 2022-01-01
@@ -513,8 +526,35 @@ func TestSnapshotPreview1_ClockTimeGet_Errors(t *testing.T) {
 	}
 }
 
-// TODO: TestSnapshotPreview1_FdAdvise TestSnapshotPreview1_FdAdvise_Errors
-// TODO: TestSnapshotPreview1_FdAllocate TestSnapshotPreview1_FdAllocate_Errors
+// TestSnapshotPreview1_FdAdvise only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdAdvise(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdAdvise, ImportFdAdvise, moduleName)
+
+	t.Run("SnapshotPreview1.FdAdvise", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdAdvise(mod.Instance.Ctx, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdAdvise, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdAllocate only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdAllocate(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdAllocate, ImportFdAllocate, moduleName)
+
+	t.Run("SnapshotPreview1.FdAllocate", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdAllocate(mod.Instance.Ctx, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdAllocate, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
 
 func TestSnapshotPreview1_FdClose(t *testing.T) {
 	fdToClose := uint32(3) // arbitrary fd
@@ -563,14 +603,113 @@ func TestSnapshotPreview1_FdClose(t *testing.T) {
 	})
 }
 
-// TODO: TestSnapshotPreview1_FdDataSync TestSnapshotPreview1_FdDataSync_Errors
+// TestSnapshotPreview1_FdDatasync only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdDatasync(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdDatasync, ImportFdDatasync, moduleName)
+
+	t.Run("SnapshotPreview1.FdDatasync", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdDatasync(mod.Instance.Ctx, 0))
+	})
+
+	t.Run(FunctionFdDatasync, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
 // TODO: TestSnapshotPreview1_FdFdstatGet TestSnapshotPreview1_FdFdstatGet_Errors
-// TODO: TestSnapshotPreview1_FdFdstatSetFlags TestSnapshotPreview1_FdFdstatSetFlags_Errors
-// TODO: TestSnapshotPreview1_FdFdstatSetRights TestSnapshotPreview1_FdFdstatSetRights_Errors
-// TODO: TestSnapshotPreview1_FdFilestatGet TestSnapshotPreview1_FdFilestatGet_Errors
-// TODO: TestSnapshotPreview1_FdFilestatSetSize TestSnapshotPreview1_FdFilestatSetSize_Errors
-// TODO: TestSnapshotPreview1_FdFilestatSetTimes TestSnapshotPreview1_FdFilestatSetTimes_Errors
-// TODO: TestSnapshotPreview1_FdPread TestSnapshotPreview1_FdPread_Errors
+
+// TestSnapshotPreview1_FdFdstatSetFlags only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdFdstatSetFlags(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdFdstatSetFlags, ImportFdFdstatSetFlags, moduleName)
+
+	t.Run("SnapshotPreview1.FdFdstatSetFlags", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdFdstatSetFlags(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionFdFdstatSetFlags, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdFdstatSetRights only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdFdstatSetRights(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdFdstatSetRights, ImportFdFdstatSetRights, moduleName)
+
+	t.Run("SnapshotPreview1.FdFdstatSetRights", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdFdstatSetRights(mod.Instance.Ctx, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdFdstatSetRights, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdFilestatGet only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdFilestatGet(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdFilestatGet, ImportFdFilestatGet, moduleName)
+
+	t.Run("SnapshotPreview1.FdFilestatGet", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdFilestatGet(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionFdFilestatGet, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdFilestatSetSize only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdFilestatSetSize(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdFilestatSetSize, ImportFdFilestatSetSize, moduleName)
+
+	t.Run("SnapshotPreview1.FdFilestatSetSize", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdFilestatSetSize(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionFdFilestatSetSize, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdFilestatSetTimes only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdFilestatSetTimes(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdFilestatSetTimes, ImportFdFilestatSetTimes, moduleName)
+
+	t.Run("SnapshotPreview1.FdFilestatSetTimes", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdFilestatSetTimes(mod.Instance.Ctx, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdFilestatSetTimes, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdPread only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdPread(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdPread, ImportFdPread, moduleName)
+
+	t.Run("SnapshotPreview1.FdPread", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdPread(mod.Instance.Ctx, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdPread, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
 // TODO: TestSnapshotPreview1_FdPrestatGet TestSnapshotPreview1_FdPrestatGet_Errors
 
 func TestSnapshotPreview1_FdPrestatDirName(t *testing.T) {
@@ -676,6 +815,21 @@ func TestSnapshotPreview1_FdPrestatDirName_Errors(t *testing.T) {
 	}
 }
 
+// TestSnapshotPreview1_FdPwrite only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdPwrite(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdPwrite, ImportFdPwrite, moduleName)
+
+	t.Run("SnapshotPreview1.FdPwrite", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdPwrite(mod.Instance.Ctx, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdPwrite, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
 func TestSnapshotPreview1_FdRead(t *testing.T) {
 	fd := uint32(3)   // arbitrary fd after 0, 1, and 2, that are stdin/out/err
 	iovs := uint32(1) // arbitrary offset
@@ -687,7 +841,7 @@ func TestSnapshotPreview1_FdRead(t *testing.T) {
 		2, 0, 0, 0, // = iovs[1].length
 		'?',
 	}
-	iovsLen := uint32(2)     // The length of iovs
+	iovsCount := uint32(2)   // The count of iovs
 	resultSize := uint32(26) // arbitrary offset
 	expectedMemory := append(
 		initialMemory,
@@ -707,7 +861,7 @@ func TestSnapshotPreview1_FdRead(t *testing.T) {
 	mem := mod.Memory("memory")
 
 	// TestSnapshotPreview1_FdRead uses a matrix because setting up test files is complicated and has to be clean each time.
-	type fdReadFn func(ctx publicwasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno
+	type fdReadFn func(ctx publicwasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno
 	tests := []struct {
 		name   string
 		fdRead func() fdReadFn
@@ -716,8 +870,8 @@ func TestSnapshotPreview1_FdRead(t *testing.T) {
 			return api.FdRead
 		}},
 		{FunctionFdRead, func() fdReadFn {
-			return func(ctx publicwasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
-				ret, err := fn.Call(context.Background(), uint64(fd), uint64(iovs), uint64(iovsLen), uint64(resultSize))
+			return func(ctx publicwasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno {
+				ret, err := fn.Call(context.Background(), uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultSize))
 				require.NoError(t, err)
 				return wasi.Errno(ret[0])
 			}
@@ -739,7 +893,7 @@ func TestSnapshotPreview1_FdRead(t *testing.T) {
 			ok := mem.Write(0, initialMemory)
 			require.True(t, ok)
 
-			errno := tc.fdRead()(mod.Instance.Ctx, fd, iovs, iovsLen, resultSize)
+			errno := tc.fdRead()(mod.Instance.Ctx, fd, iovs, iovsCount, resultSize)
 			require.Equal(t, wasi.ErrnoSuccess, errno)
 
 			actual, ok := mem.Read(0, uint32(len(expectedMemory)))
@@ -763,10 +917,10 @@ func TestSnapshotPreview1_FdRead_Errors(t *testing.T) {
 	mem := mod.Memory("memory")
 
 	tests := []struct {
-		name                          string
-		fd, iovs, iovsLen, resultSize uint64
-		memory                        []byte
-		expectedErrno                 wasi.Errno
+		name                            string
+		fd, iovs, iovsCount, resultSize uint64
+		memory                          []byte
+		expectedErrno                   wasi.Errno
 	}{
 		{
 			name:          "invalid fd",
@@ -783,7 +937,7 @@ func TestSnapshotPreview1_FdRead_Errors(t *testing.T) {
 		{
 			name: "out-of-memory reading iovs[0].length",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			memory: []byte{
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
@@ -793,7 +947,7 @@ func TestSnapshotPreview1_FdRead_Errors(t *testing.T) {
 		{
 			name: "iovs[0].offset is outside memory",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			memory: []byte{
 				'?',          // `iovs` is after this
 				0, 0, 0x1, 0, // = iovs[0].offset on the secod page
@@ -804,7 +958,7 @@ func TestSnapshotPreview1_FdRead_Errors(t *testing.T) {
 		{
 			name: "length to read exceeds memory by 1",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			memory: []byte{
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
@@ -816,7 +970,7 @@ func TestSnapshotPreview1_FdRead_Errors(t *testing.T) {
 		{
 			name: "resultSize offset is outside memory",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			resultSize: 10, // 1 past memory
 			memory: []byte{
 				'?',        // `iovs` is after this
@@ -836,18 +990,87 @@ func TestSnapshotPreview1_FdRead_Errors(t *testing.T) {
 			memoryWriteOK := mem.Write(uint32(offset), tc.memory)
 			require.True(t, memoryWriteOK)
 
-			results, err := fn.Call(context.Background(), tc.fd, tc.iovs+offset, tc.iovsLen+offset, tc.resultSize+offset)
+			results, err := fn.Call(context.Background(), tc.fd, tc.iovs+offset, tc.iovsCount+offset, tc.resultSize+offset)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedErrno, wasi.Errno(results[0])) // results[0] is the errno
 		})
 	}
 }
 
-// TODO: TestSnapshotPreview1_FdReaddir TestSnapshotPreview1_FdReaddir_Errors
-// TODO: TestSnapshotPreview1_FdRenumber TestSnapshotPreview1_FdRenumber_Errors
-// TODO: TestSnapshotPreview1_FdSeek TestSnapshotPreview1_FdSeek_Errors
-// TODO: TestSnapshotPreview1_FdSync TestSnapshotPreview1_FdSync_Errors
-// TODO: TestSnapshotPreview1_FdTell TestSnapshotPreview1_FdTell_Errors
+// TestSnapshotPreview1_FdReaddir only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdReaddir(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdReaddir, ImportFdReaddir, moduleName)
+
+	t.Run("SnapshotPreview1.FdReaddir", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdReaddir(mod.Instance.Ctx, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdReaddir, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdRenumber only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdRenumber(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdRenumber, ImportFdRenumber, moduleName)
+
+	t.Run("SnapshotPreview1.FdRenumber", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdRenumber(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionFdRenumber, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdSeek only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdSeek(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdSeek, ImportFdSeek, moduleName)
+
+	t.Run("SnapshotPreview1.FdSeek", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdSeek(mod.Instance.Ctx, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionFdSeek, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdSync only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdSync(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdSync, ImportFdSync, moduleName)
+
+	t.Run("SnapshotPreview1.FdSync", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdSync(mod.Instance.Ctx, 0))
+	})
+
+	t.Run(FunctionFdSync, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_FdTell only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_FdTell(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionFdTell, ImportFdTell, moduleName)
+
+	t.Run("SnapshotPreview1.FdTell", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().FdTell(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionFdTell, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
 
 func TestSnapshotPreview1_FdWrite(t *testing.T) {
 	fd := uint32(3)   // arbitrary fd after 0, 1, and 2, that are stdin/out/err
@@ -864,7 +1087,7 @@ func TestSnapshotPreview1_FdWrite(t *testing.T) {
 		'r', 'o', // iovs[1].length bytes
 		'?',
 	}
-	iovsLen := uint32(2)     // The length of iovs
+	iovsCount := uint32(2)   // The count of iovs
 	resultSize := uint32(26) // arbitrary offset
 	expectedMemory := append(
 		initialMemory,
@@ -880,7 +1103,7 @@ func TestSnapshotPreview1_FdWrite(t *testing.T) {
 	mem := mod.Memory("memory")
 
 	// TestSnapshotPreview1_FdWrite uses a matrix because setting up test files is complicated and has to be clean each time.
-	type fdWriteFn func(ctx publicwasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno
+	type fdWriteFn func(ctx publicwasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno
 	tests := []struct {
 		name    string
 		fdWrite func() fdWriteFn
@@ -889,8 +1112,8 @@ func TestSnapshotPreview1_FdWrite(t *testing.T) {
 			return api.FdWrite
 		}},
 		{FunctionFdWrite, func() fdWriteFn {
-			return func(ctx publicwasm.ModuleContext, fd, iovs, iovsLen, resultSize uint32) wasi.Errno {
-				ret, err := fn.Call(context.Background(), uint64(fd), uint64(iovs), uint64(iovsLen), uint64(resultSize))
+			return func(ctx publicwasm.ModuleContext, fd, iovs, iovsCount, resultSize uint32) wasi.Errno {
+				ret, err := fn.Call(context.Background(), uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultSize))
 				require.NoError(t, err)
 				return wasi.Errno(ret[0])
 			}
@@ -911,7 +1134,7 @@ func TestSnapshotPreview1_FdWrite(t *testing.T) {
 			ok := mem.Write(0, initialMemory)
 			require.True(t, ok)
 
-			errno := tc.fdWrite()(mod.Instance.Ctx, fd, iovs, iovsLen, resultSize)
+			errno := tc.fdWrite()(mod.Instance.Ctx, fd, iovs, iovsCount, resultSize)
 			require.Equal(t, wasi.ErrnoSuccess, errno)
 
 			actual, ok := mem.Read(0, uint32(len(expectedMemory)))
@@ -936,10 +1159,10 @@ func TestSnapshotPreview1_FdWrite_Errors(t *testing.T) {
 	mem := mod.Memory("memory")
 
 	tests := []struct {
-		name                          string
-		fd, iovs, iovsLen, resultSize uint64
-		memory                        []byte
-		expectedErrno                 wasi.Errno
+		name                            string
+		fd, iovs, iovsCount, resultSize uint64
+		memory                          []byte
+		expectedErrno                   wasi.Errno
 	}{
 		{
 			name:          "invalid fd",
@@ -956,7 +1179,7 @@ func TestSnapshotPreview1_FdWrite_Errors(t *testing.T) {
 		{
 			name: "out-of-memory reading iovs[0].length",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			memory: []byte{
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
@@ -966,7 +1189,7 @@ func TestSnapshotPreview1_FdWrite_Errors(t *testing.T) {
 		{
 			name: "iovs[0].offset is outside memory",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			memory: []byte{
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset = one past the size of this memory
@@ -977,7 +1200,7 @@ func TestSnapshotPreview1_FdWrite_Errors(t *testing.T) {
 		{
 			name: "length to write exceeds memory by 1",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			memory: []byte{
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
@@ -989,7 +1212,7 @@ func TestSnapshotPreview1_FdWrite_Errors(t *testing.T) {
 		{
 			name: "resultSize offset is outside memory",
 			fd:   validFD,
-			iovs: 1, iovsLen: 1,
+			iovs: 1, iovsCount: 1,
 			resultSize: 10, // 1 past memory
 			memory: []byte{
 				'?',        // `iovs` is after this
@@ -1009,7 +1232,7 @@ func TestSnapshotPreview1_FdWrite_Errors(t *testing.T) {
 			memoryWriteOK := mem.Write(uint32(offset), tc.memory)
 			require.True(t, memoryWriteOK)
 
-			results, err := fn.Call(context.Background(), tc.fd, tc.iovs+offset, tc.iovsLen+offset, tc.resultSize+offset)
+			results, err := fn.Call(context.Background(), tc.fd, tc.iovs+offset, tc.iovsCount+offset, tc.resultSize+offset)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedErrno, wasi.Errno(results[0])) // results[0] is the errno
 		})
@@ -1028,17 +1251,157 @@ func createFile(t *testing.T, path string, contents []byte) (*memFile, *MemFS) {
 	return f.(*memFile), memFS
 }
 
-// TODO: TestSnapshotPreview1_PathCreateDirectory TestSnapshotPreview1_PathCreateDirectory_Errors
-// TODO: TestSnapshotPreview1_PathFilestatGet TestSnapshotPreview1_PathFilestatGet_Errors
-// TODO: TestSnapshotPreview1_PathFilestatSetTimes TestSnapshotPreview1_PathFilestatSetTimes_Errors
-// TODO: TestSnapshotPreview1_PathLink TestSnapshotPreview1_PathLink_Errors
+// TestSnapshotPreview1_PathCreateDirectory only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathCreateDirectory(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathCreateDirectory, ImportPathCreateDirectory, moduleName)
+
+	t.Run("SnapshotPreview1.PathCreateDirectory", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathCreateDirectory(mod.Instance.Ctx, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathCreateDirectory, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathFilestatGet only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathFilestatGet(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathFilestatGet, ImportPathFilestatGet, moduleName)
+
+	t.Run("SnapshotPreview1.PathFilestatGet", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathFilestatGet(mod.Instance.Ctx, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathFilestatGet, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathFilestatSetTimes only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathFilestatSetTimes(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathFilestatSetTimes, ImportPathFilestatSetTimes, moduleName)
+
+	t.Run("SnapshotPreview1.PathFilestatSetTimes", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathFilestatSetTimes(mod.Instance.Ctx, 0, 0, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathFilestatSetTimes, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathLink only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathLink(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathLink, ImportPathLink, moduleName)
+
+	t.Run("SnapshotPreview1.PathLink", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathLink(mod.Instance.Ctx, 0, 0, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathLink, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
 // TODO: TestSnapshotPreview1_PathOpen TestSnapshotPreview1_PathOpen_Errors
-// TODO: TestSnapshotPreview1_PathReadlink TestSnapshotPreview1_PathReadlink_Errors
-// TODO: TestSnapshotPreview1_PathRemoveDirectory TestSnapshotPreview1_PathRemoveDirectory_Errors
-// TODO: TestSnapshotPreview1_PathRename TestSnapshotPreview1_PathRename_Errors
-// TODO: TestSnapshotPreview1_PathSymlink TestSnapshotPreview1_PathSymlink_Errors
-// TODO: TestSnapshotPreview1_PathUnlinkFile TestSnapshotPreview1_PathUnlinkFile_Errors
-// TODO: TestSnapshotPreview1_PollOneoff TestSnapshotPreview1_PollOneoff_Errors
+
+// TestSnapshotPreview1_PathReadlink only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathReadlink(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathReadlink, ImportPathReadlink, moduleName)
+
+	t.Run("SnapshotPreview1.PathLink", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathReadlink(mod.Instance.Ctx, 0, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathReadlink, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathRemoveDirectory only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathRemoveDirectory(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathRemoveDirectory, ImportPathRemoveDirectory, moduleName)
+
+	t.Run("SnapshotPreview1.PathRemoveDirectory", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathRemoveDirectory(mod.Instance.Ctx, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathRemoveDirectory, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathRename only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathRename(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathRename, ImportPathRename, moduleName)
+
+	t.Run("SnapshotPreview1.PathRename", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathRename(mod.Instance.Ctx, 0, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathRename, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathSymlink only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathSymlink(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathSymlink, ImportPathSymlink, moduleName)
+
+	t.Run("SnapshotPreview1.PathSymlink", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathSymlink(mod.Instance.Ctx, 0, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathSymlink, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PathUnlinkFile only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PathUnlinkFile(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPathUnlinkFile, ImportPathUnlinkFile, moduleName)
+
+	t.Run("SnapshotPreview1.PathUnlinkFile", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PathUnlinkFile(mod.Instance.Ctx, 0, 0, 0))
+	})
+
+	t.Run(FunctionPathUnlinkFile, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_PollOneoff only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_PollOneoff(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionPollOneoff, ImportPollOneoff, moduleName)
+
+	t.Run("SnapshotPreview1.PollOneoff", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().PollOneoff(mod.Instance.Ctx, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionPollOneoff, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
 
 func TestSnapshotPreview1_ProcExit(t *testing.T) {
 	tests := []struct {
@@ -1071,8 +1434,35 @@ func TestSnapshotPreview1_ProcExit(t *testing.T) {
 	}
 }
 
-// TODO: TestSnapshotPreview1_ProcRaise TestSnapshotPreview1_ProcRaise_Errors
-// TODO: TestSnapshotPreview1_SchedYield TestSnapshotPreview1_SchedYield_Errors
+// TestSnapshotPreview1_ProcRaise only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_ProcRaise(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionProcRaise, ImportProcRaise, moduleName)
+
+	t.Run("SnapshotPreview1.ProcRaise", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().ProcRaise(mod.Instance.Ctx, 0))
+	})
+
+	t.Run(FunctionProcRaise, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_SchedYield only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_SchedYield(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionSchedYield, ImportSchedYield, moduleName)
+
+	t.Run("SnapshotPreview1.SchedYield", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().SchedYield(mod.Instance.Ctx))
+	})
+
+	t.Run(FunctionSchedYield, func(t *testing.T) {
+		results, err := fn.Call(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
 
 func TestSnapshotPreview1_RandomGet(t *testing.T) {
 	expectedMemory := []byte{
@@ -1169,9 +1559,50 @@ func TestSnapshotPreview1_RandomGet_SourceError(t *testing.T) {
 	require.Equal(t, uint64(wasi.ErrnoIo), results[0]) // results[0] is the errno
 }
 
-// TODO: TestSnapshotPreview1_SockRecv TestSnapshotPreview1_SockRecv_Errors
-// TODO: TestSnapshotPreview1_SockSend TestSnapshotPreview1_SockSend_Errors
-// TODO: TestSnapshotPreview1_SockShutdown TestSnapshotPreview1_SockShutdown_Errors
+// TestSnapshotPreview1_SockRecv only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_SockRecv(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionSockRecv, ImportSockRecv, moduleName)
+
+	t.Run("SnapshotPreview1.SockRecv", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().SockRecv(mod.Instance.Ctx, 0, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionSockRecv, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_SockSend only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_SockSend(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionSockSend, ImportSockSend, moduleName)
+
+	t.Run("SnapshotPreview1.SockSend", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().SockSend(mod.Instance.Ctx, 0, 0, 0, 0, 0))
+	})
+
+	t.Run(FunctionSockSend, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0, 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
+
+// TestSnapshotPreview1_SockShutdown only tests it is stubbed for GrainLang per #271
+func TestSnapshotPreview1_SockShutdown(t *testing.T) {
+	mod, fn := instantiateModule(t, FunctionSockShutdown, ImportSockShutdown, moduleName)
+
+	t.Run("SnapshotPreview1.SockShutdown", func(t *testing.T) {
+		require.Equal(t, wasi.ErrnoNosys, NewAPI().SockShutdown(mod.Instance.Ctx, 0, 0))
+	})
+
+	t.Run(FunctionSockShutdown, func(t *testing.T) {
+		results, err := fn.Call(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, wasi.ErrnoNosys, wasi.Errno(results[0])) // cast because results are always uint64
+	})
+}
 
 const testMemoryPageSize = 1
 

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -12,12 +12,14 @@ const (
 // TODO: rename these according to other naming conventions
 const (
 	// WASI open flags
+
 	O_CREATE = 1 << iota
 	O_DIR
 	O_EXCL
 	O_TRUNC
 
 	// WASI fs rights
+
 	R_FD_READ = 1 << iota
 	R_FD_SEEK
 	R_FD_FDSTAT_SET_FLAGS


### PR DESCRIPTION
This stubs all of the known WASI functions so that runtimes like Grain can compile even if they don't use them.

See:

https://github.com/meshx-org/meshx-old/blob/197aa5f7f84f4decc9587cf3477ba378ee68778f/crates/meshx_wasm_runner/src/syscalls/wasi.rs
https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
https://github.com/pgavlin/warp/blob/2bac1014889b11205d410a6c0930b036067c0e61/wasi/module_definition.go
https://github.com/ziglang/zig/blob/master/lib/std/os/wasi.zig