### PR TITLE
Exposes api.Memory Grow

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -221,13 +221,20 @@ type MutableGlobal interface {
 // Note: This includes all value types available in WebAssembly 1.0 (20191205) and all are encoded little-endian.
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#storage%E2%91%A0
 type Memory interface {
+
 	// Size returns the size in bytes available. Ex. If the underlying memory has 1 page: 65536
-	//
-	// Note: this will not grow during a host function call, even if the underlying memory can.  Ex. If the underlying
-	// memory has min 0 and max 2 pages, this returns zero.
 	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
 	Size(context.Context) uint32
+
+	// Grow increases memory by the delta in pages (65536 bytes per page). The return val is the previous memory size in
+	// pages, or false if the delta was ignored as it exceeds max memory.
+	//
+	// Note: This is the same as the "memory.grow" instruction defined in the WebAssembly Core Specification, except
+	// returns false instead of -1 on failure
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem
+	// See MemorySizer
+	Grow(ctx context.Context, deltaPages uint32) (previousPages uint32, ok bool)
 
 	// IndexByte returns the index of the first instance of c in the underlying buffer at the offset or returns false if
 	// not found or out of range.

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -882,8 +882,11 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 		case wazeroir.OperationKindMemoryGrow:
 			{
 				n := ce.popValue()
-				res := memoryInst.Grow(ctx, uint32(n))
-				ce.pushValue(uint64(res))
+				if res, ok := memoryInst.Grow(ctx, uint32(n)); !ok {
+					ce.pushValue(uint64(0xffffffff)) // = -1 in signed 32-bit integer.
+				} else {
+					ce.pushValue(uint64(res))
+				}
 				frame.pc++
 			}
 		case wazeroir.OperationKindConstI32, wazeroir.OperationKindConstI64,

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -774,8 +774,11 @@ func (ce *callEngine) builtinFunctionGrowCallFrameStack() {
 func (ce *callEngine) builtinFunctionMemoryGrow(ctx context.Context, mem *wasm.MemoryInstance) {
 	newPages := ce.popValue()
 
-	res := mem.Grow(ctx, uint32(newPages))
-	ce.pushValue(uint64(res))
+	if res, ok := mem.Grow(ctx, uint32(newPages)); !ok {
+		ce.pushValue(uint64(0xffffffff)) // = -1 in signed 32-bit integer.
+	} else {
+		ce.pushValue(uint64(res))
+	}
 
 	// Update the moduleContext fields as they become stale after the update ^^.
 	bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&mem.Buffer))

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -66,22 +66,33 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 			} else {
 				m = &MemoryInstance{Max: max, Buffer: make([]byte, 0)}
 			}
-			require.Equal(t, uint32(0), m.Grow(ctx, 5))
+
+			res, ok := m.Grow(ctx, 5)
+			require.True(t, ok)
+			require.Equal(t, uint32(0), res)
 			require.Equal(t, uint32(5), m.PageSize(ctx))
 
 			// Zero page grow is well-defined, should return the current page correctly.
-			require.Equal(t, uint32(5), m.Grow(ctx, 0))
+			res, ok = m.Grow(ctx, 0)
+			require.True(t, ok)
+			require.Equal(t, uint32(5), res)
 			require.Equal(t, uint32(5), m.PageSize(ctx))
-			require.Equal(t, uint32(5), m.Grow(ctx, 4))
+
+			res, ok = m.Grow(ctx, 4)
+			require.True(t, ok)
+			require.Equal(t, uint32(5), res)
 			require.Equal(t, uint32(9), m.PageSize(ctx))
 
 			// At this point, the page size equal 9,
 			// so trying to grow two pages should result in failure.
-			require.Equal(t, int32(-1), int32(m.Grow(ctx, 2)))
+			_, ok = m.Grow(ctx, 2)
+			require.False(t, ok)
 			require.Equal(t, uint32(9), m.PageSize(ctx))
 
 			// But growing one page is still permitted.
-			require.Equal(t, uint32(9), m.Grow(ctx, 1))
+			res, ok = m.Grow(ctx, 1)
+			require.True(t, ok)
+			require.Equal(t, uint32(9), res)
 
 			// Ensure that the current page size equals the max.
 			require.Equal(t, max, m.PageSize(ctx))


### PR DESCRIPTION
This exports an API which allows host-defined functions access to
increase the memory size.

Fixes #483