### PR TITLE
Prevent callFrame and value stack from allocated on gorutine stack

### DIFF
--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -489,6 +489,8 @@ func newEngine() *engine {
 //
 // [1] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/cmd/compile/internal/escape/utils.go#L206-L208
 // [2] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/runtime/mgc.go#L9
+// [3] https://mayurwadekar2.medium.com/escape-analysis-in-golang-ee40a1c064c1
+// [4] https://medium.com/@yulang.chu/go-stack-or-heap-2-slices-which-keep-in-stack-have-limitation-of-size-b3f3adfd6190
 var (
 	initialValueStackSize     = 64
 	initialCallFrameStackSize = 16

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -474,21 +474,22 @@ func newEngine() *engine {
 // Background: Go has a mechanism called "goroutine stack-shrink" where Go
 // runtime shrinks Gorotuine's stack when it is GCing. Shrinking means that
 // all the contents on the goroutine stack will be relocated by runtime,
-// therefore the memory address of these contents change undeterministically.
+// Therefore, the memory address of these contents change undeterministically.
 // Not only shrinks, but also Goruntime grows the goroutine stack at any point
 // of function call entries, which also might end up relcating contents.
 //
 // On the other hand, we hold pointers to the data region of value stack and
-// callframe stack slices and use these raw pointers from  native code.
+// callframe stack slices and use these raw pointers from native code.
 // Therefore, it is dangerous if these two stacks are allocated on stack
 // as these stack's address might be changed by Goruntime which we cannot
 // detect.
 //
-// By declaring thses values as values, slices created via make([]..., var) will
-// never be allocated on stack [1], therefore we can ensure that accessing these
-// slices via raw pointers is safe because Go's GC never relocate heap-allocated
-// objects (aka no compation of memory [2]). We can actually check how go compiler
-// does escape analysis on these variables lile 'go build -gcflags='-m' ./internal/wasm/jit/...'.
+// By declaring theses values as `var`, slices created via `make([]..., var)`
+// will never be allocated on stack [1]. This means accessing these slices via
+// raw pointers is safe: As of version 1.18, Go's garbage collectornever relocates
+// heap-allocated objects (aka no compilation of memory [2]).
+//
+// On Go upgrades, re-validate heap-allocation via `go build -gcflags='-m' ./internal/wasm/jit/...`.
 //
 // [1] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/cmd/compile/internal/escape/utils.go#L206-L208
 // [2] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/runtime/mgc.go#L9

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -468,7 +468,27 @@ func newEngine() *engine {
 	return &engine{compiledFunctions: map[*wasm.FunctionInstance]*compiledFunction{}}
 }
 
-// TODO: better make them configurable?
+// Do not make these variables as constants, otherwise there would be
+// dangerous memory accees from native code.
+//
+// Background: Go has a mechanism called "goroutine stack-shrink" where Go
+// runtime shrinks Gorotuine's stack when it is GCing. Shrinking means that
+// all the contents on the goroutine stack will be relocated by runtime,/
+// therefore the memory address of these contents change undeterministically.
+// On the other hand, we hold pointers to the data region of value stack and
+// callframe stack slices and use these raw pointers from  native code.
+// Therefore, it is dangerous if these two stacks are allocated on stack
+// as these stack's address might be changed by Goruntime which we cannot
+// detect.
+//
+// By declaring thses values as values, slices created via make([]..., var) will
+// never be allocated on stack [1], therefore we can ensure that accessing these
+// slices via raw pointers is safe because Go's GC never relocate heap-allocated
+// objects (aka no compation of memory [2]). We can actually check how go compiler
+// does escape analysis on these variables lile 'go build -gcflags='-m' ./internal/wasm/jit/...'.
+//
+// [1] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/cmd/compile/internal/escape/utils.go#L206-L208
+// [2] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/runtime/mgc.go#L9
 var (
 	initialValueStackSize     = 64
 	initialCallFrameStackSize = 16

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -473,8 +473,11 @@ func newEngine() *engine {
 //
 // Background: Go has a mechanism called "goroutine stack-shrink" where Go
 // runtime shrinks Gorotuine's stack when it is GCing. Shrinking means that
-// all the contents on the goroutine stack will be relocated by runtime,/
+// all the contents on the goroutine stack will be relocated by runtime,
 // therefore the memory address of these contents change undeterministically.
+// Not only shrinks, but also Goruntime grows the goroutine stack at any point
+// of function call entries, which also might end up relcating contents.
+//
 // On the other hand, we hold pointers to the data region of value stack and
 // callframe stack slices and use these raw pointers from  native code.
 // Therefore, it is dangerous if these two stacks are allocated on stack

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -284,7 +284,7 @@ func TestRelease(t *testing.T) {
 	}
 }
 
-func TestSliceConsistency(t *testing.T) {
+func TestSliceAllocatedOnHeap(t *testing.T) {
 	e := newEngine()
 	store := wasm.NewStore(context.Background(), e, wasm.Features20191205)
 

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -345,7 +345,7 @@ func TestSliceAllocatedOnHeap(t *testing.T) {
 				Body: []byte{
 					wasm.OpcodeCall, 3, // Call the wasm function below.
 					// At this point, call stack's memory looks like [call_stack_corruption, index3]
-					// With this function call it should up  [call_stack_corruption, index0 (grow_and_shrink_goroutine_stack)]
+					// With this function call it should end up [call_stack_corruption, host func]
 					// but if the callframe stack is allocated on goroutine stack, we exit the native code
 					// with  [call_stack_corruption, index3] (old call frame stack) with HostCall status code,
 					// and end up trying to call index3 as a host function which results in nil pointer exception.

--- a/internal/wasm/jit/jit_arm64_test.go
+++ b/internal/wasm/jit/jit_arm64_test.go
@@ -300,7 +300,6 @@ func TestArm64Compiler_releaseRegisterToStack(t *testing.T) {
 
 			// Run native code after growing the value stack.
 			env.callEngine().builtinFunctionGrowValueStack(tc.stackPointer)
-			env.callEngine().resetValueStackElement0Address()
 			env.exec(code)
 
 			// JIT status must be returned and stack pointer must end up the specified one.
@@ -383,7 +382,6 @@ func TestArm64Compiler_compileLoadValueOnStackToRegister(t *testing.T) {
 
 			// Run native code after growing the value stack, and place the original value.
 			env.callEngine().builtinFunctionGrowValueStack(tc.stackPointer)
-			env.callEngine().resetValueStackElement0Address()
 			env.stack()[tc.stackPointer] = val
 			env.exec(code)
 


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>