### PR TITLE
Removes testify dependency

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -415,7 +415,7 @@ func requireHostModuleEquals(t *testing.T, expected, actual *wasm.Module) {
 	require.Equal(t, expected.ExportSection, actual.ExportSection)
 	require.Equal(t, expected.StartSection, actual.StartSection)
 	require.Equal(t, expected.ElementSection, actual.ElementSection)
-	require.Nil(t, actual.CodeSection) // Host functions are implemented in Go, not Wasm!
+	require.Zero(t, len(actual.CodeSection)) // Host functions are implemented in Go, not Wasm!
 	require.Equal(t, expected.DataSection, actual.DataSection)
 	require.Equal(t, expected.NameSection, actual.NameSection)
 

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,5 @@ module github.com/tetratelabs/wazero
 // This should be the minimum supported Go version per https://go.dev/doc/devel/release (1 version behind latest)
 go 1.17
 
-require (
-	// Test-only dependency.
-	github.com/stretchr/testify v1.7.0
-	// Test-only dependency.
-	github.com/twitchyliquid64/golang-asm v0.15.1
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)
+// Test-only dependency.
+require github.com/twitchyliquid64/golang-asm v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,2 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/asm/amd64_debug/impl_test.go
+++ b/internal/asm/amd64_debug/impl_test.go
@@ -1190,7 +1190,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.Len(t, a.OnGenerateCallbacks, 1)
+		require.Equal(t, 1, len(a.OnGenerateCallbacks))
 		cb := a.OnGenerateCallbacks[0]
 
 		targetNode := a.Current
@@ -1707,11 +1707,11 @@ func TestNodeImpl_GetRegisterToRegisterModRM(t *testing.T) {
 
 							// Skip the opcode for MOVL to make this test opcode-independent.
 							if rexPrefix != amd64.RexPrefixNone {
-								require.Len(t, expectedBytes, 3)
+								require.Equal(t, 3, len(expectedBytes))
 								require.Equal(t, expectedBytes[0], rexPrefix)
 								require.Equal(t, expectedBytes[2], modRM)
 							} else {
-								require.Len(t, expectedBytes, 2)
+								require.Equal(t, 2, len(expectedBytes))
 								require.Equal(t, expectedBytes[1], modRM)
 							}
 						})
@@ -1739,11 +1739,11 @@ func TestNodeImpl_GetRegisterToRegisterModRM(t *testing.T) {
 					require.NoError(t, err)
 
 					if rexPrefix != amd64.RexPrefixNone {
-						require.Len(t, expectedBytes, 5)
+						require.Equal(t, 5, len(expectedBytes))
 						require.Equal(t, expectedBytes[1], rexPrefix)
 						require.Equal(t, expectedBytes[4], modRM)
 					} else {
-						require.Len(t, expectedBytes, 4)
+						require.Equal(t, 4, len(expectedBytes))
 						require.Equal(t, expectedBytes[3], modRM)
 					}
 				})
@@ -1769,11 +1769,11 @@ func TestNodeImpl_GetRegisterToRegisterModRM(t *testing.T) {
 					require.NoError(t, err)
 
 					if rexPrefix != amd64.RexPrefixNone {
-						require.Len(t, expectedBytes, 5)
+						require.Equal(t, 5, len(expectedBytes))
 						require.Equal(t, expectedBytes[1], rexPrefix)
 						require.Equal(t, expectedBytes[4], modRM)
 					} else {
-						require.Len(t, expectedBytes, 4)
+						require.Equal(t, 4, len(expectedBytes))
 						require.Equal(t, expectedBytes[3], modRM)
 					}
 				})
@@ -1799,11 +1799,11 @@ func TestNodeImpl_GetRegisterToRegisterModRM(t *testing.T) {
 					require.NoError(t, err)
 
 					if rexPrefix != amd64.RexPrefixNone {
-						require.Len(t, expectedBytes, 5)
+						require.Equal(t, 5, len(expectedBytes))
 						require.Equal(t, expectedBytes[1], rexPrefix)
 						require.Equal(t, expectedBytes[4], modRM)
 					} else {
-						require.Len(t, expectedBytes, 4)
+						require.Equal(t, 4, len(expectedBytes))
 						require.Equal(t, expectedBytes[3], modRM)
 					}
 				})

--- a/internal/asm/arm64_debug/impl_test.go
+++ b/internal/asm/arm64_debug/impl_test.go
@@ -32,7 +32,7 @@ func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 
 		// NOP must be ignored.
 		actual := a.Buf.Bytes()
-		require.Len(t, actual, 0)
+		require.Zero(t, len(actual))
 	})
 }
 
@@ -1037,7 +1037,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.Len(t, a.OnGenerateCallbacks, 1)
+		require.Equal(t, 1, len(a.OnGenerateCallbacks))
 		cb := a.OnGenerateCallbacks[0]
 
 		targetNode := a.Current

--- a/internal/leb128/leb128_test.go
+++ b/internal/leb128/leb128_test.go
@@ -6,8 +6,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
@@ -121,8 +119,8 @@ func TestDecodeUint32(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			assert.Equal(t, c.exp, actual)
-			assert.Equal(t, uint64(len(c.bytes)), num)
+			require.Equal(t, c.exp, actual)
+			require.Equal(t, uint64(len(c.bytes)), num)
 		}
 	}
 }
@@ -146,8 +144,8 @@ func TestDecodeUint64(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			assert.Equal(t, c.exp, actual)
-			assert.Equal(t, uint64(len(c.bytes)), num)
+			require.Equal(t, c.exp, actual)
+			require.Equal(t, uint64(len(c.bytes)), num)
 		}
 	}
 }
@@ -172,11 +170,11 @@ func TestDecodeInt32(t *testing.T) {
 	} {
 		actual, num, err := DecodeInt32(bytes.NewReader(c.bytes))
 		if c.expErr {
-			assert.Error(t, err, fmt.Sprintf("%d-th got value %d", i, actual))
+			require.Error(t, err, fmt.Sprintf("%d-th got value %d", i, actual))
 		} else {
-			assert.NoError(t, err, i)
-			assert.Equal(t, c.exp, actual, i)
-			assert.Equal(t, uint64(len(c.bytes)), num, i)
+			require.NoError(t, err, i)
+			require.Equal(t, c.exp, actual, i)
+			require.Equal(t, uint64(len(c.bytes)), num, i)
 		}
 	}
 }
@@ -201,8 +199,8 @@ func TestDecodeInt33AsInt64(t *testing.T) {
 	} {
 		actual, num, err := DecodeInt33AsInt64(bytes.NewReader(c.bytes))
 		require.NoError(t, err)
-		assert.Equal(t, c.exp, actual)
-		assert.Equal(t, uint64(len(c.bytes)), num)
+		require.Equal(t, c.exp, actual)
+		require.Equal(t, uint64(len(c.bytes)), num)
 	}
 }
 
