### PR TITLE
Enable concurrent instantiation, and release

### DIFF
--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -140,7 +140,7 @@ func (s *Store) compileHostFunction(f *FunctionInstance) (err error) {
 
 	if err = s.engine.Compile(f); err != nil {
 		// On failure, we must release the function instance.
-		if err = s.releaseFunctionInstances(f); err != nil {
+		if err = s.releaseFunctionInstances(true, f); err != nil {
 			return err
 		}
 		return fmt.Errorf("failed to compile %s: %v", f.Name, err)
@@ -149,6 +149,8 @@ func (s *Store) compileHostFunction(f *FunctionInstance) (err error) {
 }
 
 func (s *Store) requireModuleUnused(moduleName string) error {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
 	if _, ok := s.moduleInstances[moduleName]; ok {
 		return fmt.Errorf("module %s has already been instantiated", moduleName)
 	}

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -142,7 +142,7 @@ func (s *Store) compileHostFunction(f *FunctionInstance) (err error) {
 
 	if err = s.engine.Compile(f); err != nil {
 		// On failure, we must release the function instance.
-		if err = s.releaseFunctionInstances(true, f); err != nil {
+		if err = s.releaseFunctionInstances(f); err != nil {
 			return fmt.Errorf("failed to compile %s: %v", f.Name, err)
 		}
 	}

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -141,9 +141,8 @@ func (s *Store) compileHostFunction(f *FunctionInstance) (err error) {
 	if err = s.engine.Compile(f); err != nil {
 		// On failure, we must release the function instance.
 		if err = s.releaseFunctionInstances(true, f); err != nil {
-			return err
+			return fmt.Errorf("failed to compile %s: %v", f.Name, err)
 		}
-		return fmt.Errorf("failed to compile %s: %v", f.Name, err)
 	}
 	return nil
 }

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -91,6 +91,8 @@ func (f *exportedFunction) Call(ctx context.Context, params ...uint64) ([]uint64
 }
 
 // NewHostModule is defined internally for use in WASI tests and to keep the code size in the root directory small.
+//
+// TOOD: make this goroutine-safe like store.Instantiate.
 func (s *Store) NewHostModule(moduleName string, nameToGoFunc map[string]interface{}) (*HostModule, error) {
 	if err := s.requireModuleUnused(moduleName); err != nil {
 		return nil, err

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -459,7 +459,7 @@ func TestStore_NewHostModule(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure it was added to module instances
-	hm := s.moduleInstances["test"]
+	hm := s.modules["test"]
 	require.NotNil(t, hm)
 
 	// The function was added to the store, prefixed by the owning module name

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -535,7 +535,7 @@ func (ce *callEngine) callHostFunc(ctx *wasm.ModuleContext, f *compiledFunction)
 
 	// A host function is invoked with the calling frame's memory, which may be different if in another module.
 	if len(ce.frames) > 0 {
-		ctx = ctx.WithMemory(ce.frames[len(ce.frames)-1].f.funcInstance.Module.MemoryInstance)
+		ctx = ctx.WithMemory(ce.frames[len(ce.frames)-1].f.funcInstance.Module.Memory)
 	}
 
 	// Handle any special parameter zero
@@ -565,9 +565,9 @@ func (ce *callEngine) callHostFunc(ctx *wasm.ModuleContext, f *compiledFunction)
 func (ce *callEngine) callNativeFunc(ctx *wasm.ModuleContext, f *compiledFunction) {
 	frame := &callFrame{f: f}
 	moduleInst := f.funcInstance.Module
-	memoryInst := moduleInst.MemoryInstance
+	memoryInst := moduleInst.Memory
 	globals := moduleInst.Globals
-	table := moduleInst.TableInstance
+	table := moduleInst.Table
 	ce.pushFrame(frame)
 	bodyLen := uint64(len(frame.f.body))
 	for frame.pc < bodyLen {

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -89,7 +89,7 @@ func TestEngine_Call_HostFn(t *testing.T) {
 	})
 
 	e := NewEngine()
-	module := &wasm.ModuleInstance{MemoryInstance: memory}
+	module := &wasm.ModuleInstance{Memory: memory}
 	modCtx := wasm.NewModuleContext(context.Background(), e, module)
 	f := &wasm.FunctionInstance{
 		GoFunc: &hostFn,

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -100,9 +100,9 @@ type (
 		// i.e. &ModuleInstance.Globals[0] as uintptr.
 		globalElement0Address uintptr
 		// memoryElement0Address is the address of the first element in the global slice,
-		// i.e. &ModuleInstance.MemoryInstance.Buffer[0] as uintptr.
+		// i.e. &ModuleInstance.Memory.Buffer[0] as uintptr.
 		memoryElement0Address uintptr
-		// memorySliceLen is the length of the memory buffer, i.e. len(ModuleInstance.MemoryInstance.Buffer).
+		// memorySliceLen is the length of the memory buffer, i.e. len(ModuleInstance.Memory.Buffer).
 		memorySliceLen uint64
 		// tableElement0Address is the address of the first item in the global slice,
 		// i.e. &ModuleInstance.Tables[0].Table[0] as uintptr.
@@ -235,11 +235,11 @@ const (
 	moduleInstanceMemoryOffset  = 72
 	moduleInstanceTableOffset   = 80
 
-	// Offsets for wasm.TableInstance.
+	// Offsets for wasm.Table.
 	tableInstanceTableOffset    = 0
 	tableInstanceTableLenOffset = 8
 
-	// Offsets for wasm.MemoryInstance.
+	// Offsets for wasm.Memory.
 	memoryInstanceBufferOffset    = 0
 	memoryInstanceBufferLenOffset = 8
 
@@ -583,14 +583,14 @@ jitentry:
 			callerCompiledFunction := ce.callFrameAt(1).compiledFunction
 			// A host function is invoked with the calling frame's memory, which may be different if in another module.
 			ce.execHostFunction(fn.source.Kind, fn.source.GoFunc,
-				ctx.WithMemory(callerCompiledFunction.source.Module.MemoryInstance),
+				ctx.WithMemory(callerCompiledFunction.source.Module.Memory),
 			)
 			goto jitentry
 		case jitCallStatusCodeCallBuiltInFunction:
 			switch ce.exitContext.functionCallAddress {
 			case builtinFunctionIndexMemoryGrow:
 				callerCompiledFunction := ce.callFrameTop().compiledFunction
-				ce.builtinFunctionMemoryGrow(callerCompiledFunction.source.Module.MemoryInstance)
+				ce.builtinFunctionMemoryGrow(callerCompiledFunction.source.Module.Memory)
 			case builtinFunctionIndexGrowValueStack:
 				callerCompiledFunction := ce.callFrameTop().compiledFunction
 				ce.builtinFunctionGrowValueStack(callerCompiledFunction.stackPointerCeil)

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -64,17 +64,17 @@ func TestVerifyOffsetValue(t *testing.T) {
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Globals)), moduleInstanceGlobalsOffset)
-	require.Equal(t, int(unsafe.Offsetof(moduleInstance.MemoryInstance)), moduleInstanceMemoryOffset)
-	require.Equal(t, int(unsafe.Offsetof(moduleInstance.TableInstance)), moduleInstanceTableOffset)
+	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Memory)), moduleInstanceMemoryOffset)
+	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Table)), moduleInstanceTableOffset)
 
-	// Offsets for wasm.TableInstance.
+	// Offsets for wasm.Table.
 	var tableInstance wasm.TableInstance
 	require.Equal(t, int(unsafe.Offsetof(tableInstance.Table)), tableInstanceTableOffset)
 	// We add "+8" to get the length of Tables[0].Table
 	// since the slice header is laid out as {Data uintptr, Len int64, Cap int64} on memory.
 	require.Equal(t, int(unsafe.Offsetof(tableInstance.Table)+8), tableInstanceTableLenOffset)
 
-	// Offsets for wasm.MemoryInstance
+	// Offsets for wasm.Memory
 	var memoryInstance wasm.MemoryInstance
 	require.Equal(t, int(unsafe.Offsetof(memoryInstance.Buffer)), memoryInstanceBufferOffset)
 	// "+8" because the slice header is laid out as {Data uintptr, Len int64, Cap int64} on memory.
@@ -132,7 +132,7 @@ func TestEngine_Call_HostFn(t *testing.T) {
 	})
 
 	e := NewEngine()
-	module := &wasm.ModuleInstance{MemoryInstance: memory}
+	module := &wasm.ModuleInstance{Memory: memory}
 	modCtx := wasm.NewModuleContext(context.Background(), e, module)
 	f := &wasm.FunctionInstance{
 		GoFunc: &hostFn,

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -222,62 +222,62 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 		{
 			name: "no nil",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "memory nil",
 			moduleInstance: &wasm.ModuleInstance{
-				TableInstance: &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
-				Globals:       []*wasm.GlobalInstance{{Val: 100}},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},
 		{
 			name: "table length zero",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: nil},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: nil},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table length zero part2",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table nil part2",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 	} {
@@ -312,14 +312,14 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Globals))
 			require.Equal(t, bufSliceHeader.Data, ce.moduleContext.globalElement0Address)
 
-			if tc.moduleInstance.MemoryInstance != nil {
-				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.MemoryInstance.Buffer))
+			if tc.moduleInstance.Memory != nil {
+				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Memory.Buffer))
 				require.Equal(t, uint64(bufSliceHeader.Len), ce.moduleContext.memorySliceLen)
 				require.Equal(t, bufSliceHeader.Data, ce.moduleContext.memoryElement0Address)
 			}
 
-			if tc.moduleInstance.TableInstance != nil {
-				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.TableInstance.Table))
+			if tc.moduleInstance.Table != nil {
+				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Table.Table))
 				require.Equal(t, uint64(tableHeader.Len), ce.moduleContext.tableSliceLen)
 				require.Equal(t, tableHeader.Data, ce.moduleContext.tableElement0Address)
 			}
