### PR TITLE
Extracts CompileConfig and consolidates code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ For example, here's how you can allow WebAssembly modules to read
 wm, err := wasi.InstantiateSnapshotPreview1(ctx, r)
 defer wm.Close(ctx)
 
-config := wazero.ModuleConfig().WithFS(os.DirFS("/work/home"))
-module, err := r.InstantiateModule(ctx, binary, config)
+config := wazero.NewModuleConfig().WithFS(os.DirFS("/work/home"))
+module, err := r.InstantiateModule(ctx, compiled, config)
 defer module.Close(ctx)
 ...
 ```

--- a/api/wasm_test.go
+++ b/api/wasm_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+func TestExternTypeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    ExternType
+		expected string
+	}{
+		{"func", ExternTypeFunc, "func"},
+		{"table", ExternTypeTable, "table"},
+		{"mem", ExternTypeMemory, "memory"},
+		{"global", ExternTypeGlobal, "global"},
+		{"unknown", 100, "0x64"},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, ExternTypeName(tc.input))
+		})
+	}
+}
+
 func TestValueTypeName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/examples/wasi/cat.go
+++ b/examples/wasi/cat.go
@@ -47,10 +47,17 @@ func main() {
 	}
 	defer wm.Close(ctx)
 
-	// InstantiateModuleFromCodeWithConfig runs the "_start" function which is what TinyGo compiles "main" to.
+	// Compile the WebAssembly module using the default configuration.
+	code, err := r.CompileModule(ctx, catWasm, wazero.NewCompileConfig())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer code.Close(ctx)
+
+	// InstantiateModule runs the "_start" function which is what TinyGo compiles "main" to.
 	// * Set the program name (arg[0]) to "wasi" and add args to write "test.txt" to stdout twice.
 	// * We use "/test.txt" or "./test.txt" because WithFS by default maps the workdir "." to "/".
-	cat, err := r.InstantiateModuleFromCodeWithConfig(ctx, catWasm, config.WithArgs("wasi", os.Args[1]))
+	cat, err := r.InstantiateModule(ctx, code, config.WithArgs("wasi", os.Args[1]))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -66,14 +66,20 @@ func Example_listener() {
 	}
 	defer wm.Close(ctx)
 
-	cfg := wazero.NewModuleConfig().WithStdout(os.Stdout)
-	mod, err := r.InstantiateModuleFromCodeWithConfig(ctx, []byte(`(module $listener
+	// Compile the WebAssembly module using the default configuration.
+	code, err := r.CompileModule(ctx, []byte(`(module $listener
   (import "wasi_snapshot_preview1" "random_get"
     (func $wasi.random_get (param $buf i32) (param $buf_len i32) (result (;errno;) i32)))
   (func i32.const 0 i32.const 4 call 0 drop) ;; write 4 bytes of random data
   (memory 1 1)
   (start 1) ;; call the second function
-)`), cfg)
+)`), wazero.NewCompileConfig())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer code.Close(ctx)
+
+	mod, err := r.InstantiateModule(ctx, code, wazero.NewModuleConfig().WithStdout(os.Stdout))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/experimental/sys_test.go
+++ b/experimental/sys_test.go
@@ -43,14 +43,19 @@ func Example_sys() {
 	}
 	defer wm.Close(ctx)
 
-	cfg := wazero.NewModuleConfig().WithStdout(os.Stdout)
-	mod, err := r.InstantiateModuleFromCodeWithConfig(ctx, []byte(`(module
+	code, err := r.CompileModule(ctx, []byte(`(module
   (import "wasi_snapshot_preview1" "random_get"
     (func $wasi.random_get (param $buf i32) (param $buf_len i32) (result (;errno;) i32)))
   (func i32.const 0 i32.const 4 call 0 drop) ;; write 4 bytes of random data
   (memory 1 1)
   (start 1) ;; call the second function
-)`), cfg)
+)`), wazero.NewCompileConfig())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer code.Close(ctx)
+
+	mod, err := r.InstantiateModule(ctx, code, wazero.NewModuleConfig().WithStdout(os.Stdout))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/asm/impl.go
+++ b/internal/asm/impl.go
@@ -31,7 +31,7 @@ func (a *BaseAssemblerImpl) AddOnGenerateCallBack(cb func([]byte) error) {
 // BuildJumpTable implements AssemblerBase.BuildJumpTable
 func (a *BaseAssemblerImpl) BuildJumpTable(table []byte, labelInitialInstructions []Node) {
 	a.AddOnGenerateCallBack(func(code []byte) error {
-		// Build the offset table for each target.
+		// Compile the offset table for each target.
 		base := labelInitialInstructions[0].OffsetInBinary()
 		for i, nop := range labelInitialInstructions {
 			if uint64(nop.OffsetInBinary())-uint64(base) >= JumpTableMaximumOffset {

--- a/internal/integration_test/asm/golang_asm/golang_asm.go
+++ b/internal/integration_test/asm/golang_asm/golang_asm.go
@@ -89,7 +89,7 @@ func (a *GolangAsmBaseAssembler) AddOnGenerateCallBack(cb func([]byte) error) {
 // BuildJumpTable implements the same method as documented on asm.AssemblerBase.
 func (a *GolangAsmBaseAssembler) BuildJumpTable(table []byte, labelInitialInstructions []asm.Node) {
 	a.AddOnGenerateCallBack(func(code []byte) error {
-		// Build the offset table for each target.
+		// Compile the offset table for each target.
 		base := labelInitialInstructions[0].OffsetInBinary()
 		for i, nop := range labelInitialInstructions {
 			if uint64(nop.OffsetInBinary())-uint64(base) >= asm.JumpTableMaximumOffset {

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -50,14 +50,14 @@ func BenchmarkInitialization(b *testing.B) {
 }
 
 func runInitializationBench(b *testing.B, r wazero.Runtime) {
-	compiled, err := r.CompileModule(testCtx, caseWasm)
+	compiled, err := r.CompileModule(testCtx, caseWasm, wazero.NewCompileConfig())
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer compiled.Close(testCtx)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		mod, err := r.InstantiateModule(testCtx, compiled)
+		mod, err := r.InstantiateModule(testCtx, compiled, wazero.NewModuleConfig())
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/integration_test/spectest/encoder_test.go
+++ b/internal/integration_test/spectest/encoder_test.go
@@ -68,7 +68,7 @@ func TestBinaryEncoder(t *testing.T) {
 
 						buf = requireStripCustomSections(t, buf)
 
-						mod, err := binary.DecodeModule(buf, wasm.Features20191205, wasm.MemoryLimitPages)
+						mod, err := binary.DecodeModule(buf, wasm.Features20191205, wasm.MemorySizer)
 						require.NoError(t, err)
 
 						encodedBuf := binary.EncodeModule(mod)

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -238,7 +238,7 @@ func addSpectestModule(t *testing.T, store *wasm.Store) {
 
   (func (param f64 f64) local.get 0 drop local.get 1 drop)
      (export "print_f64_f64" (func 6))
-)`), wasm.Features20191205, wasm.MemoryLimitPages)
+)`), wasm.Features20191205, wasm.MemorySizer)
 	require.NoError(t, err)
 
 	// (global (export "global_i32") i32 (i32.const 666))
@@ -321,7 +321,7 @@ func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.E
 					case "module":
 						buf, err := testDataFS.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-						mod, err := binary.DecodeModule(buf, enabledFeatures, wasm.MemoryLimitPages)
+						mod, err := binary.DecodeModule(buf, enabledFeatures, wasm.MemorySizer)
 						require.NoError(t, err, msg)
 						require.NoError(t, mod.Validate(enabledFeatures))
 						mod.AssignModuleID(buf)
@@ -455,7 +455,7 @@ func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.E
 }
 
 func requireInstantiationError(t *testing.T, store *wasm.Store, buf []byte, msg string) {
-	mod, err := binary.DecodeModule(buf, store.EnabledFeatures, wasm.MemoryLimitPages)
+	mod, err := binary.DecodeModule(buf, store.EnabledFeatures, wasm.MemorySizer)
 	if err != nil {
 		return
 	}

--- a/internal/integration_test/vs/codec.go
+++ b/internal/integration_test/vs/codec.go
@@ -55,7 +55,7 @@ func newExample() *wasm.Module {
 			}},
 			{Body: []byte{wasm.OpcodeLocalGet, 1, wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}},
 		},
-		MemorySection: &wasm.Memory{Min: 1, Max: three, IsMaxEncoded: true},
+		MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: three, IsMaxEncoded: true},
 		ExportSection: []*wasm.Export{
 			{Name: "AddInt", Type: wasm.ExternTypeFunc, Index: wasm.Index(4)},
 			{Name: "", Type: wasm.ExternTypeFunc, Index: wasm.Index(3)},
@@ -92,7 +92,7 @@ func newExample() *wasm.Module {
 func BenchmarkWat2Wasm(b *testing.B, vsName string, vsWat2Wasm func([]byte) error) {
 	b.Run("wazero", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if m, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemoryLimitPages); err != nil {
+			if m, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemorySizer); err != nil {
 				b.Fatal(err)
 			} else {
 				_ = binary.EncodeModule(m)

--- a/internal/integration_test/vs/codec_test.go
+++ b/internal/integration_test/vs/codec_test.go
@@ -14,13 +14,13 @@ import (
 
 func TestExampleUpToDate(t *testing.T) {
 	t.Run("binary.DecodeModule", func(t *testing.T) {
-		m, err := binary.DecodeModule(exampleBinary, wasm.Features20220419, wasm.MemoryLimitPages)
+		m, err := binary.DecodeModule(exampleBinary, wasm.Features20220419, wasm.MemorySizer)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
 
 	t.Run("text.DecodeModule", func(t *testing.T) {
-		m, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemoryLimitPages)
+		m, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemorySizer)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
@@ -49,7 +49,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("binary.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := binary.DecodeModule(exampleBinary, wasm.Features20220419, wasm.MemoryLimitPages); err != nil {
+			if _, err := binary.DecodeModule(exampleBinary, wasm.Features20220419, wasm.MemorySizer); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -63,7 +63,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("text.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemoryLimitPages); err != nil {
+			if _, err := text.DecodeModule(exampleText, wasm.Features20220419, wasm.MemorySizer); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/internal/modgen/modgen_test.go
+++ b/internal/modgen/modgen_test.go
@@ -49,7 +49,7 @@ func TestModGen(t *testing.T) {
 				// Encode the generated module (*wasm.Module) as binary.
 				bin := binary.EncodeModule(m)
 				// Pass the generated binary into our compilers.
-				code, err := runtime.CompileModule(testCtx, bin)
+				code, err := runtime.CompileModule(testCtx, bin, wazero.NewCompileConfig())
 				require.NoError(t, err)
 				err = code.Close(testCtx)
 				require.NoError(t, err)

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -8,7 +8,12 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeImport(r *bytes.Reader, idx uint32, memoryLimitPages uint32, enabledFeatures wasm.Features) (i *wasm.Import, err error) {
+func decodeImport(
+	r *bytes.Reader,
+	idx uint32,
+	memorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32),
+	enabledFeatures wasm.Features,
+) (i *wasm.Import, err error) {
 	i = &wasm.Import{}
 	if i.Module, _, err = decodeUTF8(r, "import module"); err != nil {
 		return nil, fmt.Errorf("import[%d] error decoding module: %w", idx, err)
@@ -29,7 +34,7 @@ func decodeImport(r *bytes.Reader, idx uint32, memoryLimitPages uint32, enabledF
 	case wasm.ExternTypeTable:
 		i.DescTable, err = decodeTable(r, enabledFeatures)
 	case wasm.ExternTypeMemory:
-		i.DescMem, err = decodeMemory(r, memoryLimitPages)
+		i.DescMem, err = decodeMemory(r, memorySizer)
 	case wasm.ExternTypeGlobal:
 		i.DescGlobal, err = decodeGlobalType(r)
 	default:

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -92,7 +92,7 @@ func TestMemorySection(t *testing.T) {
 				0x01,             // 1 memory
 				0x01, 0x02, 0x03, // (memory 2 3)
 			},
-			expected: &wasm.Memory{Min: 2, Max: three, IsMaxEncoded: true},
+			expected: &wasm.Memory{Min: 2, Cap: 2, Max: three, IsMaxEncoded: true},
 		},
 	}
 
@@ -100,7 +100,7 @@ func TestMemorySection(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			memories, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemoryLimitPages)
+			memories, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemorySizer)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, memories)
 		})
@@ -109,10 +109,9 @@ func TestMemorySection(t *testing.T) {
 
 func TestMemorySection_Errors(t *testing.T) {
 	tests := []struct {
-		name             string
-		input            []byte
-		memoryLimitPages uint32
-		expectedErr      string
+		name        string
+		input       []byte
+		expectedErr string
 	}{
 		{
 			name: "min and min with max",
@@ -128,12 +127,8 @@ func TestMemorySection_Errors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 
-		if tc.memoryLimitPages == 0 {
-			tc.memoryLimitPages = wasm.MemoryLimitPages
-		}
-
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeMemorySection(bytes.NewReader(tc.input), tc.memoryLimitPages)
+			_, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemorySizer)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -11,7 +11,7 @@ func TestModule_ValidateFunction_validateFunctionWithMaxStackValues(t *testing.T
 	const max = 100
 	const valuesNum = max + 1
 
-	// Build a function which has max+1 const instructions.
+	// Compile a function which has max+1 const instructions.
 	var body []byte
 	for i := 0; i < valuesNum; i++ {
 		body = append(body, OpcodeI32Const, 1)

--- a/internal/wasm/jit/jit_controlflow_test.go
+++ b/internal/wasm/jit/jit_controlflow_test.go
@@ -860,7 +860,7 @@ func TestCompiler_returnFunction(t *testing.T) {
 	t.Run("exit", func(t *testing.T) {
 		env := newJITEnvironment()
 
-		// Build code.
+		// Compile code.
 		compiler := env.requireNewCompiler(t, newCompiler, nil)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)

--- a/internal/wasm/jit/jit_numeric_test.go
+++ b/internal/wasm/jit/jit_numeric_test.go
@@ -36,7 +36,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 				t.Run(fmt.Sprintf("0x%x", val), func(t *testing.T) {
 					env := newJITEnvironment()
 
-					// Build code.
+					// Compile code.
 					compiler := env.requireNewCompiler(t, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)

--- a/internal/wasm/jit/jit_stack_test.go
+++ b/internal/wasm/jit/jit_stack_test.go
@@ -26,7 +26,7 @@ func TestCompiler_releaseRegisterToStack(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newJITEnvironment()
 
-			// Build code.
+			// Compile code.
 			compiler := env.requireNewCompiler(t, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestCompiler_compileLoadValueOnStackToRegister(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newJITEnvironment()
 
-			// Build code.
+			// Compile code.
 			compiler := env.requireNewCompiler(t, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -24,6 +24,15 @@ const (
 	MemoryPageSizeInBits = 16
 )
 
+// MemorySizer is the default function that derives min, capacity and max pages from decoded source. The capacity
+// returned is set to minPages and max defaults to MemoryLimitPages when maxPages is nil.
+var MemorySizer api.MemorySizer = func(minPages uint32, maxPages *uint32) (min, capacity, max uint32) {
+	if maxPages != nil {
+		return minPages, minPages, *maxPages
+	}
+	return minPages, minPages, MemoryLimitPages
+}
+
 // compile-time check to ensure MemoryInstance implements api.Memory
 var _ api.Memory = &MemoryInstance{}
 

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -14,6 +14,21 @@ func TestMemoryPageConsts(t *testing.T) {
 	require.Equal(t, MemoryLimitPages, uint32(1<<16))
 }
 
+func TestMemoryPages(t *testing.T) {
+	t.Run("cap=min, nil max", func(t *testing.T) {
+		min, capacity, max := MemorySizer(1, nil)
+		require.Equal(t, uint32(1), min)
+		require.Equal(t, uint32(1), capacity)
+		require.Equal(t, MemoryLimitPages, max)
+	})
+	t.Run("cap=min, max", func(t *testing.T) {
+		min, capacity, max := MemorySizer(1, uint32Ptr(2))
+		require.Equal(t, uint32(1), min)
+		require.Equal(t, uint32(1), capacity)
+		require.Equal(t, uint32(2), max)
+	})
+}
+
 func Test_MemoryPagesToBytesNum(t *testing.T) {
 	for _, numPage := range []uint32{0, 1, 5, 10} {
 		require.Equal(t, uint64(numPage*MemoryPageSize), MemoryPagesToBytesNum(numPage))

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -68,29 +68,7 @@ func TestSectionIDName(t *testing.T) {
 	}
 }
 
-func TestExternTypeName(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    ExternType
-		expected string
-	}{
-		{"func", ExternTypeFunc, "func"},
-		{"table", ExternTypeTable, "table"},
-		{"mem", ExternTypeMemory, "memory"},
-		{"global", ExternTypeGlobal, "global"},
-		{"unknown", 100, "0x64"},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, ExternTypeName(tc.input))
-		})
-	}
-}
-
-func TestMemory_ValidateCap(t *testing.T) {
+func TestMemory_Validate(t *testing.T) {
 	tests := []struct {
 		name        string
 		mem         *Memory
@@ -98,58 +76,32 @@ func TestMemory_ValidateCap(t *testing.T) {
 	}{
 		{
 			name: "ok",
-			mem:  &Memory{Min: 2, Cap: 2},
+			mem:  &Memory{Min: 2, Cap: 2, Max: 2},
 		},
 		{
 			name:        "cap < min",
-			mem:         &Memory{Min: 2, Cap: 1},
+			mem:         &Memory{Min: 2, Cap: 1, Max: 2},
 			expectedErr: "capacity 1 pages (64 Ki) less than minimum 2 pages (128 Ki)",
 		},
 		{
 			name:        "cap > maxLimit",
-			mem:         &Memory{Min: 2, Cap: 4},
-			expectedErr: "capacity 4 pages (256 Ki) over limit of 3 pages (192 Ki)",
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.mem.ValidateCap(3)
-			if tc.expectedErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.EqualError(t, err, tc.expectedErr)
-			}
-		})
-	}
-}
-
-func TestMemory_ValidateMinMax(t *testing.T) {
-	tests := []struct {
-		name        string
-		mem         *Memory
-		expectedErr string
-	}{
-		{
-			name: "ok",
-			mem:  &Memory{Min: 2},
+			mem:         &Memory{Min: 2, Cap: math.MaxUint32, Max: 2},
+			expectedErr: "capacity 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 		{
 			name:        "max < min",
-			mem:         &Memory{Min: 2, Max: 0, IsMaxEncoded: true},
+			mem:         &Memory{Min: 2, Cap: 2, Max: 0, IsMaxEncoded: true},
 			expectedErr: "min 2 pages (128 Ki) > max 0 pages (0 Ki)",
 		},
 		{
 			name:        "min > limit",
 			mem:         &Memory{Min: math.MaxUint32},
-			expectedErr: "min 4294967295 pages (3 Ti) over limit of 3 pages (192 Ki)",
+			expectedErr: "min 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 		{
 			name:        "max > limit",
 			mem:         &Memory{Max: math.MaxUint32, IsMaxEncoded: true},
-			expectedErr: "max 4294967295 pages (3 Ti) over limit of 3 pages (192 Ki)",
+			expectedErr: "max 4294967295 pages (3 Ti) over limit of 65536 pages (4 Gi)",
 		},
 	}
 
@@ -157,7 +109,7 @@ func TestMemory_ValidateMinMax(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.mem.ValidateMinMax(3)
+			err := tc.mem.Validate()
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -390,7 +390,7 @@ func (s *Store) Instantiate(
 	// Now all the validation passes, we are safe to mutate memory instances (possibly imported ones).
 	m.applyData(module.DataSection)
 
-	// Build the default context for calls to this module.
+	// Compile the default context for calls to this module.
 	m.CallCtx = NewCallContext(s, m, sys)
 
 	// Execute the start function.

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -1226,14 +1226,14 @@ func TestDecodeModule(t *testing.T) {
 			name:  "memory",
 			input: "(module (memory 1))",
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages},
+				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: wasm.MemoryLimitPages},
 			},
 		},
 		{
 			name:  "memory ID",
 			input: "(module (memory $mem 1))",
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages},
+				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: wasm.MemoryLimitPages},
 			},
 		},
 		{
@@ -1465,7 +1465,7 @@ func TestDecodeModule(t *testing.T) {
     (export "memory" (memory $mem))
 )`,
 			expected: &wasm.Module{
-				MemorySection: &wasm.Memory{Min: 1, Max: wasm.MemoryLimitPages},
+				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: wasm.MemoryLimitPages},
 				ExportSection: []*wasm.Export{
 					{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0},
 				},
