### PR TITLE
jit: reduce the cost of each function call

### DIFF
--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -432,8 +432,8 @@ func newEngine() *engine {
 
 // TODO: better make them configurable?
 const (
-	initialValueStackSize             = 1024
-	initialCallFrameStackSize         = 256
+	initialValueStackSize             = 64
+	initialCallFrameStackSize         = 16
 	initialCompiledFunctionsSliceSize = 128
 )
 

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -190,7 +190,7 @@ func TestAmd64Compiler_returnFunction(t *testing.T) {
 			// Pushes the frame whose return address equals the beginning of the function just compiled ^.
 			frame := callFrame{
 				returnAddress: codeInitialAddress,
-				// Note that return stack base pointer is set to funcaddr*10 and this is where the const should be pushed.
+				// Note that return stack base pointer is set to funcaddr*5 and this is where the const should be pushed.
 				returnStackBasePointer: uint64(funcaddr) * 5,
 				compiledFunction:       compiledFunction,
 			}

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -191,7 +191,7 @@ func TestAmd64Compiler_returnFunction(t *testing.T) {
 			frame := callFrame{
 				returnAddress: codeInitialAddress,
 				// Note that return stack base pointer is set to funcaddr*10 and this is where the const should be pushed.
-				returnStackBasePointer: uint64(funcaddr) * 10,
+				returnStackBasePointer: uint64(funcaddr) * 5,
 				compiledFunction:       compiledFunction,
 			}
 			vm.callFrameStack[vm.globalContext.callFrameStackPointer] = frame

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -132,8 +132,8 @@ func TestArm64Compiler_returnFunction(t *testing.T) {
 				frame := callFrame{
 					// Set the return address to the beginning of the function so that we can execute the constI32 above.
 					returnAddress: compiledFunction.codeInitialAddress,
-					// Note: return stack base pointer is set to funcaddr*10 and this is where the const should be pushed.
-					returnStackBasePointer: uint64(funcaddr) * 10,
+					// Note: return stack base pointer is set to funcaddr*5 and this is where the const should be pushed.
+					returnStackBasePointer: uint64(funcaddr) * 5,
 					compiledFunction:       compiledFunction,
 				}
 				vm.callFrameStack[vm.globalContext.callFrameStackPointer] = frame


### PR DESCRIPTION
Previously, we allocate stacks per engine, therefore there were no
allocation overhead for each function call. Since #287, we create
stack per store.Call and resulted in increasing the cost of each
store.Call. This commit reduces the pre-allocation stack size
so that we could reduce the each store.Call.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>