@@ -6073,7 +6073,7 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 					// Each function takes one argument, adds the value with 100 + i and returns the result.
 					addTargetValue := uint32(100 + i)
 					moduleInstance := &wasm.ModuleInstance{
-						MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 1024)},
+						Memory: &wasm.MemoryInstance{Buffer: make([]byte, 1024)},
 					}
 					moduleInstanceToExpectedValueInMemory[moduleInstance] = addTargetValue
 
@@ -6167,7 +6167,7 @@ func TestAmd64Compiler_callFunction(t *testing.T) {
 
 				// Also, in the middle of function call, we write the added value into each memory instance.
 				for mod, expValue := range moduleInstanceToExpectedValueInMemory {
-					require.Equal(t, expValue, binary.LittleEndian.Uint32(mod.MemoryInstance.Buffer[0:]))
+					require.Equal(t, expValue, binary.LittleEndian.Uint32(mod.Memory.Buffer[0:]))
 				}
 			})
 		})

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -473,7 +473,7 @@ func (c *arm64Compiler) compileMaybeGrowValueStack() error {
 		math.MaxInt32,
 		tmpY,
 	)
-	// At this point of compilation, we don't know the value of stack pointe ceil,
+	// At this point of compilation, we don't know the value of stack point ceil,
 	// so we layzily resolve the value later.
 	c.onStackPointerCeilDeterminedCallBack = func(stackPointerCeil uint64) { loadStackPointerCeil.From.Offset = int64(stackPointerCeil) }
 
