### PR TITLE
wasi: stops enforcing _start function export

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -87,7 +87,22 @@ runtime vs interpreting Wasm directly (the `naivevm` interpreter).
 Note: `microwasm` was never specified formally, and only exists in a historical codebase of wasmtime:
 https://github.com/bytecodealliance/wasmtime/blob/v0.29.0/crates/lightbeam/src/microwasm.rs
 
-## Why is `SysConfig` decoupled from WASI?
+## WASI
+
+### Why aren't all WASI rules enforced?
+
+The [snapshot-01](https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md) version of WASI has a
+number of rules for a "command module", but only the memory export rule is enforced. If a "_start" function exists, it
+is enforced to be the correct signature and succeed, but the export itself isn't enforced. It follows that this means
+exports are not required to be contained to a "_start" function invocation. Finally, the "__indirect_function_table"
+export is also not enforced.
+
+The reason for the exceptions are that implementations aren't following the rules. For example, TinyGo doesn't export
+"__indirect_function_table", so crashing on this would make wazero unable to run TinyGo modules. Similarly, modules
+loaded by wapc-go don't always define a "_start" function. Since "snapshot-01" is not a proper version, and certainly
+not a W3C recommendation, there's no sense in breaking users over matters like this.
+
+### Why is `SysConfig` decoupled from WASI?
 
 WebAssembly System Interfaces (WASI) is a formalization of a practice that can be done anyway: Define a host function to
 access a system interface, such as writing to STDOUT. WASI stalled at snapshot-01 and as of early 2022, is being

--- a/internal/wasi/wasi.go
+++ b/internal/wasi/wasi.go
@@ -1505,9 +1505,9 @@ func openFileEntry(rootFS fs.FS, pathName string) (*internalwasm.FileEntry, wasi
 }
 
 func ValidateWASICommand(module *internalwasm.Module, moduleName string) error {
-	if start, err := requireExport(module, moduleName, FunctionStart, internalwasm.ExternTypeFunc); err != nil {
-		return err
-	} else {
+	// The snapshot-01 specification requires a "_start" function, but we don't enforce it is present. We only enforce
+	// if present, it is valid. In practice, not all modules importing WASI define a "_start" function (ex. wapc-go).
+	if start, err := requireExport(module, moduleName, FunctionStart, internalwasm.ExternTypeFunc); err == nil {
 		// TODO: this should be verified during decode so that errors have the correct source positions
 		ft := module.TypeOfFunction(start.Index)
 		if ft == nil {

--- a/wasi.go
+++ b/wasi.go
@@ -58,7 +58,7 @@ func StartWASICommandFromSource(r Runtime, source []byte) (wasm.Module, error) {
 // memory to implement multiple returns. StartWASICommand errs if there is no memory exported as "memory".
 //
 // ## "_start" function export
-// WASI snapshot-01 requires exporting a function named "_start", but wazero does not enforce this. If it is defined,
+// WASI snapshot-01 requires exporting a function named "_start" for WASI command, but wazero does not enforce this. If it is defined,
 // it is called directly after any module-defined start function, in the runtime context (RuntimeConfig.WithContext).
 //
 // ## "__indirect_function_table" function export


### PR DESCRIPTION
Currently, we have custom code in wapc-go because our library forces a
failure when a module that uses WASI doesn't define a "_start" function.
Using the same pragmatism that resulted in us not enforcing the WASI
table, this makes the "_start" function optional. This doesn't add a
flag as the spec is not a proper version anyway (snapshot-01), so
there's no need to further complicate configuration.

If a "_start" function exists, we enforce it is of the proper signature
and succeeds. Otherwise, we allow it to be absent.
