### PR TITLE
Propagates error return Close to public API

### DIFF
--- a/internal/wasm/module_context.go
+++ b/internal/wasm/module_context.go
@@ -57,8 +57,9 @@ func (m *ModuleContext) WithContext(ctx context.Context) publicwasm.Module {
 	return m
 }
 
-func (m *ModuleContext) Close() {
-	m.store.CloseModule(m.module.Name)
+// Close implements io.Closer
+func (m *ModuleContext) Close() error {
+	return m.store.CloseModule(m.module.Name)
 }
 
 // Memory implements wasm.Module Memory

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -338,12 +338,13 @@ func (s *Store) Instantiate(ctx context.Context, module *Module, name string) (*
 }
 
 // CloseModule deallocates resources if a module with the given name exists.
-func (s *Store) CloseModule(moduleName string) {
+func (s *Store) CloseModule(moduleName string) (err error) {
 	m := s.module(moduleName)
 	if m != nil {
-		m.Engine.Close()
+		err = m.Engine.Close()
 		s.deleteModule(moduleName)
 	}
+	return
 }
 
 // deleteModule makes the moduleName available for instantiation again.

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -147,15 +147,15 @@ func TestStore_CloseModule(t *testing.T) {
 			_, ok = s.modules[importingModuleName]
 			require.True(t, ok)
 
-			// Release the importing module
-			s.CloseModule(importingModuleName)
+			// Close the importing module
+			require.NoError(t, s.CloseModule(importingModuleName))
 			require.NotContains(t, s.modules, importingModuleName)
 
-			// Can re-release the importing module
-			s.CloseModule(importingModuleName)
+			// Can re-close the importing module
+			require.NoError(t, s.CloseModule(importingModuleName))
 
-			// Now we release the imported module.
-			s.CloseModule(importedModuleName)
+			// Now we close the imported module.
+			require.NoError(t, s.CloseModule(importedModuleName))
 			require.Nil(t, s.modules[importedModuleName])
 			require.NotContains(t, s.modules, importedModuleName)
 		})
@@ -206,13 +206,13 @@ func TestStore_concurrent(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func(i int) {
 			defer wg.Done()
-			s.CloseModule(strconv.Itoa(i))
+			require.NoError(t, s.CloseModule(strconv.Itoa(i)))
 			require.NoError(t, err)
 		}(i)
 	}
 	wg.Wait()
 
-	s.CloseModule(hm.Name)
+	require.NoError(t, s.CloseModule(hm.Name))
 
 	// All instances are freed.
 	require.Len(t, s.modules, 0)

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -4,6 +4,7 @@ package wasm
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 )
 
@@ -62,6 +63,11 @@ func ValueTypeName(t ValueType) string {
 type Module interface {
 	fmt.Stringer
 
+	// Closer (Close) releases resources allocated for this Module. Using this while having outstanding function calls
+	// is safe. After calling this function, re-instantiating a module for the same name is allowed.
+	io.Closer
+	// ^^ io.Closer not due to I/O, but to allow future static analysis to catch leaks (unclosed Closers).
+
 	// Context returns any propagated context from the Runtime or a prior function call.
 	//
 	// The returned context is always non-nil; it defaults to context.Background.
@@ -87,10 +93,6 @@ type Module interface {
 
 	// ExportedGlobal a global exported from this module or nil if it wasn't.
 	ExportedGlobal(name string) Global
-
-	// Close releases resources allocated for this Module. Using this while having outstanding function calls is
-	// safe. After calling this function, re-instantiating a module for the same name is allowed.
-	Close()
 }
 
 // Function is a WebAssembly 1.0 (20191205) function exported from an instantiated module (wazero.Runtime InstantiateModule).


### PR DESCRIPTION
Before, we only handled errors internally and swallowed them when re-exporting to the public API.