### PR TITLE
Makes wazero.CompiledCode an interface instead of a struct

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -344,8 +344,9 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			b := tc.input(NewRuntime()).(*moduleBuilder)
-			m, err := b.Build(testCtx)
+			compiled, err := b.Build(testCtx)
 			require.NoError(t, err)
+			m := compiled.(*compiledCode)
 
 			requireHostModuleEquals(t, tc.expected, m.module)
 

--- a/config_test.go
+++ b/config_test.go
@@ -853,12 +853,12 @@ func TestCompiledCode_Close(t *testing.T) {
 	for _, ctx := range []context.Context{nil, testCtx} { // Ensure it doesn't crash on nil!
 		e := &mockEngine{name: "1", cachedModules: map[*wasm.Module]struct{}{}}
 
-		var cs []*CompiledCode
+		var cs []*compiledCode
 		for i := 0; i < 10; i++ {
 			m := &wasm.Module{}
 			err := e.CompileModule(ctx, m)
 			require.NoError(t, err)
-			cs = append(cs, &CompiledCode{module: m, compiledEngine: e})
+			cs = append(cs, &compiledCode{module: m, compiledEngine: e})
 		}
 
 		// Before Close.

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -364,7 +364,7 @@ func testCloseInFlight(t *testing.T, r wazero.Runtime) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			var importingCode, importedCode *wazero.CompiledCode
+			var importingCode, importedCode wazero.CompiledCode
 			var imported, importing api.Module
 			var err error
 			closeAndReturn := func(ctx context.Context, x uint32) uint32 {

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -54,7 +54,7 @@ type wazeroRuntime struct {
 	config        wazero.RuntimeConfig
 	runtime       wazero.Runtime
 	logFn         func([]byte) error
-	env, compiled *wazero.CompiledCode
+	env, compiled wazero.CompiledCode
 }
 
 type wazeroModule struct {


### PR DESCRIPTION
This makes wazero.CompiledCode an interface instead of a struct to
prevent it from being used incorrectly. For example, even though the
fields are not exported, someone can mistakenly instantiate this
when it is a struct, and in doing so violate internal assumptions.

Follow-up from #518 and the next and final PR will be ModuleConfig.