### PR TITLE
CI: change non-amd64 job into scratch platform tests

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -113,7 +113,7 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: Build scratch container
-        run:
+        run: |
           echo 'FROM scratch' >> Dockerfile
           echo 'CMD ["/test"]' >> Dockerfile
           docker buildx build -t wazero:test --platform linux/${{ matrix.arch }} .

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [scratch]
 
 env:  # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.17"  # 1.xx == latest patch of 1.xx
@@ -70,12 +70,12 @@ jobs:
 
       - run: make test
 
-  test_non_amd64:
+  test_scratch:
     # Only amd64 is viable with "make test" because other architectures require emulation:
     # the process of installing depedencies and building the project through an emulator is unacceptably slow.
     # Instead, we build cross-platform test binaries on our amd64 runner, which limits what is emulated to
     # only executing the tests. This is why below uses "bash -c 'testbin test.v'" (running test binary) instead of make.
-    name: ${{ matrix.target.arch }}, ubuntu, Go-${{ matrix.go-version }}
+    name: ${{ matrix.arch }}, linux, Go-${{ matrix.go-version }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
@@ -83,11 +83,10 @@ jobs:
         go-version:
         - "1.17"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
         - "1.18"
-        target:
-        - arch: arm64
-          image: arm64v8/ubuntu
-        - arch: riscv64
-          image: riscv64/ubuntu
+        arch:
+        - "amd64"
+        - "arm64"
+        - "riscv64"
 
     steps:
       - uses: actions/setup-go@v2
@@ -113,8 +112,14 @@ jobs:
         with:
           platforms: ${{ matrix.target.arch }}
 
+      - name: Build scratch container
+        run:
+          echo 'FROM scratch' >> Dockerfile
+          echo 'CMD ["/test"]' >> Dockerfile
+          docker buildx build -t wazero:test --platform linux/${{ matrix.arch }} .
+
       - name: Run built test binaries
-        run: docker run -w /tmp/wazero -v $(pwd):/tmp/wazero --rm -t ${{ matrix.target.image }} /bin/bash -c 'find . -name "*.test" | xargs -Itestbin bash -c "testbin test.v"'
+        run: find . -name "*.test" | xargs -Itestbin docker run -v $(pwd)/testbin:/test --rm -t wazero:test
 
   bench:
     name: Benchmark

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [scratch]
+    branches: [main]
 
 env:  # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.17"  # 1.xx == latest patch of 1.xx
@@ -102,6 +102,7 @@ jobs:
         run: go list ./... | xargs -Ipkg go test pkg -c
         env:
           GOARCH: ${{ matrix.arch }}
+          CGO_ENABLED: 0
 
       - name: Set up QEMU
         if: ${{ matrix.arch != 'amd64' }}

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -113,11 +113,11 @@ jobs:
       - name: Build scratch container
         run: |
           echo 'FROM scratch' >> Dockerfile
-          echo 'CMD ["/wazero/test"]' >> Dockerfile
+          echo 'CMD ["/test"]' >> Dockerfile
           docker buildx build -t wazero:test --platform linux/${{ matrix.arch }} .
 
       - name: Run built test binaries
-        run: find . -name "*.test" | xargs -Itestbin docker run -w /wazero -v $(pwd)/testbin:/wazero/test --rm -t wazero:test
+        run: find . -name "*.test" | xargs -Itestbin docker run -v $(pwd)/testbin:/test --rm -t wazero:test
 
   bench:
     name: Benchmark

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -71,11 +71,7 @@ jobs:
       - run: make test
 
   test_scratch:
-    # Only amd64 is viable with "make test" because other architectures require emulation:
-    # the process of installing depedencies and building the project through an emulator is unacceptably slow.
-    # Instead, we build cross-platform test binaries on our amd64 runner, which limits what is emulated to
-    # only executing the tests. This is why below uses "bash -c 'testbin test.v'" (running test binary) instead of make.
-    name: ${{ matrix.arch }}, linux, Go-${{ matrix.go-version }}
+    name: ${{ matrix.arch }}, Linux (scratch), Go-${{ matrix.go-version }}
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
@@ -108,6 +104,7 @@ jobs:
           GOARCH: ${{ matrix.arch }}
 
       - name: Set up QEMU
+        if: ${{ matrix.arch != 'amd64' }}
         uses: docker/setup-qemu-action@v1
         with:
           platforms: ${{ matrix.arch }}
@@ -115,11 +112,11 @@ jobs:
       - name: Build scratch container
         run: |
           echo 'FROM scratch' >> Dockerfile
-          echo 'CMD ["/test"]' >> Dockerfile
+          echo 'CMD ["/wazero/test"]' >> Dockerfile
           docker buildx build -t wazero:test --platform linux/${{ matrix.arch }} .
 
       - name: Run built test binaries
-        run: find . -name "*.test" | xargs -Itestbin docker run -v $(pwd)/testbin:/test --rm -t wazero:test
+        run: find . -name "*.test" | xargs -Itestbin docker run -w /wazero -v $(pwd)/testbin:/wazero/test --rm -t wazero:test
 
   bench:
     name: Benchmark

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -100,17 +100,17 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: test-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}-${{ matrix.target.arch }}
+          key: test-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}-${{ matrix.arch }}
 
       - name: Build test binaries
         run: go list ./... | xargs -Ipkg go test pkg -c
         env:
-          GOARCH: ${{ matrix.target.arch }}
+          GOARCH: ${{ matrix.arch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: ${{ matrix.target.arch }}
+          platforms: ${{ matrix.arch }}
 
       - name: Build scratch container
         run:

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ We currently test ubuntu-20.04, macos-11 and windows-2022 as packaged by
 [GitHub Actions](https://github.com/actions/virtual-environments).
 
 * Interpreter
-  * Ubuntu is tested on amd64 (native) as well arm64 and riscv64 via emulation.
+  * Linux is tested on amd64 (native) as well arm64 and riscv64 via emulation.
   * MacOS and Windows are only tested on amd64.
 * JIT
-  * Ubuntu is tested on amd64 (native) as well arm64 via emulation.
+  * Linux is tested on amd64 (native) as well arm64 via emulation.
   * MacOS and Windows are only tested on amd64.
 
 wazero has no dependencies and doesn't require CGO. This means it can also be


### PR DESCRIPTION
fixes #385 