### PR TITLE
require: make stack file names absolute

### DIFF
--- a/internal/testing/require/require.go
+++ b/internal/testing/require/require.go
@@ -291,7 +291,7 @@ func fail(t TestingT, m1, m2 string, formatWithArgs ...interface{}) {
 
 	// Don't write the failStack in our own package!
 	if fs := failStack(); len(fs) > 0 {
-		t.Fatal(failure, "\n", strings.Join(fs, "\n\t\t\t"))
+		t.Fatal(failure + "\n" + strings.Join(fs, "\n"))
 	} else {
 		t.Fatal(failure)
 	}
@@ -323,7 +323,7 @@ func failStack() (fs []string) {
 		// Ensure we don't add functions in the require package to the failure stack.
 		dir := path.Dir(file)
 		if path.Base(dir) != "require" {
-			fs = append(fs, fmt.Sprintf("%s:%d", path.Base(file), line))
+			fs = append(fs, fmt.Sprintf("%s:%d", file, line))
 		}
 
 		// Stop the stack when we get to a test. Strip off any leading package name first!


### PR DESCRIPTION

source

```

func Test_a(t *testing.T) {
	a(t)
}

func a(t *testing.T) {
	b(t)
}

func b(t *testing.T) {
	require.Equal(t, 0, 1)
}

```


Before:

```
=== RUN   Test_a
    /home/mathetake/wazero/internal/wasm/jit/require.go:294: expected 0, but was 1
         engine_test.go:26
        			engine_test.go:22
        			engine_test.go:18
```

After:

```
--- FAIL: Test_a (0.00s)
    require.go:294: expected 0, but was 1
        /home/mathetake/wazero/internal/wasm/jit/engine_test.go:26
        /home/mathetake/wazero/internal/wasm/jit/engine_test.go:22
        /home/mathetake/wazero/internal/wasm/jit/engine_test.go:18
```





This allows me to do easy navigation like before with testify