### PR TITLE
Adds VS go-wasm3

### DIFF
--- a/vs/go.mod
+++ b/vs/go.mod
@@ -3,7 +3,8 @@ module github.com/tetratelabs/wazero/vs
 go 1.17
 
 require (
-	github.com/bytecodealliance/wasmtime-go v0.34.0
+	github.com/birros/go-wasm3 v0.0.0-20211020090627-378da49d5646
+	github.com/bytecodealliance/wasmtime-go v0.35.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tetratelabs/wazero v0.0.0
 	github.com/wasmerio/wasmer-go v1.0.4

--- a/vs/go.mod
+++ b/vs/go.mod
@@ -3,7 +3,7 @@ module github.com/tetratelabs/wazero/vs
 go 1.17
 
 require (
-	github.com/birros/go-wasm3 v0.0.0-20211020090627-378da49d5646
+	github.com/birros/go-wasm3 v0.0.0-20220320175540-c625eebef38c
 	github.com/bytecodealliance/wasmtime-go v0.35.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tetratelabs/wazero v0.0.0

--- a/vs/go.sum
+++ b/vs/go.sum
@@ -1,5 +1,7 @@
-github.com/bytecodealliance/wasmtime-go v0.34.0 h1:PaWS0DUusaXaU3aNoSYjag6WmuxjyPYBHgkrC4EXips=
-github.com/bytecodealliance/wasmtime-go v0.34.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/birros/go-wasm3 v0.0.0-20211020090627-378da49d5646 h1:SKGXUujhXKwF3liHbxIWLCskbWsnXPQWWdglAZEyV6I=
+github.com/birros/go-wasm3 v0.0.0-20211020090627-378da49d5646/go.mod h1:ds0edhoDmxZ0y52GRV+dqJ80c0CujOybk1VdhQwNqNw=
+github.com/bytecodealliance/wasmtime-go v0.35.0 h1:VZjaZ0XOY0qp9TQfh0CQj9zl/AbdeXePVTALy8V1sKs=
+github.com/bytecodealliance/wasmtime-go v0.35.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vs/go.sum
+++ b/vs/go.sum
@@ -1,5 +1,5 @@
-github.com/birros/go-wasm3 v0.0.0-20211020090627-378da49d5646 h1:SKGXUujhXKwF3liHbxIWLCskbWsnXPQWWdglAZEyV6I=
-github.com/birros/go-wasm3 v0.0.0-20211020090627-378da49d5646/go.mod h1:ds0edhoDmxZ0y52GRV+dqJ80c0CujOybk1VdhQwNqNw=
+github.com/birros/go-wasm3 v0.0.0-20220320175540-c625eebef38c h1:vbkbn5+ZIBGeI3RmJcj0c1SuHaxcJTcC1wTLOvhcqlw=
+github.com/birros/go-wasm3 v0.0.0-20220320175540-c625eebef38c/go.mod h1:ds0edhoDmxZ0y52GRV+dqJ80c0CujOybk1VdhQwNqNw=
 github.com/bytecodealliance/wasmtime-go v0.35.0 h1:VZjaZ0XOY0qp9TQfh0CQj9zl/AbdeXePVTALy8V1sKs=
 github.com/bytecodealliance/wasmtime-go v0.35.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
[go-wasm3](https://github.com/matiasinsaurralde/go-wasm3) is the first implementation to beat wazero at a benchmark. Its
initialization time is less than half our time in our bench case. While
wazero JIT is still faster at runtime in our tests, it is great to have
such a strong competitor in OSS!

Thanks very much to @birros for making the go-wasm3 project. Hopefully,
it can be updated to latest wasm3 so that things are completely fair!

```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/vs
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkFacIter_Init
BenchmarkFacIter_Init/Interpreter
BenchmarkFacIter_Init/Interpreter-16         	   82864	     14101 ns/op
BenchmarkFacIter_Init/JIT
BenchmarkFacIter_Init/JIT-16                 	    5263	    236023 ns/op
BenchmarkFacIter_Init/wasmer-go
BenchmarkFacIter_Init/wasmer-go-16           	    4240	    287632 ns/op
BenchmarkFacIter_Init/wasmtime-go
BenchmarkFacIter_Init/wasmtime-go-16         	    4178	    287083 ns/op
BenchmarkFacIter_Init/go-wasm3
BenchmarkFacIter_Init/go-wasm3-16            	  197017	      6063 ns/op
BenchmarkFacIter_Invoke
BenchmarkFacIter_Invoke/Interpreter
BenchmarkFacIter_Invoke/Interpreter-16       	  533972	      1886 ns/op
BenchmarkFacIter_Invoke/JIT
BenchmarkFacIter_Invoke/JIT-16               	 2551698	       475.6 ns/op
BenchmarkFacIter_Invoke/wasmer-go
BenchmarkFacIter_Invoke/wasmer-go-16         	 1000000	      1181 ns/op
BenchmarkFacIter_Invoke/wasmtime-go
BenchmarkFacIter_Invoke/wasmtime-go-16       	  546175	      2152 ns/op
BenchmarkFacIter_Invoke/go-wasm3
BenchmarkFacIter_Invoke/go-wasm3-16          	 1629741	       752.2 ns/op
PASS
```
