### PR TITLE
Fix build.examples so it builds all examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ build.bench:
 tinygo_sources := $(wildcard examples/*/testdata/*.go examples/*/*/testdata/*.go)
 .PHONY: build.examples
 build.examples: $(tinygo_sources)
-	@echo $< | xargs -Ip /bin/sh -c 'tinygo build -o $$(echo p | sed -e 's/\.go/\.wasm/') -scheduler=none --no-debug --target=wasi p'
+	@for f in $^; do \
+	    tinygo build -o $$(echo $$f | sed -e 's/\.go/\.wasm/') -scheduler=none --no-debug --target=wasi $$f; \
+	done
 
 spectest_testdata_dir := internal/integration_test/spectest/testdata
 spec_version := wg-1.0


### PR DESCRIPTION
`$<` as we currently have only returns one of the matched files, meaning that currently `build.examples` doesn't build all the matched examples. `$^` returns all of them, so I added a for loop through that so they're all built.