### PR TITLE
Deduplicates internalwasm.Engine tests

### DIFF
--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -1,0 +1,197 @@
+// Package enginetest contains tests common to any internalwasm.Engine implementation. Defining these as top-level
+// functions is less burden than copy/pasting the implementations, while still allowing test caching to operate.
+//
+// Ex. In simplest case, dispatch:
+//	func TestEngine_Call(t *testing.T) {
+//		enginetest.RunTestEngine_Call(t, NewEngine)
+//	}
+//
+// Ex. Some tests using the JIT Engine may need to guard as they use compiled features:
+//	func TestEngine_Call(t *testing.T) {
+//		requireSupportedOSArch(t)
+//		enginetest.RunTestEngine_Call(t, NewEngine)
+//	}
+package enginetest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	wasm "github.com/tetratelabs/wazero/internal/wasm"
+	publicwasm "github.com/tetratelabs/wazero/wasm"
+)
+
+func RunTestEngine_Call(t *testing.T, newEngine func() wasm.Engine) {
+	i64 := wasm.ValueTypeI64
+	m := &wasm.Module{
+		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}},
+		FunctionSection: []wasm.Index{wasm.Index(0)},
+		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
+		ExportSection:   map[string]*wasm.Export{"fn": {Type: wasm.ExternTypeFunc, Index: 0, Name: "fn"}},
+	}
+
+	// Use exported functions to simplify instantiation of a Wasm function
+	e := newEngine()
+	store := wasm.NewStore(e, wasm.Features20191205)
+	mod, err := store.Instantiate(context.Background(), m, t.Name(), nil)
+	require.NoError(t, err)
+
+	fn := mod.ExportedFunction("fn")
+	require.NotNil(t, fn)
+
+	// ensure base case doesn't fail
+	results, err := fn.Call(nil, 3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), results[0])
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		_, err := fn.Call(nil)
+		require.EqualError(t, err, "expected 1 params, but passed 0")
+	})
+
+	t.Run("errs when too many parameters", func(t *testing.T) {
+		_, err := fn.Call(nil, 1, 2)
+		require.EqualError(t, err, "expected 1 params, but passed 2")
+	})
+}
+
+func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, initTable func(me wasm.ModuleEngine, initTableLen uint32, initTableIdxToFnIdx map[wasm.Index]wasm.Index) []interface{}, newEngine func() wasm.Engine) {
+	e := newEngine()
+
+	t.Run("no table elements", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		var importedFunctions []*wasm.FunctionInstance
+		var moduleFunctions []*wasm.FunctionInstance
+		var tableInit map[wasm.Index]wasm.Index
+
+		// Instantiate the module, which has nothing but an empty table.
+		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+		defer me.Close()
+
+		// Since there are no elements to initialize, we expect the table to be nil.
+		require.Equal(t, table.Table, make([]interface{}, 2))
+	})
+
+	t.Run("module-defined function", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		var importedFunctions []*wasm.FunctionInstance
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		tableInit := map[wasm.Index]wasm.Index{0: 2}
+
+		// Instantiate the module whose table points to its own functions.
+		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+		defer me.Close()
+
+		// The functions mapped to the table are defined in the same moduleEngine
+		require.Equal(t, table.Table, initTable(me, table.Min, tableInit))
+	})
+
+	t.Run("imported function", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		var moduleFunctions []*wasm.FunctionInstance
+		tableInit := map[wasm.Index]wasm.Index{0: 2}
+
+		// Imported functions are compiled before the importing module is instantiated.
+		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
+		require.NoError(t, err)
+		defer imported.Close()
+
+		// Instantiate the importing module, which is whose table is initialized.
+		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+		defer imported.Close()
+
+		// A moduleEngine's compiled function slice includes its imports, so the offsets is absolute.
+		require.Equal(t, table.Table, initTable(importing, table.Min, tableInit))
+	})
+
+	t.Run("mixed functions", func(t *testing.T) {
+		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
+		importedFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		moduleFunctions := []*wasm.FunctionInstance{
+			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		}
+		tableInit := map[wasm.Index]wasm.Index{0: 0, 1: 4}
+
+		// Imported functions are compiled before the importing module is instantiated.
+		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
+		require.NoError(t, err)
+		defer imported.Close()
+
+		// Instantiate the importing module, which is whose table is initialized.
+		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
+		require.NoError(t, err)
+		defer importing.Close()
+
+		// A moduleEngine's compiled function slice includes its imports, so the offsets are absolute.
+		require.Equal(t, table.Table, initTable(importing, table.Min, tableInit))
+	})
+}
+
+func RunTestModuleEngine_Call_HostFn(t *testing.T, newEngine func() wasm.Engine) {
+	memory := &wasm.MemoryInstance{}
+	var ctxMemory publicwasm.Memory
+	hostFn := reflect.ValueOf(func(ctx publicwasm.Module, v uint64) uint64 {
+		ctxMemory = ctx.Memory()
+		return v
+	})
+
+	e := newEngine()
+	module := &wasm.ModuleInstance{Memory: memory}
+	modCtx := wasm.NewModuleContext(context.Background(), wasm.NewStore(e, wasm.Features20191205), module, nil)
+
+	f := &wasm.FunctionInstance{
+		GoFunc: &hostFn,
+		Kind:   wasm.FunctionKindGoModule,
+		Type: &wasm.FunctionType{
+			Params:  []wasm.ValueType{wasm.ValueTypeI64},
+			Results: []wasm.ValueType{wasm.ValueTypeI64},
+		},
+		Module: module,
+	}
+
+	me, err := e.NewModuleEngine(t.Name(), nil, []*wasm.FunctionInstance{f}, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
+		// When calling a host func directly, there may be no stack. This ensures the module's memory is used.
+		results, err := me.Call(modCtx, f, 3)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), results[0])
+		require.Same(t, memory, ctxMemory)
+	})
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		_, err := me.Call(modCtx, f)
+		require.EqualError(t, err, "expected 1 params, but passed 0")
+	})
+
+	t.Run("errs when too many parameters", func(t *testing.T) {
+		_, err := me.Call(modCtx, f, 1, 2)
+		require.EqualError(t, err, "expected 1 params, but passed 2")
+	})
+}

