### PR TITLE
Adds stricter enforcement of Table element validation.

### DIFF
--- a/internal/leb128/leb128.go
+++ b/internal/leb128/leb128.go
@@ -32,7 +32,14 @@ var encodeCache = [0x80][]byte{
 // EncodeUint32 encodes the value into a buffer in LEB128 format
 //
 // See https://en.wikipedia.org/wiki/LEB128#Encode_unsigned_integer
-func EncodeUint32(value uint32) (buf []byte) {
+func EncodeUint32(value uint32) []byte {
+	return EncodeUint64(uint64(value))
+}
+
+// EncodeUint64 encodes the value into a buffer in LEB128 format
+//
+// See https://en.wikipedia.org/wiki/LEB128#Encode_unsigned_integer
+func EncodeUint64(value uint64) (buf []byte) {
 	if value < 0x80 {
 		return encodeCache[value]
 	}

--- a/internal/leb128/leb128_test.go
+++ b/internal/leb128/leb128_test.go
@@ -3,6 +3,7 @@ package leb128
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,9 +21,27 @@ func TestEncodeUint32(t *testing.T) {
 		{input: 16256, expected: []byte{0x80, 0x7f}},
 		{input: 624485, expected: []byte{0xe5, 0x8e, 0x26}},
 		{input: 165675008, expected: []byte{0x80, 0x80, 0x80, 0x4f}},
-		{input: 0xffffffff, expected: []byte{0xff, 0xff, 0xff, 0xff, 0xf}},
+		{input: uint32(math.MaxUint32), expected: []byte{0xff, 0xff, 0xff, 0xff, 0xf}},
 	} {
 		require.Equal(t, c.expected, EncodeUint32(c.input))
+	}
+}
+
+func TestEncodeUint64(t *testing.T) {
+	for _, c := range []struct {
+		input    uint64
+		expected []byte
+	}{
+		{input: 0, expected: []byte{0x00}},
+		{input: 1, expected: []byte{0x01}},
+		{input: 4, expected: []byte{0x04}},
+		{input: 16256, expected: []byte{0x80, 0x7f}},
+		{input: 624485, expected: []byte{0xe5, 0x8e, 0x26}},
+		{input: 165675008, expected: []byte{0x80, 0x80, 0x80, 0x4f}},
+		{input: math.MaxUint32, expected: []byte{0xff, 0xff, 0xff, 0xff, 0xf}},
+		{input: math.MaxUint64, expected: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1}},
+	} {
+		require.Equal(t, c.expected, EncodeUint64(c.input))
 	}
 }
 

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -10,10 +10,12 @@ type Engine interface {
 	// * name is the name the module was instantiated with used for error handling.
 	// * importedFunctions: functions this module imports, already compiled in this engine.
 	// * moduleFunctions: functions declared in this module that must be compiled.
+	// * table: a possibly shared table used by this module. When nil tableInit will be nil.
+	// * tableInit: a mapping of TableInstance.Table index to the function index it should point to.
 	//
 	// Note: Input parameters must be pre-validated with internalwasm.Module Validate, to ensure no fields are invalid
 	// due to reasons such as out-of-bounds.
-	NewModuleEngine(name string, importedFunctions, moduleFunctions []*FunctionInstance) (ModuleEngine, error)
+	NewModuleEngine(name string, importedFunctions, moduleFunctions []*FunctionInstance, table *TableInstance, tableInit map[Index]Index) (ModuleEngine, error)
 }
 
 // ModuleEngine implements function calls for a given module.
@@ -21,12 +23,6 @@ type ModuleEngine interface {
 	// Closer releases the resources allocated by functions in this ModuleEngine.
 	io.Closer
 	// ^^ io.Closer not due to I/O, but to allow future static analysis to catch leaks (unclosed Closers).
-
-	// FunctionAddress returns the absolute address of the compiled function for index.
-	// The returned address is stored and used as a TableInstance.Table element.
-	//
-	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-funcaddr
-	FunctionAddress(index Index) uintptr
 
 	// Call invokes a function instance f with given parameters.
 	// Returns the results from the function.

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -58,6 +58,111 @@ func TestEngine_NewModuleEngine(t *testing.T) {
 	})
 }
 