@@ -223,7 +221,7 @@ func TestDecodeInt64(t *testing.T) {
 	} {
 		actual, num, err := DecodeInt64(bytes.NewReader(c.bytes))
 		require.NoError(t, err)
-		assert.Equal(t, c.exp, actual)
-		assert.Equal(t, uint64(len(c.bytes)), num)
+		require.Equal(t, c.exp, actual)
+		require.Equal(t, uint64(len(c.bytes)), num)
 	}
 }

--- a/internal/testing/require/require.go
+++ b/internal/testing/require/require.go
@@ -6,72 +6,199 @@
 package require
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
-	"testing"
-
-	"github.com/stretchr/testify/require"
+	"path"
+	"reflect"
+	"runtime"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 )
+
+// TestingT is an interface wrapper of functions used in TestingT
+type TestingT interface {
+	Fatal(args ...interface{})
+}
 
 // TODO: implement, test and document each function without using testify
 
-func Contains(t *testing.T, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-	require.Contains(t, s, contains, msgAndArgs)
+// Contains fails if `s` does not contain `substr` using strings.Contains.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func Contains(t TestingT, s, substr string, formatWithArgs ...interface{}) {
+	if !strings.Contains(s, substr) {
+		fail(t, fmt.Sprintf("expected %q to contain %q", s, substr), "", formatWithArgs...)
+	}
 }
 
-func Empty(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
-	require.Empty(t, object, msgAndArgs)
+// Equal fails if the actual value is not equal to the expected.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func Equal(t TestingT, expected, actual interface{}, formatWithArgs ...interface{}) {
+	if equal(expected, actual) {
+		return
+	}
+	_, expectString := expected.(string)
+	if actual == nil {
+		if expectString {
+			fail(t, fmt.Sprintf("expected %q, but was nil", expected), "", formatWithArgs...)
+		} else {
+			fail(t, fmt.Sprintf("expected %#v, but was nil", expected), "", formatWithArgs...)
+		}
+		return
+	}
+
+	// Include the type name if the actual wasn't the same
+	et, at := reflect.ValueOf(expected).Type(), reflect.ValueOf(actual).Type()
+	if et != at {
+		if expectString {
+			fail(t, fmt.Sprintf("expected %q, but was %s(%v)", expected, at, actual), "", formatWithArgs...)
+		} else {
+			fail(t, fmt.Sprintf("expected %s(%v), but was %s(%v)", et, expected, at, actual), "", formatWithArgs...)
+		}
+		return
+	}
+
+	// Inline the comparison if the types are likely small:
+	if expectString {
+		fail(t, fmt.Sprintf("expected %q, but was %q", expected, actual), "", formatWithArgs...)
+		return
+	} else if et.Kind() < reflect.Array {
+		fail(t, fmt.Sprintf("expected %v, but was %v", expected, actual), "", formatWithArgs...)
+		return
+	}
+
+	// If we have the same type, and it isn't a string, but the expected and actual values on a different line.
+	// This allows easier comparison without using a diff library.
+	fail(t, "unexpected value", fmt.Sprintf("expected:\n\t%#v\nwas:\n\t%#v\n", expected, actual), formatWithArgs...)
 }
 
-func Equal(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	require.Equal(t, expected, actual, msgAndArgs)
+// equal speculatively tries to cast the inputs as byte arrays and falls back to reflection.
+func equal(expected, actual interface{}) bool {
+	if b1, ok := expected.([]byte); !ok {
+		return reflect.DeepEqual(expected, actual)
+	} else if b2, ok := actual.([]byte); ok {
+		return bytes.Equal(b1, b2)
+	}
+	return false
 }
 
-func EqualError(t *testing.T, theError error, errString string, msgAndArgs ...interface{}) {
-	require.EqualError(t, theError, errString, msgAndArgs)
+// EqualError fails if the err is nil or its `Error()` value is not equal to the expected.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func EqualError(t TestingT, err error, expected string, formatWithArgs ...interface{}) {
+	if err == nil {
+		fail(t, "expected an error, but was nil", "", formatWithArgs...)
+		return
+	}
+	actual := err.Error()
+	if actual != expected {
+		fail(t, fmt.Sprintf("expected error %q, but was %q", expected, actual), "", formatWithArgs...)
+	}
 }
 
-func Error(t *testing.T, err error, msgAndArgs ...interface{}) {
-	require.Error(t, err, msgAndArgs)
+// Error fails if the err is nil.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func Error(t TestingT, err error, formatWithArgs ...interface{}) {
+	if err == nil {
+		fail(t, "expected an error, but was nil", "", formatWithArgs...)
+	}
 }
 
-func ErrorIs(t *testing.T, err error, target error, msgAndArgs ...interface{}) {
-	require.ErrorIs(t, err, target, msgAndArgs)
+// ErrorIs fails if the err is nil or errors.Is fails against the expected.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func ErrorIs(t TestingT, err, target error, formatWithArgs ...interface{}) {
+	if err == nil {
+		fail(t, "expected an error, but was nil", "", formatWithArgs...)
+		return
+	}
+	if !errors.Is(err, target) {
+		fail(t, fmt.Sprintf("expected errors.Is(%v, %v), but it wasn't", err, target), "", formatWithArgs...)
+	}
 }
 
-func False(t *testing.T, value bool, msgAndArgs ...interface{}) {
-	require.False(t, value, msgAndArgs)
+// False fails if the actual value was true.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func False(t TestingT, actual bool, formatWithArgs ...interface{}) {
+	if actual {
+		fail(t, "expected false, but was true", "", formatWithArgs...)
+	}
 }
 
-func Len(t *testing.T, object interface{}, length int, msgAndArgs ...interface{}) {
-	require.Len(t, object, length, msgAndArgs)
+// Nil fails if the object is not nil.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func Nil(t TestingT, object interface{}, formatWithArgs ...interface{}) {
+	if !isNil(object) {
+		fail(t, fmt.Sprintf("expected nil, but was %v", object), "", formatWithArgs...)
+	}
 }
 
-func Nil(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
-	require.Nil(t, object, msgAndArgs)
+// NoError fails if the err is not nil.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func NoError(t TestingT, err error, formatWithArgs ...interface{}) {
+	if err != nil {
+		fail(t, fmt.Sprintf("expected no error, but was %v", err), "", formatWithArgs...)
+	}
 }
 
-func NoError(t *testing.T, err error, msgAndArgs ...interface{}) {
-	require.NoError(t, err, msgAndArgs)
+// NotEqual fails if the actual value is equal to the expected.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func NotEqual(t TestingT, expected, actual interface{}, formatWithArgs ...interface{}) {
+	if !equal(expected, actual) {
+		return
+	}
+	_, expectString := expected.(string)
+	if expectString {
+		fail(t, fmt.Sprintf("expected to not equal %q", actual), "", formatWithArgs...)
+		return
+	}
+	fail(t, fmt.Sprintf("expected to not equal %#v", actual), "", formatWithArgs...)
 }
 
-func NotContains(t *testing.T, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-	require.NotContains(t, s, contains, msgAndArgs)
+// NotNil fails if the object is nil.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func NotNil(t TestingT, object interface{}, formatWithArgs ...interface{}) {
+	if isNil(object) {
+		fail(t, "expected to not be nil", "", formatWithArgs...)
+	}
 }
 
-func NotEmpty(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
-	require.NotEmpty(t, object, msgAndArgs)
+// isNil is less efficient for the sake of less code vs tracking all the nil types in Go.
+func isNil(object interface{}) (isNil bool) {
+	if object == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(object)
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			// ignore problems using isNil on a type that can't be nil
+			isNil = false
+		}
+	}()
+
+	isNil = v.IsNil()
+	return
 }
 
