### PR TITLE
Use interface as table element to pass tests with `-race`

### DIFF
--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -9,11 +9,9 @@ type Engine interface {
 
 // ModuleEngine implements function calls for a given module.
 type ModuleEngine interface {
-	// FunctionAddress returns the absolute address of the compiled function for index.
-	// The returned address is stored and used as a TableInstance.Table element.
-	//
-	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr
-	FunctionAddress(index Index) uintptr
+	// FunctionPointer returns the pointer the compiled function for index as interface{}.
+	// The returned interface is stored and used as a TableInstance.Table element.
+	FunctionPointer(index Index) interface{}
 
 	// Call invokes a function instance f with given parameters.
 	// Returns the results from the function.

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -9,7 +9,6 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
-	"unsafe"
 
 	"github.com/tetratelabs/wazero/internal/moremath"
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
@@ -464,9 +463,9 @@ func (e *engine) lowerIROps(f *wasm.FunctionInstance,
 	return ret, nil
 }
 
-// FunctionAddress implements internalwasm.ModuleEngine FunctionAddress.
-func (me *moduleEngine) FunctionAddress(index wasm.Index) uintptr {
-	return uintptr(unsafe.Pointer(me.compiledFunctions[index]))
+// FunctionPointer implements internalwasm.ModuleEngine FunctionPointer.
+func (me *moduleEngine) FunctionPointer(index wasm.Index) interface{} {
+	return me.compiledFunctions[index]
 }
 
 // Call implements internalwasm.ModuleEngine Call.
@@ -641,8 +640,8 @@ func (ce *callEngine) callNativeFunc(ctx *wasm.ModuleContext, f *compiledFunctio
 				if offset >= uint64(len(table.Table)) {
 					panic(wasm.ErrRuntimeInvalidTableAccess)
 				}
-				targetCompiledFunction := (*compiledFunction)(unsafe.Pointer(table.Table[offset]))
-				if targetCompiledFunction == nil {
+				targetCompiledFunction, ok := table.Table[offset].(*compiledFunction)
+				if !ok {
 					panic(wasm.ErrRuntimeInvalidTableAccess)
 				} else if uint64(targetCompiledFunction.funcInstance.TypeID) != op.us[1] {
 					panic(wasm.ErrRuntimeIndirectCallTypeMismatch)

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -369,9 +369,9 @@ func (e *engine) getCompiledFunction(f *wasm.FunctionInstance) (cf *compiledFunc
 	return
 }
 
-// FunctionAddress implements internalwasm.ModuleEngine FunctionAddress
-func (me *moduleEngine) FunctionAddress(index wasm.Index) uintptr {
-	return uintptr(unsafe.Pointer(me.compiledFunctions[index]))
+// FunctionPointer implements internalwasm.ModuleEngine FunctionPointer
+func (me *moduleEngine) FunctionPointer(index wasm.Index) interface{} {
+	return me.compiledFunctions[index]
 }
 
 // Release implements internalwasm.ModuleEngine Release

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -997,15 +997,15 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 
 	// Next we check if the target's type matches the operation's one.
 	// In order to get the type instance's address, we have to multiply the offset
-	// by 8 as the offset is the "length" of table in Go's "[]uintptr",
-	// and size of uintptr equals 64 bit.
+	// by 16 as the offset is the "length" of table in Go's "[]interface{}",
+	// and size of interface{} equals 16 bytes == (2^4).
 	getTypeInstanceAddress := c.newProg()
 	notLengthExceedJump.To.SetTarget(getTypeInstanceAddress)
 	getTypeInstanceAddress.As = x86.ASHLQ
 	getTypeInstanceAddress.To.Type = obj.TYPE_REG
 	getTypeInstanceAddress.To.Reg = offset.register
 	getTypeInstanceAddress.From.Type = obj.TYPE_CONST
-	getTypeInstanceAddress.From.Offset = 3
+	getTypeInstanceAddress.From.Offset = 4
 	c.addInstruction(getTypeInstanceAddress)
 
 	// Adds the address of wasm.Table[0] stored as callEngine.tableElement0Address to the offset.
@@ -1025,6 +1025,7 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 	derefCompiledFunctionPointer.To.Reg = offset.register
 	derefCompiledFunctionPointer.From.Type = obj.TYPE_MEM
 	derefCompiledFunctionPointer.From.Reg = offset.register
+	derefCompiledFunctionPointer.From.Offset = interfaceDataOffset
 	c.addInstruction(derefCompiledFunctionPointer)
 
 	// At this point offset.register holds the address of *compiledFunction (as uintptr) at wasm.Table[offset].

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -1018,7 +1018,7 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 	movTableSliceAddress.From.Offset = callEngineModuleContextTableElement0AddressOffset
 	c.addInstruction(movTableSliceAddress)
 
-	// "offset = *offset (== table[offset] == *compiledFunction type)"
+	// "offset = (*offset+interfaceDataOffset) (== (table[offset] + interfaceDataOffset) == *compiledFunction type)"
 	derefCompiledFunctionPointer := c.newProg()
 	derefCompiledFunctionPointer.As = x86.AMOVQ
 	derefCompiledFunctionPointer.To.Type = obj.TYPE_REG

--- a/internal/wasm/jit/jit_amd64_test.go
+++ b/internal/wasm/jit/jit_amd64_test.go
@@ -230,7 +230,7 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
@@ -238,7 +238,7 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			name: "memory nil",
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
@@ -246,7 +246,7 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
@@ -265,7 +265,7 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 0)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 0)},
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
@@ -291,7 +291,7 @@ func TestAmd64Compiler_initializeModuleContext(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine: modEngine,
 				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:  &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:  &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 	} {
@@ -6137,7 +6137,7 @@ func TestAmd64Compiler_compileCall(t *testing.T) {
 func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 	t.Run("out of bounds", func(t *testing.T) {
 		env := newJITEnvironment()
-		env.setTable(make([]uintptr, 10))
+		env.setTable(make([]interface{}, 10))
 		compiler := env.requireNewCompiler(t)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -6181,9 +6181,9 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 			Kind:   wasm.FunctionKindWasm,
 		}
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
-		table := make([]uintptr, 10)
+		table := make([]interface{}, 10)
 		env.setTable(table)
-		table[0] = 0
+		table[0] = nil
 
 		// Place the offset value.
 		err = compiler.compileConstI32(targetOffset)
@@ -6213,11 +6213,10 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 		env.module().Types = []*wasm.TypeInstance{{Type: &wasm.FunctionType{}, TypeID: 1000}}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
-		table := make([]uintptr, 10)
+		table := make([]interface{}, 10)
 		env.setTable(table)
 
-		cf := &compiledFunction{source: &wasm.FunctionInstance{TypeID: 50}}
-		table[0] = uintptr(unsafe.Pointer(cf))
+		table[0] = &compiledFunction{source: &wasm.FunctionInstance{TypeID: 50}}
 
 		// Place the offfset value.
 		err = compiler.compileConstI32(targetOffset)
@@ -6252,7 +6251,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 				moduleInstance := &wasm.ModuleInstance{Types: make([]*wasm.TypeInstance, 100), Engine: &moduleEngine{compiledFunctions: []*compiledFunction{}}}
 				moduleInstance.Types[operation.TableIndex] = &wasm.TypeInstance{Type: targetType, TypeID: targetTypeID}
 
-				table := make([]uintptr, 10)
+				table := make([]interface{}, 10)
 				env := newJITEnvironment()
 				env.setTable(table)
 				me := env.moduleEngine()
@@ -6285,7 +6284,7 @@ func TestAmd64Compiler_compileCallIndirect(t *testing.T) {
 							},
 						}
 						me.compiledFunctions = append(me.compiledFunctions, cf)
-						table[i] = uintptr(unsafe.Pointer(cf))
+						table[i] = cf
 					})
 				}
 

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -1421,17 +1421,17 @@ func (c *arm64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 		reservedRegisterForCallEngine, callEngineModuleContextTableElement0AddressOffset,
 		tmp,
 	)
-	// "offset = tmp + (offset << 3) (== &table[offset])"
-	// Here we left shiting by 3 in order to get the offset in bytes,
-	// and the table element type is uintptr which is 8 bytes.
+	// "offset = tmp + (offset << 4) (== &table[offset])"
+	// Here we left shiting by 4 in order to get the offset in bytes,
+	// and the table element type is interface which is 16 bytes (two pointers).
 	c.compileAddInstructionWithLeftShiftedRegister(
-		offset.register, 3,
+		offset.register, 4,
 		tmp,
 		offset.register,
 	)
 
-	// "offset = *offset (== table[offset] == *compiledFunction type)"
-	c.compileMemoryToRegisterInstruction(arm64.AMOVD, offset.register, 0, offset.register)
+	// "offset = (*offset) + interfaceDataOffset (== table[offset] + interfaceDataOffset == *compiledFunction type)"
+	c.compileMemoryToRegisterInstruction(arm64.AMOVD, offset.register, interfaceDataOffset, offset.register)
 
 	// Check if the value of table[offset] equals zero, meaning that the target element is uninitialized.
 	c.compileTwoRegistersToNoneInstruction(arm64.ACMP, zeroRegister, offset.register)

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -1821,7 +1821,7 @@ func TestArm64Compiler_compileCall(t *testing.T) {
 func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 	t.Run("out of bounds", func(t *testing.T) {
 		env := newJITEnvironment()
-		env.setTable(make([]uintptr, 10))
+		env.setTable(make([]interface{}, 10))
 		compiler := env.requireNewCompiler(t)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -1866,9 +1866,9 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 			Kind:   wasm.FunctionKindWasm,
 		}
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
-		table := make([]uintptr, 10)
+		table := make([]interface{}, 10)
 		env.setTable(table)
-		table[0] = 0
+		table[0] = nil
 
 		// Place the offset value.
 		err = compiler.compileConstI32(targetOffset)
@@ -1899,11 +1899,10 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 		env.module().Types = []*wasm.TypeInstance{{Type: &wasm.FunctionType{}, TypeID: 1000}}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
-		table := make([]uintptr, 10)
+		table := make([]interface{}, 10)
 		env.setTable(table)
 
-		cf := &compiledFunction{source: &wasm.FunctionInstance{TypeID: 50}}
-		table[0] = uintptr(unsafe.Pointer(cf))
+		table[0] = &compiledFunction{source: &wasm.FunctionInstance{TypeID: 50}}
 
 		// Place the offfset value.
 		err = compiler.compileConstI32(targetOffset)
@@ -1939,7 +1938,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 				moduleInstance := &wasm.ModuleInstance{Types: make([]*wasm.TypeInstance, 100), Engine: &moduleEngine{compiledFunctions: []*compiledFunction{}}}
 				moduleInstance.Types[operation.TableIndex] = &wasm.TypeInstance{Type: targetType, TypeID: targetTypeID}
 
-				table := make([]uintptr, 10)
+				table := make([]interface{}, 10)
 				env := newJITEnvironment()
 				env.setTable(table)
 				me := env.moduleEngine()
@@ -1971,7 +1970,7 @@ func TestArm64Compiler_compileCallIndirect(t *testing.T) {
 							},
 						}
 						me.compiledFunctions = append(me.compiledFunctions, cf)
-						table[i] = uintptr(unsafe.Pointer(cf))
+						table[i] = cf
 					})
 				}
 
@@ -2148,7 +2147,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 				Engine:  modEngine,
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 		{
@@ -2156,7 +2155,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine: modEngine,
 				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:  &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:  &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 		{
@@ -2164,7 +2163,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 		{
@@ -2181,7 +2180,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 0)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 0)},
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 			},
 		},
