### PR TITLE
Refactors API to ensure context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ For the impatient, here's how invoking a factorial function looks in wazero:
 
 ```golang
 func main() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
 	// Read a WebAssembly binary containing an exported "fac" function.
 	// * Ex. (func (export "fac") (param i64) (result i64) ...
 	source, _ := os.ReadFile("./tests/bench/testdata/fac.wasm")
 
 	// Instantiate the module and return its exported functions
-	module, _ := wazero.NewRuntime().InstantiateModuleFromCode(source)
+	module, _ := wazero.NewRuntime().InstantiateModuleFromCode(ctx, source)
 	defer module.Close()
 
 	// Discover 7! is 5040
-	fmt.Println(module.ExportedFunction("fac").Call(nil, 7))
+	fmt.Println(module.ExportedFunction("fac").Call(ctx, 7))
 }
 ```
 
@@ -56,7 +59,7 @@ env, err := r.NewModuleBuilder("env").
 	ExportFunction("log_i32", func(v uint32) {
 		fmt.Println("log_i32 >>", v)
 	}).
-	Instantiate()
+	Instantiate(ctx)
 if err != nil {
 	log.Fatal(err)
 }
@@ -73,11 +76,11 @@ bundles an implementation. That way, you don't have to write these functions.
 For example, here's how you can allow WebAssembly modules to read
 "/work/home/a.txt" as "/a.txt" or "./a.txt":
 ```go
-wm, err := wasi.InstantiateSnapshotPreview1(r)
+wm, err := wasi.InstantiateSnapshotPreview1(ctx, r)
 defer wm.Close()
 
 config := wazero.ModuleConfig().WithFS(os.DirFS("/work/home"))
-module, err := r.InstantiateModule(binary, config)
+module, err := r.InstantiateModule(ctx, binary, config)
 defer module.Close()
 ...
 ```

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -84,14 +84,6 @@ type Module interface {
 	// with the exitCode.
 	CloseWithExitCode(exitCode uint32) error
 
-	// Context returns any propagated context from the Runtime or a prior function call.
-	//
-	// The returned context is always non-nil; it defaults to context.Background.
-	Context() context.Context
-
-	// WithContext allows callers to override the propagated context, for example, to add values to it.
-	WithContext(ctx context.Context) Module
-
 	// Memory returns a memory defined in this module or nil if there are none wasn't.
 	Memory() Memory
 
@@ -129,23 +121,11 @@ type Function interface {
 	// encoded according to ResultTypes. An error is returned for any failure looking up or invoking the function
 	// including signature mismatch.
 	//
-	// If `m` is nil, it defaults to the module the function was defined in.
-	//
-	// To override context propagation, use Module.WithContext
-	//	fn = m.ExportedFunction("fib")
-	//	results, err := fn(m.WithContext(ctx), 5)
-	//	--snip--
-	//
-	// To ensure context propagation in a host function body, pass the `ctx` parameter:
-	//	hostFunction := func(m api.Module, offset, byteCount uint32) uint32 {
-	//		fn = m.ExportedFunction("__read")
-	//		results, err := fn(m, offset, byteCount)
-	//	--snip--
-	//
+	// Note: when `ctx` is nil, it defaults to context.Background.
 	// Note: If Module.Close or Module.CloseWithExitCode were invoked during this call, the error returned may be a
 	// sys.ExitError. Interpreting this is specific to the module. For example, some "main" functions always call a
 	// function that exits.
-	Call(m Module, params ...uint64) ([]uint64, error)
+	Call(ctx context.Context, params ...uint64) ([]uint64, error)
 }
 
 // Global is a WebAssembly 1.0 (20191205) global exported from an instantiated module (wazero.Runtime InstantiateModule).

--- a/builder.go
+++ b/builder.go
@@ -1,6 +1,7 @@
 package wazero
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/tetratelabs/wazero/api"
@@ -13,19 +14,20 @@ import (
 //
 // Ex. Below defines and instantiates a module named "env" with one function:
 //
+//	ctx := context.Background()
 //	hello := func() {
 //		fmt.Fprintln(stdout, "hello!")
 //	}
-//	env, _ := r.NewModuleBuilder("env").ExportFunction("hello", hello).Instantiate()
+//	env, _ := r.NewModuleBuilder("env").ExportFunction("hello", hello).Instantiate(ctx)
 //
 // If the same module may be instantiated multiple times, it is more efficient to separate steps. Ex.
 //
-//	env, _ := r.NewModuleBuilder("env").ExportFunction("get_random_string", getRandomString).Build()
+//	env, _ := r.NewModuleBuilder("env").ExportFunction("get_random_string", getRandomString).Build(ctx)
 //
-//	env1, _ := r.InstantiateModuleWithConfig(env, NewModuleConfig().WithName("env.1"))
+//	env1, _ := r.InstantiateModuleWithConfig(ctx, env, NewModuleConfig().WithName("env.1"))
 //	defer env1.Close()
 //
-//	env2, _ := r.InstantiateModuleWithConfig(env, NewModuleConfig().WithName("env.2"))
+//	env2, _ := r.InstantiateModuleWithConfig(ctx, env, NewModuleConfig().WithName("env.2"))
 //	defer env2.Close()
 //
 // Note: Builder methods do not return errors, to allow chaining. Any validation errors are deferred until Build.
@@ -56,17 +58,22 @@ type ModuleBuilder interface {
 	//		return x + y + m.Value(extraKey).(uint32)
 	//	}
 	//
-	// The most sophisticated context is api.Module, which allows access to the Go context, but also
-	// allows writing to memory. This is important because there are only numeric types in Wasm. The only way to share other
-	// data is via writing memory and sharing offsets.
-	//
-	// Ex. This reads the parameters from!
+	// Ex. This uses an api.Module to reads the parameters from memory. This is important because there are only numeric
+	// types in Wasm. The only way to share other data is via writing memory and sharing offsets.
 	//
 	//	addInts := func(m api.Module, offset uint32) uint32 {
 	//		x, _ := m.Memory().ReadUint32Le(offset)
 	//		y, _ := m.Memory().ReadUint32Le(offset + 4) // 32 bits == 4 bytes!
 	//		return x + y
 	//	}
+	//
+	// If both parameters exist, they must be in order at positions zero and one.
+	//
+	// Ex. This uses propagates context properly when calling other functions exported in the api.Module:
+	//	callRead := func(ctx context.Context, m api.Module, offset, byteCount uint32) uint32 {
+	//		fn = m.ExportedFunction("__read")
+	//		results, err := fn(ctx, offset, byteCount)
+	//	--snip--
 	//
 	// Note: If a function is already exported with the same name, this overwrites it.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#host-functions%E2%91%A2
@@ -144,12 +151,12 @@ type ModuleBuilder interface {
 	ExportGlobalF64(name string, v float64) ModuleBuilder
 
 	// Build returns a module to instantiate, or returns an error if any of the configuration is invalid.
-	Build() (*CompiledCode, error)
+	Build(ctx context.Context) (*CompiledCode, error)
 
 	// Instantiate is a convenience that calls Build, then Runtime.InstantiateModule
 	//
 	// Note: Fields in the builder are copied during instantiation: Later changes do not affect the instantiated result.
-	Instantiate() (api.Module, error)
+	Instantiate(ctx context.Context) (api.Module, error)
 }
 
 // moduleBuilder implements ModuleBuilder
@@ -237,7 +244,7 @@ func (b *moduleBuilder) ExportGlobalF64(name string, v float64) ModuleBuilder {
 }
 
 // Build implements ModuleBuilder.Build
-func (b *moduleBuilder) Build() (*CompiledCode, error) {
+func (b *moduleBuilder) Build(ctx context.Context) (*CompiledCode, error) {
 	// Verify the maximum limit here, so we don't have to pass it to wasm.NewHostModule
 	maxLimit := b.r.memoryMaxPages
 	for name, mem := range b.nameToMemory {
@@ -252,7 +259,7 @@ func (b *moduleBuilder) Build() (*CompiledCode, error) {
 		return nil, err
 	}
 
-	if err = b.r.store.Engine.CompileModule(module); err != nil {
+	if err = b.r.store.Engine.CompileModule(ctx, module); err != nil {
 		return nil, err
 	}
 
@@ -260,15 +267,15 @@ func (b *moduleBuilder) Build() (*CompiledCode, error) {
 }
 
 // Instantiate implements ModuleBuilder.Instantiate
-func (b *moduleBuilder) Instantiate() (api.Module, error) {
-	if module, err := b.Build(); err != nil {
+func (b *moduleBuilder) Instantiate(ctx context.Context) (api.Module, error) {
+	if module, err := b.Build(ctx); err != nil {
 		return nil, err
 	} else {
-		if err = b.r.store.Engine.CompileModule(module.module); err != nil {
+		if err = b.r.store.Engine.CompileModule(ctx, module.module); err != nil {
 			return nil, err
 		}
 		// *wasm.ModuleInstance cannot be tracked, so we release the cache inside of this function.
 		defer module.Close()
-		return b.r.InstantiateModuleWithConfig(module, NewModuleConfig().WithName(b.moduleName))
+		return b.r.InstantiateModuleWithConfig(ctx, module, NewModuleConfig().WithName(b.moduleName))
 	}
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -344,7 +344,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			b := tc.input(NewRuntime()).(*moduleBuilder)
-			m, err := b.Build()
+			m, err := b.Build(testCtx)
 			require.NoError(t, err)
 
 			requireHostModuleEquals(t, tc.expected, m.module)
@@ -352,7 +352,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			require.Equal(t, b.r.store.Engine, m.compiledEngine)
 
 			// Built module must be instantiable by Engine.
-			_, err = b.r.InstantiateModule(m)
+			_, err = b.r.InstantiateModule(testCtx, m)
 			require.NoError(t, err)
 		})
 	}
@@ -385,7 +385,7 @@ func TestNewModuleBuilder_Build_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, e := tc.input(NewRuntime()).Build()
+			_, e := tc.input(NewRuntime()).Build(testCtx)
 			require.EqualError(t, e, tc.expectedErr)
 		})
 	}
@@ -394,7 +394,7 @@ func TestNewModuleBuilder_Build_Errors(t *testing.T) {
 // TestNewModuleBuilder_Instantiate ensures Runtime.InstantiateModule is called on success.
 func TestNewModuleBuilder_Instantiate(t *testing.T) {
 	r := NewRuntime()
-	m, err := r.NewModuleBuilder("env").Instantiate()
+	m, err := r.NewModuleBuilder("env").Instantiate(testCtx)
 	require.NoError(t, err)
 
 	// If this was instantiated, it would be added to the store under the same name
@@ -404,10 +404,10 @@ func TestNewModuleBuilder_Instantiate(t *testing.T) {
 // TestNewModuleBuilder_Instantiate_Errors ensures errors propagate from Runtime.InstantiateModule
 func TestNewModuleBuilder_Instantiate_Errors(t *testing.T) {
 	r := NewRuntime()
-	_, err := r.NewModuleBuilder("env").Instantiate()
+	_, err := r.NewModuleBuilder("env").Instantiate(testCtx)
 	require.NoError(t, err)
 
-	_, err = r.NewModuleBuilder("env").Instantiate()
+	_, err = r.NewModuleBuilder("env").Instantiate(testCtx)
 	require.EqualError(t, err, "module env has already been instantiated")
 }
 

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package wazero
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -18,14 +17,12 @@ import (
 type RuntimeConfig struct {
 	enabledFeatures wasm.Features
 	newEngine       func(wasm.Features) wasm.Engine
-	ctx             context.Context
 	memoryMaxPages  uint32
 }
 
 // engineLessConfig helps avoid copy/pasting the wrong defaults.
 var engineLessConfig = &RuntimeConfig{
 	enabledFeatures: wasm.Features20191205,
-	ctx:             context.Background(),
 	memoryMaxPages:  wasm.MemoryMaxPages,
 }
 
@@ -34,7 +31,6 @@ func (c *RuntimeConfig) clone() *RuntimeConfig {
 	return &RuntimeConfig{
 		enabledFeatures: c.enabledFeatures,
 		newEngine:       c.newEngine,
-		ctx:             c.ctx,
 		memoryMaxPages:  c.memoryMaxPages,
 	}
 }
@@ -53,23 +49,6 @@ func NewRuntimeConfigJIT() *RuntimeConfig {
 func NewRuntimeConfigInterpreter() *RuntimeConfig {
 	ret := engineLessConfig.clone()
 	ret.newEngine = interpreter.NewEngine
-	return ret
-}
-
-// WithContext sets the default context used to initialize the module. Defaults to context.Background if nil.
-//
-// Notes:
-// * If the Module defines a start function, this is used to invoke it.
-// * This is the outer-most ancestor of api.Module Context() during api.Function invocations.
-// * This is the default context of api.Function when callers pass nil.
-//
-// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#start-function%E2%91%A0
-func (c *RuntimeConfig) WithContext(ctx context.Context) *RuntimeConfig {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ret := c.clone()
-	ret.ctx = ctx
 	return ret
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package wazero
 
 import (
-	"context"
 	"io"
 	"math"
 	"testing"
@@ -17,24 +16,6 @@ func TestRuntimeConfig(t *testing.T) {
 		with     func(*RuntimeConfig) *RuntimeConfig
 		expected *RuntimeConfig
 	}{
-		{
-			name: "WithContext",
-			with: func(c *RuntimeConfig) *RuntimeConfig {
-				return c.WithContext(context.TODO())
-			},
-			expected: &RuntimeConfig{
-				ctx: context.TODO(),
-			},
-		},
-		{
-			name: "WithContext - nil",
-			with: func(c *RuntimeConfig) *RuntimeConfig {
-				return c.WithContext(nil) //nolint
-			},
-			expected: &RuntimeConfig{
-				ctx: context.Background(),
-			},
-		},
 		{
 			name: "WithMemoryMaxPages",
 			with: func(c *RuntimeConfig) *RuntimeConfig {

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package wazero
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"log"
@@ -10,11 +11,14 @@ import (
 //
 // See https://github.com/tetratelabs/wazero/tree/main/examples for more examples.
 func Example() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
 	// Create a new WebAssembly Runtime.
 	r := NewRuntime()
 
 	// Add a module to the runtime named "wasm/math" which exports one function "add", implemented in WebAssembly.
-	mod, err := r.InstantiateModuleFromCode([]byte(`(module $wasm/math
+	mod, err := r.InstantiateModuleFromCode(ctx, []byte(`(module $wasm/math
     (func $add (param i32 i32) (result i32)
         local.get 0
         local.get 1
@@ -31,7 +35,7 @@ func Example() {
 	add := mod.ExportedFunction("add")
 
 	x, y := uint64(1), uint64(2)
-	results, err := add.Call(nil, x, y)
+	results, err := add.Call(ctx, x, y)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/basic/add.go
+++ b/examples/basic/add.go
@@ -1,6 +1,7 @@
 package add
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"log"
@@ -13,11 +14,14 @@ import (
 
 // main implements a basic function in both Go and WebAssembly.
 func main() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
 	// Create a new WebAssembly Runtime.
 	r := wazero.NewRuntime()
 
 	// Add a module to the runtime named "wasm/math" which exports one function "add", implemented in WebAssembly.
-	wasm, err := r.InstantiateModuleFromCode([]byte(`(module $wasm/math
+	wasm, err := r.InstantiateModuleFromCode(ctx, []byte(`(module $wasm/math
     (func $add (param i32 i32) (result i32)
         local.get 0
         local.get 1
@@ -34,7 +38,7 @@ func main() {
 	host, err := r.NewModuleBuilder("host/math").
 		ExportFunction("add", func(v1, v2 uint32) uint32 {
 			return v1 + v2
-		}).Instantiate()
+		}).Instantiate(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,7 +50,7 @@ func main() {
 	// Call the same function in both modules and print the results to the console.
 	for _, mod := range []api.Module{wasm, host} {
 		add := mod.ExportedFunction("add")
-		results, err := add.Call(nil, x, y)
+		results, err := add.Call(ctx, x, y)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/examples/import-go/age-calculator.go
+++ b/examples/import-go/age-calculator.go
@@ -1,6 +1,7 @@
 package age_calculator
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"log"
@@ -16,6 +17,10 @@ import (
 //
 // See README.md for a full description.
 func main() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
+	// Create a new WebAssembly Runtime.
 	r := wazero.NewRuntime()
 
 	// Instantiate a module named "env" that exports functions to get the
@@ -35,7 +40,7 @@ func main() {
 			}
 			return uint32(time.Now().Year())
 		}).
-		Instantiate()
+		Instantiate(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,7 +51,7 @@ func main() {
 	//
 	// Note: The import syntax in both Text and Binary format is the same
 	// regardless of if the function was defined in Go or WebAssembly.
-	ageCalculator, err := r.InstantiateModuleFromCode([]byte(`
+	ageCalculator, err := r.InstantiateModuleFromCode(ctx, []byte(`
 ;; Define the optional module name. '$' prefixing is a part of the text format.
 (module $age-calculator
 
@@ -91,14 +96,14 @@ func main() {
 	}
 
 	// First, try calling the "get_age" function and printing to the console externally.
-	results, err := ageCalculator.ExportedFunction("get_age").Call(nil, birthYear)
+	results, err := ageCalculator.ExportedFunction("get_age").Call(ctx, birthYear)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("println >>", results[0])
 
 	// First, try calling the "log_age" function and printing to the console externally.
-	_, err = ageCalculator.ExportedFunction("log_age").Call(nil, birthYear)
+	_, err = ageCalculator.ExportedFunction("log_age").Call(ctx, birthYear)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/replace-import/replace-import.go
+++ b/examples/replace-import/replace-import.go
@@ -1,6 +1,7 @@
 package replace_import
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"log"
@@ -11,20 +12,24 @@ import (
 
 // main shows how you can replace a module import when it doesn't match instantiated modules.
 func main() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
+	// Create a new WebAssembly Runtime.
 	r := wazero.NewRuntime()
 
 	// Instantiate a function that closes the module under "assemblyscript.abort".
 	host, err := r.NewModuleBuilder("assemblyscript").
 		ExportFunction("abort", func(m api.Module, messageOffset, fileNameOffset, line, col uint32) {
 			_ = m.CloseWithExitCode(255)
-		}).Instantiate()
+		}).Instantiate(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer host.Close()
 
 	// Compile code that needs the function "env.abort".
-	code, err := r.CompileModule([]byte(`(module $needs-import
+	code, err := r.CompileModule(ctx, []byte(`(module $needs-import
 	(import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
 
 	(export "abort" (func 0)) ;; exports the import for testing
@@ -35,7 +40,7 @@ func main() {
 	defer code.Close()
 
 	// Instantiate the module, replacing the import "env.abort" with "assemblyscript.abort".
-	mod, err := r.InstantiateModuleWithConfig(code, wazero.NewModuleConfig().
+	mod, err := r.InstantiateModuleWithConfig(ctx, code, wazero.NewModuleConfig().
 		WithImport("env", "abort", "assemblyscript", "abort"))
 	if err != nil {
 		log.Fatal(err)
@@ -43,6 +48,6 @@ func main() {
 	defer mod.Close()
 
 	// Since the above worked, the exported function closes the module.
-	_, err = mod.ExportedFunction("abort").Call(nil, 0, 0, 0, 0)
+	_, err = mod.ExportedFunction("abort").Call(ctx, 0, 0, 0, 0)
 	fmt.Println(err)
 }

--- a/examples/wasi/cat.go
+++ b/examples/wasi/cat.go
@@ -1,6 +1,7 @@
 package wasi_example
 
 import (
+	"context"
 	"embed"
 	_ "embed"
 	"io/fs"
@@ -24,6 +25,10 @@ var catWasm []byte
 // This is a basic introduction to the WebAssembly System Interface (WASI).
 // See https://github.com/WebAssembly/WASI
 func main() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
+	// Create a new WebAssembly Runtime.
 	r := wazero.NewRuntime()
 
 	// Since wazero uses fs.FS, we can use standard libraries to do things like trim the leading path.
@@ -36,7 +41,7 @@ func main() {
 	config := wazero.NewModuleConfig().WithStdout(os.Stdout).WithFS(rooted)
 
 	// Instantiate WASI, which implements system I/O such as console output.
-	wm, err := wasi.InstantiateSnapshotPreview1(r)
+	wm, err := wasi.InstantiateSnapshotPreview1(ctx, r)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +50,7 @@ func main() {
 	// InstantiateModuleFromCodeWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
 	// * Set the program name (arg[0]) to "wasi" and add args to write "test.txt" to stdout twice.
 	// * We use "/test.txt" or "./test.txt" because WithFS by default maps the workdir "." to "/".
-	cat, err := r.InstantiateModuleFromCodeWithConfig(catWasm, config.WithArgs("wasi", os.Args[1]))
+	cat, err := r.InstantiateModuleFromCodeWithConfig(ctx, catWasm, config.WithArgs("wasi", os.Args[1]))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 )
 
+// testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
+var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
+
 var tests = map[string]func(t *testing.T, r wazero.Runtime){
 	"huge stack":                              testHugeStack,
 	"unreachable":                             testUnreachable,
@@ -37,17 +40,13 @@ func TestEngineInterpreter(t *testing.T) {
 	runAllTests(t, tests, wazero.NewRuntimeConfigInterpreter())
 }
 
-type configContextKey string
-
-var configContext = context.WithValue(context.Background(), configContextKey("wa"), "zero")
-
 func runAllTests(t *testing.T, tests map[string]func(t *testing.T, r wazero.Runtime), config *wazero.RuntimeConfig) {
 	for name, testf := range tests {
 		name := name   // pin
 		testf := testf // pin
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			testf(t, wazero.NewRuntimeWithConfig(config.WithContext(configContext)))
+			testf(t, wazero.NewRuntimeWithConfig(config))
 		})
 	}
 }
@@ -62,14 +61,14 @@ var (
 )
 
 func testHugeStack(t *testing.T, r wazero.Runtime) {
-	module, err := r.InstantiateModuleFromCode(hugestackWasm)
+	module, err := r.InstantiateModuleFromCode(testCtx, hugestackWasm)
 	require.NoError(t, err)
 	defer module.Close()
 
 	fn := module.ExportedFunction("main")
 	require.NotNil(t, fn)
 
-	_, err = fn.Call(nil)
+	_, err = fn.Call(testCtx)
 	require.NoError(t, err)
 }
 
@@ -78,14 +77,14 @@ func testUnreachable(t *testing.T, r wazero.Runtime) {
 		panic("panic in host function")
 	}
 
-	_, err := r.NewModuleBuilder("host").ExportFunction("cause_unreachable", callUnreachable).Instantiate()
+	_, err := r.NewModuleBuilder("host").ExportFunction("cause_unreachable", callUnreachable).Instantiate(testCtx)
 	require.NoError(t, err)
 
-	module, err := r.InstantiateModuleFromCode(unreachableWasm)
+	module, err := r.InstantiateModuleFromCode(testCtx, unreachableWasm)
 	require.NoError(t, err)
 	defer module.Close()
 
-	_, err = module.ExportedFunction("main").Call(nil)
+	_, err = module.ExportedFunction("main").Call(testCtx)
 	exp := `panic in host function (recovered by wazero)
 wasm stack trace:
 	host.cause_unreachable()
@@ -97,18 +96,18 @@ wasm stack trace:
 
 func testRecursiveEntry(t *testing.T, r wazero.Runtime) {
 	hostfunc := func(mod api.Module) {
-		_, err := mod.ExportedFunction("called_by_host_func").Call(nil)
+		_, err := mod.ExportedFunction("called_by_host_func").Call(testCtx)
 		require.NoError(t, err)
 	}
 
-	_, err := r.NewModuleBuilder("env").ExportFunction("host_func", hostfunc).Instantiate()
+	_, err := r.NewModuleBuilder("env").ExportFunction("host_func", hostfunc).Instantiate(testCtx)
 	require.NoError(t, err)
 
-	module, err := r.InstantiateModuleFromCode(recursiveWasm)
+	module, err := r.InstantiateModuleFromCode(testCtx, recursiveWasm)
 	require.NoError(t, err)
 	defer module.Close()
 
-	_, err = module.ExportedFunction("main").Call(nil, 1)
+	_, err = module.ExportedFunction("main").Call(testCtx, 1)
 	require.NoError(t, err)
 }
 
@@ -130,11 +129,11 @@ func testImportedAndExportedFunc(t *testing.T, r wazero.Runtime) {
 		return 0
 	}
 
-	host, err := r.NewModuleBuilder("").ExportFunction("store_int", storeInt).Instantiate()
+	host, err := r.NewModuleBuilder("").ExportFunction("store_int", storeInt).Instantiate(testCtx)
 	require.NoError(t, err)
 	defer host.Close()
 
-	module, err := r.InstantiateModuleFromCode([]byte(`(module $test
+	module, err := r.InstantiateModuleFromCode(testCtx, []byte(`(module $test
 		(import "" "store_int"
 			(func $store_int (param $offset i32) (param $val i64) (result (;errno;) i32)))
 		(memory $memory 1 1)
@@ -147,7 +146,7 @@ func testImportedAndExportedFunc(t *testing.T, r wazero.Runtime) {
 
 	// Call store_int and ensure it didn't return an error code.
 	fn := module.ExportedFunction("store_int")
-	results, err := fn.Call(nil, 1, math.MaxUint64)
+	results, err := fn.Call(testCtx, 1, math.MaxUint64)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), results[0])
 
@@ -166,7 +165,7 @@ func testHostFunctionContextParameter(t *testing.T, r wazero.Runtime) {
 			return p + 1
 		},
 		"go_context": func(ctx context.Context, p uint32) uint32 {
-			require.Equal(t, configContext, ctx)
+			require.Equal(t, testCtx, ctx)
 			return p + 1
 		},
 		"module_context": func(module api.Module, p uint32) uint32 {
@@ -175,14 +174,14 @@ func testHostFunctionContextParameter(t *testing.T, r wazero.Runtime) {
 		},
 	}
 
-	imported, err := r.NewModuleBuilder(importedName).ExportFunctions(fns).Instantiate()
+	imported, err := r.NewModuleBuilder(importedName).ExportFunctions(fns).Instantiate(testCtx)
 	require.NoError(t, err)
 	defer imported.Close()
 
 	for test := range fns {
 		t.Run(test, func(t *testing.T) {
 			// Instantiate a module that uses Wasm code to call the host function.
-			importing, err = r.InstantiateModuleFromCode([]byte(fmt.Sprintf(`(module $%[1]s
+			importing, err = r.InstantiateModuleFromCode(testCtx, []byte(fmt.Sprintf(`(module $%[1]s
 	(import "%[2]s" "%[3]s" (func $%[3]s (param i32) (result i32)))
 	(func $call_%[3]s (param i32) (result i32) local.get 0 call $%[3]s)
 	(export "call->%[3]s" (func $call_%[3]s))
@@ -190,7 +189,7 @@ func testHostFunctionContextParameter(t *testing.T, r wazero.Runtime) {
 			require.NoError(t, err)
 			defer importing.Close()
 
-			results, err := importing.ExportedFunction("call->"+test).Call(nil, math.MaxUint32-1)
+			results, err := importing.ExportedFunction("call->"+test).Call(testCtx, math.MaxUint32-1)
 			require.NoError(t, err)
 			require.Equal(t, uint64(math.MaxUint32), results[0])
 		})
@@ -217,7 +216,7 @@ func testHostFunctionNumericParameter(t *testing.T, r wazero.Runtime) {
 		},
 	}
 
-	imported, err := r.NewModuleBuilder(importedName).ExportFunctions(fns).Instantiate()
+	imported, err := r.NewModuleBuilder(importedName).ExportFunctions(fns).Instantiate(testCtx)
 	require.NoError(t, err)
 	defer imported.Close()
 
@@ -248,7 +247,7 @@ func testHostFunctionNumericParameter(t *testing.T, r wazero.Runtime) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			// Instantiate a module that uses Wasm code to call the host function.
-			importing, err := r.InstantiateModuleFromCode([]byte(fmt.Sprintf(`(module $%[1]s
+			importing, err := r.InstantiateModuleFromCode(testCtx, []byte(fmt.Sprintf(`(module $%[1]s
 	(import "%[2]s" "%[3]s" (func $%[3]s (param %[3]s) (result %[3]s)))
 	(func $call_%[3]s (param %[3]s) (result %[3]s) local.get 0 call $%[3]s)
 	(export "call->%[3]s" (func $call_%[3]s))
@@ -256,7 +255,7 @@ func testHostFunctionNumericParameter(t *testing.T, r wazero.Runtime) {
 			require.NoError(t, err)
 			defer importing.Close()
 
-			results, err := importing.ExportedFunction("call->"+test.name).Call(nil, test.input)
+			results, err := importing.ExportedFunction("call->"+test.name).Call(testCtx, test.input)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, results[0])
 		})
@@ -340,19 +339,19 @@ func testCloseInFlight(t *testing.T, r wazero.Runtime) {
 
 			// Create the host module, which exports the function that closes the importing module.
 			importedCode, err = r.NewModuleBuilder(t.Name()+"-imported").
-				ExportFunction("return_input", closeAndReturn).Build()
+				ExportFunction("return_input", closeAndReturn).Build(testCtx)
 			require.NoError(t, err)
 
-			imported, err = r.InstantiateModule(importedCode)
+			imported, err = r.InstantiateModule(testCtx, importedCode)
 			require.NoError(t, err)
 			defer imported.Close()
 
 			// Import that module.
 			source := callReturnImportSource(imported.Name(), t.Name()+"-importing")
-			importingCode, err = r.CompileModule(source)
+			importingCode, err = r.CompileModule(testCtx, source)
 			require.NoError(t, err)
 
-			importing, err = r.InstantiateModule(importingCode)
+			importing, err = r.InstantiateModule(testCtx, importingCode)
 			require.NoError(t, err)
 			defer importing.Close()
 
@@ -369,14 +368,14 @@ func testCloseInFlight(t *testing.T, r wazero.Runtime) {
 			}
 
 			// Functions that return after being closed should have an exit error.
-			_, err = importing.ExportedFunction(tc.function).Call(nil, 5)
+			_, err = importing.ExportedFunction(tc.function).Call(testCtx, 5)
 			require.Equal(t, expectedErr, err)
 		})
 	}
 }
 
 func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
-	compiled, err := r.CompileModule([]byte(`(module $test
+	compiled, err := r.CompileModule(testCtx, []byte(`(module $test
 		(memory 1)
 		(func $store
           i32.const 1    ;; memory offset
@@ -390,7 +389,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 
 	// Instantiate multiple modules with the same source (*CompiledCode).
 	for i := 0; i < 100; i++ {
-		module, err := r.InstantiateModuleWithConfig(compiled, wazero.NewModuleConfig().WithName(strconv.Itoa(i)))
+		module, err := r.InstantiateModuleWithConfig(testCtx, compiled, wazero.NewModuleConfig().WithName(strconv.Itoa(i)))
 		require.NoError(t, err)
 		defer module.Close()
 
@@ -403,7 +402,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 		f := module.ExportedFunction("store")
 		require.NotNil(t, f)
 
-		_, err = f.Call(nil)
+		_, err = f.Call(testCtx)
 		require.NoError(t, err)
 
 		// After the call, the value must be set properly.

--- a/internal/integration_test/post1_0/sign-extension-ops/sign_extension_ops_test.go
+++ b/internal/integration_test/post1_0/sign-extension-ops/sign_extension_ops_test.go
@@ -1,6 +1,7 @@
 package sign_extension_ops
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"testing"
@@ -8,6 +9,9 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
+
+// testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
+var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
 func TestSignExtensionOps_JIT(t *testing.T) {
 	if !wazero.JITSupported {
@@ -45,12 +49,12 @@ func testSignExtensionOps(t *testing.T, newRuntimeConfig func() *wazero.RuntimeC
 	t.Run("disabled", func(t *testing.T) {
 		// Sign-extension is disabled by default.
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())
-		_, err := r.InstantiateModuleFromCode(signExtend)
+		_, err := r.InstantiateModuleFromCode(testCtx, signExtend)
 		require.Error(t, err)
 	})
 	t.Run("enabled", func(t *testing.T) {
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig().WithFeatureSignExtensionOps(true))
-		module, err := r.InstantiateModuleFromCode(signExtend)
+		module, err := r.InstantiateModuleFromCode(testCtx, signExtend)
 		require.NoError(t, err)
 
 		signExtend32from8Name, signExtend32from16Name := "i32.extend8_s", "i32.extend16_s"
@@ -83,7 +87,7 @@ func testSignExtensionOps(t *testing.T, newRuntimeConfig func() *wazero.RuntimeC
 					fn := module.ExportedFunction(tc.funcname)
 					require.NotNil(t, fn)
 
-					actual, err := fn.Call(nil, uint64(uint32(tc.in)))
+					actual, err := fn.Call(testCtx, uint64(uint32(tc.in)))
 					require.NoError(t, err)
 					require.Equal(t, tc.expected, int32(actual[0]))
 				})
@@ -131,7 +135,7 @@ func testSignExtensionOps(t *testing.T, newRuntimeConfig func() *wazero.RuntimeC
 					fn := module.ExportedFunction(tc.funcname)
 					require.NotNil(t, fn)
 
-					actual, err := fn.Call(nil, uint64(tc.in))
+					actual, err := fn.Call(testCtx, uint64(tc.in))
 					require.NoError(t, err)
 					require.Equal(t, tc.expected, int64(actual[0]))
 				})

--- a/internal/integration_test/vs/codec_test.go
+++ b/internal/integration_test/vs/codec_test.go
@@ -110,17 +110,17 @@ func TestExampleUpToDate(t *testing.T) {
 		r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFinishedFeatures())
 
 		// Add WASI to satisfy import tests
-		wm, err := wasi.InstantiateSnapshotPreview1(r)
+		wm, err := wasi.InstantiateSnapshotPreview1(testCtx, r)
 		require.NoError(t, err)
 		defer wm.Close()
 
 		// Decode and instantiate the module
-		module, err := r.InstantiateModuleFromCode(exampleBinary)
+		module, err := r.InstantiateModuleFromCode(testCtx, exampleBinary)
 		require.NoError(t, err)
 		defer module.Close()
 
 		// Call the swap function as a smoke test
-		results, err := module.ExportedFunction("swap").Call(nil, 1, 2)
+		results, err := module.ExportedFunction("swap").Call(testCtx, 1, 2)
 		require.NoError(t, err)
 		require.Equal(t, []uint64{2, 1}, results)
 	})

--- a/internal/wasm/call_context.go
+++ b/internal/wasm/call_context.go
@@ -24,6 +24,11 @@ func NewCallContext(store *Store, instance *ModuleInstance, Sys *SysContext) *Ca
 // functionality like trace propagation.
 // Note: this also implements api.Module in order to simplify usage as a host function parameter.
 type CallContext struct {
+	// TODO: We've never found a great name for this. It is only used for function calls, hence CallContext, but it
+	// moves on a different axis than, for example, the context.Context. context.Context is the same root for the whole
+	// call stack, where the CallContext can change depending on where memory is defined and who defines the calling
+	// function. When we rename this again, we should try to capture as many key points possible on the docs.
+
 	module *ModuleInstance
 	// memory is returned by Memory and overridden WithMemory
 	memory api.Memory

--- a/internal/wasm/call_context_test.go
+++ b/internal/wasm/call_context_test.go
@@ -8,55 +8,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func TestCallContext_WithContext(t *testing.T) {
-	type key string
-	tests := []struct {
-		name       string
-		mod        *CallContext
-		ctx        context.Context
-		expectSame bool
-	}{
-		{
-			name:       "nil->nil: same",
-			mod:        &CallContext{},
-			ctx:        nil,
-			expectSame: true,
-		},
-		{
-			name:       "nil->ctx: not same",
-			mod:        &CallContext{},
-			ctx:        context.WithValue(context.Background(), key("a"), "b"),
-			expectSame: false,
-		},
-		{
-			name:       "ctx->nil: same",
-			mod:        &CallContext{ctx: context.Background()},
-			ctx:        nil,
-			expectSame: true,
-		},
-		{
-			name:       "ctx1->ctx2: not same",
-			mod:        &CallContext{ctx: context.Background()},
-			ctx:        context.WithValue(context.Background(), key("a"), "b"),
-			expectSame: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			mod2 := tc.mod.WithContext(tc.ctx)
-			if tc.expectSame {
-				require.Same(t, tc.mod, mod2)
-			} else {
-				require.NotSame(t, tc.mod, mod2)
-				require.Equal(t, tc.ctx, mod2.Context())
-			}
-		})
-	}
-}
-
 func TestCallContext_WithMemory(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -1,10 +1,12 @@
 package wasm
 
+import "context"
+
 // Engine is a Store-scoped mechanism to compile functions declared or imported by a module.
 // This is a top-level type implemented by an interpreter or JIT compiler.
 type Engine interface {
 	// CompileModule implements the same method as documented on wasm.Engine.
-	CompileModule(module *Module) error
+	CompileModule(ctx context.Context, module *Module) error
 
 	// NewModuleEngine compiles down the function instances in a module, and returns ModuleEngine for the module.
 	//
@@ -17,7 +19,13 @@ type Engine interface {
 	//
 	// Note: Input parameters must be pre-validated with wasm.Module Validate, to ensure no fields are invalid
 	// due to reasons such as out-of-bounds.
-	NewModuleEngine(name string, module *Module, importedFunctions, moduleFunctions []*FunctionInstance, table *TableInstance, tableInit map[Index]Index) (ModuleEngine, error)
+	NewModuleEngine(
+		name string,
+		module *Module,
+		importedFunctions, moduleFunctions []*FunctionInstance,
+		table *TableInstance,
+		tableInit map[Index]Index,
+	) (ModuleEngine, error)
 
 	// DeleteCompiledModule releases compilation caches for the given module (source).
 	// Note: it is safe to call this function for a module from which module instances are instantiated even when these module instances
@@ -31,7 +39,5 @@ type ModuleEngine interface {
 	Name() string
 
 	// Call invokes a function instance f with given parameters.
-	// Returns the results from the function.
-	// The ctx's context.Context will be the outer-most ancestor of the argument to api.Function.
-	Call(ctx *CallContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
+	Call(ctx context.Context, m *CallContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
 }

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -21,8 +21,11 @@ const (
 	// a context.Context.
 	FunctionKindGoContext
 	// FunctionKindGoModule is a function implemented in Go, with a signature matching FunctionType, except arg
-	// zero is a Module.
+	// zero is an api.Module.
 	FunctionKindGoModule
+	// FunctionKindGoContextModule is a function implemented in Go, with a signature matching FunctionType, except arg
+	// zero is a context.Context and arg one is an api.Module.
+	FunctionKindGoContextModule
 )
 
 // Below are reflection code to get the interface type used to parse functions and set values.
@@ -30,22 +33,6 @@ const (
 var moduleType = reflect.TypeOf((*api.Module)(nil)).Elem()
 var goContextType = reflect.TypeOf((*context.Context)(nil)).Elem()
 var errorType = reflect.TypeOf((*error)(nil)).Elem()
-
-// getGoFuncCallContextValue returns a reflect.Value for a context param[0], or nil if there isn't one.
-func getGoFuncCallContextValue(fk FunctionKind, ctx *CallContext) *reflect.Value {
-	switch fk {
-	case FunctionKindGoNoContext: // no special param zero
-	case FunctionKindGoContext:
-		val := reflect.New(goContextType).Elem()
-		val.Set(reflect.ValueOf(ctx.Context()))
-		return &val
-	case FunctionKindGoModule:
-		val := reflect.New(moduleType).Elem()
-		val.Set(reflect.ValueOf(ctx))
-		return &val
-	}
-	return nil
-}
 
 // PopGoFuncParams pops the correct number of parameters off the stack into a parameter slice for use in CallGoFunc
 //
@@ -55,7 +42,11 @@ func getGoFuncCallContextValue(fk FunctionKind, ctx *CallContext) *reflect.Value
 func PopGoFuncParams(f *FunctionInstance, popParam func() uint64) []uint64 {
 	// First, determine how many values we need to pop
 	paramCount := f.GoFunc.Type().NumIn()
-	if f.Kind != FunctionKindGoNoContext {
+	switch f.Kind {
+	case FunctionKindGoNoContext:
+	case FunctionKindGoContextModule:
+		paramCount -= 2
+	default:
 		paramCount--
 	}
 
@@ -82,22 +73,30 @@ func PopValues(count int, popper func() uint64) []uint64 {
 // * callCtx is passed to the host function as a first argument.
 //
 // Note: ctx must use the caller's memory, which might be different from the defining module on an imported function.
-func CallGoFunc(callCtx *CallContext, f *FunctionInstance, params []uint64) []uint64 {
+func CallGoFunc(ctx context.Context, callCtx *CallContext, f *FunctionInstance, params []uint64) []uint64 {
 	tp := f.GoFunc.Type()
 
 	var in []reflect.Value
 	if tp.NumIn() != 0 {
 		in = make([]reflect.Value, tp.NumIn())
 
-		wasmParamOffset := 0
-		if f.Kind != FunctionKindGoNoContext {
-			wasmParamOffset = 1
+		i := 0
+		switch f.Kind {
+		case FunctionKindGoContext:
+			in[0] = newContextVal(ctx)
+			i = 1
+		case FunctionKindGoModule:
+			in[0] = newModuleVal(callCtx)
+			i = 1
+		case FunctionKindGoContextModule:
+			in[0] = newContextVal(ctx)
+			in[1] = newModuleVal(callCtx)
+			i = 2
 		}
 
-		for i, raw := range params {
-			inI := i + wasmParamOffset
-			val := reflect.New(tp.In(inI)).Elem()
-			switch tp.In(inI).Kind() {
+		for _, raw := range params {
+			val := reflect.New(tp.In(i)).Elem()
+			switch tp.In(i).Kind() {
 			case reflect.Float32:
 				val.SetFloat(float64(math.Float32frombits(uint32(raw))))
 			case reflect.Float64:
@@ -107,12 +106,8 @@ func CallGoFunc(callCtx *CallContext, f *FunctionInstance, params []uint64) []ui
 			case reflect.Int32, reflect.Int64:
 				val.SetInt(int64(raw))
 			}
-			in[inI] = val
-		}
-
-		// Handle any special parameter zero
-		if val := getGoFuncCallContextValue(f.Kind, callCtx); val != nil {
-			in[0] = *val
+			in[i] = val
+			i++
 		}
 	}
 
@@ -138,6 +133,18 @@ func CallGoFunc(callCtx *CallContext, f *FunctionInstance, params []uint64) []ui
 	return results
 }
 
+func newContextVal(ctx context.Context) reflect.Value {
+	val := reflect.New(goContextType).Elem()
+	val.Set(reflect.ValueOf(ctx))
+	return val
+}
+
+func newModuleVal(m api.Module) reflect.Value {
+	val := reflect.New(moduleType).Elem()
+	val.Set(reflect.ValueOf(m))
+	return val
+}
+
 // getFunctionType returns the function type corresponding to the function signature or errs if invalid.
 func getFunctionType(fn *reflect.Value, enabledFeatures Features) (fk FunctionKind, ft *FunctionType, err error) {
 	p := fn.Type()
@@ -147,8 +154,13 @@ func getFunctionType(fn *reflect.Value, enabledFeatures Features) (fk FunctionKi
 		return
 	}
 
+	fk = kind(p)
 	pOffset := 0
-	if fk = kind(p); fk != FunctionKindGoNoContext {
+	switch fk {
+	case FunctionKindGoNoContext:
+	case FunctionKindGoContextModule:
+		pOffset = 2
+	default:
 		pOffset = 1
 	}
 
@@ -212,6 +224,9 @@ func kind(p reflect.Type) FunctionKind {
 		if p0.Implements(moduleType) {
 			return FunctionKindGoModule
 		} else if p0.Implements(goContextType) {
+			if pCount >= 2 && p.In(1).Implements(moduleType) {
+				return FunctionKindGoContextModule
+			}
 			return FunctionKindGoContext
 		}
 	}

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
+// testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
+var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
+
 func TestInterpreter_CallEngine_PushFrame(t *testing.T) {
 	f1 := &callFrame{}
 	f2 := &callFrame{}
@@ -136,7 +139,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
 					},
 				}
-				ce.callNativeFunc(context.Background(), &wasm.CallContext{}, f)
+				ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
 				require.Equal(t, tc.expected, int32(uint32(ce.popValue())))
 			})
 		}
@@ -188,7 +191,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
 					},
 				}
-				ce.callNativeFunc(context.Background(), &wasm.CallContext{}, f)
+				ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
 				require.Equal(t, tc.expected, int64(ce.popValue()))
 			})
 		}
@@ -221,7 +224,7 @@ func TestInterpreter_Compile(t *testing.T) {
 			ID: wasm.ModuleID{},
 		}
 
-		err := e.CompileModule(context.Background(), errModule)
+		err := e.CompileModule(testCtx, errModule)
 		require.EqualError(t, err, "failed to lower func[2/3] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, all the compiled functions including succeeded ones must be released.
@@ -242,7 +245,7 @@ func TestInterpreter_Compile(t *testing.T) {
 			},
 			ID: wasm.ModuleID{},
 		}
-		err := e.CompileModule(context.Background(), okModule)
+		err := e.CompileModule(testCtx, okModule)
 		require.NoError(t, err)
 
 		compiled, ok := e.codes[okModule.ID]

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -1,6 +1,7 @@
 package interpreter
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -135,7 +136,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
 					},
 				}
-				ce.callNativeFunc(&wasm.CallContext{}, f)
+				ce.callNativeFunc(context.Background(), &wasm.CallContext{}, f)
 				require.Equal(t, tc.expected, int32(uint32(ce.popValue())))
 			})
 		}
@@ -187,7 +188,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
 					},
 				}
-				ce.callNativeFunc(&wasm.CallContext{}, f)
+				ce.callNativeFunc(context.Background(), &wasm.CallContext{}, f)
 				require.Equal(t, tc.expected, int64(ce.popValue()))
 			})
 		}
@@ -220,7 +221,7 @@ func TestInterpreter_Compile(t *testing.T) {
 			ID: wasm.ModuleID{},
 		}
 
-		err := e.CompileModule(errModule)
+		err := e.CompileModule(context.Background(), errModule)
 		require.EqualError(t, err, "failed to lower func[2/3] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, all the compiled functions including succeeded ones must be released.
@@ -241,7 +242,7 @@ func TestInterpreter_Compile(t *testing.T) {
 			},
 			ID: wasm.ModuleID{},
 		}
-		err := e.CompileModule(okModule)
+		err := e.CompileModule(context.Background(), okModule)
 		require.NoError(t, err)
 
 		compiled, ok := e.codes[okModule.ID]

--- a/internal/wasm/jit/jit_impl_arm64.go
+++ b/internal/wasm/jit/jit_impl_arm64.go
@@ -3056,8 +3056,8 @@ func (c *arm64Compiler) compileReservedMemoryRegisterInitialization() {
 	}
 }
 
-// compileModuleContextInitialization adds instructions to initialize ce.CallContext's fields based on
-// ce.CallContext.ModuleInstanceAddress.
+// compileModuleContextInitialization adds instructions to initialize ce.moduleContext's fields based on
+// ce.moduleContext.ModuleInstanceAddress.
 // This is called in two cases: in function preamble, and on the return from (non-Go) function calls.
 func (c *arm64Compiler) compileModuleContextInitialization() error {
 	c.markRegisterUsed(arm64CallingConventionModuleInstanceAddressRegister)

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -2,6 +2,7 @@ package wazeroir
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -180,7 +181,7 @@ type CompilationResult struct {
 	HasTable bool
 }
 
-func CompileFunctions(enabledFeatures wasm.Features, module *wasm.Module) ([]*CompilationResult, error) {
+func CompileFunctions(_ context.Context, enabledFeatures wasm.Features, module *wasm.Module) ([]*CompilationResult, error) {
 	functions, globals, mem, table, err := module.AllDeclarations()
 	if err != nil {
 		return nil, err

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -1,6 +1,7 @@
 package wazeroir
 
 import (
+	"context"
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
@@ -8,6 +9,9 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasm/text"
 )
+
+// ctx is an arbitrary, non-default context.
+var ctx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
 var (
 	f64, i32   = wasm.ValueTypeF64, wasm.ValueTypeI32
@@ -65,7 +69,7 @@ func TestCompile(t *testing.T) {
 				enabledFeatures = wasm.FeaturesFinished
 			}
 
-			res, err := CompileFunctions(enabledFeatures, tc.module)
+			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0])
 		})
@@ -395,7 +399,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			if enabledFeatures == 0 {
 				enabledFeatures = wasm.FeaturesFinished
 			}
-			res, err := CompileFunctions(enabledFeatures, tc.module)
+			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0])
 		})
@@ -406,7 +410,7 @@ func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expec
 	if enabledFeatures == 0 {
 		enabledFeatures = wasm.FeaturesFinished
 	}
-	res, err := CompileFunctions(enabledFeatures, module)
+	res, err := CompileFunctions(ctx, enabledFeatures, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
 }

--- a/wasi/example_test.go
+++ b/wasi/example_test.go
@@ -1,6 +1,7 @@
 package wasi
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -13,10 +14,14 @@ import (
 //
 // See https://github.com/tetratelabs/wazero/tree/main/examples/wasi for another example.
 func Example() {
+	// Choose the context to use for function calls.
+	ctx := context.Background()
+
+	// Create a new WebAssembly Runtime.
 	r := wazero.NewRuntime()
 
 	// Instantiate WASI, which implements system I/O such as console output.
-	wm, err := InstantiateSnapshotPreview1(r)
+	wm, err := InstantiateSnapshotPreview1(ctx, r)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -26,7 +31,7 @@ func Example() {
 	config := wazero.NewModuleConfig().WithStdout(os.Stdout)
 
 	// InstantiateModuleFromCodeWithConfig runs the "_start" function which is like a "main" function.
-	_, err = r.InstantiateModuleFromCodeWithConfig([]byte(`
+	_, err = r.InstantiateModuleFromCodeWithConfig(ctx, []byte(`
 (module
   (import "wasi_snapshot_preview1" "proc_exit" (func $wasi.proc_exit (param $rval i32)))
 

--- a/wasi/usage_test.go
+++ b/wasi/usage_test.go
@@ -20,17 +20,17 @@ func TestInstantiateModuleWithConfig(t *testing.T) {
 
 	// Configure WASI to write stdout to a buffer, so that we can verify it later.
 	sys := wazero.NewModuleConfig().WithStdout(stdout)
-	wm, err := InstantiateSnapshotPreview1(r)
+	wm, err := InstantiateSnapshotPreview1(testCtx, r)
 	require.NoError(t, err)
 	defer wm.Close()
 
-	compiled, err := r.CompileModule(wasiArg)
+	compiled, err := r.CompileModule(testCtx, wasiArg)
 	require.NoError(t, err)
 	defer compiled.Close()
 
 	// Re-use the same module many times.
 	for _, tc := range []string{"a", "b", "c"} {
-		mod, err := r.InstantiateModuleWithConfig(compiled, sys.WithArgs(tc).WithName(tc))
+		mod, err := r.InstantiateModuleWithConfig(testCtx, compiled, sys.WithArgs(tc).WithName(tc))
 		require.NoError(t, err)
 
 		// Ensure the scoped configuration applied. As the args are null-terminated, we append zero (NUL).

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -5,6 +5,7 @@
 package wasi
 
 import (
+	"context"
 	crand "crypto/rand"
 	"errors"
 	"fmt"
@@ -25,9 +26,9 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 // InstantiateSnapshotPreview1 instantiates ModuleSnapshotPreview1, so that other modules can import them.
 //
 // Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
-func InstantiateSnapshotPreview1(r wazero.Runtime) (api.Module, error) {
+func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Module, error) {
 	_, fns := snapshotPreview1Functions()
-	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate()
+	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate(ctx)
 }
 
 const (

--- a/wasi/wasi_bench_test.go
+++ b/wasi/wasi_bench_test.go
@@ -1,7 +1,6 @@
 package wasi
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -59,7 +58,7 @@ func Benchmark_EnvironGet(b *testing.B) {
 }
 
 func newCtx(buf []byte, sys *wasm.SysContext) *wasm.CallContext {
-	return wasm.NewCallContext(context.Background(), nil, &wasm.ModuleInstance{
+	return wasm.NewCallContext(nil, &wasm.ModuleInstance{
 		Memory: &wasm.MemoryInstance{Min: 1, Buffer: buf},
 	}, sys)
 }

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 )
 
+// testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
+var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
+
 func TestRuntime_DecodeModule(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -54,7 +57,7 @@ func TestRuntime_DecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			code, err := r.CompileModule(tc.source)
+			code, err := r.CompileModule(testCtx, tc.source)
 			require.NoError(t, err)
 			defer code.Close()
 			if tc.expectedName != "" {
@@ -115,7 +118,7 @@ func TestRuntime_DecodeModule_Errors(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.runtime.CompileModule(tc.source)
+			_, err := tc.runtime.CompileModule(testCtx, tc.source)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -151,7 +154,7 @@ func TestModule_Memory(t *testing.T) {
 		r := NewRuntime()
 		t.Run(tc.name, func(t *testing.T) {
 			// Instantiate the module and get the export of the above memory
-			module, err := tc.builder(r).Instantiate()
+			module, err := tc.builder(r).Instantiate(testCtx)
 			require.NoError(t, err)
 			defer module.Close()
 
@@ -224,14 +227,14 @@ func TestModule_Global(t *testing.T) {
 			if tc.module != nil {
 				code = &CompiledCode{module: tc.module}
 			} else {
-				code, _ = tc.builder(r).Build()
+				code, _ = tc.builder(r).Build(testCtx)
 			}
 
-			err := r.store.Engine.CompileModule(code.module)
+			err := r.store.Engine.CompileModule(testCtx, code.module)
 			require.NoError(t, err)
 
 			// Instantiate the module and get the export of the above global
-			module, err := r.InstantiateModule(code)
+			module, err := r.InstantiateModule(testCtx, code)
 			require.NoError(t, err)
 			defer module.Close()
 
@@ -253,26 +256,20 @@ func TestModule_Global(t *testing.T) {
 }
 
 func TestFunction_Context(t *testing.T) {
-	type key string
-	runtimeCtx := context.WithValue(context.Background(), key("wa"), "zero")
-	config := NewRuntimeConfig().WithContext(runtimeCtx)
-
-	notStoreCtx := context.WithValue(context.Background(), key("wazer"), "o")
-
 	tests := []struct {
 		name     string
 		ctx      context.Context
 		expected context.Context
 	}{
 		{
-			name:     "nil defaults to runtime context",
+			name:     "nil defaults to context.Background",
 			ctx:      nil,
-			expected: runtimeCtx,
+			expected: context.Background(),
 		},
 		{
-			name:     "set overrides runtime context",
-			ctx:      notStoreCtx,
-			expected: notStoreCtx,
+			name:     "set context",
+			ctx:      testCtx,
+			expected: testCtx,
 		},
 	}
 
@@ -280,49 +277,48 @@ func TestFunction_Context(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewRuntimeWithConfig(config)
+			r := NewRuntime()
 
 			// Define a host function so that we can catch the context propagated from a module function call
 			functionName := "fn"
 			expectedResult := uint64(math.MaxUint64)
-			hostFn := func(ctx api.Module) uint64 {
-				require.Equal(t, tc.expected, ctx.Context())
+			hostFn := func(ctx context.Context) uint64 {
+				require.Equal(t, tc.expected, ctx)
 				return expectedResult
 			}
 			source, closer := requireImportAndExportFunction(t, r, hostFn, functionName)
 			defer closer() // nolint
 
 			// Instantiate the module and get the export of the above hostFn
-			module, err := r.InstantiateModuleFromCodeWithConfig(source, NewModuleConfig().WithName(t.Name()))
+			module, err := r.InstantiateModuleFromCodeWithConfig(tc.ctx, source, NewModuleConfig().WithName(t.Name()))
 			require.NoError(t, err)
 			defer module.Close()
 
 			// This fails if the function wasn't invoked, or had an unexpected context.
-			results, err := module.ExportedFunction(functionName).Call(module.WithContext(tc.ctx))
+			results, err := module.ExportedFunction(functionName).Call(tc.ctx)
 			require.NoError(t, err)
 			require.Equal(t, expectedResult, results[0])
 		})
 	}
 }
 
-func TestRuntime_NewModule_UsesConfiguredContext(t *testing.T) {
-	type key string
-	runtimeCtx := context.WithValue(context.Background(), key("wa"), "zero")
-	config := NewRuntimeConfig().WithContext(runtimeCtx)
-	r := NewRuntimeWithConfig(config)
+func TestRuntime_InstantiateModule_UsesContext(t *testing.T) {
+	r := NewRuntime()
 
 	// Define a function that will be set as the start function
 	var calledStart bool
-	start := func(ctx api.Module) {
+	start := func(ctx context.Context) {
 		calledStart = true
-		require.Equal(t, runtimeCtx, ctx.Context())
+		require.Equal(t, testCtx, ctx)
 	}
 
-	env, err := r.NewModuleBuilder("env").ExportFunction("start", start).Instantiate()
+	env, err := r.NewModuleBuilder("env").
+		ExportFunction("start", start).
+		Instantiate(testCtx)
 	require.NoError(t, err)
 	defer env.Close()
 
-	code, err := r.CompileModule([]byte(`(module $runtime_test.go
+	code, err := r.CompileModule(testCtx, []byte(`(module $runtime_test.go
 	(import "env" "start" (func $start))
 	(start $start)
 )`))
@@ -330,7 +326,7 @@ func TestRuntime_NewModule_UsesConfiguredContext(t *testing.T) {
 	defer code.Close()
 
 	// Instantiate the module, which calls the start function. This will fail if the context wasn't as intended.
-	m, err := r.InstantiateModule(code)
+	m, err := r.InstantiateModule(testCtx, code)
 	require.NoError(t, err)
 	defer m.Close()
 
@@ -341,7 +337,7 @@ func TestRuntime_NewModule_UsesConfiguredContext(t *testing.T) {
 func TestInstantiateModuleFromCode_DoesntEnforce_Start(t *testing.T) {
 	r := NewRuntime()
 
-	mod, err := r.InstantiateModuleFromCode([]byte(`(module $wasi_test.go
+	mod, err := r.InstantiateModuleFromCode(testCtx, []byte(`(module $wasi_test.go
 	(memory 1)
 	(export "memory" (memory 0))
 )`))
@@ -349,24 +345,24 @@ func TestInstantiateModuleFromCode_DoesntEnforce_Start(t *testing.T) {
 	require.NoError(t, mod.Close())
 }
 
-func TestInstantiateModuleFromCode_UsesRuntimeContext(t *testing.T) {
-	type key string
-	config := NewRuntimeConfig().WithContext(context.WithValue(context.Background(), key("wa"), "zero"))
-	r := NewRuntimeWithConfig(config)
+func TestRuntime_InstantiateModuleFromCode_UsesContext(t *testing.T) {
+	r := NewRuntime()
 
 	// Define a function that will be re-exported as the WASI function: _start
 	var calledStart bool
-	start := func(ctx api.Module) {
+	start := func(ctx context.Context) {
 		calledStart = true
-		require.Equal(t, config.ctx, ctx.Context())
+		require.Equal(t, testCtx, ctx)
 	}
 
-	host, err := r.NewModuleBuilder("").ExportFunction("start", start).Instantiate()
+	host, err := r.NewModuleBuilder("").
+		ExportFunction("start", start).
+		Instantiate(testCtx)
 	require.NoError(t, err)
 	defer host.Close()
 
 	// Start the module as a WASI command. This will fail if the context wasn't as intended.
-	mod, err := r.InstantiateModuleFromCode([]byte(`(module $start
+	mod, err := r.InstantiateModuleFromCode(testCtx, []byte(`(module $start
 	(import "" "start" (func $start))
 	(memory 1)
 	(export "_start" (func $start))
@@ -382,7 +378,7 @@ func TestInstantiateModuleFromCode_UsesRuntimeContext(t *testing.T) {
 // different names. This pattern is used in wapc-go.
 func TestInstantiateModuleWithConfig_WithName(t *testing.T) {
 	r := NewRuntime()
-	base, err := r.CompileModule([]byte(`(module $0 (memory 1))`))
+	base, err := r.CompileModule(testCtx, []byte(`(module $0 (memory 1))`))
 	require.NoError(t, err)
 	defer base.Close()
 
@@ -390,14 +386,14 @@ func TestInstantiateModuleWithConfig_WithName(t *testing.T) {
 
 	// Use the same runtime to instantiate multiple modules
 	internal := r.(*runtime).store
-	m1, err := r.InstantiateModuleWithConfig(base, NewModuleConfig().WithName("1"))
+	m1, err := r.InstantiateModuleWithConfig(testCtx, base, NewModuleConfig().WithName("1"))
 	require.NoError(t, err)
 	defer m1.Close()
 
 	require.Nil(t, internal.Module("0"))
 	require.Equal(t, internal.Module("1"), m1)
 
-	m2, err := r.InstantiateModuleWithConfig(base, NewModuleConfig().WithName("2"))
+	m2, err := r.InstantiateModuleWithConfig(testCtx, base, NewModuleConfig().WithName("2"))
 	require.NoError(t, err)
 	defer m2.Close()
 
@@ -412,15 +408,15 @@ func TestInstantiateModuleWithConfig_ExitError(t *testing.T) {
 		require.NoError(t, m.CloseWithExitCode(2))
 	}
 
-	_, err := r.NewModuleBuilder("env").ExportFunction("_start", start).Instantiate()
+	_, err := r.NewModuleBuilder("env").ExportFunction("_start", start).Instantiate(testCtx)
 
 	// Ensure the exit error propagated and didn't wrap.
 	require.Equal(t, err, sys.NewExitError("env", 2))
 }
 
 // requireImportAndExportFunction re-exports a host function because only host functions can see the propagated context.
-func requireImportAndExportFunction(t *testing.T, r Runtime, hostFn func(ctx api.Module) uint64, functionName string) ([]byte, func() error) {
-	mod, err := r.NewModuleBuilder("host").ExportFunction(functionName, hostFn).Instantiate()
+func requireImportAndExportFunction(t *testing.T, r Runtime, hostFn func(ctx context.Context) uint64, functionName string) ([]byte, func() error) {
+	mod, err := r.NewModuleBuilder("host").ExportFunction(functionName, hostFn).Instantiate(testCtx)
 	require.NoError(t, err)
 
 	return []byte(fmt.Sprintf(
@@ -434,7 +430,7 @@ func TestCompiledCode_Close(t *testing.T) {
 	var cs []*CompiledCode
 	for i := 0; i < 10; i++ {
 		m := &wasm.Module{}
-		err := e.CompileModule(m)
+		err := e.CompileModule(testCtx, m)
 		require.NoError(t, err)
 		cs = append(cs, &CompiledCode{module: m, compiledEngine: e})
 	}
@@ -465,7 +461,7 @@ func (e *mockEngine) DeleteCompiledModule(module *wasm.Module) {
 	delete(e.cachedModules, module)
 }
 
-func (e *mockEngine) CompileModule(module *wasm.Module) error {
+func (e *mockEngine) CompileModule(_ context.Context, module *wasm.Module) error {
 	e.cachedModules[module] = struct{}{}
 	return nil
 }


### PR DESCRIPTION
This is an API breaking change that does a few things:

* Stop encouraging practice that can break context propagation:
  * Stops caching `context.Context` in `wazero.RuntimeConfig`
  * Stops caching `context.Context` in `api.Module`

* Fixes context propagation in function calls:
  * Changes `api.Function`'s arg0 from `api.Module` to `context.Context`
  * Adds `context.Context` parameter in instantiation (propagates to
    .start)

* Allows context propagation for heavy operations like compile:
  * Adds `context.Context` as the initial parameter of `CompileModule`

The design we had earlier was a good start, but this is the only way to
ensure coherence when users start correlating or tracing. While adding a
`context.Context` parameter may seem difficult, wazero is a low-level
library and WebAssembly is notoriously difficult to troubleshoot. In
other words, it will be easier to explain to users to pass (even nil) as
the context parameter vs try to figure out things without coherent
context.

## Example impact in normal usage

Users should pass non-nil context, but we allow nil to coerce to `context.Background()`
```diff
+        // Choose the context to use for function calls.
+        ctx := context.Background()
+
        // Read a WebAssembly binary containing an exported "fac" function.
        // * Ex. (func (export "fac") (param i64) (result i64) ...
        source, _ := os.ReadFile("./tests/bench/testdata/fac.wasm")
 
        // Instantiate the module and return its exported functions
-       module, _ := wazero.NewRuntime().InstantiateModuleFromCode(source)
+       module, _ := wazero.NewRuntime().InstantiateModuleFromCode(ctx, source)
        defer module.Close()
 
        // Discover 7! is 5040
-       fmt.Println(module.ExportedFunction("fac").Call(nil, 7))
+       fmt.Println(module.ExportedFunction("fac").Call(ctx, 7))
```

## Example impact defining host functions

Since modules no longer cache a `context.Context` to access the inbound context, you need to define arg0 as such:
```diff
-               ExportFunction("call_get_age", func(m api.Module) (age uint64) {
+               ExportFunction("call_get_age", func(ctx context.Context, m api.Module) (age uint64) {
                        resultOffsetAge := uint32(8) // arbitrary memory offset (in bytes)
-                       _, _ = m.ExportedFunction("get_age").Call(m, uint64(resultOffsetAge))
+                       _, _ = m.ExportedFunction("get_age").Call(ctx, uint64(resultOffsetAge))
                        age, _ = m.Memory().ReadUint64Le(resultOffsetAge)
                        return
-               }).Instantiate()
+               }).Instantiate(ctx)
```