### PR TITLE
Use same CompiledCode for import replacement

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -256,9 +256,7 @@ func (b *moduleBuilder) Build() (*CompiledCode, error) {
 		return nil, err
 	}
 
-	ret := &CompiledCode{module: module}
-	ret.addCacheEntry(module, b.r.store.Engine)
-	return &CompiledCode{module: module}, nil
+	return &CompiledCode{module: module, compiledEngine: b.r.store.Engine}, nil
 }
 
 // Instantiate implements ModuleBuilder.Instantiate

--- a/builder_test.go
+++ b/builder_test.go
@@ -346,7 +346,10 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			b := tc.input(NewRuntime()).(*moduleBuilder)
 			m, err := b.Build()
 			require.NoError(t, err)
+
 			requireHostModuleEquals(t, tc.expected, m.module)
+
+			require.Equal(t, b.r.store.Engine, m.compiledEngine)
 
 			// Built module must be instantiable by Engine.
 			_, err = b.r.InstantiateModule(m)

--- a/internal/integration_test/spectest/spec_test.go
+++ b/internal/integration_test/spectest/spec_test.go
@@ -2,7 +2,6 @@ package spectests
 
 import (
 	"context"
-	"crypto/sha256"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -327,7 +326,7 @@ func runTest(t *testing.T, newEngine func(wasm.Features) wasm.Engine) {
 						mod, err := binary.DecodeModule(buf, enabledFeatures, wasm.MemoryMaxPages)
 						require.NoError(t, err, msg)
 						require.NoError(t, mod.Validate(enabledFeatures))
-						mod.ID = sha256.Sum256(buf)
+						mod.AssignModuleID(buf)
 
 						moduleName := c.Name
 						if moduleName == "" { // When "(module ...) directive doesn't have name.
@@ -467,7 +466,7 @@ func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg 
 		return
 	}
 
-	mod.ID = sha256.Sum256(buf)
+	mod.AssignModuleID(buf)
 
 	err = store.Engine.CompileModule(mod)
 	if err != nil {

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -115,6 +115,7 @@ func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, et EngineTester) {
 			TypeSection:     []*wasm.FunctionType{},
 			FunctionSection: []uint32{},
 			CodeSection:     []*wasm.Code{},
+			ID:              wasm.ModuleID{0},
 		}
 		err := e.CompileModule(m)
 		require.NoError(t, err)
@@ -135,6 +136,7 @@ func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, et EngineTester) {
 			CodeSection: []*wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}},
 			},
+			ID: wasm.ModuleID{1},
 		}
 
 		err := e.CompileModule(m)
@@ -165,6 +167,7 @@ func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, et EngineTester) {
 			CodeSection: []*wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}},
 			},
+			ID: wasm.ModuleID{2},
 		}
 
 		err := e.CompileModule(importedModule)
@@ -189,6 +192,7 @@ func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, et EngineTester) {
 			TypeSection:     []*wasm.FunctionType{},
 			FunctionSection: []uint32{},
 			CodeSection:     []*wasm.Code{},
+			ID:              wasm.ModuleID{3},
 		}
 		err = e.CompileModule(importingModule)
 		require.NoError(t, err)
@@ -210,6 +214,7 @@ func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, et EngineTester) {
 			CodeSection: []*wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}},
 			},
+			ID: wasm.ModuleID{4},
 		}
 
 		err := e.CompileModule(importedModule)
@@ -233,6 +238,7 @@ func RunTestEngine_NewModuleEngine_InitTable(t *testing.T, et EngineTester) {
 			CodeSection: []*wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}},
 			},
+			ID: wasm.ModuleID{5},
 		}
 
 		err = e.CompileModule(importingModule)
@@ -506,6 +512,7 @@ func setupCallTests(t *testing.T, e wasm.Engine) (*wasm.ModuleInstance, *wasm.Mo
 		HostFunctionSection: []*reflect.Value{&hostFnVal},
 		TypeSection:         []*wasm.FunctionType{ft},
 		FunctionSection:     []wasm.Index{0},
+		ID:                  wasm.ModuleID{0},
 	}
 
 	err := e.CompileModule(hostFnModule)
@@ -526,6 +533,7 @@ func setupCallTests(t *testing.T, e wasm.Engine) (*wasm.ModuleInstance, *wasm.Mo
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, byte(0), // Calling imported host function ^.
 				wasm.OpcodeEnd}},
 		},
