### PR TITLE
ci: fix test binary name duplicates

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -99,7 +99,7 @@ jobs:
           key: test-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}-${{ matrix.arch }}
 
       - name: Build test binaries
-        run: go list ./... | xargs -Ipkg go test pkg -c
+        run: go list ./... | sed 's/github\.com\/tetratelabs\/wazero\//.\//' | xargs -Ipkg go test pkg -c -o pkg.test
         env:
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: 0


### PR DESCRIPTION
Previously, the prebuilt binaries have been named as `${last part of import path}.test`
and placed on the project root. Therefore, the test binary for `./wasm/` has the same 
name for `internal/wasm/` and resulted in running only one of these two tests.
This fixes that by producing the binary on each pkg's parent directory.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>