### PR TITLE
Adds Memory.IndexByte and memory grow example

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -179,7 +179,11 @@ type Memory interface {
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
 	Size() uint32
 
-	// ReadByte reads a single byte from the underlying buffer at the offset in or returns false if out of range.
+	// IndexByte returns the index of the first instance of c in the underlying buffer at the offset or returns false if
+	// not found or out of range.
+	IndexByte(offset uint32, c byte) (uint32, bool)
+
+	// ReadByte reads a single byte from the underlying buffer at the offset or returns false if out of range.
 	ReadByte(offset uint32) (byte, bool)
 
 	// ReadUint32Le reads a uint32 in little-endian encoding from the underlying buffer at the offset in or returns

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -45,6 +45,19 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 	require.Equal(t, max, m.PageSize())
 }
 
+func TestIndexByte(t *testing.T) {
+	var mem = &MemoryInstance{Buffer: []byte{0, 0, 0, 0, 16, 0, 0, 0}, Min: 1}
+	v, ok := mem.IndexByte(4, 16)
+	require.True(t, ok)
+	require.Equal(t, uint32(4), v)
+
+	_, ok = mem.IndexByte(5, 16)
+	require.False(t, ok)
+
+	_, ok = mem.IndexByte(9, 16)
+	require.False(t, ok)
+}
+
 func TestReadByte(t *testing.T) {
 	var mem = &MemoryInstance{Buffer: []byte{0, 0, 0, 0, 0, 0, 0, 16}, Min: 1}
 	v, ok := mem.ReadByte(7)

--- a/internal/wasm/text/func_parser_test.go
+++ b/internal/wasm/text/func_parser_test.go
@@ -63,6 +63,25 @@ func TestFuncParser(t *testing.T) {
 			}},
 		},
 		{
+			name:   "i32.load",
+			source: "(func i32.const 8 i32.load)",
+			expected: &wasm.Code{Body: []byte{
+				wasm.OpcodeI32Const, 8, // dynamic memory offset to load
+				wasm.OpcodeI32Load, 0x2, 0x0, // load alignment=2 (natural alignment) staticOffset=0
+				wasm.OpcodeEnd,
+			}},
+		},
+		{
+			name:   "i32.store",
+			source: "(func i32.const 8 i32.const 37 i32.store)",
+			expected: &wasm.Code{Body: []byte{
+				wasm.OpcodeI32Const, 8, // dynamic memory offset to store
+				wasm.OpcodeI32Const, 37, // value to store
+				wasm.OpcodeI32Store, 0x2, 0x0, // load alignment=2 (natural alignment) staticOffset=0
+				wasm.OpcodeEnd,
+			}},
+		},
+		{
 			name:     "i64.const",
 			source:   "(func i64.const 356)",
 			expected: &wasm.Code{Body: []byte{wasm.OpcodeI64Const, 0xe4, 0x02, wasm.OpcodeEnd}},
@@ -83,6 +102,25 @@ func TestFuncParser(t *testing.T) {
 				wasm.OpcodeI32Const, 8, // dynamic memory offset to store
 				wasm.OpcodeI64Const, 37, // value to store
 				wasm.OpcodeI64Store, 0x3, 0x0, // load alignment=3 (natural alignment) staticOffset=0
+				wasm.OpcodeEnd,
+			}},
+		},
+		{
+			name:   "memory.grow",
+			source: "(func i32.const 2 memory.grow drop)",
+			expected: &wasm.Code{Body: []byte{
+				wasm.OpcodeI32Const, 2, // how many pages to grow
+				wasm.OpcodeMemoryGrow, 0, // memory index zero
+				wasm.OpcodeDrop, // drop the previous page count (or -1 if grow failed)
+				wasm.OpcodeEnd,
+			}},
+		},
+		{
+			name:   "memory.size",
+			source: "(func memory.size drop)",
+			expected: &wasm.Code{Body: []byte{
+				wasm.OpcodeMemorySize, 0, // memory index zero
+				wasm.OpcodeDrop, // drop the page count
 				wasm.OpcodeEnd,
 			}},
 		},


### PR DESCRIPTION
This adds Memory.IndexByte which allows efficent scanning for a
delimiter, ex NUL(0) in null-terminated strings.

This also adds an ad-hoc test to ensure we can export memory functions
such as grow. While this is implicitly in the spectests, it is easier to
find in the ad-hoc tests.