### PR TITLE
Adds random module generator for fuzzing the compiler

### DIFF
--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -389,6 +389,9 @@ func (g *generator) dataSection() {
 		}
 
 		init := make([]byte, g.nextRandom().Intn(min-offset))
+		if len(init) == 0 {
+			continue
+		}
 		_, err := g.nextRandom().Read(init)
 		if err != nil {
 			panic(err)

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -293,6 +293,7 @@ func (g *generator) exportSection() {
 	numExports := g.nextRandom().Intn(g.size)
 	for i := 0; i < numExports; i++ {
 		target := possibleExports[g.nextRandom().Intn(len(possibleExports))]
+
 		g.m.ExportSection = append(g.m.ExportSection, &wasm.Export{
 			Type:  target.Type,
 			Index: target.Index,

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -243,12 +243,18 @@ func (g *generator) newConstExpr() (*wasm.ConstantExpression, wasm.ValueType) {
 	case 2:
 		opcode = wasm.OpcodeF32Const
 		data = make([]byte, 4)
-		g.nextRandom().Read(data)
+		_, err := g.nextRandom().Read(data)
+		if err != nil {
+			panic(err)
+		}
 		valueType = wasm.ValueTypeF32
 	case 3:
 		opcode = wasm.OpcodeF64Const
 		data = make([]byte, 8)
-		g.nextRandom().Read(data)
+		_, err := g.nextRandom().Read(data)
+		if err != nil {
+			panic(err)
+		}
 		valueType = wasm.ValueTypeF64
 	case 4:
 		opcode = wasm.OpcodeGlobalGet

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -375,11 +375,11 @@ func (g *generator) dataSection() {
 		panic("BUG:" + err.Error())
 	}
 
-	min := int(mem.Min * wasm.MemoryPageSize)
-	if mem == nil || min == 0 {
+	if mem == nil || mem.Min == 0 {
 		return
 	}
 
+	min := int(mem.Min * wasm.MemoryPageSize)
 	dataSectionSize := g.nextRandom().Intn(g.size)
 	for i := 0; i < dataSectionSize; i++ {
 		offset := g.nextRandom().Intn(min)

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -16,6 +16,8 @@ import (
 // the generated module corresponds to the size of the seed. For example,
 // the more larger len(seed) is, the more functions the module *likely* has.
 //
+// TODO: make explicitly the size of each section controllable.
+//
 // Note: "Pseudo" here means the determinism of the generated results,
 // e.g. giving same seed returns exactly the same module for
 // the same code base in Gen.

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -16,10 +16,10 @@ import (
 // the generated module corresponds to the size of the seed. For example,
 // the more larger len(seed) is, the more functions the module *likely* has.
 //
-// TODO: make explicitly the size of each section controllable.
+// TODO: make it possible to explicitly control the size of each section.
 // TODO: have an option to have whether or not the result has imports.
 //
-// Note: "Pseudo" here means the determinism of the generated results,
+// Note: "pseudo" here means the determinism of the generated results,
 // e.g. giving same seed returns exactly the same module for
 // the same code base in Gen.
 //
@@ -50,6 +50,9 @@ type generator struct {
 	// m is the resulting module.
 	m *wasm.Module
 }
+
+// random is the interface over methods of rand.Rand which are used by our generator.
+// This is only for testing the generator implmenetation.
 
 type random interface {
 	// See rand.Intn.
@@ -400,7 +403,7 @@ func (g *generator) dataSection() {
 			Data:   leb128.EncodeInt32(int32(offset)),
 		}
 
-		init := make([]byte, g.nextRandom().Intn(min-offset))
+		init := make([]byte, g.nextRandom().Intn(min-offset+1))
 		if len(init) == 0 {
 			continue
 		}

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -303,7 +303,17 @@ func (g *generator) exportSection() {
 }
 
 func (g *generator) startSection() {
+	funcs, _, _, _, err := g.m.AllDeclarations()
+	if err != nil {
+		panic("BUG:" + err.Error())
+	}
 
+	if len(funcs) == 0 {
+		return
+	}
+
+	index := wasm.Index(g.nextRandom().Intn(len(funcs)))
+	g.m.StartSection = &index
 }
 
 func (g *generator) elementSection() {

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -17,6 +17,7 @@ import (
 // the more larger len(seed) is, the more functions the module *likely* has.
 //
 // TODO: make explicitly the size of each section controllable.
+// TODO: have an option to have whether or not the result has imports.
 //
 // Note: "Pseudo" here means the determinism of the generated results,
 // e.g. giving same seed returns exactly the same module for

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -317,12 +317,10 @@ func (g *generator) startSection() {
 		}
 	}
 
-	if len(candidates) == 0 {
+	if len(candidates) > 0 {
+		g.m.StartSection = &candidates[g.nextRandom().Intn(len(candidates))]
 		return
 	}
-
-	index := wasm.Index(g.nextRandom().Intn(len(candidates)))
-	g.m.StartSection = &candidates[index]
 }
 
 func (g *generator) elementSection() {

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -12,8 +12,11 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// Gen generates a pseudo random compilable module based on `seed`.
-// "Pseudo" here means the determinism of the generated results,
+// Gen generates a pseudo random compilable module based on `seed`. The size of
+// the generated module corresponds to the size of the seed. For example,
+// the more larger len(seed) is, the more functions the module *likely* has.
+//
+// Note: "Pseudo" here means the determinism of the generated results,
 // e.g. giving same seed returns exactly the same module for
 // the same code base in Gen.
 //

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -308,12 +308,21 @@ func (g *generator) startSection() {
 		panic("BUG:" + err.Error())
 	}
 
-	if len(funcs) == 0 {
+	var candidates []wasm.Index
+	for funcIndex, typeIndex := range funcs {
+		sig := g.m.TypeSection[typeIndex]
+		// Start function must have the empty signature.
+		if sig.EqualsSignature(nil, nil) {
+			candidates = append(candidates, wasm.Index(funcIndex))
+		}
+	}
+
+	if len(candidates) == 0 {
 		return
 	}
 
-	index := wasm.Index(g.nextRandom().Intn(len(funcs)))
-	g.m.StartSection = &index
+	index := wasm.Index(g.nextRandom().Intn(len(candidates)))
+	g.m.StartSection = &candidates[index]
 }
 
 func (g *generator) elementSection() {

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -357,9 +357,18 @@ func (g *generator) elementSection() {
 }
 
 func (g *generator) codeSection() {
-
+	codeSectionSize := len(g.m.FunctionSection)
+	for i := 0; i < codeSectionSize; i++ {
+		g.m.CodeSection = append(g.m.CodeSection, g.newCode())
+	}
 }
 
 func (g *generator) dataSection() {
 
+}
+
+func (g *generator) newCode() *wasm.Code {
+	// TODO: generate random body.
+	return &wasm.Code{Body: []byte{wasm.OpcodeUnreachable, // With unreachable allows us to make this body valid for any signature.
+		wasm.OpcodeEnd}}
 }

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -1,0 +1,127 @@
+package modgen
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+// Gen generates a pseudo random compilable module based on `seed`.
+// "Pseudo" here means the determinism of the generated results,
+// e.g. giving same seed returns exactly the same module for
+// the same code base in Gen.
+//
+// Note: this is only used for testing wazero runtime.
+func Gen(seed []byte) *wasm.Module {
+	if len(seed) == 0 {
+		return &wasm.Module{}
+	}
+
+	checksum := sha256.Sum256(seed)
+	g := &generator{size: len(seed)}
+	for i := 0; i < 4; i++ {
+		g.rands[i] = rand.New(rand.NewSource(
+			int64(binary.LittleEndian.Uint64(checksum[i*8 : (i+1)*8]))))
+	}
+	return g.gen()
+}
+
+type generator struct {
+	// rands holds 4 Rand created from the unique sha256 hash value of the seed.
+	rands         [4]*rand.Rand
+	nextRandIndex int
+
+	// size holds the original size of the seed.
+	size int
+
+	// m is the resulting module.
+	m *wasm.Module
+}
+
+func (g *generator) nextRand() (ret *rand.Rand) {
+	ret = g.rands[g.nextRandIndex]
+	g.nextRandIndex = (g.nextRandIndex) % 4
+	return
+}
+
+func (g *generator) gen() *wasm.Module {
+	g.m = &wasm.Module{}
+
+	g.typeSection()
+	g.importSection()
+	return g.m
+}
+
+func (g *generator) getSectionSize() int {
+	// TODO comment
+	return g.nextRand().Intn(g.size&0x00ff_ffff) + 1
+}
+
+func (g *generator) typeSection() {
+	numTypes := g.getSectionSize()
+	fmt.Println(numTypes)
+	for i := 0; i < numTypes; i++ {
+		ft := g.newFunctionType(g.nextRand().Intn(g.size), g.nextRand().Intn(g.size))
+		g.m.TypeSection = append(g.m.TypeSection, ft)
+	}
+}
+
+func (g *generator) newFunctionType(params, results int) *wasm.FunctionType {
+	ret := &wasm.FunctionType{}
+	for i := 0; i < params; i++ {
+		ret.Params = append(ret.Params, g.newValueType())
+	}
+	for i := 0; i < results; i++ {
+		ret.Results = append(ret.Results, g.newValueType())
+	}
+	return ret
+}
+
+func (g *generator) newValueType() (ret wasm.ValueType) {
+	switch g.nextRand().Intn(4) {
+	case 0:
+		ret = wasm.ValueTypeI32
+	case 1:
+		ret = wasm.ValueTypeI64
+	case 2:
+		ret = wasm.ValueTypeF32
+	case 3:
+		ret = wasm.ValueTypeF64
+	default:
+		panic("BUG")
+	}
+	return
+}
+
+func (g *generator) importSection() {
+	numImports := g.getSectionSize()
+	var memoryImported, tableImported int
+	for i := 0; i < numImports; i++ {
+		imp := &wasm.Import{}
+		switch g.nextRand().Intn(4 - memoryImported - tableImported) {
+		case 0:
+			imp.Type = wasm.ExternTypeFunc
+			imp.DescFunc = uint32(g.nextRand().Intn(len(g.m.TypeSection)))
+		case 1:
+			imp.Type = wasm.ExternTypeGlobal
+			imp.DescGlobal = &wasm.GlobalType{
+				ValType: g.newValueType(),
+				Mutable: g.nextRand().Intn(2) == 0,
+			}
+		case 2:
+			imp.Type = wasm.ExternTypeTable
+			tableImported = 1
+			imp.DescTable = &wasm.Table{}
+		case 3:
+			imp.Type = wasm.ExternTypeMemory
+			imp.DescMem = &wasm.Memory{}
+			memoryImported = 1
+		default:
+			panic("BUG")
+		}
+		g.m.ImportSection = append(g.m.ImportSection, imp)
+	}
+}

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -13,6 +13,8 @@ import (
 )
 
 // Gen generates a pseudo random compilable module based on `seed`.
+// The size of each section is controlled by the corresponding params.
+// For example, `numImports` controls the number of segment in the import section.
 //
 // Note: "pseudo" here means the determinism of the generated results,
 // e.g. giving same seed returns exactly the same module for

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -712,16 +712,3 @@ func TestGenerator_dataSection(t *testing.T) {
 		}
 	})
 }
-
-func FuzzCompiler(f *testing.F) {
-	r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFeatureMultiValue(true))
-	f.Fuzz(func(t *testing.T, seed []byte) {
-		// Generate a random WebAssembly module.
-		m := Gen(seed)
-		// Encode the generated module (*wasm.Module) as binary.
-		bin := binary.EncodeModule(m)
-		// Pass the generated binary into our compilers.
-		_, err := r.CompileModule(context.Background(), bin)
-		require.NoError(t, err)
-	})
-}

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -1,11 +1,21 @@
 package modgen
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/binary"
+)
+
+const (
+	i32 = wasm.ValueTypeI32
+	i64 = wasm.ValueTypeI64
+	f32 = wasm.ValueTypeF32
+	f64 = wasm.ValueTypeF64
 )
 
 func TestModGen(t *testing.T) {
@@ -31,6 +41,217 @@ func TestModGen(t *testing.T) {
 			r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig())
 			_, err := r.CompileModule(buf)
 			require.NoError(t, err)
+		})
+	}
+}
+
+type testRand struct {
+	ints   []int
+	intPos int
+	bufs   [][]byte
+	bufPos int
+}
+
+var _ random = &testRand{}
+
+func (tr *testRand) Intn(n int) int {
+	ret := tr.ints[tr.intPos] % n
+	tr.intPos = (tr.intPos + 1) % len(tr.ints)
+	return ret
+}
+
+func (tr *testRand) Read(p []byte) (n int, err error) {
+	buf := tr.bufs[tr.bufPos]
+	copy(p, buf)
+	tr.bufPos = (tr.bufPos + 1) % len(tr.bufs)
+	return
+}
+
+func newGenerator(size int, ints []int, bufs [][]byte) *generator {
+	return &generator{size: size,
+		rands: []random{&testRand{ints: ints}},
+		m:     &wasm.Module{},
+	}
+}
+
+func TestGenerator_newFunctionType(t *testing.T) {
+	for _, tc := range []struct {
+		params, results int
+		exp             *wasm.FunctionType
+	}{
+		{params: 1, results: 1, exp: &wasm.FunctionType{
+			Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i64}}},
+		{params: 1, results: 2, exp: &wasm.FunctionType{
+			Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i64, f32}}},
+		{params: 2, results: 2, exp: &wasm.FunctionType{
+			Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}}},
+		{params: 0, results: 2, exp: &wasm.FunctionType{
+			Results: []wasm.ValueType{i32, i64}}},
+		{params: 2, results: 0, exp: &wasm.FunctionType{
+			Params: []wasm.ValueType{i32, i64}}},
+		{params: 6, results: 6, exp: &wasm.FunctionType{
+			Params:  []wasm.ValueType{i32, i64, f32, f64, i32, i32},
+			Results: []wasm.ValueType{i64, f32, f64, i32, i32, i64},
+		},
+		},
+	} {
+		t.Run(tc.exp.String(), func(t *testing.T) {
+			g := newGenerator(0, []int{0, 1, 2, 3, 4}, nil)
+			actual := g.newFunctionType(tc.params, tc.results)
+			require.Equal(t, tc.exp.String(), actual.String())
+		})
+	}
+}
+
+func TestGenerator_newValueType(t *testing.T) {
+	g := newGenerator(0, []int{0, 1, 2, 3, 4, 5}, nil)
+	require.Equal(t,
+		[]wasm.ValueType{i32, i64, f32, f64, i32},
+		[]wasm.ValueType{g.newValueType(), g.newValueType(), g.newValueType(), g.newValueType(), g.newValueType()},
+	)
+}
+
+func TestGenerator_typeSection(t *testing.T) {
+	g := newGenerator(100, []int{
+		3, // type section size == 3
+		// Params = 1, Reults = 1, i32, i32
+		1, 1, 0, 0,
+		// Params = 2, Results = 2, i32f32, i64f64
+		2, 2, 0, 2, 1, 3,
+		// Params = 0, Results = 4, f64f32i64i32
+		0, 4, 3, 2, 1, 0,
+	}, nil)
+	g.typeSection()
+
+	expected := []*wasm.FunctionType{
+		{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}},
+		{Params: []wasm.ValueType{i32, f32}, Results: []wasm.ValueType{i64, f64}},
+		{Params: []wasm.ValueType{}, Results: []wasm.ValueType{f64, f32, i64, i32}},
+	}
+
+	require.Equal(t, len(expected), len(g.m.TypeSection))
+	for i := range expected {
+		require.Equal(t, expected[i].String(), g.m.TypeSection[i].String())
+	}
+}
+
+func TestGenerator_importSection(t *testing.T) {
+	five := uint32(5)
+	for i, tc := range []struct {
+		ints  []int
+		types []*wasm.FunctionType
+		exp   []*wasm.Import
+	}{
+		{
+			types: []*wasm.FunctionType{{}},
+			ints: []int{
+				2, // import section size
+				// function type with type of index = 0  x 2
+				0, 0,
+				0, 0,
+			},
+			exp: []*wasm.Import{
+				{Type: wasm.ExternTypeFunc, DescFunc: 0, Module: "module-0", Name: "0"},
+				{Type: wasm.ExternTypeFunc, DescFunc: 0, Module: "module-1", Name: "1"},
+			},
+		},
+		{
+			types: []*wasm.FunctionType{{}, {}},
+			ints: []int{
+				2, // import section size
+				// function type with type of index = 1
+				0, 1,
+				// function type with type of index = 0
+				0, 0,
+			},
+			exp: []*wasm.Import{
+				{Type: wasm.ExternTypeFunc, DescFunc: 1, Module: "module-0", Name: "0"},
+				{Type: wasm.ExternTypeFunc, DescFunc: 0, Module: "module-1", Name: "1"},
+			},
+		},
+		{
+			types: []*wasm.FunctionType{{}, {}},
+			ints: []int{
+				2, // import section size
+				// function type with type of index = 1
+				0, 1,
+				// global type with type f32, and mutable
+				1, 2, 0,
+			},
+			exp: []*wasm.Import{
+				{Type: wasm.ExternTypeFunc, DescFunc: 1, Module: "module-0", Name: "0"},
+				{Type: wasm.ExternTypeGlobal, DescGlobal: &wasm.GlobalType{
+					Mutable: true, ValType: f32,
+				}, Module: "module-1", Name: "1"},
+			},
+		},
+		{
+			types: []*wasm.FunctionType{{}, {}},
+			ints: []int{
+				2, // import section size
+				// function type with type of index = 1
+				0, 1,
+				// global type with type f64, and immutable
+				1, 3, 1,
+			},
+			exp: []*wasm.Import{
+				{Type: wasm.ExternTypeFunc, DescFunc: 1, Module: "module-0", Name: "0"},
+				{Type: wasm.ExternTypeGlobal, DescGlobal: &wasm.GlobalType{
+					Mutable: false, ValType: f64,
+				}, Module: "module-1", Name: "1"},
+			},
+		},
+		{
+			ints: []int{
+				2, // import section size
+				// global type with type i32, and mutable
+				0 /* func types are not given so 0 should be global */, 0, 0,
+				// global type with type f64, and immutable
+				1, 3, 1,
+			},
+			exp: []*wasm.Import{
+				{Type: wasm.ExternTypeGlobal, DescGlobal: &wasm.GlobalType{
+					Mutable: true, ValType: i32,
+				}, Module: "module-0", Name: "0"},
+				{Type: wasm.ExternTypeGlobal, DescGlobal: &wasm.GlobalType{
+					Mutable: false, ValType: f64,
+				}, Module: "module-1", Name: "1"},
+			},
+		},
+		{
+			types: []*wasm.FunctionType{{}, {}},
+			ints: []int{
+				3, // import section size
+				// Memory import with min=1,max=3,
+				2, 1, 2, /* max is rand + min = 2 + 1 = 3 */
+				// Table import with min=1,max=5
+				2, 1, 4, /* max is rand + min = 4 + 1 = 5 */
+				// function type with type of index = 1
+				2, 1,
+			},
+			exp: []*wasm.Import{
+				{Type: wasm.ExternTypeMemory, DescMem: &wasm.Memory{
+					Min: 1, Max: 3, IsMaxEncoded: true,
+				}, Module: "module-0", Name: "0"},
+				{Type: wasm.ExternTypeTable, DescTable: &wasm.Table{
+					Min: 1, Max: &five,
+				}, Module: "module-1", Name: "1"},
+				{Type: wasm.ExternTypeFunc, DescFunc: 1, Module: "module-2", Name: "2"},
+			},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			g := newGenerator(100, tc.ints, nil)
+			g.m.TypeSection = tc.types
+
+			g.importSection()
+			require.Equal(t, len(tc.exp), len(g.m.ImportSection))
+
+			for i := range tc.exp {
+				fmt.Println(tc.exp[i].DescTable)
+				fmt.Println(g.m.ImportSection[i].DescTable)
+				require.Equal(t, tc.exp[i], g.m.ImportSection[i])
+			}
 		})
 	}
 }

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -1,8 +1,8 @@
 package modgen
 
 import (
+	"context"
 	"encoding/hex"
-	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -41,13 +41,14 @@ func TestModGen(t *testing.T) {
 				buf := binary.EncodeModule(m)
 
 				r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFeatureMultiValue(true))
-				_, err := r.CompileModule(buf)
+				_, err := r.CompileModule(context.Background(), buf)
 				require.NoError(t, err)
 			})
 		}
 	}
 }
 
