### PR TITLE
jit: decouple compiled code from moduleInstance's pointer

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -724,6 +724,9 @@ func (a *AssemblerImpl) encodeNoneToNone(n *NodeImpl) (err error) {
 	case RET:
 		// https://www.felixcloutier.com/x86/ret
 		err = a.Buf.WriteByte(0xc3)
+	case UD2:
+		// https://mudongliang.github.io/x86/html/file_module_x86_id_318.html
+		_, err = a.Buf.Write([]byte{0x0f, 0x0b})
 	default:
 		err = errorEncodingUnsupported(n)
 	}

--- a/internal/wasm/jit/arch.go
+++ b/internal/wasm/jit/arch.go
@@ -11,4 +11,4 @@ var (
 // ce is "*callEngine" as uintptr.
 //
 // Note: this is implemented in per-arch Go assembler file. For example, arch_amd64.s implements this for amd64.
-func jitcall(codeSegment, ce uintptr)
+func jitcall(codeSegment, ce uintptr, moduleInstanceAddress uintptr)

--- a/internal/wasm/jit/arch_amd64.s
+++ b/internal/wasm/jit/arch_amd64.s
@@ -4,6 +4,6 @@
 // jitcall(codeSegment, ce, moduleInstanceAddress)
 TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
         MOVQ ce+8(FP),R13                     // Load the address of *callEngine. into amd64ReservedRegisterForCallEngine.
-        MOVQ moduleInstanceAddress+16(FP),R12 // Load the address of *wasm.ModuleInstance into amd64CallingConvensionModuleInstanceAddressRegister.
+        MOVQ moduleInstanceAddress+16(FP),R12 // Load the address of *wasm.ModuleInstance into amd64CallingConventionModuleInstanceAddressRegister.
         MOVQ codeSegment+0(FP),AX             // Load the address of native code.
         JMP AX                                // Jump to native code.

--- a/internal/wasm/jit/arch_amd64.s
+++ b/internal/wasm/jit/arch_amd64.s
@@ -3,7 +3,7 @@
 
 // jitcall(codeSegment, ce, moduleInstanceAddress)
 TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
-        MOVQ codeSegment+0(FP),AX  // Load the address of native code.
-        MOVQ ce+8(FP),R13          // Load the address of *callEngine.
-        MOVQ moduleInstanceAddress+16(FP),R12          // Load the address of *callEngine.
-        JMP AX                     // Jump to native code.
+        MOVQ ce+8(FP),R13                     // Load the address of *callEngine. into amd64ReservedRegisterForCallEngine.
+        MOVQ moduleInstanceAddress+16(FP),R12 // Load the address of *wasm.ModuleInstance into amd64CallingConvensionModuleInstanceAddressRegister.
+        MOVQ codeSegment+0(FP),AX             // Load the address of native code.
+        JMP AX                                // Jump to native code.

--- a/internal/wasm/jit/arch_amd64.s
+++ b/internal/wasm/jit/arch_amd64.s
@@ -1,8 +1,9 @@
 #include "funcdata.h"
 #include "textflag.h"
 
-// jitcall(codeSegment, ce)
-TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-16
+// jitcall(codeSegment, ce, moduleInstanceAddress)
+TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
         MOVQ codeSegment+0(FP),AX  // Load the address of native code.
         MOVQ ce+8(FP),R13          // Load the address of *callEngine.
+        MOVQ moduleInstanceAddress+16(FP),R12          // Load the address of *callEngine.
         JMP AX                     // Jump to native code.

--- a/internal/wasm/jit/arch_arm64.s
+++ b/internal/wasm/jit/arch_arm64.s
@@ -9,7 +9,7 @@ TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
         // We save the return address value into archContext.jitReturnAddress in Engine.
         // Note that the const 120 drifts after editting Engine or archContext struct. See TestArchContextOffsetInEngine.
         MOVD R30,120(R0)
-        // Load the address of *wasm.ModuleInstance into arm64CallingConvensionModuleInstanceAddressRegister.
+        // Load the address of *wasm.ModuleInstance into arm64CallingConventionModuleInstanceAddressRegister.
         MOVD moduleInstanceAddress+16(FP),R29
         // Load the address of native code.
         MOVD codeSegment+0(FP),R1

--- a/internal/wasm/jit/arch_arm64.s
+++ b/internal/wasm/jit/arch_arm64.s
@@ -1,15 +1,17 @@
 #include "funcdata.h"
 #include "textflag.h"
 
-// jitcall(codeSegment, ce)
-TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-16
-        // Load the address of native code.
-        MOVD codeSegment+0(FP),R1
-        // Load the address of *callEngine.
+// jitcall(codeSegment, ce, moduleInstanceAddress)
+TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
+        // Load the address of *callEngine into arm64ReservedRegisterForCallEngine.
         MOVD ce+8(FP),R0
         // In arm64, return address is stored in R30 after jumping into the code.
         // We save the return address value into archContext.jitReturnAddress in Engine.
         // Note that the const 120 drifts after editting Engine or archContext struct. See TestArchContextOffsetInEngine.
         MOVD R30,120(R0)
+        // Load the address of *wasm.ModuleInstance into arm64CallingConvensionModuleInstanceAddressRegister.
+        MOVD moduleInstanceAddress+16(FP),R29
+        // Load the address of native code.
+        MOVD codeSegment+0(FP),R1
         // Jump to native code.
         JMP (R1)

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -176,7 +176,7 @@ type (
 		// source is the source function instance from which this is compiled.
 		source *wasm.FunctionInstance
 		// moduleInstanceAddress holds the address of source.ModuleInstance.
-		moduleInstanceAddress uintptr //nolint
+		moduleInstanceAddress uintptr
 
 		// Followings are not accessed by JITed code.
 

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -166,16 +166,16 @@ type (
 	compiledFunction struct {
 		// The following fields are accessed by JITed code.
 
-		// Pre-calculated pointer pointing to the initial byte of .codeSegment slice.
+		// codeInitialAddress is the pre-calculated pointer pointing to the initial byte of .codeSegment slice.
 		// That mean codeInitialAddress always equals uintptr(unsafe.Pointer(&.codeSegment[0]))
 		// and we cache the value (uintptr(unsafe.Pointer(&.codeSegment[0]))) to this field,
 		// so we don't need to repeat the calculation on each function call.
 		codeInitialAddress uintptr
-		// The max of the stack pointer this function can reach. Lazily applied via maybeGrowValueStack.
+		// stackPointerCeil is the max of the stack pointer this function can reach. Lazily applied via maybeGrowValueStack.
 		stackPointerCeil uint64
-		// The source function instance from which this is compiled.
+		// source is the source function instance from which this is compiled.
 		source *wasm.FunctionInstance
-
+		// moduleInstanceAddress holds the address of source.ModuleInstance.
 		moduleInstanceAddress uintptr //nolint
 
 		// Followings are not accessed by JITed code.

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -60,6 +60,7 @@ func TestJIT_VerifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof(compiledFunc.codeInitialAddress)), compiledFunctionCodeInitialAddressOffset)
 	require.Equal(t, int(unsafe.Offsetof(compiledFunc.stackPointerCeil)), compiledFunctionStackPointerCeilOffset)
 	require.Equal(t, int(unsafe.Offsetof(compiledFunc.source)), compiledFunctionSourceOffset)
+	require.Equal(t, int(unsafe.Offsetof(compiledFunc.moduleInstanceAddress)), compiledFunctionModuleInstanceAddressOffset)
 
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance

--- a/internal/wasm/jit/jit_impl_amd64.go
+++ b/internal/wasm/jit/jit_impl_amd64.go
@@ -3581,7 +3581,6 @@ func (c *amd64Compiler) compileCallFunctionImpl(index wasm.Index, compiledFuncti
 	// This could be reached after returnFunction(), so callEngine.valueStackContext.stackBasePointer
 	// and callEngine.moduleContext.moduleInstanceAddress are changed (See comments in returnFunction()).
 	// Therefore we have to initialize the state according to these changes.
-	// Due to the change to callEngine.moduleContext.moduleInstanceAddress.
 	if err := c.compileModuleContextInitialization(); err != nil {
 		return err
 	}

--- a/internal/wasm/jit/jit_impl_arm64.go
+++ b/internal/wasm/jit/jit_impl_arm64.go
@@ -81,6 +81,10 @@ const (
 	arm64ReservedRegisterForTemporary asm.Register = arm64.REG_R27
 )
 
+var (
+	arm64CallingConvensionModuleInstanceAddressRegister = arm64.REG_R29
+)
+
 const (
 	// arm64CallEngineArchContextJITCallReturnAddressOffset is the offset of archContext.jitCallReturnAddress in callEngine.
 	arm64CallEngineArchContextJITCallReturnAddressOffset = 120
@@ -201,12 +205,12 @@ func (c *arm64Compiler) compilePreamble() error {
 		return err
 	}
 
-	// We must initialize the stack base pointer register so that we can manipulate the stack properly.
-	c.compileReservedStackBasePointerRegisterInitialization()
-
 	if err := c.compileModuleContextInitialization(); err != nil {
 		return err
 	}
+
+	// We must initialize the stack base pointer register so that we can manipulate the stack properly.
+	c.compileReservedStackBasePointerRegisterInitialization()
 
 	c.compileReservedMemoryRegisterInitialization()
 	return nil
@@ -278,6 +282,11 @@ func (c *arm64Compiler) compileReturnFunction() error {
 		return err
 	}
 
+	// arm64CallingConvensionModuleInstanceAddressRegister holds the module intstance's address
+	// so mark it used so that it won't be used as a free register.
+	c.locationStack.markRegisterUsed(arm64CallingConvensionModuleInstanceAddressRegister)
+	defer c.locationStack.markRegisterUnused(arm64CallingConvensionModuleInstanceAddressRegister)
+
 	tmpRegs, found := c.locationStack.takeFreeRegisters(generalPurposeRegisterTypeInt, 3)
 	if !found {
 		return fmt.Errorf("BUG: all the registers should be free at this point")
@@ -331,7 +340,8 @@ func (c *arm64Compiler) compileReturnFunction() error {
 	//
 	// What we have to do in the following is that
 	//   1) Set ce.valueStackContext.stackBasePointer to the value on "rb.caller".
-	//   2) Jump into the address of "ra.caller".
+	//   2) Load rc.caller.moduleInstanceAddress into arm64CallingConvensionModuleInstanceAddressRegister.
+	//   3) Jump into the address of "ra.caller".
 
 	// 1) Set ce.valueStackContext.stackBasePointer to the value on "rb.caller".
 	c.assembler.CompileMemoryToRegister(arm64.MOVD,
@@ -342,7 +352,16 @@ func (c *arm64Compiler) compileReturnFunction() error {
 		tmpReg,
 		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset)
 
-	// 2) Branch into the address of "ra.caller".
+	// 2) Load rc.caller.moduleInstanceAddress into arm64CallingConvensionModuleInstanceAddressRegister.
+	c.assembler.CompileMemoryToRegister(arm64.MOVD,
+		// "rb.caller" is below the top address.
+		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameCompiledFunctionOffset),
+		arm64CallingConvensionModuleInstanceAddressRegister)
+	c.assembler.CompileMemoryToRegister(arm64.MOVD,
+		arm64CallingConvensionModuleInstanceAddressRegister, compiledFunctionModuleInstanceAddressOffset,
+		arm64CallingConvensionModuleInstanceAddressRegister)
+
+	// 3) Branch into the address of "ra.caller".
 	c.assembler.CompileMemoryToRegister(arm64.MOVD,
 		// "rb.caller" is below the top address.
 		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnAddressOffset),
@@ -990,6 +1009,12 @@ func (c *arm64Compiler) compileCallImpl(index wasm.Index, compiledFunctionAddres
 		tmp,
 		arm64ReservedRegisterForCallEngine, callEngineGlobalContextCallFrameStackPointerOffset)
 
+	// Also, we have to put the compiledFunction's moduleinstance address into arm64CallingConvensionModuleInstanceAddressRegister.
+	c.assembler.CompileMemoryToRegister(arm64.MOVD,
+		compiledFunctionRegister, compiledFunctionModuleInstanceAddressOffset,
+		arm64CallingConvensionModuleInstanceAddressRegister,
+	)
+
 	// Then, br into the target function's initial address.
 	c.assembler.CompileMemoryToRegister(arm64.MOVD,
 		compiledFunctionRegister, compiledFunctionCodeInitialAddressOffset,
@@ -1016,12 +1041,12 @@ func (c *arm64Compiler) compileCallImpl(index wasm.Index, compiledFunctionAddres
 		}
 	}
 
-	// On the function return, we initialize the state for this function.
-	c.compileReservedStackBasePointerRegisterInitialization()
-
 	if err := c.compileModuleContextInitialization(); err != nil {
 		return err
 	}
+
+	// On the function return, we initialize the state for this function.
+	c.compileReservedStackBasePointerRegisterInitialization()
 
 	c.compileReservedMemoryRegisterInitialization()
 	return nil
@@ -3030,27 +3055,32 @@ func (c *arm64Compiler) compileReservedMemoryRegisterInitialization() {
 // ce.ModuleContext.ModuleInstanceAddress.
 // This is called in two cases: in function preamble, and on the return from (non-Go) function calls.
 func (c *arm64Compiler) compileModuleContextInitialization() error {
-	regs, found := c.locationStack.takeFreeRegisters(generalPurposeRegisterTypeInt, 3)
+	c.markRegisterUsed(arm64CallingConvensionModuleInstanceAddressRegister)
+	defer c.markRegisterUnused(arm64CallingConvensionModuleInstanceAddressRegister)
+
+	regs, found := c.locationStack.takeFreeRegisters(generalPurposeRegisterTypeInt, 2)
 	if !found {
 		return fmt.Errorf("BUG: all the registers should be free at this point")
 	}
 	c.markRegisterUsed(regs...)
 
 	// Alias these free registers for readability.
-	moduleInstanceAddressRegister, tmpX, tmpY := regs[0], regs[1], regs[2]
-
-	// Load the absolute address of the current function's module instance.
-	// Note: this should be modified to support Clone() functionality per #179.
-	c.assembler.CompileConstToRegister(arm64.MOVD, int64(uintptr(unsafe.Pointer(c.f.Module))), moduleInstanceAddressRegister)
+	tmpX, tmpY := regs[0], regs[1]
 
 	// "tmpX = ce.ModuleInstanceAddress"
 	c.assembler.CompileMemoryToRegister(arm64.MOVD, arm64ReservedRegisterForCallEngine, callEngineModuleContextModuleInstanceAddressOffset, tmpX)
 
 	// If the module instance address stays the same, we could skip the entire code below.
-	c.assembler.CompileTwoRegistersToNone(arm64.CMP, moduleInstanceAddressRegister, tmpX)
+	c.assembler.CompileTwoRegistersToNone(arm64.CMP, arm64CallingConvensionModuleInstanceAddressRegister, tmpX)
 	brIfModuleUnchanged := c.assembler.CompileJump(arm64.BEQ)
 
-	// Otherwise, we have to update the following fields:
+	// Otherwise, update the moduleEngine.moduleContext.ModuleInstanceAddress.
+	c.assembler.CompileRegisterToMemory(arm64.MOVD,
+		arm64CallingConvensionModuleInstanceAddressRegister,
+		arm64ReservedRegisterForCallEngine, callEngineModuleContextModuleInstanceAddressOffset,
+	)
+
+	// Also, we have to update the following fields:
 	// * callEngine.moduleContext.globalElement0Address
 	// * callEngine.moduleContext.memoryElement0Address
 	// * callEngine.moduleContext.memorySliceLen
@@ -3066,7 +3096,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 	if len(c.f.Module.Globals) > 0 {
 		// "tmpX = &moduleInstance.Globals[0]"
 		c.assembler.CompileMemoryToRegister(arm64.MOVD,
-			moduleInstanceAddressRegister, moduleInstanceGlobalsOffset,
+			arm64CallingConvensionModuleInstanceAddressRegister, moduleInstanceGlobalsOffset,
 			tmpX,
 		)
 
@@ -3086,7 +3116,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 		// "tmpX = moduleInstance.Memory"
 		c.assembler.CompileMemoryToRegister(
 			arm64.MOVD,
-			moduleInstanceAddressRegister, moduleInstanceMemoryOffset,
+			arm64CallingConvensionModuleInstanceAddressRegister, moduleInstanceMemoryOffset,
 			tmpX,
 		)
 
@@ -3130,7 +3160,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 		// "tmpX = &tables[0] (type of **wasm.Table)"
 		c.assembler.CompileMemoryToRegister(
 			arm64.MOVD,
-			moduleInstanceAddressRegister, moduleInstanceTableOffset,
+			arm64CallingConvensionModuleInstanceAddressRegister, moduleInstanceTableOffset,
 			tmpX,
 		)
 
@@ -3175,7 +3205,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 		// * https://github.com/golang/go/blob/release-branch.go1.17/src/runtime/runtime2.go#L207-L210
 		c.assembler.CompileMemoryToRegister(
 			arm64.MOVD,
-			moduleInstanceAddressRegister, moduleInstanceEngineOffset+interfaceDataOffset,
+			arm64CallingConvensionModuleInstanceAddressRegister, moduleInstanceEngineOffset+interfaceDataOffset,
 			tmpX,
 		)
 

--- a/internal/wasm/jit/jit_initialization_test.go
+++ b/internal/wasm/jit/jit_initialization_test.go
@@ -177,7 +177,10 @@ func TestCompiler_compileMaybeGrowValueStack(t *testing.T) {
 		// Reenter from the return address.
 		returnAddress := env.callFrameStackPeek().returnAddress
 		require.NotZero(t, returnAddress)
-		jitcall(returnAddress, uintptr(unsafe.Pointer(env.callEngine())))
+		jitcall(
+			returnAddress, uintptr(unsafe.Pointer(env.callEngine())),
+			uintptr(unsafe.Pointer(env.module())),
+		)
 
 		// Check the result. This should be "Returned".
 		require.Equal(t, jitCallStatusCodeReturned, env.jitStatus())

--- a/internal/wasm/jit/jit_memory_test.go
+++ b/internal/wasm/jit/jit_memory_test.go
@@ -40,7 +40,10 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 	require.Equal(t, builtinFunctionIndexMemoryGrow, env.builtinFunctionCallAddress())
 
 	// Reenter from the return address.
-	jitcall(env.callFrameStackPeek().returnAddress, uintptr(unsafe.Pointer(env.callEngine())))
+	jitcall(
+		env.callFrameStackPeek().returnAddress, uintptr(unsafe.Pointer(env.callEngine())),
+		uintptr(unsafe.Pointer(env.module())),
+	)
 
 	// Check if the code successfully executed the code after builtin function call.
 	require.Equal(t, expValue, env.stackTopAsUint32())

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -120,8 +120,9 @@ func (j *jitEnv) callEngine() *callEngine {
 
 func (j *jitEnv) exec(code []byte) {
 	compiledFunction := &compiledFunction{
-		codeSegment:        code,
-		codeInitialAddress: uintptr(unsafe.Pointer(&code[0])),
+		codeSegment:           code,
+		codeInitialAddress:    uintptr(unsafe.Pointer(&code[0])),
+		moduleInstanceAddress: uintptr(unsafe.Pointer(j.moduleInstance)),
 		source: &wasm.FunctionInstance{
 			Kind:   wasm.FunctionKindWasm,
 			Type:   &wasm.FunctionType{},
@@ -134,6 +135,7 @@ func (j *jitEnv) exec(code []byte) {
 	jitcall(
 		uintptr(unsafe.Pointer(&code[0])),
 		uintptr(unsafe.Pointer(j.ce)),
+		uintptr(unsafe.Pointer(j.moduleInstance)),
 	)
 }
 

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -130,7 +130,8 @@ func (j *jitEnv) exec(code []byte) {
 		},
 	}
 
-	j.ce.pushCallFrame(compiledFunction)
+	j.ce.callFrameStack[j.ce.globalContext.callFrameStackPointer] = callFrame{compiledFunction: compiledFunction}
+	j.ce.globalContext.callFrameStackPointer++
 
 	jitcall(
 		uintptr(unsafe.Pointer(&code[0])),


### PR DESCRIPTION
This commit decouples the *wasm.ModuleInstance from the compiled code.

This is necessary to reuse same machine code for multiple module instances
originating from the same binary (or text), which is a necessary mechanism for
compilation caches I will do in the next PRs.
