### PR TITLE
Adds global binary encoder and fixes scope of mutable-global flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,7 +54,7 @@ func (r *RuntimeConfig) WithContext(ctx context.Context) *RuntimeConfig {
 // WithFeatureMutableGlobal allows globals to be mutable. This defaults to true as the feature was finished in
 // WebAssembly 1.0 (20191205).
 //
-// When false, a wasm.Global can never be cast to a wasm.MutableGlobal, and any source that includes mutable globals
+// When false, a wasm.Global can never be cast to a wasm.MutableGlobal, and any source that includes global vars
 // will fail to parse.
 //
 func (r *RuntimeConfig) WithFeatureMutableGlobal(enabled bool) *RuntimeConfig {

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -147,26 +146,6 @@ func TestDecodeModule_Errors(t *testing.T) {
 				0x04, 'n', 'a', 'm', 'e',
 				subsectionIDModuleName, 0x02, 0x01, 'x'),
 			expectedErr: "section custom: redundant custom section name",
-		},
-		{
-			name:     fmt.Sprintf("define mutable global when %s disabled", wasm.FeatureMutableGlobal),
-			features: wasm.Features20191205.Set(wasm.FeatureMutableGlobal, false),
-			input: append(append(Magic, version...),
-				wasm.SectionIDGlobal, 0x06, // 6 bytes in this section
-				0x01, wasm.ValueTypeI32, 0x01, // 1 global i32 mutable
-				wasm.OpcodeI32Const, 0x00, wasm.OpcodeEnd, // arbitrary init to zero
-			),
-			expectedErr: "global[0]: feature mutable-global is disabled",
-		},
-		{
-			name:     fmt.Sprintf("import mutable global when %s disabled", wasm.FeatureMutableGlobal),
-			features: wasm.Features20191205.Set(wasm.FeatureMutableGlobal, false),
-			input: append(append(Magic, version...),
-				wasm.SectionIDImport, 0x08, // 8 bytes in this section
-				0x01, 0x01, 'a', 0x01, 'b', wasm.ExternTypeGlobal, // 1 import a.b of type global
-				wasm.ValueTypeI32, 0x01, // 1 global i32 mutable
-			),
-			expectedErr: "import[0] global[a.b]: feature mutable-global is disabled",
 		},
 	}
 

--- a/internal/wasm/binary/encoder.go
+++ b/internal/wasm/binary/encoder.go
@@ -31,7 +31,7 @@ func EncodeModule(m *wasm.Module) (bytes []byte) {
 		bytes = append(bytes, encodeMemorySection(m.MemorySection)...)
 	}
 	if m.SectionElementCount(wasm.SectionIDGlobal) > 0 {
-		panic("TODO: GlobalSection")
+		bytes = append(bytes, encodeGlobalSection(m.GlobalSection)...)
 	}
 	if m.SectionElementCount(wasm.SectionIDExport) > 0 {
 		bytes = append(bytes, encodeExportSection(m.ExportSection)...)

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -159,6 +159,29 @@ func TestModule_Encode(t *testing.T) {
 				0x01, 0x07, 'v', 'a', 'l', 'u', 'e', '_', '2', // index 1, size of "value_2", "value_2"
 			),
 		},
+		{
+			name: "exported global var",
+			input: &wasm.Module{
+				GlobalSection: []*wasm.Global{
+					{
+						Type: &wasm.GlobalType{ValType: i32, Mutable: true},
+						Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0}},
+					},
+				},
+				ExportSection: map[string]*wasm.Export{
+					"sp": {Name: "sp", Type: wasm.ExternTypeGlobal, Index: wasm.Index(0)},
+				},
+			},
+			expected: append(append(Magic, version...),
+				wasm.SectionIDGlobal, 0x06, // 6 bytes in this section
+				0x01, wasm.ValueTypeI32, 0x01, // 1 global i32 mutable
+				wasm.OpcodeI32Const, 0x00, wasm.OpcodeEnd, // arbitrary init to zero
+				wasm.SectionIDExport, 0x06, // 6 bytes in this section
+				0x01,           // 1 export
+				0x02, 's', 'p', // size of "sp", "sp"
+				wasm.ExternTypeGlobal, 0x00, // global[0]
+			),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -32,7 +32,7 @@ func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
 	return
 }
 
