### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+/internal/asm/ @mathetake
+/internal/wasm/jit/ @mathetake
+
+* @codefromthecrypt @mathetake


### PR DESCRIPTION
Currently contributors have to hit the "Request" link to add a reviewer on a PR. This will allow reviewers to be added automatically.  I doubt this actually has an effect on response time to PRs :P But it's nice so contributors know that someone's on it.