### PR TITLE
Documents Memory.Read as a way to share memory between Go and Wasm

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -215,6 +215,20 @@ type Memory interface {
 	ReadFloat64Le(ctx context.Context, offset uint32) (float64, bool)
 
 	// Read reads byteCount bytes from the underlying buffer at the offset or returns false if out of range.
+	//
+	// This returns a view of the underlying memory, not a copy. This means any writes to the slice returned are visible
+	// to Wasm, and any updates from Wasm are visible reading the returned slice.
+	//
+	// For example:
+	//	buf, _ = memory.Read(ctx, offset, byteCount)
+	//	buf[1] = 'a' // writes through to memory, meaning Wasm code see 'a' at that position.
+	//
+	// If you don't desire this behavior, make a copy of the returned slice before affecting it.
+	//
+	// Note: The returned slice is no longer shared on a capacity change. For example, `buf = append(buf, 'a')` results
+	// in a slice that is no longer shared. The same exists Wasm side. For example, if Wasm changes its memory capacity,
+	// ex via "memory.grow"), the host slice is no longer shared. Those who need a stable view must set Wasm memory
+	// min=max, or use wazero.RuntimeConfig WithMemoryCapacityPages to ensure max is always allocated.
 	Read(ctx context.Context, offset, byteCount uint32) ([]byte, bool)
 
 	// WriteByte writes a single byte to the underlying buffer at the offset in or returns false if out of range.

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -225,7 +225,7 @@ type Memory interface {
 	//
 	// If you don't desire this behavior, make a copy of the returned slice before affecting it.
 	//
-	// Note: The returned slice is no longer shared on a capacity change. For example, `buf = append(buf, 'a')` results
+	// Note: The returned slice is no longer shared on a capacity change. For example, `buf = append(buf, 'a')` might result
 	// in a slice that is no longer shared. The same exists Wasm side. For example, if Wasm changes its memory capacity,
 	// ex via "memory.grow"), the host slice is no longer shared. Those who need a stable view must set Wasm memory
 	// min=max, or use wazero.RuntimeConfig WithMemoryCapacityPages to ensure max is always allocated.

--- a/internal/wasm/interpreter/interpreter_test.go
+++ b/internal/wasm/interpreter/interpreter_test.go
@@ -98,6 +98,10 @@ func TestInterpreter_ModuleEngine_Call_Errors(t *testing.T) {
 	enginetest.RunTestModuleEngine_Call_Errors(t, et)
 }
 
+func TestInterpreter_ModuleEngine_Memory(t *testing.T) {
+	enginetest.RunTestModuleEngine_Memory(t, et)
+}
+
 func TestInterpreter_NonTrappingFloatToIntConversion(t *testing.T) {
 	_0x80000000 := uint32(0x80000000)
 	_0xffffffff := uint32(0xffffffff)

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -165,6 +165,11 @@ func TestJIT_ModuleEngine_Call_Errors(t *testing.T) {
 	enginetest.RunTestModuleEngine_Call_Errors(t, et)
 }
 
+func TestJIT_ModuleEngine_Memory(t *testing.T) {
+	requireSupportedOSArch(t)
+	enginetest.RunTestModuleEngine_Memory(t, et)
+}
+
 func requireSupportedOSArch(t *testing.T) {
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Skip()

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -37,6 +37,18 @@ type MemoryInstance struct {
 	Min, Cap, Max uint32
 }
 
+// NewMemoryInstance creates a new instance based on the parameters in the SectionIDMemory.
+func NewMemoryInstance(memSec *Memory) *MemoryInstance {
+	min := MemoryPagesToBytesNum(memSec.Min)
+	capacity := MemoryPagesToBytesNum(memSec.Cap)
+	return &MemoryInstance{
+		Buffer: make([]byte, min, capacity),
+		Min:    memSec.Min,
+		Cap:    memSec.Cap,
+		Max:    memSec.Max,
+	}
+}
+
 // Size implements the same method as documented on api.Memory.
 func (m *MemoryInstance) Size(_ context.Context) uint32 {
 	// Note: If you use the context.Context param, don't forget to coerce nil to context.Background()!

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -559,14 +559,7 @@ func paramNames(localNames IndirectNameMap, funcIdx uint32, paramLen int) []stri
 func (m *Module) buildMemory() (mem *MemoryInstance) {
 	memSec := m.MemorySection
 	if memSec != nil {
-		min := MemoryPagesToBytesNum(memSec.Min)
-		capacity := MemoryPagesToBytesNum(memSec.Cap)
-		mem = &MemoryInstance{
-			Buffer: make([]byte, min, capacity),
-			Min:    memSec.Min,
-			Cap:    memSec.Cap,
-			Max:    memSec.Max,
-		}
+		mem = NewMemoryInstance(memSec)
 	}
 	return
 }


### PR DESCRIPTION
By testing the side-effects of Memory.Read, we ensure users who control
the underlying memory capacity can use the returned slice for
write-through access to Wasm addressible memory. Notably, this allows a
shared fixed length data structure to exist with a pointer on the Go
side and a memory offset on the Wasm side.

Thanks to @inkeliz for this idea and help on the code.

Fixes #525