### PR TITLE
Adds ModuleConfig.WithImport and WithImportModule

### DIFF
--- a/examples/file_system_test.go
+++ b/examples/file_system_test.go
@@ -42,19 +42,15 @@ func Test_Cat(t *testing.T) {
 	// Combine the above into our baseline config, overriding defaults (which discard stdout and have no file system).
 	config := wazero.NewModuleConfig().WithStdout(stdoutBuf).WithFS(rooted)
 
-	// Compile the `cat` module.
-	code, err := r.CompileModule(catWasm)
-	require.NoError(t, err)
-
 	// Instantiate WASI, which implements system I/O such as console output.
 	wm, err := wasi.InstantiateSnapshotPreview1(r)
 	require.NoError(t, err)
 	defer wm.Close()
 
-	// InstantiateModuleWithConfig by default runs the "_start" function which is what TinyGo compiles "main" to.
+	// InstantiateModuleFromCodeWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
 	// * Set the program name (arg[0]) to "cat" and add args to write "cat.go" to stdout twice.
 	// * We use both "/cat.go" and "./cat.go" because WithFS by default maps the workdir "." to "/".
-	cat, err := r.InstantiateModuleWithConfig(code, config.WithArgs("cat", "/cat.go", "./cat.go"))
+	cat, err := r.InstantiateModuleFromCodeWithConfig(catWasm, config.WithArgs("cat", "/cat.go", "./cat.go"))
 	require.NoError(t, err)
 	defer cat.Close()
 

--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -60,10 +60,6 @@ func Test_hostFunc(t *testing.T) {
 	_, err := r.NewModuleBuilder("env").ExportFunction("get_random_bytes", getRandomBytes).Instantiate()
 	require.NoError(t, err)
 
-	// Compile the `hostFunc` module.
-	code, err := r.CompileModule(hostFuncWasm)
-	require.NoError(t, err)
-
 	// Configure stdout (console) to write to a buffer.
 	stdout := bytes.NewBuffer(nil)
 	config := wazero.NewModuleConfig().WithStdout(stdout)
@@ -73,8 +69,8 @@ func Test_hostFunc(t *testing.T) {
 	require.NoError(t, err)
 	defer wm.Close()
 
-	// InstantiateModuleWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
-	module, err := r.InstantiateModuleWithConfig(code, config)
+	// InstantiateModuleFromCodeWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
+	module, err := r.InstantiateModuleFromCodeWithConfig(hostFuncWasm, config)
 	require.NoError(t, err)
 	defer wm.Close()
 

--- a/examples/replace_test.go
+++ b/examples/replace_test.go
@@ -1,0 +1,42 @@
+package examples
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+)
+
+// Test_Replace shows how you can replace a module import when it doesn't match instantiated modules.
+func Test_Replace(t *testing.T) {
+	r := wazero.NewRuntime()
+
+	// Instantiate a function that closes the module under "assemblyscript.abort".
+	host, err := r.NewModuleBuilder("assemblyscript").
+		ExportFunction("abort", func(m api.Module, messageOffset, fileNameOffset, line, col uint32) {
+			_ = m.CloseWithExitCode(255)
+		}).Instantiate()
+	require.NoError(t, err)
+	defer host.Close()
+
+	// Compile code that needs the function "env.abort".
+	code, err := r.CompileModule([]byte(`(module
+	(import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
+
+	(export "abort" (func 0)) ;; exports the import for testing
+)`))
+	require.NoError(t, err)
+
+	// Instantiate the module, replacing the import "env.abort" with "assemblyscript.abort".
+	mod, err := r.InstantiateModuleWithConfig(code, wazero.NewModuleConfig().
+		WithName(t.Name()).
+		WithImport("env", "abort", "assemblyscript", "abort"))
+	require.NoError(t, err)
+	defer mod.Close()
+
+	// Since the above worked, the exported function closes the module.
+	_, err = mod.ExportedFunction("abort").Call(nil, 0, 0, 0, 0)
+	require.EqualError(t, err, `module "Test_Replace" closed with exit_code(255)`)
+}

--- a/examples/stdio_test.go
+++ b/examples/stdio_test.go
@@ -19,10 +19,6 @@ var stdioWasm []byte
 func Test_stdio(t *testing.T) {
 	r := wazero.NewRuntime()
 
-	// Compile the `stdioWasm` module.
-	code, err := r.CompileModule(stdioWasm)
-	require.NoError(t, err)
-
 	// Configure standard I/O (ex stdout) to write to buffers instead of no-op.
 	stdinBuf := bytes.NewBuffer([]byte("WASI\n"))
 	stdoutBuf := bytes.NewBuffer(nil)
@@ -34,8 +30,8 @@ func Test_stdio(t *testing.T) {
 	require.NoError(t, err)
 	defer wm.Close()
 
-	// InstantiateModuleWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
-	module, err := r.InstantiateModuleWithConfig(code, config)
+	// InstantiateModuleFromCodeWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
+	module, err := r.InstantiateModuleFromCodeWithConfig(stdioWasm, config)
 	require.NoError(t, err)
 	defer module.Close()
 

--- a/wasm.go
+++ b/wasm.go
@@ -181,7 +181,9 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 		name = code.module.NameSection.ModuleName
 	}
 
-	mod, err = r.store.Instantiate(r.ctx, code.module, name, sys)
+	module := config.replaceImports(code.module)
+
+	mod, err = r.store.Instantiate(r.ctx, module, name, sys)
 	if err != nil {
 		return
 	}

--- a/wasm.go
+++ b/wasm.go
@@ -57,6 +57,16 @@ type Runtime interface {
 	// source multiple times, use CompileModule as InstantiateModule avoids redundant decoding and/or compilation.
 	InstantiateModuleFromCode(source []byte) (api.Module, error)
 
+	// InstantiateModuleFromCodeWithConfig is a convenience function that chains CompileModule to
+	// InstantiateModuleWithConfig.
+	//
+	// Ex. To only change the module name:
+	//	wasm, _ := wazero.NewRuntime().InstantiateModuleFromCodeWithConfig(source, wazero.NewModuleConfig().
+	//		WithName("wasm")
+	//	)
+	//	defer wasm.Close()
+	InstantiateModuleFromCodeWithConfig(source []byte, config *ModuleConfig) (api.Module, error)
+
 	// InstantiateModule instantiates the module namespace or errs if the configuration was invalid.
 	//
 	// Ex.
@@ -161,6 +171,15 @@ func (r *runtime) InstantiateModuleFromCode(source []byte) (api.Module, error) {
 		return nil, err
 	} else {
 		return r.InstantiateModule(code)
+	}
+}
+
+// InstantiateModuleFromCodeWithConfig implements Runtime.InstantiateModuleFromCodeWithConfig
+func (r *runtime) InstantiateModuleFromCodeWithConfig(source []byte, config *ModuleConfig) (api.Module, error) {
+	if code, err := r.CompileModule(source); err != nil {
+		return nil, err
+	} else {
+		return r.InstantiateModuleWithConfig(code, config)
 	}
 }
 

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -288,10 +288,7 @@ func TestFunction_Context(t *testing.T) {
 			defer closer() // nolint
 
 			// Instantiate the module and get the export of the above hostFn
-			code, err := r.CompileModule(source)
-			require.NoError(t, err)
-
-			module, err := r.InstantiateModuleWithConfig(code, NewModuleConfig().WithName(t.Name()))
+			module, err := r.InstantiateModuleFromCodeWithConfig(source, NewModuleConfig().WithName(t.Name()))
 			require.NoError(t, err)
 			defer module.Close()
 


### PR DESCRIPTION
Before, complicated wasm could be hard to implement, particularly as it
might have cyclic imports. This change allows users to re-map imports to
untangle any cycles or to break up monolithic modules like "env".

Ex.
```go
// Instantiate a function that closes the module under "assemblyscript.abort".
host, err := r.NewModuleBuilder("assemblyscript").
	ExportFunction("abort", func(m api.Module, messageOffset, fileNameOffset, line, col uint32) {
		_ = m.CloseWithExitCode(255)
	}).Instantiate()
require.NoError(t, err)
defer host.Close()

// Compile code that needs the function "env.abort".
code, err := r.CompileModule([]byte(`(module
	(import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))

	(export "abort" (func 0)) ;; exports the import for testing
)`))
require.NoError(t, err)

// Instantiate the module, replacing the import "env.abort" with "assemblyscript.abort".
mod, err := r.InstantiateModuleWithConfig(code, wazero.NewModuleConfig().
	WithName(t.Name()).
	WithImport("env", "abort", "assemblyscript", "abort"))
require.NoError(t, err)
defer mod.Close()

// Since the above worked, the exported function closes the module.
_, err = mod.ExportedFunction("abort").Call(nil, 0, 0, 0, 0)
require.EqualError(t, err, `module "Test_Replace" closed with exit_code(255)`)
```