### PR TITLE
Adds Runtime.Close

### DIFF
--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -633,10 +633,11 @@ func (s *Store) Close(ctx context.Context) error {
 	var err error
 	// Close modules in reverse initialization order.
 	for i := len(s.moduleNames) - 1; i >= 0; i-- {
-		_, err = s.modules[s.moduleNames[i]].CallCtx.close(ctx, 0)
+		if _, e := s.modules[s.moduleNames[i]].CallCtx.close(ctx, 0); e != nil && err == nil {
+			err = e // first error
+		}
 	}
 	s.moduleNames = nil
 	s.modules = map[string]*ModuleInstance{}
-	// Only returns last error.
 	return err
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -186,32 +186,54 @@ func TestStore_CloseStore(t *testing.T) {
 	const importedModuleName = "imported"
 	const importingModuleName = "test"
 
-	s := newStore()
+	for _, tc := range []struct {
+		name       string
+		testClosed bool
+	}{
+		{
+			name:       "nothing closed",
+			testClosed: false,
+		},
+		{
+			name:       "partially closed",
+			testClosed: true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStore()
 
-	m1, err := s.Instantiate(testCtx, &Module{
-		TypeSection:     []*FunctionType{{}},
-		FunctionSection: []uint32{0},
-		CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
-		ExportSection:   []*Export{{Type: ExternTypeFunc, Index: 0, Name: "fn"}},
-	}, importedModuleName, nil, nil)
-	require.NoError(t, err)
+			m1, err := s.Instantiate(testCtx, &Module{
+				TypeSection:     []*FunctionType{{}},
+				FunctionSection: []uint32{0},
+				CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
+				ExportSection:   []*Export{{Type: ExternTypeFunc, Index: 0, Name: "fn"}},
+			}, importedModuleName, nil, nil)
+			require.NoError(t, err)
 
-	m2, err := s.Instantiate(testCtx, &Module{
-		TypeSection:   []*FunctionType{{}},
-		ImportSection: []*Import{{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
-		MemorySection: &Memory{Min: 1, Cap: 1},
-		GlobalSection: []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
-		TableSection:  []*Table{{Min: 10}},
-	}, importingModuleName, nil, nil)
-	require.NoError(t, err)
+			m2, err := s.Instantiate(testCtx, &Module{
+				TypeSection:   []*FunctionType{{}},
+				ImportSection: []*Import{{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
+				MemorySection: &Memory{Min: 1, Cap: 1},
+				GlobalSection: []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
+				TableSection:  []*Table{{Min: 10}},
+			}, importingModuleName, nil, nil)
+			require.NoError(t, err)
 
-	err = s.Close(testCtx)
-	require.NoError(t, err)
-	require.Nil(t, s.modules[importedModuleName])
-	require.Nil(t, s.modules[importingModuleName])
+			if tc.testClosed {
+				err = m2.CloseWithExitCode(testCtx, 2)
+				require.NoError(t, err)
+			}
 
-	require.Equal(t, uint64(1), *m1.closed)
-	require.Equal(t, uint64(1), *m2.closed)
+			err = s.CloseWithExitCode(testCtx, 2)
+			require.NoError(t, err)
+			require.Nil(t, s.modules[importedModuleName])
+			require.Nil(t, s.modules[importingModuleName])
+
+			require.Equal(t, uint64(1)+uint64(2)<<32, *m1.closed)
+			require.Equal(t, uint64(1)+uint64(2)<<32, *m2.closed)
+		})
+	}
 }
 
 func TestStore_hammer(t *testing.T) {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -182,6 +182,38 @@ func TestStore_CloseModule(t *testing.T) {
 	}
 }
 
+func TestStore_CloseStore(t *testing.T) {
+	const importedModuleName = "imported"
+	const importingModuleName = "test"
+
+	s := newStore()
+
+	m1, err := s.Instantiate(testCtx, &Module{
+		TypeSection:     []*FunctionType{{}},
+		FunctionSection: []uint32{0},
+		CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
+		ExportSection:   []*Export{{Type: ExternTypeFunc, Index: 0, Name: "fn"}},
+	}, importedModuleName, nil, nil)
+	require.NoError(t, err)
+
+	m2, err := s.Instantiate(testCtx, &Module{
+		TypeSection:   []*FunctionType{{}},
+		ImportSection: []*Import{{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
+		MemorySection: &Memory{Min: 1, Cap: 1},
+		GlobalSection: []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
+		TableSection:  []*Table{{Min: 10}},
+	}, importingModuleName, nil, nil)
+	require.NoError(t, err)
+
+	err = s.Close(testCtx)
+	require.NoError(t, err)
+	require.Nil(t, s.modules[importedModuleName])
+	require.Nil(t, s.modules[importingModuleName])
+
+	require.Equal(t, uint64(1), *m1.closed)
+	require.Equal(t, uint64(1), *m2.closed)
+}
+
 func TestStore_hammer(t *testing.T) {
 	const importedModuleName = "imported"
 

--- a/wasm.go
+++ b/wasm.go
@@ -100,10 +100,22 @@ type Runtime interface {
 	//	ctx := context.Background()
 	//  r := wazero.NewRuntime()
 	//  defer r.Close(ctx)
-	//	_, _ = r.InstantiateModuleFromCode(ctx, sourceLib)
-	//	mod, _ := r.InstantiateModuleFromCode(ctx, sourceApp)
+	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
+	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
 	//
-	Close(ctx context.Context) error
+	Close(context.Context) error
+
+	// CloseWithExitCode closes all the modules that have been initialized in this Runtime with the provided exit code.
+	// An error is returned if any module returns an error when closed.
+	//
+	// Ex.
+	//	ctx := context.Background()
+	//  r := wazero.NewRuntime()
+	//  defer r.CloseWithExitCode(ctx, 2)
+	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
+	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
+	//
+	CloseWithExitCode(ctx context.Context, exitCode uint32) error
 }
 
 func NewRuntime() Runtime {
@@ -295,5 +307,10 @@ func (r *runtime) InstantiateModule(ctx context.Context, compiled CompiledModule
 
 // Close implements Runtime.Close
 func (r *runtime) Close(ctx context.Context) error {
-	return r.store.Close(ctx)
+	return r.CloseWithExitCode(ctx, 0)
+}
+
+// CloseWithExitCode implements Runtime.CloseWithExitCode
+func (r *runtime) CloseWithExitCode(ctx context.Context, exitCode uint32) error {
+	return r.store.CloseWithExitCode(ctx, exitCode)
 }

--- a/wasm.go
+++ b/wasm.go
@@ -98,11 +98,10 @@ type Runtime interface {
 	//
 	// Ex.
 	//	ctx := context.Background()
-	//  r := wazero.NewRuntime()
-	//  defer r.Close(ctx)
+	//	r := wazero.NewRuntime()
+	//	defer r.Close(ctx)
 	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
 	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
-	//
 	Close(context.Context) error
 
 	// CloseWithExitCode closes all the modules that have been initialized in this Runtime with the provided exit code.
@@ -110,11 +109,10 @@ type Runtime interface {
 	//
 	// Ex.
 	//	ctx := context.Background()
-	//  r := wazero.NewRuntime()
-	//  defer r.CloseWithExitCode(ctx, 2)
+	//	r := wazero.NewRuntime()
+	//	defer r.CloseWithExitCode(ctx, 2)
 	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
 	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
-	//
 	CloseWithExitCode(ctx context.Context, exitCode uint32) error
 }
 

--- a/wasm.go
+++ b/wasm.go
@@ -92,6 +92,18 @@ type Runtime interface {
 	// Note: Config is copied during instantiation: Later changes to config do not affect the instantiated result.
 	// Note: When the context is nil, it defaults to context.Background.
 	InstantiateModule(ctx context.Context, compiled CompiledModule, config ModuleConfig) (api.Module, error)
+
+	// Close closes all the modules that have been initialized in this Runtime with an exit code of 0.
+	// An error is returned if any module returns an error when closed.
+	//
+	// Ex.
+	//	ctx := context.Background()
+	//  r := wazero.NewRuntime()
+	//  defer r.Close(ctx)
+	//	_, _ = r.InstantiateModuleFromCode(ctx, sourceLib)
+	//	mod, _ := r.InstantiateModuleFromCode(ctx, sourceApp)
+	//
+	Close(ctx context.Context) error
 }
 
 func NewRuntime() Runtime {
@@ -279,4 +291,9 @@ func (r *runtime) InstantiateModule(ctx context.Context, compiled CompiledModule
 		}
 	}
 	return
+}
+
+// Close implements Runtime.Close
+func (r *runtime) Close(ctx context.Context) error {
+	return r.store.Close(ctx)
 }

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -571,6 +571,7 @@ func TestClose(t *testing.T) {
 
 		// Modules closed so calls fail
 		_, err = func1.Call(testCtx)
+		// TODO: This could be neater with ErrorIs
 		require.Error(t, err, sys.NewExitError("mod1", tc.exitCode).Error())
 
 		_, err = func2.Call(testCtx)
@@ -578,7 +579,7 @@ func TestClose(t *testing.T) {
 	}
 }
 
-func TestCloseClosesCompiledModules(t *testing.T) {
+func TestClose_ClosesCompiledModules(t *testing.T) {
 	engine := &mockEngine{name: "mock", cachedModules: map[*wasm.Module]struct{}{}}
 	conf := *engineLessConfig
 	conf.newEngine = func(_ wasm.Features) wasm.Engine {


### PR DESCRIPTION
Fixes #382

It can be tedious to close many modules that have been instantiated, particularly when they are not instantiated in a scope where it is appropriate to use `defer`. `Runtime.Close` closes all the modules in a runtime's store, in reverse order of instantiation. I am wondering whether we should provide a version of this that takes an exit code like the `Module` version or if that would be overkill. It wouldn't be hard to add that if we need it here.

To keep track of order, `moduleNames` changes from a map to a slice - with a huge number of modules this could reduce instantiation performance. If this seems like it needs to be avoided, I can use a separate field instead, which would be something like inlining a linked map of modules into the store.

Also because Go locks aren't reentrant, I had to provide an internal module close codepath that doesn't remove from the store. There is a bit of circularity in that a module calls into store to remove itself, but when closing the store it is the other way around. Perhaps we may consider changing `Module.Close` to `Runtime.CloseModule(Module)` as a random idea.