+func TestEngine_NewModuleEngine_InitTable(t *testing.T) {
+	e := NewEngine()
+
+	t.Run("no table elements", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		var importedFunctions []*wasm.FunctionInstance
+		var moduleFunctions []*wasm.FunctionInstance
+		var tableInit map[wasm.Index]wasm.Index
+
+		// Instantiate the module, which has nothing but an empty table.
+		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// Since there are no elements to initialize, we expect the table to be nil.
+		require.Equal(t, table.Table, make([]interface{}, 2))
+
+		// Clean up.
+		require.NoError(t, me.Close())
+	})
+
+	t.Run("module-defined function", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		var importedFunctions []*wasm.FunctionInstance
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		tableInit := map[wasm.Index]wasm.Index{0: 2}
+
+		// Instantiate the module whose table points to its own functions.
+		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// The functions mapped to the table are defined in the same moduleEngine
+		require.Equal(t, table.Table, []interface{}{me.(*moduleEngine).compiledFunctions[2], nil})
+
+		// Clean up.
+		require.NoError(t, me.Close())
+	})
+
+	t.Run("imported function", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		var moduleFunctions []*wasm.FunctionInstance
+		tableInit := map[wasm.Index]wasm.Index{0: 2}
+
+		// Imported functions are compiled before the importing module is instantiated.
+		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
+		require.NoError(t, err)
+
+		// Instantiate the importing module, which is whose table is initialized.
+		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// A moduleEngine's compiled function slice includes its imports, so the offsets is absolute.
+		require.Equal(t, table.Table, []interface{}{importing.(*moduleEngine).compiledFunctions[2], nil})
+
+		// Clean up.
+		require.NoError(t, importing.Close())
+		require.NoError(t, imported.Close())
+	})
+
+	t.Run("mixed functions", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		tableInit := map[wasm.Index]wasm.Index{0: 0, 1: 4}
+
+		// Imported functions are compiled before the importing module is instantiated.
+		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
+		require.NoError(t, err)
+
+		// Instantiate the importing module, which is whose table is initialized.
+		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// A moduleEngine's compiled function slice includes its imports, so the offsets are absolute.
+		require.Equal(t, table.Table, []interface{}{
+			importing.(*moduleEngine).compiledFunctions[0],
+			importing.(*moduleEngine).compiledFunctions[4],
+		})
+
+		// Clean up.
+		require.NoError(t, importing.Close())
+		require.NoError(t, imported.Close())
+	})
+}
+
 func TestEngine_Call(t *testing.T) {
 	i64 := wasm.ValueTypeI64
 	m := &wasm.Module{

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -332,7 +332,7 @@ func (c *callFrame) String() string {
 }
 
 // NewModuleEngine implements internalwasm.Engine NewModuleEngine
-func (e *engine) NewModuleEngine(name string, importedFunctions, moduleFunctions []*wasm.FunctionInstance) (wasm.ModuleEngine, error) {
+func (e *engine) NewModuleEngine(name string, importedFunctions, moduleFunctions []*wasm.FunctionInstance, table *wasm.TableInstance, tableInit map[wasm.Index]wasm.Index) (wasm.ModuleEngine, error) {
 	imported := len(importedFunctions)
 	me := &moduleEngine{
 		name:                   name,
@@ -368,12 +368,10 @@ func (e *engine) NewModuleEngine(name string, importedFunctions, moduleFunctions
 		e.addCompiledFunction(f, compiled)
 	}
 
+	for elemIdx, funcidx := range tableInit { // Initialize any elements with compiled functions
+		table.Table[elemIdx] = me.compiledFunctions[funcidx]
+	}
 	return me, nil
-}
-
-// FunctionAddress implements internalwasm.ModuleEngine FunctionAddress
-func (me *moduleEngine) FunctionAddress(index wasm.Index) uintptr {
-	return uintptr(unsafe.Pointer(me.compiledFunctions[index]))
 }
 
 // Close implements io.Closer

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -149,6 +149,111 @@ func TestEngine_Call(t *testing.T) {
 	})
 }
 
+func TestEngine_NewModuleEngine_InitTable(t *testing.T) {
+	e := NewEngine()
+
+	t.Run("no table elements", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		var importedFunctions []*wasm.FunctionInstance
+		var moduleFunctions []*wasm.FunctionInstance
+		var tableInit map[wasm.Index]wasm.Index
+
+		// Instantiate the module, which has nothing but an empty table.
+		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// Since there are no elements to initialize, we expect the table to be nil.
+		require.Equal(t, table.Table, make([]interface{}, 2))
+
+		// Clean up.
+		require.NoError(t, me.Close())
+	})
+
+	t.Run("module-defined function", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		var importedFunctions []*wasm.FunctionInstance
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		tableInit := map[wasm.Index]wasm.Index{0: 2}
+
+		// Instantiate the module whose table points to its own functions.
+		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// The functions mapped to the table are defined in the same moduleEngine
+		require.Equal(t, table.Table, []interface{}{me.(*moduleEngine).compiledFunctions[2], nil})
+
+		// Clean up.
+		require.NoError(t, me.Close())
+	})
+
+	t.Run("imported function", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		var moduleFunctions []*wasm.FunctionInstance
+		tableInit := map[wasm.Index]wasm.Index{0: 2}
+
+		// Imported functions are compiled before the importing module is instantiated.
+		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
+		require.NoError(t, err)
+
+		// Instantiate the importing module, which is whose table is initialized.
+		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// A moduleEngine's compiled function slice includes its imports, so the offsets is absolute.
+		require.Equal(t, table.Table, []interface{}{importing.(*moduleEngine).compiledFunctions[2], nil})
+
+		// Clean up.
+		require.NoError(t, importing.Close())
+		require.NoError(t, imported.Close())
+	})
+
+	t.Run("mixed functions", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		tableInit := map[wasm.Index]wasm.Index{0: 0, 1: 4}
+
+		// Imported functions are compiled before the importing module is instantiated.
+		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
+		require.NoError(t, err)
+
+		// Instantiate the importing module, which is whose table is initialized.
+		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+
+		// A moduleEngine's compiled function slice includes its imports, so the offsets are absolute.
+		require.Equal(t, table.Table, []interface{}{
+			importing.(*moduleEngine).compiledFunctions[0],
+			importing.(*moduleEngine).compiledFunctions[4],
+		})
+
+		// Clean up.
+		require.NoError(t, importing.Close())
+		require.NoError(t, imported.Close())
+	})
+}
+
 func TestEngine_Call_HostFn(t *testing.T) {
 	requireSupportedOSArch(t)
 

--- a/internal/wasm/jit/jit_amd64.go
+++ b/internal/wasm/jit/jit_amd64.go
@@ -1057,16 +1057,16 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 
 	// Next we check if the target's type matches the operation's one.
 	// In order to get the type instance's address, we have to multiply the offset
-	// by 8 as the offset is the "length" of table in Go's "[]uintptr",
-	// and size of uintptr equals 64 bit.
-	c.compileConstToRegisterInstruction(x86.ASHLQ, 3, offset.register)
+	// by 16 as the offset is the "length" of table in Go's "[]interface{}",
+	// and size of interface{} equals 16 bytes == (2^4).
+	c.compileConstToRegisterInstruction(x86.ASHLQ, 4, offset.register)
 
 	// Adds the address of wasm.Table[0] stored as callEngine.tableElement0Address to the offset.
 	c.compileMemoryToRegisterInstruction(x86.AADDQ,
 		reservedRegisterForCallEngine, callEngineModuleContextTableElement0AddressOffset, offset.register)
 
-	// "offset = *offset (== table[offset] == *compiledFunction type)"
-	c.compileMemoryToRegisterInstruction(x86.AMOVQ, offset.register, 0, offset.register)
+	// "offset = (*offset) + interfaceDataOffset (== table[offset] + interfaceDataOffset == *compiledFunction type)"
+	c.compileMemoryToRegisterInstruction(x86.AMOVQ, offset.register, interfaceDataOffset, offset.register)
 
 	// At this point offset.register holds the address of *compiledFunction (as uintptr) at wasm.Table[offset].
 	//
@@ -1097,7 +1097,7 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 	c.compileExitFromNativeCode(jitCallStatusCodeTypeMismatchOnIndirectCall)
 
 	c.addSetJmpOrigins(jumpIfTypeMatch)
-	if err := c.compileCallFunctionImpl(0, offset.register, targetFunctionType); err != nil {
+	if err = c.compileCallFunctionImpl(0, offset.register, targetFunctionType); err != nil {
 		return nil
 	}
 
@@ -3545,7 +3545,7 @@ func (c *amd64Compiler) compileConstF32(o *wazeroir.OperationConstF32) error {
 		return err
 	}
 
-	c.compileConstToRegisterInstruction(x86.AMOVL, int64(uint64(math.Float32bits(o.Value))), tmpReg)
+	c.compileConstToRegisterInstruction(x86.AMOVL, int64(math.Float32bits(o.Value)), tmpReg)
 	c.compileRegisterToRegister(x86.AMOVL, tmpReg, reg)
 	return nil
 }
@@ -3801,7 +3801,7 @@ func (c *amd64Compiler) compileCallFunctionImpl(index wasm.Index, compiledFuncti
 	}
 
 	// 2) Set callEngine.valueStackContext.stackBasePointer for the next function.
-	if offset := (int64(c.locationStack.sp) - int64(len(functype.Params))); offset > 0 {
+	if offset := int64(c.locationStack.sp) - int64(len(functype.Params)); offset > 0 {
 		// At this point, tmpRegister holds the old stack base pointer. We could get the new frame's
 		// stack base pointer by "old stack base pointer + old stack pointer - # of function params"
 		// See the comments in callEngine.pushCallFrame which does exactly the same calculation in Go.

--- a/internal/wasm/jit/jit_arm64.go
+++ b/internal/wasm/jit/jit_arm64.go
@@ -1401,17 +1401,17 @@ func (c *arm64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 		reservedRegisterForCallEngine, callEngineModuleContextTableElement0AddressOffset,
 		tmp,
 	)
-	// "offset = tmp + (offset << 3) (== &table[offset])"
-	// Here we left shifting by 3 in order to get the offset in bytes,
-	// and the table element type is uintptr which is 8 bytes.
+	// "offset = tmp + (offset << 4) (== &table[offset])"
+	// Here we left shifting by 4 in order to get the offset in bytes,
+	// and the table element type is interface which is 16 bytes (two pointers).
 	c.compileAddInstructionWithLeftShiftedRegister(
-		offset.register, 3,
+		offset.register, 4,
 		tmp,
 		offset.register,
 	)
 
-	// "offset = *offset (== table[offset] == *compiledFunction type)"
-	c.compileMemoryToRegisterInstruction(arm64.AMOVD, offset.register, 0, offset.register)
+	// "offset = (*offset) + interfaceDataOffset (== table[offset] + interfaceDataOffset == *compiledFunction type)"
+	c.compileMemoryToRegisterInstruction(arm64.AMOVD, offset.register, interfaceDataOffset, offset.register)
 
 	// Check if the value of table[offset] equals zero, meaning that the target element is uninitialized.
 	c.compileTwoRegistersToNoneInstruction(arm64.ACMP, zeroRegister, offset.register)

--- a/internal/wasm/jit/jit_controlflow_test.go
+++ b/internal/wasm/jit/jit_controlflow_test.go
@@ -530,7 +530,7 @@ func TestCompiler_compileBr(t *testing.T) {
 func TestCompiler_compileCallIndirect(t *testing.T) {
 	t.Run("out of bounds", func(t *testing.T) {
 		env := newJITEnvironment()
-		env.setTable(make([]uintptr, 10))
+		env.setTable(make([]interface{}, 10))
 		compiler := env.requireNewCompiler(t, nil)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -569,9 +569,9 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		env.module().Types = []*wasm.TypeInstance{{Type: &wasm.FunctionType{}}}
 
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
-		table := make([]uintptr, 10)
+		table := make([]interface{}, 10)
 		env.setTable(table)
-		table[0] = 0
+		table[0] = nil
 
 		// Place the offset value.
 		err = compiler.compileConstI32(targetOffset)
@@ -602,11 +602,11 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		env.module().Types = []*wasm.TypeInstance{{Type: &wasm.FunctionType{}, TypeID: 1000}}
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
 		// and the typeID doesn't match the table[targetOffset]'s type ID.
-		table := make([]uintptr, 10)
+		table := make([]interface{}, 10)
 		env.setTable(table)
 
 		cf := &compiledFunction{source: &wasm.FunctionInstance{TypeID: 50}}
-		table[0] = uintptr(unsafe.Pointer(cf))
+		table[0] = cf
 
 		// Place the offset value.
 		err = compiler.compileConstI32(targetOffset)
@@ -637,7 +637,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 				targetTypeID := wasm.FunctionTypeID(10) // Arbitrary number is fine for testing.
 				operation := &wazeroir.OperationCallIndirect{TypeIndex: 0}
 
-				table := make([]uintptr, 10)
+				table := make([]interface{}, 10)
 				env := newJITEnvironment()
 				env.setTable(table)
 
@@ -676,7 +676,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 							},
 						}
 						me.compiledFunctions = append(me.compiledFunctions, cf)
-						table[i] = uintptr(unsafe.Pointer(cf))
+						table[i] = cf
 					})
 				}
 

--- a/internal/wasm/jit/jit_initialization_test.go
+++ b/internal/wasm/jit/jit_initialization_test.go
@@ -24,21 +24,21 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
 				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:  &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:  &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 		{
 			name: "memory nil",
 			moduleInstance: &wasm.ModuleInstance{
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Table:   &wasm.TableInstance{Table: make([]uintptr, 20)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
 			},
 		},
 		{
@@ -51,7 +51,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "table empty",
 			moduleInstance: &wasm.ModuleInstance{
-				Table: &wasm.TableInstance{Table: make([]uintptr, 0)},
+				Table: &wasm.TableInstance{Table: make([]interface{}, 0)},
 			},
 		},
 		{

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -86,7 +86,7 @@ func (j *jitEnv) getGlobal(index uint32) uint64 {
 	return j.moduleInstance.Globals[index].Val
 }
 
-func (j *jitEnv) setTable(table []uintptr) {
+func (j *jitEnv) setTable(table []interface{}) {
 	j.moduleInstance.Table = &wasm.TableInstance{Table: table}
 }
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -419,16 +419,11 @@ func newStore() *Store {
 }
 
 // NewModuleEngine implements Engine.NewModuleEngine
-func (e *mockEngine) NewModuleEngine(_ string, _, _ []*FunctionInstance) (ModuleEngine, error) {
+func (e *mockEngine) NewModuleEngine(_ string, _, _ []*FunctionInstance, _ *TableInstance, _ map[Index]Index) (ModuleEngine, error) {
 	if e.shouldCompileFail {
 		return nil, fmt.Errorf("some compilation error")
 	}
 	return &mockModuleEngine{callFailIndex: e.callFailIndex}, nil
-}
-
-// FunctionAddress implements ModuleEngine.FunctionAddress
-func (e *mockModuleEngine) FunctionAddress(index Index) uintptr {
-	return uintptr(index)
 }
 
 // Call implements ModuleEngine.Call

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -45,13 +45,13 @@ type validatedElementSegment struct {
 	// opcode is OpcodeGlobalGet or OpcodeI32Const
 	opcode Opcode
 
-	// arg0 is the arg to opcode, which results in the offset to add to init indices.
+	// arg is the only argument to opcode, which when applied results in the offset to add to init indices.
 	//  * OpcodeGlobalGet: position in the global index namespace of an imported Global ValueTypeI32 holding the offset.
 	//  * OpcodeI32Const: a constant ValueTypeI32 offset.
-	arg0 uint32
+	arg uint32
 
 	// init are a range of table elements whose values are positions in the function index namespace. This range
-	// replaces any values in TableInstance.Table at an offset arg0 which is a constant if opcode == OpcodeI32Const or
+	// replaces any values in TableInstance.Table at an offset arg which is a constant if opcode == OpcodeI32Const or
 	// derived from a globalIdx if opcode == OpcodeGlobalGet
 	init []Index
 }
@@ -170,10 +170,10 @@ func (m *Module) buildTable(importedTable *TableInstance, importedGlobals []*Glo
 	for elemI, elem := range elementSegments {
 		var offset uint32
 		if elem.opcode == OpcodeGlobalGet {
-			global := importedGlobals[elem.arg0]
+			global := importedGlobals[elem.arg]
 			offset = uint32(global.Val)
 		} else {
-			offset = elem.arg0 // constant
+			offset = elem.arg // constant
 		}
 
 		// Check to see if we are out-of-bounds

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -1,6 +1,12 @@
 package internalwasm
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	"github.com/tetratelabs/wazero/internal/leb128"
+)
 
 // Table describes the limits of (function) elements in a table.
 type Table = limitsType
@@ -18,68 +24,197 @@ type ElementSegment struct {
 	Init []Index
 }
 
-// TableInstance represents a table instance in a store.
+// TableInstance represents a table of (ElemTypeFuncref) elements in a module.
+//
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#table-instances%E2%91%A0
 type TableInstance struct {
-	// Table holds the table elements managed by this table instance.
-	Table []uintptr
+	// Table holds the Engine-specific compiled functions mapped by element index.
+	Table []interface{}
 
-	// Min is the minimum (function) elements in this table.
+	// Min is the minimum (function) elements in this table and cannot grow to accommodate ElementSegment.
 	Min uint32
 
 	// Max if present is the maximum (function) elements in this table, or nil if unbounded.
 	Max *uint32
 }
 
-func (m *Module) buildTable() *TableInstance {
-	table := m.TableSection
-	if table != nil {
-		return &TableInstance{
-			Table: make([]uintptr, table.Min),
-			Min:   table.Min,
-			Max:   table.Max,
-		}
-	}
-	return nil
+// validatedElementSegment is like ElementSegment except the inputs are expanded and validated based on defining module.
+//
+// Note: The global imported at globalIdx may have an offset value that is out-of-bounds for the corresponding table.
+type validatedElementSegment struct {
+	// opcode is OpcodeGlobalGet or OpcodeI32Const
+	opcode Opcode
+
+	// arg0 is the arg to opcode, which results in the offset to add to init indices.
+	//  * OpcodeGlobalGet: position in the global index namespace of an imported Global ValueTypeI32 holding the offset.
+	//  * OpcodeI32Const: a constant ValueTypeI32 offset.
+	arg0 uint32
+
+	// init are a range of table elements whose values are positions in the function index namespace. This range
+	// replaces any values in TableInstance.Table at an offset arg0 which is a constant if opcode == OpcodeI32Const or
+	// derived from a globalIdx if opcode == OpcodeGlobalGet
+	init []Index
 }
 
-func (m *Module) validateTable(table *Table, globals []*GlobalType) error {
-	for _, elem := range m.ElementSection {
-		if table == nil {
-			return fmt.Errorf("table index out of range")
-		}
-		err := validateConstExpression(globals, elem.OffsetExpr, ValueTypeI32)
-		if err != nil {
-			return fmt.Errorf("invalid const expression for element: %w", err)
+// validateTable ensures any ElementSegment is valid. This caches results via Module.validatedElementSegments.
+// Note: limitsType are validated by decoders, so not re-validated here.
+func (m *Module) validateTable() ([]*validatedElementSegment, error) {
+	if m.validatedElementSegments != nil {
+		return m.validatedElementSegments, nil
+	}
+
+	t := m.TableSection
+	imported := false
+	for _, im := range m.ImportSection {
+		if im.Type == ExternTypeTable {
+			t = im.DescTable
+			imported = true
+			break
 		}
 	}
-	return nil
-}
 
-func (m *ModuleInstance) validateElements(elements []*ElementSegment) (err error) {
-	for _, elem := range elements {
-		offset := int(executeConstExpression(m.Globals, elem.OffsetExpr).(int32))
-		ceil := offset + len(elem.Init)
+	elementCount := m.SectionElementCount(SectionIDElement)
+	if elementCount > 0 && t == nil {
+		return nil, fmt.Errorf("%s was defined, but not table", SectionIDName(SectionIDElement))
+	}
 
-		if offset < 0 || ceil > len(m.Table.Table) {
-			return fmt.Errorf("out of bounds table access")
-		}
-		for _, elm := range elem.Init {
-			if elm >= uint32(len(m.Functions)) {
-				return fmt.Errorf("unknown function specified by element")
+	ret := make([]*validatedElementSegment, 0, elementCount)
+
+	// Create bounds checks as these can err prior to instantiation
+	funcCount := m.importCount(ExternTypeFunc) + m.SectionElementCount(SectionIDFunction)
+
+	// Now, we have to figure out which table elements can be resolved before instantiation and also fail early if there
+	// are any imported globals that are known to be invalid by their declarations.
+	for i, elem := range m.ElementSection {
+		idx := Index(i)
+
+		initCount := uint32(len(elem.Init))
+
+		// Any offset applied is to the element, not the function index: validate here if the funcidx is sound.
+		for ei, funcIdx := range elem.Init {
+			if funcIdx >= funcCount {
+				return nil, fmt.Errorf("%s[%d].init[%d] funcidx %d out of range", SectionIDName(SectionIDElement), idx, ei, funcIdx)
 			}
+		}
+
+		// global.get needs to be discovered during initialization
+		oc := elem.OffsetExpr.Opcode
+		if oc == OpcodeGlobalGet {
+			globalIdx, _, err := leb128.DecodeUint32(bytes.NewReader(elem.OffsetExpr.Data))
+			if err != nil {
+				return nil, fmt.Errorf("%s[%d] couldn't read global.get parameter: %w", SectionIDName(SectionIDElement), idx, err)
+			} else if err = m.verifyImportGlobalI32(SectionIDElement, idx, globalIdx); err != nil {
+				return nil, err
+			}
+
+			if initCount == 0 {
+				continue // Per https://github.com/WebAssembly/spec/issues/1427 init can be no-op, but validate anyway!
+			}
+
+			ret = append(ret, &validatedElementSegment{oc, globalIdx, elem.Init})
+		} else if oc == OpcodeI32Const {
+			o, _, err := leb128.DecodeInt32(bytes.NewReader(elem.OffsetExpr.Data))
+			if err != nil {
+				return nil, fmt.Errorf("%s[%d] couldn't read i32.const parameter: %w", SectionIDName(SectionIDElement), idx, err)
+			}
+			offset := Index(o)
+
+			// Per https://github.com/WebAssembly/spec/blob/wg-1.0/test/core/elem.wast#L117 we must pass if imported
+			// table has set its min=0. Per https://github.com/WebAssembly/spec/blob/wg-1.0/test/core/elem.wast#L142, we
+			// have to do fail if module-defined min=0.
+			if !imported {
+				if err = checkSegmentBounds(t.Min, uint64(initCount)+uint64(offset), idx); err != nil {
+					return nil, err
+				}
+			}
+
+			if initCount == 0 {
+				continue // Per https://github.com/WebAssembly/spec/issues/1427 init can be no-op, but validate anyway!
+			}
+
+			ret = append(ret, &validatedElementSegment{oc, offset, elem.Init})
+		} else {
+			return nil, fmt.Errorf("%s[%d] has an invalid const expression: %s", SectionIDName(SectionIDElement), idx, InstructionName(oc))
+		}
+	}
+
+	m.validatedElementSegments = ret
+	return ret, nil
+}
+
+// buildTable returns a TableInstance if the module defines or imports a table.
+//  * importedTable: returned as `table` unmodified, if non-nil.
+//  * importedGlobals: include all instantiated, imported globals.
+//
+// If the result `init` is non-nil, it is the `tableInit` parameter of Engine.NewModuleEngine.
+//
+// Note: An error is only possible when an ElementSegment.OffsetExpr is out of range of the TableInstance.Min.
+func (m *Module) buildTable(importedTable *TableInstance, importedGlobals []*GlobalInstance) (table *TableInstance, init map[Index]Index, err error) {
+	// The module defining the table is the one that sets its Min/Max etc.
+	if m.TableSection != nil {
+		t := m.TableSection
+		table = &TableInstance{Table: make([]interface{}, t.Min), Min: t.Min, Max: t.Max}
+	} else {
+		table = importedTable
+	}
+	if table == nil {
+		return // no table
+	}
+
+	elementSegments := m.validatedElementSegments
+	if len(elementSegments) == 0 {
+		return
+	}
+
+	init = make(map[Index]Index, table.Min)
+	for elemI, elem := range elementSegments {
+		var offset uint32
+		if elem.opcode == OpcodeGlobalGet {
+			global := importedGlobals[elem.arg0]
+			offset = uint32(global.Val)
+		} else {
+			offset = elem.arg0 // constant
+		}
+
+		// Check to see if we are out-of-bounds
+		initCount := uint64(len(elem.init))
+		if err = checkSegmentBounds(table.Min, uint64(offset)+initCount, Index(elemI)); err != nil {
+			return
+		}
+
+		for i, funcidx := range elem.init {
+			init[offset+uint32(i)] = funcidx
 		}
 	}
 	return
 }
 
-func (m *ModuleInstance) applyElements(elements []*ElementSegment) {
-	for _, elem := range elements {
-		offset := int(executeConstExpression(m.Globals, elem.OffsetExpr).(int32))
-		table := m.Table.Table
-		for i, elm := range elem.Init {
-			pos := i + offset
-			table[pos] = m.Engine.FunctionAddress(elm)
+// checkSegmentBounds fails if the capacity needed for an ElementSegment.Init is larger than limitsType.Min
+//
+// WebAssembly 1.0 (20191205) doesn't forbid growing to accommodate element segments, and spectests are inconsistent.
+// For example, the spectests enforce elements within Table limitsType.Min, but ignore Import.DescTable min. What this
+// means is we have to delay offset checks on imported tables until we link to them.
+// Ex. https://github.com/WebAssembly/spec/blob/wg-1.0/test/core/elem.wast#L117 wants pass on min=0 for import
+// Ex. https://github.com/WebAssembly/spec/blob/wg-1.0/test/core/elem.wast#L142 wants fail on min=0 module-defined
+func checkSegmentBounds(min uint32, requireMin uint64, idx Index) error { // uint64 in case offset was set to -1
+	if requireMin > uint64(min) {
+		return fmt.Errorf("%s[%d].init exceeds min table size", SectionIDName(SectionIDElement), idx)
+	}
+	return nil
+}
+
+func (m *Module) verifyImportGlobalI32(sectionID SectionID, sectionIdx Index, idx uint32) error {
+	ig := uint32(math.MaxUint32) // +1 == 0
+	for i, im := range m.ImportSection {
+		if im.Type == ExternTypeGlobal {
+			ig++
+			if ig == idx {
+				if im.DescGlobal.ValType != ValueTypeI32 {
+					return fmt.Errorf("%s[%d] (global.get %d): import[%d].global.ValType != i32", SectionIDName(sectionID), sectionIdx, idx, i)
+				}
+				return nil
+			}
 		}
 	}
+	return fmt.Errorf("%s[%d] (global.get %d): out of range of imported globals", SectionIDName(sectionID), sectionIdx, idx)
 }

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -100,7 +100,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeI32Const, arg0: 0, init: []uint32{0}},
+				{opcode: OpcodeI32Const, arg: 0, init: []uint32{0}},
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeI32Const, arg0: 0, init: []uint32{0}},
+				{opcode: OpcodeI32Const, arg: 0, init: []uint32{0}},
 			},
 		},
 		{
@@ -136,7 +136,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeI32Const, arg0: 0, init: []uint32{0}},
+				{opcode: OpcodeI32Const, arg: 0, init: []uint32{0}},
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeI32Const, arg0: 1, init: []uint32{0, 2}},
+				{opcode: OpcodeI32Const, arg: 1, init: []uint32{0, 2}},
 			},
 		},
 		{ // See: https://github.com/WebAssembly/spec/issues/1427
@@ -191,7 +191,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+				{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 			},
 		},
 		{
@@ -212,7 +212,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+				{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+				{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 			},
 		},
 		{
@@ -255,7 +255,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeGlobalGet, arg0: 1, init: []uint32{0, 2}},
+				{opcode: OpcodeGlobalGet, arg: 1, init: []uint32{0, 2}},
 			},
 		},
 		{
@@ -281,8 +281,8 @@ func TestModule_validateTable(t *testing.T) {
 				},
 			},
 			expected: []*validatedElementSegment{
-				{opcode: OpcodeI32Const, arg0: 1, init: []uint32{0, 2}},
-				{opcode: OpcodeGlobalGet, arg0: 1, init: []uint32{1, 2}},
+				{opcode: OpcodeI32Const, arg: 1, init: []uint32{0, 2}},
+				{opcode: OpcodeGlobalGet, arg: 1, init: []uint32{1, 2}},
 			},
 		},
 	}
@@ -573,7 +573,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeI32Const, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeI32Const, arg: 0, init: []uint32{0}},
 				},
 			},
 			expectedTable: &TableInstance{Table: make([]interface{}, 1), Min: 1},
@@ -593,7 +593,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeI32Const, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeI32Const, arg: 0, init: []uint32{0}},
 				},
 			},
 		},
