### PR TITLE
Create an internal EngineConfig type for currently holding wasm featu…

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,23 +15,27 @@ import (
 
 // RuntimeConfig controls runtime behavior, with the default implementation as NewRuntimeConfig
 type RuntimeConfig struct {
-	enabledFeatures wasm.Features
-	newEngine       func(wasm.Features) wasm.Engine
-	memoryMaxPages  uint32
+	engineConfig   wasm.EngineConfig
+	newEngine      func(config wasm.EngineConfig) wasm.Engine
+	memoryMaxPages uint32
 }
 
 // engineLessConfig helps avoid copy/pasting the wrong defaults.
 var engineLessConfig = &RuntimeConfig{
-	enabledFeatures: wasm.Features20191205,
-	memoryMaxPages:  wasm.MemoryMaxPages,
+	engineConfig: wasm.EngineConfig{
+		EnabledFeatures: wasm.Features20191205,
+	},
+	memoryMaxPages: wasm.MemoryMaxPages,
 }
 
 // clone ensures all fields are coped even if nil.
 func (c *RuntimeConfig) clone() *RuntimeConfig {
 	return &RuntimeConfig{
-		enabledFeatures: c.enabledFeatures,
-		newEngine:       c.newEngine,
-		memoryMaxPages:  c.memoryMaxPages,
+		engineConfig: wasm.EngineConfig{
+			EnabledFeatures: c.engineConfig.EnabledFeatures,
+		},
+		newEngine:      c.newEngine,
+		memoryMaxPages: c.memoryMaxPages,
 	}
 }
 
@@ -77,7 +81,7 @@ func (c *RuntimeConfig) WithMemoryMaxPages(memoryMaxPages uint32) *RuntimeConfig
 // See https://github.com/WebAssembly/spec/tree/main/proposals
 func (c *RuntimeConfig) WithFinishedFeatures() *RuntimeConfig {
 	ret := c.clone()
-	ret.enabledFeatures = wasm.FeaturesFinished
+	ret.engineConfig.EnabledFeatures = wasm.FeaturesFinished
 	return ret
 }
 
@@ -88,7 +92,7 @@ func (c *RuntimeConfig) WithFinishedFeatures() *RuntimeConfig {
 // will fail to parse.
 func (c *RuntimeConfig) WithFeatureMutableGlobal(enabled bool) *RuntimeConfig {
 	ret := c.clone()
-	ret.enabledFeatures = ret.enabledFeatures.Set(wasm.FeatureMutableGlobal, enabled)
+	ret.engineConfig.EnabledFeatures = ret.engineConfig.EnabledFeatures.Set(wasm.FeatureMutableGlobal, enabled)
 	return ret
 }
 
@@ -101,7 +105,7 @@ func (c *RuntimeConfig) WithFeatureMutableGlobal(enabled bool) *RuntimeConfig {
 // See https://github.com/WebAssembly/spec/blob/main/proposals/sign-extension-ops/Overview.md
 func (c *RuntimeConfig) WithFeatureSignExtensionOps(enabled bool) *RuntimeConfig {
 	ret := c.clone()
-	ret.enabledFeatures = ret.enabledFeatures.Set(wasm.FeatureSignExtensionOps, enabled)
+	ret.engineConfig.EnabledFeatures = ret.engineConfig.EnabledFeatures.Set(wasm.FeatureSignExtensionOps, enabled)
 	return ret
 }
 
@@ -115,7 +119,7 @@ func (c *RuntimeConfig) WithFeatureSignExtensionOps(enabled bool) *RuntimeConfig
 // See https://github.com/WebAssembly/spec/blob/main/proposals/multi-value/Overview.md
 func (c *RuntimeConfig) WithFeatureMultiValue(enabled bool) *RuntimeConfig {
 	ret := c.clone()
-	ret.enabledFeatures = ret.enabledFeatures.Set(wasm.FeatureMultiValue, enabled)
+	ret.engineConfig.EnabledFeatures = ret.engineConfig.EnabledFeatures.Set(wasm.FeatureMultiValue, enabled)
 	return ret
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -31,7 +31,9 @@ func TestRuntimeConfig(t *testing.T) {
 				return c.WithFeatureMutableGlobal(true)
 			},
 			expected: &RuntimeConfig{
-				enabledFeatures: wasm.FeatureMutableGlobal,
+				engineConfig: wasm.EngineConfig{
+					EnabledFeatures: wasm.FeatureMutableGlobal,
+				},
 			},
 		},
 		{
@@ -40,7 +42,9 @@ func TestRuntimeConfig(t *testing.T) {
 				return c.WithFeatureSignExtensionOps(true)
 			},
 			expected: &RuntimeConfig{
-				enabledFeatures: wasm.FeatureSignExtensionOps,
+				engineConfig: wasm.EngineConfig{
+					EnabledFeatures: wasm.FeatureSignExtensionOps,
+				},
 			},
 		},
 	}
@@ -87,19 +91,19 @@ func TestRuntimeConfig_FeatureToggle(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewRuntimeConfig()
-			require.Equal(t, tc.expectDefault, c.enabledFeatures.Get(tc.feature))
+			require.Equal(t, tc.expectDefault, c.engineConfig.EnabledFeatures.Get(tc.feature))
 
 			// Set to false even if it was initially false.
 			c = tc.setFeature(c, false)
-			require.False(t, c.enabledFeatures.Get(tc.feature))
+			require.False(t, c.engineConfig.EnabledFeatures.Get(tc.feature))
 
 			// Set true makes it true
 			c = tc.setFeature(c, true)
-			require.True(t, c.enabledFeatures.Get(tc.feature))
+			require.True(t, c.engineConfig.EnabledFeatures.Get(tc.feature))
 
 			// Set false makes it false again
 			c = tc.setFeature(c, false)
-			require.False(t, c.enabledFeatures.Get(tc.feature))
+			require.False(t, c.engineConfig.EnabledFeatures.Get(tc.feature))
 		})
 	}
 }

