### PR TITLE
Adds Module.Close API based on runtime.Finalizer

### DIFF
--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -20,6 +20,6 @@ type ModuleEngine interface {
 	// The ctx's context.Context will be the outer-most ancestor of the argument to wasm.FunctionVoidReturn, etc.
 	Call(ctx *ModuleContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
 
-	// Release releases the resources allocated by functions in this ModuleEngine.
-	Release() error
+	// Close releases the resources allocated by functions in this ModuleEngine.
+	Close()
 }

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -148,13 +148,12 @@ type interpreterOp struct {
 	rs     []*wazeroir.InclusiveRange
 }
 
-// Release implements wasm.Engine Release
-func (me *moduleEngine) Release() error {
+// Close implements wasm.Engine Close
+func (me *moduleEngine) Close() {
 	// Release all the function instances declared in this module.
 	for _, cf := range me.compiledFunctions[me.importedFunctionCounts:] {
 		me.parentEngine.deleteCompiledFunction(cf.funcInstance)
 	}
-	return nil
 }
 
 // Compile implements internalwasm.Engine Compile
@@ -178,14 +177,14 @@ func (e *engine) Compile(importedFunctions, moduleFunctions []*wasm.FunctionInst
 		if f.Kind == wasm.FunctionKindWasm {
 			ir, err := wazeroir.Compile(f)
 			if err != nil {
-				_ = modEngine.Release()
+				modEngine.Close()
 				// TODO(Adrian): extract Module.funcDesc so that errors here have more context
 				return nil, fmt.Errorf("function[%d/%d] failed to lower to wazeroir: %w", i, len(moduleFunctions)-1, err)
 			}
 
 			compiled, err = e.lowerIROps(f, ir.Operations)
 			if err != nil {
-				_ = modEngine.Release()
+				modEngine.Close()
 				return nil, fmt.Errorf("function[%d/%d] failed to convert wazeroir operations: %w", i, len(moduleFunctions)-1, err)
 			}
 		} else {

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -91,7 +91,7 @@ func TestEngine_Call_HostFn(t *testing.T) {
 
 	e := NewEngine()
 	module := &wasm.ModuleInstance{Memory: memory}
-	modCtx := wasm.NewModuleContext(context.Background(), e, module)
+	modCtx := wasm.NewModuleContext(context.Background(), wasm.NewStore(context.Background(), e, wasm.Features20191205), module)
 	f := &wasm.FunctionInstance{
 		GoFunc: &hostFn,
 		Kind:   wasm.FunctionKindGoModule,

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -276,7 +276,7 @@ func TestEngineCompile_Errors(t *testing.T) {
 	})
 }
 
-func TestRelease(t *testing.T) {
+func TestClose(t *testing.T) {
 	newFunctionInstance := func(id int) *wasm.FunctionInstance {
 		return &wasm.FunctionInstance{
 			Name: strconv.Itoa(id), Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}}
@@ -321,8 +321,7 @@ func TestRelease(t *testing.T) {
 				require.Contains(t, e.compiledFunctions, f)
 			}
 
-			err = modEngine.Release()
-			require.NoError(t, err)
+			modEngine.Close()
 
 			require.Len(t, e.compiledFunctions, len(tc.importedFunctions))
 			for _, f := range tc.importedFunctions {

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -458,6 +458,10 @@ func (me *moduleEngine) Call(ctx *wasm.ModuleContext, f *wasm.FunctionInstance, 
 	for i := range results {
 		results[len(results)-1-i] = ce.popValue()
 	}
+
+	// Keep all the compiledFunctions alive until we completely exit from the execution
+	// in order to prevent "freeing code while execution".
+	runtime.KeepAlive(ce)
 	return
 }
 

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -458,10 +458,6 @@ func (me *moduleEngine) Call(ctx *wasm.ModuleContext, f *wasm.FunctionInstance, 
 	for i := range results {
 		results[len(results)-1-i] = ce.popValue()
 	}
-
-	// Keep all the compiledFunctions alive until we completely exit from the execution
-	// in order to prevent "freeing code while execution".
-	runtime.KeepAlive(ce)
 	return
 }
 

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -270,8 +270,9 @@ func TestRelease(t *testing.T) {
 				require.Contains(t, e.compiledFunctions, f)
 			}
 
-			err = modEngine.Release()
-			require.NoError(t, err)
+			modEngine.Close()
+
+			// Check finalizer setup.
 
 			require.Len(t, e.compiledFunctions, len(tc.importedFunctions))
 			for _, f := range tc.importedFunctions {

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
+	"sync"
 	"testing"
 	"unsafe"
 
@@ -252,10 +253,12 @@ func TestRelease(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			e := newEngine()
+			var importedModuleEngine *moduleEngine
 			if len(tc.importedFunctions) > 0 {
-				modEngine, err := e.Compile(nil, tc.importedFunctions)
+				eng, err := e.Compile(nil, tc.importedFunctions)
 				require.NoError(t, err)
-				require.Len(t, modEngine.(*moduleEngine).compiledFunctions, len(tc.importedFunctions))
+				importedModuleEngine = eng.(*moduleEngine)
+				require.Len(t, importedModuleEngine.compiledFunctions, len(tc.importedFunctions))
 			}
 
 			modEngine, err := e.Compile(tc.importedFunctions, tc.moduleFunctions)
@@ -263,23 +266,59 @@ func TestRelease(t *testing.T) {
 			require.Len(t, modEngine.(*moduleEngine).compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
 
 			require.Len(t, e.compiledFunctions, len(tc.importedFunctions)+len(tc.moduleFunctions))
+
+			var importedMappedRegions [][]byte
 			for _, f := range tc.importedFunctions {
 				require.Contains(t, e.compiledFunctions, f)
+				importedMappedRegions = append(importedMappedRegions, e.compiledFunctions[f].codeSegment)
 			}
+			var mappedRegions [][]byte
 			for _, f := range tc.moduleFunctions {
 				require.Contains(t, e.compiledFunctions, f)
+				mappedRegions = append(mappedRegions, e.compiledFunctions[f].codeSegment)
 			}
 
-			modEngine.Close()
+			const goroutines = 100
+			var wg sync.WaitGroup
+			wg.Add(goroutines)
+			for i := 0; i < goroutines; i++ {
+				go func() {
+					defer wg.Done()
+					modEngine.Close() // concurrent mutliple execution of Close must be guarded by atomic.
+				}()
+			}
+			wg.Wait()
 
-			// Check finalizer setup.
-
+			require.True(t, modEngine.(*moduleEngine).closed == 1)
 			require.Len(t, e.compiledFunctions, len(tc.importedFunctions))
 			for _, f := range tc.importedFunctions {
 				require.Contains(t, e.compiledFunctions, f)
 			}
 			for i, f := range tc.moduleFunctions {
 				require.NotContains(t, e.compiledFunctions, f, i)
+			}
+
+			// Release the reference to ModuleEngine -> *compiledFunctions for non-imported compiledFunctions
+			// must be munmapped.
+			modEngine = nil
+			runtime.GC()
+
+			for _, mappedRegion := range mappedRegions {
+				// munmap twice should result in error.
+				err = munmapCodeSegment(mappedRegion)
+				require.Error(t, err)
+			}
+
+			if len(tc.importedFunctions) > 0 {
+				importedModuleEngine.Close()
+				importedModuleEngine = nil
+				runtime.GC()
+
+				for _, mappedRegion := range importedMappedRegions {
+					// munmap twice should result in error.
+					err = munmapCodeSegment(mappedRegion)
+					require.Error(t, err)
+				}
 			}
 		})
 	}

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -147,7 +147,7 @@ func TestEngine_Call_HostFn(t *testing.T) {
 
 	e := NewEngine()
 	module := &wasm.ModuleInstance{Memory: memory}
-	modCtx := wasm.NewModuleContext(context.Background(), e, module)
+	modCtx := wasm.NewModuleContext(context.Background(), wasm.NewStore(context.Background(), e, wasm.Features20191205), module)
 	f := &wasm.FunctionInstance{
 		GoFunc: &hostFn,
 		Kind:   wasm.FunctionKindGoModule,

--- a/internal/wasm/module_context.go
+++ b/internal/wasm/module_context.go
@@ -90,10 +90,11 @@ func (f *FunctionInstance) ResultTypes() []publicwasm.ValueType {
 
 // Call implements wasm.Function Call
 func (f *FunctionInstance) Call(ctx publicwasm.Module, params ...uint64) ([]uint64, error) {
+	mod := f.Module
 	if modCtx, ok := ctx.(*ModuleContext); !ok { // allow nil to substitute for the defining module
-		return f.Module.Engine.Call(f.Module.Ctx, f, params...)
+		return mod.Engine.Call(mod.Ctx, f, params...)
 	} else { // TODO: check if the importing context is correct
-		return f.Module.Engine.Call(modCtx, f, params...)
+		return mod.Engine.Call(modCtx, f, params...)
 	}
 }
 

--- a/internal/wasm/module_context.go
+++ b/internal/wasm/module_context.go
@@ -10,11 +10,12 @@ import (
 // compile time check to ensure ModuleContext implements wasm.Module
 var _ publicwasm.Module = &ModuleContext{}
 
-func NewModuleContext(ctx context.Context, engine Engine, instance *ModuleInstance) *ModuleContext {
+func NewModuleContext(ctx context.Context, store *Store, instance *ModuleInstance) *ModuleContext {
 	return &ModuleContext{
 		ctx:    ctx,
 		memory: instance.Memory,
 		module: instance,
+		store:  store,
 	}
 }
 
@@ -25,6 +26,7 @@ type ModuleContext struct {
 	module *ModuleInstance
 	// memory is returned by Memory and overridden WithMemory
 	memory publicwasm.Memory
+	store  *Store
 }
 
 // WithMemory allows overriding memory without re-allocation when the result would be the same.
@@ -53,6 +55,10 @@ func (m *ModuleContext) WithContext(ctx context.Context) publicwasm.Module {
 		return &ModuleContext{module: m.module, memory: m.memory, ctx: ctx}
 	}
 	return m
+}
+
+func (m *ModuleContext) Close() {
+	m.store.CloseModule(m.module.Name)
 }
 
 // Memory implements wasm.Module Memory

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -74,8 +74,6 @@ type (
 
 		// Engine implements function calls for this module.
 		Engine ModuleEngine
-
-		closed bool // guarded by mux
 	}
 
 	// ExportInstance represents an exported instance in a Store.
@@ -389,22 +387,9 @@ func (s *Store) CloseModule(moduleName string) error {
 		return nil // already closed
 	}
 
-	if err := m.Close(); err != nil {
-		return err
-	}
+	m.Engine.Close()
 
 	s.deleteModule(moduleName)
-	return nil
-}
-
-func (m *ModuleInstance) Close() error {
-	// Closing multiple times is safe!
-	if m.closed {
-		return nil // already closed
-	}
-
-	m.Engine.Close()
-	m.closed = true
 	return nil
 }
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -363,7 +363,7 @@ func (s *Store) Instantiate(module *Module, name string) (*ModuleContext, error)
 	m.applyData(module.DataSection)
 
 	// Build the default context for calls to this module.
-	m.Ctx = NewModuleContext(s.ctx, s.engine, m)
+	m.Ctx = NewModuleContext(s.ctx, s, m)
 
 	// Execute the start function.
 	if module.StartSection != nil {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -381,16 +381,12 @@ func (s *Store) Instantiate(module *Module, name string) (*ModuleContext, error)
 }
 
 // CloseModule deallocates resources if a module with the given name exists.
-func (s *Store) CloseModule(moduleName string) error {
+func (s *Store) CloseModule(moduleName string) {
 	m := s.module(moduleName)
-	if m == nil {
-		return nil // already closed
+	if m != nil {
+		m.Engine.Close()
+		s.deleteModule(moduleName)
 	}
-
-	m.Engine.Close()
-
-	s.deleteModule(moduleName)
-	return nil
 }
 
 // deleteModule makes the moduleName available for instantiation again.

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -75,18 +75,7 @@ type (
 		// Engine implements function calls for this module.
 		Engine ModuleEngine
 
-		// mux is used to guard the fields from concurrent access.
-		mux sync.Mutex
-
 		closed bool // guarded by mux
-
-		// dependentCount is the current number of modules which import this module. On Store.ReleaseModule, this number
-		// must be zero otherwise it fails.
-		dependentCount int // guarded by mux
-
-		// dependencies holds imported modules. This is used when releasing this module instance, or decrementing the
-		// dependentCount of the imported modules.
-		dependencies map[*ModuleInstance]struct{}
 	}
 
 	// ExportInstance represents an exported instance in a Store.
@@ -185,10 +174,9 @@ const (
 // addSections adds section elements to the ModuleInstance
 func (m *ModuleInstance) addSections(module *Module, importedFunctions, functions []*FunctionInstance,
 	importedGlobals, globals []*GlobalInstance, importedTable, table *TableInstance,
-	memory, importedMemory *MemoryInstance, typeInstances []*TypeInstance, moduleImports map[*ModuleInstance]struct{}) {
+	memory, importedMemory *MemoryInstance, typeInstances []*TypeInstance) {
 
 	m.Types = typeInstances
-	m.dependencies = moduleImports
 
 	m.Functions = append(m.Functions, importedFunctions...)
 	for i, f := range functions {
@@ -331,15 +319,7 @@ func (s *Store) Instantiate(module *Module, name string) (*ModuleContext, error)
 		return nil, err
 	}
 
-	moduleImportsFinalized := false
-	importedFunctions, importedGlobals, importedTable, importedMemory, moduleImports, err := s.resolveImports(module)
-	defer func() {
-		if !moduleImportsFinalized {
-			for moduleImport := range moduleImports {
-				moduleImport.decDependentCount()
-			}
-		}
-	}()
+	importedFunctions, importedGlobals, importedTable, importedMemory, err := s.resolveImports(module)
 	if err != nil {
 		s.deleteModule(name)
 		return nil, err
@@ -361,7 +341,7 @@ func (s *Store) Instantiate(module *Module, name string) (*ModuleContext, error)
 	// Now we have all instances from imports and local ones, so ready to create a new ModuleInstance.
 	m := &ModuleInstance{Name: name}
 	m.addSections(module, importedFunctions, functions, importedGlobals,
-		globals, importedTable, table, importedMemory, memory, types, moduleImports)
+		globals, importedTable, table, importedMemory, memory, types)
 
 	// Plus we are ready to compile functions.
 	m.Engine, err = s.engine.Compile(importedFunctions, functions)
@@ -386,9 +366,6 @@ func (s *Store) Instantiate(module *Module, name string) (*ModuleContext, error)
 
 	// Build the default context for calls to this module.
 	m.Ctx = NewModuleContext(s.ctx, s.engine, m)
-
-	// Plus, we can finalize the module import reference count.
-	moduleImportsFinalized = true
 
 	// Execute the start function.
 	if module.StartSection != nil {
@@ -421,42 +398,14 @@ func (s *Store) CloseModule(moduleName string) error {
 }
 
 func (m *ModuleInstance) Close() error {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-
+	// Closing multiple times is safe!
 	if m.closed {
 		return nil // already closed
 	}
 
-	if m.dependentCount > 0 {
-		// This case other modules are importing this module instance and still alive.
-		return fmt.Errorf("%d modules import this and need to be closed first", m.dependentCount)
-	}
-
-	for mod := range m.dependencies {
-		mod.decDependentCount()
-	}
-
 	m.Engine.Close()
-
 	m.closed = true
 	return nil
-}
-
-func (m *ModuleInstance) decDependentCount() {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-	m.dependentCount--
-}
-
-func (m *ModuleInstance) incDependentCount() bool {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-	if m.closed {
-		return false
-	}
-	m.dependentCount++
-	return true
 }
 
 // deleteModule makes the moduleName available for instantiation again.
@@ -504,27 +453,16 @@ func (s *Store) module(moduleName string) *ModuleInstance {
 func (s *Store) resolveImports(module *Module) (
 	importedFunctions []*FunctionInstance, importedGlobals []*GlobalInstance,
 	importedTable *TableInstance, importedMemory *MemoryInstance,
-	moduleImports map[*ModuleInstance]struct{},
 	err error,
 ) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 
-	moduleImports = map[*ModuleInstance]struct{}{}
 	for idx, i := range module.ImportSection {
 		m, ok := s.modules[i.Module]
 		if !ok {
 			err = fmt.Errorf("module[%s] not instantiated", i.Module)
 			return
-		}
-
-		if _, ok := moduleImports[m]; !ok {
-			if !m.incDependentCount() {
-				// The module is already closed.
-				err = fmt.Errorf("trying to import module[%s] but is already closed", m.Name)
-				return
-			}
-			moduleImports[m] = struct{}{}
 		}
 
 		var imported *ExportInstance

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -141,33 +141,23 @@ func TestStore_CloseModule(t *testing.T) {
 			}, importingModuleName)
 			require.NoError(t, err)
 
-			importedMod, ok := s.modules[importedModuleName]
+			_, ok := s.modules[importedModuleName]
 			require.True(t, ok)
 
-			importingMod, ok := s.modules[importingModuleName]
+			_, ok = s.modules[importingModuleName]
 			require.True(t, ok)
-
-			// Make sure modules are not closed yet.
-			require.False(t, importingMod.closed)
-			require.False(t, importedMod.closed)
 
 			// Release the importing module
 			require.NoError(t, s.CloseModule(importingModuleName))
-			require.NotContains(t, s.modules, importingMod.Name)
-			require.True(t, importingMod.closed) // only importing one is closed.
-			require.False(t, importedMod.closed)
+			require.NotContains(t, s.modules, importingModuleName)
 
 			// Can re-release the importing module
 			require.NoError(t, s.CloseModule(importingModuleName))
-			require.True(t, importingMod.closed)
-			require.False(t, importedMod.closed)
 
 			// Now we release the imported module.
 			require.NoError(t, s.CloseModule(importedModuleName))
 			require.Nil(t, s.modules[importedModuleName])
 			require.NotContains(t, s.modules, importedModuleName)
-			require.True(t, importingMod.closed)
-			require.True(t, importedMod.closed)
 		})
 	}
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -148,14 +148,14 @@ func TestStore_CloseModule(t *testing.T) {
 			require.True(t, ok)
 
 			// Release the importing module
-			require.NoError(t, s.CloseModule(importingModuleName))
+			s.CloseModule(importingModuleName)
 			require.NotContains(t, s.modules, importingModuleName)
 
 			// Can re-release the importing module
-			require.NoError(t, s.CloseModule(importingModuleName))
+			s.CloseModule(importingModuleName)
 
 			// Now we release the imported module.
-			require.NoError(t, s.CloseModule(importedModuleName))
+			s.CloseModule(importedModuleName)
 			require.Nil(t, s.modules[importedModuleName])
 			require.NotContains(t, s.modules, importedModuleName)
 		})
@@ -206,13 +206,13 @@ func TestStore_concurrent(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func(i int) {
 			defer wg.Done()
-			err := s.CloseModule(strconv.Itoa(i))
+			s.CloseModule(strconv.Itoa(i))
 			require.NoError(t, err)
 		}(i)
 	}
 	wg.Wait()
 
-	require.NoError(t, s.CloseModule(hm.Name))
+	s.CloseModule(hm.Name)
 
 	// All instances are freed.
 	require.Len(t, s.modules, 0)

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -243,7 +243,6 @@ func testAdhocCloseWhileExecution(t *testing.T, newRuntimeConfig func() *wazero.
 		require.NoError(t, err)
 
 		m, err := r.InstantiateModuleFromSource([]byte(`(module $test
-	;; these imports return the input param
 	(import "host" "close_module" (func $close_module ))
 
 	(func $close_while_execution
@@ -266,7 +265,6 @@ func testAdhocCloseWhileExecution(t *testing.T, newRuntimeConfig func() *wazero.
 		require.NoError(t, err)
 
 		m, err := r.InstantiateModuleFromSource([]byte(`(module $test
-		;; these imports return the input param
 		(import "host" "already_closed" (func $already_closed ))
 
 		(func $close_parent_before_execution

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -280,17 +280,15 @@ func testAdhocCloseWhileExecution(t *testing.T, newRuntimeConfig func() *wazero.
 		importedModule.Close()
 
 		// Even we can re-enstantiate the module for the same name.
-		var called bool
 		importedModuleNew, err := r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
-			"already_closed": func() { called = true },
+			"already_closed": func() {
+				panic("unreachable") // The new module's function must not be called.
+			},
 		}).Instantiate()
 		require.NoError(t, err)
 		defer importedModuleNew.Close()
 
 		_, err = m.ExportedFunction("close_parent_before_execution").Call(nil)
 		require.NoError(t, err)
-
-		// The new module's function must not be called.
-		require.False(t, called)
 	})
 }

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -50,6 +50,9 @@ func runAdhocTests(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) 
 	t.Run("host function with float type", func(t *testing.T) {
 		testHostFunctions(t, newRuntimeConfig)
 	})
+	t.Run("close with outstanding calls", func(t *testing.T) {
+		testAdhocCloseWhileExecution(t, newRuntimeConfig)
+	})
 }
 
 func testHugeStack(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
@@ -227,4 +230,67 @@ func testHostFunctions(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConf
 			require.Equal(t, input, publicwasm.DecodeF64(results[0]))
 		})
 	}
+}
+
+// testAdhocCloseWhileExecution ensures that calling Module.Close with outstanding calls is safe.
+func testAdhocCloseWhileExecution(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+	t.Run("singleton", func(t *testing.T) {
+		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())
+		var moduleCloser func()
+		_, err := r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
+			"close_module": func() { moduleCloser() }, // Closing while executing itself.
+		}).Instantiate()
+		require.NoError(t, err)
+
+		m, err := r.InstantiateModuleFromSource([]byte(`(module $test
+	;; these imports return the input param
+	(import "host" "close_module" (func $close_module ))
+
+	(func $close_while_execution
+		call $close_module
+	)
+	(export "close_while_execution" (func $close_while_execution))
+)`))
+		require.NoError(t, err)
+
+		moduleCloser = m.Close
+
+		_, err = m.ExportedFunction("close_while_execution").Call(nil)
+		require.NoError(t, err)
+	})
+	t.Run("close imported module", func(t *testing.T) {
+		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())
+		importedModule, err := r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
+			"already_closed": func() {},
+		}).Instantiate()
+		require.NoError(t, err)
+
+		m, err := r.InstantiateModuleFromSource([]byte(`(module $test
+		;; these imports return the input param
+		(import "host" "already_closed" (func $already_closed ))
+
+		(func $close_parent_before_execution
+			call $already_closed
+		)
+		(export "close_parent_before_execution" (func $close_parent_before_execution))
+	)`))
+		require.NoError(t, err)
+
+		// Closing the imported module before making call should also safe.
+		importedModule.Close()
+
+		// Even we can re-enstantiate the module for the same name.
+		var called bool
+		importedModuleNew, err := r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
+			"already_closed": func() { called = true },
+		}).Instantiate()
+		require.NoError(t, err)
+		defer importedModuleNew.Close()
+
+		_, err = m.ExportedFunction("close_parent_before_execution").Call(nil)
+		require.NoError(t, err)
+
+		// The new module's function must not be called.
+		require.False(t, called)
+	})
 }

--- a/tests/engine/concurrency_test.go
+++ b/tests/engine/concurrency_test.go
@@ -57,10 +57,15 @@ func runAdhocTestUnderHighConcurrency(t *testing.T, newRuntimeConfig func() *waz
 }
 
 func singleModuleHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+	args := []uint64{1, 123}
+	exp := args[0] + args[1]
+	const goroutines = 1000
+	const delay = 100 * time.Millisecond
+
 	t.Run("single module", func(t *testing.T) {
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())
 		imported, err := r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
-			"delay": func() { time.Sleep(100 * time.Millisecond) },
+			"delay": func() { time.Sleep(delay) },
 		}).Instantiate()
 		require.NoError(t, err)
 
@@ -80,15 +85,11 @@ func singleModuleHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.R
 		module, err := r.InstantiateModuleFromSource(source)
 		require.NoError(t, err)
 
-		args := []uint64{1, 123}
-		exp := args[0] + args[1]
-
 		t.Run("close importing module while in use", func(t *testing.T) {
 			fn := module.ExportedFunction("delay_add")
 			require.NotNil(t, fn)
 
 			var wg sync.WaitGroup
-			const goroutines = 1000
 			wg.Add(goroutines)
 			for i := 0; i < goroutines; i++ {
 				if i == 200 {
@@ -116,7 +117,6 @@ func singleModuleHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.R
 
 			var newImportedModuleShouldPanic bool = true
 			var wg sync.WaitGroup
-			const goroutines = 1000
 			wg.Add(goroutines)
 			for i := 0; i < goroutines; i++ {
 				if i == 200 {
@@ -126,16 +126,16 @@ func singleModuleHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.R
 					// not use the new one.
 					imported, err = r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
 						"delay": func() {
+							time.Sleep(delay)
 							if newImportedModuleShouldPanic {
 								panic("unreachable")
-							} else {
-								time.Sleep(10 * time.Millisecond)
 							}
 						},
 					}).Instantiate()
 					require.NoError(t, err)
 				} else if i == 400 {
-					// Re-instantiate the importing module, and swap the function.
+					// Re-instantiate the importing module, and swap the function which will use
+					// the new imported module.
 					module.Close()
 					module, err = r.InstantiateModuleFromSource(source)
 					require.NoError(t, err)

--- a/tests/engine/concurrency_test.go
+++ b/tests/engine/concurrency_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tetratelabs/wazero"
 )
 

--- a/tests/engine/concurrency_test.go
+++ b/tests/engine/concurrency_test.go
@@ -3,7 +3,9 @@ package adhoc
 import (
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/tetratelabs/wazero"
 )
 
@@ -12,13 +14,12 @@ func TestJITConcurrency(t *testing.T) {
 		t.Skip()
 	}
 	runAdhocTestsUnderHighConcurrency(t, wazero.NewRuntimeConfigJIT)
-	// TODO: Add concurrent instantiation, invocation and release on a single store test case in https://github.com/tetratelabs/wazero/issues/293
-
+	singleModuleHighConcurrency(t, wazero.NewRuntimeConfigJIT)
 }
 
 func TestInterpreterConcurrency(t *testing.T) {
 	runAdhocTestsUnderHighConcurrency(t, wazero.NewRuntimeConfigInterpreter)
-	// TODO: Add concurrent instantiation, invocation and release on a single store test case in https://github.com/tetratelabs/wazero/issues/293
+	singleModuleHighConcurrency(t, wazero.NewRuntimeConfigJIT)
 }
 
 func runAdhocTestsUnderHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
@@ -53,4 +54,104 @@ func runAdhocTestUnderHighConcurrency(t *testing.T, newRuntimeConfig func() *waz
 		}()
 	}
 	wg.Wait()
+}
+
+func singleModuleHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+	t.Run("single module", func(t *testing.T) {
+		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())
+		imported, err := r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
+			"delay": func() { time.Sleep(100 * time.Millisecond) },
+		}).Instantiate()
+		require.NoError(t, err)
+
+		source := []byte(`(module
+			(import "host" "delay" (func $delay ))
+			(func $delay_add
+				(param $value_1 i32) (param $value_2 i32)
+				(result i32)
+				local.get 0
+				local.get 1
+				i32.add
+				call $delay
+			)
+			(export "delay_add" (func $delay_add))
+		)`)
+
+		module, err := r.InstantiateModuleFromSource(source)
+		require.NoError(t, err)
+
+		args := []uint64{1, 123}
+		exp := args[0] + args[1]
+
+		t.Run("close importing module while in use", func(t *testing.T) {
+			fn := module.ExportedFunction("delay_add")
+			require.NotNil(t, fn)
+
+			var wg sync.WaitGroup
+			const goroutines = 1000
+			wg.Add(goroutines)
+			for i := 0; i < goroutines; i++ {
+				if i == 200 {
+					// Close the importing module.
+					module.Close()
+				} else if i == 400 {
+					// Re-instantiate the importing module, and swap the function.
+					module, err = r.InstantiateModuleFromSource(source)
+					require.NoError(t, err)
+					fn = module.ExportedFunction("delay_add")
+					require.NotNil(t, fn)
+				}
+				go func() {
+					defer wg.Done()
+					res, err := fn.Call(nil, args...)
+					require.NoError(t, err)
+					require.Equal(t, exp, res[0])
+				}()
+			}
+			wg.Wait()
+		})
+		t.Run("close imported module while in use", func(t *testing.T) {
+			fn := module.ExportedFunction("delay_add")
+			require.NotNil(t, fn)
+
+			var newImportedModuleShouldPanic bool = true
+			var wg sync.WaitGroup
+			const goroutines = 1000
+			wg.Add(goroutines)
+			for i := 0; i < goroutines; i++ {
+				if i == 200 {
+					// Close the imported module.
+					imported.Close()
+					// Re-instantiate the imported module but at this point importing module should
+					// not use the new one.
+					imported, err = r.NewModuleBuilder("host").ExportFunctions(map[string]interface{}{
+						"delay": func() {
+							if newImportedModuleShouldPanic {
+								panic("unreachable")
+							} else {
+								time.Sleep(10 * time.Millisecond)
+							}
+						},
+					}).Instantiate()
+					require.NoError(t, err)
+				} else if i == 400 {
+					// Re-instantiate the importing module, and swap the function.
+					module.Close()
+					module, err = r.InstantiateModuleFromSource(source)
+					require.NoError(t, err)
+					fn = module.ExportedFunction("delay_add")
+					require.NotNil(t, fn)
+					// The new imported module is now in use.
+					newImportedModuleShouldPanic = false
+				}
+				go func() {
+					defer wg.Done()
+					res, err := fn.Call(nil, 1, 123)
+					require.NoError(t, err)
+					require.Equal(t, exp, res[0])
+				}()
+			}
+			wg.Wait()
+		})
+	})
 }

