### PR TITLE
Ensures check lints

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -37,15 +37,9 @@ jobs:
             ~/go/bin
           key: check-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum', 'Makefile') }}
 
-      - name: Lint (arm64)
-        run: make lint golangci_lint_goarch=arm64
-
-      - name: Lint (amd64)
-        run: make lint golangci_lint_goarch=amd64
+      - run: make check
 
       - run: make build.spectest
-
-      - run: make check
 
   test_amd64:
     name: amd64, ${{ matrix.os }}, Go-${{ matrix.go-version }}

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ format:
 
 .PHONY: check
 check:
+	@$(MAKE) lint golangci_lint_goarch=arm64
+	@$(MAKE) lint golangci_lint_goarch=amd64
 	@$(MAKE) format
 	@go mod tidy
 	@if [ ! -z "`git status -s`" ]; then \


### PR DESCRIPTION
I'm frequently forgetting that `check` doesn't lint arm64. This fixes that.

The reason is we have a very large amount of code similar between amd64 and arm64 and `make check` linting both reduces the things you have to remember.