### PR TITLE
Adds Runtime.WithCapacityPages to avoid allocations during runtime.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -195,13 +195,17 @@ func (b *moduleBuilder) ExportFunctions(nameToGoFunc map[string]interface{}) Mod
 
 // ExportMemory implements ModuleBuilder.ExportMemory
 func (b *moduleBuilder) ExportMemory(name string, minPages uint32) ModuleBuilder {
-	b.nameToMemory[name] = &wasm.Memory{Min: minPages, Max: b.r.memoryMaxPages}
+	mem := &wasm.Memory{Min: minPages, Max: b.r.memoryMaxPages}
+	mem.Cap = b.r.memoryCapacityPages(mem.Min, nil)
+	b.nameToMemory[name] = mem
 	return b
 }
 
 // ExportMemoryWithMax implements ModuleBuilder.ExportMemoryWithMax
 func (b *moduleBuilder) ExportMemoryWithMax(name string, minPages, maxPages uint32) ModuleBuilder {
-	b.nameToMemory[name] = &wasm.Memory{Min: minPages, Max: maxPages}
+	mem := &wasm.Memory{Min: minPages, Max: maxPages, IsMaxEncoded: true}
+	mem.Cap = b.r.memoryCapacityPages(mem.Min, &maxPages)
+	b.nameToMemory[name] = mem
 	return b
 }
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -159,7 +159,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 				return r.NewModuleBuilder("").ExportMemory("memory", 1)
 			},
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: wasm.MemoryMaxPages},
 				ExportSection: []*wasm.Export{
 					{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -171,7 +171,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 				return r.NewModuleBuilder("").ExportMemory("memory", 1).ExportMemory("memory", 2)
 			},
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 2, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 2, Cap: 2, Max: wasm.MemoryMaxPages},
 				ExportSection: []*wasm.Export{
 					{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -183,7 +183,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 				return r.NewModuleBuilder("").ExportMemoryWithMax("memory", 1, 1)
 			},
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: 1},
+				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: 1, IsMaxEncoded: true},
 				ExportSection: []*wasm.Export{
 					{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -195,7 +195,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 				return r.NewModuleBuilder("").ExportMemoryWithMax("memory", 1, 1).ExportMemoryWithMax("memory", 1, 2)
 			},
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: 2},
+				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: 2, IsMaxEncoded: true},
 				ExportSection: []*wasm.Export{
 					{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},

--- a/config_test.go
+++ b/config_test.go
@@ -18,12 +18,12 @@ func TestRuntimeConfig(t *testing.T) {
 		expected *RuntimeConfig
 	}{
 		{
-			name: "WithMemoryMaxPages",
+			name: "WithMemoryLimitPages",
 			with: func(c *RuntimeConfig) *RuntimeConfig {
-				return c.WithMemoryMaxPages(1)
+				return c.WithMemoryLimitPages(1)
 			},
 			expected: &RuntimeConfig{
-				memoryMaxPages: 1,
+				memoryLimitPages: 1,
 			},
 		},
 		{
@@ -83,6 +83,24 @@ func TestRuntimeConfig(t *testing.T) {
 			require.Equal(t, &RuntimeConfig{}, input)
 		})
 	}
+
+	t.Run("WithMemoryCapacityPages", func(t *testing.T) {
+		c := NewRuntimeConfig()
+
+		// Test default returns min
+		require.Equal(t, uint32(1), c.memoryCapacityPages(1, nil))
+
+		// Nil ignored
+		c = c.WithMemoryCapacityPages(nil)
+		require.Equal(t, uint32(1), c.memoryCapacityPages(1, nil))
+
+		// Assign a valid function
+		c = c.WithMemoryCapacityPages(func(minPages uint32, maxPages *uint32) uint32 {
+			return 2
+		})
+		// Returns updated value
+		require.Equal(t, uint32(2), c.memoryCapacityPages(1, nil))
+	})
 }
 
 func TestRuntimeConfig_FeatureToggle(t *testing.T) {

--- a/internal/integration_test/spectest/encoder_test.go
+++ b/internal/integration_test/spectest/encoder_test.go
@@ -68,7 +68,7 @@ func TestBinaryEncoder(t *testing.T) {
 
 						buf = requireStripCustomSections(t, buf)
 
-						mod, err := binary.DecodeModule(buf, wasm.Features20191205, wasm.MemoryMaxPages)
+						mod, err := binary.DecodeModule(buf, wasm.Features20191205, wasm.MemoryLimitPages)
 						require.NoError(t, err)
 
 						encodedBuf := binary.EncodeModule(mod)

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -238,7 +238,7 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 
   (func (param f64 f64) local.get 0 drop local.get 1 drop)
      (export "print_f64_f64" (func 6))
-)`), wasm.Features20191205, wasm.MemoryMaxPages)
+)`), wasm.Features20191205, wasm.MemoryLimitPages)
 	require.NoError(t, err)
 
 	// (global (export "global_i32") i32 (i32.const 666))
@@ -313,7 +313,7 @@ func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.E
 					case "module":
 						buf, err := testDataFS.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-						mod, err := binary.DecodeModule(buf, enabledFeatures, wasm.MemoryMaxPages)
+						mod, err := binary.DecodeModule(buf, enabledFeatures, wasm.MemoryLimitPages)
 						require.NoError(t, err, msg)
 						require.NoError(t, mod.Validate(enabledFeatures))
 						mod.AssignModuleID(buf)
@@ -446,7 +446,7 @@ func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.E
 }
 
 func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg string) {
-	mod, err := binary.DecodeModule(buf, store.EnabledFeatures, wasm.MemoryMaxPages)
+	mod, err := binary.DecodeModule(buf, store.EnabledFeatures, wasm.MemoryLimitPages)
 	if err != nil {
 		return
 	}

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -267,6 +267,7 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 	mod.TableSection = &wasm.Table{Min: 10, Max: &tableLimitMax}
 	mod.ExportSection = append(mod.ExportSection, &wasm.Export{Name: "table", Index: 0, Type: wasm.ExternTypeTable})
 
+	maybeSetMemoryCap(mod)
 	err = store.Engine.CompileModule(testCtx, mod)
 	require.NoError(t, err)
 
@@ -274,7 +275,14 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 	require.NoError(t, err)
 }
 
