### PR TITLE
Use leb128 u32 for data/element segment prefixes

### DIFF
--- a/internal/wasm/binary/data.go
+++ b/internal/wasm/binary/data.go
@@ -12,7 +12,7 @@ import (
 // dataSegmentPrefix represents three types of data segments.
 //
 // https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/binary/modules.html#data-section
-type dataSegmentPrefix = byte
+type dataSegmentPrefix = uint32
 
 const (
 	// dataSegmentPrefixActive is the prefix for the version 1.0 compatible data segment, which is classified as "active" in 2.0.
@@ -24,9 +24,9 @@ const (
 )
 
 func decodeDataSegment(r *bytes.Reader, enabledFeatures wasm.Features) (*wasm.DataSegment, error) {
-	dataSegmentPrefx, err := r.ReadByte()
+	dataSegmentPrefx, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return nil, fmt.Errorf("read data segment prefix: %w", err)
+		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
 	if dataSegmentPrefx != dataSegmentPrefixActive {

--- a/internal/wasm/binary/data.go
+++ b/internal/wasm/binary/data.go
@@ -26,7 +26,7 @@ const (
 func decodeDataSegment(r *bytes.Reader, enabledFeatures wasm.Features) (*wasm.DataSegment, error) {
 	dataSegmentPrefx, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return nil, fmt.Errorf("get size of vector: %w", err)
+		return nil, fmt.Errorf("read data segment prefix: %w", err)
 	}
 
 	if dataSegmentPrefx != dataSegmentPrefixActive {

--- a/internal/wasm/binary/element.go
+++ b/internal/wasm/binary/element.go
@@ -101,7 +101,7 @@ const (
 func decodeElementSegment(r *bytes.Reader, enabledFeatures wasm.Features) (*wasm.ElementSegment, error) {
 	prefix, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return nil, fmt.Errorf("get size of vector: %w", err)
+		return nil, fmt.Errorf("read element prefix: %w", err)
 	}
 
 	if prefix != elementSegmentPrefixLegacy {

--- a/internal/wasm/binary/element.go
+++ b/internal/wasm/binary/element.go
@@ -99,9 +99,9 @@ const (
 )
 
 func decodeElementSegment(r *bytes.Reader, enabledFeatures wasm.Features) (*wasm.ElementSegment, error) {
-	prefix, err := r.ReadByte()
+	prefix, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return nil, fmt.Errorf("read element prefix: %w", err)
+		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
 	if prefix != elementSegmentPrefixLegacy {


### PR DESCRIPTION
Reflect the changes for https://github.com/WebAssembly/spec/commit/1ffb924e94856e89f787fc2000fa4c5dc069a24f

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>