@@ -611,7 +611,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeI32Const, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeI32Const, arg: 0, init: []uint32{0}},
 				},
 			},
 		},
@@ -629,7 +629,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeI32Const, arg0: 1, init: []uint32{0, 2}},
+					{opcode: OpcodeI32Const, arg: 1, init: []uint32{0, 2}},
 				},
 			},
 			expectedTable: &TableInstance{Table: make([]interface{}, 3), Min: 3},
@@ -670,7 +670,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 				},
 			},
 			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
@@ -694,7 +694,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 				},
 			},
 			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
@@ -718,7 +718,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 				},
 			},
 			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
@@ -743,7 +743,7 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeGlobalGet, arg0: 1, init: []uint32{0, 2}},
+					{opcode: OpcodeGlobalGet, arg: 1, init: []uint32{0, 2}},
 				},
 			},
 			importedGlobals: []*GlobalInstance{
@@ -775,8 +775,8 @@ func TestModule_buildTable(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeI32Const, arg0: 1, init: []uint32{0, 2}},
-					{opcode: OpcodeGlobalGet, arg0: 1, init: []uint32{1, 2}},
+					{opcode: OpcodeI32Const, arg: 1, init: []uint32{0, 2}},
+					{opcode: OpcodeGlobalGet, arg: 1, init: []uint32{1, 2}},
 				},
 			},
 			importedGlobals: []*GlobalInstance{
@@ -827,7 +827,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeI32Const, arg0: 2, init: []uint32{0}},
+					{opcode: OpcodeI32Const, arg: 2, init: []uint32{0}},
 				},
 			},
 			importedTable: &TableInstance{Table: make([]interface{}, 2), Min: 2},
