### PR TITLE
ci: suppress WARNING on emulation

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -117,7 +117,7 @@ jobs:
           docker buildx build -t wazero:test --platform linux/${{ matrix.arch }} .
 
       - name: Run built test binaries
-        run: find . -name "*.test" | xargs -Itestbin docker run -v $(pwd)/testbin:/test --rm -t wazero:test
+        run: find . -name "*.test" | xargs -Itestbin docker run --platform linux/${{ matrix.arch }} -v $(pwd)/testbin:/test --rm -t wazero:test
 
   bench:
     name: Benchmark


### PR DESCRIPTION
For example, we've seen `WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested` for arm64 emulation

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>