### PR TITLE
Adds vs benchmark WasmEdge and splits compile from instantiate

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -129,6 +129,15 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # Unlike the other CGO libraries, WasmEdge requires offline installation.
+      - name: Install WasmEdge
+        run: |
+          wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | sudo bash -s -- -p /usr/local -e all -v ${WASMEDGE_VERSION}
+        # The version here is coupled to internal/integration_test/go.mod, but it
+        # isn't always the same as sometimes the Go layer has a broken release.
+        env:
+          WASMEDGE_VERSION: 0.9.1
+
       - uses: actions/checkout@v3
 
       - uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ bench:
 
 .PHONY: bench.check
 bench.check:
-	@go test -run=NONE -benchmem -bench=. ./internal/integration_test/bench/...
-	@cd ./internal/integration_test/vs && go test -benchmem -bench=. . -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
+	@go build ./internal/integration_test/bench/...
+	@cd ./internal/integration_test/vs && go test -benchmem -bench=. . -tags='wasmedge' -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
 
 bench_testdata_dir := internal/integration_test/bench/testdata
 

--- a/config.go
+++ b/config.go
@@ -131,11 +131,16 @@ type CompiledCode struct {
 	compiledEngine wasm.Engine
 }
 
+// compile-time check to ensure CompiledCode implements io.Closer (consistent with api.Module)
+var _ io.Closer = &CompiledCode{}
+
 // Close releases all the allocated resources for this CompiledCode.
 //
