### PR TITLE
Fix example typo

### DIFF
--- a/examples/host_func_test.go
+++ b/examples/host_func_test.go
@@ -76,7 +76,7 @@ func Test_hostFunc(t *testing.T) {
 	// InstantiateModuleWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
 	module, err := r.InstantiateModuleWithConfig(code, config)
 	require.NoError(t, err)
-	defer wm.Close()
+	defer module.Close()
 
 	allocateInWasmBufferFn := module.ExportedFunction("allocate_buffer")
 	require.NotNil(t, allocateInWasmBuffer)


### PR DESCRIPTION
The vm has been handled before, here should be the module.