### PR TITLE
Fix bytes capacity on Read

### DIFF
--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -122,7 +122,7 @@ func (m *MemoryInstance) Read(_ context.Context, offset, byteCount uint32) ([]by
 	if !m.hasSize(offset, byteCount) {
 		return nil, false
 	}
-	return m.Buffer[offset : offset+byteCount], true
+	return m.Buffer[offset : offset+byteCount : offset+byteCount], true
 }
 
 // WriteByte implements the same method as documented on api.Memory.


### PR DESCRIPTION
Before that change it was possible to overwrite content out of specified range.

See #527 