+		ID: wasm.ModuleID{1},
 	}
 
 	err = e.CompileModule(importedModule)
@@ -550,6 +558,7 @@ func setupCallTests(t *testing.T, e wasm.Engine) (*wasm.ModuleInstance, *wasm.Mo
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0 /* only one imported function */, wasm.OpcodeEnd}},
 		},
 		ImportSection: []*wasm.Import{{}},
+		ID:            wasm.ModuleID{2},
 	}
 	err = e.CompileModule(importingModule)
 	require.NoError(t, err)

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -1,6 +1,7 @@
 package wasm
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"reflect"
 	"sort"
@@ -64,6 +65,10 @@ func NewHostModule(
 			return
 		}
 	}
+
+	// Assins the ModuleID by calculating sha256 on inputs as host modules do not have `source` to hash.
+	m.ID = sha256.Sum256([]byte(fmt.Sprintf("%s:%v:%v:%v:%v",
+		moduleName, nameToGoFunc, nameToMemory, nameToGlobal, enabledFeatures)))
 	return
 }
 

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"reflect"
 	"sort"
@@ -67,7 +66,7 @@ func NewHostModule(
 	}
 
 	// Assins the ModuleID by calculating sha256 on inputs as host modules do not have `source` to hash.
-	m.ID = sha256.Sum256([]byte(fmt.Sprintf("%s:%v:%v:%v:%v",
+	m.AssignModuleID([]byte(fmt.Sprintf("%s:%v:%v:%v:%v",
 		moduleName, nameToGoFunc, nameToMemory, nameToGlobal, enabledFeatures)))
 	return
 }

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -22,14 +22,14 @@ var callStackCeiling = buildoptions.CallStackCeiling
 // engine is an interpreter implementation of wasm.Engine
 type engine struct {
 	enabledFeatures wasm.Features
-	codes           map[*wasm.Module][]*code // guarded by mutex.
+	codes           map[wasm.ModuleID][]*code // guarded by mutex.
 	mux             sync.RWMutex
 }
 
 func NewEngine(enabledFeatures wasm.Features) wasm.Engine {
 	return &engine{
 		enabledFeatures: enabledFeatures,
-		codes:           map[*wasm.Module][]*code{},
+		codes:           map[wasm.ModuleID][]*code{},
 	}
 }
 
@@ -41,19 +41,19 @@ func (e *engine) DeleteCompiledModule(m *wasm.Module) {
 func (e *engine) deleteCodes(module *wasm.Module) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
-	delete(e.codes, module)
+	delete(e.codes, module.ID)
 }
 
 func (e *engine) addCodes(module *wasm.Module, fs []*code) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
-	e.codes[module] = fs
+	e.codes[module.ID] = fs
 }
 
 func (e *engine) getCodes(module *wasm.Module) (fs []*code, ok bool) {
 	e.mux.RLock()
 	defer e.mux.RUnlock()
-	fs, ok = e.codes[module]
+	fs, ok = e.codes[module.ID]
 	return
 }
 

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -217,13 +217,14 @@ func TestInterpreter_Compile(t *testing.T) {
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeCall}}, // Call instruction without immediate for call target index is invalid and should fail to compile.
 			},
+			ID: wasm.ModuleID{},
 		}
 
 		err := e.CompileModule(errModule)
 		require.EqualError(t, err, "failed to lower func[2/3] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, all the compiled functions including succeeded ones must be released.
-		_, ok := e.codes[errModule]
+		_, ok := e.codes[errModule.ID]
 		require.False(t, ok)
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -238,15 +239,16 @@ func TestInterpreter_Compile(t *testing.T) {
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
 			},
+			ID: wasm.ModuleID{},
 		}
 		err := e.CompileModule(okModule)
 		require.NoError(t, err)
 
-		compiled, ok := e.codes[okModule]
+		compiled, ok := e.codes[okModule.ID]
 		require.True(t, ok)
 		require.Equal(t, len(okModule.FunctionSection), len(compiled))
 
-		_, ok = e.codes[okModule]
+		_, ok = e.codes[okModule.ID]
 		require.True(t, ok)
 	})
 }

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -173,6 +173,7 @@ func TestJIT_CompileModule(t *testing.T) {
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
 			},