@@ -1564,7 +1564,7 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := DecodeModule([]byte(tc.input), wasm.Features20220419, wasm.MemoryLimitPages)
+			m, err := DecodeModule([]byte(tc.input), wasm.Features20220419, wasm.MemorySizer)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, m)
 		})
@@ -1573,9 +1573,8 @@ func TestDecodeModule(t *testing.T) {
 
 func TestParseModule_Errors(t *testing.T) {
 	tests := []struct {
-		name, input      string
-		memoryLimitPages uint32
-		expectedErr      string
+		name, input string
+		expectedErr string
 	}{
 		{
 			name:        "forgot parens",
@@ -1998,10 +1997,9 @@ func TestParseModule_Errors(t *testing.T) {
 			expectedErr: "2:47: i32.trunc_sat_f32_s invalid as feature \"nontrapping-float-to-int-conversion\" is disabled in module.func[0]",
 		},
 		{
-			name:             "memory over max",
-			input:            "(module (memory 1 4))",
-			memoryLimitPages: 3,
-			expectedErr:      "1:19: max 4 pages (256 Ki) over limit of 3 pages (192 Ki) in module.memory[0]",
+			name:        "memory over max",
+			input:       "(module (memory 1 70000))",
+			expectedErr: "1:19: max 70000 pages (4 Gi) over limit of 65536 pages (4 Gi) in module.memory[0]",
 		},
 		{
 			name:        "second memory",
@@ -2145,17 +2143,14 @@ func TestParseModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.memoryLimitPages == 0 {
-				tc.memoryLimitPages = wasm.MemoryLimitPages
-			}
-			_, err := DecodeModule([]byte(tc.input), wasm.Features20191205, tc.memoryLimitPages)
+			_, err := DecodeModule([]byte(tc.input), wasm.Features20191205, wasm.MemorySizer)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
 }
 
 func TestModuleParser_ErrorContext(t *testing.T) {
-	p := newModuleParser(&wasm.Module{}, 0, 0)
+	p := newModuleParser(&wasm.Module{}, 0, wasm.MemorySizer)
 	tests := []struct {
 		input    string
 		pos      parserPosition

--- a/internal/wasm/text/memory_parser_test.go
+++ b/internal/wasm/text/memory_parser_test.go
@@ -29,12 +29,12 @@ func TestMemoryParser(t *testing.T) {
 		{
 			name:     "min largest",
 			input:    "(memory 65536)",
-			expected: &wasm.Memory{Min: max, Max: max},
+			expected: &wasm.Memory{Min: max, Cap: max, Max: max},
 		},
 		{
-			name:       "min largest - ID",
+			name:       "min largest ID",
 			input:      "(memory $mem 65536)",
-			expected:   &wasm.Memory{Min: max, Max: max},
+			expected:   &wasm.Memory{Min: max, Cap: max, Max: max},
 			expectedID: "mem",
 		},
 		{
@@ -45,12 +45,12 @@ func TestMemoryParser(t *testing.T) {
 		{
 			name:     "min largest max largest",
 			input:    "(memory 65536 65536)",
-			expected: &wasm.Memory{Min: max, Max: max, IsMaxEncoded: true},
+			expected: &wasm.Memory{Min: max, Cap: max, Max: max, IsMaxEncoded: true},
 		},
 		{
-			name:       "min largest max largest - ID",
+			name:       "min largest max largest ID",
 			input:      "(memory $mem 65536 65536)",
-			expected:   &wasm.Memory{Min: max, Max: max, IsMaxEncoded: true},
+			expected:   &wasm.Memory{Min: max, Cap: max, Max: max, IsMaxEncoded: true},
 			expectedID: "mem",
 		},
 	}
@@ -162,11 +162,11 @@ func TestMemoryParser_Errors(t *testing.T) {
 
 func parseMemoryType(memoryNamespace *indexNamespace, input string) (*wasm.Memory, *memoryParser, error) {
 	var parsed *wasm.Memory
-	var setFunc onMemory = func(min, max uint32, maxDecoded bool) tokenParser {
-		parsed = &wasm.Memory{Min: min, Max: max, IsMaxEncoded: maxDecoded}
+	var setFunc onMemory = func(mem *wasm.Memory) tokenParser {
+		parsed = mem
 		return parseErr
 	}
-	tp := newMemoryParser(wasm.MemoryLimitPages, memoryNamespace, setFunc)
+	tp := newMemoryParser(wasm.MemorySizer, memoryNamespace, setFunc)
 	// memoryParser starts after the '(memory', so we need to eat it first!
 	_, _, err := lex(skipTokens(2, tp.begin), []byte(input))
 	return parsed, tp, err

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -558,7 +558,7 @@ func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expec
 }
 
 func requireModuleText(t *testing.T, source string) *wasm.Module {
-	m, err := text.DecodeModule([]byte(source), wasm.Features20220419, wasm.MemoryLimitPages)
+	m, err := text.DecodeModule([]byte(source), wasm.Features20220419, wasm.MemorySizer)
 	require.NoError(t, err)
 	return m
 }

--- a/wasi/usage_test.go
+++ b/wasi/usage_test.go
@@ -13,7 +13,7 @@ import (
 //go:embed testdata/wasi_arg.wasm
 var wasiArg []byte
 
-func TestInstantiateModuleWithConfig(t *testing.T) {
+func TestInstantiateModule(t *testing.T) {
 	r := wazero.NewRuntime()
 
 	stdout := bytes.NewBuffer(nil)
@@ -24,13 +24,13 @@ func TestInstantiateModuleWithConfig(t *testing.T) {
 	require.NoError(t, err)
 	defer wm.Close(testCtx)
 
-	compiled, err := r.CompileModule(testCtx, wasiArg)
+	compiled, err := r.CompileModule(testCtx, wasiArg, wazero.NewCompileConfig())
 	require.NoError(t, err)
 	defer compiled.Close(testCtx)
 
 	// Re-use the same module many times.
 	for _, tc := range []string{"a", "b", "c"} {
-		mod, err := r.InstantiateModuleWithConfig(testCtx, compiled, sys.WithArgs(tc).WithName(tc))
+		mod, err := r.InstantiateModule(testCtx, compiled, sys.WithArgs(tc).WithName(tc))
 		require.NoError(t, err)
 
 		// Ensure the scoped configuration applied. As the args are null-terminated, we append zero (NUL).

--- a/wasi/wasi_test.go
+++ b/wasi/wasi_test.go
@@ -2040,11 +2040,11 @@ func instantiateModule(ctx context.Context, t *testing.T, wasifunction, wasiimpo
   (memory 1 1)  ;; just an arbitrary size big enough for tests
   (export "memory" (memory 0))
   (export "%[1]s" (func $wasi.%[1]s))
-)`, wasifunction, wasiimport)))
+)`, wasifunction, wasiimport)), wazero.NewCompileConfig())
 	require.NoError(t, err)
 	defer compiled.Close(ctx)
 
-	mod, err := r.InstantiateModuleWithConfig(ctx, compiled, wazero.NewModuleConfig().WithName(t.Name()))
+	mod, err := r.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().WithName(t.Name()))
 	require.NoError(t, err)
 
 	if sysCtx != nil {


### PR DESCRIPTION
This performs several changes to allow compilation config to be
centralized and scoped properly. The immediate effects are that we can
now process external types during `Runtime.CompileModule` instead of
doing so later during `Runtime.InstantiateModule`.

ex.
```go
// Compile the WebAssembly module, replacing the import "env.abort" with "assemblyscript.abort".
compileConfig := wazero.NewCompileConfig().
	WithImportRenamer(func(externType api.ExternType, oldModule, oldName string) (newModule, newName string) {
		if oldModule == "env" && oldName == "abort" {
			return "assemblyscript", "abort"
		}
		return oldModule, oldName
	})
```

Another nice side effect is memory size problems can err at a source line
instead of having to be handled in several places. Also, we can limit max
memory more directly.

Ex. To set a hard limit on pages after you've tested this limit works.
```go
limitPages := 4
compileConfig := wazero.NewCompileConfig().
	WithMemorySizer(func(minPages uint32, maxPages *uint32) (min, capacity, max uint32) {
		if maxPages != nil {
			limit := uint32(math.Max(limitPages, float64(*maxPages)))
			return minPages, limit, limit
		}
		return minPages, limitPages, limitPages
	})
```

As noticeable above, there are some API changes here. To pay for them
I've removed some more awkward APIs. Regardless, the "easy APIs" are
left alone. For example, the APIs to compile and instantiate a module
from Go or Wasm in one step are left alone.

Ex. This isn't any different than before:
```go
module, _ := wazero.NewRuntime().InstantiateModuleFromCode(ctx, source)
defer module.Close(ctx)
```

Here are the changes, some of which are only for consistency. Rationale
is summarized in each point.
* ModuleBuilder.Build -> ModuleBuilder.Compile
  * The result of this is similar to `CompileModule`, and pairs better
    with `ModuleBuilder.Instantiate` which is like `InstantiateModule`.
* CompiledCode -> CompiledModule
  * We punted on this name, the result is more than just code. This is
    better I think and more consistent as it introduces less terms.
* Adds CompileConfig param to Runtime.CompileModule.
  * This holds existing features and will have future ones, such as
    mapping externtypes to uint64 for wasm that doesn't yet support it.
* Merges Runtime.InstantiateModuleWithConfig with Runtime.InstantiateModule
  * This allows us to explain APIs in terms of implicit or explicit
    compilation and config, vs implicit, kindof implicit, and explicit.
* Removes Runtime.InstantiateModuleFromCodeWithConfig
  * Similar to above, this API only saves the compilation step and also
    difficult to reason with from a name POV.
* RuntimeConfig.WithMemory(CapacityPages|LimitPages) -> CompileConfig.WithMemorySizer
  * This allows all error handling to be attached to the source line
  * This also allows someone to reduce unbounded memory while knowing
    what its minimum is.
* ModuleConfig.With(Import|ImportModule) -> CompileConfig.WithImportRenamer
  * This allows more types of import manipulation, also without
    conflating functions with globals.
* Adds api.ExternType
  * Needed for ImportRenamer and will be needed later for ExportRenamer.