-// encodeExport returns the wasm.Export encoded in WebAssembly 1.0 (20191205) Binary Format.
+// encodeExport returns the internalwasm.Export encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
 func encodeExport(i *wasm.Export) []byte {

--- a/internal/wasm/binary/export_test.go
+++ b/internal/wasm/binary/export_test.go
@@ -50,6 +50,41 @@ func TestEncodeExport(t *testing.T) {
 			},
 		},
 		{
+			name: "global no name, index 0",
+			input: &wasm.Export{ // Ex. (export "" (global 0)))
+				Type:  wasm.ExternTypeGlobal,
+				Name:  "",
+				Index: 0,
+			},
+			expected: []byte{0x00, wasm.ExternTypeGlobal, 0x00},
+		},
+		{
+			name: "global name, global index 0",
+			input: &wasm.Export{ // Ex. (export "pi" (global 0))
+				Type:  wasm.ExternTypeGlobal,
+				Name:  "pi",
+				Index: 0,
+			},
+			expected: []byte{
+				0x02, 'p', 'i',
+				wasm.ExternTypeGlobal,
+				0x00,
+			},
+		},
+		{
+			name: "global name, index 10",
+			input: &wasm.Export{ // Ex. (export "pi" (global 10))
+				Type:  wasm.ExternTypeGlobal,
+				Name:  "pi",
+				Index: 10,
+			},
+			expected: []byte{
+				0x02, 'p', 'i',
+				wasm.ExternTypeGlobal,
+				0x0a,
+			},
+		},
+		{
 			name: "memory no name, index 0",
 			input: &wasm.Export{ // Ex. (export "" (memory 0)))
 				Type:  wasm.ExternTypeMemory,

--- a/internal/wasm/binary/global.go
+++ b/internal/wasm/binary/global.go
@@ -19,3 +19,16 @@ func decodeGlobal(r *bytes.Reader, features wasm.Features) (*wasm.Global, error)
 
 	return &wasm.Global{Type: gt, Init: init}, nil
 }
+
+// encodeGlobal returns the internalwasm.Global encoded in WebAssembly 1.0 (20191205) Binary Format.
+//
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-section%E2%91%A0
+func encodeGlobal(g *wasm.Global) []byte {
+	var mutable byte
+	if g.Type.Mutable {
+		mutable = 1
+	}
+	data := []byte{g.Type.ValType, mutable, g.Init.Opcode}
+	data = append(data, g.Init.Data...)
+	return append(data, wasm.OpcodeEnd)
+}

--- a/internal/wasm/binary/global_test.go
+++ b/internal/wasm/binary/global_test.go
@@ -1,0 +1,49 @@
+package binary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	wasm "github.com/tetratelabs/wazero/internal/wasm"
+)
+
+func TestEncodeGlobal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *wasm.Global
+		expected []byte
+	}{
+		{
+			name: "const",
+			input: &wasm.Global{
+				Type: &wasm.GlobalType{ValType: wasm.ValueTypeI32},
+				Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{1}},
+			},
+			expected: []byte{
+				wasm.ValueTypeI32, 0x00, // 0 == const
+				wasm.OpcodeI32Const, 0x01, wasm.OpcodeEnd,
+			},
+		},
+		{
+			name: "var",
+			input: &wasm.Global{
+				Type: &wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true},
+				Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{1}},
+			},
+			expected: []byte{
+				wasm.ValueTypeI32, 0x01, // 1 == var
+				wasm.OpcodeI32Const, 0x01, wasm.OpcodeEnd,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			bytes := encodeGlobal(tc.input)
+			require.Equal(t, tc.expected, bytes)
+		})
+	}
+}

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -41,7 +41,7 @@ func decodeImport(r *bytes.Reader, idx uint32, features wasm.Features) (i *wasm.
 	return
 }
 