@@ -850,7 +850,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 				},
 			},
 			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 2}},
@@ -874,7 +874,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 					},
 				},
 				validatedElementSegments: []*validatedElementSegment{
-					{opcode: OpcodeGlobalGet, arg0: 0, init: []uint32{0}},
+					{opcode: OpcodeGlobalGet, arg: 0, init: []uint32{0}},
 				},
 			},
 			importedTable:   &TableInstance{Table: make([]interface{}, 2), Min: 2},

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -322,6 +322,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 
 						mod, err := binary.DecodeModule(buf, wasm.Features20191205)
 						require.NoError(t, err, msg)
+						require.NoError(t, mod.Validate(wasm.Features20191205))
 
 						moduleName := c.Name
 						if moduleName == "" { // When "(module ...) directive doesn't have name.

--- a/wasm.go
+++ b/wasm.go
@@ -66,7 +66,7 @@ type Runtime interface {
 	//
 	// While a Module is pre-validated, there are a few situations which can cause an error:
 	//  * The Module name is already in use.
-	//  * The Module has a table element initializer that uses an imported global offset that puts it out of range.
+	//  * The Module has a table element initializer that resolves to an index outside the Table minimum size.
 	//  * The Module has a start function, and it failed to execute.
 	//
 	// Note: The last value of RuntimeConfig.WithContext is used for any start function.


### PR DESCRIPTION
This enforces all ElementSegment rules prior to creating a new module
engine. This allows flexibility and less errors inside that function.

This also uses interface as table element to pass tests with -race