### PR TITLE
Fix overflow on MemoryInstance.hasSize

### DIFF
--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -35,7 +35,7 @@ func (m *MemoryInstance) Size() uint32 {
 
 // hasSize returns true if Len is sufficient for sizeInBytes at the given offset.
 func (m *MemoryInstance) hasSize(offset uint32, sizeInBytes uint32) bool {
-	return uint64(offset+sizeInBytes) <= uint64(m.Size()) // uint64 prevents overflow on add
+	return uint64(offset)+uint64(sizeInBytes) <= uint64(m.Size()) // uint64 prevents overflow on add
 }
 
 // ReadByte implements wasm.Memory ReadByte

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -89,7 +89,7 @@ func TestWriteUint32Le(t *testing.T) {
 	require.False(t, mem.WriteUint32Le(9, 16))
 }
 
-func TestMemoryInstance_HasLen(t *testing.T) {
+func TestMemoryInstance_HasSize(t *testing.T) {
 	memory := &MemoryInstance{Buffer: make([]byte, 100)}
 
 	tests := []struct {
@@ -120,6 +120,12 @@ func TestMemoryInstance_HasLen(t *testing.T) {
 			name:        "offset exceeds the memory size",
 			offset:      memory.Size(),
 			sizeInBytes: 1, // arbitrary size
+			expected:    false,
+		},
+		{
+			name:        "offset + sizeInBytes overflows in uint32",
+			offset:      math.MaxUint32 - 1, // invalid too large offset
+			sizeInBytes: 4,                  // if there's overflow, offset + sizeInBytes is 3, and it may pass the check
 			expected:    false,
 		},
 	}


### PR DESCRIPTION
This PR fixes a bug on bound checking of a memory instance.

Signed-off-by: Takaya Saeki <abc.tkys+pub@gmail.com>