-// encodeImport returns the wasm.Import encoded in WebAssembly 1.0 (20191205) Binary Format.
+// encodeImport returns the internalwasm.Import encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-import
 func encodeImport(i *wasm.Import) []byte {
@@ -56,7 +56,12 @@ func encodeImport(i *wasm.Import) []byte {
 	case wasm.ExternTypeMemory:
 		panic("TODO: encodeExternTypeMemory")
 	case wasm.ExternTypeGlobal:
-		panic("TODO: encodeExternTypeGlobal")
+		g := i.DescGlobal
+		var mutable byte
+		if g.Mutable {
+			mutable = 1
+		}
+		data = append(data, g.ValType, mutable)
 	default:
 		panic(fmt.Errorf("invalid externtype: %s", wasm.ExternTypeName(i.Type)))
 	}

--- a/internal/wasm/binary/import_test.go
+++ b/internal/wasm/binary/import_test.go
@@ -69,6 +69,36 @@ func TestEncodeImport(t *testing.T) {
 				0x0a,
 			},
 		},
+		{
+			name: "global const",
+			input: &wasm.Import{
+				Type:       wasm.ExternTypeGlobal,
+				Module:     "math",
+				Name:       "pi",
+				DescGlobal: &wasm.GlobalType{ValType: wasm.ValueTypeF64},
+			},
+			expected: []byte{
+				0x04, 'm', 'a', 't', 'h',
+				0x02, 'p', 'i',
+				wasm.ExternTypeGlobal,
+				wasm.ValueTypeF64, 0x00, // 0 == const
+			},
+		},
+		{
+			name: "global var",
+			input: &wasm.Import{
+				Type:       wasm.ExternTypeGlobal,
+				Module:     "math",
+				Name:       "pi",
+				DescGlobal: &wasm.GlobalType{ValType: wasm.ValueTypeF64, Mutable: true},
+			},
+			expected: []byte{
+				0x04, 'm', 'a', 't', 'h',
+				0x02, 'p', 'i',
+				wasm.ExternTypeGlobal,
+				wasm.ValueTypeF64, 0x01, // 1 == var
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/wasm/binary/limits.go
+++ b/internal/wasm/binary/limits.go
@@ -40,7 +40,7 @@ func decodeLimitsType(r *bytes.Reader) (*wasm.LimitsType, error) {
 	return ret, nil
 }
 
-// encodeLimitsType returns the wasm.LimitsType encoded in WebAssembly 1.0 (20191205) Binary Format.
+// encodeLimitsType returns the internalwasm.LimitsType encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#limits%E2%91%A6
 func encodeLimitsType(l *wasm.LimitsType) []byte {

--- a/internal/wasm/binary/memory.go
+++ b/internal/wasm/binary/memory.go
@@ -28,7 +28,7 @@ func decodeMemoryType(r *bytes.Reader) (*wasm.MemoryType, error) {
 	return ret, nil
 }
 
-// encodeMemoryType returns the wasm.MemoryType encoded in WebAssembly 1.0 (20191205) Binary Format.
+// encodeMemoryType returns the internalwasm.MemoryType encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
 func encodeMemoryType(i *wasm.MemoryType) []byte {

--- a/internal/wasm/binary/names.go
+++ b/internal/wasm/binary/names.go
@@ -150,7 +150,8 @@ func decodeFunctionCount(r *bytes.Reader, subsectionID uint8) (uint32, error) {
 	return functionCount, nil
 }
 
-// encodeNameSectionData serializes the data for the "name" key in SectionIDCustom according to the standard:
+// encodeNameSectionData serializes the data for the "name" key in internalwasm.SectionIDCustom according to the
+// standard:
 //
 // Note: The result can be nil because this does not encode empty subsections
 //

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -215,7 +215,8 @@ func encodeSection(sectionID wasm.SectionID, contents []byte) []byte {
 	return append([]byte{sectionID}, encodeSizePrefixed(contents)...)
 }
 
-// encodeTypeSection encodes a SectionIDType for the given imports in WebAssembly 1.0 (20191205) Binary Format.
+// encodeTypeSection encodes a internalwasm.SectionIDType for the given imports in WebAssembly 1.0 (20191205) Binary
+// Format.
 //
 // See encodeFunctionType
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#type-section%E2%91%A0
@@ -227,7 +228,8 @@ func encodeTypeSection(types []*wasm.FunctionType) []byte {
 	return encodeSection(wasm.SectionIDType, contents)
 }
 
-// encodeImportSection encodes a SectionIDImport for the given imports in WebAssembly 1.0 (20191205) Binary Format.
+// encodeImportSection encodes a internalwasm.SectionIDImport for the given imports in WebAssembly 1.0 (20191205) Binary
+// Format.
 //
 // See encodeImport
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#import-section%E2%91%A0
@@ -239,8 +241,8 @@ func encodeImportSection(imports []*wasm.Import) []byte {
 	return encodeSection(wasm.SectionIDImport, contents)
 }
 
-// encodeFunctionSection encodes a SectionIDFunction for the type indices associated with module-defined functions in
-// WebAssembly 1.0 (20191205) Binary Format.
+// encodeFunctionSection encodes a internalwasm.SectionIDFunction for the type indices associated with module-defined
+// functions in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#function-section%E2%91%A0
 func encodeFunctionSection(typeIndices []wasm.Index) []byte {
@@ -251,7 +253,8 @@ func encodeFunctionSection(typeIndices []wasm.Index) []byte {
 	return encodeSection(wasm.SectionIDFunction, contents)
 }
 
-// encodeCodeSection encodes a SectionIDCode for the module-defined function in WebAssembly 1.0 (20191205) Binary Format.
+// encodeCodeSection encodes a internalwasm.SectionIDCode for the module-defined function in WebAssembly 1.0 (20191205)
+// Binary Format.
 //
 // See encodeCode
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#code-section%E2%91%A0
@@ -263,7 +266,8 @@ func encodeCodeSection(code []*wasm.Code) []byte {
 	return encodeSection(wasm.SectionIDCode, contents)
 }
 
-// encodeMemorySection encodes a SectionIDMemory for the module-defined function in WebAssembly 1.0 (20191205) Binary Format.
+// encodeMemorySection encodes a internalwasm.SectionIDMemory for the module-defined function in WebAssembly 1.0
+// (20191205) Binary Format.
 //
 // See encodeMemoryType
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-section%E2%91%A0
@@ -275,7 +279,21 @@ func encodeMemorySection(memories []*wasm.MemoryType) []byte {
 	return encodeSection(wasm.SectionIDMemory, contents)
 }
 
-// encodeExportSection encodes a SectionIDExport for the given exports in WebAssembly 1.0 (20191205) Binary Format.
+// encodeGlobalSection encodes a internalwasm.SectionIDGlobal for the given globals in WebAssembly 1.0 (20191205) Binary
+// Format.
+//
+// See encodeGlobal
+// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-section%E2%91%A0
+func encodeGlobalSection(globals []*wasm.Global) []byte {
+	contents := leb128.EncodeUint32(uint32(len(globals)))
+	for _, g := range globals {
+		contents = append(contents, encodeGlobal(g)...)
+	}
+	return encodeSection(wasm.SectionIDGlobal, contents)
+}
+
+// encodeExportSection encodes a internalwasm.SectionIDExport for the given exports in WebAssembly 1.0 (20191205) Binary
+// Format.
 //
 // See encodeExport
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
@@ -287,7 +305,8 @@ func encodeExportSection(exports map[string]*wasm.Export) []byte {
 	return encodeSection(wasm.SectionIDExport, contents)
 }
 
-// encodeStartSection encodes a SectionIDStart for the given function index in WebAssembly 1.0 (20191205) Binary Format.
+// encodeStartSection encodes a internalwasm.SectionIDStart for the given function index in WebAssembly 1.0 (20191205)
+// Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#start-section%E2%91%A0
 func encodeStartSection(funcidx wasm.Index) []byte {

--- a/internal/wasm/binary/types.go
+++ b/internal/wasm/binary/types.go
@@ -44,11 +44,8 @@ func decodeGlobalType(r *bytes.Reader, features wasm.Features) (*wasm.GlobalType
 	}
 
 	switch mut := b; mut {
-	case 0x00:
-	case 0x01:
-		if err = features.Require(wasm.FeatureMutableGlobal); err != nil {
-			return nil, err
-		}
+	case 0x00: // not mutable
+	case 0x01: // mutable
 		ret.Mutable = true
 	default:
 		return nil, fmt.Errorf("%w for mutability: %#x != 0x00 or 0x01", ErrInvalidByte, mut)

--- a/internal/wasm/features.go
+++ b/internal/wasm/features.go
@@ -16,9 +16,10 @@ type Features uint64
 const Features20191205 = FeatureMutableGlobal
 
 const (
-	// FeatureMutableGlobal decides if parsing should succeed on internalwasm.GlobalType Mutable
+	// FeatureMutableGlobal decides if global vars are allowed to be imported or exported (ExternTypeGlobal)
 	// See https://github.com/WebAssembly/mutable-global
 	FeatureMutableGlobal Features = 1 << iota
+
 	// FeatureSignExtensionOps decides if parsing should succeed on internalwasm.GlobalType Mutable
 	// See https://github.com/WebAssembly/spec/blob/main/proposals/sign-extension-ops/Overview.md
 	FeatureSignExtensionOps

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -22,6 +22,7 @@ import (
 // Returns an error if the instruction sequence is not valid,
 // or potentially it can exceed the maximum number of values on the stack.
 func validateFunction(
+	enabledFeatures Features,
 	functionType *FunctionType,
 	body []byte,
 	localTypes []ValueType,
@@ -31,7 +32,6 @@ func validateFunction(
 	tables []*TableType,
 	types []*FunctionType,
 	maxStackValues int,
-	enabledFeatures Features,
 ) error {
 	// Note: In WebAssembly 1.0 (20191205), multiple memories are not allowed.
 	hasMemory := len(memories) > 0
@@ -337,7 +337,7 @@ func validateFunction(
 				if index >= uint32(len(globals)) {
 					return fmt.Errorf("invalid global index")
 				} else if !globals[index].Mutable {
-					return fmt.Errorf("globa.set on immutable global type")
+					return fmt.Errorf("global.set when not mutable")
 				} else if err := valueTypeStack.popAndVerifyType(
 					globals[index].ValType); err != nil {
 					return err

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -26,11 +26,11 @@ func TestValidateFunction_valueStackLimit(t *testing.T) {
 	body = append(body, OpcodeEnd)
 
 	t.Run("not exceed", func(t *testing.T) {
-		err := validateFunction(&FunctionType{}, body, nil, nil, nil, nil, nil, nil, max+1, Features20191205)
+		err := validateFunction(Features20191205, &FunctionType{}, body, nil, nil, nil, nil, nil, nil, max+1)
 		require.NoError(t, err)
 	})
 	t.Run("exceed", func(t *testing.T) {
-		err := validateFunction(&FunctionType{}, body, nil, nil, nil, nil, nil, nil, max, Features20191205)
+		err := validateFunction(Features20191205, &FunctionType{}, body, nil, nil, nil, nil, nil, nil, max)
 		require.Error(t, err)
 		expMsg := fmt.Sprintf("function may have %d stack values, which exceeds limit %d", valuesNum, max)
 		require.Equal(t, expMsg, err.Error())
@@ -69,7 +69,7 @@ func TestValidateFunction_SignExtensionOps(t *testing.T) {
 		tc := tt
 		t.Run(InstructionName(tc.input), func(t *testing.T) {
 			t.Run("disabled", func(t *testing.T) {
-				err := validateFunction(&FunctionType{}, []byte{tc.input}, nil, nil, nil, nil, nil, nil, maxStackHeight, Features20191205)
+				err := validateFunction(Features20191205, &FunctionType{}, []byte{tc.input}, nil, nil, nil, nil, nil, nil, maxStackHeight)
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
@@ -81,8 +81,7 @@ func TestValidateFunction_SignExtensionOps(t *testing.T) {
 					body = append(body, OpcodeI64Const)
 				}
 				body = append(body, tc.input, 123, OpcodeDrop, OpcodeEnd)
-				fmt.Println(body)
-				err := validateFunction(&FunctionType{}, body, nil, nil, nil, nil, nil, nil, maxStackHeight, FeatureSignExtensionOps)
+				err := validateFunction(Features20191205, &FunctionType{}, body, nil, nil, nil, nil, nil, nil, maxStackHeight)
 				require.NoError(t, err)
 			})
 		})

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -186,7 +186,7 @@ func TestModule_validateHostFunctions(t *testing.T) {
 		}
 		err := m.validateHostFunctions()
 		require.Error(t, err)
-		require.EqualError(t, err, `host_function[0] (export "f1") is not a valid go func: kind != func: ptr`)
+		require.EqualError(t, err, `host_function[0] export["f1"] is not a valid go func: kind != func: ptr`)
 	})
 	t.Run("not a function  - exported after import", func(t *testing.T) {
 		m := Module{
@@ -198,7 +198,7 @@ func TestModule_validateHostFunctions(t *testing.T) {
 		}
 		err := m.validateHostFunctions()
 		require.Error(t, err)
-		require.EqualError(t, err, `host_function[0] (export "f1") is not a valid go func: kind != func: ptr`)
+		require.EqualError(t, err, `host_function[0] export["f1"] is not a valid go func: kind != func: ptr`)
 	})
 	t.Run("not a function - exported twice", func(t *testing.T) {
 		m := Module{
@@ -212,6 +212,6 @@ func TestModule_validateHostFunctions(t *testing.T) {
 		}
 		err := m.validateHostFunctions()
 		require.Error(t, err)
-		require.EqualError(t, err, `host_function[0] (export "f1","f2") is not a valid go func: kind != func: ptr`)
+		require.EqualError(t, err, `host_function[0] export["f1","f2"] is not a valid go func: kind != func: ptr`)
 	})
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -293,7 +293,7 @@ func TestModule_Validate_Errors(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name: "StartSection points to an infunc",
+			name: "StartSection points to an invalid func",
 			input: &Module{
 				TypeSection:     nil,
 				FunctionSection: []uint32{0},

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -103,7 +103,7 @@ type moduleParser struct {
 // DecodeModule implements internalwasm.DecodeModule for the WebAssembly 1.0 (20191205) Text Format
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-format%E2%91%A0
 func DecodeModule(source []byte, enabledFeatures wasm.Features) (result *wasm.Module, err error) {
-	// TODO: when globals are supported, err on mutable globals if disabled
+	// TODO: when globals are supported, err on global vars if disabled
 
 	// names are the wasm.Module NameSection
 	//

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -150,7 +150,7 @@ type Global interface {
 	Get() uint64
 }
 
-// MutableGlobal is a Global whose value can be updated at runtime.
+// MutableGlobal is a Global whose value can be updated at runtime (variable).
 type MutableGlobal interface {
 	Global
 


### PR DESCRIPTION
Before, we denied mutable globals when mutable-global=false, when really
that flag is about import/export. This fixes the flag so that it
disables externalizing a mutable global. Non-exported mutable globals
are common as implenented by compilers such as Emscripten.

See https://github.com/emscripten-core/emscripten/blob/main/system%2Flib%2Fcompiler-rt%2Fstack_ops.S