@@ -3491,7 +3491,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's table doesn't exist.
 	if c.f.Module.TableInstance != nil {
-		// "tmpX = &tables[0] (type of **wasm.TableInstance)"
+		// "tmpX = &tables[0] (type of **wasm.Table)"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,
 			moduleInstanceAddressRegister, moduleInstanceTableOffset,

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -3380,7 +3380,7 @@ func (c *arm64Compiler) compileReservedStackBasePointerRegisterInitialization() 
 }
 
 func (c *arm64Compiler) compileReservedMemoryRegisterInitialization() {
-	if c.f.Module.MemoryInstance != nil {
+	if c.f.Module.Memory != nil {
 		// "reservedRegisterForMemory = ce.MemoryElement0Address"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,
@@ -3446,7 +3446,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// Note: if there's memory instruction in the function, memory instance must be non-nil.
 	// That is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's memory instance is nil.
-	if c.f.Module.MemoryInstance != nil {
+	if c.f.Module.Memory != nil {
 		// "tmpX = moduleInstance.Memory"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,
@@ -3490,7 +3490,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	// Note: if there's table instruction in the function, the existence of the table
 	// is ensured by function validation at module instantiation phase, and that's
 	// why it is ok to skip the initialization if the module's table doesn't exist.
-	if c.f.Module.TableInstance != nil {
+	if c.f.Module.Table != nil {
 		// "tmpX = &tables[0] (type of **wasm.Table)"
 		c.compileMemoryToRegisterInstruction(
 			arm64.AMOVD,

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -2222,14 +2222,14 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Globals))
 			require.Equal(t, bufSliceHeader.Data, ce.moduleContext.globalElement0Address)
 
-			if tc.moduleInstance.MemoryInstance != nil {
-				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.MemoryInstance.Buffer))
+			if tc.moduleInstance.Memory != nil {
+				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Memory.Buffer))
 				require.Equal(t, uint64(bufSliceHeader.Len), ce.moduleContext.memorySliceLen)
 				require.Equal(t, bufSliceHeader.Data, ce.moduleContext.memoryElement0Address)
 			}
 
-			if tc.moduleInstance.TableInstance != nil {
-				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.TableInstance.Table))
+			if tc.moduleInstance.Table != nil {
+				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Table.Table))
 				require.Equal(t, uint64(tableHeader.Len), ce.moduleContext.tableSliceLen)
 				require.Equal(t, tableHeader.Data, ce.moduleContext.tableElement0Address)
 			}

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -2142,47 +2142,47 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "no nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:  &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 		{
 			name: "memory nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals:       []*wasm.GlobalInstance{{Val: 100}},
