### PR TITLE
Implements errors.Is for sys.ExitError

### DIFF
--- a/sys/sys.go
+++ b/sys/sys.go
@@ -42,3 +42,10 @@ func (e *ExitError) ExitCode() uint32 {
 func (e *ExitError) Error() string {
 	return fmt.Sprintf("module %q closed with exit_code(%d)", e.moduleName, e.exitCode)
 }
+
+func (e *ExitError) Is(err error) bool {
+	if target, ok := err.(*ExitError); ok {
+		return e.moduleName == target.moduleName && e.exitCode == target.exitCode
+	}
+	return false
+}

--- a/sys/sys.go
+++ b/sys/sys.go
@@ -43,6 +43,7 @@ func (e *ExitError) Error() string {
 	return fmt.Sprintf("module %q closed with exit_code(%d)", e.moduleName, e.exitCode)
 }
 
+// Is allows use via errors.Is
 func (e *ExitError) Is(err error) bool {
 	if target, ok := err.(*ExitError); ok {
 		return e.moduleName == target.moduleName && e.exitCode == target.exitCode

--- a/sys/sys_test.go
+++ b/sys/sys_test.go
@@ -1,0 +1,60 @@
+package sys
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+type notExitError struct {
+	moduleName string
+	exitCode   uint32
+}
+
+func (e *notExitError) Error() string {
+	return "not exit error"
+}
+
+func TestIs(t *testing.T) {
+	err := NewExitError("some module", 2)
+	for _, tc := range []struct {
+		name    string
+		target  error
+		matches bool
+	}{
+		{
+			name:    "same object",
+			target:  err,
+			matches: true,
+		},
+		{
+			name:    "same content",
+			target:  NewExitError("some module", 2),
+			matches: true,
+		},
+		{
+			name:    "different module name",
+			target:  NewExitError("not some module", 2),
+			matches: false,
+		},
+		{
+			name:    "different exit code",
+			target:  NewExitError("some module", 0),
+			matches: false,
+		},
+		{
+			name: "different type",
+			target: &notExitError{
+				moduleName: "some module",
+				exitCode:   2,
+			},
+			matches: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := errors.Is(err, tc.target)
+			require.Equal(t, tc.matches, matches)
+		})
+	}
+}

--- a/wasm_test.go
+++ b/wasm_test.go
@@ -571,11 +571,10 @@ func TestClose(t *testing.T) {
 
 		// Modules closed so calls fail
 		_, err = func1.Call(testCtx)
-		// TODO: This could be neater with ErrorIs
-		require.Error(t, err, sys.NewExitError("mod1", tc.exitCode).Error())
+		require.ErrorIs(t, err, sys.NewExitError("mod1", tc.exitCode))
 
 		_, err = func2.Call(testCtx)
-		require.Error(t, err, sys.NewExitError("mod2", tc.exitCode).Error())
+		require.ErrorIs(t, err, sys.NewExitError("mod2", tc.exitCode))
 	}
 }
 


### PR DESCRIPTION
Allows use with test assertions like `require.ErrorIs`, which delegates to `errors.Is` both here and in testify.

Cleans up a related TODO.