### PR TITLE
Fixes where vs benchmark stopped running after drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bench:
 .PHONY: bench.check
 bench.check:
 	@go build ./internal/integration_test/bench/...
-	@cd ./internal/integration_test/vs && go test -benchmem -bench=. . -tags='wasmedge' -ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
+	@cd ./internal/integration_test/vs && go test -benchmem -bench=. . -tags='wasmedge' -ldflags '-X github.com/tetratelabs/wazero/internal/integration_test/vs.ensureJITFastest=true'
 
 bench_testdata_dir := internal/integration_test/bench/testdata
 

--- a/internal/integration_test/vs/bench_test.go
+++ b/internal/integration_test/vs/bench_test.go
@@ -15,14 +15,14 @@ import (
 var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
 // ensureJITFastest is overridable via ldflags. Ex.
-//	-ldflags '-X github.com/tetratelabs/wazero/vs.ensureJITFastest=true'
+//	-ldflags '-X github.com/tetratelabs/wazero/internal/integration_test/vs.ensureJITFastest=true'
 var ensureJITFastest = "false"
 
 const jitRuntime = "wazero-jit"
 
 var jitFastestBench = func(rt runtime) func(b *testing.B) {
 	return func(b *testing.B) {
-		benchmarkFn(rt, facConfig, facCall)
+		benchmarkFn(rt, facConfig, facCall)(b)
 	}
 }
 
@@ -58,7 +58,7 @@ func TestFac_JIT_Fastest(t *testing.T) {
 	// Print results before deciding if this failed
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	for _, result := range results {
-		w.Write([]byte(fmt.Sprintf("%s:\t%.2f\n", result.name, result.nsOp)))
+		w.Write([]byte(fmt.Sprintf("%s\t%.2f\tns/call\n", result.name, result.nsOp)))
 	}
 	w.Flush()
 


### PR DESCRIPTION
whoops.

works again
```bash
$ make bench.check
wazero-jit         1022.99 ns/call
wasmer-go          1392.13 ns/call
wasm3-go           2074.38 ns/call
wasmtime-go        2501.56 ns/call
wazero-interpreter 6936.58 ns/call
WasmEdge-go        9801.48 ns/call
--snip--
```