### PR TITLE
bench: bumps wasmtime-go

### DIFF
--- a/internal/integration_test/vs/wasmtime/go.mod
+++ b/internal/integration_test/vs/wasmtime/go.mod
@@ -3,7 +3,7 @@ module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmtime
 go 1.17
 
 require (
-	github.com/bytecodealliance/wasmtime-go v0.35.0
+	github.com/bytecodealliance/wasmtime-go v0.36.0
 	github.com/tetratelabs/wazero v0.0.0
 )
 

--- a/internal/integration_test/vs/wasmtime/go.sum
+++ b/internal/integration_test/vs/wasmtime/go.sum
@@ -1,2 +1,2 @@
-github.com/bytecodealliance/wasmtime-go v0.35.0 h1:VZjaZ0XOY0qp9TQfh0CQj9zl/AbdeXePVTALy8V1sKs=
-github.com/bytecodealliance/wasmtime-go v0.35.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.36.0 h1:B6thr7RMM9xQmouBtUqm1RpkJjuLS37m6nxX+iwsQSc=
+github.com/bytecodealliance/wasmtime-go v0.36.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=


### PR DESCRIPTION
I looked and there are no API changes that affect our benchmarks. The performance isn't notably different either.