-// Note: it is safe to call Close while having outstanding calls from Modules instantiated from this *CompiledCode.
-func (c *CompiledCode) Close() {
+// Note: It is safe to call Close while having outstanding calls from Modules instantiated from this *CompiledCode.
+func (c *CompiledCode) Close() error {
 	c.compiledEngine.DeleteCompiledModule(c.module)
+	// It is possible the underlying may need to return an error later, but in any case this matches api.Module.Close.
+	return nil
 }
 
 // ModuleConfig configures resources needed by functions that have low-level interactions with the host operating system.

--- a/internal/integration_test/vs/bench_fac_test.go
+++ b/internal/integration_test/vs/bench_fac_test.go
@@ -16,82 +16,35 @@ const (
 //go:embed testdata/fac.wasm
 var facWasm []byte
 
-func facInit(rt runtimeTester) error {
-	return rt.Init(testCtx, &runtimeConfig{
-		moduleName: "math",
-		moduleWasm: facWasm,
-		funcNames:  []string{"fac"},
-	})
+var facConfig = &runtimeConfig{
+	moduleName: "math",
+	moduleWasm: facWasm,
+	funcNames:  []string{"fac"},
 }
 
-func facInvoke(rt runtimeTester) (uint64, error) {
-	return rt.CallI64_I64(testCtx, "fac", facArgument)
+func facCall(m module) (uint64, error) {
+	return m.CallI64_I64(testCtx, "fac", facArgument)
 }
 
-func testFacInvoke(rt runtimeTester) func(t *testing.T) {
-	return func(t *testing.T) {
-		err := facInit(rt)
-		require.NoError(t, err)
-		defer rt.Close()
-
-		// Large loop in test is only to show the function is stable (ex doesn't leak or crash on Nth use).
-		for i := 0; i < 10000; i++ {
-			res, err := facInvoke(rt)
-			require.NoError(t, err)
-			require.Equal(t, facResult, res)
-		}
-	}
-}
-
-func benchFacInvoke(rt runtimeTester) func(b *testing.B) {
-	return func(b *testing.B) {
-		// Initialize outside the benchmark loop
-		if err := facInit(rt); err != nil {
-			b.Fatal(err)
-		}
-		defer rt.Close()
-
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			if _, err := facInvoke(rt); err != nil {
-				b.Fatal(err)
-			}
-		}
-	}
+func testFacCall(t *testing.T, m module) {
+	res, err := m.CallI64_I64(testCtx, "fac", facArgument)
+	require.NoError(t, err)
+	require.Equal(t, facResult, res)
 }
 
 // TestFac ensures that the code in BenchmarkFac works as expected.
 func TestFac(t *testing.T) {
-	for name, rtFn := range runtimeTesters {
-		t.Run(name, testFacInvoke(rtFn()))
-	}
+	testCall(t, facConfig, testFacCall)
 }
 
-// BenchmarkFac_Init tracks the time spent readying a function for use
-func BenchmarkFac_Init(b *testing.B) {
-	for name, rtFn := range runtimeTesters {
-		rt := rtFn()
-		b.Run(name, func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if err := facInit(rt); err != nil {
-					b.Fatal(err)
-				} else {
-					rt.Close()
-				}
-			}
-		})
-	}
+func BenchmarkFac_Compile(b *testing.B) {
+	benchmarkCompile(b, facConfig)
 }
 
-// BenchmarkFac_Invoke benchmarks the time spent invoking a factorial calculation.
-func BenchmarkFac_Invoke(b *testing.B) {
-	if ensureJITFastest == "true" {
-		// If ensureJITFastest == "true", the benchmark for invocation will be run by
-		// TestFac_JIT_Fastest so skip here.
-		b.Skip()
-	}
-	for name, rtFn := range runtimeTesters {
-		b.Run(name, benchFacInvoke(rtFn()))
-	}
+func BenchmarkFac_Instantiate(b *testing.B) {
+	benchmarkInstantiate(b, facConfig)
+}
+
+func BenchmarkFac_Call(b *testing.B) {
+	benchmarkCall(b, facConfig, facCall)
 }

--- a/internal/integration_test/vs/bench_fac_test.go
+++ b/internal/integration_test/vs/bench_fac_test.go
@@ -17,7 +17,11 @@ const (
 var facWasm []byte
 
 func facInit(rt runtimeTester) error {
-	return rt.Init(testCtx, facWasm, "fac")
+	return rt.Init(testCtx, &runtimeConfig{
+		moduleName: "math",
+		moduleWasm: facWasm,
+		funcNames:  []string{"fac"},
+	})
 }
 
 func facInvoke(rt runtimeTester) (uint64, error) {

--- a/internal/integration_test/vs/go.mod
+++ b/internal/integration_test/vs/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/second-state/WasmEdge-go v0.9.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 

--- a/internal/integration_test/vs/go.sum
+++ b/internal/integration_test/vs/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/second-state/WasmEdge-go v0.9.2 h1:lwbhJY6/uV/hzHOqwKMEASD+GbqN9EmUQzlIR+qoDjM=
+github.com/second-state/WasmEdge-go v0.9.2/go.mod h1:HyBf9hVj1sRAjklsjc1Yvs9b5RcmthPG9z99dY78TKg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -1,0 +1,98 @@
+package vs
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+)
+
+type runtimeConfig struct {
+	moduleName string
+	moduleWasm []byte
+	funcNames  []string
+}
+
+type runtime interface {
+	Compile(ctx context.Context, cfg *runtimeConfig) error
+	Instantiate(ctx context.Context, cfg *runtimeConfig) (module, error)
+	io.Closer
+}
+
+type module interface {
+	CallI64_I64(ctx context.Context, funcName string, param uint64) (uint64, error)
+	io.Closer
+}
+
+func newWazeroInterpreterRuntime() runtime {
+	return newWazeroRuntime(wazero.NewRuntimeConfigInterpreter().WithFinishedFeatures())
+}
+
+func newWazeroJITRuntime() runtime {
+	return newWazeroRuntime(wazero.NewRuntimeConfigJIT().WithFinishedFeatures())
+}
+
+func newWazeroRuntime(config *wazero.RuntimeConfig) runtime {
+	return &wazeroRuntime{config: config}
+}
+
+type wazeroRuntime struct {
+	config   *wazero.RuntimeConfig
+	runtime  wazero.Runtime
+	compiled *wazero.CompiledCode
+}
+
+type wazeroModule struct {
+	mod   api.Module
+	funcs map[string]api.Function
+}
+
+func (r *wazeroRuntime) Compile(ctx context.Context, cfg *runtimeConfig) (err error) {
+	r.runtime = wazero.NewRuntimeWithConfig(r.config)
+	r.compiled, err = r.runtime.CompileModule(ctx, cfg.moduleWasm)
+	return
+}
+
+func (r *wazeroRuntime) Instantiate(ctx context.Context, cfg *runtimeConfig) (mod module, err error) {
+	wazeroCfg := wazero.NewModuleConfig().WithName(cfg.moduleName)
+	m := &wazeroModule{funcs: map[string]api.Function{}}
+	if m.mod, err = r.runtime.InstantiateModuleWithConfig(ctx, r.compiled, wazeroCfg); err != nil {
+		return
+	}
+	for _, funcName := range cfg.funcNames {
+		if fn := m.mod.ExportedFunction(funcName); fn == nil {
+			return nil, fmt.Errorf("%s is not an exported function", fn)
+		} else {
+			m.funcs[funcName] = fn
+		}
+	}
+	mod = m
+	return
+}
+
+func (r *wazeroRuntime) Close() (err error) {
+	if compiled := r.compiled; compiled != nil {
+		err = compiled.Close()
+	}
+	r.compiled = nil
+	return
+}
+
+func (m *wazeroModule) CallI64_I64(ctx context.Context, funcName string, param uint64) (uint64, error) {
+	if results, err := m.funcs[funcName].Call(ctx, param); err != nil {
+		return 0, err
+	} else if len(results) > 0 {
+		return results[0], nil
+	}
+	return 0, nil
+}
+
+func (m *wazeroModule) Close() (err error) {
+	if mod := m.mod; mod != nil {
+		err = mod.Close()
+	}
+	m.mod = nil
+	return
+}

--- a/internal/integration_test/vs/wasm3_test.go
+++ b/internal/integration_test/vs/wasm3_test.go
@@ -22,23 +22,24 @@ type wasm3Tester struct {
 	funcs   map[string]wasm3.FunctionWrapper
 }
 
-func (w *wasm3Tester) Init(_ context.Context, wasm []byte, funcNames ...string) (err error) {
+func (w *wasm3Tester) Init(_ context.Context, cfg *runtimeConfig) (err error) {
 	w.runtime = wasm3.NewRuntime(&wasm3.Config{
 		Environment: wasm3.NewEnvironment(),
 		StackSize:   64 * 1024, // from example
 	})
 
-	module, err := w.runtime.ParseModule(wasm)
+	module, err := w.runtime.ParseModule(cfg.moduleWasm)
 	if err != nil {
 		return err
 	}
 
+	// TODO: not sure we can set cfg.moduleName in wasm3-go
 	_, err = w.runtime.LoadModule(module)
 	if err != nil {
 		return err
 	}
 
-	for _, funcName := range funcNames {
+	for _, funcName := range cfg.funcNames {
 		var fn wasm3.FunctionWrapper
 		if fn, err = w.runtime.FindFunction(funcName); err != nil {
 			return

--- a/internal/integration_test/vs/wasmedge_test.go
+++ b/internal/integration_test/vs/wasmedge_test.go
@@ -1,0 +1,72 @@
+//go:build amd64 && cgo && wasmedge
+
+// wasmedge depends on manual installation of a shared library, so is guarded by a flag by default.
+
+package vs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/second-state/WasmEdge-go/wasmedge"
+)
+
+func init() {
+	runtimeTesters["WasmEdge-go"] = newWasmedgeTester
+}
+
+func newWasmedgeTester() runtimeTester {
+	return &wasmedgeTester{}
+}
+
+type wasmedgeTester struct {
+	conf  *wasmedge.Configure
+	store *wasmedge.Store
+	vm    *wasmedge.VM
+}
+
+func (w *wasmedgeTester) Init(_ context.Context, cfg *runtimeConfig) (err error) {
+	w.conf = wasmedge.NewConfigure()
+	w.store = wasmedge.NewStore()
+	w.vm = wasmedge.NewVMWithConfigAndStore(w.conf, w.store)
+
+	if err = w.vm.RegisterWasmBuffer(cfg.moduleName, cfg.moduleWasm); err != nil {
+		return
+	}
+	if err = w.vm.LoadWasmBuffer(cfg.moduleWasm); err != nil {
+		return
+	}
+	if err = w.vm.Validate(); err != nil {
+		return
+	}
+	if err = w.vm.Instantiate(); err != nil {
+		return
+	}
+	for _, funcName := range cfg.funcNames {
+		if fn := w.vm.GetFunctionType(funcName); fn == nil {
+			return fmt.Errorf("%s is not an exported function", funcName)
+		}
+	}
+	return
+}
+
+func (w *wasmedgeTester) CallI64_I64(_ context.Context, funcName string, param uint64) (uint64, error) {
+	if result, err := w.vm.Execute(funcName, int64(param)); err != nil {
+		return 0, err
+	} else {
+		return uint64(result[0].(int64)), nil
+	}
+}
+
+func (w *wasmedgeTester) Close() error {
+	for _, closer := range []func(){w.vm.Release, w.store.Release, w.conf.Release} {
+		if closer == nil {
+			continue
+		}
+		closer()
+	}
+	w.vm = nil
+	w.store = nil
+	w.conf = nil
+	return nil
+}

--- a/internal/integration_test/vs/wasmer_test.go
+++ b/internal/integration_test/vs/wasmer_test.go
@@ -24,16 +24,17 @@ type wasmerTester struct {
 	funcs    map[string]*wasmer.Function
 }
 
-func (w *wasmerTester) Init(_ context.Context, wasm []byte, funcNames ...string) (err error) {
+func (w *wasmerTester) Init(_ context.Context, cfg *runtimeConfig) (err error) {
 	w.store = wasmer.NewStore(wasmer.NewEngine())
 	importObject := wasmer.NewImportObject()
-	if w.module, err = wasmer.NewModule(w.store, wasm); err != nil {
+	if w.module, err = wasmer.NewModule(w.store, cfg.moduleWasm); err != nil {
 		return
 	}
+	// TODO: not sure we can set cfg.moduleName in wasmer-go
 	if w.instance, err = wasmer.NewInstance(w.module, importObject); err != nil {
 		return
 	}
-	for _, funcName := range funcNames {
+	for _, funcName := range cfg.funcNames {
 		var fn *wasmer.Function
 		if fn, err = w.instance.Exports.GetRawFunction(funcName); err != nil {
 			return

--- a/internal/integration_test/vs/wasmer_test.go
+++ b/internal/integration_test/vs/wasmer_test.go
@@ -10,45 +10,64 @@ import (
 )
 
 func init() {
-	runtimeTesters["wasmer-go"] = newWasmerTester
+	runtimes["wasmer-go"] = newWasmerRuntime
 }
 
-func newWasmerTester() runtimeTester {
-	return &wasmerTester{funcs: map[string]*wasmer.Function{}}
+func newWasmerRuntime() runtime {
+	return &wasmerRuntime{}
 }
 
-type wasmerTester struct {
+type wasmerRuntime struct {
+	engine *wasmer.Engine
+}
+
+type wasmerModule struct {
 	store    *wasmer.Store
 	module   *wasmer.Module
 	instance *wasmer.Instance
 	funcs    map[string]*wasmer.Function
 }
 
-func (w *wasmerTester) Init(_ context.Context, cfg *runtimeConfig) (err error) {
-	w.store = wasmer.NewStore(wasmer.NewEngine())
-	importObject := wasmer.NewImportObject()
-	if w.module, err = wasmer.NewModule(w.store, cfg.moduleWasm); err != nil {
+func (r *wasmerRuntime) Compile(_ context.Context, _ *runtimeConfig) (err error) {
+	r.engine = wasmer.NewEngine()
+	// We can't reuse a store because even if we call close, re-instantiating too many times leads to:
+	// >> resource limit exceeded: instance count too high at 10001
+	return
+}
+
+func (r *wasmerRuntime) Instantiate(_ context.Context, cfg *runtimeConfig) (mod module, err error) {
+	wm := &wasmerModule{funcs: map[string]*wasmer.Function{}}
+	wm.store = wasmer.NewStore(r.engine)
+	if wm.module, err = wasmer.NewModule(wm.store, cfg.moduleWasm); err != nil {
 		return
 	}
-	// TODO: not sure we can set cfg.moduleName in wasmer-go
-	if w.instance, err = wasmer.NewInstance(w.module, importObject); err != nil {
+	importObject := wasmer.NewImportObject()
+
+	// TODO: wasmer_module_set_name is not exposed in wasmer-go
+	if wm.instance, err = wasmer.NewInstance(wm.module, importObject); err != nil {
 		return
 	}
 	for _, funcName := range cfg.funcNames {
 		var fn *wasmer.Function
-		if fn, err = w.instance.Exports.GetRawFunction(funcName); err != nil {
+		if fn, err = wm.instance.Exports.GetRawFunction(funcName); err != nil {
 			return
 		} else if fn == nil {
-			return fmt.Errorf("%s is not an exported function", funcName)
+			return nil, fmt.Errorf("%s is not an exported function", funcName)
 		} else {
-			w.funcs[funcName] = fn
+			wm.funcs[funcName] = fn
 		}
 	}
+	mod = wm
 	return
 }
 
-func (w *wasmerTester) CallI64_I64(_ context.Context, funcName string, param uint64) (uint64, error) {
-	fn := w.funcs[funcName]
+func (r *wasmerRuntime) Close() error {
+	r.engine = nil
+	return nil
+}
+
+func (m *wasmerModule) CallI64_I64(_ context.Context, funcName string, param uint64) (uint64, error) {
+	fn := m.funcs[funcName]
 	if result, err := fn.Call(int64(param)); err != nil {
 		return 0, err
 	} else {
@@ -56,15 +75,19 @@ func (w *wasmerTester) CallI64_I64(_ context.Context, funcName string, param uin
 	}
 }
 
-func (w *wasmerTester) Close() error {
-	for _, closer := range []func(){w.instance.Close, w.module.Close, w.store.Close} {
-		if closer == nil {
-			continue
-		}
-		closer()
+func (m *wasmerModule) Close() error {
+	if instance := m.instance; instance != nil {
+		instance.Close()
 	}
-	w.instance = nil
-	w.module = nil
-	w.store = nil
+	m.instance = nil
+	if mod := m.module; mod != nil {
+		mod.Close()
+	}
+	m.module = nil
+	if store := m.store; store != nil {
+		store.Close()
+	}
+	m.store = nil
+	m.funcs = nil
 	return nil
 }

--- a/internal/integration_test/vs/wasmtime_test.go
+++ b/internal/integration_test/vs/wasmtime_test.go
@@ -22,17 +22,18 @@ type wasmtimeTester struct {
 	funcs map[string]*wasmtime.Func
 }
 
-func (w *wasmtimeTester) Init(_ context.Context, wasm []byte, funcNames ...string) (err error) {
+func (w *wasmtimeTester) Init(_ context.Context, cfg *runtimeConfig) (err error) {
 	w.store = wasmtime.NewStore(wasmtime.NewEngine())
-	module, err := wasmtime.NewModule(w.store.Engine, wasm)
+	module, err := wasmtime.NewModule(w.store.Engine, cfg.moduleWasm)
 	if err != nil {
 		return
 	}
+	// TODO: not sure we can set cfg.moduleName in wasmtime-go
 	instance, err := wasmtime.NewInstance(w.store, module, nil)
 	if err != nil {
 		return
 	}
-	for _, funcName := range funcNames {
+	for _, funcName := range cfg.funcNames {
 		if fn := instance.GetFunc(w.store, funcName); fn == nil {
 			return fmt.Errorf("%s is not an exported function", funcName)
 		} else {

--- a/internal/integration_test/vs/wasmtime_test.go
+++ b/internal/integration_test/vs/wasmtime_test.go
@@ -10,48 +10,78 @@ import (
 )
 
 func init() {
-	runtimeTesters["wasmtime-go"] = newWasmtimeTester
+	runtimes["wasmtime-go"] = newWasmtimeRuntime
 }
 
-func newWasmtimeTester() runtimeTester {
-	return &wasmtimeTester{funcs: map[string]*wasmtime.Func{}}
+func newWasmtimeRuntime() runtime {
+	return &wasmtimeRuntime{}
 }
 
-type wasmtimeTester struct {
+type wasmtimeRuntime struct {
+	engine *wasmtime.Engine
+}
+
+type wasmtimeModule struct {
 	store *wasmtime.Store
-	funcs map[string]*wasmtime.Func
+	// instance is here because there's no close/destroy function. The only thing is garbage collection.
+	instance *wasmtime.Instance
+	funcs    map[string]*wasmtime.Func
 }
 
-func (w *wasmtimeTester) Init(_ context.Context, cfg *runtimeConfig) (err error) {
-	w.store = wasmtime.NewStore(wasmtime.NewEngine())
-	module, err := wasmtime.NewModule(w.store.Engine, cfg.moduleWasm)
-	if err != nil {
-		return
-	}
-	// TODO: not sure we can set cfg.moduleName in wasmtime-go
-	instance, err := wasmtime.NewInstance(w.store, module, nil)
-	if err != nil {
-		return
-	}
-	for _, funcName := range cfg.funcNames {
-		if fn := instance.GetFunc(w.store, funcName); fn == nil {
-			return fmt.Errorf("%s is not an exported function", funcName)
-		} else {
-			w.funcs[funcName] = fn
-		}
-	}
+func (r *wasmtimeRuntime) Compile(_ context.Context, _ *runtimeConfig) (err error) {
+	r.engine = wasmtime.NewEngine()
+	// We can't reuse a store because even if we call close, re-instantiating too many times leads to:
+	// >> resource limit exceeded: instance count too high at 10001
 	return
 }
 
-func (w *wasmtimeTester) CallI64_I64(_ context.Context, funcName string, param uint64) (uint64, error) {
-	fn := w.funcs[funcName]
-	if result, err := fn.Call(w.store, int64(param)); err != nil {
+func (r *wasmtimeRuntime) Instantiate(_ context.Context, cfg *runtimeConfig) (mod module, err error) {
+	wm := &wasmtimeModule{funcs: map[string]*wasmtime.Func{}}
+	wm.store = wasmtime.NewStore(r.engine)
+	var m *wasmtime.Module
+	if m, err = wasmtime.NewModule(wm.store.Engine, cfg.moduleWasm); err != nil {
+		return
+	}
+
+	// Set the module name
+	linker := wasmtime.NewLinker(wm.store.Engine)
+	if err = linker.DefineModule(wm.store, cfg.moduleName, m); err != nil {
+		return
+	}
+	instance, err := linker.Instantiate(wm.store, m)
+	if err != nil {
+		return
+	}
+
+	for _, funcName := range cfg.funcNames {
+		if fn := instance.GetFunc(wm.store, funcName); fn == nil {
+			err = fmt.Errorf("%s is not an exported function", funcName)
+			return
+		} else {
+			wm.funcs[funcName] = fn
+		}
+	}
+	mod = wm
+	return
+}
+
+func (r *wasmtimeRuntime) Close() error {
+	r.engine = nil
+	return nil // wasmtime only closes via finalizer
+}
+
+func (m *wasmtimeModule) CallI64_I64(_ context.Context, funcName string, param uint64) (uint64, error) {
+	fn := m.funcs[funcName]
+	if result, err := fn.Call(m.store, int64(param)); err != nil {
 		return 0, err
 	} else {
 		return uint64(result.(int64)), nil
 	}
 }
 
-func (w *wasmtimeTester) Close() error {
-	return nil
+func (m *wasmtimeModule) Close() error {
+	m.store = nil
+	m.instance = nil
+	m.funcs = nil
+	return nil // wasmtime only closes via finalizer
 }

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -28,8 +28,8 @@ type Engine interface {
 	) (ModuleEngine, error)
 
 	// DeleteCompiledModule releases compilation caches for the given module (source).
-	// Note: it is safe to call this function for a module from which module instances are instantiated even when these module instances
-	// are having outstanding calls.
+	// Note: it is safe to call this function for a module from which module instances are instantiated even when these
+	// module instances have outstanding calls.
 	DeleteCompiledModule(module *Module)
 }
 


### PR DESCRIPTION
This adds WasmEdge-go to the list of benchmarks and also extracts out compile from instantiate as users like wapc-go instantiate the same module multiple times.

Right now, only wazero is the only option that can do this without crashing, but we can update the code for the alternatives if the bugs are ever fixed.

```
BenchmarkFac_Compile/wasmtime-go-16         	  120554	      8508 ns/op	       8 B/op	       1 allocs/op
BenchmarkFac_Compile/wazero-interpreter-16  	   79351	     14140 ns/op	    9661 B/op	     320 allocs/op
BenchmarkFac_Compile/wazero-jit-16          	   10000	    100324 ns/op	   59818 B/op	    1203 allocs/op
BenchmarkFac_Compile/wasm3-go-16            	  447822	      2637 ns/op	      48 B/op	       3 allocs/op
BenchmarkFac_Compile/WasmEdge-go-16         	 5915394	       205.5 ns/op	      24 B/op	       2 allocs/op
BenchmarkFac_Compile/wasmer-go-16           	  201061	      6744 ns/op	       8 B/op	       1 allocs/op
BenchmarkFac_Instantiate/WasmEdge-go-16     	   30994	     33484 ns/op	     146 B/op	      14 allocs/op
BenchmarkFac_Instantiate/wasmer-go-16       	    2368	    468641 ns/op	    1400 B/op	      38 allocs/op
BenchmarkFac_Instantiate/wasmtime-go-16     	    2632	    452265 ns/op	     711 B/op	      29 allocs/op
BenchmarkFac_Instantiate/wazero-interpreter-16         	  505310	      2304 ns/op	    2241 B/op	      41 allocs/op
BenchmarkFac_Instantiate/wazero-jit-16                 	  532336	      2246 ns/op	    2193 B/op	      39 allocs/op
BenchmarkFac_Instantiate/wasm3-go-16                   	  306972	      4264 ns/op	     384 B/op	      10 allocs/op
BenchmarkFac_Call/wasmer-go-16                         	  884352	      1402 ns/op	     176 B/op	      12 allocs/op
BenchmarkFac_Call/wasmtime-go-16                       	  579540	      2833 ns/op	     247 B/op	      18 allocs/op
BenchmarkFac_Call/wazero-interpreter-16                	  144517	      7470 ns/op	    2096 B/op	     129 allocs/op
BenchmarkFac_Call/wazero-jit-16                        	 1000000	      1067 ns/op	    1216 B/op	       5 allocs/op
BenchmarkFac_Call/wasm3-go-16                          	  656781	      1848 ns/op	      56 B/op	       5 allocs/op
BenchmarkFac_Call/WasmEdge-go-16                       	  119894	      9818 ns/op	     128 B/op	       8 allocs/op
```