### PR TITLE
Fix validate start section with imports

### DIFF
--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -193,7 +193,7 @@ func (m *Module) TypeOfFunction(funcIdx Index) *FunctionType {
 	funcImportCount := Index(0)
 	for _, im := range m.ImportSection {
 		if im.Type == ExternTypeFunc {
-			if funcIdx == Index(funcImportCount) {
+			if funcIdx == funcImportCount {
 				if im.DescFunc >= typeSectionLength {
 					return nil
 				}

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -191,9 +191,9 @@ func (m *Module) TypeOfFunction(funcIdx Index) *FunctionType {
 		return nil
 	}
 	funcImportCount := Index(0)
-	for i, im := range m.ImportSection {
+	for _, im := range m.ImportSection {
 		if im.Type == ExternTypeFunc {
-			if funcIdx == Index(i) {
+			if funcIdx == Index(funcImportCount) {
 				if im.DescFunc >= typeSectionLength {
 					return nil
 				}

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -331,6 +331,21 @@ func TestModule_validateStartSection(t *testing.T) {
 			})
 		}
 	})
+	t.Run("imported valid func", func(t *testing.T) {
+		index := Index(1)
+		m := Module{
+			StartSection: &index,
+			TypeSection:  []*FunctionType{{}, {Results: []ValueType{ValueTypeI32}}},
+			ImportSection: []*Import{
+				{Type: ExternTypeFunc, DescFunc: 1},
+				// import with index 1 is global but this should be skipped when searching imported functions.
+				{Type: ExternTypeGlobal},
+				{Type: ExternTypeFunc, DescFunc: 0}, // This one must be selected.
+			},
+		}
+		err := m.validateStartSection()
+		require.NoError(t, err)
+	})
 }
 
 func TestModule_validateGlobals(t *testing.T) {


### PR DESCRIPTION
Previously, when searching the signature of imported function start section,
we haven't skipped non-function imports for indexes.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>