### PR TITLE
Sets lf line endings in gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-# Ignore the auto-generated Wasm spectest files from language statistics of wazero repo.
-# https://stackoverflow.com/questions/19052834/is-it-possible-to-exclude-files-from-git-language-statistics
-wasm/internal/spectests/cases/* linguist-vendored
+# Improves experience of commands like `make format` on Windows
+* text=auto eol=lf


### PR DESCRIPTION
Also removes unused linguist setting for stats

When developing on Windows, git will often give warnings like

`warning: CRLF will be replaced by LF in internal/wasm/text/decoder.go.`

and `make format` touches all files causing a huge "no-op diff" where git is seeing different line endings, but they don't actually show up in a PR.

I've generally not been able to have good results on developing on Windows without this `.gitattributes` line to force LF-always, which is appropriate for any modern codebase (even Windows ones :-) )