+// testRand implements randm for testing.
 type testRand struct {
 	ints   []int
 	intPos int
@@ -251,8 +252,6 @@ func TestGenerator_importSection(t *testing.T) {
 			require.Equal(t, len(tc.exp), len(g.m.ImportSection))
 
 			for i := range tc.exp {
-				fmt.Println(tc.exp[i].DescTable)
-				fmt.Println(g.m.ImportSection[i].DescTable)
 				require.Equal(t, tc.exp[i], g.m.ImportSection[i])
 			}
 		})
@@ -305,7 +304,7 @@ func TestGenerator_memorySection(t *testing.T) {
 	t.Run("without memory import", func(t *testing.T) {
 		g := newGenerator(100, []int{1, 100}, nil)
 		g.memorySection()
-		require.Equal(t, &wasm.Memory{Min: 1, Max: 101}, g.m.MemorySection)
+		require.Equal(t, &wasm.Memory{Min: 1, Max: 101, IsMaxEncoded: true}, g.m.MemorySection)
 	})
 }
 

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -1,0 +1,36 @@
+package modgen
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm/binary"
+)
+
+func TestModGen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed []byte
+	}{
+		{name: "empty", seed: []byte{}},
+		{name: "small", seed: []byte{1}},
+		{name: "small", seed: []byte{2}},
+		{name: "small", seed: []byte{1, 1}},
+		{name: "small", seed: []byte{1, 2}},
+		{name: "small", seed: []byte{1, 3}},
+		{name: "small", seed: []byte{1, 4}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := Gen(tc.seed)
+			// Generating with the same seed must result in the same module.
+			require.Equal(t, m, Gen(tc.seed))
+			buf := binary.EncodeModule(m)
+
+			r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig())
+			_, err := r.CompileModule(buf)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -21,23 +21,24 @@ const (
 	f64 = wasm.ValueTypeF64
 )
 
+// TestModGen is like a end-to-end test and verifies that our module generator only generates valid compilable modules.
 func TestModGen(t *testing.T) {
 	tested := map[string]struct{}{}
+	r := rand.New(rand.NewSource(0)) // use deterministic seed source for easy debugging.
 	for _, size := range []int{0, 1, 2, 5, 10, 50, 100} {
-		r := rand.New(rand.NewSource(0))
 		for i := 0; i < 100; i++ {
-			buf := make([]byte, size)
-			_, err := r.Read(buf)
+			seed := make([]byte, size)
+			_, err := r.Read(seed)
 			require.NoError(t, err)
 
-			encoded := hex.EncodeToString(buf)
+			encoded := hex.EncodeToString(seed)
 			if _, ok := tested[encoded]; ok {
 				continue
 			}
 			t.Run(encoded, func(t *testing.T) {
-				m := Gen(buf)
+				m := Gen(seed)
 				// Generating with the same seed must result in the same module.
-				require.Equal(t, m, Gen(buf))
+				require.Equal(t, m, Gen(seed))
 				buf := binary.EncodeModule(m)
 
 				r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFeatureMultiValue(true))

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -456,3 +456,45 @@ func TestGenerator_globalSection(t *testing.T) {
 		require.Equal(t, expected[i], actual[i])
 	}
 }
+
+func TestGenerator_exportSection(t *testing.T) {
+	m := &wasm.Module{
+		FunctionSection: make([]uint32, 10),
+		GlobalSection: []*wasm.Global{
+			{Type: &wasm.GlobalType{}},
+			{Type: &wasm.GlobalType{}},
+			{Type: &wasm.GlobalType{}},
+			{Type: &wasm.GlobalType{}},
+			{Type: &wasm.GlobalType{}},
+		},
+		TableSection:  &wasm.Table{},
+		MemorySection: &wasm.Memory{},
+	}
+
+	g := newGenerator(100, []int{
+		5,  // number of exports
+		2,  // funcs[2]
+		13, // globals[3]
+		15, // table
+		16, // memory
+		7,  // funcs[7]
+	}, nil)
+	g.m = m
+
+	g.exportSection()
+
+	expected := []*wasm.Export{
+		{Type: wasm.ExternTypeFunc, Index: 2, Name: "0"},
+		{Type: wasm.ExternTypeGlobal, Index: 3, Name: "1"},
+		{Type: wasm.ExternTypeTable, Index: 0, Name: "2"},
+		{Type: wasm.ExternTypeMemory, Index: 0, Name: "3"},
+		{Type: wasm.ExternTypeFunc, Index: 7, Name: "4"},
+	}
+
+	actual := g.m.ExportSection
+
+	require.Equal(t, len(expected), len(actual))
+	for i := range actual {
+		require.Equal(t, expected[i], actual[i])
+	}
+}

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -23,7 +23,7 @@ const (
 
 func TestModGen(t *testing.T) {
 	tested := map[string]struct{}{}
-	for _, size := range []int{0, 1, 2, 5, 10, 100} {
+	for _, size := range []int{0, 1, 2, 5, 10, 50, 100} {
 		r := rand.New(rand.NewSource(0))
 		for i := 0; i < 100; i++ {
 			buf := make([]byte, size)

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -48,20 +48,6 @@ func TestModGen(t *testing.T) {
 	}
 }
 
-func Test_a(t *testing.T) {
-	buf, err := hex.DecodeString("81ac8120c7")
-	if err != nil {
-		panic(err)
-	}
-
-	m := Gen(buf)
-	buf = binary.EncodeModule(m)
-
-	r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFeatureMultiValue(true))
-	_, err = r.CompileModule(buf)
-	require.NoError(t, err)
-}
-
 type testRand struct {
 	ints   []int
 	intPos int

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -25,6 +25,7 @@ const (
 func TestModGen(t *testing.T) {
 	tested := map[string]struct{}{}
 	r := rand.New(rand.NewSource(0)) // use deterministic seed source for easy debugging.
+	rand := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFeatureMultiValue(true))
 	for _, size := range []int{0, 1, 2, 5, 10, 50, 100} {
 		for i := 0; i < 100; i++ {
 			seed := make([]byte, size)
@@ -41,9 +42,9 @@ func TestModGen(t *testing.T) {
 				require.Equal(t, m, Gen(seed))
 				buf := binary.EncodeModule(m)
 
-				r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFeatureMultiValue(true))
-				_, err := r.CompileModule(context.Background(), buf)
+				code, err := rand.CompileModule(context.Background(), buf)
 				require.NoError(t, err)
+				code.Close()
 			})
 		}
 	}

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -21,7 +21,7 @@ const (
 )
 
 func TestModGen(t *testing.T) {
-	for _, size := range []int{0, 1, 2, 5, 10} {
+	for _, size := range []int{0, 1, 2, 5, 10, 100} {
 		r := rand.New(rand.NewSource(0))
 		for i := 0; i < 10; i++ {
 			buf := make([]byte, size)

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -436,7 +436,8 @@ func validateConstExpression(globals []*GlobalType, expr *ConstantExpression, ex
 	}
 
 	if actualType != expectedType {
-		return fmt.Errorf("const expression type mismatch")
+		return fmt.Errorf("const expression type mismatch expected %s but got %s",
+			ValueTypeName(expectedType), ValueTypeName(actualType))
 	}
 	return nil
 }


### PR DESCRIPTION
This commit adds the random module generator for compiler testing.
Notably, it only generates valid and (supposedly) compilable Wasm modules.
Generating such random sources/programs and using them for testing or 
fuzzing compilers is the widely known way of securing and hardening them [1,2].

This commit only creates random modules where functions do not have
any meaningful body. That will be resolved in a subsequent commit
as the implementation for generating random function body could be
huge.

Note that the implementation has already found a bug #485, and can be
easily integrated with the [fuzzing feature of Go 1.18](https://tip.golang.org/doc/fuzz/):


```go
func FuzzCompiler(f *testing.F) {
	r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().
		WithFeatureMultiValue(true))
	f.Fuzz(func(t *testing.T, seed []byte, numTypes, numFunctions, numImports, numExports, numGlobals, numElements, numData uint32, needStartSection bool) {
		// Generate a random WebAssembly module.
		m := Gen(seed, wasm.FeaturesFinished, numTypes, numFunctions, numImports, numExports, numGlobals, numElements, numData, needStartSection)
		// Encode the generated module (*wasm.Module) as binary.
		bin := binary.EncodeModule(m)
		// Pass the generated binary into our compilers.
		_, err := r.CompileModule(context.Background(), bin)
		require.NoError(t, err)
	})
}

```

[1] https://dl.acm.org/doi/fullHtml/10.1145/3363562
[2] https://en.wikipedia.org/wiki/Compiler_correctness