+			ID: wasm.ModuleID{},
 		}
 
 		err := e.CompileModule(okModule)
@@ -182,7 +183,7 @@ func TestJIT_CompileModule(t *testing.T) {
 		err = e.CompileModule(okModule)
 		require.NoError(t, err)
 
-		compiled, ok := e.codes[okModule]
+		compiled, ok := e.codes[okModule.ID]
 		require.True(t, ok)
 		require.Equal(t, len(okModule.FunctionSection), len(compiled))
 
@@ -201,6 +202,7 @@ func TestJIT_CompileModule(t *testing.T) {
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeCall}}, // Call instruction without immediate for call target index is invalid and should fail to compile.
 			},
+			ID: wasm.ModuleID{},
 		}
 
 		e := et.NewEngine(wasm.Features20191205).(*engine)
@@ -208,7 +210,7 @@ func TestJIT_CompileModule(t *testing.T) {
 		require.EqualError(t, err, "failed to lower func[2/3] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, the compiled functions must not be cached.
-		_, ok := e.codes[errModule]
+		_, ok := e.codes[errModule.ID]
 		require.False(t, ok)
 	})
 }
@@ -306,6 +308,7 @@ func TestJIT_SliceAllocatedOnHeap(t *testing.T) {
 			{Type: wasm.ExternTypeFunc, Index: 1, Name: valueStackCorruption},
 			{Type: wasm.ExternTypeFunc, Index: 2, Name: callStackCorruption},
 		},
+		ID: wasm.ModuleID{1},
 	}
 
 	err = store.Engine.CompileModule(m)

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -177,6 +177,7 @@ const (
 	MaximumFunctionIndex = uint32(1 << 27)
 )
 
+// AssignModuleID calculates a sha256 checksum on `source` and set Module.ID to the result.
 func (m *Module) AssignModuleID(source []byte) {
 	m.ID = sha256.Sum256(source)
 }

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -177,6 +177,10 @@ const (
 	MaximumFunctionIndex = uint32(1 << 27)
 )
 
+func (m *Module) AssignModuleID(source []byte) {
+	m.ID = sha256.Sum256(source)
+}
+
 // TypeOfFunction returns the wasm.SectionIDType index for the given function namespace index or nil.
 // Note: The function index namespace is preceded by imported functions.
 // TODO: Returning nil should be impossible when decode results are validated. Validate decode before back-filling tests.

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"reflect"
@@ -161,7 +162,13 @@ type Module struct {
 	// preservation ensures a consistent initialization result.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#table-instances%E2%91%A0
 	validatedElementSegments []*validatedElementSegment
+
+	// ID is the sha256 value of the source code (text/binary) and is used for caching.
+	ID ModuleID
 }
+
+// ModuleID represents sha256 hash value uniquely assigned to Module.
+type ModuleID = [sha256.Size]byte
 
 // The wazero specific limitation described at RATIONALE.md.
 // TL;DR; We multiply by 8 (to get offsets in bytes) and the multiplication result must be less than 32bit max

--- a/wasm.go
+++ b/wasm.go
@@ -3,7 +3,6 @@ package wazero
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 
@@ -165,9 +164,7 @@ func (r *runtime) CompileModule(source []byte) (*CompiledCode, error) {
 		return nil, err
 	}
 
-	// ID is used as a key for compilation caches.
-	// TODO: should be possible to calculate sha256 during decoding.
-	internal.ID = sha256.Sum256(source)
+	internal.AssignModuleID(source)
 
 	if err = r.store.Engine.CompileModule(internal); err != nil {
 		return nil, err

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -434,7 +434,8 @@ func TestCompiledCode_Close(t *testing.T) {
 	var cs []*CompiledCode
 	for i := 0; i < 10; i++ {
 		m := &wasm.Module{}
-		e.CompileModule(m)
+		err := e.CompileModule(m)
+		require.NoError(t, err)
 		cs = append(cs, &CompiledCode{module: m, compiledEngine: e})
 	}
 


### PR DESCRIPTION
This commit allows CompiledCode to be re-used regardless of 
the existence of import replacement configs for instantiation. 

In order to achieve this, we introduce `ModuleID`, which is sha256
checksum calculated on source bytes, as a key for module compilation 
cache. Previously, we used`*wasm.Module` as keys for caches which 
differ before/after import replacement.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>