--- a/internal/integration_test/spectest/spec_test.go
+++ b/internal/integration_test/spectest/spec_test.go
@@ -288,7 +288,7 @@ func TestInterpreter(t *testing.T) {
 	runTest(t, interpreter.NewEngine)
 }
 
-func runTest(t *testing.T, newEngine func(wasm.Features) wasm.Engine) {
+func runTest(t *testing.T, newEngine func(config wasm.EngineConfig) wasm.Engine) {
 	files, err := testcases.ReadDir("testdata")
 	require.NoError(t, err)
 
@@ -315,7 +315,7 @@ func runTest(t *testing.T, newEngine func(wasm.Features) wasm.Engine) {
 
 		t.Run(wastName, func(t *testing.T) {
 			enabledFeatures := wasm.Features20191205
-			store := wasm.NewStore(enabledFeatures, newEngine(enabledFeatures))
+			store := wasm.NewStore(enabledFeatures, newEngine(wasm.EngineConfig{EnabledFeatures: enabledFeatures}))
 			addSpectestModule(t, store)
 
 			var lastInstantiatedModuleName string

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -1,6 +1,8 @@
 package wasm
 
-import "context"
+import (
+	"context"
+)
 
 // Engine is a Store-scoped mechanism to compile functions declared or imported by a module.
 // This is a top-level type implemented by an interpreter or JIT compiler.
@@ -40,4 +42,10 @@ type ModuleEngine interface {
 
 	// Call invokes a function instance f with given parameters.
 	Call(ctx context.Context, m *CallContext, f *FunctionInstance, params ...uint64) (results []uint64, err error)
+}
+
+// EngineConfig is the configuration for an Engine
+type EngineConfig struct {
+	// EnabledFeatures are the wasm features enabled for the Engine.
+	EnabledFeatures Features
 }

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -27,9 +27,9 @@ type engine struct {
 	mux             sync.RWMutex
 }
 
-func NewEngine(enabledFeatures wasm.Features) wasm.Engine {
+func NewEngine(config wasm.EngineConfig) wasm.Engine {
 	return &engine{
-		enabledFeatures: enabledFeatures,
+		enabledFeatures: config.EnabledFeatures,
 		codes:           map[wasm.ModuleID][]*code{},
 	}
 }

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -56,7 +56,7 @@ type engineTester struct {
 }
 
 func (e engineTester) NewEngine(enabledFeatures wasm.Features) wasm.Engine {
-	return NewEngine(enabledFeatures)
+	return NewEngine(wasm.EngineConfig{EnabledFeatures: enabledFeatures})
 }
 
 func (e engineTester) InitTable(me wasm.ModuleEngine, initTableLen uint32, initTableIdxToFnIdx map[wasm.Index]wasm.Index) []interface{} {

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -554,8 +554,8 @@ func (me *moduleEngine) Call(ctx context.Context, callCtx *wasm.CallContext, f *
 	return
 }
 
-func NewEngine(enabledFeatures wasm.Features) wasm.Engine {
-	return newEngine(enabledFeatures)
+func NewEngine(config wasm.EngineConfig) wasm.Engine {
+	return newEngine(config.EnabledFeatures)
 }
 
 func newEngine(enabledFeatures wasm.Features) *engine {

--- a/wasm.go
+++ b/wasm.go
@@ -123,8 +123,8 @@ func NewRuntime() Runtime {
 // NewRuntimeWithConfig returns a runtime with the given configuration.
 func NewRuntimeWithConfig(config *RuntimeConfig) Runtime {
 	return &runtime{
-		store:           wasm.NewStore(config.enabledFeatures, config.newEngine(config.enabledFeatures)),
-		enabledFeatures: config.enabledFeatures,
+		store:           wasm.NewStore(config.engineConfig.EnabledFeatures, config.newEngine(config.engineConfig)),
+		enabledFeatures: config.engineConfig.EnabledFeatures,
 		memoryMaxPages:  config.memoryMaxPages,
 	}
 }


### PR DESCRIPTION
…res and in the future more.

I would like to add the ability for a user to register a function listener to trace function calls. Currently we only allow configuring wasm opt-in features. To add configurability I could come up with some approaches

- Create a `EngineConfig`, currently only containing the wasm features knob, but also allowing adding non-wasm related engine configuration in the future
- Extend the function signature of `NewEngine` for new parameters such as the function listeners
- Adding `With` type of functions to both engines to forward additional configuration through

This PR implements the first idea as a strawman's proposal.