### PR TITLE
Makes memory limit configurable and a compile error

### DIFF
--- a/internal/wasi/wasi_test.go
+++ b/internal/wasi/wasi_test.go
@@ -2198,7 +2198,7 @@ func instantiateModule(t *testing.T, ctx context.Context, wasiFunction, wasiImpo
   (memory 1)  ;; just an arbitrary size big enough for tests
   (export "memory" (memory 0))
   (export "%[1]s" (func $wasi.%[1]s))
-)`, wasiFunction, wasiImport)), enabledFeatures)
+)`, wasiFunction, wasiImport)), enabledFeatures, wasm.MemoryMaxPages)
 	require.NoError(t, err)
 
 	mod, err := store.Instantiate(ctx, m, moduleName, sysCtx)

--- a/internal/wasm/binary/decoder.go
+++ b/internal/wasm/binary/decoder.go
@@ -11,7 +11,7 @@ import (
 
 // DecodeModule implements internalwasm.DecodeModule for the WebAssembly 1.0 (20191205) Binary Format
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-format%E2%91%A0
-func DecodeModule(binary []byte, features wasm.Features) (*wasm.Module, error) {
+func DecodeModule(binary []byte, _ wasm.Features, memoryMaxPages uint32) (*wasm.Module, error) {
 	r := bytes.NewReader(binary)
 
 	// Magic number.
@@ -71,7 +71,7 @@ func DecodeModule(binary []byte, features wasm.Features) (*wasm.Module, error) {
 		case wasm.SectionIDType:
 			m.TypeSection, err = decodeTypeSection(r)
 		case wasm.SectionIDImport:
-			if m.ImportSection, err = decodeImportSection(r, features); err != nil {
+			if m.ImportSection, err = decodeImportSection(r, memoryMaxPages); err != nil {
 				return nil, err // avoid re-wrapping the error.
 			}
 		case wasm.SectionIDFunction:
@@ -79,7 +79,7 @@ func DecodeModule(binary []byte, features wasm.Features) (*wasm.Module, error) {
 		case wasm.SectionIDTable:
 			m.TableSection, err = decodeTableSection(r)
 		case wasm.SectionIDMemory:
-			m.MemorySection, err = decodeMemorySection(r)
+			m.MemorySection, err = decodeMemorySection(r, memoryMaxPages)
 		case wasm.SectionIDGlobal:
 			if m.GlobalSection, err = decodeGlobalSection(r); err != nil {
 				return nil, err // avoid re-wrapping the error.

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -109,15 +109,15 @@ func TestModule_Encode(t *testing.T) {
 			name: "table and memory section",
 			input: &wasm.Module{
 				TableSection:  &wasm.Table{Min: 3},
-				MemorySection: &wasm.Memory{Min: 1},
+				MemorySection: &wasm.Memory{Min: 1, Max: 1},
 			},
 			expected: append(append(Magic, version...),
 				wasm.SectionIDTable, 0x04, // 4 bytes in this section
 				0x01,                            // 1 table
 				wasm.ElemTypeFuncref, 0x0, 0x03, // func, only min: 3
-				wasm.SectionIDMemory, 0x03, // 3 bytes in this section
-				0x01,      // 1 memory
-				0x0, 0x01, // only min: 01
+				wasm.SectionIDMemory, 0x04, // 4 bytes in this section
+				0x01,             // 1 memory
+				0x01, 0x01, 0x01, // min and max = 1
 			),
 		},
 		{

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -8,7 +8,7 @@ import (
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeImport(r *bytes.Reader, idx uint32, features wasm.Features) (i *wasm.Import, err error) {
+func decodeImport(r *bytes.Reader, idx uint32, memoryMaxPages uint32) (i *wasm.Import, err error) {
 	i = &wasm.Import{}
 	if i.Module, _, err = decodeUTF8(r, "import module"); err != nil {
 		return nil, fmt.Errorf("import[%d] error decoding module: %w", idx, err)
@@ -29,7 +29,7 @@ func decodeImport(r *bytes.Reader, idx uint32, features wasm.Features) (i *wasm.
 	case wasm.ExternTypeTable:
 		i.DescTable, err = decodeTable(r)
 	case wasm.ExternTypeMemory:
-		i.DescMem, err = decodeMemory(r)
+		i.DescMem, err = decodeMemory(r, memoryMaxPages)
 	case wasm.ExternTypeGlobal:
 		i.DescGlobal, err = decodeGlobalType(r)
 	default:

--- a/internal/wasm/binary/memory.go
+++ b/internal/wasm/binary/memory.go
@@ -10,20 +10,23 @@ import (
 // decodeMemory returns the wasm.Memory decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
-func decodeMemory(r *bytes.Reader) (*wasm.Memory, error) {
-	min, max, err := decodeLimitsType(r)
+func decodeMemory(r *bytes.Reader, memoryMaxPages uint32) (*wasm.Memory, error) {
+	min, maxP, err := decodeLimitsType(r)
 	if err != nil {
 		return nil, err
 	}
-	if min > wasm.MemoryMaxPages {
-		return nil, fmt.Errorf("memory min must be at most 65536 pages (4GiB)")
+	var max uint32
+	if maxP != nil {
+		max = *maxP
+	} else {
+		max = memoryMaxPages
 	}
-	if max != nil {
-		if *max < min {
-			return nil, fmt.Errorf("memory size minimum must not be greater than maximum")
-		} else if *max > wasm.MemoryMaxPages {
-			return nil, fmt.Errorf("memory max must be at most 65536 pages (4GiB)")
-		}
+	if max > memoryMaxPages {
+		return nil, fmt.Errorf("max %d pages (%s) outside range of %d pages (%s)", max, wasm.PagesToUnitOfBytes(max), memoryMaxPages, wasm.PagesToUnitOfBytes(memoryMaxPages))
+	} else if min > memoryMaxPages {
+		return nil, fmt.Errorf("min %d pages (%s) outside range of %d pages (%s)", min, wasm.PagesToUnitOfBytes(min), memoryMaxPages, wasm.PagesToUnitOfBytes(memoryMaxPages))
+	} else if min > max {
+		return nil, fmt.Errorf("min %d pages (%s) > max %d pages (%s)", min, wasm.PagesToUnitOfBytes(min), max, wasm.PagesToUnitOfBytes(max))
 	}
 	return &wasm.Memory{Min: min, Max: max}, nil
 }
@@ -32,5 +35,5 @@ func decodeMemory(r *bytes.Reader) (*wasm.Memory, error) {
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
 func encodeMemory(i *wasm.Memory) []byte {
-	return encodeLimitsType(i.Min, i.Max)
+	return encodeLimitsType(i.Min, &i.Max)
 }

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -61,7 +61,7 @@ func decodeFunctionType(r *bytes.Reader) (*wasm.FunctionType, error) {
 	}, nil
 }
 
-func decodeImportSection(r *bytes.Reader, features wasm.Features) ([]*wasm.Import, error) {
+func decodeImportSection(r *bytes.Reader, memoryMaxPages uint32) ([]*wasm.Import, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
@@ -69,7 +69,7 @@ func decodeImportSection(r *bytes.Reader, features wasm.Features) ([]*wasm.Impor
 
 	result := make([]*wasm.Import, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeImport(r, i, features); err != nil {
+		if result[i], err = decodeImport(r, i, memoryMaxPages); err != nil {
 			return nil, err
 		}
 	}
@@ -103,7 +103,7 @@ func decodeTableSection(r *bytes.Reader) (*wasm.Table, error) {
 	return decodeTable(r)
 }
 
-func decodeMemorySection(r *bytes.Reader) (*wasm.Memory, error) {
+func decodeMemorySection(r *bytes.Reader, memoryMaxPages uint32) (*wasm.Memory, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("error reading size")
@@ -112,7 +112,7 @@ func decodeMemorySection(r *bytes.Reader) (*wasm.Memory, error) {
 		return nil, fmt.Errorf("at most one memory allowed in module, but read %d", vs)
 	}
 
-	return decodeMemory(r)
+	return decodeMemory(r, memoryMaxPages)
 }
 
 func decodeGlobalSection(r *bytes.Reader) ([]*wasm.Global, error) {

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -77,7 +77,7 @@ func TestMemorySection(t *testing.T) {
 				0x01,             // 1 memory
 				0x01, 0x02, 0x03, // (memory 2 3)
 			},
-			expected: &wasm.Memory{Min: 2, Max: &three},
+			expected: &wasm.Memory{Min: 2, Max: three},
 		},
 	}
 
@@ -85,7 +85,7 @@ func TestMemorySection(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			memories, err := decodeMemorySection(bytes.NewReader(tc.input))
+			memories, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemoryMaxPages)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, memories)
 		})
@@ -94,9 +94,10 @@ func TestMemorySection(t *testing.T) {
 
 func TestMemorySection_Errors(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       []byte
-		expectedErr string
+		name           string
+		input          []byte
+		memoryMaxPages uint32
+		expectedErr    string
 	}{
 		{
 			name: "min and min with max",
@@ -112,8 +113,12 @@ func TestMemorySection_Errors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 
+		if tc.memoryMaxPages == 0 {
+			tc.memoryMaxPages = wasm.MemoryMaxPages
+		}
+
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeMemorySection(bytes.NewReader(tc.input))
+			_, err := decodeMemorySection(bytes.NewReader(tc.input), tc.memoryMaxPages)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestMemoryPageConsts(t *testing.T) {
 	require.Equal(t, MemoryPageSize, uint32(1)<<MemoryPageSizeInBits)
-	require.Equal(t, MemoryPageSize, MemoryMaxPages)
 	require.Equal(t, MemoryPageSize, uint32(1<<16))
+	require.Equal(t, MemoryMaxPages, uint32(1<<16))
 }
 
 func Test_MemoryPagesToBytesNum(t *testing.T) {
@@ -26,33 +26,23 @@ func Test_MemoryBytesNumToPages(t *testing.T) {
 }
 
 func TestMemoryInstance_Grow_Size(t *testing.T) {
-	t.Run("with max", func(t *testing.T) {
-		max := uint32(10)
-		m := &MemoryInstance{Max: &max, Buffer: make([]byte, 0)}
-		require.Equal(t, uint32(0), m.Grow(5))
-		require.Equal(t, uint32(5), m.PageSize())
-		// Zero page grow is well-defined, should return the current page correctly.
-		require.Equal(t, uint32(5), m.Grow(0))
-		require.Equal(t, uint32(5), m.PageSize())
-		require.Equal(t, uint32(5), m.Grow(4))
-		require.Equal(t, uint32(9), m.PageSize())
-		// At this point, the page size equal 9,
-		// so trying to grow two pages should result in failure.
-		require.Equal(t, int32(-1), int32(m.Grow(2)))
-		require.Equal(t, uint32(9), m.PageSize())
-		// But growing one page is still permitted.
-		require.Equal(t, uint32(9), m.Grow(1))
-		// Ensure that the current page size equals the max.
-		require.Equal(t, max, m.PageSize())
-	})
-	t.Run("without max", func(t *testing.T) {
-		m := &MemoryInstance{Buffer: make([]byte, 0)}
-		require.Equal(t, uint32(0), m.Grow(1))
-		require.Equal(t, uint32(1), m.PageSize())
-		// Trying to grow above MemoryMaxPages, the operation should fail.
-		require.Equal(t, int32(-1), int32(m.Grow(MemoryMaxPages)))
-		require.Equal(t, uint32(1), m.PageSize())
-	})
+	max := uint32(10)
+	m := &MemoryInstance{Max: max, Buffer: make([]byte, 0)}
+	require.Equal(t, uint32(0), m.Grow(5))
+	require.Equal(t, uint32(5), m.PageSize())
+	// Zero page grow is well-defined, should return the current page correctly.
+	require.Equal(t, uint32(5), m.Grow(0))
+	require.Equal(t, uint32(5), m.PageSize())
+	require.Equal(t, uint32(5), m.Grow(4))
+	require.Equal(t, uint32(9), m.PageSize())
+	// At this point, the page size equal 9,
+	// so trying to grow two pages should result in failure.
+	require.Equal(t, int32(-1), int32(m.Grow(2)))
+	require.Equal(t, uint32(9), m.PageSize())
+	// But growing one page is still permitted.
+	require.Equal(t, uint32(9), m.Grow(1))
+	// Ensure that the current page size equals the max.
+	require.Equal(t, max, m.PageSize())
 }
 
 func TestReadByte(t *testing.T) {
@@ -87,6 +77,48 @@ func TestWriteUint32Le(t *testing.T) {
 	require.Equal(t, []byte{0, 0, 0, 0, 16, 0, 0, 0}, mem.Buffer)
 	require.False(t, mem.WriteUint32Le(5, 16))
 	require.False(t, mem.WriteUint32Le(9, 16))
+}
+
+func TestPagesToUnitOfBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		pages    uint32
+		expected string
+	}{
+		{
+			name:     "zero",
+			pages:    0,
+			expected: "0 Ki",
+		},
+		{
+			name:     "one",
+			pages:    1,
+			expected: "64 Ki",
+		},
+		{
+			name:     "megs",
+			pages:    100,
+			expected: "6 Mi",
+		},
+		{
+			name:     "max memory",
+			pages:    MemoryMaxPages,
+			expected: "4 Gi",
+		},
+		{
+			name:     "max uint32",
+			pages:    math.MaxUint32,
+			expected: "3 Ti",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, PagesToUnitOfBytes(tc.pages))
+		})
+	}
 }
 
 func TestMemoryInstance_HasSize(t *testing.T) {

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -20,7 +20,7 @@ import (
 // * result is the module parsed or nil on error
 // * err is a FormatError invoking the parser, dangling block comments or unexpected characters.
 // See binary.DecodeModule and text.DecodeModule
-type DecodeModule func(source []byte, enabledFeatures Features) (result *Module, err error)
+type DecodeModule func(source []byte, enabledFeatures Features, memoryMaxPages uint32) (result *Module, err error)
 
 // EncodeModule encodes the given module into a byte slice depending on the format of the implementation.
 // See binary.EncodeModule
@@ -586,7 +586,9 @@ type limitsType struct {
 }
 
 // Memory describes the limits of pages (64KB) in a memory.
-type Memory = limitsType
+type Memory struct {
+	Min, Max uint32
+}
 
 type GlobalType struct {
 	ValType ValueType

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -141,9 +141,9 @@ func TestModule_allDeclarations(t *testing.T) {
 		// Memories.
 		{
 			module: &Module{
-				ImportSection: []*Import{{Type: ExternTypeMemory, DescMem: &limitsType{Min: 1}}},
+				ImportSection: []*Import{{Type: ExternTypeMemory, DescMem: &Memory{Min: 1, Max: 10}}},
 			},
-			expectedMemory: &Memory{Min: 1},
+			expectedMemory: &Memory{Min: 1, Max: 10},
 		},
 		{
 			module: &Module{
@@ -643,7 +643,7 @@ func TestModule_validateExports(t *testing.T) {
 			name:            "memory out of range",
 			enabledFeatures: Features20191205,
 			exportSection:   map[string]*Export{"e1": {Type: ExternTypeMemory, Index: 0}},
-			table:           &Memory{},
+			table:           &limitsType{},
 			expectedErr:     `memory for export["e1"] out of range`,
 		},
 	} {
@@ -720,9 +720,9 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 	t.Run("non-nil", func(t *testing.T) {
 		min := uint32(1)
 		max := uint32(10)
-		m := Module{MemorySection: &Memory{Min: min, Max: &max}}
+		m := Module{MemorySection: &Memory{Min: min, Max: max}}
 		mem := m.buildMemory()
 		require.Equal(t, min, mem.Min)
-		require.Equal(t, max, *mem.Max)
+		require.Equal(t, max, mem.Max)
 	})
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -456,7 +456,7 @@ func TestStore_getTypeInstance(t *testing.T) {
 	t.Run("too many functions", func(t *testing.T) {
 		s := newStore()
 		const max = 10
-		s.maximumFunctionTypes = max
+		s.functionMaxTypes = max
 		s.typeIDs = make(map[string]FunctionTypeID)
 		for i := 0; i < max; i++ {
 			s.typeIDs[strconv.Itoa(i)] = 0
@@ -662,12 +662,12 @@ func TestStore_resolveImports(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
 			s := newStore()
 			max := uint32(10)
-			memoryInst := &MemoryInstance{Max: &max}
+			memoryInst := &MemoryInstance{Max: max}
 			s.modules[moduleName] = &ModuleInstance{Exports: map[string]*ExportInstance{name: {
 				Type:   ExternTypeMemory,
 				Memory: memoryInst,
 			}}, Name: moduleName}
-			_, _, _, memory, err := s.resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: &Memory{Max: &max}}}})
+			_, _, _, memory, err := s.resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: &Memory{Max: max}}}})
 			require.NoError(t, err)
 			require.Equal(t, memory, memoryInst)
 		})
@@ -684,13 +684,13 @@ func TestStore_resolveImports(t *testing.T) {
 		t.Run("maximum size mismatch", func(t *testing.T) {
 			s := newStore()
 			max := uint32(10)
-			importMemoryType := &Memory{Max: &max}
+			importMemoryType := &Memory{Max: max}
 			s.modules[moduleName] = &ModuleInstance{Exports: map[string]*ExportInstance{name: {
 				Type:   ExternTypeMemory,
-				Memory: &MemoryInstance{},
+				Memory: &MemoryInstance{Max: MemoryMaxPages},
 			}}, Name: moduleName}
 			_, _, _, _, err := s.resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}})
-			require.EqualError(t, err, "import[0] memory[test.target]: maximum size mismatch: 10, but actual has no max")
+			require.EqualError(t, err, "import[0] memory[test.target]: maximum size mismatch: 10 < 65536")
 		})
 	})
 }

--- a/tests/bench/memory_bench_test.go
+++ b/tests/bench/memory_bench_test.go
@@ -1,14 +1,13 @@
 package bench
 
 import (
-	"math"
 	"testing"
 
 	wasm "github.com/tetratelabs/wazero/internal/wasm"
 )
 
 func BenchmarkMemory(b *testing.B) {
-	var mem = &wasm.MemoryInstance{Buffer: make([]byte, math.MaxUint16), Min: 1}
+	var mem = &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize), Min: 1}
 	if !mem.WriteByte(10, 16) {
 		b.Fail()
 	}

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -245,7 +245,7 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 			},
 		},
 		MemorySection: &wasm.Memory{
-			Min: 1, Max: &memoryLimitMax,
+			Min: 1, Max: memoryLimitMax,
 		},
 		TableSection: &wasm.Table{
 			Min: 10, Max: &tableLimitMax,
@@ -319,8 +319,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 					case "module":
 						buf, err := testcases.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-
-						mod, err := binary.DecodeModule(buf, wasm.Features20191205)
+						mod, err := binary.DecodeModule(buf, wasm.Features20191205, wasm.MemoryMaxPages)
 						require.NoError(t, err, msg)
 						require.NoError(t, mod.Validate(wasm.Features20191205))
 
@@ -448,7 +447,7 @@ func runTest(t *testing.T, newEngine func() wasm.Engine) {
 }
 
 func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg string) {
-	mod, err := binary.DecodeModule(buf, store.EnabledFeatures)
+	mod, err := binary.DecodeModule(buf, store.EnabledFeatures, wasm.MemoryMaxPages)
 	if err != nil {
 		return
 	}

--- a/vs/codec_test.go
+++ b/vs/codec_test.go
@@ -59,7 +59,7 @@ func newExample() *wasm.Module {
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeI64Extend16S, wasm.OpcodeEnd}},
 		},
-		MemorySection: &wasm.Memory{Min: 1, Max: &three},
+		MemorySection: &wasm.Memory{Min: 1, Max: three},
 		ExportSection: map[string]*wasm.Export{
 			"AddInt": {Name: "AddInt", Type: wasm.ExternTypeFunc, Index: wasm.Index(4)},
 			"":       {Name: "", Type: wasm.ExternTypeFunc, Index: wasm.Index(3)},
@@ -93,13 +93,13 @@ func newExample() *wasm.Module {
 
 func TestExampleUpToDate(t *testing.T) {
 	t.Run("binary.DecodeModule", func(t *testing.T) {
-		m, err := binary.DecodeModule(exampleBinary, enabledFeatures)
+		m, err := binary.DecodeModule(exampleBinary, enabledFeatures, wasm.MemoryMaxPages)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
 
 	t.Run("text.DecodeModule", func(t *testing.T) {
-		m, err := text.DecodeModule(exampleText, enabledFeatures)
+		m, err := text.DecodeModule(exampleText, enabledFeatures, wasm.MemoryMaxPages)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
@@ -126,7 +126,7 @@ func BenchmarkCodecExample(b *testing.B) {
 	b.Run("binary.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := binary.DecodeModule(exampleBinary, enabledFeatures); err != nil {
+			if _, err := binary.DecodeModule(exampleBinary, enabledFeatures, wasm.MemoryMaxPages); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -140,7 +140,7 @@ func BenchmarkCodecExample(b *testing.B) {
 	b.Run("text.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := text.DecodeModule(exampleText, enabledFeatures); err != nil {
+			if _, err := text.DecodeModule(exampleText, enabledFeatures, wasm.MemoryMaxPages); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -148,7 +148,7 @@ func BenchmarkCodecExample(b *testing.B) {
 	b.Run("wat2wasm via text.DecodeModule->binary.EncodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if m, err := text.DecodeModule(exampleText, enabledFeatures); err != nil {
+			if m, err := text.DecodeModule(exampleText, enabledFeatures, wasm.MemoryMaxPages); err != nil {
 				b.Fatal(err)
 			} else {
 				_ = binary.EncodeModule(m)


### PR DESCRIPTION
This allows users to reduce the memory limit per module below 4 Gi. This
is often needed because Wasm routinely leaves off the max, which implies
spec max (4 Gi). This uses Ki Gi etc in error messages because the spec
chooses to, though we can change to make it less awkward.

This also fixes an issue where we instantiated an engine inside config.

Fixes #417