### PR TITLE
Changes RuntimeConfig to an interface and exposes WithWasmCore2

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,13 @@ as well as how to classify a request for a feature we don't yet support.
 
 ### WebAssembly Core
 wazero conforms with spectests [7] defined alongside WebAssembly Core
-Specification [1.0][1]. There is also [work in progress][14] towards release
-[2.0][2], despite it not being a Web Standard, yet.
+Specification [1.0][1]. This is the default [RuntimeConfig][18].
+
+The WebAssembly Core Specification [2.0][2] is in draft form and wazero has
+[work in progress][14] towards that. Opt in via the below configuration:
+```go
+rConfig = wazero.NewRuntimeConfig().WithWasmCore2()
+```
 
 One current limitation of wazero is that it doesn't fully implement the Text
 Format, yet, e.g. compiling `.wat` files. The intent is to [finish this][15],

--- a/builder_test.go
+++ b/builder_test.go
@@ -362,12 +362,12 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 func TestNewModuleBuilder_Build_Errors(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       func(*RuntimeConfig) ModuleBuilder
+		input       func(RuntimeConfig) ModuleBuilder
 		expectedErr string
 	}{
 		{
 			name: "memory min > limit", // only one test to avoid duplicating tests in module_test.go
-			input: func(cfg *RuntimeConfig) ModuleBuilder {
+			input: func(cfg RuntimeConfig) ModuleBuilder {
 				return NewRuntimeWithConfig(cfg).NewModuleBuilder("").
 					ExportMemory("memory", math.MaxUint32)
 			},
@@ -375,7 +375,7 @@ func TestNewModuleBuilder_Build_Errors(t *testing.T) {
 		},
 		{
 			name: "memory cap < min", // only one test to avoid duplicating tests in module_test.go
-			input: func(cfg *RuntimeConfig) ModuleBuilder {
+			input: func(cfg RuntimeConfig) ModuleBuilder {
 				cfg = cfg.WithMemoryCapacityPages(func(minPages uint32, maxPages *uint32) uint32 {
 					return 1
 				})

--- a/config_supported.go
+++ b/config_supported.go
@@ -5,6 +5,6 @@ package wazero
 const JITSupported = true
 
 // NewRuntimeConfig returns NewRuntimeConfigJIT
-func NewRuntimeConfig() *RuntimeConfig {
+func NewRuntimeConfig() RuntimeConfig {
 	return NewRuntimeConfigJIT()
 }

--- a/config_unsupported.go
+++ b/config_unsupported.go
@@ -5,6 +5,6 @@ package wazero
 const JITSupported = false
 
 // NewRuntimeConfig returns NewRuntimeConfigInterpreter
-func NewRuntimeConfig() *RuntimeConfig {
+func NewRuntimeConfig() RuntimeConfig {
 	return NewRuntimeConfigInterpreter()
 }

--- a/examples/multiple-results/multiple-results.go
+++ b/examples/multiple-results/multiple-results.go
@@ -48,7 +48,7 @@ func main() {
 	// wazero enables only W3C recommended features by default. Opt-in to other features like so:
 	runtimeWithMultiValue := wazero.NewRuntimeWithConfig(
 		wazero.NewRuntimeConfig().WithFeatureMultiValue(true),
-		// ^^ Note: You can enable all features via WithFinishedFeatures.
+		// ^^ Note: You can enable release 2.0 features via WithWasmCore2.
 	)
 
 	// Add a module that uses multiple results values, with functions defined in WebAssembly.

--- a/examples/multiple-results/multiple-results.go
+++ b/examples/multiple-results/multiple-results.go
@@ -48,7 +48,7 @@ func main() {
 	// wazero enables only W3C recommended features by default. Opt-in to other features like so:
 	runtimeWithMultiValue := wazero.NewRuntimeWithConfig(
 		wazero.NewRuntimeConfig().WithFeatureMultiValue(true),
-		// ^^ Note: You can enable release 2.0 features via WithWasmCore2.
+		// ^^ Note: WebAssembly 2.0 (WithWasmCore2) includes "multi-value".
 	)
 
 	// Add a module that uses multiple results values, with functions defined in WebAssembly.

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -153,8 +153,8 @@ func runRandomMatMul(b *testing.B, m api.Module) {
 	}
 }
 
-func instantiateHostFunctionModuleWithEngine(b *testing.B, engine *wazero.RuntimeConfig) api.Module {
-	r := createRuntime(b, engine)
+func instantiateHostFunctionModuleWithEngine(b *testing.B, config wazero.RuntimeConfig) api.Module {
+	r := createRuntime(b, config)
 
 	// InstantiateModuleFromCode runs the "_start" function which is what TinyGo compiles "main" to.
 	m, err := r.InstantiateModuleFromCode(testCtx, caseWasm)
@@ -164,7 +164,7 @@ func instantiateHostFunctionModuleWithEngine(b *testing.B, engine *wazero.Runtim
 	return m
 }
 
-func createRuntime(b *testing.B, engine *wazero.RuntimeConfig) wazero.Runtime {
+func createRuntime(b *testing.B, config wazero.RuntimeConfig) wazero.Runtime {
 	getRandomString := func(ctx context.Context, m api.Module, retBufPtr uint32, retBufSize uint32) {
 		results, err := m.ExportedFunction("allocate_buffer").Call(ctx, 10)
 		if err != nil {
@@ -179,7 +179,7 @@ func createRuntime(b *testing.B, engine *wazero.RuntimeConfig) wazero.Runtime {
 		m.Memory().Write(ctx, offset, b)
 	}
 
-	r := wazero.NewRuntimeWithConfig(engine)
+	r := wazero.NewRuntimeWithConfig(config)
 
 	_, err := r.NewModuleBuilder("env").
 		ExportFunction("get_random_string", getRandomString).

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -42,7 +42,7 @@ func TestEngineInterpreter(t *testing.T) {
 	runAllTests(t, tests, wazero.NewRuntimeConfigInterpreter())
 }
 
-func runAllTests(t *testing.T, tests map[string]func(t *testing.T, r wazero.Runtime), config *wazero.RuntimeConfig) {
+func runAllTests(t *testing.T, tests map[string]func(t *testing.T, r wazero.Runtime), config wazero.RuntimeConfig) {
 	for name, testf := range tests {
 		name := name   // pin
 		testf := testf // pin

--- a/internal/integration_test/post1_0/bulk-memory-operations/spec_test.go
+++ b/internal/integration_test/post1_0/bulk-memory-operations/spec_test.go
@@ -45,7 +45,7 @@ var (
 	elemDropWasm []byte
 )
 
-func requireErrorOnBulkMemoryFeatureDisabled(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig, bin []byte) {
+func requireErrorOnBulkMemoryFeatureDisabled(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig, bin []byte) {
 	t.Run("disabled", func(t *testing.T) {
 		// bulk-memory-operations is disabled by default.
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())
@@ -54,7 +54,7 @@ func requireErrorOnBulkMemoryFeatureDisabled(t *testing.T, newRuntimeConfig func
 	})
 }
 
-func testTableCopy(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testTableCopy(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	t.Run("table.copy", func(t *testing.T) {
 
 		requireErrorOnBulkMemoryFeatureDisabled(t, newRuntimeConfig, tableCopyWasm)
@@ -123,7 +123,7 @@ func testTableCopy(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) 
 	})
 }
 
-func testTableInit(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testTableInit(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	t.Run("table.init", func(t *testing.T) {
 		requireErrorOnBulkMemoryFeatureDisabled(t, newRuntimeConfig, tableInitWasm)
 
@@ -166,7 +166,7 @@ func testTableInit(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) 
 	})
 }
 
-func testElemDrop(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testElemDrop(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	t.Run("elem.drop", func(t *testing.T) {
 		requireErrorOnBulkMemoryFeatureDisabled(t, newRuntimeConfig, elemDropWasm)
 
@@ -194,7 +194,7 @@ func testElemDrop(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
 	})
 }
 
-func testBulkMemoryOperations(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testBulkMemoryOperations(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	requireErrorOnBulkMemoryFeatureDisabled(t, newRuntimeConfig, bulkMemoryOperationsWasm)
 
 	t.Run("enabled", func(t *testing.T) {

--- a/internal/integration_test/post1_0/multi-value/spec_test.go
+++ b/internal/integration_test/post1_0/multi-value/spec_test.go
@@ -28,7 +28,7 @@ func TestMultiValue_Interpreter(t *testing.T) {
 //go:embed testdata/multi_value.wasm
 var multiValueWasm []byte
 
-func testMultiValue(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testMultiValue(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	t.Run("disabled", func(t *testing.T) {
 		// multi-value is disabled by default.
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())

--- a/internal/integration_test/post1_0/nontrapping-float-to-int-conversion/spec_test.go
+++ b/internal/integration_test/post1_0/nontrapping-float-to-int-conversion/spec_test.go
@@ -56,7 +56,7 @@ var nonTrappingFloatToIntConversion = []byte(`(module $conversions.wast
 )
 `)
 
-func testNonTrappingFloatToIntConversion(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testNonTrappingFloatToIntConversion(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	t.Run("disabled", func(t *testing.T) {
 		// Non-trapping Float-to-int Conversions are disabled by default.
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())

--- a/internal/integration_test/post1_0/sign-extension-ops/spec_test.go
+++ b/internal/integration_test/post1_0/sign-extension-ops/spec_test.go
@@ -45,7 +45,7 @@ var signExtend = []byte(`(module
 )
 `)
 
-func testSignExtensionOps(t *testing.T, newRuntimeConfig func() *wazero.RuntimeConfig) {
+func testSignExtensionOps(t *testing.T, newRuntimeConfig func() wazero.RuntimeConfig) {
 	t.Run("disabled", func(t *testing.T) {
 		// Sign-extension is disabled by default.
 		r := wazero.NewRuntimeWithConfig(newRuntimeConfig())

--- a/internal/integration_test/vs/codec.go
+++ b/internal/integration_test/vs/codec.go
@@ -92,7 +92,7 @@ func newExample() *wasm.Module {
 func BenchmarkWat2Wasm(b *testing.B, vsName string, vsWat2Wasm func([]byte) error) {
 	b.Run("wazero", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if m, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryLimitPages); err != nil {
+			if m, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemoryLimitPages); err != nil {
 				b.Fatal(err)
 			} else {
 				_ = binary.EncodeModule(m)

--- a/internal/integration_test/vs/codec_test.go
+++ b/internal/integration_test/vs/codec_test.go
@@ -14,19 +14,19 @@ import (
 
 func TestExampleUpToDate(t *testing.T) {
 	t.Run("binary.DecodeModule", func(t *testing.T) {
-		m, err := binary.DecodeModule(exampleBinary, wasm.FeaturesFinished, wasm.MemoryLimitPages)
+		m, err := binary.DecodeModule(exampleBinary, wasm.Features20220419, wasm.MemoryLimitPages)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
 
 	t.Run("text.DecodeModule", func(t *testing.T) {
-		m, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryLimitPages)
+		m, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemoryLimitPages)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
 
 	t.Run("Executable", func(t *testing.T) {
-		r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFinishedFeatures())
+		r := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithWasmCore2())
 
 		// Add WASI to satisfy import tests
 		wm, err := wasi.InstantiateSnapshotPreview1(testCtx, r)
@@ -49,7 +49,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("binary.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := binary.DecodeModule(exampleBinary, wasm.FeaturesFinished, wasm.MemoryLimitPages); err != nil {
+			if _, err := binary.DecodeModule(exampleBinary, wasm.Features20220419, wasm.MemoryLimitPages); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -63,7 +63,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("text.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := text.DecodeModule(exampleText, wasm.FeaturesFinished, wasm.MemoryLimitPages); err != nil {
+			if _, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemoryLimitPages); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -38,20 +38,20 @@ type Module interface {
 }
 
 func NewWazeroInterpreterRuntime() Runtime {
-	return newWazeroRuntime("wazero-interpreter", wazero.NewRuntimeConfigInterpreter().WithFinishedFeatures())
+	return newWazeroRuntime("wazero-interpreter", wazero.NewRuntimeConfigInterpreter().WithWasmCore2())
 }
 
 func NewWazeroJITRuntime() Runtime {
-	return newWazeroRuntime(jitRuntime, wazero.NewRuntimeConfigJIT().WithFinishedFeatures())
+	return newWazeroRuntime(jitRuntime, wazero.NewRuntimeConfigJIT().WithWasmCore2())
 }
 
-func newWazeroRuntime(name string, config *wazero.RuntimeConfig) *wazeroRuntime {
+func newWazeroRuntime(name string, config wazero.RuntimeConfig) *wazeroRuntime {
 	return &wazeroRuntime{name: name, config: config}
 }
 
 type wazeroRuntime struct {
 	name          string
-	config        *wazero.RuntimeConfig
+	config        wazero.RuntimeConfig
 	runtime       wazero.Runtime
 	logFn         func([]byte) error
 	env, compiled *wazero.CompiledCode

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -28,7 +28,7 @@ const (
 func TestModGen(t *testing.T) {
 	tested := map[string]struct{}{}
 	rand := rand.New(rand.NewSource(0)) // use deterministic seed source for easy debugging.
-	runtime := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithFinishedFeatures())
+	runtime := wazero.NewRuntimeWithConfig(wazero.NewRuntimeConfig().WithWasmCore2())
 	for _, size := range []int{1, 2, 5, 10, 50, 100} {
 		for i := 0; i < 100; i++ {
 			seed := make([]byte, size)

--- a/internal/wasm/binary/function_test.go
+++ b/internal/wasm/binary/function_test.go
@@ -72,7 +72,7 @@ func TestFunctionType(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("decode - %s", tc.name), func(t *testing.T) {
-			binary, err := decodeFunctionType(wasm.FeaturesFinished, bytes.NewReader(b))
+			binary, err := decodeFunctionType(wasm.Features20220419, bytes.NewReader(b))
 			require.NoError(t, err)
 			require.Equal(t, binary, tc.input)
 		})

--- a/internal/wasm/features.go
+++ b/internal/wasm/features.go
@@ -12,14 +12,20 @@ type Features uint64
 
 // Features20191205 include those finished in WebAssembly 1.0 (20191205).
 //
-// See https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205
 const Features20191205 = FeatureMutableGlobal
 
-// FeaturesFinished include all supported finished features, regardless of W3C status.
+// Features20220419 include those finished in WebAssembly 2.0 (20220419).
 //
-// See https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md
-const FeaturesFinished = 0xffffffffffffffff
+// TODO: not yet complete https://github.com/tetratelabs/wazero/issues/484
+// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/appendix/changes.html#release-1-1
+const Features20220419 = Features20191205 |
+	FeatureBulkMemoryOperations |
+	FeatureMultiValue |
+	FeatureNonTrappingFloatToIntConversion |
+	// TODO: FeatureReferenceTypes |
+	FeatureSignExtensionOps
+	// TODO: FeatureSIMD
 
 const (
 	// FeatureBulkMemoryOperations decides if parsing should succeed on the following instructions:

--- a/internal/wasm/features_test.go
+++ b/internal/wasm/features_test.go
@@ -62,7 +62,7 @@ func TestFeatures_String(t *testing.T) {
 		{name: "multi-value", feature: FeatureMultiValue, expected: "multi-value"},
 		{name: "features", feature: FeatureMutableGlobal | FeatureMultiValue, expected: "multi-value|mutable-global"},
 		{name: "undefined", feature: 1 << 63, expected: ""},
-		{name: "all", feature: FeaturesFinished, expected: "bulk-memory-operations|multi-value|mutable-global|nontrapping-float-to-int-conversion|sign-extension-ops"},
+		{name: "2.0", feature: Features20220419, expected: "bulk-memory-operations|multi-value|mutable-global|nontrapping-float-to-int-conversion|sign-extension-ops"},
 	}
 
 	for _, tt := range tests {

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -247,7 +247,7 @@ func TestPopGoFuncParams(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			goFunc := reflect.ValueOf(tc.inputFunc)
-			fk, _, err := getFunctionType(&goFunc, FeaturesFinished)
+			fk, _, err := getFunctionType(&goFunc, Features20220419)
 			require.NoError(t, err)
 
 			vals := PopGoFuncParams(&FunctionInstance{Kind: fk, GoFunc: &goFunc}, (&stack{stackVals}).pop)
@@ -387,7 +387,7 @@ func TestCallGoFunc(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			goFunc := reflect.ValueOf(tc.inputFunc)
-			fk, _, err := getFunctionType(&goFunc, FeaturesFinished)
+			fk, _, err := getFunctionType(&goFunc, Features20220419)
 			require.NoError(t, err)
 
 			results := CallGoFunc(testCtx, callCtx, &FunctionInstance{Kind: fk, GoFunc: &goFunc}, tc.inputParams)

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -1564,7 +1564,7 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := DecodeModule([]byte(tc.input), wasm.FeaturesFinished, wasm.MemoryLimitPages)
+			m, err := DecodeModule([]byte(tc.input), wasm.Features20220419, wasm.MemoryLimitPages)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, m)
 		})

--- a/internal/wasm/text/func_parser_test.go
+++ b/internal/wasm/text/func_parser_test.go
@@ -272,7 +272,7 @@ func TestFuncParser(t *testing.T) {
 			}
 
 			module := &wasm.Module{}
-			fp := newFuncParser(wasm.FeaturesFinished, &typeUseParser{module: module}, newIndexNamespace(module.SectionElementCount), setFunc)
+			fp := newFuncParser(wasm.Features20220419, &typeUseParser{module: module}, newIndexNamespace(module.SectionElementCount), setFunc)
 			require.NoError(t, parseFunc(fp, tc.source))
 			require.Equal(t, tc.expected, parsedCode)
 		})
@@ -390,7 +390,7 @@ func TestFuncParser_Call_Resolved(t *testing.T) {
 				return parseErr, nil
 			}
 
-			fp := newFuncParser(wasm.FeaturesFinished, &typeUseParser{module: &wasm.Module{}}, funcNamespace, setFunc)
+			fp := newFuncParser(wasm.Features20220419, &typeUseParser{module: &wasm.Module{}}, funcNamespace, setFunc)
 			require.NoError(t, parseFunc(fp, tc.source))
 			require.Equal(t, tc.expected, parsedCode)
 		})

--- a/internal/wasm/text/type_parser_test.go
+++ b/internal/wasm/text/type_parser_test.go
@@ -189,7 +189,7 @@ func TestTypeParser(t *testing.T) {
 				require.Equal(t, wasm.SectionIDType, sectionID)
 				return 0
 			})
-			parsed, tp, err := parseFunctionType(wasm.FeaturesFinished, typeNamespace, tc.input)
+			parsed, tp, err := parseFunctionType(wasm.Features20220419, typeNamespace, tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, parsed)
 			require.Equal(t, uint32(1), tp.typeNamespace.count)
@@ -291,13 +291,13 @@ func TestTypeParser_Errors(t *testing.T) {
 		{
 			name:            "result second wrong",
 			input:           "(type (func (result i32) (result i33)))",
-			enabledFeatures: wasm.FeaturesFinished,
+			enabledFeatures: wasm.Features20220419,
 			expectedErr:     "unknown type: i33",
 		},
 		{
 			name:            "result second redundant type wrong",
 			input:           "(type (func (result i32) (result i32 i33)))",
-			enabledFeatures: wasm.FeaturesFinished,
+			enabledFeatures: wasm.Features20220419,
 			expectedErr:     "unknown type: i33",
 		},
 		{

--- a/internal/wasm/text/typeuse_parser_test.go
+++ b/internal/wasm/text/typeuse_parser_test.go
@@ -160,7 +160,7 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 
 	runTypeUseParserTests(t, tests, func(tc *typeUseParserTest) (*typeUseParser, func(t *testing.T)) {
 		module := &wasm.Module{}
-		tp := newTypeUseParser(wasm.FeaturesFinished, module, newIndexNamespace(module.SectionElementCount))
+		tp := newTypeUseParser(wasm.Features20220419, module, newIndexNamespace(module.SectionElementCount))
 		return tp, func(t *testing.T) {
 			// We should have inlined the type, and it is the first type use, which means the inlined index is zero
 			require.Zero(t, tp.inlinedTypeIndices[0].inlinedIdx)
@@ -196,7 +196,7 @@ func TestTypeUseParser_UnresolvedType(t *testing.T) {
 	}
 	runTypeUseParserTests(t, tests, func(tc *typeUseParserTest) (*typeUseParser, func(t *testing.T)) {
 		module := &wasm.Module{}
-		tp := newTypeUseParser(wasm.FeaturesFinished, module, newIndexNamespace(module.SectionElementCount))
+		tp := newTypeUseParser(wasm.Features20220419, module, newIndexNamespace(module.SectionElementCount))
 		return tp, func(t *testing.T) {
 			require.NotNil(t, tp.typeNamespace.unresolvedIndices)
 			if tc.expectedInlinedType == nil {
@@ -306,7 +306,7 @@ func TestTypeUseParser_ReuseExistingType(t *testing.T) {
 		require.NoError(t, err)
 		typeNamespace.count++
 
-		tp := newTypeUseParser(wasm.FeaturesFinished, module, typeNamespace)
+		tp := newTypeUseParser(wasm.Features20220419, module, typeNamespace)
 		return tp, func(t *testing.T) {
 			require.Zero(t, len(tp.typeNamespace.unresolvedIndices))
 			require.Zero(t, len(tp.inlinedTypes))
@@ -340,7 +340,7 @@ func TestTypeUseParser_ReuseExistingInlinedType(t *testing.T) {
 	}
 	runTypeUseParserTests(t, tests, func(tc *typeUseParserTest) (*typeUseParser, func(t *testing.T)) {
 		module := &wasm.Module{}
-		tp := newTypeUseParser(wasm.FeaturesFinished, module, newIndexNamespace(module.SectionElementCount))
+		tp := newTypeUseParser(wasm.Features20220419, module, newIndexNamespace(module.SectionElementCount))
 		// inline a type that doesn't match the test
 		require.NoError(t, parseTypeUse(tp, "((param i32 i64))", ignoreTypeUse))
 		// inline the test type
@@ -386,7 +386,7 @@ func TestTypeUseParser_BeginResets(t *testing.T) {
 	}
 	runTypeUseParserTests(t, tests, func(tc *typeUseParserTest) (*typeUseParser, func(t *testing.T)) {
 		module := &wasm.Module{}
-		tp := newTypeUseParser(wasm.FeaturesFinished, module, newIndexNamespace(module.SectionElementCount))
+		tp := newTypeUseParser(wasm.Features20220419, module, newIndexNamespace(module.SectionElementCount))
 		// inline a type that uses all fields
 		require.NoError(t, parseTypeUse(tp, "((type $i32i64_i32) (param $x i32) (param $y i64) (result i32))", ignoreTypeUse))
 		require.NoError(t, parseTypeUse(tp, tc.input, ignoreTypeUse))
@@ -510,13 +510,13 @@ func TestTypeUseParser_Errors(t *testing.T) {
 		{
 			name:            "result second wrong",
 			input:           "((result i32) (result i33))",
-			enabledFeatures: wasm.FeaturesFinished,
+			enabledFeatures: wasm.Features20220419,
 			expectedErr:     "1:23: unknown type: i33",
 		},
 		{
 			name:            "result second redundant type wrong",
 			input:           "((result i32) (result i32 i33))",
-			enabledFeatures: wasm.FeaturesFinished,
+			enabledFeatures: wasm.Features20220419,
 			expectedErr:     "1:27: unknown type: i33",
 		},
 		{
@@ -600,7 +600,7 @@ func TestTypeUseParser_FailsMatch(t *testing.T) {
 	require.NoError(t, err)
 	typeNamespace.count++
 
-	tp := newTypeUseParser(wasm.FeaturesFinished, module, typeNamespace)
+	tp := newTypeUseParser(wasm.Features20220419, module, typeNamespace)
 	tests := []struct{ name, source, expectedErr string }{
 		{
 			name:        "nullary index",

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -85,7 +85,7 @@ func TestCompile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			enabledFeatures := tc.enabledFeatures
 			if enabledFeatures == 0 {
-				enabledFeatures = wasm.FeaturesFinished
+				enabledFeatures = wasm.Features20220419
 			}
 
 			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
@@ -487,7 +487,7 @@ func TestCompile_MultiValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			enabledFeatures := tc.enabledFeatures
 			if enabledFeatures == 0 {
-				enabledFeatures = wasm.FeaturesFinished
+				enabledFeatures = wasm.Features20220419
 			}
 			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
 			require.NoError(t, err)
@@ -550,7 +550,7 @@ func TestCompile_SignExtensionOps(t *testing.T) {
 
 func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expected *CompilationResult, module *wasm.Module) {
 	if enabledFeatures == 0 {
-		enabledFeatures = wasm.FeaturesFinished
+		enabledFeatures = wasm.Features20220419
 	}
 	res, err := CompileFunctions(ctx, enabledFeatures, module)
 	require.NoError(t, err)
@@ -558,7 +558,7 @@ func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expec
 }
 
 func requireModuleText(t *testing.T, source string) *wasm.Module {
-	m, err := text.DecodeModule([]byte(source), wasm.FeaturesFinished, wasm.MemoryLimitPages)
+	m, err := text.DecodeModule([]byte(source), wasm.Features20220419, wasm.MemoryLimitPages)
 	require.NoError(t, err)
 	return m
 }

--- a/wasm.go
+++ b/wasm.go
@@ -122,7 +122,11 @@ func NewRuntime() Runtime {
 }
 
 // NewRuntimeWithConfig returns a runtime with the given configuration.
-func NewRuntimeWithConfig(config *RuntimeConfig) Runtime {
+func NewRuntimeWithConfig(rConfig RuntimeConfig) Runtime {
+	config, ok := rConfig.(*runtimeConfig)
+	if !ok {
+		panic(fmt.Errorf("unsupported wazero.RuntimeConfig implementation: %#v", rConfig))
+	}
 	return &runtime{
 		store:               wasm.NewStore(config.enabledFeatures, config.newEngine(config.enabledFeatures)),
 		enabledFeatures:     config.enabledFeatures,

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -18,6 +18,16 @@ import (
 // testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
 var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
+func TestNewRuntimeWithConfig_PanicsOnWrongImpl(t *testing.T) {
+	// It is too burdensome to define an impl of RuntimeConfig in tests just to verify the error when it is wrong.
+	// Instead, we pass nil which is implicitly the wrong type, as that's less work!
+	err := require.CapturePanic(func() {
+		NewRuntimeWithConfig(nil)
+	})
+
+	require.EqualError(t, err, "unsupported wazero.RuntimeConfig implementation: <nil>")
+}
+
 func TestRuntime_CompileModule(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
WebAssembly Core Working Draft 1 recently came out. Before that, we had
a toe-hold feature bucked called FinishedFeatures. This replaces
`RuntimeConfig.WithFinishedFeatures` with `RuntimeConfig.WithWasmCore2`.
This also adds `WithWasmCore1` for those who want to lock into 1.0
features as opposed to relying on defaults.

This also fixes some design debt where we hadn't finished migrating
public types that require constructor functions (NewXxx) to interfaces.
By using interfaces, we prevent people from accidentally initializing
key configuration directly (via &Xxx), causing nil field refs. This also
helps prevent confusion about how to use the type (ex pointer or not) as
there's only one way (as an interface).

See https://www.w3.org/blog/news/archives/9509
See https://github.com/tetratelabs/wazero/issues/516