### PR TITLE
Flattens FunctionInstance FunctionType field

### DIFF
--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -931,7 +931,7 @@ type wasiAPI struct {
 
 // SnapshotPreview1Functions returns all go functions that implement SnapshotPreview1.
 // These should be exported in the module named wasi.ModuleSnapshotPreview1.
-// See internalwasm.NewGoFunc
+// See internalwasm.newGoFunc
 func SnapshotPreview1Functions(opts ...Option) (nameToGoFunc map[string]interface{}) {
 	a := NewAPI(opts...)
 	// Note: these are ordered per spec for consistency even if the resulting map can't guarantee that.

--- a/internal/wasm/binary/types.go
+++ b/internal/wasm/binary/types.go
@@ -58,7 +58,7 @@ func decodeGlobalType(r *bytes.Reader, features wasm.Features) (*wasm.GlobalType
 
 var nullary = []byte{0x60, 0, 0}
 
-// encodedOneParam is a cache of FunctionType.encode values for param length 1 and result length 0
+// encodedOneParam is a cache of internalwasm.FunctionType values for param length 1 and result length 0
 var encodedOneParam = map[wasm.ValueType][]byte{
 	wasm.ValueTypeI32: {0x60, 1, wasm.ValueTypeI32, 0},
 	wasm.ValueTypeI64: {0x60, 1, wasm.ValueTypeI64, 0},
@@ -66,7 +66,7 @@ var encodedOneParam = map[wasm.ValueType][]byte{
 	wasm.ValueTypeF64: {0x60, 1, wasm.ValueTypeF64, 0},
 }
 
-// encodedOneResult is a cache of FunctionType.encode values for param length 0 and result length 1
+// encodedOneResult is a cache of internalwasm.FunctionType values for param length 0 and result length 1
 var encodedOneResult = map[wasm.ValueType][]byte{
 	wasm.ValueTypeI32: {0x60, 0, 1, wasm.ValueTypeI32},
 	wasm.ValueTypeI64: {0x60, 0, 1, wasm.ValueTypeI64},
@@ -74,7 +74,7 @@ var encodedOneResult = map[wasm.ValueType][]byte{
 	wasm.ValueTypeF64: {0x60, 0, 1, wasm.ValueTypeF64},
 }
 
-// encodeFunctionType returns the wasm.FunctionType encoded in WebAssembly 1.0 (20191205) Binary Format.
+// encodeFunctionType returns the internalwasm.FunctionType encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // Note: Function types are encoded by the byte 0x60 followed by the respective vectors of parameter and result types.
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-types%E2%91%A4

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -103,7 +103,7 @@ func TestGetFunctionType(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			rVal := reflect.ValueOf(tc.inputFunc)
-			fk, ft, hasErrorResult, err := GetFunctionType("fn", &rVal, tc.allowErrorResult)
+			fk, ft, hasErrorResult, err := getFunctionType(&rVal, tc.allowErrorResult)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedKind, fk)
 			require.Equal(t, tc.expectedType, ft)
@@ -122,42 +122,42 @@ func TestGetFunctionTypeErrors(t *testing.T) {
 		{
 			name:        "not a func",
 			input:       struct{}{},
-			expectedErr: "fn is a struct, but should be a Func",
+			expectedErr: "kind != func: struct",
 		},
 		{
 			name:        "unsupported param",
 			input:       func(uint32, string) {},
-			expectedErr: "fn param[1] is unsupported: string",
+			expectedErr: "param[1] is unsupported: string",
 		},
 		{
 			name:        "unsupported result",
 			input:       func() string { return "" },
-			expectedErr: "fn result[0] is unsupported: string",
+			expectedErr: "result[0] is unsupported: string",
 		},
 		{
 			name:        "error result",
 			input:       func() error { return nil },
-			expectedErr: "fn result[0] is an error, which is unsupported",
+			expectedErr: "result[0] is an error, which is unsupported",
 		},
 		{
 			name:        "multiple results",
 			input:       func() (uint64, uint32) { return 0, 0 },
-			expectedErr: "fn has more than one result",
+			expectedErr: "multiple results are unsupported",
 		},
 		{
 			name:        "multiple context types",
 			input:       func(publicwasm.ModuleContext, context.Context) error { return nil },
-			expectedErr: "fn param[1] is a context.Context, which may be defined only once as param[0]",
+			expectedErr: "param[1] is a context.Context, which may be defined only once as param[0]",
 		},
 		{
 			name:        "multiple context.Context",
 			input:       func(context.Context, uint64, context.Context) error { return nil },
-			expectedErr: "fn param[2] is a context.Context, which may be defined only once as param[0]",
+			expectedErr: "param[2] is a context.Context, which may be defined only once as param[0]",
 		},
 		{
 			name:        "multiple wasm.ModuleContext",
 			input:       func(publicwasm.ModuleContext, uint64, publicwasm.ModuleContext) error { return nil },
-			expectedErr: "fn param[2] is a wasm.ModuleContext, which may be defined only once as param[0]",
+			expectedErr: "param[2] is a wasm.ModuleContext, which may be defined only once as param[0]",
 		},
 	}
 
@@ -166,7 +166,7 @@ func TestGetFunctionTypeErrors(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			rVal := reflect.ValueOf(tc.input)
-			_, _, _, err := GetFunctionType("fn", &rVal, tc.allowErrorResult)
+			_, _, _, err := getFunctionType(&rVal, tc.allowErrorResult)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -477,6 +477,24 @@ func TestStore_NewHostModule(t *testing.T) {
 	require.EqualError(t, err, "module test has already been instantiated")
 }
 
+func TestStore_NewHostModule_Errors(t *testing.T) {
+	s := newStore()
+
+	t.Run("Adds export name to error message", func(t *testing.T) {
+		_, err := s.NewHostModule("test", map[string]interface{}{"fn": "hello"})
+		require.EqualError(t, err, "func[fn] kind != func: string")
+
+	})
+
+	t.Run("Fails if module name already in use", func(t *testing.T) {
+		_, err := s.NewHostModule("test", map[string]interface{}{"host_fn": func(wasm.ModuleContext) {}})
+		require.NoError(t, err)
+		// Trying to register it again should fail
+		_, err = s.NewHostModule("test", map[string]interface{}{"host_fn": func(wasm.ModuleContext) {}})
+		require.EqualError(t, err, "module test has already been instantiated")
+	})
+}
+
 func TestHostModule_String(t *testing.T) {
 	s := newStore()
 

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -89,15 +89,13 @@ func TestEngine_Call_HostFn(t *testing.T) {
 	module := &wasm.ModuleInstance{MemoryInstance: memory}
 	modCtx := wasm.NewModuleContext(context.Background(), e, module)
 	f := &wasm.FunctionInstance{
-		HostFunction: &hostFn,
-		FunctionKind: wasm.FunctionKindGoModuleContext,
-		FunctionType: &wasm.TypeInstance{
-			Type: &wasm.FunctionType{
-				Params:  []wasm.ValueType{wasm.ValueTypeI64},
-				Results: []wasm.ValueType{wasm.ValueTypeI64},
-			},
+		GoFunc: &hostFn,
+		Kind:   wasm.FunctionKindGoModuleContext,
+		Type: &wasm.FunctionType{
+			Params:  []wasm.ValueType{wasm.ValueTypeI64},
+			Results: []wasm.ValueType{wasm.ValueTypeI64},
 		},
-		ModuleInstance: module,
+		Module: module,
 	}
 	require.NoError(t, e.Compile(f))
 

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -135,15 +135,13 @@ func TestEngine_Call_HostFn(t *testing.T) {
 	module := &wasm.ModuleInstance{MemoryInstance: memory}
 	modCtx := wasm.NewModuleContext(context.Background(), e, module)
 	f := &wasm.FunctionInstance{
-		HostFunction: &hostFn,
-		FunctionKind: wasm.FunctionKindGoModuleContext,
-		FunctionType: &wasm.TypeInstance{
-			Type: &wasm.FunctionType{
-				Params:  []wasm.ValueType{wasm.ValueTypeI64},
-				Results: []wasm.ValueType{wasm.ValueTypeI64},
-			},
+		GoFunc: &hostFn,
+		Kind:   wasm.FunctionKindGoModuleContext,
+		Type: &wasm.FunctionType{
+			Params:  []wasm.ValueType{wasm.ValueTypeI64},
+			Results: []wasm.ValueType{wasm.ValueTypeI64},
 		},
-		ModuleInstance: module,
+		Module: module,
 	}
 	require.NoError(t, e.Compile(f))
 

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -401,7 +401,7 @@ func (c *arm64Compiler) pushFunctionParams() {
 	if c.f == nil || c.f.FunctionType == nil {
 		return
 	}
-	for _, t := range c.f.FunctionType.Type.Params {
+	for _, t := range c.f.FunctionType.Params {
 		loc := c.locationStack.pushValueLocationOnStack()
 		switch t {
 		case wasm.ValueTypeI32, wasm.ValueTypeI64:
@@ -702,7 +702,7 @@ func (c *arm64Compiler) compileGlobalGet(o *wazeroir.OperationGlobalGet) error {
 	}
 
 	var intMov, floatMov obj.As = obj.ANOP, obj.ANOP
-	switch c.f.ModuleInstance.Globals[o.Index].Type.ValType {
+	switch c.f.Module.Globals[o.Index].Type.ValType {
 	case wasm.ValueTypeI32:
 		intMov = arm64.AMOVWU
 	case wasm.ValueTypeI64:
@@ -750,7 +750,7 @@ func (c *arm64Compiler) compileGlobalSet(o *wazeroir.OperationGlobalSet) error {
 	}
 
 	var mov obj.As
-	switch c.f.ModuleInstance.Globals[o.Index].Type.ValType {
+	switch c.f.Module.Globals[o.Index].Type.ValType {
 	case wasm.ValueTypeI32:
 		mov = arm64.AMOVWU
 	case wasm.ValueTypeI64:
@@ -1088,8 +1088,8 @@ func (c *arm64Compiler) compileBrTable(o *wazeroir.OperationBrTable) error {
 
 // compileCall implements compiler.compileCall for the arm64 architecture.
 func (c *arm64Compiler) compileCall(o *wazeroir.OperationCall) error {
-	target := c.f.ModuleInstance.Functions[o.FunctionIndex]
-	return c.compileCallImpl(target.Index, nilRegister, target.FunctionType.Type)
+	target := c.f.Module.Functions[o.FunctionIndex]
+	return c.compileCallImpl(target.Index, nilRegister, target.FunctionType)
 }
 
 // compileCallImpl implements compiler.compileCall and compiler.compileCallIndirect for the arm64 architecture.
@@ -1429,7 +1429,7 @@ func (c *arm64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 	)
 
 	// Check if table[offset].TypeID == targetFunctionType.
-	targetFunctionType := c.f.ModuleInstance.Types[o.TypeIndex]
+	targetFunctionType := c.f.Module.Types[o.TypeIndex]
 	// "tmp = table[offset].TypeID"
 	c.compileMemoryToRegisterInstruction(
 		arm64.AMOVD, offset.register, tableElementFunctionTypeIDOffset,
@@ -1468,7 +1468,7 @@ func (c *arm64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 		offset.register,
 	)
 
-	if err := c.compileCallImpl(0, offset.register, targetFunctionType.Type); err != nil {
+	if err := c.compileCallImpl(0, offset.register, targetFunctionType); err != nil {
 		return err
 	}
 
@@ -3355,7 +3355,7 @@ func (c *arm64Compiler) compileReservedStackBasePointerRegisterInitialization() 
 }
 
 func (c *arm64Compiler) compileReservedMemoryRegisterInitialization() {
-	if c.f.ModuleInstance.MemoryInstance != nil {
+	if c.f.Module.MemoryInstance != nil {
 		// "reservedRegisterForMemory = ce.MemoryElement0Address"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,
@@ -3380,7 +3380,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 
 	// Load the absolute address of the current function's module instance.
 	// Note: this should be modified to support Clone() functionality per #179.
-	c.compileConstToRegisterInstruction(arm64.AMOVD, int64(uintptr(unsafe.Pointer(c.f.ModuleInstance))), moduleInstanceAddressRegister)
+	c.compileConstToRegisterInstruction(arm64.AMOVD, int64(uintptr(unsafe.Pointer(c.f.Module))), moduleInstanceAddressRegister)
 
 	// "tmpX = ce.ModuleInstanceAddress"
 	c.compileMemoryToRegisterInstruction(arm64.AMOVD, reservedRegisterForCallEngine, callEngineModuleContextModuleInstanceAddressOffset, tmpX)
@@ -3402,7 +3402,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// Note: if there's global.get or set instruction in the function, the existence of the globals
 	// is ensured by function validation at module instantiation phase, and that's why it is ok to
 	// skip the initialization if the module's globals slice is empty.
-	if len(c.f.ModuleInstance.Globals) > 0 {
+	if len(c.f.Module.Globals) > 0 {
 		// "tmpX = &moduleInstance.Globals[0]"
 		c.compileMemoryToRegisterInstruction(arm64.AMOVD,
 			moduleInstanceAddressRegister, moduleInstanceGlobalsOffset,
@@ -3421,7 +3421,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// Note: if there's memory instruction in the function, memory instance must be non-nil.
 	// That is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's memory instance is nil.
-	if c.f.ModuleInstance.MemoryInstance != nil {
+	if c.f.Module.MemoryInstance != nil {
 		// "tmpX = moduleInstance.Memory"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,
@@ -3465,7 +3465,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// Note: if there's table instruction in the function, the existence of the table
 	// is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's table doesn't exist.
-	if c.f.ModuleInstance.TableInstance != nil {
+	if c.f.Module.TableInstance != nil {
 		// "tmpX = &tables[0] (type of **wasm.TableInstance)"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -43,8 +43,8 @@ func requirePushTwoFloat32Consts(t *testing.T, x1, x2 float32, compiler *arm64Co
 
 func (j *jitEnv) requireNewCompiler(t *testing.T) *arm64Compiler {
 	cmp, done, err := newCompiler(&wasm.FunctionInstance{
-		ModuleInstance: j.moduleInstance,
-		FunctionKind:   wasm.FunctionKindWasm,
+		Module: j.moduleInstance,
+		Kind:   wasm.FunctionKindWasm,
 	}, nil)
 	require.NoError(t, err)
 	t.Cleanup(done)
@@ -1746,9 +1746,9 @@ func TestArm64Compiler_compileCall(t *testing.T) {
 				t.Run(fmt.Sprintf("compiling call target %d", i), func(t *testing.T) {
 					compiler := env.requireNewCompiler(t)
 					compiler.f = &wasm.FunctionInstance{
-						FunctionKind:   wasm.FunctionKindWasm,
-						FunctionType:   &wasm.TypeInstance{Type: targetFunctionType},
-						ModuleInstance: &wasm.ModuleInstance{},
+						Kind:   wasm.FunctionKindWasm,
+						Type:   targetFunctionType,
+						Module: &wasm.ModuleInstance{},
 					}
 
 					err := compiler.compilePreamble()
@@ -1769,7 +1769,7 @@ func TestArm64Compiler_compileCall(t *testing.T) {
 						codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 					})
 					env.module().Functions = append(env.module().Functions,
-						&wasm.FunctionInstance{FunctionType: &wasm.TypeInstance{Type: targetFunctionType}, Index: index})
+						&wasm.FunctionInstance{Type: targetFunctionType, Index: index})
 				})
 			}
 
@@ -1830,8 +1830,8 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 		targetOperation := &wazeroir.OperationCallIndirect{}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex.
 		compiler.f = &wasm.FunctionInstance{
-			FunctionKind:   wasm.FunctionKindWasm,
-			ModuleInstance: &wasm.ModuleInstance{Types: []*wasm.TypeInstance{{Type: &wasm.FunctionType{}}}},
+			Kind:   wasm.FunctionKindWasm,
+			Module: &wasm.ModuleInstance{Types: []*wasm.TypeInstance{{Type: &wasm.FunctionType{}}}},
 		}
 
 		// Place the offfset value.
@@ -1863,8 +1863,8 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 		targetOffset := &wazeroir.OperationConstI32{Value: uint32(0)}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
 		compiler.f = &wasm.FunctionInstance{
-			ModuleInstance: &wasm.ModuleInstance{Types: []*wasm.TypeInstance{{Type: &wasm.FunctionType{}}}},
-			FunctionKind:   wasm.FunctionKindWasm,
+			Module: &wasm.ModuleInstance{Types: []*wasm.TypeInstance{{Type: &wasm.FunctionType{}}}},
+			Kind:   wasm.FunctionKindWasm,
 		}
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
 		table := make([]wasm.TableElement, 10)
@@ -1984,7 +1984,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 						err := compiler.compilePreamble()
 						require.NoError(t, err)
 
-						compiler.f = &wasm.FunctionInstance{ModuleInstance: moduleInstance, FunctionKind: wasm.FunctionKindWasm}
+						compiler.f = &wasm.FunctionInstance{Module: moduleInstance, Kind: wasm.FunctionKindWasm}
 
 						// Place the offfset value. Here we try calling a function of functionaddr == table[i].FunctionIndex.
 						err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: uint32(i)})
@@ -2194,7 +2194,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newJITEnvironment()
 			compiler := env.requireNewCompiler(t)
-			compiler.f.ModuleInstance = tc.moduleInstance
+			compiler.f.Module = tc.moduleInstance
 
 			// The assembler skips the first instruction so we intentionally add NOP here.
 			// TODO: delete after #233

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -112,8 +112,8 @@ func (j *jitEnv) exec(code []byte) {
 		codeSegment:        code,
 		codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
 		source: &wasm.FunctionInstance{
-			FunctionKind: wasm.FunctionKindWasm,
-			FunctionType: &wasm.TypeInstance{Type: &wasm.FunctionType{}},
+			Kind: wasm.FunctionKindWasm,
+			Type: &wasm.FunctionType{},
 		},
 	}
 

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -14,13 +14,13 @@ func TestFunctionType_String(t *testing.T) {
 		functype *FunctionType
 		exp      string
 	}{
-		{functype: &FunctionType{}, exp: "null_null"},
-		{functype: &FunctionType{Params: []ValueType{ValueTypeI32}}, exp: "i32_null"},
-		{functype: &FunctionType{Params: []ValueType{ValueTypeI32, ValueTypeF64}}, exp: "i32f64_null"},
-		{functype: &FunctionType{Params: []ValueType{ValueTypeF32, ValueTypeI32, ValueTypeF64}}, exp: "f32i32f64_null"},
-		{functype: &FunctionType{Results: []ValueType{ValueTypeI64}}, exp: "null_i64"},
-		{functype: &FunctionType{Results: []ValueType{ValueTypeI64, ValueTypeF32}}, exp: "null_i64f32"},
-		{functype: &FunctionType{Results: []ValueType{ValueTypeF32, ValueTypeI32, ValueTypeF64}}, exp: "null_f32i32f64"},
+		{functype: &FunctionType{}, exp: "v_v"},
+		{functype: &FunctionType{Params: []ValueType{ValueTypeI32}}, exp: "i32_v"},
+		{functype: &FunctionType{Params: []ValueType{ValueTypeI32, ValueTypeF64}}, exp: "i32f64_v"},
+		{functype: &FunctionType{Params: []ValueType{ValueTypeF32, ValueTypeI32, ValueTypeF64}}, exp: "f32i32f64_v"},
+		{functype: &FunctionType{Results: []ValueType{ValueTypeI64}}, exp: "v_i64"},
+		{functype: &FunctionType{Results: []ValueType{ValueTypeI64, ValueTypeF32}}, exp: "v_i64f32"},
+		{functype: &FunctionType{Results: []ValueType{ValueTypeF32, ValueTypeI32, ValueTypeF64}}, exp: "v_f32i32f64"},
 		{functype: &FunctionType{Params: []ValueType{ValueTypeI32}, Results: []ValueType{ValueTypeI64}}, exp: "i32_i64"},
 		{functype: &FunctionType{Params: []ValueType{ValueTypeI64, ValueTypeF32}, Results: []ValueType{ValueTypeI64, ValueTypeF32}}, exp: "i64f32_i64f32"},
 		{functype: &FunctionType{Params: []ValueType{ValueTypeI64, ValueTypeF32, ValueTypeF64}, Results: []ValueType{ValueTypeF32, ValueTypeI32, ValueTypeF64}}, exp: "i64f32f64_f32i32f64"},
@@ -28,6 +28,8 @@ func TestFunctionType_String(t *testing.T) {
 		tc := tc
 		t.Run(tc.functype.String(), func(t *testing.T) {
 			require.Equal(t, tc.exp, tc.functype.String())
+			require.Equal(t, tc.exp, tc.functype.key())
+			require.Equal(t, tc.exp, tc.functype.string)
 		})
 	}
 }

--- a/internal/wasm/text/type_parser.go
+++ b/internal/wasm/text/type_parser.go
@@ -14,7 +14,7 @@ func newTypeParser(typeNamespace *indexNamespace, onType onType) *typeParser {
 
 type onType func(ft *wasm.FunctionType) tokenParser
 
-// typeParser parses a wasm.FunctionType from and dispatches to onType.
+// typeParser parses a wasm.Type from and dispatches to onType.
 //
 // Ex. `(module (type (func (param i32) (result i64)))`
 //      starts here --^                             ^

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -157,7 +157,7 @@ func Compile(f *wasm.FunctionInstance) (*CompilationResult, error) {
 	c := compiler{controlFrames: &controlFrames{}, f: f, result: CompilationResult{LabelCallers: map[string]uint32{}}}
 
 	// Push function arguments.
-	for _, t := range f.FunctionType.Type.Params {
+	for _, t := range f.Type.Params {
 		c.stackPush(wasmValueTypeToUnsignedType(t))
 	}
 	// Emit const expressions for locals.
@@ -169,13 +169,13 @@ func Compile(f *wasm.FunctionInstance) (*CompilationResult, error) {
 	}
 
 	// Insert the function control frame.
-	returns := make([]UnsignedType, 0, len(f.FunctionType.Type.Results))
-	for _, t := range f.FunctionType.Type.Results {
+	returns := make([]UnsignedType, 0, len(f.Type.Results))
+	for _, t := range f.Type.Results {
 		returns = append(returns, wasmValueTypeToUnsignedType(t))
 	}
 	c.controlFrames.push(&controlFrame{
 		frameID:          c.nextID(),
-		originalStackLen: len(f.FunctionType.Type.Params),
+		originalStackLen: len(f.Type.Params),
 		returns:          returns,
 		kind:             controlFrameKindFunction,
 	})
@@ -220,7 +220,7 @@ operatorSwitch:
 	case wasm.OpcodeNop:
 		// Nop is noop!
 	case wasm.OpcodeBlock:
-		bt, num, err := wasm.DecodeBlockType(c.f.ModuleInstance.Types,
+		bt, num, err := wasm.DecodeBlockType(c.f.Module.Types,
 			bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading block type for block instruction: %w", err)
@@ -246,7 +246,7 @@ operatorSwitch:
 		c.controlFrames.push(frame)
 
 	case wasm.OpcodeLoop:
-		bt, num, err := wasm.DecodeBlockType(c.f.ModuleInstance.Types,
+		bt, num, err := wasm.DecodeBlockType(c.f.Module.Types,
 			bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading block type for loop instruction: %w", err)
@@ -284,7 +284,7 @@ operatorSwitch:
 		)
 
 	case wasm.OpcodeIf:
-		bt, num, err := wasm.DecodeBlockType(c.f.ModuleInstance.Types,
+		bt, num, err := wasm.DecodeBlockType(c.f.Module.Types,
 			bytes.NewReader(c.f.Body[c.pc+1:]))
 		if err != nil {
 			return fmt.Errorf("reading block type for if instruction: %w", err)

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -160,9 +160,9 @@ func wasmOpcodeSignature(f *wasm.FunctionInstance, op wasm.Opcode, index uint32)
 	case wasm.OpcodeReturn:
 		return signature_None_None, nil
 	case wasm.OpcodeCall:
-		return funcTypeToSignature(f.ModuleInstance.Functions[index].FunctionType.Type), nil
+		return funcTypeToSignature(f.Module.Functions[index].Type), nil
 	case wasm.OpcodeCallIndirect:
-		ret := funcTypeToSignature(f.ModuleInstance.Types[index].Type)
+		ret := funcTypeToSignature(f.Module.Types[index].Type)
 		ret.in = append(ret.in, UnsignedTypeI32)
 		return ret, nil
 	case wasm.OpcodeDrop:
@@ -170,54 +170,54 @@ func wasmOpcodeSignature(f *wasm.FunctionInstance, op wasm.Opcode, index uint32)
 	case wasm.OpcodeSelect:
 		return signature_UnknownUnkownI32_Unknown, nil
 	case wasm.OpcodeLocalGet:
-		inputLen := uint32(len(f.FunctionType.Type.Params))
+		inputLen := uint32(len(f.Type.Params))
 		if l := uint32(len(f.LocalTypes)) + inputLen; index >= l {
 			return nil, fmt.Errorf("invalid local index for local.get %d >= %d", index, l)
 		}
 		var t UnsignedType
 		if index < inputLen {
-			t = wasmValueTypeToUnsignedType(f.FunctionType.Type.Params[index])
+			t = wasmValueTypeToUnsignedType(f.Type.Params[index])
 		} else {
 			t = wasmValueTypeToUnsignedType(f.LocalTypes[index-inputLen])
 		}
 		return &signature{out: []UnsignedType{t}}, nil
 	case wasm.OpcodeLocalSet:
-		inputLen := uint32(len(f.FunctionType.Type.Params))
+		inputLen := uint32(len(f.Type.Params))
 		if l := uint32(len(f.LocalTypes)) + inputLen; index >= l {
 			return nil, fmt.Errorf("invalid local index for local.get %d >= %d", index, l)
 		}
 		var t UnsignedType
 		if index < inputLen {
-			t = wasmValueTypeToUnsignedType(f.FunctionType.Type.Params[index])
+			t = wasmValueTypeToUnsignedType(f.Type.Params[index])
 		} else {
 			t = wasmValueTypeToUnsignedType(f.LocalTypes[index-inputLen])
 		}
 		return &signature{in: []UnsignedType{t}}, nil
 	case wasm.OpcodeLocalTee:
-		inputLen := uint32(len(f.FunctionType.Type.Params))
+		inputLen := uint32(len(f.Type.Params))
 		if l := uint32(len(f.LocalTypes)) + inputLen; index >= l {
 			return nil, fmt.Errorf("invalid local index for local.get %d >= %d", index, l)
 		}
 		var t UnsignedType
 		if index < inputLen {
-			t = wasmValueTypeToUnsignedType(f.FunctionType.Type.Params[index])
+			t = wasmValueTypeToUnsignedType(f.Type.Params[index])
 		} else {
 			t = wasmValueTypeToUnsignedType(f.LocalTypes[index-inputLen])
 		}
 		return &signature{in: []UnsignedType{t}, out: []UnsignedType{t}}, nil
 	case wasm.OpcodeGlobalGet:
-		if len(f.ModuleInstance.Globals) <= int(index) {
-			return nil, fmt.Errorf("invalid global index for global.get %d >= %d", index, len(f.ModuleInstance.Globals))
+		if len(f.Module.Globals) <= int(index) {
+			return nil, fmt.Errorf("invalid global index for global.get %d >= %d", index, len(f.Module.Globals))
 		}
 		return &signature{
-			out: []UnsignedType{wasmValueTypeToUnsignedType(f.ModuleInstance.Globals[index].Type.ValType)},
+			out: []UnsignedType{wasmValueTypeToUnsignedType(f.Module.Globals[index].Type.ValType)},
 		}, nil
 	case wasm.OpcodeGlobalSet:
-		if len(f.ModuleInstance.Globals) <= int(index) {
-			return nil, fmt.Errorf("invalid global index for global.get %d >= %d", index, len(f.ModuleInstance.Globals))
+		if len(f.Module.Globals) <= int(index) {
+			return nil, fmt.Errorf("invalid global index for global.get %d >= %d", index, len(f.Module.Globals))
 		}
 		return &signature{
-			in: []UnsignedType{wasmValueTypeToUnsignedType(f.ModuleInstance.Globals[index].Type.ValType)},
+			in: []UnsignedType{wasmValueTypeToUnsignedType(f.Module.Globals[index].Type.ValType)},
 		}, nil
 	case wasm.OpcodeI32Load:
 		return signature_I32_I32, nil


### PR DESCRIPTION
This flattens `FunctionInstance.FunctionType` into `Type` and `TypeID`
fields, where the former is known prior to instantiation. This helps
pave a way for integration between Wasm declared and host defined
modules.

This also clarifies that `FunctionInstance.String` was used as a lookup
key, by renaming and caching its impl. While at it, I renamed "null" to
"v" in its output as I had been using v for void noticing others were
doing that also. Moreover, null is easy to misunderstand as a bug.