### PR TITLE
Fix Release for engines

### DIFF
--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -165,10 +165,10 @@ func (e *engine) Compile(importedFunctions, moduleFunctions []*wasm.FunctionInst
 		importedFunctionCounts: len(importedFunctions),
 	}
 
-	for _, f := range importedFunctions {
+	for idx, f := range importedFunctions {
 		cf, ok := e.getCompiledFunction(f)
 		if !ok {
-			return nil, fmt.Errorf("uncompiled imported function: %s.%s", f.Module.Name, f.Name)
+			return nil, fmt.Errorf("import[%d] func[%s.%s]: uncompiled", idx, f.Module.Name, f.Name)
 		}
 		modEngine.compiledFunctions = append(modEngine.compiledFunctions, cf)
 	}
@@ -179,6 +179,7 @@ func (e *engine) Compile(importedFunctions, moduleFunctions []*wasm.FunctionInst
 			ir, err := wazeroir.Compile(f)
 			if err != nil {
 				_ = modEngine.Release()
+				// TODO(Adrian): extract Module.funcDesc so that errors here have more context
 				return nil, fmt.Errorf("function[%d/%d] failed to lower to wazeroir: %w", i, len(moduleFunctions)-1, err)
 			}
 

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -33,7 +33,7 @@ func NewEngine() wasm.Engine {
 
 func (e *engine) deleteCompiledFunction(f *wasm.FunctionInstance) {
 	e.mux.Lock()
-	defer e.mux.Lock()
+	defer e.mux.Unlock()
 	delete(e.compiledFunctions, f)
 }
 
@@ -57,7 +57,8 @@ type moduleEngine struct {
 	compiledFunctions []*compiledFunction
 
 	// parentEngine holds *engine from which this module engine is created from.
-	parentEngine *engine
+	parentEngine           *engine
+	importedFunctionCounts int
 }
 
 // callEngine holds context per moduleEngine.Call, and shared across all the
@@ -149,7 +150,8 @@ type interpreterOp struct {
 
 // Release implements wasm.Engine Release
 func (me *moduleEngine) Release() error {
-	for _, cf := range me.compiledFunctions {
+	// Release all the function instances declared in this module.
+	for _, cf := range me.compiledFunctions[me.importedFunctionCounts:] {
 		me.parentEngine.deleteCompiledFunction(cf.funcInstance)
 	}
 	return nil
@@ -157,37 +159,45 @@ func (me *moduleEngine) Release() error {
 
 // Compile implements internalwasm.Engine Compile
 func (e *engine) Compile(importedFunctions, moduleFunctions []*wasm.FunctionInstance) (me wasm.ModuleEngine, err error) {
-	compiledFunctions := make([]*compiledFunction, len(importedFunctions)+len(moduleFunctions))
-	for i, f := range importedFunctions {
-		cf, ok := e.getCompiledFunction(f)
-		if !ok {
-			return nil, fmt.Errorf("uncompiled imported function: %s", f.Name)
-		}
-		compiledFunctions[i] = cf
+	modEngine := &moduleEngine{
+		compiledFunctions:      make([]*compiledFunction, 0, len(importedFunctions)+len(moduleFunctions)),
+		parentEngine:           e,
+		importedFunctionCounts: len(importedFunctions),
 	}
 
-	ret := &moduleEngine{compiledFunctions: compiledFunctions, parentEngine: e}
-	for _, f := range moduleFunctions {
+	for _, f := range importedFunctions {
+		cf, ok := e.getCompiledFunction(f)
+		if !ok {
+			return nil, fmt.Errorf("uncompiled imported function: %s.%s", f.Module.Name, f.Name)
+		}
+		modEngine.compiledFunctions = append(modEngine.compiledFunctions, cf)
+	}
+
+	for i, f := range moduleFunctions {
 		var compiled *compiledFunction
 		if f.Kind == wasm.FunctionKindWasm {
 			ir, err := wazeroir.Compile(f)
 			if err != nil {
-				return nil, fmt.Errorf("failed to compile Wasm to wazeroir: %w", err)
+				_ = modEngine.Release()
+				return nil, fmt.Errorf("function[%d/%d] failed to lower to wazeroir: %w", i, len(moduleFunctions)-1, err)
 			}
 
 			compiled, err = e.lowerIROps(f, ir.Operations)
 			if err != nil {
-				return nil, fmt.Errorf("failed to convert wazeroir operations to engine ones: %w", err)
+				_ = modEngine.Release()
+				return nil, fmt.Errorf("function[%d/%d] failed to convert wazeroir operations: %w", i, len(moduleFunctions)-1, err)
 			}
 		} else {
 			compiled = &compiledFunction{hostFn: f.GoFunc, funcInstance: f}
 		}
+		compiled.moduleEngine = modEngine
+		modEngine.compiledFunctions = append(modEngine.compiledFunctions, compiled)
 
-		compiled.moduleEngine = ret
-		compiledFunctions[f.Index] = compiled
+		// Add the compiled function to the store-wide engine as well so that
+		// the future importing module can refer the function instance.
 		e.addCompiledFunction(f, compiled)
 	}
-	return ret, nil
+	return modEngine, nil
 }
 
 // Lowers the wazeroir operations to engine friendly struct.

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -233,4 +234,103 @@ func TestCallEngine_callNativeFunc_signExtend(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestEngineCompile_Errors(t *testing.T) {
+	t.Run("invalid import", func(t *testing.T) {
+		e := NewEngine().(*engine)
+		_, err := e.Compile([]*wasm.FunctionInstance{{Module: &wasm.ModuleInstance{Name: "uncompiled"}, Name: "fn"}}, nil)
+		require.EqualError(t, err, "uncompiled imported function: uncompiled.fn")
+	})
+
+	t.Run("release on compilation error", func(t *testing.T) {
+		e := NewEngine().(*engine)
+
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		_, err := e.Compile(nil, importedFunctions)
+		require.NoError(t, err)
+
+		require.Len(t, e.compiledFunctions, len(importedFunctions))
+
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "ok1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "ok2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "invalid code", Type: &wasm.FunctionType{}, Body: []byte{
+				wasm.OpcodeCall, // Call instruction without immediate for call target index is invalid and should fail to compile.
+			}, Module: &wasm.ModuleInstance{}},
+		}
+
+		_, err = e.Compile(importedFunctions, moduleFunctions)
+		require.EqualError(t, err, "function[2/2] failed to lower to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
+
+		// On the compilation failrue, all the compiled functions including suceeded ones must be released.
+		require.Len(t, e.compiledFunctions, len(importedFunctions))
+		for _, f := range moduleFunctions {
+			require.NotContains(t, e.compiledFunctions, f)
+		}
+	})
+}
+
+func TestRelase(t *testing.T) {
+	newFunctionInstance := func(id int) *wasm.FunctionInstance {
+		return &wasm.FunctionInstance{
+			Name: strconv.Itoa(id), Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}}
+	}
+
+	for _, tc := range []struct {
+		name                               string
+		importedFunctions, moduleFunctions []*wasm.FunctionInstance
+	}{
+		{
+			name:            "no imports",
+			moduleFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
+		},
+		{
+			name:              "only imports",
+			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
+		},
+		{
+			name:              "mix",
+			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
+			moduleFunctions:   []*wasm.FunctionInstance{newFunctionInstance(100), newFunctionInstance(200), newFunctionInstance(300)},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEngine().(*engine)
+			if len(tc.importedFunctions) > 0 {
+				modEngine, err := e.Compile(nil, tc.importedFunctions)
+				require.NoError(t, err)
+				require.Len(t, modEngine.(*moduleEngine).compiledFunctions, len(tc.importedFunctions))
+			}
+
+			modEngine, err := e.Compile(tc.importedFunctions, tc.moduleFunctions)
+			require.NoError(t, err)
+			require.Len(t, modEngine.(*moduleEngine).compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
+
+			require.Len(t, e.compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
+			for _, f := range tc.importedFunctions {
+				require.Contains(t, e.compiledFunctions, f)
+			}
+			for _, f := range tc.moduleFunctions {
+				require.Contains(t, e.compiledFunctions, f)
+			}
+
+			err = modEngine.Release()
+			require.NoError(t, err)
+
+			require.Len(t, e.compiledFunctions, len(tc.importedFunctions))
+			for _, f := range tc.importedFunctions {
+				require.Contains(t, e.compiledFunctions, f)
+			}
+			for i, f := range tc.moduleFunctions {
+				require.NotContains(t, e.compiledFunctions, f, i)
+			}
+		})
+	}
 }

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -240,7 +240,7 @@ func TestEngineCompile_Errors(t *testing.T) {
 	t.Run("invalid import", func(t *testing.T) {
 		e := NewEngine().(*engine)
 		_, err := e.Compile([]*wasm.FunctionInstance{{Module: &wasm.ModuleInstance{Name: "uncompiled"}, Name: "fn"}}, nil)
-		require.EqualError(t, err, "uncompiled imported function: uncompiled.fn")
+		require.EqualError(t, err, "import[0] func[uncompiled.fn]: uncompiled")
 	})
 
 	t.Run("release on compilation error", func(t *testing.T) {

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -276,7 +276,7 @@ func TestEngineCompile_Errors(t *testing.T) {
 	})
 }
 
-func TestRelase(t *testing.T) {
+func TestRelease(t *testing.T) {
 	newFunctionInstance := func(id int) *wasm.FunctionInstance {
 		return &wasm.FunctionInstance{
 			Name: strconv.Itoa(id), Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}}

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -31,8 +31,7 @@ type (
 		compiledFunctions []*compiledFunction
 
 		// parentEngine holds *engine from which this module engine is created from.
-		parentEngine *engine
-
+		parentEngine           *engine
 		importedFunctionCounts int
 	}
 

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -331,10 +331,10 @@ func (e *engine) Compile(importedFunctions, moduleFunctions []*wasm.FunctionInst
 		importedFunctionCounts: imported,
 	}
 
-	for _, f := range importedFunctions {
+	for idx, f := range importedFunctions {
 		cf, ok := e.getCompiledFunction(f)
 		if !ok {
-			return nil, fmt.Errorf("uncompiled imported function: %s.%s", f.Module.Name, f.Name)
+			return nil, fmt.Errorf("import[%d] func[%s.%s]: uncompiled", idx, f.Module.Name, f.Name)
 		}
 		modEngine.compiledFunctions = append(modEngine.compiledFunctions, cf)
 	}

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -225,7 +225,7 @@ func TestEngineCompile_Errors(t *testing.T) {
 	})
 }
 
-func TestRelase(t *testing.T) {
+func TestRelease(t *testing.T) {
 	newFunctionInstance := func(id int) *wasm.FunctionInstance {
 		return &wasm.FunctionInstance{
 			Name: strconv.Itoa(id), Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}}

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"runtime"
+	"strconv"
 	"testing"
 	"unsafe"
 
@@ -181,5 +182,102 @@ func TestEngine_Call_HostFn(t *testing.T) {
 func requireSupportedOSArch(t *testing.T) {
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Skip()
+	}
+}
+
+func TestEngineCompile_Errors(t *testing.T) {
+	t.Run("invalid import", func(t *testing.T) {
+		e := newEngine()
+		_, err := e.Compile([]*wasm.FunctionInstance{{Module: &wasm.ModuleInstance{Name: "uncompiled"}, Name: "fn"}}, nil)
+		require.EqualError(t, err, "uncompiled imported function: uncompiled.fn")
+	})
+
+	t.Run("release on compilation error", func(t *testing.T) {
+		e := newEngine()
+
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		_, err := e.Compile(nil, importedFunctions)
+		require.NoError(t, err)
+
+		require.Len(t, e.compiledFunctions, len(importedFunctions))
+
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "ok1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "ok2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "invalid code", Type: &wasm.FunctionType{}, Body: []byte{
+				wasm.OpcodeCall, // Call instruction without immediate for call target index is invalid and should fail to compile.
+			}, Module: &wasm.ModuleInstance{}},
+		}
+
+		_, err = e.Compile(importedFunctions, moduleFunctions)
+		require.EqualError(t, err, "function[2/2] failed to lower to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
+
+		// On the compilation failrue, all the compiled functions including suceeded ones must be released.
+		require.Len(t, e.compiledFunctions, len(importedFunctions))
+		for _, f := range moduleFunctions {
+			require.NotContains(t, e.compiledFunctions, f)
+		}
+	})
+}
+
+func TestRelase(t *testing.T) {
+	newFunctionInstance := func(id int) *wasm.FunctionInstance {
+		return &wasm.FunctionInstance{
+			Name: strconv.Itoa(id), Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}}
+	}
+
+	for _, tc := range []struct {
+		name                               string
+		importedFunctions, moduleFunctions []*wasm.FunctionInstance
+	}{
+		{
+			name:            "no imports",
+			moduleFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
+		},
+		{
+			name:              "only imports",
+			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
+		},
+		{
+			name:              "mix",
+			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
+			moduleFunctions:   []*wasm.FunctionInstance{newFunctionInstance(100), newFunctionInstance(200), newFunctionInstance(300)},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEngine()
+			if len(tc.importedFunctions) > 0 {
+				_, err := e.Compile(nil, tc.importedFunctions)
+				require.NoError(t, err)
+			}
+
+			modEngine, err := e.Compile(tc.importedFunctions, tc.moduleFunctions)
+			require.NoError(t, err)
+
+			require.Len(t, e.compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
+			for _, f := range tc.importedFunctions {
+				require.Contains(t, e.compiledFunctions, f)
+			}
+			for _, f := range tc.moduleFunctions {
+				require.Contains(t, e.compiledFunctions, f)
+			}
+
+			err = modEngine.Release()
+			require.NoError(t, err)
+
+			require.Len(t, e.compiledFunctions, len(tc.importedFunctions))
+			for _, f := range tc.importedFunctions {
+				require.Contains(t, e.compiledFunctions, f)
+			}
+			for i, f := range tc.moduleFunctions {
+				require.NotContains(t, e.compiledFunctions, f, i)
+			}
+		})
 	}
 }

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -253,12 +253,14 @@ func TestRelase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			e := newEngine()
 			if len(tc.importedFunctions) > 0 {
-				_, err := e.Compile(nil, tc.importedFunctions)
+				modEngine, err := e.Compile(nil, tc.importedFunctions)
 				require.NoError(t, err)
+				require.Len(t, modEngine.(*moduleEngine).compiledFunctions, len(tc.importedFunctions))
 			}
 
 			modEngine, err := e.Compile(tc.importedFunctions, tc.moduleFunctions)
 			require.NoError(t, err)
+			require.Len(t, modEngine.(*moduleEngine).compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
 
 			require.Len(t, e.compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
 			for _, f := range tc.importedFunctions {

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -189,7 +189,7 @@ func TestEngineCompile_Errors(t *testing.T) {
 	t.Run("invalid import", func(t *testing.T) {
 		e := newEngine()
 		_, err := e.Compile([]*wasm.FunctionInstance{{Module: &wasm.ModuleInstance{Name: "uncompiled"}, Name: "fn"}}, nil)
-		require.EqualError(t, err, "uncompiled imported function: uncompiled.fn")
+		require.EqualError(t, err, "import[0] func[uncompiled.fn]: uncompiled")
 	})
 
 	t.Run("release on compilation error", func(t *testing.T) {

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -183,7 +183,7 @@ func Compile(f *wasm.FunctionInstance) (*CompilationResult, error) {
 	// Now enter the function body.
 	for !c.controlFrames.empty() {
 		if err := c.handleInstruction(); err != nil {
-			return nil, fmt.Errorf("handling instruction: %w\ndisassemble: %v", err, Format(c.result.Operations))
+			return nil, fmt.Errorf("handling instruction: %w", err)
 		}
 	}
 	return &c.result, nil
@@ -205,9 +205,8 @@ func (c *compiler) handleInstruction() error {
 	// applyToStack and advance c.pc inside the function.
 	index, err := c.applyToStack(op)
 	if err != nil {
-		return fmt.Errorf("apply stack failed for 0x%x: %w: stack: %s", op, err, c.stackDump())
+		return fmt.Errorf("apply stack failed for %s: %w", wasm.InstructionName(op), err)
 	}
-
 	// Now we handle each instruction, and
 	// emit the corresponding wazeroir operations to the results.
 operatorSwitch:

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -116,6 +116,7 @@ type compiler struct {
 }
 
 // For debugging only.
+//nolint
 func (c *compiler) stackDump() string {
 	strs := make([]string, 0, len(c.stack))
 	for _, s := range c.stack {


### PR DESCRIPTION
This commit fixes a few bugs in engine.Release, and backfills 
unittests. Notably, moduleEngines must not release the imported
functions. 


Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>