### PR TITLE
Sets floor go version to 1.17

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -56,7 +56,6 @@ jobs:
         os: [ubuntu-20.04, macos-11, windows-2022]
         go-version:
         - "1.17" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.16" # temporarily support go 1.16 per #37
 
     steps:
       - uses: actions/setup-go@v2
@@ -86,7 +85,6 @@ jobs:
       matrix:
         go-version:
         - "1.17"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.16"  # temporarily support go 1.16 per #37
         target:
         - arch: arm64
           image: arm64v8/ubuntu

--- a/config_supported.go
+++ b/config_supported.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package wazero
 

--- a/config_unsupported.go
+++ b/config_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package wazero
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,15 @@
 module github.com/tetratelabs/wazero
 
-// temporarily support go 1.16 per #37
-go 1.16
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.0
 	// Once we reach some maturity, remove this dep and implement our own assembler.
 	github.com/twitchyliquid64/golang-asm v0.15.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/internal/wasm/buildoptions/debug_disabled.go
+++ b/internal/wasm/buildoptions/debug_disabled.go
@@ -1,5 +1,4 @@
 //go:build !debug_mode
-// +build !debug_mode
 
 package buildoptions
 

--- a/internal/wasm/buildoptions/debug_enabled.go
+++ b/internal/wasm/buildoptions/debug_enabled.go
@@ -1,5 +1,4 @@
 //go:build debug_mode
-// +build debug_mode
 
 package buildoptions
 

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 package jit
 

--- a/internal/wasm/jit/jit_amd64.s
+++ b/internal/wasm/jit/jit_amd64.s
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 #include "funcdata.h"
 #include "textflag.h"

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 package jit
 

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 // This file implements the compiler for arm64 target.
 // Please refer to https://developer.arm.com/documentation/102374/latest/

--- a/internal/wasm/jit/jit_arm64.s
+++ b/internal/wasm/jit/jit_arm64.s
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 #include "funcdata.h"
 #include "textflag.h"

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 package jit
 

--- a/internal/wasm/jit/jit_other.go
+++ b/internal/wasm/jit/jit_other.go
@@ -1,5 +1,4 @@
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package jit
 

--- a/internal/wasm/jit/jit_value_location.go
+++ b/internal/wasm/jit/jit_value_location.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package jit
 

--- a/internal/wasm/jit/jit_value_location_amd64.go
+++ b/internal/wasm/jit/jit_value_location_amd64.go
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 package jit
 

--- a/internal/wasm/jit/jit_value_location_arm64.go
+++ b/internal/wasm/jit/jit_value_location_arm64.go
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 package jit
 

--- a/internal/wasm/jit/jit_value_location_test.go
+++ b/internal/wasm/jit/jit_value_location_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64
-// +build amd64 arm64
 
 package jit
 

--- a/internal/wasm/jit/mmap.go
+++ b/internal/wasm/jit/mmap.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package jit
 

--- a/vs/bench_fac_iter_test.go
+++ b/vs/bench_fac_iter_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 && cgo && !windows
-// +build amd64,cgo,!windows
 
 // Wasmtime can only be used in amd64 with CGO
 // Wasmer doesn't link on Windows

--- a/vs/codec_test.go
+++ b/vs/codec_test.go
@@ -1,5 +1,4 @@
 //go:build amd64 && cgo && !windows
-// +build amd64,cgo,!windows
 
 // Wasmtime can only be used in amd64 with CGO
 // Wasmer doesn't link on Windows

--- a/vs/go.mod
+++ b/vs/go.mod
@@ -1,14 +1,18 @@
 module github.com/tetratelabs/wazero/vs
 
-// temporarily support go 1.16 per #37
-go 1.16
+go 1.17
 
 require (
 	github.com/bytecodealliance/wasmtime-go v0.34.0
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/tetratelabs/wazero v0.0.0
 	github.com/wasmerio/wasmer-go v1.0.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 


### PR DESCRIPTION
We temporarily supported go 1.16 to allow migration. By setting the
floor to 1.17, we can improve performance and focus on only two versions
(1.17 and soon 1.18).

See https://go.googlesource.com/proposal/+/refs/changes/78/248178/1/design/40724-register-calling.md
See #37