### PR TITLE
Propagates module name to module engine panic nicer

### DIFF
--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -1,20 +1,27 @@
 package internalwasm
 
+import "io"
+
 // Engine is a Store-scoped mechanism to compile functions declared or imported by a module.
 // This is a top-level type implemented by an interpreter or JIT compiler.
 type Engine interface {
 	// NewModuleEngine compiles down the function instances in a module, and returns ModuleEngine for the module.
 	//
+	// * name is the name the module was instantiated with used for error handling.
 	// * importedFunctions: functions this module imports, already compiled in this engine.
 	// * moduleFunctions: functions declared in this module that must be compiled.
 	//
 	// Note: Input parameters must be pre-validated with internalwasm.Module Validate, to ensure no fields are invalid
 	// due to reasons such as out-of-bounds.
-	NewModuleEngine(importedFunctions, moduleFunctions []*FunctionInstance) (ModuleEngine, error)
+	NewModuleEngine(name string, importedFunctions, moduleFunctions []*FunctionInstance) (ModuleEngine, error)
 }
 
 // ModuleEngine implements function calls for a given module.
 type ModuleEngine interface {
+	// Closer releases the resources allocated by functions in this ModuleEngine.
+	io.Closer
+	// ^^ io.Closer not due to I/O, but to allow future static analysis to catch leaks (unclosed Closers).
+
 	// FunctionAddress returns the absolute address of the compiled function for index.
 	// The returned address is stored and used as a TableInstance.Table element.
 	//
@@ -25,7 +32,4 @@ type ModuleEngine interface {
 	// Returns the results from the function.
 	// The ctx's context.Context will be the outer-most ancestor of the argument to wasm.Function.
 	Call(ctx *ModuleContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
-
-	// Close releases the resources allocated by functions in this ModuleEngine.
-	Close()
 }

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -260,7 +260,7 @@ func TestPublicModule_Global(t *testing.T) {
 		s := newStore()
 		t.Run(tc.name, func(t *testing.T) {
 			// Instantiate the module and get the export of the above global
-			module, err := s.Instantiate(context.Background(), tc.module, "")
+			module, err := s.Instantiate(context.Background(), tc.module, t.Name())
 			require.NoError(t, err)
 
 			if global := module.ExportedGlobal("global"); tc.expected != nil {

--- a/internal/wasm/jit/mmap.go
+++ b/internal/wasm/jit/mmap.go
@@ -3,6 +3,7 @@
 package jit
 
 import (
+	"errors"
 	"runtime"
 	"syscall"
 )
@@ -10,6 +11,9 @@ import (
 // mmapCodeSegment copies the code into the executable region and returns the byte slice of the region.
 // See https://man7.org/linux/man-pages/man2/mmap.2.html for mmap API and flags.
 func mmapCodeSegment(code []byte) ([]byte, error) {
+	if len(code) == 0 {
+		panic(errors.New("BUG: mmapCodeSegment with zero length"))
+	}
 	if runtime.GOARCH == "amd64" {
 		return mmapCodeSegmentAMD64(code)
 	} else {
@@ -19,6 +23,9 @@ func mmapCodeSegment(code []byte) ([]byte, error) {
 
 // munmapCodeSegment unmaps the given memory region.
 func munmapCodeSegment(code []byte) error {
+	if len(code) == 0 {
+		panic(errors.New("BUG: munmapCodeSegment with zero length"))
+	}
 	return syscall.Munmap(code)
 }
 

--- a/internal/wasm/jit/mmap_test.go
+++ b/internal/wasm/jit/mmap_test.go
@@ -17,17 +17,32 @@ func Test_mmapCodeSegment(t *testing.T) {
 	assert.NoError(err)
 	// Verify that the mmap is the same as the original.
 	assert.Equal(code, newCode)
-
 	// TODO: test newCode can executed.
+
+	t.Run("panic on zero length", func(t *testing.T) {
+		require.PanicsWithError(t, "BUG: mmapCodeSegment with zero length", func() {
+			_, _ = mmapCodeSegment(make([]byte, 0))
+		})
+	})
 }
 
 func Test_munmapCodeSegment(t *testing.T) {
 	requireSupportedOSArch(t)
 	assert := require.New(t)
+
+	// Errors if never mapped
+	assert.Error(munmapCodeSegment(code))
+
 	newCode, err := mmapCodeSegment(code)
 	assert.NoError(err)
 	// First munmap should succeed.
 	assert.NoError(munmapCodeSegment(newCode))
 	// Double munmap should fail.
 	assert.Error(munmapCodeSegment(newCode))
+
+	t.Run("panic on zero length", func(t *testing.T) {
+		require.PanicsWithError(t, "BUG: munmapCodeSegment with zero length", func() {
+			_ = munmapCodeSegment(make([]byte, 0))
+		})
+	})
 }

--- a/internal/wasm/jit/mmap_windows.go
+++ b/internal/wasm/jit/mmap_windows.go
@@ -1,6 +1,8 @@
 package jit
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"runtime"
 	"syscall"
@@ -12,17 +14,21 @@ var (
 	procVirtualAlloc   = kernel32.NewProc("VirtualAlloc")
 	procVirtualProtect = kernel32.NewProc("VirtualProtect")
 	procVirtualFree    = kernel32.NewProc("VirtualFree")
+	procGetLastError   = kernel32.NewProc("GetLastError")
 )
 
 const (
-	windows_MEM_COMMIT             = 0x00001000
-	windows_MEM_RELEASE            = 0x00008000
-	windows_PAGE_READWRITE         = 0x00000004
-	windows_PAGE_EXECUTE_READ      = 0x00000020
-	windows_PAGE_EXECUTE_READWRITE = 0x00000040
+	windows_MEM_COMMIT             uintptr = 0x00001000
+	windows_MEM_RELEASE            uintptr = 0x00008000
+	windows_PAGE_READWRITE         uintptr = 0x00000004
+	windows_PAGE_EXECUTE_READ      uintptr = 0x00000020
+	windows_PAGE_EXECUTE_READWRITE uintptr = 0x00000040
 )
 
 func mmapCodeSegment(code []byte) ([]byte, error) {
+	if len(code) == 0 {
+		panic(errors.New("BUG: mmapCodeSegment with zero length"))
+	}
 	if runtime.GOARCH == "amd64" {
 		return mmapCodeSegmentAMD64(code)
 	} else {
@@ -31,39 +37,46 @@ func mmapCodeSegment(code []byte) ([]byte, error) {
 }
 
 func munmapCodeSegment(code []byte) error {
-	// size must be 0 because we're using MEM_RELEASE.
-	// See https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree
-	return virtualFree(uintptr(unsafe.Pointer(&code[0])), 0, windows_MEM_RELEASE)
-}
-
-func virtualAlloc(address uintptr, size uintptr, alloctype uint32, protect uint32) (uintptr, error) {
-	r0, _, err := procVirtualAlloc.Call(address, size, uintptr(alloctype), uintptr(protect))
-	if r0 == 0 {
-		return 0, err
+	if len(code) == 0 {
+		panic(errors.New("BUG: munmapCodeSegment with zero length"))
 	}
-	return r0, nil
+	return freeMemory(code)
 }
 
-func virtualProtect(address uintptr, size uintptr, newprotect uint32, oldprotect *uint32) error {
-	r1, _, e1 := procVirtualProtect.Call(address, size, uintptr(newprotect), uintptr(unsafe.Pointer(oldprotect)))
-	if r1 == 0 {
-		return e1
+// allocateMemory commits the memory region via the "VirtualAlloc" function.
+// See https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc
+func allocateMemory(code []byte, protect uintptr) (uintptr, error) {
+	address := uintptr(0) // TODO: document why zero
+	size := uintptr(len(code))
+	alloctype := windows_MEM_COMMIT
+	if r, _, _ := procVirtualAlloc.Call(address, size, alloctype, protect); r == 0 {
+		return 0, fmt.Errorf("jit: VirtualAlloc error: %w", getLastError())
+	} else {
+		return r, nil
+	}
+}
+
+// freeMemory releases the memory region via the "VirtualFree" function.
+// See https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree
+func freeMemory(code []byte) error {
+	address := uintptr(unsafe.Pointer(&code[0]))
+	size := uintptr(0) // size must be 0 because we're using MEM_RELEASE.
+	freetype := windows_MEM_RELEASE
+	if r, _, _ := procVirtualFree.Call(address, size, freetype); r == 0 {
+		return fmt.Errorf("jit: VirtualFree error: %w", getLastError())
 	}
 	return nil
 }
 
-func virtualFree(address uintptr, size uintptr, freetype uint32) error {
-	r1, _, e1 := procVirtualFree.Call(address, size, uintptr(freetype))
-	// 0 indicates failure.
-	// See https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree#return-value
-	if r1 == 0 {
-		return e1
+func virtualProtect(address, size, newprotect uintptr, oldprotect *uint32) error {
+	if r, _, _ := procVirtualProtect.Call(address, size, newprotect, uintptr(unsafe.Pointer(oldprotect))); r == 0 {
+		return fmt.Errorf("jit: VirtualProtect error: %w", getLastError())
 	}
 	return nil
 }
 
 func mmapCodeSegmentAMD64(code []byte) ([]byte, error) {
-	p, err := virtualAlloc(0, uintptr(len(code)), windows_MEM_COMMIT, windows_PAGE_EXECUTE_READWRITE)
+	p, err := allocateMemory(code, windows_PAGE_EXECUTE_READWRITE)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +91,7 @@ func mmapCodeSegmentAMD64(code []byte) ([]byte, error) {
 }
 
 func mmapCodeSegmentARM64(code []byte) ([]byte, error) {
-	p, err := virtualAlloc(0, uintptr(len(code)), windows_MEM_COMMIT, windows_PAGE_READWRITE)
+	p, err := allocateMemory(code, windows_PAGE_READWRITE)
 	if err != nil {
 		return nil, err
 	}
@@ -96,4 +109,15 @@ func mmapCodeSegmentARM64(code []byte) ([]byte, error) {
 		return nil, err
 	}
 	return mem, nil
+}
+
+// getLastError casts the last error on the calling thread to a syscall.Errno or returns syscall.EINVAL.
+//
+// See https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+// See https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
+func getLastError() syscall.Errno {
+	if errno, _, _ := procGetLastError.Call(); errno != 0 {
+		return syscall.Errno(errno)
+	}
+	return syscall.EINVAL
 }

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -299,7 +299,7 @@ func (s *Store) Instantiate(ctx context.Context, module *Module, name string) (*
 		globals, importedTable, table, importedMemory, memory, types)
 
 	// Plus we are ready to compile functions.
-	m.Engine, err = s.engine.NewModuleEngine(importedFunctions, functions)
+	m.Engine, err = s.engine.NewModuleEngine(name, importedFunctions, functions)
 	if err != nil {
 		s.deleteModule(name)
 		return nil, fmt.Errorf("compilation failed: %w", err)

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -457,7 +457,7 @@ func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg 
 		return
 	}
 
-	_, err = store.Instantiate(context.Background(), mod, "")
+	_, err = store.Instantiate(context.Background(), mod, t.Name())
 	require.Error(t, err, msg)
 }
 

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -303,11 +303,11 @@ func TestRuntime_NewModule_UsesStoreContext(t *testing.T) {
 		require.Equal(t, runtimeCtx, ctx.Context())
 	}
 
-	_, err := r.NewModuleBuilder("").ExportFunction("start", start).Instantiate()
+	_, err := r.NewModuleBuilder("env").ExportFunction("start", start).Instantiate()
 	require.NoError(t, err)
 
 	decoded, err := r.CompileModule([]byte(`(module $runtime_test.go
-	(import "" "start" (func $start))
+	(import "env" "start" (func $start))
 	(start $start)
 )`))
 	require.NoError(t, err)


### PR DESCRIPTION
Before, if there was an unexpected panic on munmap of a code section,
we'd only see "invalid argument" and have to guess why. This propagates
context and stubs out the finalizer so we can test a better error, like:

"jit: failed to munmap code segment for test.function[0]: invalid argument"

This also attempts to improve troubleshooting time by making all module
instantiation that used empty module name, use the test name instead.
