### PR TITLE
Isolates testify to one file, so that it is easier to remove

### DIFF
--- a/api/wasm_test.go
+++ b/api/wasm_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestValueTypeName(t *testing.T) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -5,10 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )

--- a/config_test.go
+++ b/config_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/asm/amd64/impl_test.go
+++ b/internal/asm/amd64/impl_test.go
@@ -4,9 +4,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestNodeImpl_AssignJumpTarget(t *testing.T) {

--- a/internal/asm/amd64_debug/impl_test.go
+++ b/internal/asm/amd64_debug/impl_test.go
@@ -7,10 +7,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
 	amd64 "github.com/tetratelabs/wazero/internal/asm/amd64"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestAssemblerImpl_Assemble(t *testing.T) {

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -3,9 +3,8 @@ package asm_arm64
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestNodeImpl_AssignJumpTarget(t *testing.T) {

--- a/internal/asm/arm64_debug/impl_test.go
+++ b/internal/asm/arm64_debug/impl_test.go
@@ -6,10 +6,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
 	asm_arm64 "github.com/tetratelabs/wazero/internal/asm/arm64"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 // TODO: Comment why tmpReg is unused.

--- a/internal/leb128/leb128_test.go
+++ b/internal/leb128/leb128_test.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestEncode_DecodeInt32(t *testing.T) {

--- a/internal/moremath/moremath_test.go
+++ b/internal/moremath/moremath_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestWasmCompatMin(t *testing.T) {

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -23,9 +23,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
 )

--- a/internal/testing/require/require.go
+++ b/internal/testing/require/require.go
@@ -1,0 +1,102 @@
+// Package require includes test assertions that fail the test immediately. This is like to testify, but without a
+// dependency.
+//
+// Note: Assertions here are internal and are free to be customized to only support valid WebAssembly types, or to
+// reduce code in tests that only require certain types.
+package require
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: implement, test and document each function without using testify
+
+func Contains(t *testing.T, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	require.Contains(t, s, contains, msgAndArgs)
+}
+
+func Empty(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
+	require.Empty(t, object, msgAndArgs)
+}
+
+func Equal(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	require.Equal(t, expected, actual, msgAndArgs)
+}
+
+func EqualError(t *testing.T, theError error, errString string, msgAndArgs ...interface{}) {
+	require.EqualError(t, theError, errString, msgAndArgs)
+}
+
+func Error(t *testing.T, err error, msgAndArgs ...interface{}) {
+	require.Error(t, err, msgAndArgs)
+}
+
+func ErrorIs(t *testing.T, err error, target error, msgAndArgs ...interface{}) {
+	require.ErrorIs(t, err, target, msgAndArgs)
+}
+
+func False(t *testing.T, value bool, msgAndArgs ...interface{}) {
+	require.False(t, value, msgAndArgs)
+}
+
+func Len(t *testing.T, object interface{}, length int, msgAndArgs ...interface{}) {
+	require.Len(t, object, length, msgAndArgs)
+}
+
+func Nil(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
+	require.Nil(t, object, msgAndArgs)
+}
+
+func NoError(t *testing.T, err error, msgAndArgs ...interface{}) {
+	require.NoError(t, err, msgAndArgs)
+}
+
+func NotContains(t *testing.T, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	require.NotContains(t, s, contains, msgAndArgs)
+}
+
+func NotEmpty(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
+	require.NotEmpty(t, object, msgAndArgs)
+}
+
+func NotEqual(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	require.NotEqual(t, expected, actual, msgAndArgs)
+}
+
+func NotNil(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
+	require.NotNil(t, object, msgAndArgs)
+}
+
+func NotSame(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	require.NotSame(t, expected, actual, msgAndArgs)
+}
+
+// CapturePanic returns an error recovered from a panic. If the panic was not an error, this converts it to one.
+func CapturePanic(panics func()) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if e, ok := recovered.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("%v", recovered)
+			}
+		}
+	}()
+	panics()
+	return
+}
+
+func Same(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	require.Same(t, expected, actual, msgAndArgs)
+}
+
+func True(t *testing.T, value bool, msgAndArgs ...interface{}) {
+	require.True(t, value, msgAndArgs)
+}
+
+func Zero(t *testing.T, i interface{}, msgAndArgs ...interface{}) {
+	require.Zero(t, i, msgAndArgs)
+}