-func NotEqual(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	require.NotEqual(t, expected, actual, msgAndArgs)
-}
-
-func NotNil(t *testing.T, object interface{}, msgAndArgs ...interface{}) {
-	require.NotNil(t, object, msgAndArgs)
-}
-
-func NotSame(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	require.NotSame(t, expected, actual, msgAndArgs)
+// NotSame fails if the inputs point to the same object.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func NotSame(t TestingT, expected, actual interface{}, formatWithArgs ...interface{}) {
+	if equalsPointer(expected, actual) {
+		fail(t, fmt.Sprintf("expected %v to point to a different object", actual), "", formatWithArgs...)
+		return
+	}
 }
 
 // CapturePanic returns an error recovered from a panic. If the panic was not an error, this converts it to one.
@@ -89,14 +216,140 @@ func CapturePanic(panics func()) (err error) {
 	return
 }
 
-func Same(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	require.Same(t, expected, actual, msgAndArgs)
+// Same fails if the inputs don't point to the same object.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func Same(t TestingT, expected, actual interface{}, formatWithArgs ...interface{}) {
+	if !equalsPointer(expected, actual) {
+		fail(t, fmt.Sprintf("expected %v to point to the same object as %v", actual, expected), "", formatWithArgs...)
+		return
+	}
 }
 
