### PR TITLE
Updates tooling versions and makes notes about Go 1.18

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.17"  # Latest patch
+  GO_VERSION: "1.17"  # 1.xx == latest patch of 1.xx
 
 defaults:
   run:  # use bash for all operating systems unless overridden
@@ -19,11 +19,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
+          # TODO: Change to a matrix to ensure developers can use the latest version, noting often there is a lag of
+          # weeks before the latest version is usable. Ex. golangci/golangci-lint#2649
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Install wast2json
+      - name: Install latest wast2json
         run: |  # Needed for build.spectest. wabt includes wast2json
-          wabt_version=1.0.24
+          wabt_version=1.0.27
           wabt_url=https://github.com/WebAssembly/wabt/releases/download/${wabt_version}/wabt-${wabt_version}-ubuntu.tar.gz
           curl -sSL ${wabt_url} | tar --strip-components 2 -C /usr/local/bin -xzf - wabt-${wabt_version}/bin/wast2json
 

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Build examples
     runs-on: ubuntu-20.04
     steps:
-      - name: Install TinyGo
+      - name: Install latest TinyGo
         run: |  # installing via curl so commands are similar on OS/x
           tinygo_version=0.22.0
           curl -sSL https://github.com/tinygo-org/tinygo/releases/download/v${tinygo_version}/tinygo${tinygo_version}.linux-amd64.tar.gz | sudo tar -C /usr/local -xzf -

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-goimports := golang.org/x/tools/cmd/goimports@v0.1.5
-golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
+goimports := golang.org/x/tools/cmd/goimports@v0.1.10
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
 
 .PHONY: bench
 bench:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/tetratelabs/wazero
 
+// This should be the minimum supported Go version per https://go.dev/doc/devel/release (1 version behind latest)
 go 1.17
 
 require (


### PR DESCRIPTION
We should be able to build locally, including running `make check`, if
using Go 1.18, but that's not possible, yet. Meanwhile, I added notes
and updated tooling versions.