-				TableInstance: &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 20)},
 			},
 		},
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: nil},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: nil},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "table empty",
 			moduleInstance: &wasm.ModuleInstance{
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
 		{
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals:        []*wasm.GlobalInstance{{Val: 100}},
-				TableInstance:  &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
-				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
+				Globals: []*wasm.GlobalInstance{{Val: 100}},
+				Table:   &wasm.TableInstance{Table: make([]wasm.TableElement, 0)},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},
 		{

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -40,7 +40,7 @@ func (j *jitEnv) stackTopAsFloat64() float64 {
 }
 
 func (j *jitEnv) memory() []byte {
-	return j.moduleInstance.MemoryInstance.Buffer
+	return j.moduleInstance.Memory.Buffer
 }
 
 func (j *jitEnv) stack() []uint64 {
@@ -76,7 +76,7 @@ func (j *jitEnv) getGlobal(index uint32) uint64 {
 }
 
 func (j *jitEnv) setTable(table []wasm.TableElement) {
-	j.moduleInstance.TableInstance = &wasm.TableInstance{Table: table}
+	j.moduleInstance.Table = &wasm.TableInstance{Table: table}
 }
 
 func (j *jitEnv) callFrameStackPeek() *callFrame {
@@ -132,9 +132,9 @@ func newJITEnvironment() *jitEnv {
 	return &jitEnv{
 		eng: eng,
 		moduleInstance: &wasm.ModuleInstance{
-			MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
-			TableInstance:  &wasm.TableInstance{},
-			Globals:        []*wasm.GlobalInstance{},
+			Memory:  &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
+			Table:   &wasm.TableInstance{},
+			Globals: []*wasm.GlobalInstance{},
 		},
 		ce: eng.newCallEngine(),
 	}

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -367,7 +367,7 @@ func validateConstExpression(globals []*GlobalType, expr *ConstantExpression, ex
 	return nil
 }
 
-func (m *Module) buildGlobalInstances(importedGlobals []*GlobalInstance) (globals []*GlobalInstance) {
+func (m *Module) buildGlobals(importedGlobals []*GlobalInstance) (globals []*GlobalInstance) {
 	for _, gs := range m.GlobalSection {
 		var gv uint64
 		// Global's initialization constant expression can only reference the imported globals.
@@ -390,7 +390,7 @@ func (m *Module) buildGlobalInstances(importedGlobals []*GlobalInstance) (global
 	return
 }
 
-func (m *Module) buildFunctionInstances() (functions []*FunctionInstance) {
+func (m *Module) buildFunctions() (functions []*FunctionInstance) {
 	var functionNames NameMap
 	if m.NameSection != nil {
 		functionNames = m.NameSection.FunctionNames
@@ -424,7 +424,7 @@ func (m *Module) buildFunctionInstances() (functions []*FunctionInstance) {
 	return
 }
 
-func (m *Module) buildMemoryInstance() (mem *MemoryInstance) {
+func (m *Module) buildMemory() (mem *MemoryInstance) {
 	for _, memSec := range m.MemorySection {
 		mem = &MemoryInstance{
 			Buffer: make([]byte, MemoryPagesToBytesNum(memSec.Min)),
@@ -435,7 +435,7 @@ func (m *Module) buildMemoryInstance() (mem *MemoryInstance) {
 	return
 }
 
-func (m *Module) buildTableInstance() (table *TableInstance) {
+func (m *Module) buildTable() (table *TableInstance) {
 	for _, tableSeg := range m.TableSection {
 		table = newTableInstance(tableSeg.Limit.Min, tableSeg.Limit.Max)
 	}

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -674,7 +674,7 @@ func TestModule_buildGlobalInstances(t *testing.T) {
 		},
 	}}
 
-	globals := m.buildGlobalInstances(nil)
+	globals := m.buildGlobals(nil)
 	expectedGlobals := []*GlobalInstance{
 		{Type: &GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: math.Float64bits(1.0)},
 		{Type: &GlobalType{ValType: ValueTypeI32, Mutable: false}, Val: uint64(1)},
@@ -701,7 +701,7 @@ func TestModule_buildFunctionInstances(t *testing.T) {
 		CodeSection: []*Code{nopCode, nopCode, nopCode, nopCode, nopCode},
 	}
 
-	actual := m.buildFunctionInstances()
+	actual := m.buildFunctions()
 	expectedNames := []string{"unknown", "two", "unknown", "four", "five"}
 	for i, f := range actual {
 		require.Equal(t, expectedNames[i], f.Name)
@@ -712,14 +712,14 @@ func TestModule_buildFunctionInstances(t *testing.T) {
 func TestModule_buildMemoryInstance(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		m := Module{MemorySection: []*MemoryType{}}
-		mem := m.buildMemoryInstance()
+		mem := m.buildMemory()
 		require.Nil(t, mem)
 	})
 	t.Run("non-nil", func(t *testing.T) {
 		min := uint32(1)
 		max := uint32(10)
 		m := Module{MemorySection: []*MemoryType{&LimitsType{Min: min, Max: &max}}}
-		mem := m.buildMemoryInstance()
+		mem := m.buildMemory()
 		require.Equal(t, min, mem.Min)
 		require.Equal(t, max, *mem.Max)
 	})
@@ -727,6 +727,6 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 
 func TestModule_buildTableInstance(t *testing.T) {
 	m := Module{TableSection: []*TableType{{Limit: &LimitsType{Min: 1}}}}
-	table := m.buildTableInstance()
+	table := m.buildTable()
 	require.Equal(t, uint32(1), table.Min)
 }

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -413,7 +413,7 @@ func (s *Store) checkFunctionIndexOverflow(newInstanceNum int) error {
 }
 
 func (s *Store) Instantiate(module *Module, name string) (*PublicModule, error) {
-	// Note: we do not take lock here in order to enable conccurent instantiation and compilation
+	// Note: we do not take lock here in order to enable concurrent instantiation and compilation
 	// of multiuple modules. When necessary, we take read or write locks in each method of store used here.
 
 	if err := s.requireModuleUnused(name); err != nil {
@@ -553,7 +553,7 @@ func (instance *ModuleInstance) decImportedCount() {
 func (instance *ModuleInstance) incImportedCount() {
 	instance.mux.Lock()
 	defer instance.mux.Unlock()
-	instance.importedCount--
+	instance.importedCount++
 }
 
 func (s *Store) releaseFunctionInstances(lock bool, fs ...*FunctionInstance) error {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -536,14 +536,6 @@ func (s *Store) ReleaseModule(moduleName string) error {
 
 	s.releaseGlobal(m.Globals...)
 
-	// Explicitly assign nil so that we ensure this module no longer holds reference to instances.
-	m.Exports = nil
-	m.Globals = nil
-	m.Functions = nil
-	m.Table = nil
-	m.Memory = nil
-	m.Types = nil
-
 	s.deleteModule(m)
 	return nil
 }

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -91,6 +91,7 @@ type (
 		// The slice index is to be interpreted as tableaddr (https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-tableaddr).
 		tables []*TableInstance
 
+		// mux is used to guard the fields from concurrent access.
 		mux sync.RWMutex
 	}
 
@@ -116,9 +117,13 @@ type (
 		// hostModule holds HostModule if this is a "host module" which is created in store.NewHostModule.
 		hostModule *HostModule
 
-		// TODO: https://github.com/tetratelabs/wazero/issues/293
-		mux           sync.Mutex
+		// mux is used to guard the fields from concurrent access.
+		mux sync.Mutex
+		// importedCount equals the current number of modules which import this module instance.
+		// On store.ReleaseModuleInstance, this number must be zero otherwise it fails.
 		importedCount int
+		// moduleImports holds the module instances which this module instance imports.
+		// Used when releasing this moulde instance, and decrement importedCount of the imported modules.
 		moduleImports map[*ModuleInstance]struct{}
 	}
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -220,6 +220,9 @@ func TestStore_concurrent(t *testing.T) {
 				require.Error(t, err)
 			}
 		}(i)
+
+		// TODO: in addition to the normal instantiation, we should try to instantiate host module in conjunction.
+		// after making store.NewHostModule goroutine-safe.
 	}
 	wg.Wait()
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -629,7 +629,7 @@ func TestStore_releaseFunctionInstances(t *testing.T) {
 		s.functions[f.Index] = &FunctionInstance{} // Non-nil!
 	}
 
-	err := s.releaseFunctionInstances(false, fs...)
+	err := s.releaseFunctionInstances(fs...)
 	require.NoError(t, err)
 
 	// Ensure the release targets become nil.

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -201,7 +201,6 @@ func TestStore_concurrent(t *testing.T) {
 		GlobalSection:   []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{0x1}}}},
 		TableSection:    []*TableType{{Limit: &LimitsType{Min: 10}}},
 		ImportSection: []*Import{
-			// Fisrt import resolve succeeds -> increment the hm.importedCount.
 			{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 		},
 	}
@@ -283,7 +282,7 @@ func TestSotre_Instantiate_Errors(t *testing.T) {
 		_, err = s.Instantiate(&Module{
 			TypeSection: []*FunctionType{{}},
 			ImportSection: []*Import{
-				// Fisrt import resolve succeeds -> increment the hm.importedCount.
+				// The fisrt import resolve succeeds -> increment hm.importedCount.
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 				// But the second one tries to import uninitialized-module ->
 				{Type: ExternTypeFunc, Module: "non-exist", Name: "fn", DescFunc: 0},
@@ -320,7 +319,6 @@ func TestSotre_Instantiate_Errors(t *testing.T) {
 				{Body: []byte{OpcodeEnd}},
 			},
 			ImportSection: []*Import{
-				// Fisrt import resolve succeeds -> increment the hm.importedCount.
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 			},
 		}, importingModuleName)
@@ -350,7 +348,6 @@ func TestSotre_Instantiate_Errors(t *testing.T) {
 			CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
 			StartSection:    &startFuncIndex,
 			ImportSection: []*Import{
-				// Fisrt import resolve succeeds -> increment the hm.importedCount.
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 			},
 		}, importingModuleName)

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -1079,5 +1079,5 @@ func Test_newModuleInstance(t *testing.T) {
 }
 
 func newStore() *Store {
-	return NewStore(context.Background(), &catchContext{}, Features20191205)
+	return NewStore(context.Background(), &catchContext{compilationFailIndex: -1}, Features20191205)
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -384,7 +384,7 @@ func TestStore_releaseFunctionInstances(t *testing.T) {
 		expectedReleasedAddr = append(expectedReleasedAddr, f.Index)
 	}
 
-	err := s.releaseFunctionInstances(fs...)
+	err := s.releaseFunctionInstances(false, fs...)
 	require.NoError(t, err)
 
 	// Ensure the release targets become nil.

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -209,15 +209,16 @@ func TestStore_concurrent(t *testing.T) {
 	// Concurrent instantiation.
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
-		if i == goroutines/2 {
-			// Trying to release the imported module concurrently, but should fail as it's in use.
-			err := s.ReleaseModuleInstance(importedModuleName)
-			require.Error(t, err)
-		}
 		go func(i int) {
 			defer wg.Done()
 			_, err := s.Instantiate(improtingModule, strconv.Itoa(i))
 			require.NoError(t, err)
+
+			if i == goroutines/2 {
+				// Trying to release the imported module concurrently, but should fail as it's in use.
+				err := s.ReleaseModuleInstance(importedModuleName)
+				require.Error(t, err)
+			}
 		}(i)
 	}
 	wg.Wait()
@@ -1172,10 +1173,6 @@ func TestModuleInstance_incImportedCount(t *testing.T) {
 	}
 	wg.Wait()
 	require.Equal(t, count, m.importedCount)
-}
-
-func Test_newModuleInstance(t *testing.T) {
-	// TODO
 }
 
 func newStore() *Store {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -259,6 +259,9 @@ func TestSotre_concurrent(t *testing.T) {
 	// No all the importing instances were released, the imported module can be freed.
 	require.Zero(t, hm.importedCount)
 	require.NoError(t, s.ReleaseModuleInstance(hm.Name))
+
+	// All instances are freed.
+	require.Len(t, s.moduleInstances, 0)
 }
 
 func TestSotre_Instantiate_Errors(t *testing.T) {

--- a/tests/engine/concurrency_test.go
+++ b/tests/engine/concurrency_test.go
@@ -12,13 +12,13 @@ func TestJITConcurrency(t *testing.T) {
 		t.Skip()
 	}
 	runAdhocTestsUnderHighConcurrency(t, wazero.NewRuntimeConfigJIT)
-	// TODO: Add conccurent instantiation, invocation and release on a single store test case in https://github.com/tetratelabs/wazero/issues/293
+	// TODO: Add concurrent instantiation, invocation and release on a single store test case in https://github.com/tetratelabs/wazero/issues/293
 
 }
 
 func TestInterpreterConcurrency(t *testing.T) {
 	runAdhocTestsUnderHighConcurrency(t, wazero.NewRuntimeConfigInterpreter)
-	// TODO: Add conccurent instantiation, invocation and release on a single store test case in https://github.com/tetratelabs/wazero/issues/293
+	// TODO: Add concurrent instantiation, invocation and release on a single store test case in https://github.com/tetratelabs/wazero/issues/293
 }
 
 func runAdhocTestsUnderHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {


### PR DESCRIPTION
This makes sure that concurrent use of Instantiate and
ReleaseModuleInstance is goroutine-safe. 

Note that it is still not safe to expose Release in the public API
as we haven't taken into account the outstanding calls. That
would be addressed in the follow-up commit.


part of #293.
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>