### PR TITLE
Renames Runtime.DecodeModule to CompileModule

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -114,7 +114,7 @@ func (b *moduleBuilder) Build() (*Module, error) {
 	}
 }
 
-// InstantiateModule implements ModuleBuilder.InstantiateModule
+// Instantiate implements ModuleBuilder.Instantiate
 func (b *moduleBuilder) Instantiate() (wasm.Module, error) {
 	if module, err := b.Build(); err != nil {
 		return nil, err

--- a/wasi.go
+++ b/wasi.go
@@ -88,9 +88,9 @@ func WASISnapshotPreview1WithConfig(c *WASIConfig) *Module {
 //	wasi, _ := r.NewHostModule(wazero.WASISnapshotPreview1())
 //	module, _ := StartWASICommandFromSource(r, source)
 //
-// Note: This is a convenience utility that chains Runtime.DecodeModule with StartWASICommand.
+// Note: This is a convenience utility that chains Runtime.CompileModule with StartWASICommand.
 func StartWASICommandFromSource(r Runtime, source []byte) (wasm.Module, error) {
-	if decoded, err := r.DecodeModule(source); err != nil {
+	if decoded, err := r.CompileModule(source); err != nil {
 		return nil, err
 	} else {
 		return StartWASICommand(r, decoded)
@@ -104,7 +104,7 @@ func StartWASICommandFromSource(r Runtime, source []byte) (wasm.Module, error) {
 // Ex.
 //	r := wazero.NewRuntime()
 //	wasi, _ := r.NewHostModule(wazero.WASISnapshotPreview1())
-//	decoded, _ := r.DecodeModule(source)
+//	decoded, _ := r.CompileModule(source)
 //	module, _ := StartWASICommand(r, decoded)
 //
 // Prerequisites of the "Current Unstable ABI" from wasi.ModuleSnapshotPreview1:

--- a/wasi_test.go
+++ b/wasi_test.go
@@ -27,7 +27,7 @@ func TestStartWASICommand_UsesStoreContext(t *testing.T) {
 	_, err = r.InstantiateModule(WASISnapshotPreview1())
 	require.NoError(t, err)
 
-	decoded, err := r.DecodeModule([]byte(`(module $wasi_test.go
+	decoded, err := r.CompileModule([]byte(`(module $wasi_test.go
 	(import "" "start" (func $start))
 	(memory 1)
 	(export "_start" (func $start))

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -52,7 +52,7 @@ func TestRuntime_DecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			decoded, err := r.DecodeModule(tc.source)
+			decoded, err := r.CompileModule(tc.source)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedName, decoded.name)
 		})
@@ -86,7 +86,7 @@ func TestRuntime_DecodeModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := r.DecodeModule(tc.source)
+			_, err := r.CompileModule(tc.source)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -96,7 +96,7 @@ func TestRuntime_DecodeModule_Errors(t *testing.T) {
 // names. This pattern is used in wapc-go.
 func TestDecodedModule_WithName(t *testing.T) {
 	r := NewRuntime()
-	base, err := r.DecodeModule([]byte(`(module $0 (memory 1))`))
+	base, err := r.CompileModule([]byte(`(module $0 (memory 1))`))
 	require.NoError(t, err)
 
 	require.Equal(t, "0", base.name)
@@ -138,7 +138,7 @@ func TestModule_Memory(t *testing.T) {
 
 		r := NewRuntime()
 		t.Run(tc.name, func(t *testing.T) {
-			decoded, err := r.DecodeModule([]byte(tc.wat))
+			decoded, err := r.CompileModule([]byte(tc.wat))
 			require.NoError(t, err)
 
 			// Instantiate the module and get the export of the above hostFn
@@ -276,7 +276,7 @@ func TestFunction_Context(t *testing.T) {
 			source := requireImportAndExportFunction(t, r, hostFn, functionName)
 
 			// Instantiate the module and get the export of the above hostFn
-			decoded, err := r.DecodeModule(source)
+			decoded, err := r.CompileModule(source)
 			require.NoError(t, err)
 
 			module, err := r.InstantiateModule(decoded)
@@ -306,7 +306,7 @@ func TestRuntime_NewModule_UsesStoreContext(t *testing.T) {
 	_, err := r.NewModuleBuilder("").ExportFunction("start", start).Instantiate()
 	require.NoError(t, err)
 
-	decoded, err := r.DecodeModule([]byte(`(module $runtime_test.go
+	decoded, err := r.CompileModule([]byte(`(module $runtime_test.go
 	(import "" "start" (func $start))
 	(start $start)
 )`))


### PR DESCRIPTION
The best way to reduce performance impact of instantiating a module
multiple times is lowering it to wazero's IR or even generating
assembly. This renames `DecodeModule` to `CompileModule` to allow that
sort of side-effect to be obvious even if it isn't currently
implemented.