-func True(t *testing.T, value bool, msgAndArgs ...interface{}) {
-	require.True(t, value, msgAndArgs)
+func equalsPointer(expected, actual interface{}) bool {
+	expectedV := reflect.ValueOf(expected)
+	if expectedV.Kind() != reflect.Ptr {
+		panic("BUG: expected was not a pointer")
+	}
+	actualV := reflect.ValueOf(actual)
+	if actualV.Kind() != reflect.Ptr {
+		panic("BUG: actual was not a pointer")
+	}
+
+	if t1, t2 := reflect.TypeOf(expectedV), reflect.TypeOf(actualV); t1 != t2 {
+		return false
+	} else {
+		return expected == actual
+	}
 }
 
-func Zero(t *testing.T, i interface{}, msgAndArgs ...interface{}) {
-	require.Zero(t, i, msgAndArgs)
+// True fails if the actual value wasn't.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+func True(t TestingT, actual bool, formatWithArgs ...interface{}) {
+	if !actual {
+		fail(t, "expected true, but was false", "", formatWithArgs...)
+	}
+}
+
+// Zero fails if the actual value wasn't.
+//
+//  * formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
+//
+// Note: This isn't precise to numeric types, but we don't care as being more precise is more code and tests.
+func Zero(t TestingT, i interface{}, formatWithArgs ...interface{}) {
+	if i == nil {
+		fail(t, "expected zero, but was nil", "", formatWithArgs...)
+	}
+	zero := reflect.Zero(reflect.TypeOf(i))
+	if i != zero.Interface() {
+		fail(t, fmt.Sprintf("expected zero, but was %v", i), "", formatWithArgs...)
+	}
+}
+
+// fail tries to treat the formatWithArgs as fmt.Sprintf parameters or joins on space.
+func fail(t TestingT, m1, m2 string, formatWithArgs ...interface{}) {
+	var failure string
+	if len(formatWithArgs) > 0 {
+		if s, ok := formatWithArgs[0].(string); ok && strings.Contains(s, "%") {
+			failure = fmt.Sprintf(m1+": "+s, formatWithArgs[1:]...)
+		} else {
+			var builder strings.Builder
+			builder.WriteString(fmt.Sprintf("%s: %v", m1, formatWithArgs[0]))
+			for _, v := range formatWithArgs[1:] {
+				builder.WriteByte(' ')
+				builder.WriteString(fmt.Sprintf("%v", v))
+			}
+			failure = builder.String()
+		}
+	} else {
+		failure = m1
+	}
+	if m2 != "" {
+		failure = failure + "\n" + m2
+	}
+
+	// Don't write the failStack in our own package!
+	if fs := failStack(); len(fs) > 0 {
+		t.Fatal(failure, "\n", strings.Join(fs, "\n\t\t\t"))
+	} else {
+		t.Fatal(failure)
+	}
+}
+
+// failStack returns the stack leading to the require fail, without test infrastructure.
+//
+// Note: This is similar to assert.CallerInfo in testify
+// Note: This is untested because it is a lot of work to do that. The rationale to punt is this is a test-only internal
+// type which returns optional info. Someone can add tests, but they'd need to do that as an integration test in a
+// different package with something stable line-number-wise.
+func failStack() (fs []string) {
+	for i := 0; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break // don't loop forever on a bug
+		}
+
+		f := runtime.FuncForPC(pc)
+		if f == nil {
+			break // don't loop forever on a bug
+		}
+		name := f.Name()
+
+		if name == "testing.tRunner" {
+			break // Don't add the runner from src/testing/testing.go
+		}
+
+		// Ensure we don't add functions in the require package to the failure stack.
+		dir := path.Dir(file)
+		if path.Base(dir) != "require" {
+			fs = append(fs, fmt.Sprintf("%s:%d", path.Base(file), line))
+		}
+
+		// Stop the stack when we get to a test. Strip off any leading package name first!
+		if dot := strings.Index(name, "."); dot > 0 {
+			if isTest(name[dot+1:]) {
+				return
+			}
+		}
+	}
+	return
+}
+
+var testPrefixes = []string{"Test", "Benchmark", "Example"}
+
+// isTest is similar to load.isTest in Go's src/cmd/go/internal/load/test.go
+func isTest(name string) bool {
+	for _, prefix := range testPrefixes {
+		if !strings.HasPrefix(name, prefix) {
+			return false
+		}
+		if len(name) == len(prefix) { // "Test" is ok
+			return true
+		}
+		if r, _ := utf8.DecodeRuneInString(name[len(prefix):]); !unicode.IsLower(r) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/testing/require/require_test.go
+++ b/internal/testing/require/require_test.go
@@ -2,6 +2,8 @@ package require
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"testing"
 )
 
@@ -48,5 +50,622 @@ func TestCapturePanic(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFail(t *testing.T) {
+	tests := []struct {
+		name           string
+		formatWithArgs []interface{}
+		expectedLog    string
+	}{
+		{
+			name:        "message no formatWithArgs",
+			expectedLog: "failed",
+		},
+		{
+			name:           "message formatWithArgs =: string",
+			formatWithArgs: []interface{}{"because"},
+			expectedLog:    "failed: because",
+		},
+		{
+			name:           "message formatWithArgs = [number]",
+			formatWithArgs: []interface{}{1},
+			expectedLog:    "failed: 1",
+		},
+		{
+			name:           "message formatWithArgs = [struct]",
+			formatWithArgs: []interface{}{struct{}{}},
+			expectedLog:    "failed: {}",
+		},
+		{
+			name:           "message formatWithArgs = [string, string]",
+			formatWithArgs: []interface{}{"because", "this"},
+			expectedLog:    "failed: because this",
+		},
+		{
+			name:           "message formatWithArgs = [format, string]",
+			formatWithArgs: []interface{}{"because %s", "this"},
+			expectedLog:    "failed: because this",
+		},
+		{
+			name:           "message formatWithArgs = [format, struct]",
+			formatWithArgs: []interface{}{"because %s", struct{}{}},
+			expectedLog:    "failed: because {}",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			m := &mockT{t: t}
+			fail(m, "failed", "", tc.formatWithArgs...)
+			m.require(tc.expectedLog)
+		})
+	}
+}
+
+type testStruct struct {
+	name string
+}
+
+func TestRequire(t *testing.T) {
+	zero := uint64(0)
+	struct1 := &testStruct{"hello"}
+	struct2 := &testStruct{"hello"}
+
+	tests := []struct {
+		name        string
+		require     func(TestingT)
+		expectedLog string
+	}{
+		{
+			name: "Contains passes on contains",
+			require: func(t TestingT) {
+				Contains(t, "hello cat", "cat")
+			},
+		},
+		{
+			name: "Contains fails on empty",
+			require: func(t TestingT) {
+				Contains(t, "", "dog")
+			},
+			expectedLog: `expected "" to contain "dog"`,
+		},
+		{
+			name: "Contains fails on not contains",
+			require: func(t TestingT) {
+				Contains(t, "hello cat", "dog")
+			},
+			expectedLog: `expected "hello cat" to contain "dog"`,
+		},
+		{
+			name: "Contains fails on not contains with format",
+			require: func(t TestingT) {
+				Contains(t, "hello cat", "dog", "pay me %d", 5)
+			},
+			expectedLog: `expected "hello cat" to contain "dog": pay me 5`,
+		},
+		{
+			name: "Equal passes on equal: string",
+			require: func(t TestingT) {
+				Equal(t, "wazero", "wazero")
+			},
+		},
+		{
+			name: "Equal passes on equal: []byte",
+			require: func(t TestingT) {
+				Equal(t, []byte{1, 2, 3, 4}, []byte{1, 2, 3, 4})
+			},
+		},
+		{
+			name: "Equal passes on equal: struct",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, &testStruct{name: "takeshi"})
+			},
+		},
+		{
+			name: "Equal fails on nil: string",
+			require: func(t TestingT) {
+				Equal(t, "wazero", nil)
+			},
+			expectedLog: `expected "wazero", but was nil`,
+		},
+		{
+			name: "Equal fails on nil: []byte",
+			require: func(t TestingT) {
+				Equal(t, []byte{1, 2, 3, 4}, nil)
+			},
+			expectedLog: `expected []byte{0x1, 0x2, 0x3, 0x4}, but was nil`,
+		},
+		{
+			name: "Equal fails on nil: struct",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, nil)
+			},
+			expectedLog: `expected &require.testStruct{name:"takeshi"}, but was nil`,
+		},
+
+		{
+			name: "Equal fails on not same type: string",
+			require: func(t TestingT) {
+				Equal(t, "wazero", uint32(1))
+			},
+			expectedLog: `expected "wazero", but was uint32(1)`,
+		},
+		{
+			name: "Equal fails on not same type: []byte",
+			require: func(t TestingT) {
+				Equal(t, []byte{1, 2, 3, 4}, "wazero")
+			},
+			expectedLog: `expected []uint8([1 2 3 4]), but was string(wazero)`,
+		},
+		{
+			name: "Equal fails on not same type: struct",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, "wazero")
+			},
+			expectedLog: `expected *require.testStruct(&{takeshi}), but was string(wazero)`,
+		},
+		{
+			name: "Equal fails on not equal: string",
+			require: func(t TestingT) {
+				Equal(t, "wazero", "walero")
+			},
+			expectedLog: `expected "wazero", but was "walero"`,
+		},
+		{
+			name: "Equal fails on not equal: uint64", // ensure we don't use multi-line output!
+			require: func(t TestingT) {
+				Equal(t, uint64(12), uint64(13))
+			},
+			expectedLog: `expected 12, but was 13`,
+		},
+		{
+			name: "Equal fails on not equal: []byte",
+			require: func(t TestingT) {
+				Equal(t, []byte{1, 2, 3, 4}, []byte{1, 2, 4})
+			},
+			expectedLog: `unexpected value
+expected:
+	[]byte{0x1, 0x2, 0x3, 0x4}
+was:
+	[]byte{0x1, 0x2, 0x4}
+`,
+		},
+		{
+			name: "Equal fails on not equal: struct",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, &testStruct{name: "adrian"})
+			},
+			expectedLog: `unexpected value
+expected:
+	&require.testStruct{name:"takeshi"}
+was:
+	&require.testStruct{name:"adrian"}
+`,
+		},
+		{
+			name: "Equal fails on not equal: struct with format",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, &testStruct{name: "adrian"}, "pay me %d", 5)
+			},
+			expectedLog: `unexpected value: pay me 5
+expected:
+	&require.testStruct{name:"takeshi"}
+was:
+	&require.testStruct{name:"adrian"}
+`,
+		},
+		{
+			name: "EqualError passes on equal",
+			require: func(t TestingT) {
+				EqualError(t, io.EOF, io.EOF.Error())
+			},
+		},
+		{
+			name: "EqualError fails on nil",
+			require: func(t TestingT) {
+				EqualError(t, nil, "crash")
+			},
+			expectedLog: "expected an error, but was nil",
+		},
+		{
+			name: "EqualError fails on not equal",
+			require: func(t TestingT) {
+				EqualError(t, io.EOF, "crash")
+			},
+			expectedLog: `expected error "crash", but was "EOF"`,
+		},
+		{
+			name: "EqualError fails on not equal with format",
+			require: func(t TestingT) {
+				EqualError(t, io.EOF, "crash", "pay me %d", 5)
+			},
+			expectedLog: `expected error "crash", but was "EOF": pay me 5`,
+		},
+		{
+			name: "Error passes on not nil",
+			require: func(t TestingT) {
+				Error(t, io.EOF)
+			},
+		},
+		{
+			name: "Error fails on nil",
+			require: func(t TestingT) {
+				Error(t, nil)
+			},
+			expectedLog: "expected an error, but was nil",
+		},
+		{
+			name: "Error fails on nil with format",
+			require: func(t TestingT) {
+				Error(t, nil, "pay me %d", 5)
+			},
+			expectedLog: `expected an error, but was nil: pay me 5`,
+		},
+		{
+			name: "ErrorIs passes on same",
+			require: func(t TestingT) {
+				ErrorIs(t, io.EOF, io.EOF)
+			},
+		},
+		{
+			name: "ErrorIs passes on wrapped",
+			require: func(t TestingT) {
+				ErrorIs(t, fmt.Errorf("cause: %w", io.EOF), io.EOF)
+			},
+		},
+		{
+			name: "ErrorIs fails on not equal",
+			require: func(t TestingT) {
+				ErrorIs(t, io.EOF, io.ErrUnexpectedEOF)
+			},
+			expectedLog: "expected errors.Is(EOF, unexpected EOF), but it wasn't",
+		},
+		{
+			name: "ErrorIs fails on not equal with format",
+			require: func(t TestingT) {
+				ErrorIs(t, io.EOF, io.ErrUnexpectedEOF, "pay me %d", 5)
+			},
+			expectedLog: `expected errors.Is(EOF, unexpected EOF), but it wasn't: pay me 5`,
+		},
+		{
+			name: "Nil passes on nil",
+			require: func(t TestingT) {
+				Nil(t, nil)
+			},
+		},
+		{
+			name: "Nil fails on not nil",
+			require: func(t TestingT) {
+				Nil(t, io.EOF)
+			},
+			expectedLog: "expected nil, but was EOF",
+		},
+		{
+			name: "Nil fails on not nil with format",
+			require: func(t TestingT) {
+				Nil(t, io.EOF, "pay me %d", 5)
+			},
+			expectedLog: `expected nil, but was EOF: pay me 5`,
+		},
+		{
+			name: "NoError passes on nil",
+			require: func(t TestingT) {
+				NoError(t, nil)
+			},
+		},
+		{
+			name: "NoError fails on not nil",
+			require: func(t TestingT) {
+				NoError(t, io.EOF)
+			},
+			expectedLog: "expected no error, but was EOF",
+		},
+		{
+			name: "NoError fails on not nil with format",
+			require: func(t TestingT) {
+				NoError(t, io.EOF, "pay me %d", 5)
+			},
+			expectedLog: `expected no error, but was EOF: pay me 5`,
+		},
+		{
+			name: "NotNil passes on not nil",
+			require: func(t TestingT) {
+				NotNil(t, io.EOF)
+			},
+		},
+		{
+			name: "NotNil fails on nil",
+			require: func(t TestingT) {
+				NotNil(t, nil)
+			},
+			expectedLog: "expected to not be nil",
+		},
+		{
+			name: "NotNil fails on nil with format",
+			require: func(t TestingT) {
+				NotNil(t, nil, "pay me %d", 5)
+			},
+			expectedLog: `expected to not be nil: pay me 5`,
+		},
+		{
+			name: "False passes on false",
+			require: func(t TestingT) {
+				False(t, false)
+			},
+		},
+		{
+			name: "False fails on true",
+			require: func(t TestingT) {
+				False(t, true)
+			},
+			expectedLog: "expected false, but was true",
+		},
+		{
+			name: "False fails on true with format",
+			require: func(t TestingT) {
+				False(t, true, "pay me %d", 5)
+			},
+			expectedLog: "expected false, but was true: pay me 5",
+		},
+		{
+			name: "Equal passes on equal: string",
+			require: func(t TestingT) {
+				Equal(t, "wazero", "wazero")
+			},
+		},
+		{
+			name: "Equal passes on equal: []byte",
+			require: func(t TestingT) {
+				Equal(t, []byte{1, 2, 3, 4}, []byte{1, 2, 3, 4})
+			},
+		},
+		{
+			name: "Equal passes on equal: struct",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, &testStruct{name: "takeshi"})
+			},
+		},
+		{
+			name: "Equal fails on nil: string",
+			require: func(t TestingT) {
+				Equal(t, "wazero", nil)
+			},
+			expectedLog: `expected "wazero", but was nil`,
+		},
+		{
+			name: "Equal fails on nil: []byte",
+			require: func(t TestingT) {
+				Equal(t, []byte{1, 2, 3, 4}, nil)
+			},
+			expectedLog: `expected []byte{0x1, 0x2, 0x3, 0x4}, but was nil`,
+		},
+		{
+			name: "Equal fails on nil: struct",
+			require: func(t TestingT) {
+				Equal(t, &testStruct{name: "takeshi"}, nil)
+			},
+			expectedLog: `expected &require.testStruct{name:"takeshi"}, but was nil`,
+		},
+		{
+			name: "NotEqual passes on not equal",
+			require: func(t TestingT) {
+				NotEqual(t, uint32(1), uint32(2))
+			},
+		},
+		{
+			name: "NotEqual fails on equal: nil",
+			require: func(t TestingT) {
+				NotEqual(t, nil, nil)
+			},
+			expectedLog: `expected to not equal <nil>`,
+		},
+		{
+			name: "NotEqual fails on equal: string",
+			require: func(t TestingT) {
+				NotEqual(t, "wazero", "wazero")
+			},
+			expectedLog: `expected to not equal "wazero"`,
+		},
+		{
+			name: "NotEqual fails on equal: []byte",
+			require: func(t TestingT) {
+				NotEqual(t, []byte{1, 2, 3, 4}, []byte{1, 2, 3, 4})
+			},
+			expectedLog: `expected to not equal []byte{0x1, 0x2, 0x3, 0x4}`,
+		},
+		{
+			name: "NotEqual fails on equal: struct",
+			require: func(t TestingT) {
+				NotEqual(t, &testStruct{name: "takeshi"}, &testStruct{name: "takeshi"})
+			},
+			expectedLog: `expected to not equal &require.testStruct{name:"takeshi"}`,
+		},
+		{
+			name: "NotEqual fails on equal: struct with format",
+			require: func(t TestingT) {
+				NotEqual(t, &testStruct{name: "takeshi"}, &testStruct{name: "takeshi"}, "pay me %d", 5)
+			},
+			expectedLog: `expected to not equal &require.testStruct{name:"takeshi"}: pay me 5`,
+		},
+		{
+			name: "NotSame passes on not same",
+			require: func(t TestingT) {
+				NotSame(t, struct1, struct2)
+			},
+		},
+		{
+			name: "NotSame passes on different types",
+			require: func(t TestingT) {
+				NotSame(t, struct1, &zero)
+			},
+		},
+		{
+			name: "NotSame fails on same pointers",
+			require: func(t TestingT) {
+				NotSame(t, struct1, struct1)
+			},
+			expectedLog: "expected &{hello} to point to a different object",
+		},
+		{
+			name: "NotSame fails on same pointers with format",
+			require: func(t TestingT) {
+				NotSame(t, struct1, struct1, "pay me %d", 5)
+			},
+			expectedLog: "expected &{hello} to point to a different object: pay me 5",
+		},
+		{
+			name: "Same passes on same",
+			require: func(t TestingT) {
+				Same(t, struct1, struct1)
+			},
+		},
+		{
+			name: "Same fails on different types",
+			require: func(t TestingT) {
+				Same(t, struct1, &zero)
+			},
+			expectedLog: fmt.Sprintf("expected %v to point to the same object as &{hello}", &zero),
+		},
+		{
+			name: "Same fails on different pointers",
+			require: func(t TestingT) {
+				Same(t, struct1, struct2)
+			},
+			expectedLog: "expected &{hello} to point to the same object as &{hello}",
+		},
+		{
+			name: "Same fails on different pointers with format",
+			require: func(t TestingT) {
+				Same(t, struct1, struct2, "pay me %d", 5)
+			},
+			expectedLog: "expected &{hello} to point to the same object as &{hello}: pay me 5",
+		},
+		{
+			name: "True passes on true",
+			require: func(t TestingT) {
+				True(t, true)
+			},
+		},
+		{
+			name: "True fails on false",
+			require: func(t TestingT) {
+				True(t, false)
+			},
+			expectedLog: "expected true, but was false",
+		},
+		{
+			name: "True fails on false with format",
+			require: func(t TestingT) {
+				True(t, false, "pay me %d", 5)
+			},
+			expectedLog: "expected true, but was false: pay me 5",
+		},
+		{
+			name: "Zero passes on float32(0)",
+			require: func(t TestingT) {
+				Zero(t, float32(0))
+			},
+		},
+		{
+			name: "Zero passes on float64(0)",
+			require: func(t TestingT) {
+				Zero(t, float64(0))
+			},
+		},
+		{
+			name: "Zero passes on int(0)",
+			require: func(t TestingT) {
+				Zero(t, int(0))
+			},
+		},
+		{
+			name: "Zero passes on uint32(0)",
+			require: func(t TestingT) {
+				Zero(t, uint32(0))
+			},
+		},
+		{
+			name: "Zero passes on uint64(0)",
+			require: func(t TestingT) {
+				Zero(t, uint64(0))
+			},
+		},
+		{
+			name: "Zero fails on float32(1)",
+			require: func(t TestingT) {
+				Zero(t, float32(1))
+			},
+			expectedLog: "expected zero, but was 1",
+		},
+		{
+			name: "Zero fails on float64(1)",
+			require: func(t TestingT) {
+				Zero(t, float64(1))
+			},
+			expectedLog: "expected zero, but was 1",
+		},
+		{
+			name: "Zero fails on int(1)",
+			require: func(t TestingT) {
+				Zero(t, int(1))
+			},
+			expectedLog: "expected zero, but was 1",
+		},
+		{
+			name: "Zero fails on uint32(1)",
+			require: func(t TestingT) {
+				Zero(t, uint32(1))
+			},
+			expectedLog: "expected zero, but was 1",
+		},
+		{
+			name: "Zero fails on uint64(1)",
+			require: func(t TestingT) {
+				Zero(t, uint64(1))
+			},
+			expectedLog: "expected zero, but was 1",
+		},
+		{
+			name: "Zero fails on uint64(1) with format",
+			require: func(t TestingT) {
+				Zero(t, uint64(1), "pay me %d", 5)
+			},
+			expectedLog: "expected zero, but was 1: pay me 5",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			m := &mockT{t: t}
+			tc.require(m)
+			m.require(tc.expectedLog)
+		})
+	}
+}
+
+// compile-time check to ensure mockT implements TestingT
+var _ TestingT = &mockT{}
+
+type mockT struct {
+	t   *testing.T
+	log string
+}
+
+// Fatal implements TestingT.Fatal
+func (t *mockT) Fatal(args ...interface{}) {
+	if t.log != "" {
+		t.t.Fatal("already called Fatal(")
+	}
+	t.log = fmt.Sprint(args...)
+}
+
+func (t *mockT) require(expectedLog string) {
+	if expectedLog != t.log {
+		t.t.Fatalf("expected log=%q, but found %q", expectedLog, t.log)
 	}
 }

