### PR TITLE
Documents why we don't use Option pattern

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -152,7 +152,7 @@ Ex instead of:
 ```go
 type ModuleConfig interface {
 	WithName(string) ModuleConfig
-    WithFS(fs.FS) ModuleConfig
+	WithFS(fs.FS) ModuleConfig
 }
 
 config := r.NewModuleConfig().WithFS(fs)

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -117,8 +117,8 @@ if err != nil {
 ```
 
 This allows users one place to look for errors, and also the benefit that if anything internally opens a resource, but
-errs, there's nothing they need to close. In other words the call site using config is fully responsible to close any
-resources that happened with later errors.
+errs, there's nothing they need to close. In other words, users don't need to track which resources need closing on
+partial error, as that is handled internally by the only code that can read configuration fields.
 
 ### Why are configuration immutable?
 While it seems certain scopes like `Runtime` won't repeat within a process, they do, possibly in different goroutines.


### PR DESCRIPTION
It has happened a couple times where folks have suggested options pattern, probably guessing we didn't have it in the past or explicitly remove it. All the API decisions were quite thought through, and particularly options, but that wasn't obvious if you read the rationale. This adds the rationale into the repo to help conserve time. Instead of spending time re-explaining why options isn't used here, we can spend the same time on more pressing and important design or maintenance issues.

Closes #480