--- a/tests/engine/concurrency_test.go
+++ b/tests/engine/concurrency_test.go
@@ -19,7 +19,7 @@ func TestJITConcurrency(t *testing.T) {
 
 func TestInterpreterConcurrency(t *testing.T) {
 	runAdhocTestsUnderHighConcurrency(t, wazero.NewRuntimeConfigInterpreter)
-	singleModuleHighConcurrency(t, wazero.NewRuntimeConfigJIT)
+	singleModuleHighConcurrency(t, wazero.NewRuntimeConfigInterpreter)
 }
 
 func runAdhocTestsUnderHighConcurrency(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -87,6 +87,10 @@ type Module interface {
 
 	// ExportedGlobal a global exported from this module or nil if it wasn't.
 	ExportedGlobal(name string) Global
+
+	// Close releases resources allocated for this Module. Using this while having outstanding function calls is
+	// safe. After calling this function, re-instantiating a module for the same name is allowed.
+	Close()
 }
 
 // Function is a WebAssembly 1.0 (20191205) function exported from an instantiated module (wazero.Runtime InstantiateModule).


### PR DESCRIPTION
This commit adds Module.Close API, which can be used to indicate that
the module will no longer be used and setting finalizers for the allocated
resources. Notably, this will set finalizers on compiledFunction to deallocate
mapped memory regions as well as removing them from the store-wide
storage. As a result, users can re-instantiate a module for the same name
while having the safety -- Calling Module.Close is safe even when there are
outstanding function calls as we never explicitly deallocate but indirectly
do that via Goruntine's finalizers.


partially resolves: #293 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
