### PR TITLE
ci: add bench.check target to ensure JIT is the fastest 

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -136,4 +136,4 @@ jobs:
             ~/go/pkg/mod
           key: bench-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
 
-      - run: make bench
+      - run: make bench.check

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
 .PHONY: bench
 bench:
 	@go test -run=NONE -benchmem -bench=. ./tests/...
-	@cd vs && go test -run=NONE -benchmem -bench=. .
+	@cd vs && go test -benchmem -bench=. .
+
+.PHONY: bench.check
+bench.check:
+	@go test -run=NONE -benchmem -bench=. ./tests/...
+	@cd vs && go test -benchmem -bench=. . -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
 
 bench_testdata_dir := tests/bench/testdata
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ bench:
 
 .PHONY: bench.check
 bench.check:
-	@go test -run=NONE -benchmem -bench=. ./tests/...
 	@cd vs && go test -benchmem -bench=. . -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
 
 bench_testdata_dir := tests/bench/testdata

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -432,8 +432,8 @@ func newEngine() *engine {
 
 // TODO: better make them configurable?
 const (
-	initialValueStackSize             = 1024
-	initialCallFrameStackSize         = 1024
+	initialValueStackSize             = 64
+	initialCallFrameStackSize         = 16
 	initialCompiledFunctionsSliceSize = 128
 )
 

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -432,8 +432,8 @@ func newEngine() *engine {
 
 // TODO: better make them configurable?
 const (
-	initialValueStackSize             = 64
-	initialCallFrameStackSize         = 16
+	initialValueStackSize             = 1024
+	initialCallFrameStackSize         = 1024
 	initialCompiledFunctionsSliceSize = 128
 )
 

--- a/vs/bench_fac_iter_test.go
+++ b/vs/bench_fac_iter_test.go
@@ -128,11 +128,10 @@ var facIterArgumentI64 int64 = int64(facIterArgumentU64)
 // This is disabled by default, and can be run with -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'.
 func TestFacIter_JIT_Fastest(t *testing.T) {
 	if ensureJITFastest != "true" {
-		t.Skip()
+		// t.Skip()
 	}
 
 	jitResult := testing.Benchmark(jitFacIterInvoke)
-	fmt.Println("JIT", jitResult)
 
 	cases := []struct {
 		runtimeName string
@@ -152,13 +151,23 @@ func TestFacIter_JIT_Fastest(t *testing.T) {
 		},
 	}
 
+	// Print results before running each subtest.
+	fmt.Println("JIT", jitResult)
+	for _, tc := range cases {
+		fmt.Println(tc.runtimeName, tc.result)
+	}
+
 	jitNanoPerOp := float64(jitResult.T.Nanoseconds()) / float64(jitResult.N)
 	for _, tc := range cases {
-		// https://github.com/golang/go/blob/fd09e88722e0af150bf8960e95e8da500ad91001/src/testing/benchmark.go#L428-L432
-		nanoPerOp := float64(tc.result.T.Nanoseconds()) / float64(tc.result.N)
-		fmt.Println(tc.runtimeName, tc.result)
-		require.Lessf(t, jitNanoPerOp, nanoPerOp,
-			"JIT engine must be faster than %s. Run BenchmarkFacIter_Invoke with ensureJITFastest=false instead to see the detailed result", tc.runtimeName)
+		tc := tc
+		t.Run(tc.runtimeName, func(t *testing.T) {
+			// https://github.com/golang/go/blob/fd09e88722e0af150bf8960e95e8da500ad91001/src/testing/benchmark.go#L428-L432
+			nanoPerOp := float64(tc.result.T.Nanoseconds()) / float64(tc.result.N)
+			msg := fmt.Sprintf("JIT engine must be faster than %s. "+
+				"Run BenchmarkFacIter_Invoke with ensureJITFastest=false instead to see the detailed result",
+				tc.runtimeName)
+			require.Lessf(t, jitNanoPerOp, nanoPerOp, msg)
+		})
 	}
 }
 

--- a/vs/bench_fac_iter_test.go
+++ b/vs/bench_fac_iter_test.go
@@ -27,7 +27,6 @@ var facWasm []byte
 
 // TestFacIter ensures that the code in BenchmarkFacIter works as expected.
 func TestFacIter(t *testing.T) {
-	t.Skip()
 	ctx := context.Background()
 	const in = 30
 	expValue := uint64(0x865df5dd54000000)
@@ -129,11 +128,10 @@ var facIterArgumentI64 int64 = int64(facIterArgumentU64)
 // This is disabled by default, and can be run with -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'.
 func TestFacIter_JIT_Fastest(t *testing.T) {
 	if ensureJITFastest != "true" {
+		t.Skip()
 	}
 
 	jitResult := testing.Benchmark(jitFacIterInvoke)
-	jitNanoPerOp := float64(jitResult.T.Nanoseconds()) / float64(jitResult.N)
-
 	fmt.Println("JIT", jitResult)
 
 	cases := []struct {
@@ -154,6 +152,7 @@ func TestFacIter_JIT_Fastest(t *testing.T) {
 		},
 	}
 
+	jitNanoPerOp := float64(jitResult.T.Nanoseconds()) / float64(jitResult.N)
 	for _, tc := range cases {
 		// https://github.com/golang/go/blob/fd09e88722e0af150bf8960e95e8da500ad91001/src/testing/benchmark.go#L428-L432
 		nanoPerOp := float64(tc.result.T.Nanoseconds()) / float64(tc.result.N)

--- a/vs/bench_fac_iter_test.go
+++ b/vs/bench_fac_iter_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/tetratelabs/wazero/wasm"
 )
 
+// ensureJITFastest is overridable via ldflags. Ex.
+//	-ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
 var ensureJITFastest string = "false"
 
 // facWasm is compiled from testdata/fac.wat

--- a/vs/bench_fac_iter_test.go
+++ b/vs/bench_fac_iter_test.go
@@ -79,6 +79,7 @@ func TestFacIter(t *testing.T) {
 	})
 }
 
+// BenchmarkFacIter_Init tracks the time spent readying a function for use
 func BenchmarkFacIter_Init(b *testing.B) {
 	b.Run("Interpreter", func(b *testing.B) {
 		b.ResetTimer()

--- a/vs/bench_fac_iter_test.go
+++ b/vs/bench_fac_iter_test.go
@@ -128,7 +128,7 @@ var facIterArgumentI64 int64 = int64(facIterArgumentU64)
 // This is disabled by default, and can be run with -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'.
 func TestFacIter_JIT_Fastest(t *testing.T) {
 	if ensureJITFastest != "true" {
-		// t.Skip()
+		t.Skip()
 	}
 
 	jitResult := testing.Benchmark(jitFacIterInvoke)


### PR DESCRIPTION
This commit adds `bench.check` make target to ensure that JIT is the 
fastest engine among others.  There was a performance degration 
in #287 which has been resolved in #316, but only found manually.

The target sets a linker flag in vs/bench_test.go which results in running 
`TestFacIter_JIT_Fastest`  instead of `BenchmarkFacIter_Invoke`. 
The `bench` make target doesn't set the flag so 
`BenchmarkFacIter_Invoke` is run and produces rich benchmark output 
into stdout and doesn't run `TestFacIter_JIT_Fastest.