--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -2190,8 +2190,9 @@ func instantiateModule(t *testing.T, ctx context.Context, wasiFunction, wasiImpo
 	// Double-check what we created passes same validity as module-defined modules.
 	require.NoError(t, m.Validate(enabledFeatures))
 
-	_, err = store.Instantiate(ctx, m, m.NameSection.ModuleName, nil) // TODO: close
+	w, err := store.Instantiate(ctx, m, m.NameSection.ModuleName, nil)
 	require.NoError(t, err)
+	defer w.Close()
 
 	m, err = text.DecodeModule([]byte(fmt.Sprintf(`(module
   %[2]s

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -68,8 +68,8 @@ func TestEngine_NewModuleEngine_InitTable(t *testing.T) {
 	enginetest.RunTestEngine_NewModuleEngine_InitTable(t, initTable, NewEngine)
 }
 
-func TestEngine_Call(t *testing.T) {
-	enginetest.RunTestEngine_Call(t, NewEngine)
+func TestModuleEngine_Call(t *testing.T) {
+	enginetest.RunTestModuleEngine_Call(t, NewEngine)
 }
 
 func TestTestModuleEngine_Call_HostFn(t *testing.T) {

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -1,19 +1,17 @@
 package interpreter
 
 import (
-	"context"
 	"fmt"
 	"math"
-	"reflect"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/internal/testing/enginetest"
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/buildoptions"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
-	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
 func TestCallEngine_PushFrame(t *testing.T) {
@@ -59,186 +57,23 @@ func TestEngine_NewModuleEngine(t *testing.T) {
 }
 
 func TestEngine_NewModuleEngine_InitTable(t *testing.T) {
-	e := NewEngine()
-
-	t.Run("no table elements", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		var importedFunctions []*wasm.FunctionInstance
-		var moduleFunctions []*wasm.FunctionInstance
-		var tableInit map[wasm.Index]wasm.Index
-
-		// Instantiate the module, which has nothing but an empty table.
-		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// Since there are no elements to initialize, we expect the table to be nil.
-		require.Equal(t, table.Table, make([]interface{}, 2))
-
-		// Clean up.
-		require.NoError(t, me.Close())
-	})
-
-	t.Run("module-defined function", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		var importedFunctions []*wasm.FunctionInstance
-		moduleFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+	initTable := func(me wasm.ModuleEngine, tableInitLen uint32, initTableIdxToFnIdx map[wasm.Index]wasm.Index) []interface{} {
+		table := make([]interface{}, tableInitLen)
+		internal := me.(*moduleEngine)
+		for idx, fnidx := range initTableIdxToFnIdx {
+			table[idx] = internal.compiledFunctions[fnidx]
 		}
-		tableInit := map[wasm.Index]wasm.Index{0: 2}
-
-		// Instantiate the module whose table points to its own functions.
-		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// The functions mapped to the table are defined in the same moduleEngine
-		require.Equal(t, table.Table, []interface{}{me.(*moduleEngine).compiledFunctions[2], nil})
-
-		// Clean up.
-		require.NoError(t, me.Close())
-	})
-
-	t.Run("imported function", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		importedFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		var moduleFunctions []*wasm.FunctionInstance
-		tableInit := map[wasm.Index]wasm.Index{0: 2}
-
-		// Imported functions are compiled before the importing module is instantiated.
-		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
-		require.NoError(t, err)
-
-		// Instantiate the importing module, which is whose table is initialized.
-		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// A moduleEngine's compiled function slice includes its imports, so the offsets is absolute.
-		require.Equal(t, table.Table, []interface{}{importing.(*moduleEngine).compiledFunctions[2], nil})
-
-		// Clean up.
-		require.NoError(t, importing.Close())
-		require.NoError(t, imported.Close())
-	})
-
-	t.Run("mixed functions", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		importedFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		moduleFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		tableInit := map[wasm.Index]wasm.Index{0: 0, 1: 4}
-
-		// Imported functions are compiled before the importing module is instantiated.
-		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
-		require.NoError(t, err)
-
-		// Instantiate the importing module, which is whose table is initialized.
-		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// A moduleEngine's compiled function slice includes its imports, so the offsets are absolute.
-		require.Equal(t, table.Table, []interface{}{
-			importing.(*moduleEngine).compiledFunctions[0],
-			importing.(*moduleEngine).compiledFunctions[4],
-		})
-
-		// Clean up.
-		require.NoError(t, importing.Close())
-		require.NoError(t, imported.Close())
-	})
+		return table
+	}
+	enginetest.RunTestEngine_NewModuleEngine_InitTable(t, initTable, NewEngine)
 }
 
 func TestEngine_Call(t *testing.T) {
-	i64 := wasm.ValueTypeI64
-	m := &wasm.Module{
-		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}},
-		FunctionSection: []wasm.Index{wasm.Index(0)},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
-		ExportSection:   map[string]*wasm.Export{"fn": {Type: wasm.ExternTypeFunc, Index: 0, Name: "fn"}},
-	}
-
-	// Use exported functions to simplify instantiation of a Wasm function
-	e := NewEngine()
-	store := wasm.NewStore(e, wasm.Features20191205)
-	mod, err := store.Instantiate(context.Background(), m, t.Name(), nil)
-	require.NoError(t, err)
-
-	fn := mod.ExportedFunction("fn")
-	require.NotNil(t, fn)
-
-	// ensure base case doesn't fail
-	results, err := fn.Call(nil, 3)
-	require.NoError(t, err)
-	require.Equal(t, uint64(3), results[0])
-
-	t.Run("errs when not enough parameters", func(t *testing.T) {
-		_, err := fn.Call(nil)
-		require.EqualError(t, err, "expected 1 params, but passed 0")
-	})
-
-	t.Run("errs when too many parameters", func(t *testing.T) {
-		_, err := fn.Call(nil, 1, 2)
-		require.EqualError(t, err, "expected 1 params, but passed 2")
-	})
+	enginetest.RunTestEngine_Call(t, NewEngine)
 }
 
-func TestEngine_Call_HostFn(t *testing.T) {
-	memory := &wasm.MemoryInstance{}
-	var ctxMemory publicwasm.Memory
-	hostFn := reflect.ValueOf(func(ctx publicwasm.Module, v uint64) uint64 {
-		ctxMemory = ctx.Memory()
-		return v
-	})
-
-	e := NewEngine()
-	module := &wasm.ModuleInstance{Memory: memory}
-	modCtx := wasm.NewModuleContext(context.Background(), wasm.NewStore(e, wasm.Features20191205), module, nil)
-
-	f := &wasm.FunctionInstance{
-		GoFunc: &hostFn,
-		Kind:   wasm.FunctionKindGoModule,
-		Type: &wasm.FunctionType{
-			Params:  []wasm.ValueType{wasm.ValueTypeI64},
-			Results: []wasm.ValueType{wasm.ValueTypeI64},
-		},
-		Module: module,
-	}
-
-	me, err := e.NewModuleEngine(t.Name(), nil, []*wasm.FunctionInstance{f}, nil, nil)
-	require.NoError(t, err)
-
-	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
-		// When calling a host func directly, there may be no stack. This ensures the module's memory is used.
-		results, err := me.Call(modCtx, f, 3)
-		require.NoError(t, err)
-		require.Equal(t, uint64(3), results[0])
-		require.Same(t, memory, ctxMemory)
-	})
-
-	t.Run("errs when not enough parameters", func(t *testing.T) {
-		_, err := me.Call(modCtx, f)
-		require.EqualError(t, err, "expected 1 params, but passed 0")
-	})
-
-	t.Run("errs when too many parameters", func(t *testing.T) {
-		_, err := me.Call(modCtx, f, 1, 2)
-		require.EqualError(t, err, "expected 1 params, but passed 2")
-	})
+func TestTestModuleEngine_Call_HostFn(t *testing.T) {
+	enginetest.RunTestModuleEngine_Call_HostFn(t, NewEngine)
 }
 
 func TestCallEngine_callNativeFunc_signExtend(t *testing.T) {

--- a/internal/wasm/jit/arch_arm64.go
+++ b/internal/wasm/jit/arch_arm64.go
@@ -23,10 +23,10 @@ type archContext struct {
 
 	// minimum32BitSignedInt is used for overflow check for 32-bit signed division.
 	// Note: this can be obtained by moving $1 and doing left-shift with 31, but it is
-	// slower than directly loading fron this location.
+	// slower than directly loading from this location.
 	minimum32BitSignedInt int32
 	// Note: this can be obtained by moving $1 and doing left-shift with 63, but it is
-	// slower than directly loading fron this location.
+	// slower than directly loading from this location.
 	// minimum64BitSignedInt is used for overflow check for 64-bit signed division.
 	minimum64BitSignedInt int64
 }

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -155,7 +155,8 @@ type (
 	// That is, callFrameTop().returnAddress or returnStackBasePointer are not set
 	// until it makes a function call.
 	callFrame struct {
-		// Set when making function call from this function frame, or for the initial function frame to call from engine.execWasmFunction.
+		// Set when making function call from this function frame, or for the initial function frame to call from
+		// callEngine.execWasmFunction.
 		returnAddress uintptr
 		// Set when making function call from this function frame.
 		returnStackBasePointer uint64

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -112,9 +112,9 @@ func TestEngine_NewModuleEngine(t *testing.T) {
 	})
 }
 
-func TestEngine_Call(t *testing.T) {
+func TestModuleEngine_Call(t *testing.T) {
 	requireSupportedOSArch(t)
-	enginetest.RunTestEngine_Call(t, NewEngine)
+	enginetest.RunTestModuleEngine_Call(t, NewEngine)
 }
 
 func TestEngine_NewModuleEngine_InitTable(t *testing.T) {

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"reflect"
 	"runtime"
 	"strconv"
 	"sync"
@@ -13,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/wazero/internal/testing/enginetest"
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
-	publicwasm "github.com/tetratelabs/wazero/wasm"
 )
 
 // Ensures that the offset consts do not drift when we manipulate the target structs.
@@ -115,189 +114,24 @@ func TestEngine_NewModuleEngine(t *testing.T) {
 
 func TestEngine_Call(t *testing.T) {
 	requireSupportedOSArch(t)
-
-	i64 := wasm.ValueTypeI64
-	m := &wasm.Module{
-		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}},
-		FunctionSection: []wasm.Index{wasm.Index(0)},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
-		ExportSection:   map[string]*wasm.Export{"fn": {Type: wasm.ExternTypeFunc, Index: 0, Name: "fn"}},
-	}
-
-	// Use exported functions to simplify instantiation of a Wasm function
-	e := NewEngine()
-	store := wasm.NewStore(e, wasm.Features20191205)
-	mod, err := store.Instantiate(context.Background(), m, t.Name(), nil)
-	require.NoError(t, err)
-
-	fn := mod.ExportedFunction("fn")
-	require.NotNil(t, fn)
-
-	// ensure base case doesn't fail
-	results, err := fn.Call(nil, 3)
-	require.NoError(t, err)
-	require.Equal(t, uint64(3), results[0])
-
-	t.Run("errs when not enough parameters", func(t *testing.T) {
-		_, err := fn.Call(nil)
-		require.EqualError(t, err, "expected 1 params, but passed 0")
-	})
-
-	t.Run("errs when too many parameters", func(t *testing.T) {
-		_, err := fn.Call(nil, 1, 2)
-		require.EqualError(t, err, "expected 1 params, but passed 2")
-	})
+	enginetest.RunTestEngine_Call(t, NewEngine)
 }
 
 func TestEngine_NewModuleEngine_InitTable(t *testing.T) {
-	e := NewEngine()
-
-	t.Run("no table elements", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		var importedFunctions []*wasm.FunctionInstance
-		var moduleFunctions []*wasm.FunctionInstance
-		var tableInit map[wasm.Index]wasm.Index
-
-		// Instantiate the module, which has nothing but an empty table.
-		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// Since there are no elements to initialize, we expect the table to be nil.
-		require.Equal(t, table.Table, make([]interface{}, 2))
-
-		// Clean up.
-		require.NoError(t, me.Close())
-	})
-
-	t.Run("module-defined function", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		var importedFunctions []*wasm.FunctionInstance
-		moduleFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+	initTable := func(me wasm.ModuleEngine, tableInitLen uint32, initTableIdxToFnIdx map[wasm.Index]wasm.Index) []interface{} {
+		table := make([]interface{}, tableInitLen)
+		internal := me.(*moduleEngine)
+		for idx, fnidx := range initTableIdxToFnIdx {
+			table[idx] = internal.compiledFunctions[fnidx]
 		}
-		tableInit := map[wasm.Index]wasm.Index{0: 2}
-
-		// Instantiate the module whose table points to its own functions.
-		me, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// The functions mapped to the table are defined in the same moduleEngine
-		require.Equal(t, table.Table, []interface{}{me.(*moduleEngine).compiledFunctions[2], nil})
-
-		// Clean up.
-		require.NoError(t, me.Close())
-	})
-
-	t.Run("imported function", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		importedFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		var moduleFunctions []*wasm.FunctionInstance
-		tableInit := map[wasm.Index]wasm.Index{0: 2}
-
-		// Imported functions are compiled before the importing module is instantiated.
-		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
-		require.NoError(t, err)
-
-		// Instantiate the importing module, which is whose table is initialized.
-		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// A moduleEngine's compiled function slice includes its imports, so the offsets is absolute.
-		require.Equal(t, table.Table, []interface{}{importing.(*moduleEngine).compiledFunctions[2], nil})
-
-		// Clean up.
-		require.NoError(t, importing.Close())
-		require.NoError(t, imported.Close())
-	})
-
-	t.Run("mixed functions", func(t *testing.T) {
-		table := &wasm.TableInstance{Min: 2, Table: make([]interface{}, 2)}
-		importedFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		moduleFunctions := []*wasm.FunctionInstance{
-			{Name: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{Name: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		tableInit := map[wasm.Index]wasm.Index{0: 0, 1: 4}
-
-		// Imported functions are compiled before the importing module is instantiated.
-		imported, err := e.NewModuleEngine(t.Name(), nil, importedFunctions, nil, nil)
-		require.NoError(t, err)
-
-		// Instantiate the importing module, which is whose table is initialized.
-		importing, err := e.NewModuleEngine(t.Name(), importedFunctions, moduleFunctions, table, tableInit)
-		require.NoError(t, err)
-
-		// A moduleEngine's compiled function slice includes its imports, so the offsets are absolute.
-		require.Equal(t, table.Table, []interface{}{
-			importing.(*moduleEngine).compiledFunctions[0],
-			importing.(*moduleEngine).compiledFunctions[4],
-		})
-
-		// Clean up.
-		require.NoError(t, importing.Close())
-		require.NoError(t, imported.Close())
-	})
+		return table
+	}
+	enginetest.RunTestEngine_NewModuleEngine_InitTable(t, initTable, NewEngine)
 }
 
-func TestEngine_Call_HostFn(t *testing.T) {
+func TestTestModuleEngine_Call_HostFn(t *testing.T) {
 	requireSupportedOSArch(t)
-
-	memory := &wasm.MemoryInstance{}
-	var ctxMemory publicwasm.Memory
-	hostFn := reflect.ValueOf(func(ctx publicwasm.Module, v uint64) uint64 {
-		ctxMemory = ctx.Memory()
-		return v
-	})
-
-	e := NewEngine()
-	module := &wasm.ModuleInstance{Memory: memory}
-	modCtx := wasm.NewModuleContext(context.Background(), wasm.NewStore(e, wasm.Features20191205), module, nil)
-
-	f := &wasm.FunctionInstance{
-		GoFunc: &hostFn,
-		Kind:   wasm.FunctionKindGoModule,
-		Type: &wasm.FunctionType{
-			Params:  []wasm.ValueType{wasm.ValueTypeI64},
-			Results: []wasm.ValueType{wasm.ValueTypeI64},
-		},
-		Module: module,
-	}
-
-	modEngine, err := e.NewModuleEngine(t.Name(), nil, []*wasm.FunctionInstance{f}, nil, nil)
-	require.NoError(t, err)
-
-	t.Run("defaults to module memory when call stack empty", func(t *testing.T) {
-		// When calling a host func directly, there may be no stack. This ensures the module's memory is used.
-		results, err := modEngine.Call(modCtx, f, 3)
-		require.NoError(t, err)
-		require.Equal(t, uint64(3), results[0])
-		require.Same(t, memory, ctxMemory)
-	})
-
-	t.Run("errs when not enough parameters", func(t *testing.T) {
-		_, err := modEngine.Call(modCtx, f)
-		require.EqualError(t, err, "expected 1 params, but passed 0")
-	})
-
-	t.Run("errs when too many parameters", func(t *testing.T) {
-		_, err := modEngine.Call(modCtx, f, 1, 2)
-		require.EqualError(t, err, "expected 1 params, but passed 2")
-	})
+	enginetest.RunTestModuleEngine_Call_HostFn(t, NewEngine)
 }
 
 func requireSupportedOSArch(t *testing.T) {

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -484,7 +484,7 @@ func (m *Module) buildFunctions() (functions []*FunctionInstance) {
 			Type:       m.TypeSection[typeIndex],
 			Body:       m.CodeSection[codeIndex].Body,
 			LocalTypes: m.CodeSection[codeIndex].LocalTypes,
-			Index:      Index(importCount + uint32(codeIndex)),
+			Index:      importCount + uint32(codeIndex),
 		}
 		functions = append(functions, f)
 	}

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -305,7 +305,7 @@ func (s *Store) Instantiate(ctx context.Context, module *Module, name string, sy
 		return nil, err
 	}
 
-	// Plus we are ready to compile functions.
+	// Plus, we are ready to compile functions.
 	m.Engine, err = s.engine.NewModuleEngine(name, importedFunctions, functions, table, tableInit)
 	if err != nil {
 		return nil, fmt.Errorf("compilation failed: %w", err)


### PR DESCRIPTION
This deduplicates Engine tests so that there's less chance of copy/paste
errors and less requirement to use ad-hoc tests which are outside the
relevant source tree.