--- a/internal/wasm/jit/jit_controlflow_test.go
+++ b/internal/wasm/jit/jit_controlflow_test.go
@@ -434,7 +434,7 @@ func TestCompiler_compileBrTable(t *testing.T) {
 			err = compiler.compileBrTable(tc.o)
 			require.NoError(t, err)
 
-			require.Len(t, compiler.valueLocationStack().usedRegisters, 0)
+			require.Zero(t, len(compiler.valueLocationStack().usedRegisters))
 
 			requireRunAndExpectedValueReturned(t, env, compiler, tc.expectedValue)
 		})

--- a/internal/wasm/jit/jit_global_test.go
+++ b/internal/wasm/jit/jit_global_test.go
@@ -32,7 +32,7 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			// At this point, the top of stack must be the retrieved global on a register.
 			global := compiler.valueLocationStack().peek()
 			require.True(t, global.onRegister())
-			require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+			require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 			switch tp {
 			case wasm.ValueTypeF32, wasm.ValueTypeF64:
 				require.True(t, isFloatRegister(global.register))

--- a/internal/wasm/jit/jit_impl_amd64_test.go
+++ b/internal/wasm/jit/jit_impl_amd64_test.go
@@ -125,7 +125,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 
 						require.Equal(t, generalPurposeRegisterTypeInt, compiler.valueLocationStack().peek().regType)
 						require.Equal(t, uint64(2), compiler.valueLocationStack().sp)
-						require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+						require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 						// At this point, the previous value on the DX register is saved to the stack.
 						require.True(t, prevOnDX.onStack())
 
@@ -247,7 +247,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 
 						require.Equal(t, generalPurposeRegisterTypeInt, compiler.valueLocationStack().peek().regType)
 						require.Equal(t, uint64(2), compiler.valueLocationStack().sp)
-						require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+						require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 						// At this point, the previous value on the DX register is saved to the stack.
 						require.True(t, prevOnDX.onStack())
 

--- a/internal/wasm/jit/jit_initialization_test.go
+++ b/internal/wasm/jit/jit_initialization_test.go
@@ -77,7 +77,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 
 			err := compiler.compileModuleContextInitialization()
 			require.NoError(t, err)
-			require.Empty(t, compiler.valueLocationStack().usedRegisters)
+			require.Equal(t, 0, len(compiler.valueLocationStack().usedRegisters), "expected no usedRegisters")
 
 			compiler.compileExitFromNativeCode(jitCallStatusCodeReturned)
 

--- a/internal/wasm/jit/jit_memory_test.go
+++ b/internal/wasm/jit/jit_memory_test.go
@@ -250,7 +250,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 
 			// At this point, the loaded value must be on top of the stack, and placed on a register.
 			require.Equal(t, uint64(1), compiler.valueLocationStack().sp)
-			require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+			require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 			loadedLocation := compiler.valueLocationStack().peek()
 			require.True(t, loadedLocation.onRegister())
 			if tc.isFloatTarget {
@@ -388,7 +388,7 @@ func TestCompiler_compileStore(t *testing.T) {
 			tc.operationSetupFn(t, compiler)
 
 			// At this point, no registers must be in use, and no values on the stack since we consumed two values.
-			require.Len(t, compiler.valueLocationStack().usedRegisters, 0)
+			require.Zero(t, len(compiler.valueLocationStack().usedRegisters))
 			require.Equal(t, uint64(0), compiler.valueLocationStack().sp)
 
 			// Generate the code under test.

--- a/internal/wasm/jit/jit_numeric_test.go
+++ b/internal/wasm/jit/jit_numeric_test.go
@@ -958,13 +958,13 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 
 					// At this point two values are pushed.
 					require.Equal(t, uint64(2), compiler.valueLocationStack().sp)
-					require.Len(t, compiler.valueLocationStack().usedRegisters, 2)
+					require.Equal(t, 2, len(compiler.valueLocationStack().usedRegisters))
 
 					tc.setupFunc(t, compiler)
 
 					// We consumed two values, but push one value after operation.
 					require.Equal(t, uint64(1), compiler.valueLocationStack().sp)
-					require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+					require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
@@ -1259,13 +1259,13 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 
 					// At this point two values are pushed.
 					require.Equal(t, uint64(1), compiler.valueLocationStack().sp)
-					require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+					require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 
 					tc.setupFunc(t, compiler)
 
 					// We consumed one value, but push the result after operation.
 					require.Equal(t, uint64(1), compiler.valueLocationStack().sp)
-					require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+					require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)

--- a/internal/wasm/jit/jit_stack_test.go
+++ b/internal/wasm/jit/jit_stack_test.go
@@ -98,7 +98,7 @@ func TestCompiler_compileLoadValueOnStackToRegister(t *testing.T) {
 			compiler.valueLocationStack().stack = make([]*valueLocation, tc.stackPointer)
 
 			// Record that that top value is on top.
-			require.Len(t, compiler.valueLocationStack().usedRegisters, 0)
+			require.Zero(t, len(compiler.valueLocationStack().usedRegisters))
 			loc := compiler.valueLocationStack().pushValueLocationOnStack()
 			if tc.isFloat {
 				loc.setRegisterType(generalPurposeRegisterTypeFloat)
@@ -111,7 +111,7 @@ func TestCompiler_compileLoadValueOnStackToRegister(t *testing.T) {
 			// Release the stack-allocated value to register.
 			err = compiler.compileEnsureOnGeneralPurposeRegister(loc)
 			require.NoError(t, err)
-			require.Len(t, compiler.valueLocationStack().usedRegisters, 1)
+			require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
 			require.True(t, loc.onRegister())
 
 			// To verify the behavior, increment the value on the register.

--- a/internal/wasm/jit/jit_value_location_test.go
+++ b/internal/wasm/jit/jit_value_location_test.go
@@ -35,10 +35,10 @@ func TestValueLocationStack_basic(t *testing.T) {
 	// markRegisterUsed.
 	tmpReg2 := unreservedGeneralPurposeIntRegisters[1]
 	s.markRegisterUsed(tmpReg2)
-	require.Contains(t, s.usedRegisters, tmpReg2)
+	require.NotNil(t, s.usedRegisters[tmpReg2], tmpReg2)
 	// releaseRegister.
 	s.releaseRegister(loc)
-	require.NotContains(t, s.usedRegisters, loc.register)
+	require.Equal(t, s.usedRegisters[loc.register], struct{}{}, "expected %v to not contain %v", s.usedRegisters, loc.register)
 	require.Equal(t, asm.NilRegister, loc.register)
 	// Clone.
 	cloned := s.clone()

--- a/internal/wasm/module_context_test.go
+++ b/internal/wasm/module_context_test.go
@@ -185,13 +185,13 @@ func TestModuleContext_Close(t *testing.T) {
 
 		// We use side effects to determine if Close in fact called SysContext.Close (without repeating sys_test.go).
 		// One side effect of SysContext.Close is that it clears the openedFiles map. Verify our base case.
-		require.NotEmpty(t, sys.openedFiles)
+		require.True(t, len(sys.openedFiles) > 0, "sys.openedFiles was empty")
 
 		// Closing should not err.
 		require.NoError(t, m.Close())
 
 		// Verify our intended side-effect
-		require.Empty(t, sys.openedFiles)
+		require.Equal(t, 0, len(sys.openedFiles), "expected no opened files")
 
 		// Verify no error closing again.
 		require.NoError(t, m.Close())

--- a/internal/wasm/sys_test.go
+++ b/internal/wasm/sys_test.go
@@ -31,7 +31,7 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, eofReader{}, sys.Stdin())
 	require.Equal(t, io.Discard, sys.Stdout())
 	require.Equal(t, io.Discard, sys.Stderr())
-	require.Empty(t, sys.openedFiles)
+	require.Equal(t, 0, len(sys.openedFiles), "expected no opened files")
 
 	require.Equal(t, sys, DefaultSysContext())
 }
@@ -180,7 +180,7 @@ func TestSysContext_Close(t *testing.T) {
 
 		// Closing should delete the file descriptors after closing the files.
 		require.NoError(t, sys.Close())
-		require.Empty(t, sys.openedFiles)
+		require.Equal(t, 0, len(sys.openedFiles), "expected no opened files")
 
 		// Verify it was actually closed, by trying to close it again.
 		err = file.(*os.File).Close()
@@ -208,7 +208,7 @@ func TestSysContext_Close(t *testing.T) {
 
 		// Even if there are no open files, the descriptors for the file-system mappings should be removed.
 		require.NoError(t, sys.Close())
-		require.Empty(t, sys.openedFiles)
+		require.Equal(t, 0, len(sys.openedFiles), "expected no opened files")
 	})
 
 	t.Run("open file externally closed", func(t *testing.T) {
@@ -238,7 +238,7 @@ func TestSysContext_Close(t *testing.T) {
 		require.Contains(t, sys.Close().Error(), "file already closed")
 
 		// However, cleanup should still occur.
-		require.Empty(t, sys.openedFiles)
+		require.Equal(t, 0, len(sys.openedFiles), "expected no opened files")
 	})
 }
 

--- a/internal/wasm/text/memory_parser_test.go
+++ b/internal/wasm/text/memory_parser_test.go
@@ -68,7 +68,7 @@ func TestMemoryParser(t *testing.T) {
 			require.Equal(t, tc.expected, parsed)
 			require.Equal(t, uint32(1), tp.memoryNamespace.count)
 			if tc.expectedID == "" {
-				require.Empty(t, tp.memoryNamespace.idToIdx)
+				require.Equal(t, 0, len(tp.memoryNamespace.idToIdx), "expected no indices")
 			} else {
 				// Since the parser was initially empty, the expected index of the parsed memory is 0
 				require.Equal(t, map[string]wasm.Index{tc.expectedID: wasm.Index(0)}, tp.memoryNamespace.idToIdx)

--- a/internal/wasm/text/type_parser_test.go
+++ b/internal/wasm/text/type_parser_test.go
@@ -193,7 +193,7 @@ func TestTypeParser(t *testing.T) {
 			require.Equal(t, tc.expected, parsed)
 			require.Equal(t, uint32(1), tp.typeNamespace.count)
 			if tc.expectedID == "" {
-				require.Empty(t, tp.typeNamespace.idToIdx)
+				require.Equal(t, 0, len(tp.typeNamespace.idToIdx), "expected no indices")
 			} else {
 				// Since the parser was initially empty, the expected index of the parsed type is 0
 				require.Equal(t, map[string]wasm.Index{tc.expectedID: wasm.Index(0)}, tp.typeNamespace.idToIdx)

--- a/internal/wasm/text/typeuse_parser_test.go
+++ b/internal/wasm/text/typeuse_parser_test.go
@@ -200,7 +200,7 @@ func TestTypeUseParser_UnresolvedType(t *testing.T) {
 		return tp, func(t *testing.T) {
 			require.NotNil(t, tp.typeNamespace.unresolvedIndices)
 			if tc.expectedInlinedType == nil {
-				require.Empty(t, tp.inlinedTypes)
+				require.Equal(t, 0, len(tp.inlinedTypes), "expected no inlinedTypes")
 			} else {
 				require.Equal(t, tc.expectedInlinedType, tp.inlinedTypes[0])
 			}
@@ -308,9 +308,9 @@ func TestTypeUseParser_ReuseExistingType(t *testing.T) {
 
 		tp := newTypeUseParser(wasm.FeaturesFinished, module, typeNamespace)
 		return tp, func(t *testing.T) {
-			require.Nil(t, tp.typeNamespace.unresolvedIndices)
-			require.Nil(t, tp.inlinedTypes)
-			require.Nil(t, tp.inlinedTypeIndices)
+			require.Zero(t, len(tp.typeNamespace.unresolvedIndices))
+			require.Zero(t, len(tp.inlinedTypes))
+			require.Zero(t, len(tp.inlinedTypeIndices))
 		}
 	})
 }

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -61,7 +61,7 @@ func TestCompile(t *testing.T) {
 			}
 			functions, err := compileFunctions(enabledFeatures, tc.module)
 			require.NoError(t, err)
-			require.Len(t, functions, 1)
+			require.Equal(t, 1, len(functions))
 
 			res, err := Compile(enabledFeatures, functions[0])
 			require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			}
 			functions, err := compileFunctions(enabledFeatures, tc.module)
 			require.NoError(t, err)
-			require.Len(t, functions, 1)
+			require.Equal(t, 1, len(functions))
 
 			res, err := Compile(enabledFeatures, functions[0])
 			require.NoError(t, err)
@@ -383,7 +383,7 @@ func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expec
 	}
 	functions, err := compileFunctions(enabledFeatures, module)
 	require.NoError(t, err)
-	require.Len(t, functions, 1)
+	require.Equal(t, 1, len(functions))
 
 	res, err := Compile(enabledFeatures, functions[0])
 	require.NoError(t, err)

--- a/tests/post1_0/multi-value/multi_value_test.go
+++ b/tests/post1_0/multi-value/multi_value_test.go
@@ -299,7 +299,7 @@ func testFunctions(t *testing.T, module api.Module, tests []funcTest) {
 			results, err := module.ExportedFunction(tc.name).Call(nil, tc.params...)
 			require.NoError(t, err)
 			if tc.expected == nil {
-				require.Empty(t, results)
+				require.Equal(t, 0, len(results), "expected no results")
 			} else {
 				require.Equal(t, tc.expected, results)
 			}

--- a/tests/spectest/spec_test.go
+++ b/tests/spectest/spec_test.go
@@ -357,7 +357,7 @@ func runTest(t *testing.T, newEngine func(wasm.Features) wasm.Engine) {
 							}
 						case "get":
 							_, exps := c.getAssertReturnArgsExps()
-							require.Len(t, exps, 1)
+							require.Equal(t, 1, len(exps))
 							msg = fmt.Sprintf("%s invoke %s (%s)", msg, c.Action.Field, c.Action.Args)
 							if c.Action.Module != "" {
 								msg += " in module " + c.Action.Module

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -419,21 +419,21 @@ func TestCompiledCode_addCacheEntry(t *testing.T) {
 		c.addCacheEntry(m1, e1)
 	}
 
-	require.Contains(t, c.cachedEngines, e1)
-	require.Contains(t, c.cachedEngines[e1], m1)
-	require.Len(t, c.cachedEngines[e1], 1)
+	require.NotNil(t, c.cachedEngines[e1])
+	require.NotNil(t, c.cachedEngines[e1][m1])
+	require.Equal(t, 1, len(c.cachedEngines[e1]))
 
 	m2, e2 := &wasm.Module{}, &mockEngine{name: "2"}
 	for i := 0; i < 5; i++ {
 		c.addCacheEntry(m2, e2)
 	}
 
-	require.Contains(t, c.cachedEngines, e1)
-	require.Contains(t, c.cachedEngines, e2)
-	require.Contains(t, c.cachedEngines[e1], m1)
-	require.Contains(t, c.cachedEngines[e2], m2)
-	require.Len(t, c.cachedEngines[e1], 1)
-	require.Len(t, c.cachedEngines[e2], 1)
+	require.NotNil(t, c.cachedEngines[e1])
+	require.NotNil(t, c.cachedEngines[e2])
+	require.NotNil(t, c.cachedEngines[e1][m1])
+	require.NotNil(t, c.cachedEngines[e2][m2])
+	require.Equal(t, 1, len(c.cachedEngines[e1]))
+	require.Equal(t, 1, len(c.cachedEngines[e2]))
 }
 
 func TestCompiledCode_Close(t *testing.T) {
@@ -450,18 +450,18 @@ func TestCompiledCode_Close(t *testing.T) {
 	}
 
 	// Before Close.
-	require.Len(t, e1.cachedModules, 10)
-	require.Len(t, e2.cachedModules, 10)
-	require.Len(t, c.cachedEngines, 2)
+	require.Equal(t, 10, len(e1.cachedModules))
+	require.Equal(t, 10, len(e2.cachedModules))
+	require.Equal(t, 2, len(c.cachedEngines))
 	for _, modules := range c.cachedEngines {
-		require.Len(t, modules, 10)
+		require.Equal(t, 10, len(modules))
 	}
 
 	c.Close()
 
 	// After Close.
-	require.Len(t, e1.cachedModules, 0)
-	require.Len(t, e2.cachedModules, 0)
+	require.Zero(t, len(e1.cachedModules))
+	require.Zero(t, len(e2.cachedModules))
 }
 
 type mockEngine struct {


### PR DESCRIPTION
This implements our own assertion library so that we can remove the
testify dependency. I've changed a lot of call sites so that we only
have to maintain a minimal amount of assertions.

One tradeoff here besides the code added.. While this does not bring
in a diff dependency, it also doesn't do diffs. In practice, I think this is
ok, but we could consider adding diffs if our IDEs aren't smart enough
later.