### PR TITLE
ci: upgrade golangci-lint, enable matrix on check job

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   check:
-    name: Pre-commit check, Go-${{ matrix.go-version }})
+    name: Pre-commit check, Go-${{ matrix.go-version }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:  # use latest available versions and be consistent on all workflows!

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,14 +14,18 @@ defaults:
 
 jobs:
   check:
-    name: Pre-commit check
+    name: Pre-commit check, Go-${{ matrix.go-version }})
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:  # use latest available versions and be consistent on all workflows!
+        go-version:
+        - "1.17" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+        - "1.18"
+
     steps:
       - uses: actions/setup-go@v3
         with:
-          # TODO: Change to a matrix to ensure developers can use the latest version, noting often there is a lag of
-          # weeks before the latest version is usable. Ex. golangci/golangci-lint#2649
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Install latest wast2json
         run: |  # Needed for build.spectest. wabt includes wast2json.
@@ -37,7 +41,7 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
             ~/go/bin
-          key: check-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum', 'Makefile') }}
+          key: check-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum', 'Makefile') }}
 
       - run: make check
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 goimports := golang.org/x/tools/cmd/goimports@v0.1.10
-golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.0
 
 ensureJITFastest := -ldflags '-X github.com/tetratelabs/wazero/internal/integration_test/vs.ensureJITFastest=true'
 .PHONY: bench

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1465,7 +1465,7 @@ func (a *AssemblerImpl) EncodeTwoRegistersToNone(n *NodeImpl) (err error) {
 			ftype = 0b01
 		}
 		a.Buf.Write([]byte{
-			(src2RegBits << 5) | 0b00000,
+			(src2RegBits << 5),
 			0b001000_00 | (src2RegBits >> 3),
 			ftype<<6 | 0b1_00000 | src1RegBits,
 			0b000_11110,


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>