@@ -2190,7 +2189,7 @@ func TestArm64Compiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Engine:  modEngine,
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 0)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 0)},
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -75,7 +75,7 @@ func (j *jitEnv) getGlobal(index uint32) uint64 {
 	return j.moduleInstance.Globals[index].Val
 }
 
-func (j *jitEnv) setTable(table []uintptr) {
+func (j *jitEnv) setTable(table []interface{}) {
 	j.moduleInstance.Table = &wasm.TableInstance{Table: table}
 }
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -521,7 +521,7 @@ func (m *Module) buildMemory() (mem *MemoryInstance) {
 func (m *Module) buildTable() (table *TableInstance) {
 	for _, tableSeg := range m.TableSection {
 		table = &TableInstance{
-			Table:    make([]uintptr, tableSeg.Limit.Min),
+			Table:    make([]interface{}, tableSeg.Limit.Min),
 			Min:      tableSeg.Limit.Min,
 			Max:      tableSeg.Limit.Max,
 			ElemType: 0x70, // funcref

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -163,7 +163,7 @@ type (
 	TableInstance struct {
 		// Table holds the table elements managed by this table instance.
 		// The content of interface{} depends on the engine implementation,
-		// and set via ModuleEngine.
+		// and is set via ModuleEngine.FunctionPointer.
 		Table []interface{}
 		Min   uint32
 		Max   *uint32

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -162,7 +162,9 @@ type (
 	// Note this is fixed to function type until post 20191205 reference type is implemented.
 	TableInstance struct {
 		// Table holds the table elements managed by this table instance.
-		Table []uintptr
+		// The content of interface{} depends on the engine implementation,
+		// and set via ModuleEngine.
+		Table []interface{}
 		Min   uint32
 		Max   *uint32
 		// Currently fixed to 0x70 (funcref type).
@@ -287,7 +289,7 @@ func (m *ModuleInstance) applyElements(elements []*ElementSegment) {
 		table := m.Table.Table
 		for i, elm := range elem.Init {
 			pos := i + offset
-			table[pos] = m.Engine.FunctionAddress(elm)
+			table[pos] = m.Engine.FunctionPointer(elm)
 		}
 	}
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -446,8 +446,8 @@ func (e *mockEngine) Compile(_, _ []*FunctionInstance) (ModuleEngine, error) {
 	return &mockModuleEngine{callFailIndex: e.callFailIndex}, nil
 }
 
-func (e *mockModuleEngine) FunctionAddress(index Index) uintptr {
-	return uintptr(index)
+func (e *mockModuleEngine) FunctionPointer(index Index) interface{} {
+	return index
 }
 
 func (e *mockModuleEngine) Call(ctx *ModuleContext, f *FunctionInstance, _ ...uint64) (results []uint64, err error) {
@@ -798,7 +798,7 @@ func TestModuleInstance_applyData(t *testing.T) {
 func TestModuleInstance_validateElements(t *testing.T) {
 	functionCounts := uint32(0xa)
 	m := &ModuleInstance{
-		Table:     &TableInstance{Table: make([]uintptr, 10)},
+		Table:     &TableInstance{Table: make([]interface{}, 10)},
 		Functions: make([]*FunctionInstance, 10),
 	}
 	for _, tc := range []struct {
@@ -848,7 +848,7 @@ func TestModuleInstance_validateElements(t *testing.T) {
 func TestModuleInstance_applyElements(t *testing.T) {
 	functionCounts := uint32(0xa)
 	m := &ModuleInstance{
-		Table:     &TableInstance{Table: make([]uintptr, 10)},
+		Table:     &TableInstance{Table: make([]interface{}, 10)},
 		Functions: make([]*FunctionInstance, 10),
 		Engine:    &mockModuleEngine{},
 	}
@@ -860,8 +860,8 @@ func TestModuleInstance_applyElements(t *testing.T) {
 		{OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{targetOffset}}, Init: []uint32{targetIndex}},
 		{OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: []byte{targetOffset2}}, Init: []uint32{targetIndex2}},
 	})
-	require.Equal(t, uintptr(targetIndex), m.Table.Table[targetOffset])
-	require.Equal(t, uintptr(targetIndex2), m.Table.Table[targetOffset2])
+	require.Equal(t, targetIndex, m.Table.Table[targetOffset])
+	require.Equal(t, targetIndex2, m.Table.Table[targetOffset2])
 }
 
 func TestModuleInstance_decDependentCount(t *testing.T) {


### PR DESCRIPTION
This is a followup on the comment https://github.com/tetratelabs/wazero/pull/345#discussion_r822587159
Notably, using `uintptr` and casting to objects is considered as invalid in Go
as `fatal error: checkptr: pointer arithmetic result points to invalid allocation`
is raised when running with `-race`


Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>