### PR TITLE
Make CompileModule actually compile

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -247,17 +247,16 @@ func (b *moduleBuilder) Build() (*CompiledCode, error) {
 		}
 	}
 
-	if module, err := wasm.NewHostModule(
-		b.moduleName,
-		b.nameToGoFunc,
-		b.nameToMemory,
-		b.nameToGlobal,
-		b.r.enabledFeatures,
-	); err != nil {
+	module, err := wasm.NewHostModule(b.moduleName, b.nameToGoFunc, b.nameToMemory, b.nameToGlobal, b.r.enabledFeatures)
+	if err != nil {
 		return nil, err
-	} else {
-		return &CompiledCode{module: module}, nil
 	}
+
+	if err = b.r.store.Engine.CompileModule(module); err != nil {
+		return nil, err
+	}
+
+	return &CompiledCode{module: module}, nil
 }
 
 // Instantiate implements ModuleBuilder.Instantiate

--- a/builder.go
+++ b/builder.go
@@ -265,6 +265,9 @@ func (b *moduleBuilder) Instantiate() (api.Module, error) {
 	if module, err := b.Build(); err != nil {
 		return nil, err
 	} else {
+		if err = b.r.store.Engine.CompileModule(module.module); err != nil {
+			return nil, err
+		}
 		// *wasm.ModuleInstance cannot be tracked, so we release the cache inside of this function.
 		defer module.Close()
 		return b.r.InstantiateModuleWithConfig(module, NewModuleConfig().WithName(b.moduleName))

--- a/builder.go
+++ b/builder.go
@@ -256,6 +256,8 @@ func (b *moduleBuilder) Build() (*CompiledCode, error) {
 		return nil, err
 	}
 
+	ret := &CompiledCode{module: module}
+	ret.addCacheEntry(module, b.r.store.Engine)
 	return &CompiledCode{module: module}, nil
 }
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -343,9 +343,14 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, e := tc.input(NewRuntime()).Build()
-			require.NoError(t, e)
+			b := tc.input(NewRuntime()).(*moduleBuilder)
+			m, err := b.Build()
+			require.NoError(t, err)
 			requireHostModuleEquals(t, tc.expected, m.module)
+
+			// Built module must be instantiable by Engine.
+			_, err = b.r.InstantiateModule(m)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/config.go
+++ b/config.go
@@ -148,15 +148,35 @@ func (c *RuntimeConfig) WithFeatureMultiValue(enabled bool) *RuntimeConfig {
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#semantic-phases%E2%91%A0
 type CompiledCode struct {
 	module *wasm.Module
-	// compiledEngine holds the engine on which this `module` is compiled.
-	compiledEngine wasm.Engine
+	// cachedEngines maps wasm.Engine to []*wasm.Module which originate from this .module.
+	// This is necessary to track which engine caches *Module where latter might be different
+	// from .module via import replacement config (ModuleConfig.WithImport).
+	cachedEngines map[wasm.Engine]map[*wasm.Module]struct{}
 }
 
 // Close releases all the allocated resources for this CompiledCode.
 //
 // Note: it is safe to call Close while having outstanding calls from Modules instantiated from this *CompiledCode.
 func (c *CompiledCode) Close() {
-	c.compiledEngine.DeleteCompiledModule(c.module)
+	for engine, modules := range c.cachedEngines {
+		for module := range modules {
+			engine.DeleteCompiledModule(module)
+		}
+	}
+}
+
+func (c *CompiledCode) addCacheEntry(module *wasm.Module, engine wasm.Engine) {
+	if c.cachedEngines == nil {
+		c.cachedEngines = map[wasm.Engine]map[*wasm.Module]struct{}{}
+	}
+
+	cache, ok := c.cachedEngines[engine]
+	if !ok {
+		cache = map[*wasm.Module]struct{}{}
+		c.cachedEngines[engine] = cache
+	}
+
+	cache[module] = struct{}{}
 }
 
 // ModuleConfig configures resources needed by functions that have low-level interactions with the host operating system.

--- a/config.go
+++ b/config.go
@@ -148,35 +148,15 @@ func (c *RuntimeConfig) WithFeatureMultiValue(enabled bool) *RuntimeConfig {
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#semantic-phases%E2%91%A0
 type CompiledCode struct {
 	module *wasm.Module
-	// cachedEngines maps wasm.Engine to []*wasm.Module which originate from this .module.
-	// This is necessary to track which engine caches *Module where latter might be different
-	// from .module via import replacement config (ModuleConfig.WithImport).
-	cachedEngines map[wasm.Engine]map[*wasm.Module]struct{}
+	// compiledEngine holds the engine on which this `module` is compiled.
+	compiledEngine wasm.Engine
 }
 
 // Close releases all the allocated resources for this CompiledCode.
 //
 // Note: it is safe to call Close while having outstanding calls from Modules instantiated from this *CompiledCode.
 func (c *CompiledCode) Close() {
-	for engine, modules := range c.cachedEngines {
-		for module := range modules {
-			engine.DeleteCompiledModule(module)
-		}
-	}
-}
-
-func (c *CompiledCode) addCacheEntry(module *wasm.Module, engine wasm.Engine) {
-	if c.cachedEngines == nil {
-		c.cachedEngines = map[wasm.Engine]map[*wasm.Module]struct{}{}
-	}
-
-	cache, ok := c.cachedEngines[engine]
-	if !ok {
-		cache = map[*wasm.Module]struct{}{}
-		c.cachedEngines[engine] = cache
-	}
-
-	cache[module] = struct{}{}
+	c.compiledEngine.DeleteCompiledModule(c.module)
 }
 
 // ModuleConfig configures resources needed by functions that have low-level interactions with the host operating system.

--- a/config.go
+++ b/config.go
@@ -155,6 +155,8 @@ type CompiledCode struct {
 }
 
 // Close releases all the allocated resources for this CompiledCode.
+//
+// Note: it is safe to call Close while having outstanding calls from Modules instantiated from this *CompiledCode.
 func (c *CompiledCode) Close() {
 	for engine, modules := range c.cachedEngines {
 		for module := range modules {

--- a/config.go
+++ b/config.go
@@ -158,7 +158,7 @@ type CompiledCode struct {
 func (c *CompiledCode) Close() {
 	for engine, modules := range c.cachedEngines {
 		for module := range modules {
-			engine.ReleaseCompilationCache(module)
+			engine.DeleteCompiledModule(module)
 		}
 	}
 }

--- a/internal/integration_test/spectest/spec_test.go
+++ b/internal/integration_test/spectest/spec_test.go
@@ -267,6 +267,9 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 	mod.TableSection = &wasm.Table{Min: 10, Max: &tableLimitMax}
 	mod.ExportSection = append(mod.ExportSection, &wasm.Export{Name: "table", Index: 0, Type: wasm.ExternTypeTable})
 
+	err = store.Engine.CompileModule(mod)
+	require.NoError(t, err)
+
 	_, err = store.Instantiate(context.Background(), mod, mod.NameSection.ModuleName, wasm.DefaultSysContext())
 	require.NoError(t, err)
 }
@@ -334,6 +337,8 @@ func runTest(t *testing.T, newEngine func(wasm.Features) wasm.Engine) {
 								moduleName = c.Filename
 							}
 						}
+						err = store.Engine.CompileModule(mod)
+						require.NoError(t, err, msg)
 						moduleName = strings.TrimPrefix(moduleName, "$")
 						_, err = store.Instantiate(context.Background(), mod, moduleName, nil)
 						lastInstantiatedModuleName = moduleName
@@ -454,6 +459,11 @@ func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg 
 	}
 
 	err = mod.Validate(store.EnabledFeatures)
+	if err != nil {
+		return
+	}
+
+	err = store.Engine.CompileModule(mod)
 	if err != nil {
 		return
 	}

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -20,6 +20,8 @@ type Engine interface {
 	NewModuleEngine(name string, module *Module, importedFunctions, moduleFunctions []*FunctionInstance, table *TableInstance, tableInit map[Index]Index) (ModuleEngine, error)
 
 	// DeleteCompiledModule releases compilation caches for the given module (source).
+	// Note: it is safe to call this function for a module from which module instances are instantiated even when these module instances
+	// are having outstanding calls.
 	DeleteCompiledModule(module *Module)
 }
 

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -3,6 +3,9 @@ package wasm
 // Engine is a Store-scoped mechanism to compile functions declared or imported by a module.
 // This is a top-level type implemented by an interpreter or JIT compiler.
 type Engine interface {
+	// CompileModule implements the same method as documented on wasm.Engine.
+	CompileModule(module *Module) error
+
 	// NewModuleEngine compiles down the function instances in a module, and returns ModuleEngine for the module.
 	//
 	// * name is the name the module was instantiated with used for error handling.
@@ -16,8 +19,8 @@ type Engine interface {
 	// due to reasons such as out-of-bounds.
 	NewModuleEngine(name string, module *Module, importedFunctions, moduleFunctions []*FunctionInstance, table *TableInstance, tableInit map[Index]Index) (ModuleEngine, error)
 
-	// ReleaseCompilationCache releases compilation caches for the given module (source).
-	ReleaseCompilationCache(module *Module)
+	// DeleteCompiledModule releases compilation caches for the given module (source).
+	DeleteCompiledModule(module *Module)
 }
 
 // ModuleEngine implements function calls for a given module.
@@ -29,7 +32,4 @@ type ModuleEngine interface {
 	// Returns the results from the function.
 	// The ctx's context.Context will be the outer-most ancestor of the argument to api.Function.
 	Call(ctx *ModuleContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
-
-	// Close releases all the function instances declared in this module.
-	Close()
 }

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -729,7 +729,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 				return fmt.Errorf("invalid numeric instruction 0x%x", op)
 			}
 		} else if op == OpcodeBlock {
-			bt, num, err := decodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
+			bt, num, err := DecodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -741,7 +741,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			valueTypeStack.pushStackLimit(len(bt.Params))
 			pc += num
 		} else if op == OpcodeLoop {
-			bt, num, err := decodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
+			bt, num, err := DecodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -761,7 +761,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			valueTypeStack.pushStackLimit(len(bt.Params))
 			pc += num
 		} else if op == OpcodeIf {
-			bt, num, err := decodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
+			bt, num, err := DecodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -1117,22 +1117,12 @@ type controlBlock struct {
 	op Opcode
 }
 
-func decodeBlockType(types []*FunctionType, r *bytes.Reader, enabledFeatures Features) (*FunctionType, uint64, error) {
+func DecodeBlockType(types []*FunctionType, r *bytes.Reader, enabledFeatures Features) (*FunctionType, uint64, error) {
 	return decodeBlockTypeImpl(func(index int64) (*FunctionType, error) {
 		if index < 0 || (index >= int64(len(types))) {
 			return nil, fmt.Errorf("type index out of range: %d", index)
 		}
 		return types[index], nil
-	}, r, enabledFeatures)
-}
-
-// DecodeBlockType is exported for use in the compiler
-func DecodeBlockType(types []*TypeInstance, r *bytes.Reader, enabledFeatures Features) (*FunctionType, uint64, error) {
-	return decodeBlockTypeImpl(func(index int64) (*FunctionType, error) {
-		if index < 0 || (index >= int64(len(types))) {
-			return nil, fmt.Errorf("type index out of range: %d", index)
-		}
-		return types[index].Type, nil
 	}, r, enabledFeatures)
 }
 

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -67,7 +67,7 @@ func NewHostModule(
 	return
 }
 
-func (m *Module) IsHostMdule() bool {
+func (m *Module) IsHostModule() bool {
 	return len(m.HostFunctionSection) > 0
 }
 

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -67,6 +67,10 @@ func NewHostModule(
 	return
 }
 
+func (m *Module) IsHostMdule() bool {
+	return len(m.HostFunctionSection) > 0
+}
+
 func addFuncs(m *Module, nameToGoFunc map[string]interface{}, enabledFeatures Features) error {
 	funcCount := uint32(len(nameToGoFunc))
 	funcNames := make([]string, 0, funcCount)

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -178,6 +178,9 @@ func (e *engine) CompileModule(module *wasm.Module) error {
 
 	funcs := make([]*code, 0, len(module.FunctionSection))
 	if module.IsHostMdule() {
+		// If this is the host module, there's nothing to do as the runtime reprsentation of
+		// host function in interpreter is its Go function itself as opposed to Wasm functions,
+		// which need to be compiled down to wazeroir.
 		for _, hf := range module.HostFunctionSection {
 			funcs = append(funcs, &code{hostFn: hf})
 		}

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -177,7 +177,7 @@ func (e *engine) CompileModule(module *wasm.Module) error {
 	}
 
 	funcs := make([]*code, 0, len(module.FunctionSection))
-	if module.IsHostMdule() {
+	if module.IsHostModule() {
 		// If this is the host module, there's nothing to do as the runtime reprsentation of
 		// host function in interpreter is its Go function itself as opposed to Wasm functions,
 		// which need to be compiled down to wazeroir.

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -59,7 +59,7 @@ func (e engineTester) InitTable(me wasm.ModuleEngine, initTableLen uint32, initT
 	table := make([]interface{}, initTableLen)
 	internal := me.(*moduleEngine)
 	for idx, fnidx := range initTableIdxToFnIdx {
-		table[idx] = internal.codes[fnidx]
+		table[idx] = internal.functions[fnidx]
 	}
 	return table
 }
@@ -259,16 +259,16 @@ func TestEngine_CachedcodesPerModule(t *testing.T) {
 	}
 	m := &wasm.Module{}
 
-	e.addcodes(m, exp)
+	e.addCodes(m, exp)
 
-	actual, ok := e.getcodes(m)
+	actual, ok := e.getCodes(m)
 	require.True(t, ok)
 	require.Equal(t, len(exp), len(actual))
 	for i := range actual {
 		require.Equal(t, exp[i], actual[i])
 	}
 
-	e.deletecodes(m)
-	_, ok = e.getcodes(m)
+	e.deleteCodes(m)
+	_, ok = e.getCodes(m)
 	require.False(t, ok)
 }

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -3,9 +3,7 @@ package interpreter
 import (
 	"fmt"
 	"math"
-	"strconv"
 	"testing"
-	"unsafe"
 
 	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
@@ -129,9 +127,8 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 			tc := tc
 			t.Run(fmt.Sprintf("%s(i32.const(0x%x))", wasm.InstructionName(tc.opcode), tc.in), func(t *testing.T) {
 				ce := &callEngine{}
-				f := &compiledFunction{
-					moduleEngine: &moduleEngine{},
-					source:       &wasm.FunctionInstance{Module: &wasm.ModuleInstance{}},
+				f := &compiledFunctionInstance{
+					source: &wasm.FunctionInstance{Module: &wasm.ModuleInstance{Engine: &moduleEngine{}}},
 					body: []*interpreterOp{
 						{kind: wazeroir.OperationKindConstI32, us: []uint64{uint64(uint32(tc.in))}},
 						{kind: translateToIROperationKind(tc.opcode)},
@@ -182,9 +179,8 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 			tc := tc
 			t.Run(fmt.Sprintf("%s(i64.const(0x%x))", wasm.InstructionName(tc.opcode), tc.in), func(t *testing.T) {
 				ce := &callEngine{}
-				f := &compiledFunction{
-					moduleEngine: &moduleEngine{},
-					source:       &wasm.FunctionInstance{Module: &wasm.ModuleInstance{}},
+				f := &compiledFunctionInstance{
+					source: &wasm.FunctionInstance{Module: &wasm.ModuleInstance{Engine: &moduleEngine{}}},
 					body: []*interpreterOp{
 						{kind: wazeroir.OperationKindConstI64, us: []uint64{uint64(tc.in)}},
 						{kind: translateToIROperationKind(tc.opcode)},
@@ -198,215 +194,81 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 	})
 }
 
-func TestInterpreter_EngineCompile_Errors(t *testing.T) {
-	t.Run("invalid import", func(t *testing.T) {
+func TestInterpreter_Compile(t *testing.T) {
+	t.Run("uncompiled", func(t *testing.T) {
 		e := et.NewEngine(wasm.Features20191205).(*engine)
-		_, err := e.NewModuleEngine(t.Name(),
+		_, err := e.NewModuleEngine("foo",
 			&wasm.Module{},
-			[]*wasm.FunctionInstance{{Module: &wasm.ModuleInstance{Name: "uncompiled"}, DebugName: "uncompiled.fn"}},
+			nil, // imports
 			nil, // moduleFunctions
 			nil, // table
 			nil, // tableInit
 		)
-		require.EqualError(t, err, "import[0] func[uncompiled.fn]: uncompiled")
+		require.EqualError(t, err, "source module for foo must be compiled before instantiation")
 	})
-
-	t.Run("release on compilation error", func(t *testing.T) {
+	t.Run("fail", func(t *testing.T) {
 		e := et.NewEngine(wasm.Features20191205).(*engine)
 
-		importedFunctions := []*wasm.FunctionInstance{
-			{DebugName: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
+		errModule := &wasm.Module{
+			TypeSection:     []*wasm.FunctionType{{}},
+			FunctionSection: []wasm.Index{0, 0, 0},
+			CodeSection: []*wasm.Code{
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeCall}}, // Call instruction without immediate for call target index is invalid and should fail to compile.
+			},
 		}
 
-		// initialize the module-engine containing imported functions
-		_, err := e.NewModuleEngine(t.Name(), &wasm.Module{}, nil, importedFunctions, nil, nil)
-		require.NoError(t, err)
-
-		require.Equal(t, len(importedFunctions), len(e.compiledFunctions))
-
-		moduleFunctions := []*wasm.FunctionInstance{
-			{DebugName: "ok1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "ok2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "invalid code", Type: &wasm.FunctionType{}, Body: []byte{
-				wasm.OpcodeCall, // Call instruction without immediate for call target index is invalid and should fail to compile.
-			}, Module: &wasm.ModuleInstance{}},
-		}
-
-		_, err = e.NewModuleEngine(t.Name(), &wasm.Module{}, importedFunctions, moduleFunctions, nil, nil)
-		require.EqualError(t, err, "function[2/2] failed to lower to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
+		err := e.CompileModule(errModule)
+		require.EqualError(t, err, "failed to lower func[2/3] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, all the compiled functions including succeeded ones must be released.
-		require.Equal(t, len(importedFunctions), len(e.compiledFunctions))
-		for _, f := range moduleFunctions {
-			require.Nil(t, e.compiledFunctions[f])
-		}
+		_, ok := e.compiledFunctions[errModule]
+		require.False(t, ok)
 	})
-}
+	t.Run("ok", func(t *testing.T) {
+		e := et.NewEngine(wasm.Features20191205).(*engine)
 
-func TestInterpreter_Close(t *testing.T) {
-	for _, tc := range []struct {
-		name                               string
-		importedFunctions, moduleFunctions []*wasm.FunctionInstance
-	}{
-		{
-			name:            "only module-defined",
-			moduleFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
-		},
-		{
-			name:              "only imports",
-			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
-		},
-		{
-			name:              "imports and module-defined",
-			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
-			moduleFunctions:   []*wasm.FunctionInstance{newFunctionInstance(100), newFunctionInstance(200), newFunctionInstance(300)},
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			e := et.NewEngine(wasm.Features20191205).(*engine)
-			if len(tc.importedFunctions) > 0 {
-				// initialize the module-engine containing imported functions
-				me, err := e.NewModuleEngine(t.Name(), &wasm.Module{}, nil, tc.importedFunctions, nil, nil)
-				require.NoError(t, err)
-				require.Equal(t, len(tc.importedFunctions), len(me.(*moduleEngine).compiledFunctions))
-			}
+		okModule := &wasm.Module{
+			TypeSection:     []*wasm.FunctionType{{}},
+			FunctionSection: []wasm.Index{0, 0, 0, 0},
+			CodeSection: []*wasm.Code{
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+			},
+		}
+		err := e.CompileModule(okModule)
+		require.NoError(t, err)
 
-			me, err := e.NewModuleEngine(t.Name(), &wasm.Module{}, tc.importedFunctions, tc.moduleFunctions, nil, nil)
-			require.NoError(t, err)
-			require.Equal(t, len(tc.importedFunctions)+len(tc.moduleFunctions), len(me.(*moduleEngine).compiledFunctions))
+		compiled, ok := e.compiledFunctions[okModule]
+		require.True(t, ok)
+		require.Equal(t, len(okModule.FunctionSection), len(compiled))
 
-			require.Equal(t, len(tc.importedFunctions)+len(tc.moduleFunctions), len(e.compiledFunctions))
-			for _, f := range tc.importedFunctions {
-				require.NotNil(t, e.compiledFunctions[f], f)
-			}
-			for _, f := range tc.moduleFunctions {
-				require.NotNil(t, e.compiledFunctions[f], f)
-			}
-
-			me.Close()
-
-			require.Equal(t, len(tc.importedFunctions), len(e.compiledFunctions))
-			for _, f := range tc.importedFunctions {
-				require.NotNil(t, e.compiledFunctions[f], f)
-			}
-			for i, f := range tc.moduleFunctions {
-				require.Nil(t, e.compiledFunctions[f], i)
-			}
-		})
-	}
+		_, ok = e.compiledFunctions[okModule]
+		require.True(t, ok)
+	})
 }
 
 func TestEngine_CachedCompiledFunctionsPerModule(t *testing.T) {
 	e := et.NewEngine(wasm.Features20191205).(*engine)
 	exp := []*compiledFunction{
-		{source: &wasm.FunctionInstance{DebugName: "1"}},
-		{source: &wasm.FunctionInstance{DebugName: "2"}},
+		{body: []*interpreterOp{}},
+		{body: []*interpreterOp{}},
 	}
 	m := &wasm.Module{}
 
-	e.addCachedCompiledFunctions(m, exp)
+	e.addCompiledFunctions(m, exp)
 
-	actual, ok := e.getCachedCompiledFunctions(m)
+	actual, ok := e.getCompiledFunctions(m)
 	require.True(t, ok)
 	require.Equal(t, len(exp), len(actual))
 	for i := range actual {
 		require.Equal(t, exp[i], actual[i])
 	}
 
-	e.deleteCachedCompiledFunctions(m)
-	_, ok = e.getCachedCompiledFunctions(m)
+	e.deleteCompiledFunctions(m)
+	_, ok = e.getCompiledFunctions(m)
 	require.False(t, ok)
-}
-
-func TestEngine_NewModuleEngine_cache(t *testing.T) {
-	e := et.NewEngine(wasm.Features20191205).(*engine)
-	importedModuleSource := &wasm.Module{}
-
-	// No cache.
-	importedME, err := e.NewModuleEngine("1", importedModuleSource, nil, []*wasm.FunctionInstance{
-		newFunctionInstance(1),
-		newFunctionInstance(2),
-	}, nil, nil)
-	require.NoError(t, err)
-
-	// Cached.
-	importedMEFromCache, err := e.NewModuleEngine("2", importedModuleSource, nil, []*wasm.FunctionInstance{
-		newFunctionInstance(1),
-		newFunctionInstance(2),
-	}, nil, nil)
-	require.NoError(t, err)
-
-	require.NotEqual(t, importedME, importedMEFromCache)
-	require.NotEqual(t, importedME.Name(), importedMEFromCache.Name())
-
-	// Check compiled functions.
-	ime, imeCache := importedME.(*moduleEngine), importedMEFromCache.(*moduleEngine)
-	require.Equal(t, len(ime.compiledFunctions), len(imeCache.compiledFunctions))
-
-	for i, fn := range ime.compiledFunctions {
-		// Compiled functions must be cloend.
-		fnCached := imeCache.compiledFunctions[i]
-		require.NotEqual(t, fn, fnCached)
-		require.NotEqual(t, fn.moduleEngine, fnCached.moduleEngine)
-		require.NotEqual(t, unsafe.Pointer(fn.source), unsafe.Pointer(fnCached.source)) // unsafe.Pointer to compare the actual address.
-		// But the body stays the same.
-		require.Equal(t, fn.body, fnCached.body)
-	}
-
-	// Next is to veirfy the caching works for modules with imports.
-	importedFunc := ime.compiledFunctions[0].source
-	moduleSource := &wasm.Module{}
-
-	// No cache.
-	modEng, err := e.NewModuleEngine("3", moduleSource,
-		[]*wasm.FunctionInstance{importedFunc}, // Import one function.
-		[]*wasm.FunctionInstance{
-			newFunctionInstance(10),
-			newFunctionInstance(20),
-		}, nil, nil)
-	require.NoError(t, err)
-
-	// Cached.
-	modEngCache, err := e.NewModuleEngine("4", moduleSource,
-		[]*wasm.FunctionInstance{importedFunc}, // Import one function.
-		[]*wasm.FunctionInstance{
-			newFunctionInstance(10),
-			newFunctionInstance(20),
-		}, nil, nil)
-	require.NoError(t, err)
-
-	require.NotEqual(t, modEng, modEngCache)
-	require.NotEqual(t, modEng.Name(), modEngCache.Name())
-
-	me, meCache := modEng.(*moduleEngine), modEngCache.(*moduleEngine)
-	require.Equal(t, len(me.compiledFunctions), len(meCache.compiledFunctions))
-
-	for i, fn := range me.compiledFunctions {
-		fnCached := meCache.compiledFunctions[i]
-		if i == 0 {
-			// This case the function is imported, so it must be the same for both module engines.
-			require.Equal(t, fn, fnCached)
-			require.Equal(t, importedFunc, fn.source)
-		} else {
-			// Compiled functions must be cloend.
-			require.NotEqual(t, fn, fnCached)
-			require.NotEqual(t, fn.moduleEngine, fnCached.moduleEngine)
-			require.NotEqual(t, unsafe.Pointer(fn.source), unsafe.Pointer(fnCached.source)) // unsafe.Pointer to compare the actual address.
-			// But the code segment stays the same.
-			require.Equal(t, fn.body, fnCached.body)
-		}
-	}
-}
-
-func newFunctionInstance(id int) *wasm.FunctionInstance {
-	return &wasm.FunctionInstance{
-		DebugName: strconv.Itoa(id),
-		Type:      &wasm.FunctionType{},
-		Body:      []byte{wasm.OpcodeEnd},
-		Module:    &wasm.ModuleInstance{},
-	}
 }

--- a/internal/wasm/jit/arch_amd64.go
+++ b/internal/wasm/jit/arch_amd64.go
@@ -1,7 +1,6 @@
 package jit
 
 import (
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
@@ -24,6 +23,6 @@ func init() {
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.
 // Note: ir param can be nil for host functions.
-func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, error) {
-	return newAmd64Compiler(f, ir)
+func newCompiler(ir *wazeroir.CompilationResult) (compiler, error) {
+	return newAmd64Compiler(ir)
 }

--- a/internal/wasm/jit/arch_arm64.go
+++ b/internal/wasm/jit/arch_arm64.go
@@ -3,7 +3,6 @@ package jit
 import (
 	"math"
 
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
@@ -49,6 +48,6 @@ func init() {
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.
 // Note: ir param can be nil for host functions.
-func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, error) {
-	return newArm64Compiler(f, ir)
+func newCompiler(ir *wazeroir.CompilationResult) (compiler, error) {
+	return newArm64Compiler(ir)
 }

--- a/internal/wasm/jit/arch_arm64.s
+++ b/internal/wasm/jit/arch_arm64.s
@@ -7,8 +7,8 @@ TEXT ·jitcall(SB),NOSPLIT|NOFRAME,$0-24
         MOVD ce+8(FP),R0
         // In arm64, return address is stored in R30 after jumping into the code.
         // We save the return address value into archContext.jitReturnAddress in Engine.
-        // Note that the const 120 drifts after editting Engine or archContext struct. See TestArchContextOffsetInEngine.
-        MOVD R30,120(R0)
+        // Note that the const 128 drifts after editting Engine or archContext struct. See TestArchContextOffsetInEngine.
+        MOVD R30,128(R0)
         // Load the address of *wasm.ModuleInstance into arm64CallingConventionModuleInstanceAddressRegister.
         MOVD moduleInstanceAddress+16(FP),R29
         // Load the address of native code.

--- a/internal/wasm/jit/arch_other.go
+++ b/internal/wasm/jit/arch_other.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
@@ -14,6 +13,6 @@ import (
 type archContext struct{}
 
 // newCompiler returns an unsupported error.
-func newCompiler(f *wasm.FunctionInstance, ir *wazeroir.CompilationResult) (compiler, error) {
+func newCompiler(ir *wazeroir.CompilationResult) (compiler, error) {
 	return nil, fmt.Errorf("unsupported GOARCH %s", runtime.GOARCH)
 }

--- a/internal/wasm/jit/compiler.go
+++ b/internal/wasm/jit/compiler.go
@@ -14,8 +14,8 @@ type compiler interface {
 	compilePreamble() error
 	// compile generates the byte slice of native code.
 	// stackPointerCeil is the max stack pointer that the target function would reach.
-	// staticData is compiledFunctionStaticData for the resulting native code.
-	compile() (code []byte, staticData compiledFunctionStaticData, stackPointerCeil uint64, err error)
+	// staticData is codeStaticData for the resulting native code.
+	compile() (code []byte, staticData codeStaticData, stackPointerCeil uint64, err error)
 	// compileHostFunction emits the trampoline code from which native code can jump into the host function.
 	// TODO: maybe we wouldn't need to have trampoline for host functions.
 	compileHostFunction() error

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -164,6 +164,7 @@ type (
 		_ [8]byte
 	}
 
+	// Function corresponds to function instance in Wasm, and is created from `code`.
 	function struct {
 		// codeInitialAddress is the pre-calculated pointer pointing to the initial byte of .codeSegment slice.
 		// That mean codeInitialAddress always equals uintptr(unsafe.Pointer(&.codeSegment[0]))
@@ -176,10 +177,12 @@ type (
 		source *wasm.FunctionInstance
 		// moduleInstanceAddress holds the address of source.ModuleInstance.
 		moduleInstanceAddress uintptr
-		// parent holds code from which this is instantiated.
+		// parent holds code from which this is crated.
 		parent *code
 	}
 
+	// code corresponds to a function in a module (not insantaited one). This holds the machine code
+	// compiled by Wazero's JIT compiler.
 	code struct {
 		// codeSegment is holding the compiled native code as a byte slice.
 		codeSegment []byte

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -401,7 +401,7 @@ func (e *engine) CompileModule(module *wasm.Module) error {
 
 	funcs := make([]*code, 0, len(module.FunctionSection))
 
-	if module.IsHostMdule() {
+	if module.IsHostModule() {
 		for funcIndex := range module.HostFunctionSection {
 			compiled, err := compileHostFunction(module.TypeSection[module.FunctionSection[funcIndex]])
 			if err != nil {
@@ -428,8 +428,7 @@ func (e *engine) CompileModule(module *wasm.Module) error {
 				return fmt.Errorf("function[%d/%d] %w", funcIndex, len(module.FunctionSection)-1, err)
 			}
 
-			// As this uses mmap, we need a finalizer in case moduleEngine.Close was never called. Regardless, we need a
-			// finalizer due to how moduleEngine.Close is implemented.
+			// As this uses mmap, we need to munmap on the compiled machine code when it's GCed.
 			e.setFinalizer(compiled, releaseCode)
 
 			compiled.indexInModule = wasm.Index(funcIndex)

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"runtime"
-	"strconv"
 	"testing"
 	"unsafe"
 
@@ -35,6 +34,7 @@ func TestJIT_VerifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof(ce.tableElement0Address)), callEngineModuleContextTableElement0AddressOffset)
 	require.Equal(t, int(unsafe.Offsetof(ce.tableSliceLen)), callEngineModuleContextTableSliceLenOffset)
 	require.Equal(t, int(unsafe.Offsetof(ce.compiledFunctionsElement0Address)), callEngineModuleContextCompiledFunctionsElement0AddressOffset)
+	require.Equal(t, int(unsafe.Offsetof(ce.typeIDsElement0Address)), callEngineModuleContextTypeIDsElement0AddressOffset)
 
 	// Offsets for callEngine.valueStackContext
 	require.Equal(t, int(unsafe.Offsetof(ce.stackPointer)), callEngineValueStackContextStackPointerOffset)
@@ -55,11 +55,11 @@ func TestJIT_VerifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof(frame.compiledFunction)), callFrameCompiledFunctionOffset)
 
 	// Offsets for compiledFunction.
-	var compiledFunc compiledFunction
-	require.Equal(t, int(unsafe.Offsetof(compiledFunc.codeInitialAddress)), compiledFunctionCodeInitialAddressOffset)
-	require.Equal(t, int(unsafe.Offsetof(compiledFunc.stackPointerCeil)), compiledFunctionStackPointerCeilOffset)
-	require.Equal(t, int(unsafe.Offsetof(compiledFunc.source)), compiledFunctionSourceOffset)
-	require.Equal(t, int(unsafe.Offsetof(compiledFunc.moduleInstanceAddress)), compiledFunctionModuleInstanceAddressOffset)
+	var compiledFunc compiledFunctionInstance
+	require.Equal(t, int(unsafe.Offsetof(compiledFunc.codeInitialAddress)), compiledFunctionInstanceCodeInitialAddressOffset)
+	require.Equal(t, int(unsafe.Offsetof(compiledFunc.stackPointerCeil)), compiledFunctionInstanceStackPointerCeilOffset)
+	require.Equal(t, int(unsafe.Offsetof(compiledFunc.source)), compiledFunctionInstanceSourceOffset)
+	require.Equal(t, int(unsafe.Offsetof(compiledFunc.moduleInstanceAddress)), compiledFunctionInstanceModuleInstanceAddressOffset)
 
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance
@@ -67,6 +67,7 @@ func TestJIT_VerifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Memory)), moduleInstanceMemoryOffset)
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Table)), moduleInstanceTableOffset)
 	require.Equal(t, int(unsafe.Offsetof(moduleInstance.Engine)), moduleInstanceEngineOffset)
+	require.Equal(t, int(unsafe.Offsetof(moduleInstance.TypeIDs)), moduleInstanceTypeIDsOffset)
 
 	var functionInstance wasm.FunctionInstance
 	require.Equal(t, int(unsafe.Offsetof(functionInstance.TypeID)), functionInstanceTypeIDOffset)
@@ -147,53 +148,6 @@ func requireSupportedOSArch(t *testing.T) {
 	}
 }
 
-func TestJIT_EngineCompile_Errors(t *testing.T) {
-	t.Run("invalid import", func(t *testing.T) {
-		e := et.NewEngine(wasm.Features20191205)
-		_, err := e.NewModuleEngine(
-			t.Name(),
-			&wasm.Module{},
-			[]*wasm.FunctionInstance{{Module: &wasm.ModuleInstance{Name: "uncompiled"}, DebugName: "uncompiled.fn"}},
-			nil, // moduleFunctions
-			nil, // table
-			nil, // tableInit
-		)
-		require.EqualError(t, err, "import[0] func[uncompiled.fn]: uncompiled")
-	})
-
-	t.Run("release on compilation error", func(t *testing.T) {
-		e := et.NewEngine(wasm.Features20191205).(*engine)
-
-		importedFunctions := []*wasm.FunctionInstance{
-			{DebugName: "1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "3", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "4", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-		}
-		_, err := e.NewModuleEngine(t.Name(), &wasm.Module{}, nil, importedFunctions, nil, nil)
-		require.NoError(t, err)
-
-		require.Equal(t, len(importedFunctions), len(e.compiledFunctions))
-
-		moduleFunctions := []*wasm.FunctionInstance{
-			{DebugName: "ok1", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "ok2", Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}},
-			{DebugName: "invalid code", Type: &wasm.FunctionType{}, Body: []byte{
-				wasm.OpcodeCall, // Call instruction without immediate for call target index is invalid and should fail to compile.
-			}, Module: &wasm.ModuleInstance{}},
-		}
-
-		_, err = e.NewModuleEngine(t.Name(), &wasm.Module{}, importedFunctions, moduleFunctions, nil, nil)
-		require.EqualError(t, err, "function[invalid code(2/2)] failed to lower to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
-
-		// On the compilation failure, all the compiled functions including succeeded ones must be released.
-		require.Equal(t, len(importedFunctions), len(e.compiledFunctions))
-		for _, f := range moduleFunctions {
-			require.Nil(t, e.compiledFunctions[f])
-		}
-	})
-}
-
 type fakeFinalizer map[*compiledFunction]func(*compiledFunction)
 
 func (f fakeFinalizer) setFinalizer(obj interface{}, finalizer interface{}) {
@@ -204,162 +158,71 @@ func (f fakeFinalizer) setFinalizer(obj interface{}, finalizer interface{}) {
 	f[cf] = finalizer.(func(*compiledFunction))
 }
 
-func TestJIT_NewModuleEngine_CompiledFunctions(t *testing.T) {
-	e := et.NewEngine(wasm.Features20191205).(*engine)
+func TestJIT_CompileModule(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		e := et.NewEngine(wasm.Features20191205).(*engine)
+		ff := fakeFinalizer{}
+		e.setFinalizer = ff.setFinalizer
 
-	importedFinalizer := fakeFinalizer{}
-	e.setFinalizer = importedFinalizer.setFinalizer
+		okModule := &wasm.Module{
+			TypeSection:     []*wasm.FunctionType{{}},
+			FunctionSection: []wasm.Index{0, 0, 0, 0},
+			CodeSection: []*wasm.Code{
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+			},
+		}
 
-	importedFunctions := []*wasm.FunctionInstance{
-		newFunctionInstance(10),
-		newFunctionInstance(20),
-	}
-	modE, err := e.NewModuleEngine(t.Name(), &wasm.Module{}, nil, importedFunctions, nil, nil)
-	require.NoError(t, err)
-	defer modE.Close()
-	imported := modE.(*moduleEngine)
+		err := e.CompileModule(okModule)
+		require.NoError(t, err)
 
-	importingFinalizer := fakeFinalizer{}
-	e.setFinalizer = importingFinalizer.setFinalizer
+		// Compiling same module shouldn't be compiled again, but instead should be cached.
+		err = e.CompileModule(okModule)
+		require.NoError(t, err)
 
-	moduleFunctions := []*wasm.FunctionInstance{
-		newFunctionInstance(100),
-		newFunctionInstance(200),
-		newFunctionInstance(300),
-	}
+		compiled, ok := e.compiledFunctions[okModule]
+		require.True(t, ok)
+		require.Equal(t, len(okModule.FunctionSection), len(compiled))
 
-	modE, err = e.NewModuleEngine(t.Name(), &wasm.Module{}, importedFunctions, moduleFunctions, nil, nil)
-	require.NoError(t, err)
-	defer modE.Close()
-	importing := modE.(*moduleEngine)
+		// Pretend the finalizer executed, by invoking them one-by-one.
+		for k, v := range ff {
+			v(k)
+		}
+	})
 
-	// Ensure the importing module didn't try to finalize the imported functions.
-	require.Equal(t, len(importedFunctions), len(imported.compiledFunctions))
-	for _, f := range importedFunctions {
-		require.NotNil(t, e.compiledFunctions[f], f)
-		cf := e.compiledFunctions[f]
-		require.NotNil(t, importedFinalizer[cf], cf)
-		require.Nil(t, importingFinalizer[cf], cf)
-	}
+	t.Run("fail", func(t *testing.T) {
+		errModule := &wasm.Module{
+			TypeSection:     []*wasm.FunctionType{{}},
+			FunctionSection: []wasm.Index{0, 0, 0},
+			CodeSection: []*wasm.Code{
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeEnd}},
+				{Body: []byte{wasm.OpcodeCall}}, // Call instruction without immediate for call target index is invalid and should fail to compile.
+			},
+		}
 
-	// The importing module's compiled functions include ones it compiled (module-defined) and imported ones).
-	require.Equal(t, len(importedFunctions)+len(moduleFunctions), len(importing.compiledFunctions))
+		e := et.NewEngine(wasm.Features20191205).(*engine)
+		err := e.CompileModule(errModule)
+		require.EqualError(t, err, "failed to lower func[2/3] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
 
-	// Ensure the importing module only tried to finalize its own functions.
-	for _, f := range moduleFunctions {
-		require.NotNil(t, e.compiledFunctions[f], f)
-		cf := e.compiledFunctions[f]
-		require.Nil(t, importedFinalizer[cf], cf)
-		require.NotNil(t, importingFinalizer[cf], cf)
-	}
-
-	// Pretend the finalizer executed, by invoking them one-by-one.
-	for k, v := range importingFinalizer {
-		v(k)
-	}
-	for k, v := range importedFinalizer {
-		v(k)
-	}
-	for _, f := range e.compiledFunctions {
-		require.Nil(t, f.codeSegment) // Set to nil if the correct finalizer was associated.
-	}
+		// On the compilation failure, the compiled functions must not be cached.
+		_, ok := e.compiledFunctions[errModule]
+		require.False(t, ok)
+	})
 }
 
 // TestReleaseCompiledFunction_Panic tests that an unexpected panic has some identifying information in it.
 func TestJIT_ReleaseCompiledFunction_Panic(t *testing.T) {
 	captured := require.CapturePanic(func() {
 		releaseCompiledFunction(&compiledFunction{
-			codeSegment: []byte{wasm.OpcodeEnd},                                                         // never compiled means it was never mapped.
-			source:      &wasm.FunctionInstance{Index: 2, Module: &wasm.ModuleInstance{Name: t.Name()}}, // for error string
+			indexInModule: 2,
+			sourceModule:  &wasm.Module{NameSection: &wasm.NameSection{ModuleName: t.Name()}},
+			codeSegment:   []byte{wasm.OpcodeEnd}, // never compiled means it was never mapped.
 		})
 	})
-	require.Contains(t, captured.Error(), fmt.Sprintf("jit: failed to munmap code segment for %[1]s.function[2]:", t.Name()))
-}
-
-func TestJIT_ModuleEngine_Close(t *testing.T) {
-	newFunctionInstance := func(id int) *wasm.FunctionInstance {
-		return &wasm.FunctionInstance{
-			DebugName: strconv.Itoa(id), Type: &wasm.FunctionType{}, Body: []byte{wasm.OpcodeEnd}, Module: &wasm.ModuleInstance{}}
-	}
-
-	for _, tc := range []struct {
-		name                               string
-		importedFunctions, moduleFunctions []*wasm.FunctionInstance
-	}{
-		{
-			name:            "no imports",
-			moduleFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
-		},
-		{
-			name:              "only imports",
-			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
-		},
-		{
-			name:              "mix",
-			importedFunctions: []*wasm.FunctionInstance{newFunctionInstance(0), newFunctionInstance(1)},
-			moduleFunctions:   []*wasm.FunctionInstance{newFunctionInstance(100), newFunctionInstance(200), newFunctionInstance(300)},
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			e := et.NewEngine(wasm.Features20191205).(*engine)
-			var imported *moduleEngine
-			if len(tc.importedFunctions) > 0 {
-				// Instantiate the imported module
-				modEngine, err := e.NewModuleEngine(
-					fmt.Sprintf("%s - imported functions", t.Name()),
-					&wasm.Module{},
-					nil, // moduleFunctions
-					tc.importedFunctions,
-					nil, // table
-					nil, // tableInit
-				)
-				require.NoError(t, err)
-				imported = modEngine.(*moduleEngine)
-				require.Equal(t, len(tc.importedFunctions), len(imported.compiledFunctions))
-			}
-
-			importing, err := e.NewModuleEngine(
-				fmt.Sprintf("%s - module-defined functions", t.Name()),
-				&wasm.Module{},
-				tc.importedFunctions,
-				tc.moduleFunctions,
-				nil, // table
-				nil, // tableInit
-			)
-			require.NoError(t, err)
-			require.Equal(t, len(tc.importedFunctions)+len(tc.moduleFunctions), len(importing.(*moduleEngine).compiledFunctions))
-
-			require.Equal(t, len(tc.importedFunctions)+len(tc.moduleFunctions), len(e.compiledFunctions))
-
-			for _, f := range tc.importedFunctions {
-				require.NotNil(t, e.compiledFunctions[f], f)
-			}
-			for _, f := range tc.moduleFunctions {
-				require.NotNil(t, e.compiledFunctions[f], f)
-			}
-
-			importing.Close()
-
-			// Closing the importing module shouldn't delete the imported functions from the engine.
-			require.Equal(t, len(tc.importedFunctions), len(e.compiledFunctions))
-			for _, f := range tc.importedFunctions {
-				require.NotNil(t, e.compiledFunctions[f], f)
-			}
-
-			// However, closing the importing module should delete its own functions from the engine.
-			for i, f := range tc.moduleFunctions {
-				require.Nil(t, e.compiledFunctions[f], i)
-			}
-
-			if len(tc.importedFunctions) > 0 {
-				imported.Close()
-			}
-
-			// When all modules are closed, the engine should be empty.
-			require.Equal(t, 0, len(e.compiledFunctions), "expected no compiledFunctions")
-		})
-	}
+	require.Contains(t, captured.Error(), fmt.Sprintf("jit: failed to munmap code segment for %[1]s.function[2]", t.Name()))
 }
 
 // Ensures that value stack and call-frame stack are allocated on heap which
@@ -389,6 +252,9 @@ func TestJIT_SliceAllocatedOnHeap(t *testing.T) {
 		// goroutine stack unused after recursive call.
 		runtime.GC()
 	}}, map[string]*wasm.Memory{}, map[string]*wasm.Global{}, enabledFeatures)
+	require.NoError(t, err)
+
+	err = store.Engine.CompileModule(hm)
 	require.NoError(t, err)
 
 	_, err = store.Instantiate(context.Background(), hm, hostModuleName, nil)
@@ -442,6 +308,9 @@ func TestJIT_SliceAllocatedOnHeap(t *testing.T) {
 		},
 	}
 
+	err = store.Engine.CompileModule(m)
+	require.NoError(t, err)
+
 	mi, err := store.Instantiate(context.Background(), m, t.Name(), nil)
 	require.NoError(t, err)
 
@@ -457,114 +326,24 @@ func TestJIT_SliceAllocatedOnHeap(t *testing.T) {
 }
 
 // TODO: move most of this logic to enginetest.go so that there is less drift between interpreter and jit
-func TestEngine_CachedCompiledFunctionsPerModule(t *testing.T) {
+func TestEngine_CachedCompiledFunctions(t *testing.T) {
 	e := newEngine(wasm.Features20191205)
 	exp := []*compiledFunction{
-		{source: &wasm.FunctionInstance{DebugName: "1"}},
-		{source: &wasm.FunctionInstance{DebugName: "2"}},
+		{codeSegment: []byte{0x0}},
+		{codeSegment: []byte{0x0}},
 	}
 	m := &wasm.Module{}
 
-	e.addCachedCompiledFunctions(m, exp)
+	e.addCompiledFunctions(m, exp)
 
-	actual, ok := e.getCachedCompiledFunctions(m)
+	actual, ok := e.getCompiledFunctions(m)
 	require.True(t, ok)
 	require.Equal(t, len(exp), len(actual))
 	for i := range actual {
 		require.Equal(t, exp[i], actual[i])
 	}
 
-	e.deleteCachedCompiledFunctions(m)
-	_, ok = e.getCachedCompiledFunctions(m)
+	e.deleteCompiledFunctions(m)
+	_, ok = e.getCompiledFunctions(m)
 	require.False(t, ok)
-}
-
-// TODO: move most of this logic to enginetest.go so that there is less drift between interpreter and jit
-func TestEngine_NewModuleEngine_cache(t *testing.T) {
-	e := newEngine(wasm.Features20191205)
-	importedModuleSource := &wasm.Module{}
-
-	// No cache.
-	importedME, err := e.NewModuleEngine("1", importedModuleSource, nil, []*wasm.FunctionInstance{
-		newFunctionInstance(1),
-		newFunctionInstance(2),
-	}, nil, nil)
-	require.NoError(t, err)
-
-	// Cached.
-	importedMEFromCache, err := e.NewModuleEngine("2", importedModuleSource, nil, []*wasm.FunctionInstance{
-		newFunctionInstance(1),
-		newFunctionInstance(2),
-	}, nil, nil)
-	require.NoError(t, err)
-
-	require.NotEqual(t, importedME, importedMEFromCache)
-	require.NotEqual(t, importedME.Name(), importedMEFromCache.Name())
-
-	// Check compiled functions.
-	ime, imeCache := importedME.(*moduleEngine), importedMEFromCache.(*moduleEngine)
-	require.Equal(t, len(ime.compiledFunctions), len(imeCache.compiledFunctions))
-
-	for i, fn := range ime.compiledFunctions {
-		// Compiled functions must be cloend.
-		fnCached := imeCache.compiledFunctions[i]
-		require.NotEqual(t, fn, fnCached)
-		require.NotEqual(t, fn.moduleInstanceAddress, fnCached.moduleInstanceAddress)
-		require.NotEqual(t, unsafe.Pointer(fn.source), unsafe.Pointer(fnCached.source)) // unsafe.Pointer to compare the actual address.
-		// But the code segment stays the same.
-		require.Equal(t, fn.codeSegment, fnCached.codeSegment)
-	}
-
-	// Next is to veirfy the caching works for modules with imports.
-	importedFunc := ime.compiledFunctions[0].source
-	moduleSource := &wasm.Module{}
-
-	// No cache.
-	modEng, err := e.NewModuleEngine("3", moduleSource,
-		[]*wasm.FunctionInstance{importedFunc}, // Import one function.
-		[]*wasm.FunctionInstance{
-			newFunctionInstance(10),
-			newFunctionInstance(20),
-		}, nil, nil)
-	require.NoError(t, err)
-
-	// Cached.
-	modEngCache, err := e.NewModuleEngine("4", moduleSource,
-		[]*wasm.FunctionInstance{importedFunc}, // Import one function.
-		[]*wasm.FunctionInstance{
-			newFunctionInstance(10),
-			newFunctionInstance(20),
-		}, nil, nil)
-	require.NoError(t, err)
-
-	require.NotEqual(t, modEng, modEngCache)
-	require.NotEqual(t, modEng.Name(), modEngCache.Name())
-
-	me, meCache := modEng.(*moduleEngine), modEngCache.(*moduleEngine)
-	require.Equal(t, len(me.compiledFunctions), len(meCache.compiledFunctions))
-
-	for i, fn := range me.compiledFunctions {
-		fnCached := meCache.compiledFunctions[i]
-		if i == 0 {
-			// This case the function is imported, so it must be the same for both module engines.
-			require.Equal(t, fn, fnCached)
-			require.Equal(t, importedFunc, fn.source)
-		} else {
-			// Compiled functions must be cloend.
-			require.NotEqual(t, fn, fnCached)
-			require.NotEqual(t, fn.moduleInstanceAddress, fnCached.moduleInstanceAddress)
-			require.NotEqual(t, unsafe.Pointer(fn.source), unsafe.Pointer(fnCached.source)) // unsafe.Pointer to compare the actual address.
-			// But the code segment stays the same.
-			require.Equal(t, fn.codeSegment, fnCached.codeSegment)
-		}
-	}
-}
-
-func newFunctionInstance(id int) *wasm.FunctionInstance {
-	return &wasm.FunctionInstance{
-		DebugName: strconv.Itoa(id),
-		Type:      &wasm.FunctionType{},
-		Body:      []byte{wasm.OpcodeEnd},
-		Module:    &wasm.ModuleInstance{},
-	}
 }

--- a/internal/wasm/jit/jit_global_test.go
+++ b/internal/wasm/jit/jit_global_test.go
@@ -16,7 +16,10 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 		tp := tp
 		t.Run(wasm.ValueTypeName(tp), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+				Signature: &wasm.FunctionType{},
+				Globals:   []*wasm.GlobalType{nil, {ValType: tp}},
+			})
 
 			// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
 			globals := []*wasm.GlobalInstance{nil, {Val: globalValue, Type: &wasm.GlobalType{ValType: tp}}}
@@ -66,7 +69,10 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 		tp := tp
 		t.Run(wasm.ValueTypeName(tp), func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+				Signature: &wasm.FunctionType{},
+				Globals:   []*wasm.GlobalType{nil, {ValType: tp}},
+			})
 
 			// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
 			env.addGlobals(nil, &wasm.GlobalInstance{Val: 40, Type: &wasm.GlobalType{ValType: tp}})

--- a/internal/wasm/jit/jit_impl_arm64.go
+++ b/internal/wasm/jit/jit_impl_arm64.go
@@ -3221,10 +3221,10 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 			tmpX,
 		)
 
-		// "tmpY = [tmpX + moduleEnginecodesOffset] (== &moduleEngine.codes[0])"
+		// "tmpY = [tmpX + moduleEngineFunctionsOffset] (== &moduleEngine.codes[0])"
 		c.assembler.CompileMemoryToRegister(
 			arm64.MOVD,
-			tmpX, moduleEnginecodesOffset,
+			tmpX, moduleEngineFunctionsOffset,
 			tmpY,
 		)
 

--- a/internal/wasm/jit/jit_initialization_test.go
+++ b/internal/wasm/jit/jit_initialization_test.go
@@ -81,7 +81,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 				ir.Globals = append(ir.Globals, g.Type)
 			}
 			compiler := env.requireNewCompiler(t, newCompiler, ir)
-			me := &moduleEngine{compiledFunctions: make([]*compiledFunctionInstance, 10)}
+			me := &moduleEngine{functions: make([]*function, 10)}
 			tc.moduleInstance.Engine = me
 
 			// The golang-asm assembler skips the first instruction, so we emit NOP here which is ignored.
@@ -120,7 +120,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 				require.Equal(t, uintptr(unsafe.Pointer(&tc.moduleInstance.TypeIDs[0])), ce.moduleContext.typeIDsElement0Address)
 			}
 
-			require.Equal(t, uintptr(unsafe.Pointer(&me.compiledFunctions[0])), ce.moduleContext.compiledFunctionsElement0Address)
+			require.Equal(t, uintptr(unsafe.Pointer(&me.functions[0])), ce.moduleContext.codesElement0Address)
 		})
 	}
 }

--- a/internal/wasm/jit/jit_initialization_test.go
+++ b/internal/wasm/jit/jit_initialization_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
 func TestCompiler_compileModuleContextInitialization(t *testing.T) {
@@ -21,13 +22,15 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
+				TypeIDs: make([]wasm.FunctionTypeID, 10),
 			},
 		},
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:  &wasm.TableInstance{Table: make([]interface{}, 20)},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
+				TypeIDs: make([]wasm.FunctionTypeID, 10),
 			},
 		},
 		{
@@ -35,19 +38,22 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			moduleInstance: &wasm.ModuleInstance{
 				Globals: []*wasm.GlobalInstance{{Val: 100}},
 				Table:   &wasm.TableInstance{Table: make([]interface{}, 20)},
+				TypeIDs: make([]wasm.FunctionTypeID, 10),
 			},
 		},
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
-				Table:  &wasm.TableInstance{Table: nil},
+				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Table:   &wasm.TableInstance{Table: nil},
+				TypeIDs: make([]wasm.FunctionTypeID, 10),
 			},
 		},
 		{
 			name: "table empty",
 			moduleInstance: &wasm.ModuleInstance{
-				Table: &wasm.TableInstance{Table: make([]interface{}, 0)},
+				Table:   &wasm.TableInstance{Table: make([]interface{}, 0)},
+				TypeIDs: make([]wasm.FunctionTypeID, 10),
 			},
 		},
 		{
@@ -67,8 +73,15 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			env.moduleInstance = tc.moduleInstance
 			ce := env.callEngine()
 
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
-			me := &moduleEngine{compiledFunctions: make([]*compiledFunction, 10)}
+			ir := &wazeroir.CompilationResult{
+				HasMemory: tc.moduleInstance.Memory != nil,
+				HasTable:  tc.moduleInstance.Table != nil,
+			}
+			for _, g := range tc.moduleInstance.Globals {
+				ir.Globals = append(ir.Globals, g.Type)
+			}
+			compiler := env.requireNewCompiler(t, newCompiler, ir)
+			me := &moduleEngine{compiledFunctions: make([]*compiledFunctionInstance, 10)}
 			tc.moduleInstance.Engine = me
 
 			// The golang-asm assembler skips the first instruction, so we emit NOP here which is ignored.
@@ -104,6 +117,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 				tableHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Table.Table))
 				require.Equal(t, uint64(tableHeader.Len), ce.moduleContext.tableSliceLen)
 				require.Equal(t, tableHeader.Data, ce.moduleContext.tableElement0Address)
+				require.Equal(t, uintptr(unsafe.Pointer(&tc.moduleInstance.TypeIDs[0])), ce.moduleContext.typeIDsElement0Address)
 			}
 
 			require.Equal(t, uintptr(unsafe.Pointer(&me.compiledFunctions[0])), ce.moduleContext.compiledFunctionsElement0Address)

--- a/internal/wasm/jit/jit_memory_test.go
+++ b/internal/wasm/jit/jit_memory_test.go
@@ -51,7 +51,7 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 
 func TestCompiler_compileMemorySize(t *testing.T) {
 	env := newJITEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, nil)
+	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -235,7 +235,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestCompiler_compileStore(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newJITEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)

--- a/internal/wasm/jit/jit_test.go
+++ b/internal/wasm/jit/jit_test.go
@@ -117,10 +117,10 @@ func (j *jitEnv) callEngine() *callEngine {
 	return j.ce
 }
 
-func (j *jitEnv) exec(code []byte) {
-	compiledFunction := &compiledFunctionInstance{
-		codeSegment:           code,
-		codeInitialAddress:    uintptr(unsafe.Pointer(&code[0])),
+func (j *jitEnv) exec(codeSegment []byte) {
+	f := &function{
+		parent:                &code{codeSegment: codeSegment},
+		codeInitialAddress:    uintptr(unsafe.Pointer(&codeSegment[0])),
 		moduleInstanceAddress: uintptr(unsafe.Pointer(j.moduleInstance)),
 		source: &wasm.FunctionInstance{
 			Kind:   wasm.FunctionKindWasm,
@@ -129,11 +129,11 @@ func (j *jitEnv) exec(code []byte) {
 		},
 	}
 
-	j.ce.callFrameStack[j.ce.globalContext.callFrameStackPointer] = callFrame{compiledFunction: compiledFunction}
+	j.ce.callFrameStack[j.ce.globalContext.callFrameStackPointer] = callFrame{function: f}
 	j.ce.globalContext.callFrameStackPointer++
 
 	jitcall(
-		uintptr(unsafe.Pointer(&code[0])),
+		uintptr(unsafe.Pointer(&codeSegment[0])),
 		uintptr(unsafe.Pointer(j.ce)),
 		uintptr(unsafe.Pointer(j.moduleInstance)),
 	)

--- a/internal/wasm/jit/mmap_test.go
+++ b/internal/wasm/jit/mmap_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-var code, _ = io.ReadAll(io.LimitReader(rand.Reader, 8*1024))
+var testCode, _ = io.ReadAll(io.LimitReader(rand.Reader, 8*1024))
 
 func Test_mmapCodeSegment(t *testing.T) {
 	requireSupportedOSArch(t)
-	newCode, err := mmapCodeSegment(code)
+	newCode, err := mmapCodeSegment(testCode)
 	require.NoError(t, err)
 	// Verify that the mmap is the same as the original.
-	require.Equal(t, code, newCode)
+	require.Equal(t, testCode, newCode)
 	// TODO: test newCode can executed.
 
 	t.Run("panic on zero length", func(t *testing.T) {
@@ -30,9 +30,9 @@ func Test_munmapCodeSegment(t *testing.T) {
 	requireSupportedOSArch(t)
 
 	// Errors if never mapped
-	require.Error(t, munmapCodeSegment(code))
+	require.Error(t, munmapCodeSegment(testCode))
 
-	newCode, err := mmapCodeSegment(code)
+	newCode, err := mmapCodeSegment(testCode)
 	require.NoError(t, err)
 	// First munmap should succeed.
 	require.NoError(t, munmapCodeSegment(newCode))

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -210,7 +210,7 @@ func (m *Module) Validate(enabledFeatures Features) error {
 		return errors.New("cannot mix functions and host functions in the same module")
 	}
 
-	functions, globals, memory, table, err := m.allDeclarations()
+	functions, globals, memory, table, err := m.AllDeclarations()
 	if err != nil {
 		return err
 	}
@@ -692,8 +692,8 @@ type NameMapAssoc struct {
 	NameMap NameMap
 }
 
-// allDeclarations returns all declarations for functions, globals, memories and tables in a module including imported ones.
-func (m *Module) allDeclarations() (functions []Index, globals []*GlobalType, memory *Memory, table *Table, err error) {
+// AllDeclarations returns all declarations for functions, globals, memories and tables in a module including imported ones.
+func (m *Module) AllDeclarations() (functions []Index, globals []*GlobalType, memory *Memory, table *Table, err error) {
 	for _, imp := range m.ImportSection {
 		switch imp.Type {
 		case ExternTypeFunc:

--- a/internal/wasm/module_context.go
+++ b/internal/wasm/module_context.go
@@ -89,7 +89,6 @@ func (m *ModuleContext) CloseWithExitCode(exitCode uint32) (err error) {
 	if !atomic.CompareAndSwapUint64(m.closed, 0, closed) {
 		return nil
 	}
-	m.module.Engine.Close()
 	m.store.deleteModule(m.Name())
 	if sys := m.Sys; sys != nil { // ex nil if from ModuleBuilder
 		return sys.Close()

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -167,7 +167,7 @@ func TestModule_allDeclarations(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			functions, globals, memory, table, err := tc.module.allDeclarations()
+			functions, globals, memory, table, err := tc.module.AllDeclarations()
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedFunctions, functions)
 			require.Equal(t, tc.expectedGlobals, globals)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -70,7 +70,7 @@ type (
 		// Engine implements function calls for this module.
 		Engine ModuleEngine
 
-		// TypeIDs map type index(wasm.Index) to typeID which is uniquely assigned by store.
+		// TypeIDs is index-correlated with types and holds typeIDs which is uniquely assigned to a type by store.
 		// This is necessary to achieve fast runtime type checking for indirect function calls at runtime.
 		TypeIDs []FunctionTypeID
 	}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -444,8 +444,11 @@ func (e *mockEngine) NewModuleEngine(_ string, _ *Module, _, _ []*FunctionInstan
 	return &mockModuleEngine{callFailIndex: e.callFailIndex}, nil
 }
 
-// ReleaseCompilationCache implements the same method as documented on wasm.Engine.
-func (e *mockEngine) ReleaseCompilationCache(*Module) {}
+// DeleteCompiledModule implements the same method as documented on wasm.Engine.
+func (e *mockEngine) DeleteCompiledModule(*Module) {}
+
+// CompileModule implements the same method as documented on wasm.Engine.
+func (e *mockEngine) CompileModule(module *Module) error { return nil }
 
 // Name implements the same method as documented on wasm.ModuleEngine.
 func (e *mockModuleEngine) Name() string {
@@ -466,7 +469,7 @@ func (e *mockModuleEngine) Call(ctx *ModuleContext, f *FunctionInstance, _ ...ui
 func (e *mockModuleEngine) Close() {
 }
 
-func TestStore_getTypeInstance(t *testing.T) {
+func TestStore_getFunctionTypeID(t *testing.T) {
 	t.Run("too many functions", func(t *testing.T) {
 		s := newStore()
 		const max = 10
@@ -475,7 +478,7 @@ func TestStore_getTypeInstance(t *testing.T) {
 		for i := 0; i < max; i++ {
 			s.typeIDs[strconv.Itoa(i)] = 0
 		}
-		_, err := s.getTypeInstance(&FunctionType{})
+		_, err := s.getFunctionTypeID(&FunctionType{})
 		require.Error(t, err)
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -488,13 +491,12 @@ func TestStore_getTypeInstance(t *testing.T) {
 			tc := tc
 			t.Run(tc.String(), func(t *testing.T) {
 				s := newStore()
-				actual, err := s.getTypeInstance(tc)
+				actual, err := s.getFunctionTypeID(tc)
 				require.NoError(t, err)
 
 				expectedTypeID, ok := s.typeIDs[tc.String()]
 				require.True(t, ok)
-				require.Equal(t, expectedTypeID, actual.TypeID)
-				require.Equal(t, tc, actual.Type)
+				require.Equal(t, expectedTypeID, actual)
 			})
 		}
 	})

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -116,14 +116,18 @@ type compiler struct {
 	pc     uint64
 	result CompilationResult
 
-	// Function information
-	body       []byte
-	sig        *wasm.FunctionType
+	// body holds the code for the function's body where Wasm instructions are stored.
+	body []byte
+	// sig is the function type of the target function.
+	sig *wasm.FunctionType
+	// localTypes holds the target function locals' value types.
 	localTypes []wasm.ValueType
 
-	// Module information.
-	types   []*wasm.FunctionType
-	funcs   []uint32
+	// types hold all the function types in the module where the targe function exists.
+	types []*wasm.FunctionType
+	// funcs holds the type indexes for all declard functions in the module where the targe function exists.
+	funcs []uint32
+	// globals holds the global types for all declard globas in the module where the targe function exists.
 	globals []*wasm.GlobalType
 }
 

--- a/wasm.go
+++ b/wasm.go
@@ -164,6 +164,9 @@ func (r *runtime) CompileModule(source []byte) (*CompiledCode, error) {
 		return nil, err
 	}
 
+	if err = r.store.Engine.CompileModule(internal); err != nil {
+		return nil, err
+	}
 	return &CompiledCode{module: internal}, nil
 }
 
@@ -207,6 +210,12 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 	}
 
 	module := config.replaceImports(code.module)
+	if module != code.module {
+		// IF the module changed, we have to Compile again before instantiation.
+		if err = r.store.Engine.CompileModule(module); err != nil {
+			return nil, err
+		}
+	}
 
 	mod, err = r.store.Instantiate(r.ctx, module, name, sysCtx)
 	if err != nil {

--- a/wasm.go
+++ b/wasm.go
@@ -167,7 +167,10 @@ func (r *runtime) CompileModule(source []byte) (*CompiledCode, error) {
 	if err = r.store.Engine.CompileModule(internal); err != nil {
 		return nil, err
 	}
-	return &CompiledCode{module: internal}, nil
+
+	ret := &CompiledCode{module: internal}
+	ret.addCacheEntry(internal, r.store.Engine)
+	return ret, nil
 }
 
 // InstantiateModuleFromCode implements Runtime.InstantiateModuleFromCode
@@ -216,6 +219,7 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 		if err = r.store.Engine.CompileModule(module); err != nil {
 			return nil, err
 		}
+		code.addCacheEntry(module, r.store.Engine)
 	}
 
 	mod, err = r.store.Instantiate(r.ctx, module, name, sysCtx)
@@ -236,6 +240,5 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 			return
 		}
 	}
-	code.addCacheEntry(module, r.store.Engine)
 	return
 }

--- a/wasm.go
+++ b/wasm.go
@@ -211,7 +211,8 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 
 	module := config.replaceImports(code.module)
 	if module != code.module {
-		// IF the module changed, we have to Compile again before instantiation.
+		// If replacing imports had an effect, the module changed, so we have to recompile it.
+		// TODO: maybe we should move replaceImports configs into CompileModule.
 		if err = r.store.Engine.CompileModule(module); err != nil {
 			return nil, err
 		}

--- a/wasm.go
+++ b/wasm.go
@@ -167,7 +167,7 @@ func (r *runtime) CompileModule(source []byte) (*CompiledCode, error) {
 	if err = r.store.Engine.CompileModule(internal); err != nil {
 		return nil, err
 	}
-	return &CompiledCode{module: internal}, nil
+	return &CompiledCode{module: internal, compiledEngine: r.store.Engine}, nil
 }
 
 // InstantiateModuleFromCode implements Runtime.InstantiateModuleFromCode
@@ -210,13 +210,6 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 	}
 
 	module := config.replaceImports(code.module)
-	if module != code.module {
-		// If replacing imports had an effect, the module changed, so we have to recompile it.
-		// TODO: maybe we should move replaceImports configs into CompileModule.
-		if err = r.store.Engine.CompileModule(module); err != nil {
-			return nil, err
-		}
-	}
 
 	mod, err = r.store.Instantiate(r.ctx, module, name, sysCtx)
 	if err != nil {
@@ -236,6 +229,5 @@ func (r *runtime) InstantiateModuleWithConfig(code *CompiledCode, config *Module
 			return
 		}
 	}
-	code.addCacheEntry(module, r.store.Engine)
 	return
 }

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
@@ -427,25 +428,57 @@ func requireImportAndExportFunction(t *testing.T, r Runtime, hostFn func(ctx api
 	)), mod.Close
 }
 
-func TestCompiledCode_Close(t *testing.T) {
-	e := &mockEngine{name: "1", cachedModules: map[*wasm.Module]struct{}{}}
+func TestCompiledCode_addCacheEntry(t *testing.T) {
+	c := &CompiledCode{}
 
-	var cs []*CompiledCode
-	for i := 0; i < 10; i++ {
-		m := &wasm.Module{}
-		e.CompileModule(m)
-		cs = append(cs, &CompiledCode{module: m, compiledEngine: e})
+	m1, e1 := &wasm.Module{}, &mockEngine{name: "1"}
+	for i := 0; i < 5; i++ {
+		c.addCacheEntry(m1, e1)
+	}
+
+	require.NotNil(t, c.cachedEngines[e1])
+	require.NotNil(t, c.cachedEngines[e1][m1])
+	require.Equal(t, 1, len(c.cachedEngines[e1]))
+
+	m2, e2 := &wasm.Module{}, &mockEngine{name: "2"}
+	for i := 0; i < 5; i++ {
+		c.addCacheEntry(m2, e2)
+	}
+
+	require.NotNil(t, c.cachedEngines[e1])
+	require.NotNil(t, c.cachedEngines[e2])
+	require.NotNil(t, c.cachedEngines[e1][m1])
+	require.NotNil(t, c.cachedEngines[e2][m2])
+	require.Equal(t, 1, len(c.cachedEngines[e1]))
+	require.Equal(t, 1, len(c.cachedEngines[e2]))
+}
+
+func TestCompiledCode_Close(t *testing.T) {
+	e1, e2 := &mockEngine{name: "1", cachedModules: map[*wasm.Module]struct{}{}},
+		&mockEngine{name: "2", cachedModules: map[*wasm.Module]struct{}{}}
+
+	c := &CompiledCode{}
+	for _, e := range []wasm.Engine{e1, e2} {
+		for i := 0; i < 10; i++ {
+			m := &wasm.Module{}
+			_, _ = e.NewModuleEngine(strconv.Itoa(i), m, nil, nil, nil, nil)
+			c.addCacheEntry(m, e)
+		}
 	}
 
 	// Before Close.
-	require.Equal(t, 10, len(e.cachedModules))
-
-	for _, c := range cs {
-		c.Close()
+	require.Equal(t, 10, len(e1.cachedModules))
+	require.Equal(t, 10, len(e2.cachedModules))
+	require.Equal(t, 2, len(c.cachedEngines))
+	for _, modules := range c.cachedEngines {
+		require.Equal(t, 10, len(modules))
 	}
 
+	c.Close()
+
 	// After Close.
-	require.Zero(t, len(e.cachedModules))
+	require.Zero(t, len(e1.cachedModules))
+	require.Zero(t, len(e2.cachedModules))
 }
 
 type mockEngine struct {
@@ -454,7 +487,8 @@ type mockEngine struct {
 }
 
 // NewModuleEngine implements the same method as documented on wasm.Engine.
-func (e *mockEngine) NewModuleEngine(_ string, _ *wasm.Module, _, _ []*wasm.FunctionInstance, _ *wasm.TableInstance, _ map[wasm.Index]wasm.Index) (wasm.ModuleEngine, error) {
+func (e *mockEngine) NewModuleEngine(_ string, module *wasm.Module, _, _ []*wasm.FunctionInstance, _ *wasm.TableInstance, _ map[wasm.Index]wasm.Index) (wasm.ModuleEngine, error) {
+	e.cachedModules[module] = struct{}{}
 	return nil, nil
 }
 
@@ -463,7 +497,4 @@ func (e *mockEngine) DeleteCompiledModule(module *wasm.Module) {
 	delete(e.cachedModules, module)
 }
 
-func (e *mockEngine) CompileModule(module *wasm.Module) error {
-	e.cachedModules[module] = struct{}{}
-	return nil
-}
+func (e *mockEngine) CompileModule(module *wasm.Module) error { return nil }

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -218,7 +218,7 @@ func TestModule_Global(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 
-		r := NewRuntime()
+		r := NewRuntime().(*runtime)
 		t.Run(tc.name, func(t *testing.T) {
 			var code *CompiledCode
 			if tc.module != nil {
@@ -226,6 +226,9 @@ func TestModule_Global(t *testing.T) {
 			} else {
 				code, _ = tc.builder(r).Build()
 			}
+
+			err := r.store.Engine.CompileModule(code.module)
+			require.NoError(t, err)
 
 			// Instantiate the module and get the export of the above global
 			module, err := r.InstantiateModule(code)
@@ -489,7 +492,9 @@ func (e *mockEngine) NewModuleEngine(_ string, module *wasm.Module, _, _ []*wasm
 	return nil, nil
 }
 
-// ReleaseCompilationCache implements the same method as documented on wasm.Engine.
-func (e *mockEngine) ReleaseCompilationCache(module *wasm.Module) {
+// DeleteCompiledModule implements the same method as documented on wasm.Engine.
+func (e *mockEngine) DeleteCompiledModule(module *wasm.Module) {
 	delete(e.cachedModules, module)
 }
+
+func (e *mockEngine) CompileModule(module *wasm.Module) error { return nil }

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"fmt"
 	"math"
-	"strconv"
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
@@ -428,57 +427,25 @@ func requireImportAndExportFunction(t *testing.T, r Runtime, hostFn func(ctx api
 	)), mod.Close
 }
 
-func TestCompiledCode_addCacheEntry(t *testing.T) {
-	c := &CompiledCode{}
-
-	m1, e1 := &wasm.Module{}, &mockEngine{name: "1"}
-	for i := 0; i < 5; i++ {
-		c.addCacheEntry(m1, e1)
-	}
-
-	require.NotNil(t, c.cachedEngines[e1])
-	require.NotNil(t, c.cachedEngines[e1][m1])
-	require.Equal(t, 1, len(c.cachedEngines[e1]))
-
-	m2, e2 := &wasm.Module{}, &mockEngine{name: "2"}
-	for i := 0; i < 5; i++ {
-		c.addCacheEntry(m2, e2)
-	}
-
-	require.NotNil(t, c.cachedEngines[e1])
-	require.NotNil(t, c.cachedEngines[e2])
-	require.NotNil(t, c.cachedEngines[e1][m1])
-	require.NotNil(t, c.cachedEngines[e2][m2])
-	require.Equal(t, 1, len(c.cachedEngines[e1]))
-	require.Equal(t, 1, len(c.cachedEngines[e2]))
-}
-
 func TestCompiledCode_Close(t *testing.T) {
-	e1, e2 := &mockEngine{name: "1", cachedModules: map[*wasm.Module]struct{}{}},
-		&mockEngine{name: "2", cachedModules: map[*wasm.Module]struct{}{}}
+	e := &mockEngine{name: "1", cachedModules: map[*wasm.Module]struct{}{}}
 
-	c := &CompiledCode{}
-	for _, e := range []wasm.Engine{e1, e2} {
-		for i := 0; i < 10; i++ {
-			m := &wasm.Module{}
-			_, _ = e.NewModuleEngine(strconv.Itoa(i), m, nil, nil, nil, nil)
-			c.addCacheEntry(m, e)
-		}
+	var cs []*CompiledCode
+	for i := 0; i < 10; i++ {
+		m := &wasm.Module{}
+		e.CompileModule(m)
+		cs = append(cs, &CompiledCode{module: m, compiledEngine: e})
 	}
 
 	// Before Close.
-	require.Equal(t, 10, len(e1.cachedModules))
-	require.Equal(t, 10, len(e2.cachedModules))
-	require.Equal(t, 2, len(c.cachedEngines))
-	for _, modules := range c.cachedEngines {
-		require.Equal(t, 10, len(modules))
+	require.Equal(t, 10, len(e.cachedModules))
+
+	for _, c := range cs {
+		c.Close()
 	}
 
-	c.Close()
-
 	// After Close.
-	require.Zero(t, len(e1.cachedModules))
-	require.Zero(t, len(e2.cachedModules))
+	require.Zero(t, len(e.cachedModules))
 }
 
 type mockEngine struct {
@@ -487,8 +454,7 @@ type mockEngine struct {
 }
 
 // NewModuleEngine implements the same method as documented on wasm.Engine.
-func (e *mockEngine) NewModuleEngine(_ string, module *wasm.Module, _, _ []*wasm.FunctionInstance, _ *wasm.TableInstance, _ map[wasm.Index]wasm.Index) (wasm.ModuleEngine, error) {
-	e.cachedModules[module] = struct{}{}
+func (e *mockEngine) NewModuleEngine(_ string, _ *wasm.Module, _, _ []*wasm.FunctionInstance, _ *wasm.TableInstance, _ map[wasm.Index]wasm.Index) (wasm.ModuleEngine, error) {
 	return nil, nil
 }
 
@@ -497,4 +463,7 @@ func (e *mockEngine) DeleteCompiledModule(module *wasm.Module) {
 	delete(e.cachedModules, module)
 }
 
-func (e *mockEngine) CompileModule(module *wasm.Module) error { return nil }
+func (e *mockEngine) CompileModule(module *wasm.Module) error {
+	e.cachedModules[module] = struct{}{}
+	return nil
+}


### PR DESCRIPTION
This commie makes it possible for functions to be compiled before instantiation.
Notably, this adds `CompileModule` method on Engine interface where we pass
`wasm.Module` (which is the decoded module) to engines, and engines compile 
all the module functions  and caches them keyed on `*wasm.Module`.

In order to achieve that, this stops the compiled native code from embedding typeID
which is assigned for all the function types in a store.