--- a/internal/testing/require/require_test.go
+++ b/internal/testing/require/require_test.go
@@ -1,0 +1,52 @@
+package require
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCapturePanic(t *testing.T) {
+	tests := []struct {
+		name        string
+		panics      func()
+		expectedErr string
+	}{
+		{
+			name:        "doesn't panic",
+			panics:      func() {},
+			expectedErr: "",
+		},
+		{
+			name:        "panics with error",
+			panics:      func() { panic(errors.New("error")) },
+			expectedErr: "error",
+		},
+		{
+			name:        "panics with string",
+			panics:      func() { panic("crash") },
+			expectedErr: "crash",
+		},
+		{
+			name:        "panics with object",
+			panics:      func() { panic(struct{}{}) },
+			expectedErr: "{}",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			captured := CapturePanic(tc.panics)
+			if tc.expectedErr == "" {
+				if captured != nil {
+					t.Fatalf("expected no error, but found %v", captured)
+				}
+			} else {
+				if captured.Error() != tc.expectedErr {
+					t.Fatalf("expected %s, but found %s", tc.expectedErr, captured.Error())
+				}
+			}
+		})
+	}
+}

--- a/internal/u64/u64_test.go
+++ b/internal/u64/u64_test.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestBytes(t *testing.T) {

--- a/internal/wasm/binary/code_test.go
+++ b/internal/wasm/binary/code_test.go
@@ -3,8 +3,7 @@ package binary
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -3,8 +3,7 @@ package binary
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -4,9 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -213,7 +212,9 @@ func TestModule_Encode(t *testing.T) {
 func TestModule_Encode_HostFunctionSection_Unsupported(t *testing.T) {
 	// We don't currently have an approach to serialize reflect.Value pointers
 	fn := reflect.ValueOf(func(wasm.Module) {})
-	require.Panics(t, func() {
+
+	captured := require.CapturePanic(func() {
 		EncodeModule(&wasm.Module{HostFunctionSection: []*reflect.Value{&fn}})
 	})
+	require.EqualError(t, captured, "BUG: HostFunctionSection is not encodable")
 }

--- a/internal/wasm/binary/export_test.go
+++ b/internal/wasm/binary/export_test.go
@@ -3,8 +3,7 @@ package binary
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/function_test.go
+++ b/internal/wasm/binary/function_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/global_test.go
+++ b/internal/wasm/binary/global_test.go
@@ -3,9 +3,8 @@ package binary
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/import_test.go
+++ b/internal/wasm/binary/import_test.go
@@ -3,8 +3,7 @@ package binary
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/limits_test.go
+++ b/internal/wasm/binary/limits_test.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestLimitsType(t *testing.T) {

--- a/internal/wasm/binary/memory_test.go
+++ b/internal/wasm/binary/memory_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/names_test.go
+++ b/internal/wasm/binary/names_test.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/table_test.go
+++ b/internal/wasm/binary/table_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/binary/value_test.go
+++ b/internal/wasm/binary/value_test.go
@@ -3,8 +3,7 @@ package binary
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/counts_test.go
+++ b/internal/wasm/counts_test.go
@@ -4,9 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestModule_ImportFuncCount(t *testing.T) {

--- a/internal/wasm/features_test.go
+++ b/internal/wasm/features_test.go
@@ -3,7 +3,7 @@ package wasm
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 // TestFeatures_ZeroIsInvalid reminds maintainers that a bitset cannot use zero as a flag!

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestModule_ValidateFunction_validateFunctionWithMaxStackValues(t *testing.T) {

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -5,10 +5,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
 )
 

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -5,9 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestGetFunctionType(t *testing.T) {

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -4,10 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 // wasiAPI simulates the real WASI api

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -6,10 +6,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
@@ -42,7 +41,9 @@ func TestInterpreter_CallEngine_PushFrame_StackOverflow(t *testing.T) {
 	vm.pushFrame(f1)
 	vm.pushFrame(f2)
 	vm.pushFrame(f3)
-	require.Panics(t, func() { vm.pushFrame(f4) })
+
+	captured := require.CapturePanic(func() { vm.pushFrame(f4) })
+	require.EqualError(t, captured, "callstack overflow")
 }
 
 // et is used for tests defined in the enginetest package.

--- a/internal/wasm/jit/arch_arm64_test.go
+++ b/internal/wasm/jit/arch_arm64_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestArchContextOffsetInArm64Engine(t *testing.T) {

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -276,28 +275,13 @@ func TestJIT_NewModuleEngine_CompiledFunctions(t *testing.T) {
 
 // TestReleaseCompiledFunction_Panic tests that an unexpected panic has some identifying information in it.
 func TestJIT_ReleaseCompiledFunction_Panic(t *testing.T) {
-	// capturePanic because there's no require.PanicsWithErrorPrefix
-	errMessage := capturePanic(func() {
+	captured := require.CapturePanic(func() {
 		releaseCompiledFunction(&compiledFunction{
 			codeSegment: []byte{wasm.OpcodeEnd},                                                         // never compiled means it was never mapped.
 			source:      &wasm.FunctionInstance{Index: 2, Module: &wasm.ModuleInstance{Name: t.Name()}}, // for error string
 		})
 	})
-	require.Contains(t, errMessage.Error(),
-		fmt.Sprintf("jit: failed to munmap code segment for %[1]s.function[2]:", t.Name()))
-}
-
-// capturePanic returns an error recovered from a panic
-func capturePanic(panics func()) (err error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			if e, ok := recovered.(error); ok {
-				err = e
-			}
-		}
-	}()
-	panics()
-	return
+	require.Contains(t, captured.Error(), fmt.Sprintf("jit: failed to munmap code segment for %[1]s.function[2]:", t.Name()))
 }
 
 func TestJIT_ModuleEngine_Close(t *testing.T) {

--- a/internal/wasm/jit/jit_controlflow_test.go
+++ b/internal/wasm/jit/jit_controlflow_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )

--- a/internal/wasm/jit/jit_conversion_test.go
+++ b/internal/wasm/jit/jit_conversion_test.go
@@ -5,8 +5,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/wasm/jit/jit_global_test.go
+++ b/internal/wasm/jit/jit_global_test.go
@@ -3,8 +3,7 @@ package jit
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )

--- a/internal/wasm/jit/jit_impl_amd64_test.go
+++ b/internal/wasm/jit/jit_impl_amd64_test.go
@@ -3,11 +3,10 @@ package jit
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
 	amd64 "github.com/tetratelabs/wazero/internal/asm/amd64"
 	"github.com/tetratelabs/wazero/internal/asm/amd64_debug"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )

--- a/internal/wasm/jit/jit_impl_arm64_test.go
+++ b/internal/wasm/jit/jit_impl_arm64_test.go
@@ -3,9 +3,8 @@ package jit
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	arm64 "github.com/tetratelabs/wazero/internal/asm/arm64"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestArm64Compiler_readInstructionAddress(t *testing.T) {

--- a/internal/wasm/jit/jit_initialization_test.go
+++ b/internal/wasm/jit/jit_initialization_test.go
@@ -6,8 +6,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -176,7 +175,7 @@ func TestCompiler_compileMaybeGrowValueStack(t *testing.T) {
 
 		// Reenter from the return address.
 		returnAddress := env.callFrameStackPeek().returnAddress
-		require.NotZero(t, returnAddress)
+		require.True(t, returnAddress != 0, "returnAddress was non-zero %d", returnAddress)
 		jitcall(
 			returnAddress, uintptr(unsafe.Pointer(env.callEngine())),
 			uintptr(unsafe.Pointer(env.module())),

--- a/internal/wasm/jit/jit_memory_test.go
+++ b/internal/wasm/jit/jit_memory_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )

--- a/internal/wasm/jit/jit_numeric_test.go
+++ b/internal/wasm/jit/jit_numeric_test.go
@@ -6,9 +6,8 @@ import (
 	"math/bits"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/moremath"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/wasm/jit/jit_post1_0_test.go
+++ b/internal/wasm/jit/jit_post1_0_test.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/wasm/jit/jit_stack_test.go
+++ b/internal/wasm/jit/jit_stack_test.go
@@ -5,9 +5,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )

--- a/internal/wasm/jit/jit_value_location_test.go
+++ b/internal/wasm/jit/jit_value_location_test.go
@@ -4,9 +4,8 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func Test_isIntRegister(t *testing.T) {

--- a/internal/wasm/jit/mmap_test.go
+++ b/internal/wasm/jit/mmap_test.go
@@ -5,44 +5,44 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 var code, _ = io.ReadAll(io.LimitReader(rand.Reader, 8*1024))
 
 func Test_mmapCodeSegment(t *testing.T) {
 	requireSupportedOSArch(t)
-	assert := require.New(t)
 	newCode, err := mmapCodeSegment(code)
-	assert.NoError(err)
+	require.NoError(t, err)
 	// Verify that the mmap is the same as the original.
-	assert.Equal(code, newCode)
+	require.Equal(t, code, newCode)
 	// TODO: test newCode can executed.
 
 	t.Run("panic on zero length", func(t *testing.T) {
-		require.PanicsWithError(t, "BUG: mmapCodeSegment with zero length", func() {
+		captured := require.CapturePanic(func() {
 			_, _ = mmapCodeSegment(make([]byte, 0))
 		})
+		require.EqualError(t, captured, "BUG: mmapCodeSegment with zero length")
 	})
 }
 
 func Test_munmapCodeSegment(t *testing.T) {
 	requireSupportedOSArch(t)
-	assert := require.New(t)
 
 	// Errors if never mapped
-	assert.Error(munmapCodeSegment(code))
+	require.Error(t, munmapCodeSegment(code))
 
 	newCode, err := mmapCodeSegment(code)
-	assert.NoError(err)
+	require.NoError(t, err)
 	// First munmap should succeed.
-	assert.NoError(munmapCodeSegment(newCode))
+	require.NoError(t, munmapCodeSegment(newCode))
 	// Double munmap should fail.
-	assert.Error(munmapCodeSegment(newCode))
+	require.Error(t, munmapCodeSegment(newCode))
 
 	t.Run("panic on zero length", func(t *testing.T) {
-		require.PanicsWithError(t, "BUG: munmapCodeSegment with zero length", func() {
+		captured := require.CapturePanic(func() {
 			_ = munmapCodeSegment(make([]byte, 0))
 		})
+		require.EqualError(t, captured, "BUG: munmapCodeSegment with zero length")
 	})
 }

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestMemoryPageConsts(t *testing.T) {

--- a/internal/wasm/module_context_test.go
+++ b/internal/wasm/module_context_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestModuleContext_WithContext(t *testing.T) {

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -6,10 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
 )
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -8,11 +8,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/testing/hammer"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
 )
 

--- a/internal/wasm/sys_test.go
+++ b/internal/wasm/sys_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestDefaultSysContext(t *testing.T) {

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -4,9 +4,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestStore_resolveImports_table(t *testing.T) {

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -4,8 +4,7 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/text/errors_test.go
+++ b/internal/wasm/text/errors_test.go
@@ -4,8 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/text/func_parser_test.go
+++ b/internal/wasm/text/func_parser_test.go
@@ -4,8 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/text/index_namespace_test.go
+++ b/internal/wasm/text/index_namespace_test.go
@@ -4,8 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/text/lexer_test.go
+++ b/internal/wasm/text/lexer_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 // exampleWat was at one time in the wasmtime repo under cranelift. We added a unicode comment for fun!

--- a/internal/wasm/text/memory_parser_test.go
+++ b/internal/wasm/text/memory_parser_test.go
@@ -3,8 +3,7 @@ package text
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/text/numbers_test.go
+++ b/internal/wasm/text/numbers_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 var maxUint32 = uint32(math.MaxUint32)

--- a/internal/wasm/text/token_test.go
+++ b/internal/wasm/text/token_test.go
@@ -3,7 +3,7 @@ package text
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestTokenType_String(t *testing.T) {

--- a/internal/wasm/text/type_parser_test.go
+++ b/internal/wasm/text/type_parser_test.go
@@ -3,8 +3,7 @@ package text
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasm/text/typeuse_parser_test.go
+++ b/internal/wasm/text/typeuse_parser_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasmdebug/debug_test.go
+++ b/internal/wasmdebug/debug_test.go
@@ -5,9 +5,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
 )
 

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/text"
 )

--- a/tests/engine/adhoc_test.go
+++ b/tests/engine/adhoc_test.go
@@ -7,10 +7,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
 )

--- a/tests/engine/hammer_test.go
+++ b/tests/engine/hammer_test.go
@@ -4,11 +4,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/testing/hammer"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
 )
 

--- a/tests/post1_0/multi-value/multi_value_test.go
+++ b/tests/post1_0/multi-value/multi_value_test.go
@@ -4,10 +4,9 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestMultiValue_JIT(t *testing.T) {

--- a/tests/post1_0/sign-extension-ops/sign_extension_ops_test.go
+++ b/tests/post1_0/sign-extension-ops/sign_extension_ops_test.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestSignExtensionOps_JIT(t *testing.T) {

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -11,10 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/binary"
@@ -297,7 +296,7 @@ func runTest(t *testing.T, newEngine func(wasm.Features) wasm.Engine) {
 
 	// If the go:embed path resolution was wrong, this fails.
 	// https://github.com/tetratelabs/wazero/issues/247
-	require.Greater(t, len(jsonfiles), 1)
+	require.True(t, len(jsonfiles) > 1, "len(jsonfiles)=%d (not greater than one)", len(jsonfiles))
 
 	for _, f := range jsonfiles {
 		raw, err := testcases.ReadFile(f)

--- a/vs/bench_fac_test.go
+++ b/vs/bench_fac_test.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/birros/go-wasm3"
 	"github.com/bytecodealliance/wasmtime-go"
-	"github.com/stretchr/testify/require"
 	"github.com/wasmerio/wasmer-go/wasmer"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 // ensureJITFastest is overridable via ldflags. Ex.
@@ -201,10 +201,9 @@ func TestFac_JIT_Fastest(t *testing.T) {
 		t.Run(tc.runtimeName, func(t *testing.T) {
 			// https://github.com/golang/go/blob/fd09e88722e0af150bf8960e95e8da500ad91001/src/testing/benchmark.go#L428-L432
 			nanoPerOp := float64(tc.result.T.Nanoseconds()) / float64(tc.result.N)
-			msg := fmt.Sprintf("JIT engine must be faster than %s. "+
+			require.True(t, jitNanoPerOp < nanoPerOp, "jitNanoPerOp(%f) is not less than nanoPerOp(%f). JIT engine must be faster than %s. "+
 				"Run BenchmarkFac_Invoke with ensureJITFastest=false instead to see the detailed result",
-				tc.runtimeName)
-			require.Lessf(t, jitNanoPerOp, nanoPerOp, msg)
+				tc.runtimeName, jitNanoPerOp, nanoPerOp)
 		})
 	}
 }

--- a/vs/codec_test.go
+++ b/vs/codec_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	"github.com/bytecodealliance/wasmtime-go"
-	"github.com/stretchr/testify/require"
 	"github.com/wasmerio/wasmer-go/wasmer"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/binary"
 	"github.com/tetratelabs/wazero/internal/wasm/text"

--- a/wasi/usage_test.go
+++ b/wasi/usage_test.go
@@ -5,9 +5,8 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 // wasiArg was compiled from testdata/wasi_arg.wat

--- a/wasi/wasi_bench_test.go
+++ b/wasi/wasi_bench_test.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/wasi/wasi_test.go
+++ b/wasi/wasi_test.go
@@ -14,10 +14,9 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
 )

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -7,10 +7,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
+	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/binary"
 )


### PR DESCRIPTION
This starts the process of removing all dependencies from wazero, by
isolating all assertions we use into a single file. This allows us to
port those assertions as we have time, and when twitchy is gone, the
project literally has no dependencies except go!