### PR TITLE
Adds a Closer interface to encapsulate the API for closing a re…

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -147,20 +147,8 @@ type Module interface {
 	// ExportedGlobal a global exported from this module or nil if it wasn't.
 	ExportedGlobal(name string) Global
 
-	// Closer closes this module.
-	Closer
-}
-
-// Closer closes a resource. Any modules closed with it will be provided an exit code.
-//
-// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
-type Closer interface {
-	// Close is a convenience that invokes CloseWithExitCode with zero.
-	// Note: When the context is nil, it defaults to context.Background.
-	Close(context.Context) error
-
-	// CloseWithExitCode releases resources. The exit code will be provided to any released Modules.
-	// Use a non-zero exitCode parameter to indicate a failure to ExportedFunction callers.
+	// CloseWithExitCode releases resources allocated for this Module. Use a non-zero exitCode parameter to indicate a
+	// failure to ExportedFunction callers.
 	//
 	// The error returned here, if present, is about resource de-allocation (such as I/O errors). Only the last error is
 	// returned, so a non-nil return means at least one error happened. Regardless of error, this module instance will
@@ -170,6 +158,18 @@ type Closer interface {
 	// with the exitCode.
 	// Note: When the context is nil, it defaults to context.Background.
 	CloseWithExitCode(ctx context.Context, exitCode uint32) error
+
+	// Closer closes this module by delegating to CloseWithExitCode with an exit code of zero.
+	Closer
+}
+
+// Closer closes a resource.
+//
+// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
+type Closer interface {
+	// Close closes the resource.
+	// Note: When the context is nil, it defaults to context.Background.
+	Close(context.Context) error
 }
 
 // Function is a WebAssembly 1.0 (20191205) function exported from an instantiated module (wazero.Runtime InstantiateModule).

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -147,6 +147,7 @@ type Module interface {
 	// ExportedGlobal a global exported from this module or nil if it wasn't.
 	ExportedGlobal(name string) Global
 
+	// ModuleCloser closes this module.
 	ModuleCloser
 }
 

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -147,14 +147,14 @@ type Module interface {
 	// ExportedGlobal a global exported from this module or nil if it wasn't.
 	ExportedGlobal(name string) Global
 
-	// ModuleCloser closes this module.
-	ModuleCloser
+	// Closer closes this module.
+	Closer
 }
 
-// ModuleCloser closes a module with an exit code.
+// Closer closes a resource. Any modules closed with it will be provided an exit code.
 //
 // Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
-type ModuleCloser interface {
+type Closer interface {
 	// Close is a convenience that invokes CloseWithExitCode with zero.
 	// Note: When the context is nil, it defaults to context.Background.
 	Close(context.Context) error

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -129,22 +129,6 @@ type Module interface {
 	// Name is the name this module was instantiated with. Exported functions can be imported with this name.
 	Name() string
 
-	// Close is a convenience that invokes CloseWithExitCode with zero.
-	// Note: When the context is nil, it defaults to context.Background.
-	Close(context.Context) error
-
-	// CloseWithExitCode releases resources allocated for this Module. Use a non-zero exitCode parameter to indicate a
-	// failure to ExportedFunction callers.
-	//
-	// The error returned here, if present, is about resource de-allocation (such as I/O errors). Only the last error is
-	// returned, so a non-nil return means at least one error happened. Regardless of error, this module instance will
-	// be removed, making its name available again.
-	//
-	// Calling this inside a host function is safe, and may cause ExportedFunction callers to receive a sys.ExitError
-	// with the exitCode.
-	// Note: When the context is nil, it defaults to context.Background.
-	CloseWithExitCode(ctx context.Context, exitCode uint32) error
-
 	// Memory returns a memory defined in this module or nil if there are none wasn't.
 	Memory() Memory
 
@@ -162,6 +146,29 @@ type Module interface {
 
 	// ExportedGlobal a global exported from this module or nil if it wasn't.
 	ExportedGlobal(name string) Global
+
+	ModuleCloser
+}
+
+// ModuleCloser closes a module with an exit code.
+//
+// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
+type ModuleCloser interface {
+	// Close is a convenience that invokes CloseWithExitCode with zero.
+	// Note: When the context is nil, it defaults to context.Background.
+	Close(context.Context) error
+
+	// CloseWithExitCode releases resources allocated for a Module. Use a non-zero exitCode parameter to indicate a
+	// failure to ExportedFunction callers.
+	//
+	// The error returned here, if present, is about resource de-allocation (such as I/O errors). Only the last error is
+	// returned, so a non-nil return means at least one error happened. Regardless of error, this module instance will
+	// be removed, making its name available again.
+	//
+	// Calling this inside a host function is safe, and may cause ExportedFunction callers to receive a sys.ExitError
+	// with the exitCode.
+	// Note: When the context is nil, it defaults to context.Background.
+	CloseWithExitCode(ctx context.Context, exitCode uint32) error
 }
 
 // Function is a WebAssembly 1.0 (20191205) function exported from an instantiated module (wazero.Runtime InstantiateModule).

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -159,8 +159,8 @@ type Closer interface {
 	// Note: When the context is nil, it defaults to context.Background.
 	Close(context.Context) error
 
-	// CloseWithExitCode releases resources allocated for a Module. Use a non-zero exitCode parameter to indicate a
-	// failure to ExportedFunction callers.
+	// CloseWithExitCode releases resources. The exit code will be provided to any released Modules.
+	// Use a non-zero exitCode parameter to indicate a failure to ExportedFunction callers.
 	//
 	// The error returned here, if present, is about resource de-allocation (such as I/O errors). Only the last error is
 	// returned, so a non-nil return means at least one error happened. Regardless of error, this module instance will

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -58,8 +58,9 @@ type wazeroRuntime struct {
 }
 
 type wazeroModule struct {
-	wasi, env, mod api.Module
-	funcs          map[string]api.Function
+	wasi     api.ModuleCloser
+	env, mod api.Module
+	funcs    map[string]api.Function
 }
 
 func (r *wazeroRuntime) Name() string {

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -58,7 +58,7 @@ type wazeroRuntime struct {
 }
 
 type wazeroModule struct {
-	wasi     api.ModuleCloser
+	wasi     api.Closer
 	env, mod api.Module
 	funcs    map[string]api.Function
 }

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -36,7 +36,7 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //	mod, _ := r.InstantiateModuleFromCode(ctx, source)
 //
 // Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
-// Note: Closing the wazero.Runtime will release wasi as well.
+// Note: Closing the wazero.Runtime closes this instance of WASI as well.
 func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	_, fns := snapshotPreview1Functions(ctx)
 	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate(ctx)

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -37,7 +37,7 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //
 // Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
 // Note: Closing the wazero.Runtime closes any api.Module it instantiated.
-func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Module, error) {
+func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.ModuleCloser, error) {
 	_, fns := snapshotPreview1Functions(ctx)
 	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate(ctx)
 }

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -37,7 +37,7 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //
 // Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
 // Note: Closing the wazero.Runtime closes any api.Module it instantiated.
-func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.ModuleCloser, error) {
+func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	_, fns := snapshotPreview1Functions(ctx)
 	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate(ctx)
 }

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -36,7 +36,7 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //	mod, _ := r.InstantiateModuleFromCode(ctx, source)
 //
 // Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
-// Note: Closing the wazero.Runtime closes any api.Module it instantiated.
+// Note: Closing the wazero.Runtime will release wasi as well.
 func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	_, fns := snapshotPreview1Functions(ctx)
 	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate(ctx)

--- a/wasm.go
+++ b/wasm.go
@@ -98,10 +98,21 @@ type Runtime interface {
 	// Note: When the context is nil, it defaults to context.Background.
 	InstantiateModule(ctx context.Context, compiled CompiledModule, config ModuleConfig) (api.Module, error)
 
-	// Closer closes resources initialized by this Runtime. Any instantiated modules will be closed with
-	// an exit code.
+	// CloseWithExitCode closes all the modules that have been initialized in this Runtime with the provided exit code.
+	// An error is returned if any module returns an error when closed.
 	//
-	// Note: Methods will return an error if any module returns an error when closed.
+	// Ex.
+	//	ctx := context.Background()
+	//	r := wazero.NewRuntime()
+	//	defer r.CloseWithExitCode(ctx, 2) // This closes everything this Runtime created.
+	//
+	//	// Everything below here can be closed, but will anyway due to above.
+	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
+	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
+	CloseWithExitCode(ctx context.Context, exitCode uint32) error
+
+	// Closer closes resources initialized by this Runtime by delegating to CloseWithExitCode with an exit code of
+	// zero.
 	api.Closer
 }
 

--- a/wasm.go
+++ b/wasm.go
@@ -98,6 +98,9 @@ type Runtime interface {
 	// Note: When the context is nil, it defaults to context.Background.
 	InstantiateModule(ctx context.Context, compiled CompiledModule, config ModuleConfig) (api.Module, error)
 
+	// ModuleCloser closes all the modules that have been initialized in this Runtime.
+	//
+	// Note: Methods will return an error if any module returns an error when closed.
 	api.ModuleCloser
 }
 

--- a/wasm.go
+++ b/wasm.go
@@ -98,10 +98,11 @@ type Runtime interface {
 	// Note: When the context is nil, it defaults to context.Background.
 	InstantiateModule(ctx context.Context, compiled CompiledModule, config ModuleConfig) (api.Module, error)
 
-	// ModuleCloser closes all the modules that have been initialized in this Runtime.
+	// Closer closes resources initialized by this Runtime. Any instantiated modules will be closed with
+	// an exit code.
 	//
 	// Note: Methods will return an error if any module returns an error when closed.
-	api.ModuleCloser
+	api.Closer
 }
 
 func NewRuntime() Runtime {

--- a/wasm.go
+++ b/wasm.go
@@ -98,31 +98,7 @@ type Runtime interface {
 	// Note: When the context is nil, it defaults to context.Background.
 	InstantiateModule(ctx context.Context, compiled CompiledModule, config ModuleConfig) (api.Module, error)
 
-	// Close closes all the modules that have been initialized in this Runtime with an exit code of 0.
-	// An error is returned if any module returns an error when closed.
-	//
-	// Ex.
-	//	ctx := context.Background()
-	//	r := wazero.NewRuntime()
-	//	defer r.Close(ctx) // This closes everything this Runtime created.
-	//
-	//	// Everything below here can be closed, but will anyway due to above.
-	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
-	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
-	Close(context.Context) error
-
-	// CloseWithExitCode closes all the modules that have been initialized in this Runtime with the provided exit code.
-	// An error is returned if any module returns an error when closed.
-	//
-	// Ex.
-	//	ctx := context.Background()
-	//	r := wazero.NewRuntime()
-	//	defer r.CloseWithExitCode(ctx, 2) // This closes everything this Runtime created.
-	//
-	//	// Everything below here can be closed, but will anyway due to above.
-	//	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
-	//	mod, _ := r.InstantiateModuleFromCode(ctx, source)
-	CloseWithExitCode(ctx context.Context, exitCode uint32) error
+	api.ModuleCloser
 }
 
 func NewRuntime() Runtime {


### PR DESCRIPTION
…source with modules.

Fixes #551 

`api.Module` provides APIs for using a wasm module directly such as `Memory()` and `ExportedFunction`. Built-in modules such as wasi do not expose such functionality, but do still need to be closeable. `Closer` provides the functionality for closing a module and can be returned in these cases. It is also a natural fit with `Runtime`, which has the ability to close modules despite not being a module itself.