### PR TITLE
Adds ability to disable mutable globals and improves decode perf

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,48 @@
+package wazero
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	internalwasm "github.com/tetratelabs/wazero/internal/wasm"
+)
+
+func TestRuntimeConfig_Features(t *testing.T) {
+	tests := []struct {
+		name          string
+		feature       internalwasm.Features
+		expectDefault bool
+		setFeature    func(*RuntimeConfig, bool) *RuntimeConfig
+	}{
+		{
+			name:          "mutable-global",
+			feature:       internalwasm.FeatureMutableGlobal,
+			expectDefault: true,
+			setFeature: func(c *RuntimeConfig, v bool) *RuntimeConfig {
+				return c.WithFeatureMutableGlobal(v)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewRuntimeConfig()
+			require.Equal(t, tc.expectDefault, c.enabledFeatures.Get(tc.feature))
+
+			// Set to false even if it was initially false.
+			c = tc.setFeature(c, false)
+			require.False(t, c.enabledFeatures.Get(tc.feature))
+
+			// Set true makes it true
+			c = tc.setFeature(c, true)
+			require.True(t, c.enabledFeatures.Get(tc.feature))
+
+			// Set false makes it false again
+			c = tc.setFeature(c, false)
+			require.False(t, c.enabledFeatures.Get(tc.feature))
+		})
+	}
+}

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -1094,15 +1094,16 @@ func TestSnapshotPreview1_RandomGet_SourceError(t *testing.T) {
 // TODO: TestSnapshotPreview1_SockShutdown TestSnapshotPreview1_SockShutdown_Errors
 
 func instantiateWasmStore(t *testing.T, wasiFunction, wasiImport, moduleName string, opts ...Option) (*wasm.Store, *wasm.ModuleContext, *wasm.FunctionInstance) {
+	enabledFeatures := wasm.Features20191205
 	mod, err := text.DecodeModule([]byte(fmt.Sprintf(`(module
   %[2]s
   (memory 1)  ;; just an arbitrary size big enough for tests
   (export "memory" (memory 0))
   (export "%[1]s" (func $wasi.%[1]s))
-)`, wasiFunction, wasiImport)))
+)`, wasiFunction, wasiImport)), enabledFeatures)
 	require.NoError(t, err)
 
-	store := wasm.NewStore(context.Background(), interpreter.NewEngine())
+	store := wasm.NewStore(context.Background(), interpreter.NewEngine(), enabledFeatures)
 
 	snapshotPreview1Functions := SnapshotPreview1Functions(opts...)
 	goFunc := snapshotPreview1Functions[wasiFunction]

--- a/internal/wasm/binary/data.go
+++ b/internal/wasm/binary/data.go
@@ -1,6 +1,7 @@
 package binary
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -8,7 +9,7 @@ import (
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeDataSegment(r io.Reader) (*wasm.DataSegment, error) {
+func decodeDataSegment(r *bytes.Reader) (*wasm.DataSegment, error) {
 	d, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("read memory index: %v", err)

--- a/internal/wasm/binary/decoder.go
+++ b/internal/wasm/binary/decoder.go
@@ -9,9 +9,9 @@ import (
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (20191205) Binary Format
+// DecodeModule implements internalwasm.DecodeModule for the WebAssembly 1.0 (20191205) Binary Format
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-format%E2%91%A0
-func DecodeModule(binary []byte) (*wasm.Module, error) {
+func DecodeModule(binary []byte, features wasm.Features) (*wasm.Module, error) {
 	r := bytes.NewReader(binary)
 
 	// Magic number.
@@ -71,7 +71,9 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 		case wasm.SectionIDType:
 			m.TypeSection, err = decodeTypeSection(r)
 		case wasm.SectionIDImport:
-			m.ImportSection, err = decodeImportSection(r)
+			if m.ImportSection, err = decodeImportSection(r, features); err != nil {
+				return nil, err // avoid re-wrapping the error.
+			}
 		case wasm.SectionIDFunction:
 			m.FunctionSection, err = decodeFunctionSection(r)
 		case wasm.SectionIDTable:
@@ -79,7 +81,9 @@ func DecodeModule(binary []byte) (*wasm.Module, error) {
 		case wasm.SectionIDMemory:
 			m.MemorySection, err = decodeMemorySection(r)
 		case wasm.SectionIDGlobal:
-			m.GlobalSection, err = decodeGlobalSection(r)
+			if m.GlobalSection, err = decodeGlobalSection(r, features); err != nil {
+				return nil, err // avoid re-wrapping the error.
+			}
 		case wasm.SectionIDExport:
 			m.ExportSection, err = decodeExportSection(r)
 		case wasm.SectionIDStart:

--- a/internal/wasm/binary/element.go
+++ b/internal/wasm/binary/element.go
@@ -1,14 +1,14 @@
 package binary
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 
 	"github.com/tetratelabs/wazero/internal/leb128"
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeElementSegment(r io.Reader) (*wasm.ElementSegment, error) {
+func decodeElementSegment(r *bytes.Reader) (*wasm.ElementSegment, error) {
 	ti, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get table index: %w", err)

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -3,7 +3,6 @@ package binary
 import (
 	"bytes"
 	"fmt"
-	"io"
 
 	"github.com/tetratelabs/wazero/internal/leb128"
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
@@ -16,19 +15,19 @@ func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
 		return nil, err
 	}
 
-	b := make([]byte, 1)
-	if _, err = io.ReadFull(r, b); err != nil {
+	b, err := r.ReadByte()
+	if err != nil {
 		return nil, fmt.Errorf("error decoding export kind: %w", err)
 	}
 
-	i.Type = b[0]
+	i.Type = b
 	switch i.Type {
 	case wasm.ExternTypeFunc, wasm.ExternTypeTable, wasm.ExternTypeMemory, wasm.ExternTypeGlobal:
 		if i.Index, _, err = leb128.DecodeUint32(r); err != nil {
 			return nil, fmt.Errorf("error decoding export index: %w", err)
 		}
 	default:
-		return nil, fmt.Errorf("%w: invalid byte for exportdesc: %#x", ErrInvalidByte, b[0])
+		return nil, fmt.Errorf("%w: invalid byte for exportdesc: %#x", ErrInvalidByte, b)
 	}
 	return
 }

--- a/internal/wasm/binary/global.go
+++ b/internal/wasm/binary/global.go
@@ -1,25 +1,21 @@
 package binary
 
 import (
-	"fmt"
-	"io"
+	"bytes"
 
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeGlobal(r io.Reader) (*wasm.Global, error) {
-	gt, err := decodeGlobalType(r)
+func decodeGlobal(r *bytes.Reader, features wasm.Features) (*wasm.Global, error) {
+	gt, err := decodeGlobalType(r, features)
 	if err != nil {
-		return nil, fmt.Errorf("read global type: %v", err)
+		return nil, err
 	}
 
 	init, err := decodeConstantExpression(r)
 	if err != nil {
-		return nil, fmt.Errorf("get init expression: %v", err)
+		return nil, err
 	}
 
-	return &wasm.Global{
-		Type: gt,
-		Init: init,
-	}, nil
+	return &wasm.Global{Type: gt, Init: init}, nil
 }

--- a/internal/wasm/binary/limits.go
+++ b/internal/wasm/binary/limits.go
@@ -1,8 +1,8 @@
 package binary
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 
 	"github.com/tetratelabs/wazero/internal/leb128"
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
@@ -11,15 +11,14 @@ import (
 // decodeLimitsType returns the wasm.LimitsType decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#limits%E2%91%A6
-func decodeLimitsType(r io.Reader) (*wasm.LimitsType, error) {
-	b := make([]byte, 1)
-	_, err := io.ReadFull(r, b)
+func decodeLimitsType(r *bytes.Reader) (*wasm.LimitsType, error) {
+	b, err := r.ReadByte()
 	if err != nil {
 		return nil, fmt.Errorf("read leading byte: %v", err)
 	}
 
 	ret := &wasm.LimitsType{}
-	switch b[0] {
+	switch b {
 	case 0x00:
 		ret.Min, _, err = leb128.DecodeUint32(r)
 		if err != nil {
@@ -36,7 +35,7 @@ func decodeLimitsType(r io.Reader) (*wasm.LimitsType, error) {
 		}
 		ret.Max = &m
 	default:
-		return nil, fmt.Errorf("%v for limits: %#x != 0x00 or 0x01", ErrInvalidByte, b[0])
+		return nil, fmt.Errorf("%v for limits: %#x != 0x00 or 0x01", ErrInvalidByte, b)
 	}
 	return ret, nil
 }

--- a/internal/wasm/binary/memory.go
+++ b/internal/wasm/binary/memory.go
@@ -1,8 +1,8 @@
 package binary
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
@@ -10,7 +10,7 @@ import (
 // decodeMemoryType returns the wasm.MemoryType decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
-func decodeMemoryType(r io.Reader) (*wasm.MemoryType, error) {
+func decodeMemoryType(r *bytes.Reader) (*wasm.MemoryType, error) {
 	ret, err := decodeLimitsType(r)
 	if err != nil {
 		return nil, err

--- a/internal/wasm/binary/value.go
+++ b/internal/wasm/binary/value.go
@@ -42,7 +42,7 @@ func encodeValTypes(vt []wasm.ValueType) []byte {
 	return append(count, vt...)
 }
 
-func decodeValueTypes(r io.Reader, num uint32) ([]wasm.ValueType, error) {
+func decodeValueTypes(r *bytes.Reader, num uint32) ([]wasm.ValueType, error) {
 	if num == 0 {
 		return nil, nil
 	}

--- a/internal/wasm/features.go
+++ b/internal/wasm/features.go
@@ -1,0 +1,55 @@
+package internalwasm
+
+import (
+	"fmt"
+)
+
+// Features are the currently enabled features.
+//
+// Note: This is a bit flag until we have too many (>63). Flags are simpler to manage in multiple places than a map.
+type Features uint64
+
+// Features20191205 include those finished in WebAssembly 1.0 (20191205).
+//
+// See https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205
+const Features20191205 = FeatureMutableGlobal
+
+const (
+	// FeatureMutableGlobal decides if parsing should succeed on internalwasm.GlobalType Mutable
+	// See https://github.com/WebAssembly/mutable-global
+	FeatureMutableGlobal Features = 1 << iota
+)
+
+// Set assigns the value for the given feature.
+func (f Features) Set(feature Features, val bool) Features {
+	if val {
+		return f | feature
+	}
+	return f &^ feature
+}
+
+// Get returns the value of the given feature.
+func (f Features) Get(feature Features) bool {
+	return f&feature != 0
+}
+
+// Require fails with a configuration error if the given feature is not enabled
+func (f Features) Require(feature Features) error {
+	if f&feature == 0 {
+		return fmt.Errorf("feature %s is disabled", feature)
+	}
+	return nil
+}
+
+// String implements fmt.Stringer by returning each enabled feature.
+func (f Features) String() string {
+	switch f {
+	case 0:
+		return ""
+	case FeatureMutableGlobal:
+		return "mutable-global" // match https://github.com/WebAssembly/mutable-global
+	default:
+		return "undefined" // TODO: when there are multiple features join known ones on pipe (|)
+	}
+}

--- a/internal/wasm/features_test.go
+++ b/internal/wasm/features_test.go
@@ -1,0 +1,94 @@
+package internalwasm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFeatures_ZeroIsInvalid reminds maintainers that a bitset cannot use zero as a flag!
+// This is why we start iota with 1.
+func TestFeatures_ZeroIsInvalid(t *testing.T) {
+	f := Features(0)
+	f = f.Set(0, true)
+	require.False(t, f.Get(0))
+}
+
+// TestFeatures tests the bitset works as expected
+func TestFeatures(t *testing.T) {
+	tests := []struct {
+		name    string
+		feature Features
+	}{
+		{
+			name:    "one is the smallest flag",
+			feature: 1,
+		},
+		{
+			name:    "63 is the largest feature flag", // because uint64
+			feature: 1 << 63,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			f := Features(0)
+
+			// Defaults to false
+			require.False(t, f.Get(tc.feature))
+
+			// Set true makes it true
+			f = f.Set(tc.feature, true)
+			require.True(t, f.Get(tc.feature))
+
+			// Set false makes it false again
+			f = f.Set(tc.feature, false)
+			require.False(t, f.Get(tc.feature))
+		})
+	}
+}
+
+func TestFeatures_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		feature  Features
+		expected string
+	}{
+		{name: "none", feature: 0, expected: ""},
+		{name: "mutable-global", feature: FeatureMutableGlobal, expected: "mutable-global"},
+		{name: "undefined", feature: 1 << 63, expected: "undefined"},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.feature.String())
+		})
+	}
+}
+
+func TestFeatures_Require(t *testing.T) {
+	tests := []struct {
+		name        string
+		feature     Features
+		expectedErr string
+	}{
+		{name: "none", feature: 0, expectedErr: "feature mutable-global is disabled"},
+		{name: "mutable-global", feature: FeatureMutableGlobal},
+		{name: "undefined", feature: 1 << 63, expectedErr: "feature mutable-global is disabled"},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.feature.Require(FeatureMutableGlobal)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -1,7 +1,6 @@
 package internalwasm
 
 import (
-	"context"
 	gobinary "encoding/binary"
 	"testing"
 
@@ -257,7 +256,7 @@ func TestPublicModule_Global(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 
-		s := NewStore(context.Background(), &catchContext{})
+		s := newStore()
 		t.Run(tc.name, func(t *testing.T) {
 			// Instantiate the module and get the export of the above global
 			module, err := s.Instantiate(tc.module, "")

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -53,7 +53,7 @@ func TestEngine_Call(t *testing.T) {
 
 	// Use exported functions to simplify instantiation of a Wasm function
 	e := NewEngine()
-	store := wasm.NewStore(context.Background(), e)
+	store := wasm.NewStore(context.Background(), e, wasm.Features20191205)
 	_, err := store.Instantiate(m, "")
 	require.NoError(t, err)
 

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -97,7 +97,7 @@ func TestEngine_Call(t *testing.T) {
 
 	// Use exported functions to simplify instantiation of a Wasm function
 	e := NewEngine()
-	store := wasm.NewStore(context.Background(), e)
+	store := wasm.NewStore(context.Background(), e, wasm.Features20191205)
 	_, err := store.Instantiate(m, "")
 	require.NoError(t, err)
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -16,7 +16,7 @@ import (
 // * result is the module parsed or nil on error
 // * err is a FormatError invoking the parser, dangling block comments or unexpected characters.
 // See binary.DecodeModule and text.DecodeModule
-type DecodeModule func(source []byte) (result *Module, err error)
+type DecodeModule func(source []byte, features Features) (result *Module, err error)
 
 // EncodeModule encodes the given module into a byte slice depending on the format of the implementation.
 // See binary.EncodeModule
@@ -322,7 +322,7 @@ func (m *Module) validateExports(functions []Index, globals []*GlobalType, memor
 
 func validateConstExpression(globals []*GlobalType, expr *ConstantExpression, expectedType ValueType) (err error) {
 	var actualType ValueType
-	r := bytes.NewBuffer(expr.Data)
+	r := bytes.NewReader(expr.Data)
 	switch expr.Opcode {
 	case OpcodeI32Const:
 		_, _, err = leb128.DecodeInt32(r)

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -97,9 +97,11 @@ type moduleParser struct {
 	fieldCountFunc, fieldCountMemory uint32
 }
 
-// DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (20191205) Text Format
+// DecodeModule implements internalwasm.DecodeModule for the WebAssembly 1.0 (20191205) Text Format
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-format%E2%91%A0
-func DecodeModule(source []byte) (result *wasm.Module, err error) {
+func DecodeModule(source []byte, _ wasm.Features) (result *wasm.Module, err error) {
+	// TODO: when globals are supported, err on mutable globals if disabled
+
 	// names are the wasm.Module NameSection
 	//
 	// * ModuleName: ex. "test" if (module $test)

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -1493,7 +1493,7 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := DecodeModule([]byte(tc.input))
+			m, err := DecodeModule([]byte(tc.input), wasm.Features20191205)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, m)
 		})
@@ -2080,7 +2080,7 @@ func TestParseModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := DecodeModule([]byte(tc.input))
+			_, err := DecodeModule([]byte(tc.input), wasm.Features20191205)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -221,7 +221,7 @@ operatorSwitch:
 		// Nop is noop!
 	case wasm.OpcodeBlock:
 		bt, num, err := wasm.DecodeBlockType(c.f.ModuleInstance.Types,
-			bytes.NewBuffer(c.f.Body[c.pc+1:]))
+			bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading block type for block instruction: %w", err)
 		}
@@ -247,7 +247,7 @@ operatorSwitch:
 
 	case wasm.OpcodeLoop:
 		bt, num, err := wasm.DecodeBlockType(c.f.ModuleInstance.Types,
-			bytes.NewBuffer(c.f.Body[c.pc+1:]))
+			bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading block type for loop instruction: %w", err)
 		}
@@ -285,7 +285,7 @@ operatorSwitch:
 
 	case wasm.OpcodeIf:
 		bt, num, err := wasm.DecodeBlockType(c.f.ModuleInstance.Types,
-			bytes.NewBuffer(c.f.Body[c.pc+1:]))
+			bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading block type for if instruction: %w", err)
 		}
@@ -468,7 +468,7 @@ operatorSwitch:
 		}
 
 	case wasm.OpcodeBr:
-		targetIndex, n, err := leb128.DecodeUint32(bytes.NewBuffer(c.f.Body[c.pc+1:]))
+		targetIndex, n, err := leb128.DecodeUint32(bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("read the target for br_if: %w", err)
 		}
@@ -488,7 +488,7 @@ operatorSwitch:
 		// and can be safely removed.
 		c.markUnreachable()
 	case wasm.OpcodeBrIf:
-		targetIndex, n, err := leb128.DecodeUint32(bytes.NewBuffer(c.f.Body[c.pc+1:]))
+		targetIndex, n, err := leb128.DecodeUint32(bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("read the target for br_if: %w", err)
 		}
@@ -513,7 +513,7 @@ operatorSwitch:
 			},
 		)
 	case wasm.OpcodeBrTable:
-		r := bytes.NewBuffer(c.f.Body[c.pc+1:])
+		r := bytes.NewReader(c.f.Body[c.pc+1:])
 		numTargets, n, err := leb128.DecodeUint32(r)
 		if err != nil {
 			return fmt.Errorf("error reading number of targets in br_table: %w", err)
@@ -585,7 +585,7 @@ operatorSwitch:
 		if index == nil {
 			return fmt.Errorf("index does not exist for indirect function call")
 		}
-		tableIndex, n, err := leb128.DecodeUint32(bytes.NewBuffer(c.f.Body[c.pc+1:]))
+		tableIndex, n, err := leb128.DecodeUint32(bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("read target for br_table: %w", err)
 		}
@@ -841,7 +841,7 @@ operatorSwitch:
 			&OperationMemoryGrow{},
 		)
 	case wasm.OpcodeI32Const:
-		val, num, err := leb128.DecodeInt32(bytes.NewBuffer(c.f.Body[c.pc+1:]))
+		val, num, err := leb128.DecodeInt32(bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading i32.const value: %v", err)
 		}
@@ -850,7 +850,7 @@ operatorSwitch:
 			&OperationConstI32{Value: uint32(val)},
 		)
 	case wasm.OpcodeI64Const:
-		val, num, err := leb128.DecodeInt64(bytes.NewBuffer(c.f.Body[c.pc+1:]))
+		val, num, err := leb128.DecodeInt64(bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading i64.const value: %v", err)
 		}
@@ -1392,7 +1392,7 @@ func (c *compiler) applyToStack(opcode wasm.Opcode) (*uint32, error) {
 		wasm.OpcodeGlobalGet,
 		wasm.OpcodeGlobalSet:
 		// Assumes that we are at the opcode now so skip it before read immediates.
-		v, num, err := leb128.DecodeUint32(bytes.NewBuffer(c.f.Body[c.pc+1:]))
+		v, num, err := leb128.DecodeUint32(bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return nil, fmt.Errorf("reading immediates: %w", err)
 		}
@@ -1530,7 +1530,7 @@ func (c *compiler) getFrameDropRange(frame *controlFrame) *InclusiveRange {
 }
 
 func (c *compiler) readMemoryImmediate(tag string) (*MemoryImmediate, error) {
-	r := bytes.NewBuffer(c.f.Body[c.pc+1:])
+	r := bytes.NewReader(c.f.Body[c.pc+1:])
 	alignment, num, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("reading alignment for %s: %w", tag, err)

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -269,7 +269,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 		wastName := basename(base.SourceFile)
 
 		t.Run(wastName, func(t *testing.T) {
-			store := wasm.NewStore(context.Background(), newEngine())
+			store := wasm.NewStore(context.Background(), newEngine(), wasm.Features20191205)
 			addSpectestModule(t, store)
 
 			var lastInstanceName string
@@ -281,7 +281,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 						buf, err := testcases.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
 
-						mod, err := binary.DecodeModule(buf)
+						mod, err := binary.DecodeModule(buf, wasm.Features20191205)
 						require.NoError(t, err, msg)
 
 						lastInstanceName = c.Name
@@ -414,7 +414,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 }
 
 func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg string) {
-	mod, err := binary.DecodeModule(buf)
+	mod, err := binary.DecodeModule(buf, store.EnabledFeatures)
 	if err != nil {
 		return
 	}

--- a/vs/codec_test.go
+++ b/vs/codec_test.go
@@ -91,13 +91,13 @@ func newExample() *wasm.Module {
 
 func TestExampleUpToDate(t *testing.T) {
 	t.Run("binary.DecodeModule", func(t *testing.T) {
-		m, err := binary.DecodeModule(exampleBinary)
+		m, err := binary.DecodeModule(exampleBinary, wasm.Features20191205)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
 
 	t.Run("text.DecodeModule", func(t *testing.T) {
-		m, err := text.DecodeModule(exampleText)
+		m, err := text.DecodeModule(exampleText, wasm.Features20191205)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
@@ -124,7 +124,7 @@ func BenchmarkCodecExample(b *testing.B) {
 	b.Run("binary.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := binary.DecodeModule(exampleBinary); err != nil {
+			if _, err := binary.DecodeModule(exampleBinary, wasm.Features20191205); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -138,7 +138,7 @@ func BenchmarkCodecExample(b *testing.B) {
 	b.Run("text.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := text.DecodeModule(exampleText); err != nil {
+			if _, err := text.DecodeModule(exampleText, wasm.Features20191205); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -146,7 +146,7 @@ func BenchmarkCodecExample(b *testing.B) {
 	b.Run("wat2wasm via text.DecodeModule->binary.EncodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if m, err := text.DecodeModule(exampleText); err != nil {
+			if m, err := text.DecodeModule(exampleText, wasm.Features20191205); err != nil {
 				b.Fatal(err)
 			} else {
 				_ = binary.EncodeModule(m)

--- a/wasm.go
+++ b/wasm.go
@@ -65,12 +65,16 @@ func NewRuntime() Runtime {
 
 // NewRuntimeWithConfig returns a runtime with the given configuration.
 func NewRuntimeWithConfig(config *RuntimeConfig) Runtime {
-	return &runtime{store: internalwasm.NewStore(config.ctx, config.engine)}
+	return &runtime{
+		store:           internalwasm.NewStore(config.ctx, config.engine, config.enabledFeatures),
+		enabledFeatures: config.enabledFeatures,
+	}
 }
 
 // runtime allows decoupling of public interfaces from internal representation.
 type runtime struct {
-	store *internalwasm.Store
+	store           *internalwasm.Store
+	enabledFeatures internalwasm.Features
 }
 
 // Module implements wasm.Store Module
@@ -101,7 +105,7 @@ func (r *runtime) DecodeModule(source []byte) (*DecodedModule, error) {
 		decoder = text.DecodeModule
 	}
 
-	internal, err := decoder(source)
+	internal, err := decoder(source, r.enabledFeatures)
 	if err != nil {
 		return nil, err
 	} else if err = internal.Validate(); err != nil {


### PR DESCRIPTION
This adds `RuntimeConfig.WithFeatureMutableGlobal(enabled bool)`, which
allows disabling of mutable globals. When disabled, any attempt to add a
mutable global, either explicitly or implicitly via decoding wasm will
fail.

To support this, there's a new `Features` bitflag that can allow up to
63 feature toggles without passing structs.

While here, I fixed a significant performance problem in decoding
binary:

Before
```
BenchmarkCodecExample/binary.DecodeModule-16         	  184243	      5623 ns/op	    3848 B/op	     184 allocs/op
```

Now
```
BenchmarkCodecExample/binary.DecodeModule-16         	  294084	      3520 ns/op	    2176 B/op	      91 allocs/op

```
