### PR TITLE
Adds Module.Name and ports all hammer tests to the same impl

### DIFF
--- a/internal/wasm/module_context.go
+++ b/internal/wasm/module_context.go
@@ -28,6 +28,11 @@ type ModuleContext struct {
 	sys *SysContext
 }
 
+// Name implements the same method as documented on wasm.Module
+func (m *ModuleContext) Name() string {
+	return m.module.Name
+}
+
 // WithMemory allows overriding memory without re-allocation when the result would be the same.
 func (m *ModuleContext) WithMemory(memory *MemoryInstance) *ModuleContext {
 	if memory != nil && memory != m.memory { // only re-allocate if it will change the effective memory
@@ -36,12 +41,12 @@ func (m *ModuleContext) WithMemory(memory *MemoryInstance) *ModuleContext {
 	return m
 }
 
-// String implements fmt.Stringer
+// String implements the same method as documented on wasm.Module
 func (m *ModuleContext) String() string {
-	return fmt.Sprintf("Module[%s]", m.module.Name)
+	return fmt.Sprintf("Module[%s]", m.Name())
 }
 
-// Context implements wasm.Module Context
+// Context implements the same method as documented on wasm.Module
 func (m *ModuleContext) Context() context.Context {
 	return m.ctx
 }
@@ -51,7 +56,7 @@ func (m *ModuleContext) Sys() *SysContext {
 	return m.sys
 }
 
-// WithContext implements wasm.Module WithContext
+// WithContext implements the same method as documented on wasm.Module
 func (m *ModuleContext) WithContext(ctx context.Context) publicwasm.Module {
 	if ctx != nil && ctx != m.ctx { // only re-allocate if it will change the effective context
 		return &ModuleContext{module: m.module, memory: m.memory, ctx: ctx, sys: m.sys}
@@ -59,10 +64,10 @@ func (m *ModuleContext) WithContext(ctx context.Context) publicwasm.Module {
 	return m
 }
 
-// Close implements io.Closer
+// Close implements the same method as documented on wasm.Module
 // Note: When there are multiple errors, the error returned is the last one.
 func (m *ModuleContext) Close() (err error) {
-	err = m.store.CloseModule(m.module.Name)
+	err = m.store.CloseModule(m.Name())
 	if sys := m.sys; sys == nil { // ex from ModuleBuilder
 		return
 	} else if err2 := m.sys.Close(); err2 != nil {

--- a/internal/wasm/module_context_test.go
+++ b/internal/wasm/module_context_test.go
@@ -133,7 +133,7 @@ func TestModuleContext_String(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, m.String())
-			require.Equal(t, tc.expected, s.Module(m.module.Name).String())
+			require.Equal(t, tc.expected, s.Module(m.Name()).String())
 		})
 	}
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -184,7 +184,7 @@ func TestStore_hammer(t *testing.T) {
 	imported, err := s.Instantiate(context.Background(), m, importedModuleName, nil)
 	require.NoError(t, err)
 
-	_, ok := s.modules[imported.module.Name]
+	_, ok := s.modules[imported.Name()]
 	require.True(t, ok)
 
 	importingModule := &Module{
@@ -217,7 +217,7 @@ func TestStore_hammer(t *testing.T) {
 	}
 
 	// Close the imported module.
-	require.NoError(t, s.CloseModule(imported.module.Name))
+	require.NoError(t, s.CloseModule(imported.Name()))
 
 	// All instances are freed.
 	require.Len(t, s.modules, 0)
@@ -386,7 +386,7 @@ func TestFunctionInstance_Call(t *testing.T) {
 				TypeSection: []*FunctionType{{}},
 				ImportSection: []*Import{{
 					Type:     ExternTypeFunc,
-					Module:   hm.module.Name,
+					Module:   hm.Name(),
 					Name:     functionName,
 					DescFunc: 0,
 				}},

--- a/wasm/wasm.go
+++ b/wasm/wasm.go
@@ -63,6 +63,9 @@ func ValueTypeName(t ValueType) string {
 type Module interface {
 	fmt.Stringer
 
+	// Name is the name this module was instantiated with. Exported functions can be imported with this name.
+	Name() string
+
 	// Closer (Close) releases resources allocated for this Module. Using this while having outstanding function calls
 	// is safe. After calling this function, re-instantiating a module for the same name is allowed.
 	io.Closer


### PR DESCRIPTION
This exposes `wasm.Module.Name()` so that it is more coherent to
redefine a module with the same name, or know the name to import.

This uses that to port existing tests to use the new hammer
infrastructure (without module name collision).