-// Run runs all the test inside of the testDataFS file system where all the cases are descirbed
+// maybeSetMemoryCap assigns wasm.Memory Cap to Min, which is what wazero.CompileModule would do.
+func maybeSetMemoryCap(mod *wasm.Module) {
+	if mem := mod.MemorySection; mem != nil {
+		mem.Cap = mem.Min
+	}
+}
+
+// Run runs all the test inside the testDataFS file system where all the cases are described
 // via JSON files created from wast2json.
 func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.Engine, enabledFeatures wasm.Features) {
 	files, err := testDataFS.ReadDir("testdata")
@@ -329,6 +337,7 @@ func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.E
 							}
 						}
 
+						maybeSetMemoryCap(mod)
 						err = store.Engine.CompileModule(testCtx, mod)
 						require.NoError(t, err, msg)
 
@@ -458,6 +467,7 @@ func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg 
 
 	mod.AssignModuleID(buf)
 
+	maybeSetMemoryCap(mod)
 	err = store.Engine.CompileModule(testCtx, mod)
 	if err != nil {
 		return

--- a/internal/integration_test/vs/codec.go
+++ b/internal/integration_test/vs/codec.go
@@ -92,7 +92,7 @@ func newExample() *wasm.Module {
 func BenchmarkWat2Wasm(b *testing.B, vsName string, vsWat2Wasm func([]byte) error) {
 	b.Run("wazero", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if m, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryMaxPages); err != nil {
+			if m, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryLimitPages); err != nil {
 				b.Fatal(err)
 			} else {
 				_ = binary.EncodeModule(m)

--- a/internal/integration_test/vs/codec_test.go
+++ b/internal/integration_test/vs/codec_test.go
@@ -14,13 +14,13 @@ import (
 
 func TestExampleUpToDate(t *testing.T) {
 	t.Run("binary.DecodeModule", func(t *testing.T) {
-		m, err := binary.DecodeModule(exampleBinary, wasm.FeaturesFinished, wasm.MemoryMaxPages)
+		m, err := binary.DecodeModule(exampleBinary, wasm.FeaturesFinished, wasm.MemoryLimitPages)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
 
 	t.Run("text.DecodeModule", func(t *testing.T) {
-		m, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryMaxPages)
+		m, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryLimitPages)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
@@ -49,7 +49,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("binary.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := binary.DecodeModule(exampleBinary, wasm.FeaturesFinished, wasm.MemoryMaxPages); err != nil {
+			if _, err := binary.DecodeModule(exampleBinary, wasm.FeaturesFinished, wasm.MemoryLimitPages); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -63,7 +63,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("text.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryMaxPages); err != nil {
+			if _, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryLimitPages); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -166,7 +166,7 @@ func (g *generator) genImportSection() {
 
 		if memoryImported == 0 {
 			min := g.nextRandom().Intn(4) // Min in reality is relatively small like 4.
-			max := g.nextRandom().Intn(int(wasm.MemoryMaxPages)-min) + min
+			max := g.nextRandom().Intn(int(wasm.MemoryLimitPages)-min) + min
 
 			imp.Type = wasm.ExternTypeMemory
 			imp.DescMem = &wasm.Memory{
@@ -180,7 +180,7 @@ func (g *generator) genImportSection() {
 
 		if tableImported == 0 {
 			min := g.nextRandom().Intn(4) // Min in reality is relatively small like 4.
-			max := uint32(g.nextRandom().Intn(int(wasm.MemoryMaxPages)-min) + min)
+			max := uint32(g.nextRandom().Intn(int(wasm.MemoryLimitPages)-min) + min)
 
 			imp.Type = wasm.ExternTypeTable
 			tableImported = 1
@@ -215,7 +215,7 @@ func (g *generator) genTableSection() {
 	}
 
 	min := g.nextRandom().Intn(4) // Min in reality is relatively small like 4.
-	max := uint32(g.nextRandom().Intn(int(wasm.MemoryMaxPages)-min) + min)
+	max := uint32(g.nextRandom().Intn(int(wasm.MemoryLimitPages)-min) + min)
 	g.m.TableSection = &wasm.Table{Min: uint32(min), Max: &max}
 }
 
@@ -225,7 +225,7 @@ func (g *generator) genMemorySection() {
 		return
 	}
 	min := g.nextRandom().Intn(4) // Min in reality is relatively small like 4.
-	max := g.nextRandom().Intn(int(wasm.MemoryMaxPages)-min) + min
+	max := g.nextRandom().Intn(int(wasm.MemoryLimitPages)-min) + min
 	g.m.MemorySection = &wasm.Memory{Min: uint32(min), Max: uint32(max), IsMaxEncoded: true}
 }
 

--- a/internal/modgen/modgen.go
+++ b/internal/modgen/modgen.go
@@ -412,7 +412,7 @@ func (g *generator) newCode() *wasm.Code {
 		wasm.OpcodeEnd}}
 }
 
-// genDataSection generates random data section if memory is declared and its minums is not zero.
+// genDataSection generates random data section if memory is declared and its min is not zero.
 func (g *generator) genDataSection() {
 	_, _, mem, _, err := g.m.AllDeclarations()
 	if err != nil {

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -703,15 +703,15 @@ func TestGenerator_dataSection(t *testing.T) {
 			{
 				numData: 1,
 				ints: []int{
-					int(wasm.MemoryMaxPages) - 1, // offset
-					1,                            // size of inits
+					int(wasm.MemoryLimitPages) - 1, // offset
+					1,                              // size of inits
 				},
 				bufs: [][]byte{{0x1}},
 				exps: []*wasm.DataSegment{
 					{
 						OffsetExpression: &wasm.ConstantExpression{
 							Opcode: wasm.OpcodeI32Const,
-							Data:   leb128.EncodeUint32(uint32(wasm.MemoryMaxPages) - 1),
+							Data:   leb128.EncodeUint32(uint32(wasm.MemoryLimitPages) - 1),
 						},
 						Init: []byte{0x1},
 					},

--- a/internal/wasm/binary/decoder.go
+++ b/internal/wasm/binary/decoder.go
@@ -11,7 +11,7 @@ import (
 
 // DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (20191205) Binary Format
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-format%E2%91%A0
-func DecodeModule(binary []byte, enabledFeatures wasm.Features, memoryMaxPages uint32) (*wasm.Module, error) {
+func DecodeModule(binary []byte, enabledFeatures wasm.Features, memoryLimitPages uint32) (*wasm.Module, error) {
 	r := bytes.NewReader(binary)
 
 	// Magic number.
@@ -71,7 +71,7 @@ func DecodeModule(binary []byte, enabledFeatures wasm.Features, memoryMaxPages u
 		case wasm.SectionIDType:
 			m.TypeSection, err = decodeTypeSection(enabledFeatures, r)
 		case wasm.SectionIDImport:
-			if m.ImportSection, err = decodeImportSection(r, memoryMaxPages); err != nil {
+			if m.ImportSection, err = decodeImportSection(r, memoryLimitPages); err != nil {
 				return nil, err // avoid re-wrapping the error.
 			}
 		case wasm.SectionIDFunction:
@@ -79,7 +79,7 @@ func DecodeModule(binary []byte, enabledFeatures wasm.Features, memoryMaxPages u
 		case wasm.SectionIDTable:
 			m.TableSection, err = decodeTableSection(r)
 		case wasm.SectionIDMemory:
-			m.MemorySection, err = decodeMemorySection(r, memoryMaxPages)
+			m.MemorySection, err = decodeMemorySection(r, memoryLimitPages)
 		case wasm.SectionIDGlobal:
 			if m.GlobalSection, err = decodeGlobalSection(r, enabledFeatures); err != nil {
 				return nil, err // avoid re-wrapping the error.

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -80,7 +80,7 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, e := DecodeModule(EncodeModule(tc.input), wasm.Features20191205, wasm.MemoryMaxPages)
+			m, e := DecodeModule(EncodeModule(tc.input), wasm.Features20191205, wasm.MemoryLimitPages)
 			require.NoError(t, e)
 			require.Equal(t, tc.input, m)
 		})
@@ -91,7 +91,7 @@ func TestDecodeModule(t *testing.T) {
 			wasm.SectionIDCustom, 0xf, // 15 bytes in this section
 			0x04, 'm', 'e', 'm', 'e',
 			1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
-		m, e := DecodeModule(input, wasm.Features20191205, wasm.MemoryMaxPages)
+		m, e := DecodeModule(input, wasm.Features20191205, wasm.MemoryLimitPages)
 		require.NoError(t, e)
 		require.Equal(t, &wasm.Module{}, m)
 	})
@@ -106,24 +106,24 @@ func TestDecodeModule(t *testing.T) {
 			subsectionIDModuleName, 0x07, // 7 bytes in this subsection
 			0x06, // the Module name simple is 6 bytes long
 			's', 'i', 'm', 'p', 'l', 'e')
-		m, e := DecodeModule(input, wasm.Features20191205, wasm.MemoryMaxPages)
+		m, e := DecodeModule(input, wasm.Features20191205, wasm.MemoryLimitPages)
 		require.NoError(t, e)
 		require.Equal(t, &wasm.Module{NameSection: &wasm.NameSection{ModuleName: "simple"}}, m)
 	})
 	t.Run("data count section disabled", func(t *testing.T) {
 		input := append(append(Magic, version...),
 			wasm.SectionIDDataCount, 1, 0)
-		_, e := DecodeModule(input, wasm.Features20191205, wasm.MemoryMaxPages)
+		_, e := DecodeModule(input, wasm.Features20191205, wasm.MemoryLimitPages)
 		require.EqualError(t, e, `data count section not supported as feature "bulk-memory-operations" is disabled`)
 	})
 }
 
 func TestDecodeModule_Errors(t *testing.T) {
 	tests := []struct {
-		name           string
-		input          []byte
-		memoryMaxPages uint32
-		expectedErr    string
+		name             string
+		input            []byte
+		memoryLimitPages uint32
+		expectedErr      string
 	}{
 		{
 			name:        "wrong magic",
@@ -150,12 +150,12 @@ func TestDecodeModule_Errors(t *testing.T) {
 
 	for _, tt := range tests {
 		tc := tt
-		if tc.memoryMaxPages == 0 {
-			tc.memoryMaxPages = wasm.MemoryMaxPages
+		if tc.memoryLimitPages == 0 {
+			tc.memoryLimitPages = wasm.MemoryLimitPages
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, e := DecodeModule(tc.input, wasm.Features20191205, tc.memoryMaxPages)
+			_, e := DecodeModule(tc.input, wasm.Features20191205, tc.memoryLimitPages)
 			require.EqualError(t, e, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeImport(r *bytes.Reader, idx uint32, memoryMaxPages uint32) (i *wasm.Import, err error) {
+func decodeImport(r *bytes.Reader, idx uint32, memoryLimitPages uint32) (i *wasm.Import, err error) {
 	i = &wasm.Import{}
 	if i.Module, _, err = decodeUTF8(r, "import module"); err != nil {
 		return nil, fmt.Errorf("import[%d] error decoding module: %w", idx, err)
@@ -29,7 +29,7 @@ func decodeImport(r *bytes.Reader, idx uint32, memoryMaxPages uint32) (i *wasm.I
 	case wasm.ExternTypeTable:
 		i.DescTable, err = decodeTable(r)
 	case wasm.ExternTypeMemory:
-		i.DescMem, err = decodeMemory(r, memoryMaxPages)
+		i.DescMem, err = decodeMemory(r, memoryLimitPages)
 	case wasm.ExternTypeGlobal:
 		i.DescGlobal, err = decodeGlobalType(r)
 	default:

--- a/internal/wasm/binary/import_test.go
+++ b/internal/wasm/binary/import_test.go
@@ -139,7 +139,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:    wasm.ExternTypeMemory,
 				Module:  "my",
 				Name:    "memory",
-				DescMem: &wasm.Memory{Min: 1, Max: wasm.MemoryMaxPages, IsMaxEncoded: false},
+				DescMem: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages, IsMaxEncoded: false},
 			},
 			expected: []byte{
 				0x02, 'm', 'y',

--- a/internal/wasm/binary/memory.go
+++ b/internal/wasm/binary/memory.go
@@ -2,7 +2,6 @@ package binary
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
@@ -10,7 +9,7 @@ import (
 // decodeMemory returns the api.Memory decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-memory
-func decodeMemory(r *bytes.Reader, memoryMaxPages uint32) (*wasm.Memory, error) {
+func decodeMemory(r *bytes.Reader, memoryLimitPages uint32) (*wasm.Memory, error) {
 	min, maxP, err := decodeLimitsType(r)
 	if err != nil {
 		return nil, err
@@ -21,17 +20,9 @@ func decodeMemory(r *bytes.Reader, memoryMaxPages uint32) (*wasm.Memory, error) 
 	if maxP != nil {
 		isMaxEncoded = true
 		max = *maxP
-	} else {
-		max = memoryMaxPages
 	}
-	if max > memoryMaxPages {
-		return nil, fmt.Errorf("max %d pages (%s) outside range of %d pages (%s)", max, wasm.PagesToUnitOfBytes(max), memoryMaxPages, wasm.PagesToUnitOfBytes(memoryMaxPages))
-	} else if min > memoryMaxPages {
-		return nil, fmt.Errorf("min %d pages (%s) outside range of %d pages (%s)", min, wasm.PagesToUnitOfBytes(min), memoryMaxPages, wasm.PagesToUnitOfBytes(memoryMaxPages))
-	} else if min > max {
-		return nil, fmt.Errorf("min %d pages (%s) > max %d pages (%s)", min, wasm.PagesToUnitOfBytes(min), max, wasm.PagesToUnitOfBytes(max))
-	}
-	return &wasm.Memory{Min: min, Max: max, IsMaxEncoded: isMaxEncoded}, nil
+	mem := &wasm.Memory{Min: min, Max: max, IsMaxEncoded: isMaxEncoded}
+	return mem, mem.ValidateMinMax(memoryLimitPages)
 }
 
 // encodeMemory returns the wasm.Memory encoded in WebAssembly 1.0 (20191205) Binary Format.

--- a/internal/wasm/binary/memory_test.go
+++ b/internal/wasm/binary/memory_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestMemoryType(t *testing.T) {
 	zero := uint32(0)
-	max := wasm.MemoryMaxPages
+	max := wasm.MemoryLimitPages
 
 	tests := []struct {
 		name     string
@@ -20,12 +20,12 @@ func TestMemoryType(t *testing.T) {
 	}{
 		{
 			name:     "min 0",
-			input:    &wasm.Memory{Max: wasm.MemoryMaxPages, IsMaxEncoded: true},
+			input:    &wasm.Memory{Max: wasm.MemoryLimitPages, IsMaxEncoded: true},
 			expected: []byte{0x1, 0, 0x80, 0x80, 0x4},
 		},
 		{
 			name:     "min 0 - default max",
-			input:    &wasm.Memory{Max: wasm.MemoryMaxPages},
+			input:    &wasm.Memory{Max: wasm.MemoryLimitPages},
 			expected: []byte{0x0, 0},
 		},
 		{
@@ -68,10 +68,10 @@ func TestMemoryType(t *testing.T) {
 
 func TestDecodeMemoryType_Errors(t *testing.T) {
 	tests := []struct {
-		name           string
-		input          []byte
-		memoryMaxPages uint32
-		expectedErr    string
+		name             string
+		input            []byte
+		memoryLimitPages uint32
+		expectedErr      string
 	}{
 		{
 			name:        "max < min",
@@ -81,24 +81,24 @@ func TestDecodeMemoryType_Errors(t *testing.T) {
 		{
 			name:        "min > limit",
 			input:       []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xf},
-			expectedErr: "min 4294967295 pages (3 Ti) outside range of 65536 pages (4 Gi)",
+			expectedErr: "min 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 		{
 			name:        "max > limit",
 			input:       []byte{0x1, 0, 0xff, 0xff, 0xff, 0xff, 0xf},
-			expectedErr: "max 4294967295 pages (3 Ti) outside range of 65536 pages (4 Gi)",
+			expectedErr: "max 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 	}
 
 	for _, tt := range tests {
 		tc := tt
 
-		if tc.memoryMaxPages == 0 {
-			tc.memoryMaxPages = wasm.MemoryMaxPages
+		if tc.memoryLimitPages == 0 {
+			tc.memoryLimitPages = wasm.MemoryLimitPages
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeMemory(bytes.NewReader(tc.input), tc.memoryMaxPages)
+			_, err := decodeMemory(bytes.NewReader(tc.input), tc.memoryLimitPages)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -24,7 +24,7 @@ func decodeTypeSection(enabledFeatures wasm.Features, r *bytes.Reader) ([]*wasm.
 	return result, nil
 }
 
-func decodeImportSection(r *bytes.Reader, memoryMaxPages uint32) ([]*wasm.Import, error) {
+func decodeImportSection(r *bytes.Reader, memoryLimitPages uint32) ([]*wasm.Import, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
@@ -32,7 +32,7 @@ func decodeImportSection(r *bytes.Reader, memoryMaxPages uint32) ([]*wasm.Import
 
 	result := make([]*wasm.Import, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeImport(r, i, memoryMaxPages); err != nil {
+		if result[i], err = decodeImport(r, i, memoryLimitPages); err != nil {
 			return nil, err
 		}
 	}
@@ -66,7 +66,7 @@ func decodeTableSection(r *bytes.Reader) (*wasm.Table, error) {
 	return decodeTable(r)
 }
 
-func decodeMemorySection(r *bytes.Reader, memoryMaxPages uint32) (*wasm.Memory, error) {
+func decodeMemorySection(r *bytes.Reader, memoryLimitPages uint32) (*wasm.Memory, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("error reading size")
@@ -75,7 +75,7 @@ func decodeMemorySection(r *bytes.Reader, memoryMaxPages uint32) (*wasm.Memory, 
 		return nil, fmt.Errorf("at most one memory allowed in module, but read %d", vs)
 	}
 
-	return decodeMemory(r, memoryMaxPages)
+	return decodeMemory(r, memoryLimitPages)
 }
 
 func decodeGlobalSection(r *bytes.Reader, enabledFeatures wasm.Features) ([]*wasm.Global, error) {

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -84,7 +84,7 @@ func TestMemorySection(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			memories, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemoryMaxPages)
+			memories, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemoryLimitPages)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, memories)
 		})
@@ -93,10 +93,10 @@ func TestMemorySection(t *testing.T) {
 
 func TestMemorySection_Errors(t *testing.T) {
 	tests := []struct {
-		name           string
-		input          []byte
-		memoryMaxPages uint32
-		expectedErr    string
+		name             string
+		input            []byte
+		memoryLimitPages uint32
+		expectedErr      string
 	}{
 		{
 			name: "min and min with max",
@@ -112,12 +112,12 @@ func TestMemorySection_Errors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 
-		if tc.memoryMaxPages == 0 {
-			tc.memoryMaxPages = wasm.MemoryMaxPages
+		if tc.memoryLimitPages == 0 {
+			tc.memoryLimitPages = wasm.MemoryLimitPages
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeMemorySection(bytes.NewReader(tc.input), tc.memoryMaxPages)
+			_, err := decodeMemorySection(bytes.NewReader(tc.input), tc.memoryLimitPages)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -17,9 +17,9 @@ const (
 	// and is defined as 2^16 = 65536.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0
 	MemoryPageSize = uint32(65536)
-	// MemoryMaxPages is maximum number of pages defined (2^16).
+	// MemoryLimitPages is maximum number of pages defined (2^16).
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem
-	MemoryMaxPages = uint32(65536)
+	MemoryLimitPages = uint32(65536)
 	// MemoryPageSizeInBits satisfies the relation: "1 << MemoryPageSizeInBits == MemoryPageSize".
 	MemoryPageSizeInBits = 16
 )

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -11,7 +11,7 @@ import (
 func TestMemoryPageConsts(t *testing.T) {
 	require.Equal(t, MemoryPageSize, uint32(1)<<MemoryPageSizeInBits)
 	require.Equal(t, MemoryPageSize, uint32(1<<16))
-	require.Equal(t, MemoryMaxPages, uint32(1<<16))
+	require.Equal(t, MemoryLimitPages, uint32(1<<16))
 }
 
 func Test_MemoryPagesToBytesNum(t *testing.T) {
@@ -158,7 +158,7 @@ func TestPagesToUnitOfBytes(t *testing.T) {
 		},
 		{
 			name:     "max memory",
-			pages:    MemoryMaxPages,
+			pages:    MemoryLimitPages,
 			expected: "4 Gi",
 		},
 		{

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -27,28 +27,56 @@ func Test_MemoryBytesNumToPages(t *testing.T) {
 }
 
 func TestMemoryInstance_Grow_Size(t *testing.T) {
-	for _, ctx := range []context.Context{nil, testCtx} { // Ensure it doesn't crash on nil!
-		max := uint32(10)
-		m := &MemoryInstance{Max: max, Buffer: make([]byte, 0)}
-		require.Equal(t, uint32(0), m.Grow(ctx, 5))
-		require.Equal(t, uint32(5), m.PageSize(ctx))
+	tests := []struct {
+		name         string
+		ctx          context.Context
+		capEqualsMax bool
+	}{
+		{name: "nil context"},
+		{name: "context", ctx: testCtx},
+		{name: "nil context, capEqualsMax", capEqualsMax: true},
+		{name: "context,  capEqualsMax", ctx: testCtx, capEqualsMax: true},
+	}
 
-		// Zero page grow is well-defined, should return the current page correctly.
-		require.Equal(t, uint32(5), m.Grow(ctx, 0))
-		require.Equal(t, uint32(5), m.PageSize(ctx))
-		require.Equal(t, uint32(5), m.Grow(ctx, 4))
-		require.Equal(t, uint32(9), m.PageSize(ctx))
+	for _, tt := range tests {
+		tc := tt
 
-		// At this point, the page size equal 9,
-		// so trying to grow two pages should result in failure.
-		require.Equal(t, int32(-1), int32(m.Grow(ctx, 2)))
-		require.Equal(t, uint32(9), m.PageSize(ctx))
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := tc.ctx
+			max := uint32(10)
+			maxBytes := MemoryPagesToBytesNum(max)
+			var m *MemoryInstance
+			if tc.capEqualsMax {
+				m = &MemoryInstance{Cap: max, Max: max, Buffer: make([]byte, 0, maxBytes)}
+			} else {
+				m = &MemoryInstance{Max: max, Buffer: make([]byte, 0)}
+			}
+			require.Equal(t, uint32(0), m.Grow(ctx, 5))
+			require.Equal(t, uint32(5), m.PageSize(ctx))
 
-		// But growing one page is still permitted.
-		require.Equal(t, uint32(9), m.Grow(ctx, 1))
+			// Zero page grow is well-defined, should return the current page correctly.
+			require.Equal(t, uint32(5), m.Grow(ctx, 0))
+			require.Equal(t, uint32(5), m.PageSize(ctx))
+			require.Equal(t, uint32(5), m.Grow(ctx, 4))
+			require.Equal(t, uint32(9), m.PageSize(ctx))
 
-		// Ensure that the current page size equals the max.
-		require.Equal(t, max, m.PageSize(ctx))
+			// At this point, the page size equal 9,
+			// so trying to grow two pages should result in failure.
+			require.Equal(t, int32(-1), int32(m.Grow(ctx, 2)))
+			require.Equal(t, uint32(9), m.PageSize(ctx))
+
+			// But growing one page is still permitted.
+			require.Equal(t, uint32(9), m.Grow(ctx, 1))
+
+			// Ensure that the current page size equals the max.
+			require.Equal(t, max, m.PageSize(ctx))
+
+			if tc.capEqualsMax { // Ensure the capacity isn't more than max.
+				require.Equal(t, maxBytes, uint64(cap(m.Buffer)))
+			} else { // Slice doubles, so it should have a higher capacity than max.
+				require.True(t, maxBytes < uint64(cap(m.Buffer)))
+			}
+		})
 	}
 }
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -559,9 +559,15 @@ func paramNames(localNames IndirectNameMap, funcIdx uint32, paramLen int) []stri
 func (m *Module) buildMemory() (mem *MemoryInstance) {
 	memSec := m.MemorySection
 	if memSec != nil {
+		min := MemoryPagesToBytesNum(memSec.Min)
+		capacity := MemoryPagesToBytesNum(memSec.Cap)
+		if capacity == 0 && min != 0 {
+			capacity = min // Internal code may avoid setting Cap. Default to min.
+		}
 		mem = &MemoryInstance{
-			Buffer: make([]byte, MemoryPagesToBytesNum(memSec.Min)),
+			Buffer: make([]byte, min, capacity),
 			Min:    memSec.Min,
+			Cap:    memSec.Cap,
 			Max:    memSec.Max,
 		}
 	}
@@ -652,8 +658,8 @@ type limitsType struct {
 
 // Memory describes the limits of pages (64KB) in a memory.
 type Memory struct {
-	Min, Max uint32
-	// IsMaxEncoded true if the Max is encoded in the orignial source (binary or text).
+	Min, Cap, Max uint32
+	// IsMaxEncoded true if the Max is encoded in the original source (binary or text).
 	IsMaxEncoded bool
 }
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -23,7 +23,7 @@ import (
 // * result is the module parsed or nil on error
 // * err is a FormatError invoking the parser, dangling block comments or unexpected characters.
 // See binary.DecodeModule and text.DecodeModule
-type DecodeModule func(source []byte, enabledFeatures Features, memoryMaxPages uint32) (result *Module, err error)
+type DecodeModule func(source []byte, enabledFeatures Features, memoryLimitPages uint32) (result *Module, err error)
 
 // EncodeModule encodes the given module into a byte slice depending on the format of the implementation.
 // See binary.EncodeModule
@@ -661,6 +661,33 @@ type Memory struct {
 	Min, Cap, Max uint32
 	// IsMaxEncoded true if the Max is encoded in the original source (binary or text).
 	IsMaxEncoded bool
+}
+
+// ValidateMinMax ensures values assigned to Min and Max are within valid thresholds.
+func (m *Memory) ValidateMinMax(memoryLimitPages uint32) error {
+	if !m.IsMaxEncoded {
+		m.Max = memoryLimitPages
+	}
+	min, max := m.Min, m.Max
+	if max > memoryLimitPages {
+		return fmt.Errorf("max %d pages (%s) over limit of %d pages (%s)", max, PagesToUnitOfBytes(max), memoryLimitPages, PagesToUnitOfBytes(memoryLimitPages))
+	} else if min > memoryLimitPages {
+		return fmt.Errorf("min %d pages (%s) over limit of %d pages (%s)", min, PagesToUnitOfBytes(min), memoryLimitPages, PagesToUnitOfBytes(memoryLimitPages))
+	} else if min > max {
+		return fmt.Errorf("min %d pages (%s) > max %d pages (%s)", min, PagesToUnitOfBytes(min), max, PagesToUnitOfBytes(max))
+	}
+	return nil
+}
+
+// ValidateCap ensures the value assigned to Cap is within valid thresholds.
+func (m *Memory) ValidateCap(memoryLimitPages uint32) error {
+	capacity, min := m.Cap, m.Min
+	if capacity < min {
+		return fmt.Errorf("capacity %d pages (%s) less than minimum %d pages (%s)", capacity, PagesToUnitOfBytes(capacity), min, PagesToUnitOfBytes(min))
+	} else if capacity > memoryLimitPages {
+		return fmt.Errorf("capacity %d pages (%s) over limit of %d pages (%s)", capacity, PagesToUnitOfBytes(capacity), memoryLimitPages, PagesToUnitOfBytes(memoryLimitPages))
+	}
+	return nil
 }
 
 type GlobalType struct {

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -561,9 +561,6 @@ func (m *Module) buildMemory() (mem *MemoryInstance) {
 	if memSec != nil {
 		min := MemoryPagesToBytesNum(memSec.Min)
 		capacity := MemoryPagesToBytesNum(memSec.Cap)
-		if capacity == 0 && min != 0 {
-			capacity = min // Internal code may avoid setting Cap. Default to min.
-		}
 		mem = &MemoryInstance{
 			Buffer: make([]byte, min, capacity),
 			Min:    memSec.Min,

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -807,7 +807,7 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 	t.Run("non-nil", func(t *testing.T) {
 		min := uint32(1)
 		max := uint32(10)
-		m := Module{MemorySection: &Memory{Min: min, Max: max}}
+		m := Module{MemorySection: &Memory{Min: min, Cap: min, Max: max}}
 		mem := m.buildMemory()
 		require.Equal(t, min, mem.Min)
 		require.Equal(t, max, mem.Max)

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -90,6 +90,83 @@ func TestExternTypeName(t *testing.T) {
 	}
 }
 
+func TestMemory_ValidateCap(t *testing.T) {
+	tests := []struct {
+		name        string
+		mem         *Memory
+		expectedErr string
+	}{
+		{
+			name: "ok",
+			mem:  &Memory{Min: 2, Cap: 2},
+		},
+		{
+			name:        "cap < min",
+			mem:         &Memory{Min: 2, Cap: 1},
+			expectedErr: "capacity 1 pages (64 Ki) less than minimum 2 pages (128 Ki)",
+		},
+		{
+			name:        "cap > maxLimit",
+			mem:         &Memory{Min: 2, Cap: 4},
+			expectedErr: "capacity 4 pages (256 Ki) over limit of 3 pages (192 Ki)",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.mem.ValidateCap(3)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestMemory_ValidateMinMax(t *testing.T) {
+	tests := []struct {
+		name        string
+		mem         *Memory
+		expectedErr string
+	}{
+		{
+			name: "ok",
+			mem:  &Memory{Min: 2},
+		},
+		{
+			name:        "max < min",
+			mem:         &Memory{Min: 2, Max: 0, IsMaxEncoded: true},
+			expectedErr: "min 2 pages (128 Ki) > max 0 pages (0 Ki)",
+		},
+		{
+			name:        "min > limit",
+			mem:         &Memory{Min: math.MaxUint32},
+			expectedErr: "min 4294967295 pages (3 Ti) over limit of 3 pages (192 Ki)",
+		},
+		{
+			name:        "max > limit",
+			mem:         &Memory{Max: math.MaxUint32, IsMaxEncoded: true},
+			expectedErr: "max 4294967295 pages (3 Ti) over limit of 3 pages (192 Ki)",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.mem.ValidateMinMax(3)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
 func TestModule_allDeclarations(t *testing.T) {
 	for i, tc := range []struct {
 		module            *Module

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -650,7 +650,7 @@ func TestStore_resolveImports(t *testing.T) {
 			importMemoryType := &Memory{Max: max}
 			s.modules[moduleName] = &ModuleInstance{Exports: map[string]*ExportInstance{name: {
 				Type:   ExternTypeMemory,
-				Memory: &MemoryInstance{Max: MemoryMaxPages},
+				Memory: &MemoryInstance{Max: MemoryLimitPages},
 			}}, Name: moduleName}
 			_, _, _, _, err := s.resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}})
 			require.EqualError(t, err, "import[0] memory[test.target]: maximum size mismatch: 10 < 65536")

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -28,16 +28,16 @@ func TestModuleInstance_Memory(t *testing.T) {
 		},
 		{
 			name:  "memory not exported",
-			input: &Module{MemorySection: &Memory{Min: 1}},
+			input: &Module{MemorySection: &Memory{Min: 1, Cap: 1}},
 		},
 		{
 			name:  "memory not exported, one page",
-			input: &Module{MemorySection: &Memory{Min: 1}},
+			input: &Module{MemorySection: &Memory{Min: 1, Cap: 1}},
 		},
 		{
 			name: "memory exported, different name",
 			input: &Module{
-				MemorySection: &Memory{Min: 1},
+				MemorySection: &Memory{Min: 1, Cap: 1},
 				ExportSection: []*Export{{Type: ExternTypeMemory, Name: "momory", Index: 0}},
 			},
 		},
@@ -52,7 +52,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 		{
 			name: "memory exported, one page",
 			input: &Module{
-				MemorySection: &Memory{Min: 1},
+				MemorySection: &Memory{Min: 1, Cap: 1},
 				ExportSection: []*Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
@@ -61,7 +61,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 		{
 			name: "memory exported, two pages",
 			input: &Module{
-				MemorySection: &Memory{Min: 2},
+				MemorySection: &Memory{Min: 2, Cap: 2},
 				ExportSection: []*Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
@@ -156,7 +156,7 @@ func TestStore_CloseModule(t *testing.T) {
 			_, err := s.Instantiate(testCtx, &Module{
 				TypeSection:   []*FunctionType{{}},
 				ImportSection: []*Import{{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
-				MemorySection: &Memory{Min: 1},
+				MemorySection: &Memory{Min: 1, Cap: 1},
 				GlobalSection: []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
 				TableSection:  &Table{Min: 10},
 			}, importingModuleName, nil, nil)
@@ -205,7 +205,7 @@ func TestStore_hammer(t *testing.T) {
 		TypeSection:     []*FunctionType{{}},
 		FunctionSection: []uint32{0},
 		CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
-		MemorySection:   &Memory{Min: 1},
+		MemorySection:   &Memory{Min: 1, Cap: 1},
 		GlobalSection:   []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
 		TableSection:    &Table{Min: 10},
 		ImportSection: []*Import{
@@ -352,7 +352,7 @@ func TestCallContext_ExportedFunction(t *testing.T) {
 		importing, err := s.Instantiate(testCtx, &Module{
 			TypeSection:   []*FunctionType{{}},
 			ImportSection: []*Import{{Type: ExternTypeFunc, Module: "host", Name: "host_fn", DescFunc: 0}},
-			MemorySection: &Memory{Min: 1},
+			MemorySection: &Memory{Min: 1, Cap: 1},
 			ExportSection: []*Export{{Type: ExternTypeFunc, Name: "host.fn", Index: 0}},
 		}, "test", nil, nil)
 		require.NoError(t, err)
@@ -636,10 +636,10 @@ func TestStore_resolveImports(t *testing.T) {
 		})
 		t.Run("minimum size mismatch", func(t *testing.T) {
 			s := newStore()
-			importMemoryType := &Memory{Min: 2}
+			importMemoryType := &Memory{Min: 2, Cap: 2}
 			s.modules[moduleName] = &ModuleInstance{Exports: map[string]*ExportInstance{name: {
 				Type:   ExternTypeMemory,
-				Memory: &MemoryInstance{Min: importMemoryType.Min - 1},
+				Memory: &MemoryInstance{Min: importMemoryType.Min - 1, Cap: 2},
 			}}, Name: moduleName}
 			_, _, _, _, err := s.resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}})
 			require.EqualError(t, err, "import[0] memory[test.target]: minimum size mismatch: 2 > 1")

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -104,7 +104,7 @@ type moduleParser struct {
 
 // DecodeModule implements wasm.DecodeModule for the WebAssembly 1.0 (20191205) Text Format
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-format%E2%91%A0
-func DecodeModule(source []byte, enabledFeatures wasm.Features, memoryMaxPages uint32) (result *wasm.Module, err error) {
+func DecodeModule(source []byte, enabledFeatures wasm.Features, memoryLimitPages uint32) (result *wasm.Module, err error) {
 	// TODO: when globals are supported, err on global vars if disabled
 
 	// names are the wasm.Module NameSection
@@ -114,7 +114,7 @@ func DecodeModule(source []byte, enabledFeatures wasm.Features, memoryMaxPages u
 	// * LocalNames: nil when neither imported nor module-defined functions had named (param) fields.
 	names := &wasm.NameSection{}
 	module := &wasm.Module{NameSection: names}
-	p := newModuleParser(module, enabledFeatures, memoryMaxPages)
+	p := newModuleParser(module, enabledFeatures, memoryLimitPages)
 	p.source = source
 
 	// A valid source must begin with the token '(', but it could be preceded by whitespace or comments. For this
@@ -143,7 +143,7 @@ func DecodeModule(source []byte, enabledFeatures wasm.Features, memoryMaxPages u
 	return module, nil
 }
 
-func newModuleParser(module *wasm.Module, enabledFeatures wasm.Features, memoryMaxPages uint32) *moduleParser {
+func newModuleParser(module *wasm.Module, enabledFeatures wasm.Features, memoryLimitPages uint32) *moduleParser {
 	p := moduleParser{module: module, enabledFeatures: enabledFeatures,
 		typeNamespace:   newIndexNamespace(module.SectionElementCount),
 		funcNamespace:   newIndexNamespace(module.SectionElementCount),
@@ -152,7 +152,7 @@ func newModuleParser(module *wasm.Module, enabledFeatures wasm.Features, memoryM
 	p.typeParser = newTypeParser(enabledFeatures, p.typeNamespace, p.onTypeEnd)
 	p.typeUseParser = newTypeUseParser(enabledFeatures, module, p.typeNamespace)
 	p.funcParser = newFuncParser(enabledFeatures, p.typeUseParser, p.funcNamespace, p.endFunc)
-	p.memoryParser = newMemoryParser(memoryMaxPages, p.memoryNamespace, p.endMemory)
+	p.memoryParser = newMemoryParser(memoryLimitPages, p.memoryNamespace, p.endMemory)
 	return &p
 }
 

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -1226,14 +1226,14 @@ func TestDecodeModule(t *testing.T) {
 			name:  "memory",
 			input: "(module (memory 1))",
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages},
 			},
 		},
 		{
 			name:  "memory ID",
 			input: "(module (memory $mem 1))",
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages},
 			},
 		},
 		{
@@ -1420,7 +1420,7 @@ func TestDecodeModule(t *testing.T) {
 	(export "foo" (memory 0))
 )`,
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 0, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 0, Max: wasm.MemoryLimitPages},
 				ExportSection: []*wasm.Export{
 					{Name: "foo", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -1433,7 +1433,7 @@ func TestDecodeModule(t *testing.T) {
 	(memory 0)
 )`,
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 0, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 0, Max: wasm.MemoryLimitPages},
 				ExportSection: []*wasm.Export{
 					{Name: "foo", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -1465,7 +1465,7 @@ func TestDecodeModule(t *testing.T) {
     (export "memory" (memory $mem))
 )`,
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryMaxPages},
+				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages},
 				ExportSection: []*wasm.Export{
 					{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -1564,7 +1564,7 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := DecodeModule([]byte(tc.input), wasm.FeaturesFinished, wasm.MemoryMaxPages)
+			m, err := DecodeModule([]byte(tc.input), wasm.FeaturesFinished, wasm.MemoryLimitPages)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, m)
 		})
@@ -1573,9 +1573,9 @@ func TestDecodeModule(t *testing.T) {
 
 func TestParseModule_Errors(t *testing.T) {
 	tests := []struct {
-		name, input    string
-		memoryMaxPages uint32
-		expectedErr    string
+		name, input      string
+		memoryLimitPages uint32
+		expectedErr      string
 	}{
 		{
 			name:        "forgot parens",
@@ -1998,10 +1998,10 @@ func TestParseModule_Errors(t *testing.T) {
 			expectedErr: "2:47: i32.trunc_sat_f32_s invalid as feature \"nontrapping-float-to-int-conversion\" is disabled in module.func[0]",
 		},
 		{
-			name:           "memory over max",
-			input:          "(module (memory 1 4))",
-			memoryMaxPages: 3,
-			expectedErr:    "1:19: max 4 pages (256 Ki) outside range of 3 pages (192 Ki) in module.memory[0]",
+			name:             "memory over max",
+			input:            "(module (memory 1 4))",
+			memoryLimitPages: 3,
+			expectedErr:      "1:19: max 4 pages (256 Ki) over limit of 3 pages (192 Ki) in module.memory[0]",
 		},
 		{
 			name:        "second memory",
@@ -2145,10 +2145,10 @@ func TestParseModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.memoryMaxPages == 0 {
-				tc.memoryMaxPages = wasm.MemoryMaxPages
+			if tc.memoryLimitPages == 0 {
+				tc.memoryLimitPages = wasm.MemoryLimitPages
 			}
-			_, err := DecodeModule([]byte(tc.input), wasm.Features20191205, tc.memoryMaxPages)
+			_, err := DecodeModule([]byte(tc.input), wasm.Features20191205, tc.memoryLimitPages)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/text/memory_parser_test.go
+++ b/internal/wasm/text/memory_parser_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMemoryParser(t *testing.T) {
 	zero := uint32(0)
-	max := wasm.MemoryMaxPages
+	max := wasm.MemoryLimitPages
 	tests := []struct {
 		name       string
 		input      string
@@ -122,12 +122,12 @@ func TestMemoryParser_Errors(t *testing.T) {
 		{
 			name:        "min > limit",
 			input:       "(memory 4294967295)",
-			expectedErr: "min 4294967295 pages (3 Ti) outside range of 65536 pages (4 Gi)",
+			expectedErr: "min 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 		{
 			name:        "max > limit",
 			input:       "(memory 0 4294967295)",
-			expectedErr: "max 4294967295 pages (3 Ti) outside range of 65536 pages (4 Gi)",
+			expectedErr: "max 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 	}
 
@@ -166,7 +166,7 @@ func parseMemoryType(memoryNamespace *indexNamespace, input string) (*wasm.Memor
 		parsed = &wasm.Memory{Min: min, Max: max, IsMaxEncoded: maxDecoded}
 		return parseErr
 	}
-	tp := newMemoryParser(wasm.MemoryMaxPages, memoryNamespace, setFunc)
+	tp := newMemoryParser(wasm.MemoryLimitPages, memoryNamespace, setFunc)
 	// memoryParser starts after the '(memory', so we need to eat it first!
 	_, _, err := lex(skipTokens(2, tp.begin), []byte(input))
 	return parsed, tp, err

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -558,7 +558,7 @@ func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expec
 }
 
 func requireModuleText(t *testing.T, source string) *wasm.Module {
-	m, err := text.DecodeModule([]byte(source), wasm.FeaturesFinished, wasm.MemoryMaxPages)
+	m, err := text.DecodeModule([]byte(source), wasm.FeaturesFinished, wasm.MemoryLimitPages)
 	require.NoError(t, err)
 	return m
 }


### PR DESCRIPTION
`Runtime.WithMemoryCapacityPages` is a function that determines memory
capacity in pages (65536 bytes per page). The inputs are the min and
possibly nil max defined by the module, and the default is to return
the min.

Ex. To set capacity to max when exists:
```golang
c.WithMemoryCapacityPages(func(minPages uint32, maxPages *uint32) uint32 {
	if maxPages != nil {
		return *maxPages
	}
	return minPages
})
```

Note: This applies at compile time, ModuleBuilder.Build or Runtime.CompileModule.

Fixes #500