### PR TITLE
Implements v128.const and adds support for vector value type. 

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -59,7 +59,7 @@ func ExternTypeName(et ExternType) string {
 //  * ValueTypeI64 - uint64(int64)
 //  * ValueTypeF32 - EncodeF32 DecodeF32 from float32
 //  * ValueTypeF64 - EncodeF64 DecodeF64 from float64
-//  * ValueTypeVector TODO:
+//  * ValueTypeV128 TODO:
 //  * ValueTypeExternref - unintptr(unsafe.Pointer(p)) where p is any pointer type in Go (e.g. *string)
 //
 // Ex. Given a Text Format type use (param i64) (result i64), no conversion is necessary.
@@ -85,10 +85,10 @@ const (
 	ValueTypeF32 ValueType = 0x7d
 	// ValueTypeF64 is a 64-bit floating point number.
 	ValueTypeF64 ValueType = 0x7c
-	// ValueTypeVector is a 128-bit vector value.
+	// ValueTypeV128 is a 128-bit vector value.
 	//
 	// TODO
-	ValueTypeVector ValueType = 0x7b
+	ValueTypeV128 ValueType = 0x7b
 	// ValueTypeExternref is a externref type.
 	//
 	// Note: in wazero, externref type value are opaque raw 64-bit pointers, and the ValueTypeExternref type
@@ -117,7 +117,7 @@ func ValueTypeName(t ValueType) string {
 		return "f32"
 	case ValueTypeF64:
 		return "f64"
-	case ValueTypeVector:
+	case ValueTypeV128:
 		return "i128"
 	case ValueTypeExternref:
 		return "externref"

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -118,7 +118,7 @@ func ValueTypeName(t ValueType) string {
 	case ValueTypeF64:
 		return "f64"
 	case ValueTypeV128:
-		return "i128"
+		return "v128"
 	case ValueTypeExternref:
 		return "externref"
 	}

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -87,7 +87,12 @@ const (
 	ValueTypeF64 ValueType = 0x7c
 	// ValueTypeV128 is a 128-bit vector value.
 	//
-	// TODO
+	// The type corresponds to a 128 bit vector of packed integer or floating-point data.
+	// The packed data can be interpreted as signed or unsigned integers, single or double
+	// precision floating-point values, or a single 128 bit type. The interpretation is
+	// determined by individual operations.
+	//
+	// See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/syntax/types.html#syntax-vectype
 	ValueTypeV128 ValueType = 0x7b
 	// ValueTypeExternref is a externref type.
 	//

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -59,6 +59,7 @@ func ExternTypeName(et ExternType) string {
 //  * ValueTypeI64 - uint64(int64)
 //  * ValueTypeF32 - EncodeF32 DecodeF32 from float32
 //  * ValueTypeF64 - EncodeF64 DecodeF64 from float64
+//  * ValueTypeVector TODO:
 //  * ValueTypeExternref - unintptr(unsafe.Pointer(p)) where p is any pointer type in Go (e.g. *string)
 //
 // Ex. Given a Text Format type use (param i64) (result i64), no conversion is necessary.
@@ -84,6 +85,10 @@ const (
 	ValueTypeF32 ValueType = 0x7d
 	// ValueTypeF64 is a 64-bit floating point number.
 	ValueTypeF64 ValueType = 0x7c
+	// ValueTypeVector is a 128-bit vector value.
+	//
+	// TODO
+	ValueTypeVector ValueType = 0x7b
 	// ValueTypeExternref is a externref type.
 	//
 	// Note: in wazero, externref type value are opaque raw 64-bit pointers, and the ValueTypeExternref type
@@ -112,6 +117,8 @@ func ValueTypeName(t ValueType) string {
 		return "f32"
 	case ValueTypeF64:
 		return "f64"
+	case ValueTypeVector:
+		return "i128"
 	case ValueTypeExternref:
 		return "externref"
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -51,7 +51,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []wasm.Index{0},
 				HostFunctionSection: []*reflect.Value{&fnUint32_uint32},
@@ -70,7 +70,7 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []wasm.Index{0},
 				HostFunctionSection: []*reflect.Value{&fnUint64_uint32},
@@ -90,8 +90,8 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []wasm.Index{0, 1},
 				HostFunctionSection: []*reflect.Value{&fnUint32_uint32, &fnUint64_uint32},
@@ -114,8 +114,8 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []wasm.Index{0, 1},
 				HostFunctionSection: []*reflect.Value{&fnUint32_uint32, &fnUint64_uint32},
@@ -139,8 +139,8 @@ func TestNewModuleBuilder_Build(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []wasm.Index{0, 1},
 				HostFunctionSection: []*reflect.Value{&fnUint32_uint32, &fnUint64_uint32},

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -605,8 +605,10 @@ func requireValuesEq(t *testing.T, actual, exps []uint64, valTypes []wasm.ValueT
 			expectedTypesVectorFlattend = append(expectedTypesVectorFlattend, wasm.ValueTypeI64)
 		}
 	}
+
+	result := fmt.Sprintf("\thave (%v)\n\twant (%v)", actual, exps)
 	for i := range exps {
-		requireValueEq(t, actual[i], exps[i], expectedTypesVectorFlattend[i], msg)
+		requireValueEq(t, actual[i], exps[i], expectedTypesVectorFlattend[i], msg+"\n"+result)
 	}
 }
 

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -158,6 +158,7 @@ func (c command) getAssertReturnArgsExps() ([]uint64, []uint64) {
 	}
 	for _, exp := range c.Exps {
 		exps = append(exps, exp.toUint64s()...)
+		fmt.Println("exps", exps)
 	}
 	return args, exps
 }
@@ -194,11 +195,12 @@ func (c commandActionVal) toUint64s() (ret []uint64) {
 			low |= (v << (i * width))
 		}
 		for i := valNum / 2; i < valNum; i++ {
+			fmt.Println("hi: ", i)
 			v, err := strconv.ParseUint(strValues[i].(string), 10, width)
 			if err != nil {
 				panic(err)
 			}
-			high |= (v << (i * width))
+			high |= (v << ((i - valNum/2) * width))
 		}
 		return []uint64{low, high}
 	} else {

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -596,7 +596,7 @@ func testdataPath(filename string) string {
 func requireValuesEq(t *testing.T, actual, exps []uint64, valTypes []wasm.ValueType, msg string) {
 	var expectedTypesVectorFlattend []wasm.ValueType
 	for _, tp := range valTypes {
-		if tp != wasm.ValueTypeVector {
+		if tp != wasm.ValueTypeV128 {
 			expectedTypesVectorFlattend = append(expectedTypesVectorFlattend, tp)
 		} else {
 			expectedTypesVectorFlattend = append(expectedTypesVectorFlattend, wasm.ValueTypeI64)

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -159,7 +159,6 @@ func (c command) getAssertReturnArgsExps() ([]uint64, []uint64) {
 	}
 	for _, exp := range c.Exps {
 		exps = append(exps, exp.toUint64s()...)
-		fmt.Println("exps", exps)
 	}
 	return args, exps
 }
@@ -196,7 +195,6 @@ func (c commandActionVal) toUint64s() (ret []uint64) {
 			low |= (v << (i * width))
 		}
 		for i := valNum / 2; i < valNum; i++ {
-			fmt.Println("hi: ", i)
 			v, err := strconv.ParseUint(strValues[i].(string), 10, width)
 			if err != nil {
 				panic(err)
@@ -356,6 +354,9 @@ func maybeSetMemoryCap(mod *wasm.Module) {
 
 // Run runs all the test inside the testDataFS file system where all the cases are described
 // via JSON files created from wast2json.
+//
+// filter is a callback which is called with the target json file name and should return true if the engine wants to run tests against it, false otherwise.
+// TODO: remove filter after SIMD completion.
 func Run(t *testing.T, testDataFS embed.FS, newEngine func(wasm.Features) wasm.Engine, enabledFeatures wasm.Features, filter func(jsonname string) bool) {
 	files, err := testDataFS.ReadDir("testdata")
 	require.NoError(t, err)

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -69,8 +69,6 @@ type (
 		LaneType string      `json:"lane_type"`
 		Value    interface{} `json:"value"`
 	}
-
-	simdVal []string
 )
 
 func (c commandActionVal) String() string {
@@ -99,11 +97,15 @@ func (c commandActionVal) String() string {
 		// All the in and out funcref params are null in spectest (cannot represent non-null as it depends on runtime impl).
 		v = "null"
 	case "v128":
-		simdValues, ok := c.Value.(simdVal)
+		simdValues, ok := c.Value.([]interface{})
 		if !ok {
 			panic("BUG")
 		}
-		v = strings.Join(simdValues, ",")
+		var strs []string
+		for _, v := range simdValues {
+			strs = append(strs, v.(string))
+		}
+		v = strings.Join(strs, ",")
 	}
 	return fmt.Sprintf("{type: %s, value: %v}", c.ValType, v)
 }

--- a/internal/integration_test/spectest/v1/spec_test.go
+++ b/internal/integration_test/spectest/v1/spec_test.go
@@ -22,11 +22,11 @@ func TestJIT(t *testing.T) {
 		t.Skip()
 	}
 
-	spectest.Run(t, testcases, jit.NewEngine, enabledFeatures)
+	spectest.Run(t, testcases, jit.NewEngine, enabledFeatures, func(string) bool { return true })
 }
 
 func TestInterpreter(t *testing.T) {
-	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures)
+	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures, func(jsonname string) bool { return true })
 }
 
 func TestBinaryEncoder(t *testing.T) {

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -31,14 +31,12 @@ func TestJIT(t *testing.T) {
 
 func TestInterpreter(t *testing.T) {
 	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures, func(jsonname string) bool {
-		if path.Base(jsonname) != "simd_const.json" {
-			return true
-		}
+		return path.Base(jsonname) == "simd_const.json"
 
 		// TODO: remove after SIMD proposal
 		if strings.Contains(jsonname, "simd") {
 			return false
 		}
-		return false
+		return true
 	})
 }

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -2,7 +2,9 @@ package spectest
 
 import (
 	"embed"
+	"path"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/integration_test/spectest"
@@ -22,9 +24,21 @@ func TestJIT(t *testing.T) {
 		t.Skip()
 	}
 
-	spectest.Run(t, testcases, jit.NewEngine, enabledFeatures)
+	spectest.Run(t, testcases, jit.NewEngine, enabledFeatures, func(jsonname string) bool {
+		return strings.Contains(jsonname, "simd")
+	})
 }
 
 func TestInterpreter(t *testing.T) {
-	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures)
+	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures, func(jsonname string) bool {
+		if path.Base(jsonname) != "simd_const.json" {
+			return true
+		}
+
+		// TODO: remove after SIMD proposal
+		if strings.Contains(jsonname, "simd") {
+			return false
+		}
+		return false
+	})
 }

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -25,17 +25,16 @@ func TestJIT(t *testing.T) {
 	}
 
 	spectest.Run(t, testcases, jit.NewEngine, enabledFeatures, func(jsonname string) bool {
-		return strings.Contains(jsonname, "simd")
+		// TODO: remove after SIMD proposal
+		return !strings.Contains(jsonname, "simd")
 	})
 }
 
 func TestInterpreter(t *testing.T) {
 	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures, func(jsonname string) bool {
-		return path.Base(jsonname) == "simd_const.json"
-
 		// TODO: remove after SIMD proposal
 		if strings.Contains(jsonname, "simd") {
-			return false
+			return path.Base(jsonname) == "simd_const.json"
 		}
 		return true
 	})

--- a/internal/integration_test/vs/codec.go
+++ b/internal/integration_test/vs/codec.go
@@ -24,12 +24,12 @@ func newExample() *wasm.Module {
 	f32, i32, i64 := wasm.ValueTypeF32, wasm.ValueTypeI32, wasm.ValueTypeI64
 	return &wasm.Module{
 		TypeSection: []*wasm.FunctionType{
-			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
-			{},
-			{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
-			{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}},
-			{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}},
-			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}},
+			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+			{ParamNumInUint64: 0, ResultNumInUint64: 0},
+			{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
+			{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+			{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 		},
 		ImportSection: []*wasm.Import{
 			{

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -132,7 +132,7 @@ func RunTestModuleEngine_Call(t *testing.T, et EngineTester) {
 	// Define a basic function which defines one parameter. This is used to test results when incorrect arity is used.
 	i64 := wasm.ValueTypeI64
 	m := &wasm.Module{
-		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}},
+		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}, ParamNumInUint64: 1, ResultNumInUint64: 1}},
 		FunctionSection: []uint32{0},
 		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}, LocalTypes: []wasm.ValueType{wasm.ValueTypeI64}}},
 	}

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -353,8 +353,9 @@ func runTestModuleEngine_Call_HostFn_ModuleContext(t *testing.T, et EngineTester
 	e := et.NewEngine(features)
 
 	sig := &wasm.FunctionType{
-		Params:  []wasm.ValueType{wasm.ValueTypeI64},
-		Results: []wasm.ValueType{wasm.ValueTypeI64},
+		Params:           []wasm.ValueType{wasm.ValueTypeI64},
+		Results:          []wasm.ValueType{wasm.ValueTypeI64},
+		ParamNumInUint64: 1, ResultNumInUint64: 1,
 	}
 
 	memory := &wasm.MemoryInstance{}
@@ -588,7 +589,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 	// Define a basic function which defines one parameter. This is used to test results when incorrect arity is used.
 	one := uint32(1)
 	m := &wasm.Module{
-		TypeSection:     []*wasm.FunctionType{{Params: []api.ValueType{api.ValueTypeI32}}, {}},
+		TypeSection:     []*wasm.FunctionType{{Params: []api.ValueType{api.ValueTypeI32}, ParamNumInUint64: 1}, {}},
 		FunctionSection: []wasm.Index{0, 1},
 		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: 2},
 		DataSection: []*wasm.DataSegment{
@@ -706,7 +707,7 @@ func divBy(d uint32) uint32 {
 
 func setupCallTests(t *testing.T, e wasm.Engine) (*wasm.ModuleInstance, *wasm.ModuleInstance, *wasm.ModuleInstance, func()) {
 	i32 := wasm.ValueTypeI32
-	ft := &wasm.FunctionType{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}}
+	ft := &wasm.FunctionType{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1}
 
 	hostFnVal := reflect.ValueOf(divBy)
 	hostFnModule := &wasm.Module{

--- a/internal/wasm/binary/code.go
+++ b/internal/wasm/binary/code.go
@@ -48,7 +48,7 @@ func decodeCode(r *bytes.Reader) (*wasm.Code, error) {
 		}
 		switch vt := b; vt {
 		case wasm.ValueTypeI32, wasm.ValueTypeF32, wasm.ValueTypeI64, wasm.ValueTypeF64,
-			wasm.ValueTypeFuncref, wasm.ValueTypeExternref:
+			wasm.ValueTypeFuncref, wasm.ValueTypeExternref, wasm.ValueTypeVector:
 			types = append(types, vt)
 		default:
 			return nil, fmt.Errorf("invalid local type: 0x%x", vt)

--- a/internal/wasm/binary/code.go
+++ b/internal/wasm/binary/code.go
@@ -48,7 +48,7 @@ func decodeCode(r *bytes.Reader) (*wasm.Code, error) {
 		}
 		switch vt := b; vt {
 		case wasm.ValueTypeI32, wasm.ValueTypeF32, wasm.ValueTypeI64, wasm.ValueTypeF64,
-			wasm.ValueTypeFuncref, wasm.ValueTypeExternref, wasm.ValueTypeVector:
+			wasm.ValueTypeFuncref, wasm.ValueTypeExternref, wasm.ValueTypeV128:
 			types = append(types, vt)
 		default:
 			return nil, fmt.Errorf("invalid local type: 0x%x", vt)

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -30,8 +30,14 @@ func TestDecodeModule(t *testing.T) {
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					{},
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
+						ParamNumInUint64:  2,
+						ResultNumInUint64: 1,
+					},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32},
+						ParamNumInUint64:  4,
+						ResultNumInUint64: 1,
+					},
 				},
 			},
 		},
@@ -39,8 +45,14 @@ func TestDecodeModule(t *testing.T) {
 			name: "type and import section",
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
-					{Params: []wasm.ValueType{f32, f32}, Results: []wasm.ValueType{f32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
+						ParamNumInUint64:  2,
+						ResultNumInUint64: 1,
+					},
+					{Params: []wasm.ValueType{f32, f32}, Results: []wasm.ValueType{f32},
+						ParamNumInUint64:  2,
+						ResultNumInUint64: 1,
+					},
 				},
 				ImportSection: []*wasm.Import{
 					{

--- a/internal/wasm/binary/function.go
+++ b/internal/wasm/binary/function.go
@@ -97,6 +97,6 @@ func decodeFunctionType(enabledFeatures wasm.Features, r *bytes.Reader) (*wasm.F
 		Results: resultTypes,
 	}
 
-	ret.CacheResultsNumInUint64()
+	ret.CacheNumInUint64()
 	return ret, nil
 }

--- a/internal/wasm/binary/function.go
+++ b/internal/wasm/binary/function.go
@@ -92,8 +92,11 @@ func decodeFunctionType(enabledFeatures wasm.Features, r *bytes.Reader) (*wasm.F
 		return nil, fmt.Errorf("could not read result types: %w", err)
 	}
 
-	return &wasm.FunctionType{
+	ret := &wasm.FunctionType{
 		Params:  paramTypes,
 		Results: resultTypes,
-	}, nil
+	}
+
+	ret.CacheResultsNumInUint64()
+	return ret, nil
 }

--- a/internal/wasm/binary/function_test.go
+++ b/internal/wasm/binary/function_test.go
@@ -23,52 +23,52 @@ func TestFunctionType(t *testing.T) {
 		},
 		{
 			name:     "one param no result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1},
 			expected: []byte{0x60, 1, i32, 0},
 		},
 		{
 			name:     "no param one result",
-			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32}},
+			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32}, ResultNumInUint64: 1},
 			expected: []byte{0x60, 0, 1, i32},
 		},
 		{
 			name:     "one param one result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 			expected: []byte{0x60, 1, i64, 1, i32},
 		},
 		{
 			name:     "two params no result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, ParamNumInUint64: 2},
 			expected: []byte{0x60, 2, i32, i64, 0},
 		},
 		{
 			name:     "two param one result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
 			expected: []byte{0x60, 2, i32, i64, 1, i32},
 		},
 		{
 			name:     "no param two results",
-			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}},
+			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}, ResultNumInUint64: 2},
 			expected: []byte{0x60, 0, 2, i32, i64},
 		},
 		{
 			name:     "one param two results",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32, i64}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32, i64}, ParamNumInUint64: 1, ResultNumInUint64: 2},
 			expected: []byte{0x60, 1, i64, 2, i32, i64},
 		},
 		{
 			name:     "two param two results",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32, i64}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32, i64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 			expected: []byte{0x60, 2, i32, i64, 2, i32, i64},
 		},
 		{
 			name:     "two param two results with funcrefs",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, funcRef}, Results: []wasm.ValueType{funcRef, i64}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, funcRef}, Results: []wasm.ValueType{funcRef, i64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 			expected: []byte{0x60, 2, i32, funcRef, 2, funcRef, i64},
 		},
 		{
 			name:     "two param two results with externrefs",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, externRef}, Results: []wasm.ValueType{externRef, i64}},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, externRef}, Results: []wasm.ValueType{externRef, i64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 			expected: []byte{0x60, 2, i32, externRef, 2, externRef, i64},
 		},
 	}

--- a/internal/wasm/binary/value.go
+++ b/internal/wasm/binary/value.go
@@ -20,6 +20,7 @@ var encodedValTypes = map[wasm.ValueType][]byte{
 	wasm.ValueTypeF64:       {1, wasm.ValueTypeF64},
 	wasm.ValueTypeExternref: {1, wasm.ValueTypeExternref},
 	wasm.ValueTypeFuncref:   {1, wasm.ValueTypeFuncref},
+	wasm.ValueTypeVector:    {1, wasm.ValueTypeVector},
 }
 
 // encodeValTypes fast paths binary encoding of common value type lengths
@@ -58,7 +59,7 @@ func decodeValueTypes(r *bytes.Reader, num uint32) ([]wasm.ValueType, error) {
 	for i, v := range buf {
 		switch v {
 		case wasm.ValueTypeI32, wasm.ValueTypeF32, wasm.ValueTypeI64, wasm.ValueTypeF64,
-			wasm.ValueTypeExternref, wasm.ValueTypeFuncref:
+			wasm.ValueTypeExternref, wasm.ValueTypeFuncref, wasm.ValueTypeVector:
 			ret[i] = v
 		default:
 			return nil, fmt.Errorf("invalid value type: %d", v)

--- a/internal/wasm/binary/value.go
+++ b/internal/wasm/binary/value.go
@@ -20,7 +20,7 @@ var encodedValTypes = map[wasm.ValueType][]byte{
 	wasm.ValueTypeF64:       {1, wasm.ValueTypeF64},
 	wasm.ValueTypeExternref: {1, wasm.ValueTypeExternref},
 	wasm.ValueTypeFuncref:   {1, wasm.ValueTypeFuncref},
-	wasm.ValueTypeVector:    {1, wasm.ValueTypeVector},
+	wasm.ValueTypeV128:      {1, wasm.ValueTypeV128},
 }
 
 // encodeValTypes fast paths binary encoding of common value type lengths
@@ -59,7 +59,7 @@ func decodeValueTypes(r *bytes.Reader, num uint32) ([]wasm.ValueType, error) {
 	for i, v := range buf {
 		switch v {
 		case wasm.ValueTypeI32, wasm.ValueTypeF32, wasm.ValueTypeI64, wasm.ValueTypeF64,
-			wasm.ValueTypeExternref, wasm.ValueTypeFuncref, wasm.ValueTypeVector:
+			wasm.ValueTypeExternref, wasm.ValueTypeFuncref, wasm.ValueTypeV128:
 			ret[i] = v
 		default:
 			return nil, fmt.Errorf("invalid value type: %d", v)

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1494,19 +1494,19 @@ func DecodeBlockType(types []*FunctionType, r *bytes.Reader, enabledFeatures Fea
 	case -64: // 0x40 in original byte = nil
 		ret = &FunctionType{}
 	case -1: // 0x7f in original byte = i32
-		ret = &FunctionType{Results: []ValueType{ValueTypeI32}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeI32}, ResultNumInUint64: 1}
 	case -2: // 0x7e in original byte = i64
-		ret = &FunctionType{Results: []ValueType{ValueTypeI64}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeI64}, ResultNumInUint64: 1}
 	case -3: // 0x7d in original byte = f32
-		ret = &FunctionType{Results: []ValueType{ValueTypeF32}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeF32}, ResultNumInUint64: 1}
 	case -4: // 0x7c in original byte = f64
-		ret = &FunctionType{Results: []ValueType{ValueTypeF64}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeF64}, ResultNumInUint64: 1}
 	case -5: // 0x7b in original byte = f64
-		ret = &FunctionType{Results: []ValueType{ValueTypeVector}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeVector}, ResultNumInUint64: 2}
 	case -16: // 0x70 in original byte = funcref
-		ret = &FunctionType{Results: []ValueType{ValueTypeExternref}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeExternref}, ResultNumInUint64: 1}
 	case -17: // 0x6f in original byte = externref
-		ret = &FunctionType{Results: []ValueType{ValueTypeExternref}}
+		ret = &FunctionType{Results: []ValueType{ValueTypeExternref}, ResultNumInUint64: 1}
 	default:
 		if err = enabledFeatures.Require(FeatureMultiValue); err != nil {
 			return nil, num, fmt.Errorf("block with function type return invalid as %v", err)
@@ -1516,7 +1516,5 @@ func DecodeBlockType(types []*FunctionType, r *bytes.Reader, enabledFeatures Fea
 		}
 		ret = types[raw]
 	}
-
-	ret.CacheNumInUint64()
 	return ret, num, err
 }

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1491,7 +1491,7 @@ type controlBlock struct {
 	op Opcode
 }
 
-// decodeBlockTypeImpl decodes the type index from a positive 33-bit signed integer. Negative numbers indicate up to one
+// DecodeBlockType decodes the type index from a positive 33-bit signed integer. Negative numbers indicate up to one
 // WebAssembly 1.0 (20191205) compatible result type. Positive numbers are decoded when `enabledFeatures` include
 // FeatureMultiValue and include an index in the Module.TypeSection.
 //

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1059,6 +1059,20 @@ func (m *Module) validateFunctionWithMaxStackValues(
 				}
 				pc += 16
 				valueTypeStack.push(ValueTypeVector)
+			case OpcodeVecI32x4Add:
+				for i := 0; i < 2; i++ {
+					if err := valueTypeStack.popAndVerifyType(ValueTypeVector); err != nil {
+						return fmt.Errorf("cannot pop the operand for %s: %v", OpcodeVecI32x4AddName, err)
+					}
+				}
+				valueTypeStack.push(ValueTypeVector)
+			case OpcodeVecI64x2Add:
+				for i := 0; i < 2; i++ {
+					if err := valueTypeStack.popAndVerifyType(ValueTypeVector); err != nil {
+						return fmt.Errorf("cannot pop the operand for %s: %v", OpcodeVecI64x2AddName, err)
+					}
+				}
+				valueTypeStack.push(ValueTypeVector)
 			default:
 				return fmt.Errorf("TODO: SIMD instruction %s will be implemented in #506", vectorInstructionName[vecOpcode])
 			}

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1044,7 +1044,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			}
 		} else if op == OpcodeVecPrefix {
 			pc++
-			// Vector instructions come with two bytes which starts with OpcodeVecPrefix,
+			// Vector instructions come with two bytes where the first byte is always OpcodeVecPrefix,
 			// and the second byte determines the actual instruction.
 			vecOpcode := body[pc]
 			if err := enabledFeatures.Require(FeatureSIMD); err != nil {
@@ -1052,6 +1052,13 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			}
 
 			switch vecOpcode {
+			case OpcodeVecV128Const:
+				// Read 128-bit = 16 bytes constants
+				if int(pc+16) >= len(body) {
+					return fmt.Errorf("cannot read constant vector value for %s", vectorInstructionName[vecOpcode])
+				}
+				pc += 16
+				valueTypeStack.push(ValueTypeVector)
 			default:
 				return fmt.Errorf("TODO: SIMD instruction %s will be implemented in #506", vectorInstructionName[vecOpcode])
 			}

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1510,6 +1510,8 @@ func decodeBlockTypeImpl(functionTypeResolver func(index int64) (*FunctionType, 
 		ret = &FunctionType{Results: []ValueType{ValueTypeF32}}
 	case -4: // 0x7c in original byte = f64
 		ret = &FunctionType{Results: []ValueType{ValueTypeF64}}
+	case -5: // 0x7b in original byte = f64
+		ret = &FunctionType{Results: []ValueType{ValueTypeVector}}
 	case -16: // 0x70 in original byte = funcref
 		ret = &FunctionType{Results: []ValueType{ValueTypeExternref}}
 	case -17: // 0x6f in original byte = externref

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1058,21 +1058,21 @@ func (m *Module) validateFunctionWithMaxStackValues(
 					return fmt.Errorf("cannot read constant vector value for %s", vectorInstructionName[vecOpcode])
 				}
 				pc += 16
-				valueTypeStack.push(ValueTypeVector)
+				valueTypeStack.push(ValueTypeV128)
 			case OpcodeVecI32x4Add:
 				for i := 0; i < 2; i++ {
-					if err := valueTypeStack.popAndVerifyType(ValueTypeVector); err != nil {
+					if err := valueTypeStack.popAndVerifyType(ValueTypeV128); err != nil {
 						return fmt.Errorf("cannot pop the operand for %s: %v", OpcodeVecI32x4AddName, err)
 					}
 				}
-				valueTypeStack.push(ValueTypeVector)
+				valueTypeStack.push(ValueTypeV128)
 			case OpcodeVecI64x2Add:
 				for i := 0; i < 2; i++ {
-					if err := valueTypeStack.popAndVerifyType(ValueTypeVector); err != nil {
+					if err := valueTypeStack.popAndVerifyType(ValueTypeV128); err != nil {
 						return fmt.Errorf("cannot pop the operand for %s: %v", OpcodeVecI64x2AddName, err)
 					}
 				}
-				valueTypeStack.push(ValueTypeVector)
+				valueTypeStack.push(ValueTypeV128)
 			default:
 				return fmt.Errorf("TODO: SIMD instruction %s will be implemented in #506", vectorInstructionName[vecOpcode])
 			}
@@ -1516,7 +1516,7 @@ func DecodeBlockType(types []*FunctionType, r *bytes.Reader, enabledFeatures Fea
 	case -4: // 0x7c in original byte = f64
 		ret = &FunctionType{Results: []ValueType{ValueTypeF64}, ResultNumInUint64: 1}
 	case -5: // 0x7b in original byte = f64
-		ret = &FunctionType{Results: []ValueType{ValueTypeVector}, ResultNumInUint64: 2}
+		ret = &FunctionType{Results: []ValueType{ValueTypeV128}, ResultNumInUint64: 2}
 	case -16: // 0x70 in original byte = funcref
 		ret = &FunctionType{Results: []ValueType{ValueTypeExternref}, ResultNumInUint64: 1}
 	case -17: // 0x6f in original byte = externref

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -2760,7 +2760,7 @@ func TestModule_funcValidation_SIMD_error(t *testing.T) {
 				OpcodeEnd,
 			},
 			flag:        FeatureSIMD,
-			expectedErr: "cannot pop the operand for i32x4.add: i128 missing",
+			expectedErr: "cannot pop the operand for i32x4.add: v128 missing",
 		},
 		{
 			name: "i64x2.add operand",
@@ -2775,7 +2775,7 @@ func TestModule_funcValidation_SIMD_error(t *testing.T) {
 				OpcodeEnd,
 			},
 			flag:        FeatureSIMD,
-			expectedErr: "cannot pop the operand for i64x2.add: i128 missing",
+			expectedErr: "cannot pop the operand for i64x2.add: v128 missing",
 		},
 		{
 			// TODO delete this case after SIMD impl completion.

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -2672,6 +2672,40 @@ func TestModule_funcValidation_SIMD(t *testing.T) {
 				OpcodeEnd,
 			},
 		},
+		{
+			name: "i32x4.add",
+			body: []byte{
+				OpcodeVecPrefix,
+				OpcodeVecV128Const,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				OpcodeVecPrefix,
+				OpcodeVecV128Const,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				OpcodeVecPrefix,
+				OpcodeVecI32x4Add,
+				OpcodeDrop,
+				OpcodeEnd,
+			},
+		},
+		{
+			name: "i64x2.add",
+			body: []byte{
+				OpcodeVecPrefix,
+				OpcodeVecV128Const,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				OpcodeVecPrefix,
+				OpcodeVecV128Const,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				OpcodeVecPrefix,
+				OpcodeVecI64x2Add,
+				OpcodeDrop,
+				OpcodeEnd,
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -2712,6 +2746,36 @@ func TestModule_funcValidation_SIMD_error(t *testing.T) {
 			},
 			flag:        FeatureSIMD,
 			expectedErr: "cannot read constant vector value for v128.const",
+		},
+		{
+			name: "i32x4.add operand",
+			body: []byte{
+				OpcodeVecPrefix,
+				OpcodeVecV128Const,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				OpcodeVecPrefix,
+				OpcodeVecI32x4Add,
+				OpcodeDrop,
+				OpcodeEnd,
+			},
+			flag:        FeatureSIMD,
+			expectedErr: "cannot pop the operand for i32x4.add: i128 missing",
+		},
+		{
+			name: "i64x2.add operand",
+			body: []byte{
+				OpcodeVecPrefix,
+				OpcodeVecV128Const,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 1, 1, 1, 1, 1,
+				OpcodeVecPrefix,
+				OpcodeVecI64x2Add,
+				OpcodeDrop,
+				OpcodeEnd,
+			},
+			flag:        FeatureSIMD,
+			expectedErr: "cannot pop the operand for i64x2.add: i128 missing",
 		},
 		{
 			// TODO delete this case after SIMD impl completion.

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -178,6 +178,7 @@ func getFunctionType(fn *reflect.Value, enabledFeatures Features) (fk FunctionKi
 	}
 
 	ft = &FunctionType{Params: make([]ValueType, p.NumIn()-pOffset), Results: make([]ValueType, rCount)}
+	ft.CacheNumInUint64()
 
 	for i := 0; i < len(ft.Params); i++ {
 		pI := p.In(i + pOffset)

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -49,7 +49,7 @@ func TestGetFunctionType(t *testing.T) {
 			name:         "all supported params and i32 result",
 			inputFunc:    func(uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoNoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
 		},
 		{
 			name: "all supported params and all supported results",
@@ -58,27 +58,28 @@ func TestGetFunctionType(t *testing.T) {
 			},
 			expectedKind: FunctionKindGoNoContext,
 			expectedType: &FunctionType{
-				Params:  []ValueType{i32, i64, f32, f64, externref},
-				Results: []ValueType{i32, i64, f32, f64, externref},
+				Params:           []ValueType{i32, i64, f32, f64, externref},
+				Results:          []ValueType{i32, i64, f32, f64, externref},
+				ParamNumInUint64: 5, ResultNumInUint64: 5,
 			},
 		},
 		{
 			name:         "all supported params and i32 result - wasm.Module",
 			inputFunc:    func(api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoModule,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
 		},
 		{
 			name:         "all supported params and i32 result - context.Context",
 			inputFunc:    func(context.Context, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
 		},
 		{
 			name:         "all supported params and i32 result - context.Context and api.Module",
 			inputFunc:    func(context.Context, api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoContextModule,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -65,8 +65,8 @@ func TestNewHostModule(t *testing.T) {
 			},
 			expected: &Module{
 				TypeSection: []*FunctionType{
-					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}},
-					{Params: []ValueType{i32, i32, i32, i32}, Results: []ValueType{i32}},
+					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+					{Params: []ValueType{i32, i32, i32, i32}, Results: []ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []Index{0, 1},
 				HostFunctionSection: []*reflect.Value{&fnArgsSizesGet, &fnFdWrite},
@@ -90,7 +90,7 @@ func TestNewHostModule(t *testing.T) {
 				functionSwap: swap,
 			},
 			expected: &Module{
-				TypeSection:         []*FunctionType{{Params: []ValueType{i32, i32}, Results: []ValueType{i32, i32}}},
+				TypeSection:         []*FunctionType{{Params: []ValueType{i32, i32}, Results: []ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2}},
 				FunctionSection:     []Index{0},
 				HostFunctionSection: []*reflect.Value{&fnSwap},
 				ExportSection:       []*Export{{Name: "swap", Type: ExternTypeFunc, Index: 0}},
@@ -151,7 +151,7 @@ func TestNewHostModule(t *testing.T) {
 			},
 			expected: &Module{
 				TypeSection: []*FunctionType{
-					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}},
+					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
 				},
 				FunctionSection:     []Index{0},
 				HostFunctionSection: []*reflect.Value{&fnArgsSizesGet},

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -640,10 +640,10 @@ func (me *moduleEngine) Call(ctx context.Context, m *wasm.CallContext, f *wasm.F
 		return
 	}
 
-	paramSignature := f.Type.Params
+	paramSignature := f.Type.ParamNumInUint64
 	paramCount := len(params)
-	if len(paramSignature) != paramCount {
-		return nil, fmt.Errorf("expected %d params, but passed %d", len(paramSignature), paramCount)
+	if paramSignature != paramCount {
+		return nil, fmt.Errorf("expected %d params, but passed %d", paramSignature, paramCount)
 	}
 
 	ce := me.newCallEngine()

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -674,6 +674,7 @@ func (me *moduleEngine) Call(ctx context.Context, m *wasm.CallContext, f *wasm.F
 			ce.pushValue(param)
 		}
 		ce.callNativeFunc(ctx, m, compiled)
+		fmt.Println(f.Type.ResultNumInUint64)
 		results = wasm.PopValues(f.Type.ResultNumInUint64, ce.popValue)
 		if f.FunctionListener != nil {
 			// TODO: This doesn't get the error due to use of panic to propagate them.
@@ -722,6 +723,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 		// TODO: add description of each operation/case
 		// on, for example, how many args are used,
 		// how the stack is modified, etc.
+		fmt.Println(op.kind.String())
 		switch op.kind {
 		case wazeroir.OperationKindUnreachable:
 			panic(wasmruntime.ErrRuntimeUnreachable)
@@ -791,6 +793,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 			}
 		case wazeroir.OperationKindDrop:
 			{
+				fmt.Println(op.rs[0])
 				ce.drop(op.rs[0])
 				frame.pc++
 			}

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -575,6 +575,10 @@ func (e *engine) lowerIR(ir *wazeroir.CompilationResult) (*code, error) {
 		case *wazeroir.OperationTableFill:
 			op.us = make([]uint64, 1)
 			op.us[0] = uint64(o.TableIndex)
+		case *wazeroir.OperationConstI128:
+			op.us = make([]uint64, 2)
+			op.us[0] = o.Lo
+			op.us[1] = o.Hi
 		default:
 			return nil, fmt.Errorf("unreachable: a bug in wazeroir engine")
 		}
@@ -1922,6 +1926,11 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 					copy(targetRegion[i:], targetRegion[:i])
 				}
 			}
+			frame.pc++
+		case wazeroir.OperationKindConstI128:
+			lo, hi := op.us[0], op.us[1]
+			ce.pushValue(lo)
+			ce.pushValue(hi)
 			frame.pc++
 		}
 	}

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -674,7 +674,7 @@ func (me *moduleEngine) Call(ctx context.Context, m *wasm.CallContext, f *wasm.F
 			ce.pushValue(param)
 		}
 		ce.callNativeFunc(ctx, m, compiled)
-		results = wasm.PopValues(len(f.Type.Results), ce.popValue)
+		results = wasm.PopValues(f.Type.ResultNumInUint64, ce.popValue)
 		if f.FunctionListener != nil {
 			// TODO: This doesn't get the error due to use of panic to propagate them.
 			f.FunctionListener.After(ctx, nil, results)

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -674,7 +674,6 @@ func (me *moduleEngine) Call(ctx context.Context, m *wasm.CallContext, f *wasm.F
 			ce.pushValue(param)
 		}
 		ce.callNativeFunc(ctx, m, compiled)
-		fmt.Println(f.Type.ResultNumInUint64)
 		results = wasm.PopValues(f.Type.ResultNumInUint64, ce.popValue)
 		if f.FunctionListener != nil {
 			// TODO: This doesn't get the error due to use of panic to propagate them.
@@ -723,7 +722,6 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 		// TODO: add description of each operation/case
 		// on, for example, how many args are used,
 		// how the stack is modified, etc.
-		fmt.Println(op.kind.String())
 		switch op.kind {
 		case wazeroir.OperationKindUnreachable:
 			panic(wasmruntime.ErrRuntimeUnreachable)
@@ -793,7 +791,6 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 			}
 		case wazeroir.OperationKindDrop:
 			{
-				fmt.Println(op.rs[0])
 				ce.drop(op.rs[0])
 				frame.pc++
 			}

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -819,11 +819,17 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 			{
 				g := globals[op.us[0]] // TODO: Not yet traceable as it doesn't use the types in global.go
 				ce.pushValue(g.Val)
+				if g.Type.ValType == wasm.ValueTypeVector {
+					ce.pushValue(g.ValHi)
+				}
 				frame.pc++
 			}
 		case wazeroir.OperationKindGlobalSet:
 			{
 				g := globals[op.us[0]] // TODO: Not yet traceable as it doesn't use the types in global.go
+				if g.Type.ValType == wasm.ValueTypeVector {
+					g.ValHi = ce.popValue()
+				}
 				g.Val = ce.popValue()
 				frame.pc++
 			}

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -1929,6 +1929,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 			frame.pc++
 		case wazeroir.OperationKindConstI128:
 			lo, hi := op.us[0], op.us[1]
+			fmt.Println("low, hi =", lo, ",", hi)
 			ce.pushValue(lo)
 			ce.pushValue(hi)
 			frame.pc++

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -821,7 +821,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 			{
 				g := globals[op.us[0]] // TODO: Not yet traceable as it doesn't use the types in global.go
 				ce.pushValue(g.Val)
-				if g.Type.ValType == wasm.ValueTypeVector {
+				if g.Type.ValType == wasm.ValueTypeV128 {
 					ce.pushValue(g.ValHi)
 				}
 				frame.pc++
@@ -829,7 +829,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 		case wazeroir.OperationKindGlobalSet:
 			{
 				g := globals[op.us[0]] // TODO: Not yet traceable as it doesn't use the types in global.go
-				if g.Type.ValType == wasm.ValueTypeVector {
+				if g.Type.ValType == wasm.ValueTypeV128 {
 					g.ValHi = ce.popValue()
 				}
 				g.Val = ce.popValue()

--- a/internal/wasm/interpreter/interpreter.go
+++ b/internal/wasm/interpreter/interpreter.go
@@ -1949,8 +1949,8 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 		case wazeroir.OperationKindI64x2Add:
 			xHigh, xLow := ce.popValue(), ce.popValue()
 			yHigh, yLow := ce.popValue(), ce.popValue()
-			ce.pushValue(xHigh + yHigh)
 			ce.pushValue(xLow + yLow)
+			ce.pushValue(xHigh + yHigh)
 			frame.pc++
 		}
 	}

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -2,6 +2,7 @@ package jit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -866,6 +867,8 @@ func compileWasmFunction(enabledFeatures wasm.Features, ir *wazeroir.Compilation
 		}
 		var err error
 		switch o := op.(type) {
+		case *wazeroir.OperationLabel:
+			// Label op is already handled ^^.
 		case *wazeroir.OperationUnreachable:
 			err = compiler.compileUnreachable()
 		case *wazeroir.OperationBr:
@@ -1038,6 +1041,8 @@ func compileWasmFunction(enabledFeatures wasm.Features, ir *wazeroir.Compilation
 			err = compiler.compileTableSize(o)
 		case *wazeroir.OperationTableFill:
 			err = compiler.compileTableFill(o)
+		default:
+			err = errors.New("unsupported")
 		}
 		if err != nil {
 			return nil, fmt.Errorf("operation %s: %w", op.Kind().String(), err)

--- a/internal/wasm/jit/engine.go
+++ b/internal/wasm/jit/engine.go
@@ -600,7 +600,7 @@ func (me *moduleEngine) Call(ctx context.Context, callCtx *wasm.CallContext, f *
 			ce.pushValue(v)
 		}
 		ce.execWasmFunction(ctx, callCtx, compiled)
-		results = wasm.PopValues(len(f.Type.Results), ce.popValue)
+		results = wasm.PopValues(f.Type.ResultNumInUint64, ce.popValue)
 	} else {
 		results = wasm.CallGoFunc(ctx, callCtx, compiled.source, params)
 	}

--- a/internal/wasm/jit/engine_test.go
+++ b/internal/wasm/jit/engine_test.go
@@ -298,7 +298,7 @@ func TestJIT_SliceAllocatedOnHeap(t *testing.T) {
 	const expectedReturnValue = 0x1
 	m := &wasm.Module{
 		TypeSection: []*wasm.FunctionType{
-			{Params: []wasm.ValueType{}, Results: []wasm.ValueType{wasm.ValueTypeI32}},
+			{Params: []wasm.ValueType{}, Results: []wasm.ValueType{wasm.ValueTypeI32}, ResultNumInUint64: 1},
 			{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}},
 		},
 		FunctionSection: []wasm.Index{

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -667,6 +667,20 @@ type FunctionType struct {
 
 	// string is cached as it is used both for String and key
 	string string
+
+	// ResultsNumInUint64 is the result of ResultsNumInUint64.
+	ResultNumInUint64 int
+}
+
+func (f *FunctionType) CacheResultsNumInUint64() (cnt int) {
+	for _, tp := range f.Results {
+		cnt++
+		if tp == ValueTypeVector {
+			cnt++
+		}
+	}
+	f.ResultNumInUint64 = cnt
+	return
 }
 
 // EqualsSignature returns true if the function type has the same parameters and results.

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -668,19 +668,27 @@ type FunctionType struct {
 	// string is cached as it is used both for String and key
 	string string
 
-	// ResultsNumInUint64 is the result of ResultsNumInUint64.
+	// ParamNumInUint64 is the number of uint64 values requires to represent the Wasm param type.
+	ParamNumInUint64 int
+
+	// ResultsNumInUint64 is the number of uint64 values requires to represent the Wasm result type.
 	ResultNumInUint64 int
 }
 
-func (f *FunctionType) CacheResultsNumInUint64() (cnt int) {
-	for _, tp := range f.Results {
-		cnt++
+func (f *FunctionType) CacheNumInUint64() {
+	for _, tp := range f.Params {
+		f.ParamNumInUint64++
 		if tp == ValueTypeVector {
-			cnt++
+			f.ParamNumInUint64++
 		}
 	}
-	f.ResultNumInUint64 = cnt
-	return
+
+	for _, tp := range f.Results {
+		f.ResultNumInUint64++
+		if tp == ValueTypeVector {
+			f.ResultNumInUint64++
+		}
+	}
 }
 
 // EqualsSignature returns true if the function type has the same parameters and results.

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -972,10 +972,11 @@ func SectionIDName(sectionID SectionID) string {
 type ValueType = api.ValueType
 
 const (
-	ValueTypeI32 = api.ValueTypeI32
-	ValueTypeI64 = api.ValueTypeI64
-	ValueTypeF32 = api.ValueTypeF32
-	ValueTypeF64 = api.ValueTypeF64
+	ValueTypeI32    = api.ValueTypeI32
+	ValueTypeI64    = api.ValueTypeI64
+	ValueTypeF32    = api.ValueTypeF32
+	ValueTypeF64    = api.ValueTypeF64
+	ValueTypeVector = api.ValueTypeVector
 	// TODO: ValueTypeFuncref is not exposed in the api pkg yet.
 	ValueTypeFuncref   ValueType = 0x70
 	ValueTypeExternref ValueType = api.ValueTypeExternref

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -530,7 +530,7 @@ func validateConstExpression(globals []*GlobalType, numFuncs uint32, expr *Const
 		if len(expr.Data) != 16 {
 			return fmt.Errorf("%s needs 16 bytes but was %d bytes", OpcodeVecV128ConstName, len(expr.Data))
 		}
-		actualType = ValueTypeVector
+		actualType = ValueTypeV128
 	default:
 		return fmt.Errorf("invalid opcode for const expression: 0x%x", expr.Opcode)
 	}
@@ -685,14 +685,14 @@ type FunctionType struct {
 func (f *FunctionType) CacheNumInUint64() {
 	for _, tp := range f.Params {
 		f.ParamNumInUint64++
-		if tp == ValueTypeVector {
+		if tp == ValueTypeV128 {
 			f.ParamNumInUint64++
 		}
 	}
 
 	for _, tp := range f.Results {
 		f.ResultNumInUint64++
-		if tp == ValueTypeVector {
+		if tp == ValueTypeV128 {
 			f.ResultNumInUint64++
 		}
 	}
@@ -1001,11 +1001,11 @@ func SectionIDName(sectionID SectionID) string {
 type ValueType = api.ValueType
 
 const (
-	ValueTypeI32    = api.ValueTypeI32
-	ValueTypeI64    = api.ValueTypeI64
-	ValueTypeF32    = api.ValueTypeF32
-	ValueTypeF64    = api.ValueTypeF64
-	ValueTypeVector = api.ValueTypeVector
+	ValueTypeI32  = api.ValueTypeI32
+	ValueTypeI64  = api.ValueTypeI64
+	ValueTypeF32  = api.ValueTypeF32
+	ValueTypeF64  = api.ValueTypeF64
+	ValueTypeV128 = api.ValueTypeV128
 	// TODO: ValueTypeFuncref is not exposed in the api pkg yet.
 	ValueTypeFuncref   ValueType = 0x70
 	ValueTypeExternref ValueType = api.ValueTypeExternref

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -526,6 +526,11 @@ func validateConstExpression(globals []*GlobalType, numFuncs uint32, expr *Const
 			return fmt.Errorf("ref.func index out of range [%d] with length %d", index, numFuncs-1)
 		}
 		actualType = ValueTypeFuncref
+	case OpcodeVecV128Const:
+		if len(expr.Data) != 16 {
+			return fmt.Errorf("%s needs 16 bytes but was %d bytes", OpcodeVecV128ConstName, len(expr.Data))
+		}
+		actualType = ValueTypeVector
 	default:
 		return fmt.Errorf("invalid opcode for const expression: 0x%x", expr.Opcode)
 	}
@@ -547,20 +552,22 @@ func (m *Module) validateDataCountSection() (err error) {
 
 func (m *Module) buildGlobals(importedGlobals []*GlobalInstance) (globals []*GlobalInstance) {
 	for _, gs := range m.GlobalSection {
-		var gv uint64
+		g := &GlobalInstance{Type: gs.Type}
 		switch v := executeConstExpression(importedGlobals, gs.Init).(type) {
 		case int32:
-			gv = uint64(v)
+			g.Val = uint64(v)
 		case int64:
-			gv = uint64(v)
+			g.Val = uint64(v)
 		case float32:
-			gv = api.EncodeF32(v)
+			g.Val = api.EncodeF32(v)
 		case float64:
-			gv = api.EncodeF64(v)
+			g.Val = api.EncodeF64(v)
+		case [2]uint64:
+			g.Val, g.ValHi = v[0], v[1]
 		default:
 			panic(fmt.Errorf("BUG: invalid conversion %d", v))
 		}
-		globals = append(globals, &GlobalInstance{Type: gs.Type, Val: gv})
+		globals = append(globals, g)
 	}
 	return
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -732,7 +732,7 @@ func TestModule_validateExports(t *testing.T) {
 	}
 }
 
-func TestModule_buildGlobalInstances(t *testing.T) {
+func TestModule_buildGlobals(t *testing.T) {
 	m := Module{GlobalSection: []*Global{
 		{
 			Type: &GlobalType{Mutable: true, ValType: ValueTypeF64},
@@ -744,17 +744,27 @@ func TestModule_buildGlobalInstances(t *testing.T) {
 			Init: &ConstantExpression{Opcode: OpcodeI32Const,
 				Data: leb128.EncodeInt32(math.MaxInt32)},
 		},
+		{
+			Type: &GlobalType{Mutable: false, ValType: ValueTypeVector},
+			Init: &ConstantExpression{Opcode: OpcodeVecV128Const,
+				Data: []byte{
+					1, 0, 0, 0, 0, 0, 0, 0,
+					2, 0, 0, 0, 0, 0, 0, 0,
+				},
+			},
+		},
 	}}
 
 	globals := m.buildGlobals(nil)
 	expectedGlobals := []*GlobalInstance{
 		{Type: &GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: api.EncodeF64(math.MaxFloat64)},
 		{Type: &GlobalType{ValType: ValueTypeI32, Mutable: false}, Val: math.MaxInt32},
+		{Type: &GlobalType{ValType: ValueTypeVector, Mutable: false}, Val: 0x1, ValHi: 0x2},
 	}
 	require.Equal(t, expectedGlobals, globals)
 }
 
-func TestModule_buildFunctionInstances(t *testing.T) {
+func TestModule_buildFunctions(t *testing.T) {
 	nopCode := &Code{nil, []byte{OpcodeEnd}}
 	m := Module{
 		TypeSection:   []*FunctionType{{}},

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -745,7 +745,7 @@ func TestModule_buildGlobals(t *testing.T) {
 				Data: leb128.EncodeInt32(math.MaxInt32)},
 		},
 		{
-			Type: &GlobalType{Mutable: false, ValType: ValueTypeVector},
+			Type: &GlobalType{Mutable: false, ValType: ValueTypeV128},
 			Init: &ConstantExpression{Opcode: OpcodeVecV128Const,
 				Data: []byte{
 					1, 0, 0, 0, 0, 0, 0, 0,
@@ -759,7 +759,7 @@ func TestModule_buildGlobals(t *testing.T) {
 	expectedGlobals := []*GlobalInstance{
 		{Type: &GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: api.EncodeF64(math.MaxFloat64)},
 		{Type: &GlobalType{ValType: ValueTypeI32, Mutable: false}, Val: math.MaxInt32},
-		{Type: &GlobalType{ValType: ValueTypeVector, Mutable: false}, Val: 0x1, ValHi: 0x2},
+		{Type: &GlobalType{ValType: ValueTypeV128, Mutable: false}, Val: 0x1, ValHi: 0x2},
 	}
 	require.Equal(t, expectedGlobals, globals)
 }

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -618,7 +618,7 @@ func executeConstExpression(importedGlobals []*GlobalInstance, expr *ConstantExp
 			v = api.DecodeF32(g.Val)
 		case ValueTypeF64:
 			v = api.DecodeF64(g.Val)
-		case ValueTypeVector:
+		case ValueTypeV128:
 			v = [2]uint64{g.Val, g.ValHi}
 		}
 	case OpcodeRefNull:

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -598,7 +598,7 @@ func TestExecuteConstExpression(t *testing.T) {
 			{valueType: ValueTypeI64, val: 20},
 			{valueType: ValueTypeF32, val: uint64(math.Float32bits(634634432.12311))},
 			{valueType: ValueTypeF64, val: math.Float64bits(1.12312311)},
-			{valueType: ValueTypeVector, val: 0x1, valHi: 0x2},
+			{valueType: ValueTypeV128, val: 0x1, valHi: 0x2},
 		} {
 			t.Run(ValueTypeName(tc.valueType), func(t *testing.T) {
 				// The index specified in Data equals zero.
@@ -625,7 +625,7 @@ func TestExecuteConstExpression(t *testing.T) {
 					actual, ok := val.(float64)
 					require.True(t, ok)
 					require.Equal(t, api.DecodeF64(tc.val), actual)
-				case ValueTypeVector:
+				case ValueTypeV128:
 					vector, ok := val.([2]uint64)
 					require.True(t, ok)
 					require.Equal(t, uint64(0x1), vector[0])

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -591,18 +591,19 @@ func TestExecuteConstExpression(t *testing.T) {
 	})
 	t.Run("global expr", func(t *testing.T) {
 		for _, tc := range []struct {
-			valueType ValueType
-			val       uint64
+			valueType  ValueType
+			val, valHi uint64
 		}{
 			{valueType: ValueTypeI32, val: 10},
 			{valueType: ValueTypeI64, val: 20},
 			{valueType: ValueTypeF32, val: uint64(math.Float32bits(634634432.12311))},
 			{valueType: ValueTypeF64, val: math.Float64bits(1.12312311)},
+			{valueType: ValueTypeVector, val: 0x1, valHi: 0x2},
 		} {
 			t.Run(ValueTypeName(tc.valueType), func(t *testing.T) {
 				// The index specified in Data equals zero.
 				expr := &ConstantExpression{Data: []byte{0}, Opcode: OpcodeGlobalGet}
-				globals := []*GlobalInstance{{Val: tc.val, Type: &GlobalType{ValType: tc.valueType}}}
+				globals := []*GlobalInstance{{Val: tc.val, ValHi: tc.valHi, Type: &GlobalType{ValType: tc.valueType}}}
 
 				val := executeConstExpression(globals, expr)
 				require.NotNil(t, val)
@@ -624,9 +625,27 @@ func TestExecuteConstExpression(t *testing.T) {
 					actual, ok := val.(float64)
 					require.True(t, ok)
 					require.Equal(t, api.DecodeF64(tc.val), actual)
+				case ValueTypeVector:
+					vector, ok := val.([2]uint64)
+					require.True(t, ok)
+					require.Equal(t, uint64(0x1), vector[0])
+					require.Equal(t, uint64(0x2), vector[1])
 				}
 			})
 		}
+	})
+
+	t.Run("vector", func(t *testing.T) {
+		expr := &ConstantExpression{Data: []byte{
+			1, 0, 0, 0, 0, 0, 0, 0,
+			2, 0, 0, 0, 0, 0, 0, 0,
+		}, Opcode: OpcodeVecV128Const}
+		val := executeConstExpression(nil, expr)
+		require.NotNil(t, val)
+		vector, ok := val.([2]uint64)
+		require.True(t, ok)
+		require.Equal(t, uint64(0x1), vector[0])
+		require.Equal(t, uint64(0x2), vector[1])
 	})
 }
 

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -145,7 +145,7 @@ func DecodeModule(
 	}
 
 	for _, tp := range module.TypeSection {
-		tp.CacheResultsNumInUint64()
+		tp.CacheNumInUint64()
 	}
 	return
 }

--- a/internal/wasm/text/decoder.go
+++ b/internal/wasm/text/decoder.go
@@ -108,7 +108,7 @@ func DecodeModule(
 	source []byte,
 	enabledFeatures wasm.Features,
 	memorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32),
-) (result *wasm.Module, err error) {
+) (module *wasm.Module, err error) {
 	// TODO: when globals are supported, err on global vars if disabled
 
 	// names are the wasm.Module NameSection
@@ -117,7 +117,7 @@ func DecodeModule(
 	// * FunctionNames: nil when neither imported nor module-defined functions had a name
 	// * LocalNames: nil when neither imported nor module-defined functions had named (param) fields.
 	names := &wasm.NameSection{}
-	module := &wasm.Module{NameSection: names}
+	module = &wasm.Module{NameSection: names}
 	p := newModuleParser(module, enabledFeatures, memorySizer)
 	p.source = source
 
@@ -144,7 +144,10 @@ func DecodeModule(
 		module.NameSection = nil
 	}
 
-	return module, nil
+	for _, tp := range module.TypeSection {
+		tp.CacheResultsNumInUint64()
+	}
+	return
 }
 
 func newModuleParser(

--- a/internal/wasm/text/decoder_test.go
+++ b/internal/wasm/text/decoder_test.go
@@ -63,7 +63,7 @@ func TestDecodeModule(t *testing.T) {
 			input: "(module (type (func (param i32 i32) (result i32 i32))))",
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 				},
 			},
 		},
@@ -72,7 +72,7 @@ func TestDecodeModule(t *testing.T) {
 			input: "(module (type (func (param i32) (param i32) (result i32) (result i32))))",
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 				},
 			},
 		},
@@ -362,8 +362,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
 				},
 				ImportSection: []*wasm.Import{
 					{
@@ -549,7 +549,7 @@ func TestDecodeModule(t *testing.T) {
 			input: "(module (import \"\" \"\" (func (param i32 i32) (param $v i32) (param i64) (param $t f32))))",
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5},
 				},
 				ImportSection: []*wasm.Import{{Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				NameSection: &wasm.NameSection{
@@ -569,8 +569,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 9, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
 				},
 				ImportSection: []*wasm.Import{
 					{
@@ -598,7 +598,7 @@ func TestDecodeModule(t *testing.T) {
 	(import "foo" "bar" (func (type 0) (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -613,7 +613,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -628,7 +628,7 @@ func TestDecodeModule(t *testing.T) {
 	(import "foo" "bar" (func (type $i32) (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -643,7 +643,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -655,7 +655,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "import func multiple abbreviated results",
 			input: `(module (import "misc" "swap" (func $swap (param i32 i32) (result i32 i32))))`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2}},
 				ImportSection: []*wasm.Import{{
 					Module: "misc", Name: "swap",
 					Type:     wasm.ExternTypeFunc,
@@ -856,8 +856,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 9, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
 				},
 				FunctionSection: []wasm.Index{1, 2},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}, {Body: localGet0End}},
@@ -881,8 +881,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
 				},
 				FunctionSection: []wasm.Index{1, 2},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}, {Body: localGet0End}},
@@ -922,7 +922,7 @@ func TestDecodeModule(t *testing.T) {
 	(func (type 0) (param i32))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -934,7 +934,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -946,7 +946,7 @@ func TestDecodeModule(t *testing.T) {
 	(func (type $i32) (param i32))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -958,7 +958,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -1101,7 +1101,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "func param IDs",
 			input: "(module (func $one (param $x i32) (param $y i32) (result i32) local.get 0))",
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}},
 				NameSection: &wasm.NameSection{
@@ -1119,7 +1119,7 @@ func TestDecodeModule(t *testing.T) {
 			(func (param $l i32) (param $r i32) (result i32) local.get 0)
 		)`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1}},
 				FunctionSection: []wasm.Index{0, 0},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}, {Body: localGet0End}},
 				NameSection: &wasm.NameSection{
@@ -1134,7 +1134,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "func mixed param IDs", // Verifies we can handle less param fields than Params
 			input: "(module (func (param i32 i32) (param $v i32) (param i64) (param $t f32)))",
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32, i32, i64, f32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				NameSection: &wasm.NameSection{
@@ -1148,7 +1148,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "func multiple abbreviated results",
 			input: "(module (func $swap (param i32 i32) (result i32 i32) local.get 1 local.get 0))",
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0x01, wasm.OpcodeLocalGet, 0x00, wasm.OpcodeEnd}}},
 				NameSection: &wasm.NameSection{
@@ -1393,7 +1393,7 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection: []*wasm.Code{

--- a/internal/wasm/text/type_parser_test.go
+++ b/internal/wasm/text/type_parser_test.go
@@ -8,19 +8,45 @@ import (
 )
 
 var (
-	f32, f64, i32, i64              = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32, wasm.ValueTypeI64
-	i32_v                           = &wasm.FunctionType{Params: []wasm.ValueType{i32}}
-	v_i32                           = &wasm.FunctionType{Results: []wasm.ValueType{i32}}
-	v_i32i64                        = &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}}
-	f32_i32                         = &wasm.FunctionType{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}}
-	i64_i64                         = &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}
-	i32i64_v                        = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}}
-	i32i32_i32                      = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}
-	i32i64_i32                      = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32}}
-	i32i32i32i32_i32                = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}}
+	f32, f64, i32, i64 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32, wasm.ValueTypeI64
+	i32_v              = &wasm.FunctionType{Params: []wasm.ValueType{i32},
+		ParamNumInUint64: 1,
+	}
+	v_i32 = &wasm.FunctionType{Results: []wasm.ValueType{i32},
+		ResultNumInUint64: 1,
+	}
+	v_i32i64 = &wasm.FunctionType{Results: []wasm.ValueType{i32, i64},
+		ResultNumInUint64: 2,
+	}
+	f32_i32 = &wasm.FunctionType{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  1,
+		ResultNumInUint64: 1,
+	}
+	i64_i64 = &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64},
+		ParamNumInUint64:  1,
+		ResultNumInUint64: 1,
+	}
+	i32i64_v = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64},
+		ParamNumInUint64: 2,
+	}
+	i32i32_i32 = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  2,
+		ResultNumInUint64: 1,
+	}
+	i32i64_i32 = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  2,
+		ResultNumInUint64: 1,
+	}
+	i32i32i32i32_i32 = &wasm.FunctionType{
+		Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  4,
+		ResultNumInUint64: 1,
+	}
 	i32i32i32i32i32i64i64i32i32_i32 = &wasm.FunctionType{
-		Params:  []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
-		Results: []wasm.ValueType{i32},
+		Params:            []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
+		Results:           []wasm.ValueType{i32},
+		ParamNumInUint64:  9,
+		ResultNumInUint64: 1,
 	}
 )
 

--- a/internal/wasm/text/type_parser_test.go
+++ b/internal/wasm/text/type_parser_test.go
@@ -125,7 +125,7 @@ func TestTypeParser(t *testing.T) {
 		{
 			name:     "mixed param abbreviation", // Verifies we can handle less param fields than param types
 			input:    "(type (func (param i32 i32) (param i32) (param i64) (param f32)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5},
 		},
 
 		// Below are changes to test/core/br.wast from the commit that added "multi-value" support.
@@ -134,55 +134,58 @@ func TestTypeParser(t *testing.T) {
 		{
 			name:     "multi-value - v_i64f32 abbreviated",
 			input:    "(type (func (result i64 f32)))",
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
 		},
 		{
 			name:     "multi-value - i32i64_f32f64 abbreviated",
 			input:    "(type (func (param i32 i64) (result f32 f64)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 		},
 		{
 			name:     "multi-value - v_i64f32",
 			input:    "(type (func (result i64) (result f32)))",
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
 		},
 		{
 			name:     "multi-value - i32i64_f32f64",
 			input:    "(type (func (param i32) (param i64) (result f32) (result f64)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 		},
 		{
 			name:     "multi-value - i32i64_f32f64 named",
 			input:    "(type (func (param $x i32) (param $y i64) (result f32) (result f64)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
 		},
 		{
 			name:     "multi-value - i64i64f32_f32i32 results abbreviated in groups",
 			input:    "(type (func (result i64 i64 f32) (result f32 i32)))",
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32}},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32}, ResultNumInUint64: 5},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 params and results abbreviated in groups",
 			input: "(type (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32)))",
 			expected: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:           []wasm.ValueType{i32, i32, i64, i32},
+				Results:          []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64: 4, ResultNumInUint64: 4,
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "(type (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32)))",
 			expected: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:           []wasm.ValueType{i32, i32, i64, i32},
+				Results:          []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64: 4, ResultNumInUint64: 4,
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "(type (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32)))",
 			expected: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:           []wasm.ValueType{i32, i32, i64, i32},
+				Results:          []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64: 4, ResultNumInUint64: 4,
 			},
 		},
 		{
@@ -190,7 +193,7 @@ func TestTypeParser(t *testing.T) {
 			input: "(type (func (result) (result) (result i64 i64) (result) (result f32) (result)))",
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32}},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32}, ResultNumInUint64: 3},
 		},
 		{
 			name: "multi-value - empty abbreviated params and results",
@@ -201,8 +204,9 @@ func TestTypeParser(t *testing.T) {
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
 			expected: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:           []wasm.ValueType{i32, i32, i64, i32, i32},
+				Results:          []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64: 5, ResultNumInUint64: 4,
 			},
 		},
 	}
@@ -404,6 +408,9 @@ func parseFunctionType(
 	tp := newTypeParser(enabledFeatures, typeNamespace, setFunc)
 	// typeParser starts after the '(type', so we need to eat it first!
 	_, _, err := lex(skipTokens(2, tp.begin), []byte(input))
+	if parsed != nil {
+		parsed.CacheNumInUint64()
+	}
 	return parsed, tp, err
 }
 

--- a/internal/wasm/text/typeuse_parser_test.go
+++ b/internal/wasm/text/typeuse_parser_test.go
@@ -74,7 +74,7 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 		{
 			name:                "mixed param abbreviation", // Verifies we can handle less param fields than param types
 			input:               "((param i32 i32) (param i32) (param i64) (param f32))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5},
 		},
 
 		// Below are changes to test/core/br.wast from the commit that added "multi-value" support.
@@ -83,56 +83,73 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 		{
 			name:                "multi-value - v_i64f32 abbreviated",
 			input:               "((result i64 f32))",
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
 		},
 		{
-			name:                "multi-value - i32i64_f32f64 abbreviated",
-			input:               "((param i32 i64) (result f32 f64))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
+			name:  "multi-value - i32i64_f32f64 abbreviated",
+			input: "((param i32 i64) (result f32 f64))",
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64},
+				ParamNumInUint64:  2,
+				ResultNumInUint64: 2,
+			},
 		},
 		{
 			name:                "multi-value - v_i64f32",
 			input:               "((result i64) (result f32))",
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
 		},
 		{
-			name:                "multi-value - i32i64_f32f64",
-			input:               "((param i32) (param i64) (result f32) (result f64))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
+			name:  "multi-value - i32i64_f32f64",
+			input: "((param i32) (param i64) (result f32) (result f64))",
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64},
+				ParamNumInUint64:  2,
+				ResultNumInUint64: 2,
+			},
 		},
 		{
-			name:                "multi-value - i32i64_f32f64 named",
-			input:               "((param $x i32) (param $y i64) (result f32) (result f64))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
-			expectedParamNames:  wasm.NameMap{&wasm.NameAssoc{Index: 0, Name: "x"}, &wasm.NameAssoc{Index: 1, Name: "y"}},
+			name:  "multi-value - i32i64_f32f64 named",
+			input: "((param $x i32) (param $y i64) (result f32) (result f64))",
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64},
+				ParamNumInUint64:  2,
+				ResultNumInUint64: 2,
+			},
+			expectedParamNames: wasm.NameMap{&wasm.NameAssoc{Index: 0, Name: "x"}, &wasm.NameAssoc{Index: 1, Name: "y"}},
 		},
 		{
-			name:                "multi-value - i64i64f32_f32i32 results abbreviated in groups",
-			input:               "((result i64 i64 f32) (result f32 i32))",
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32}},
+			name:  "multi-value - i64i64f32_f32i32 results abbreviated in groups",
+			input: "((result i64 i64 f32) (result f32 i32))",
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32},
+				ResultNumInUint64: 5,
+			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 params and results abbreviated in groups",
 			input: "((param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))",
 			expectedInlinedType: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:            []wasm.ValueType{i32, i32, i64, i32},
+				Results:           []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64:  4,
+				ResultNumInUint64: 4,
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "((param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))",
 			expectedInlinedType: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:            []wasm.ValueType{i32, i32, i64, i32},
+				Results:           []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64:  4,
+				ResultNumInUint64: 4,
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "((param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))",
 			expectedInlinedType: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:            []wasm.ValueType{i32, i32, i64, i32},
+				Results:           []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64:  4,
+				ResultNumInUint64: 4,
 			},
 		},
 		{
@@ -140,7 +157,9 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 			input: "((result) (result) (result i64 i64) (result) (result f32) (result))",
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32}},
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32},
+				ResultNumInUint64: 3,
+			},
 		},
 		{
 			name: "multi-value - empty abbreviated params and results",
@@ -151,8 +170,10 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
 			expectedInlinedType: &wasm.FunctionType{
-				Params:  []wasm.ValueType{i32, i32, i64, i32, i32},
-				Results: []wasm.ValueType{f32, f64, f64, i32},
+				Params:            []wasm.ValueType{i32, i32, i64, i32, i32},
+				Results:           []wasm.ValueType{f32, f64, f64, i32},
+				ParamNumInUint64:  5,
+				ResultNumInUint64: 4,
 			},
 			expectedParamNames: wasm.NameMap{&wasm.NameAssoc{Index: 4, Name: "x"}},
 		},
@@ -164,6 +185,8 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 		return tp, func(t *testing.T) {
 			// We should have inlined the type, and it is the first type use, which means the inlined index is zero
 			require.Zero(t, tp.inlinedTypeIndices[0].inlinedIdx)
+			exp := tp.inlinedTypes[0]
+			exp.CacheNumInUint64()
 			require.Equal(t, []*wasm.FunctionType{tc.expectedInlinedType}, tp.inlinedTypes)
 		}
 	})
@@ -202,7 +225,9 @@ func TestTypeUseParser_UnresolvedType(t *testing.T) {
 			if tc.expectedInlinedType == nil {
 				require.Equal(t, 0, len(tp.inlinedTypes), "expected no inlinedTypes")
 			} else {
-				require.Equal(t, tc.expectedInlinedType, tp.inlinedTypes[0])
+				exp := tp.inlinedTypes[0]
+				exp.CacheNumInUint64()
+				require.Equal(t, tc.expectedInlinedType, exp)
 			}
 		}
 	})
@@ -347,6 +372,9 @@ func TestTypeUseParser_ReuseExistingInlinedType(t *testing.T) {
 		require.NoError(t, parseTypeUse(tp, tc.input, ignoreTypeUse))
 
 		return tp, func(t *testing.T) {
+			for _, it := range tp.inlinedTypes {
+				it.CacheNumInUint64()
+			}
 			// verify it wasn't duplicated
 			require.Equal(t, []*wasm.FunctionType{i32i64_v, tc.expectedInlinedType}, tp.inlinedTypes)
 			// last two inlined types are the same
@@ -392,6 +420,9 @@ func TestTypeUseParser_BeginResets(t *testing.T) {
 		require.NoError(t, parseTypeUse(tp, tc.input, ignoreTypeUse))
 
 		return tp, func(t *testing.T) {
+			for _, it := range tp.inlinedTypes {
+				it.CacheNumInUint64()
+			}
 			// this is the second inlined type
 			require.Equal(t, []*wasm.FunctionType{i32i64_i32, tc.expectedInlinedType}, tp.inlinedTypes)
 		}

--- a/internal/wasmdebug/debug.go
+++ b/internal/wasmdebug/debug.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
 )
 
@@ -110,9 +111,9 @@ type stackTrace struct {
 }
 
 func (s *stackTrace) FromRecovered(recovered interface{}) error {
-	// if buildoptions.IsDebugMode {
-	debug.PrintStack()
-	// }
+	if buildoptions.IsDebugMode {
+		debug.PrintStack()
+	}
 
 	stack := strings.Join(s.frames, "\n\t")
 

--- a/internal/wasmdebug/debug.go
+++ b/internal/wasmdebug/debug.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
 )
 
@@ -111,9 +110,9 @@ type stackTrace struct {
 }
 
 func (s *stackTrace) FromRecovered(recovered interface{}) error {
-	if buildoptions.IsDebugMode {
-		debug.PrintStack()
-	}
+	// if buildoptions.IsDebugMode {
+	debug.PrintStack()
+	// }
 
 	stack := strings.Join(s.frames, "\n\t")
 

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -105,6 +105,7 @@ func (c *controlFrames) push(frame *controlFrame) {
 	c.frames = append(c.frames, frame)
 }
 
+// localIndexToStackHeight initializes localIndexToStackHeight field. See the comment on localIndexToStackHeight.
 func (c *compiler) calcLocalIndexToStackHeight() {
 	c.localIndexToStackHeight = make(map[uint32]int, len(c.sig.Params)+len(c.localTypes))
 	var current int
@@ -142,8 +143,10 @@ type compiler struct {
 	body []byte
 	// sig is the function type of the target function.
 	sig *wasm.FunctionType
-	// localTypes holds the target function locals' value types.
-	localTypes              []wasm.ValueType
+	// localTypes holds the target function locals' value types except function params.
+	localTypes []wasm.ValueType
+	// localIndexToStackHeight maps the local index (starting with function params) to the stack height
+	// where the local is places. This is the necessary mapping for functions who contain vector type locals.
 	localIndexToStackHeight map[wasm.Index]int
 
 	// types hold all the function types in the module where the targe function exists.

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -110,7 +110,7 @@ func (c *compiler) calcLocalIndexToStackHeight() {
 	var current int
 	for index, lt := range c.sig.Params {
 		c.localIndexToStackHeight[wasm.Index(index)] = current
-		if lt == wasm.ValueTypeVector {
+		if lt == wasm.ValueTypeV128 {
 			current++
 		}
 		current++
@@ -119,7 +119,7 @@ func (c *compiler) calcLocalIndexToStackHeight() {
 	for index, lt := range c.localTypes {
 		index += len(c.sig.Params)
 		c.localIndexToStackHeight[wasm.Index(index)] = current
-		if lt == wasm.ValueTypeVector {
+		if lt == wasm.ValueTypeV128 {
 			current++
 		}
 		current++
@@ -724,7 +724,7 @@ operatorSwitch:
 		}
 		id := *index
 		depth := c.localDepth(id)
-		if c.localType(id) == wasm.ValueTypeVector {
+		if c.localType(id) == wasm.ValueTypeV128 {
 			c.emit(
 				// -2 because we already pushed the result of this operation into the c.stack before
 				// called localDepth ^^,
@@ -744,7 +744,7 @@ operatorSwitch:
 		}
 		id := *index
 		depth := c.localDepth(id)
-		if c.localType(id) == wasm.ValueTypeVector {
+		if c.localType(id) == wasm.ValueTypeV128 {
 			c.emit(
 				// +1 because we already popped the operands for this operation from the c.stack before
 				// called localDepth ^^,
@@ -767,7 +767,7 @@ operatorSwitch:
 		}
 		id := *index
 		depth := c.localDepth(id)
-		if c.localType(id) == wasm.ValueTypeVector {
+		if c.localType(id) == wasm.ValueTypeV128 {
 			c.emit(
 				&OperationPick{Depth: 1},
 				&OperationPick{Depth: 1},
@@ -1880,7 +1880,7 @@ func (c *compiler) emitDefaultValue(t wasm.ValueType) {
 	case wasm.ValueTypeF64:
 		c.stackPush(UnsignedTypeF64)
 		c.emit(&OperationConstF64{Value: 0})
-	case wasm.ValueTypeVector:
+	case wasm.ValueTypeV128:
 		c.stackPush(UnsignedTypeI64)
 		c.emit(&OperationConstI64{Value: 0})
 		c.stackPush(UnsignedTypeI64)

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -348,7 +348,6 @@ operatorSwitch:
 			kind:                         controlFrameKindBlockWithoutContinuationLabel,
 			blockType:                    bt,
 		}
-		fmt.Println(frame.originalStackLenWithoutParam)
 		c.controlFrames.push(frame)
 
 	case wasm.OpcodeLoop:
@@ -588,7 +587,6 @@ operatorSwitch:
 		targetFrame := c.controlFrames.get(int(targetIndex))
 		targetFrame.ensureContinuation()
 		dropOp := &OperationDrop{Depth: c.getFrameDropRange(targetFrame, false)}
-		fmt.Println(dropOp)
 		target := targetFrame.asBranchTarget()
 		c.result.LabelCallers[target.Label.String()]++
 		c.emit(
@@ -1733,9 +1731,17 @@ operatorSwitch:
 			c.pc += 8
 			hi := binary.LittleEndian.Uint64(c.body[c.pc : c.pc+8])
 			c.emit(
-				&OperationConstI128{Lo: lo, Hi: hi},
+				&OperationConstV128{Lo: lo, Hi: hi},
 			)
 			c.pc += 7
+		case wasm.OpcodeVecI32x4Add:
+			c.emit(
+				&OperationI32x4Add{},
+			)
+		case wasm.OpcodeVecI64x2Add:
+			c.emit(
+				&OperationI64x2Add{},
+			)
 		default:
 			return fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
 		}

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -344,10 +344,11 @@ operatorSwitch:
 		// Create a new frame -- entering this block.
 		frame := &controlFrame{
 			frameID:                      c.nextID(),
-			originalStackLenWithoutParam: len(c.stack) - len(bt.Params),
+			originalStackLenWithoutParam: len(c.stack) - bt.ParamNumInUint64,
 			kind:                         controlFrameKindBlockWithoutContinuationLabel,
 			blockType:                    bt,
 		}
+		fmt.Println(frame.originalStackLenWithoutParam)
 		c.controlFrames.push(frame)
 
 	case wasm.OpcodeLoop:
@@ -367,7 +368,7 @@ operatorSwitch:
 		// Create a new frame -- entering loop.
 		frame := &controlFrame{
 			frameID:                      c.nextID(),
-			originalStackLenWithoutParam: len(c.stack) - len(bt.Params),
+			originalStackLenWithoutParam: len(c.stack) - bt.ParamNumInUint64,
 			kind:                         controlFrameKindLoop,
 			blockType:                    bt,
 		}
@@ -402,7 +403,7 @@ operatorSwitch:
 		// Create a new frame -- entering if.
 		frame := &controlFrame{
 			frameID:                      c.nextID(),
-			originalStackLenWithoutParam: len(c.stack) - len(bt.Params),
+			originalStackLenWithoutParam: len(c.stack) - bt.ParamNumInUint64,
 			// Note this will be set to controlFrameKindIfWithElse
 			// when else opcode found later.
 			kind:      controlFrameKindIfWithoutElse,
@@ -587,6 +588,7 @@ operatorSwitch:
 		targetFrame := c.controlFrames.get(int(targetIndex))
 		targetFrame.ensureContinuation()
 		dropOp := &OperationDrop{Depth: c.getFrameDropRange(targetFrame, false)}
+		fmt.Println(dropOp)
 		target := targetFrame.asBranchTarget()
 		c.result.LabelCallers[target.Label.String()]++
 		c.emit(

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -1671,6 +1671,7 @@ operatorSwitch:
 			c.emit(
 				&OperationConstI128{Lo: lo, Hi: hi},
 			)
+			c.pc += 7
 		default:
 			return fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
 		}

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -1660,6 +1660,20 @@ operatorSwitch:
 		default:
 			return fmt.Errorf("unsupported misc instruction in wazeroir: 0x%x", op)
 		}
+	case wasm.OpcodeVecPrefix:
+		c.pc++
+		switch miscOp := c.body[c.pc]; miscOp {
+		case wasm.OpcodeVecV128Const:
+			c.pc++
+			lo := binary.LittleEndian.Uint64(c.body[c.pc : c.pc+8])
+			c.pc += 8
+			hi := binary.LittleEndian.Uint64(c.body[c.pc : c.pc+8])
+			c.emit(
+				&OperationConstI128{Lo: lo, Hi: hi},
+			)
+		default:
+			return fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
+		}
 	default:
 		return fmt.Errorf("unsupported instruction in wazeroir: 0x%x", op)
 	}

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -881,7 +881,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 		{
 			name: "local.get - func param",
 			mod: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeVector}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection: []*wasm.Code{{Body: []byte{
 					wasm.OpcodeLocalGet, 0,
@@ -905,7 +905,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 						wasm.OpcodeLocalGet, 0,
 						wasm.OpcodeEnd,
 					},
-					LocalTypes: []wasm.ValueType{wasm.ValueTypeVector},
+					LocalTypes: []wasm.ValueType{wasm.ValueTypeV128},
 				}},
 			},
 			expected: []Operation{
@@ -920,7 +920,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 		{
 			name: "local.set - func param",
 			mod: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeVector}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection: []*wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix, wasm.OpcodeVecV128Const, // [] -> [0x01, 0x02]
@@ -958,7 +958,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 						wasm.OpcodeLocalSet, 0, // [0x01, 0x02] -> []
 						wasm.OpcodeEnd,
 					},
-					LocalTypes: []wasm.ValueType{wasm.ValueTypeVector},
+					LocalTypes: []wasm.ValueType{wasm.ValueTypeV128},
 				}},
 			},
 			expected: []Operation{
@@ -981,7 +981,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 		{
 			name: "local.tee - func param",
 			mod: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeVector}}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection: []*wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix, wasm.OpcodeVecV128Const, // [] -> [0x01, 0x02]
@@ -1023,7 +1023,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 						wasm.OpcodeLocalTee, 0, // [0x01, 0x02] ->  [0x01, 0x02]
 						wasm.OpcodeEnd,
 					},
-					LocalTypes: []wasm.ValueType{wasm.ValueTypeVector},
+					LocalTypes: []wasm.ValueType{wasm.ValueTypeV128},
 				}},
 			},
 			expected: []Operation{

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -16,11 +16,20 @@ var ctx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
 var (
 	f32, f64, i32 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32
-	f32_i32       = &wasm.FunctionType{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}}
-	i32_i32       = &wasm.FunctionType{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}}
-	i32i32_i32    = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}
-	v_v           = &wasm.FunctionType{}
-	v_f64f64      = &wasm.FunctionType{Results: []wasm.ValueType{f64, f64}}
+	f32_i32       = &wasm.FunctionType{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  1,
+		ResultNumInUint64: 1,
+	}
+	i32_i32 = &wasm.FunctionType{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  1,
+		ResultNumInUint64: 1,
+	}
+	i32i32_i32 = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
+		ParamNumInUint64:  2,
+		ResultNumInUint64: 1,
+	}
+	v_v      = &wasm.FunctionType{}
+	v_f64f64 = &wasm.FunctionType{Results: []wasm.ValueType{f64, f64}, ResultNumInUint64: 2}
 )
 
 func TestCompile(t *testing.T) {
@@ -56,10 +65,18 @@ func TestCompile(t *testing.T) {
 					&OperationBr{Target: &BranchTarget{}},                    // return!
 				},
 				LabelCallers: map[string]uint32{},
-				Types:        []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}}},
-				Functions:    []uint32{0},
-				Signature:    &wasm.FunctionType{Params: []wasm.ValueType{wasm.ValueTypeI32}, Results: []wasm.ValueType{wasm.ValueTypeI32}},
-				TableTypes:   []wasm.RefType{},
+				Types: []*wasm.FunctionType{
+					{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32},
+						ParamNumInUint64:  1,
+						ResultNumInUint64: 1},
+				},
+				Functions: []uint32{0},
+				Signature: &wasm.FunctionType{
+					Params: []wasm.ValueType{wasm.ValueTypeI32}, Results: []wasm.ValueType{wasm.ValueTypeI32},
+					ParamNumInUint64:  1,
+					ResultNumInUint64: 1,
+				},
+				TableTypes: []wasm.RefType{},
 			},
 		},
 		{
@@ -75,10 +92,18 @@ func TestCompile(t *testing.T) {
 					&OperationBr{Target: &BranchTarget{}},                    // return!
 				},
 				LabelCallers: map[string]uint32{},
-				Types:        []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}}},
-				Functions:    []uint32{0},
-				Signature:    &wasm.FunctionType{Params: []wasm.ValueType{wasm.ValueTypeI32}, Results: []wasm.ValueType{wasm.ValueTypeI32}},
-				TableTypes:   []wasm.RefType{},
+				Types: []*wasm.FunctionType{{
+					Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32},
+					ParamNumInUint64:  1,
+					ResultNumInUint64: 1,
+				}},
+				Functions: []uint32{0},
+				Signature: &wasm.FunctionType{
+					Params: []wasm.ValueType{wasm.ValueTypeI32}, Results: []wasm.ValueType{wasm.ValueTypeI32},
+					ParamNumInUint64:  1,
+					ResultNumInUint64: 1,
+				},
+				TableTypes: []wasm.RefType{},
 			},
 		},
 	}
@@ -228,11 +253,17 @@ func TestCompile_BulkMemoryOperations(t *testing.T) {
 }
 
 func TestCompile_MultiValue(t *testing.T) {
-	i32i32_i32i32 := &wasm.FunctionType{Params: []wasm.ValueType{
-		wasm.ValueTypeI32, wasm.ValueTypeI32},
-		Results: []wasm.ValueType{wasm.ValueTypeI32, wasm.ValueTypeI32},
+	i32i32_i32i32 := &wasm.FunctionType{
+		Params:            []wasm.ValueType{wasm.ValueTypeI32, wasm.ValueTypeI32},
+		Results:           []wasm.ValueType{wasm.ValueTypeI32, wasm.ValueTypeI32},
+		ParamNumInUint64:  2,
+		ResultNumInUint64: 2,
 	}
-	_i32i64 := &wasm.FunctionType{Results: []wasm.ValueType{wasm.ValueTypeI32, wasm.ValueTypeI64}}
+	_i32i64 := &wasm.FunctionType{
+		Results:           []wasm.ValueType{wasm.ValueTypeI32, wasm.ValueTypeI64},
+		ParamNumInUint64:  0,
+		ResultNumInUint64: 2,
+	}
 
 	tests := []struct {
 		name            string

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -901,7 +901,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 			},
 			expected: []Operation{
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstI128{Lo: 0x01, Hi: 0x02},
+				&OperationConstV128{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [p[0].lo, 0x02, 0x01, p[1].hi]
 				&OperationSwap{Depth: 2},
 				// [p[0].lo, 0x02, 0x01, p[1].hi] -> [p[0].lo, 0x02, 0x01]
@@ -934,7 +934,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 				&OperationConstI64{Value: 0},
 				&OperationConstI64{Value: 0},
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstI128{Lo: 0x01, Hi: 0x02},
+				&OperationConstV128{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [p[0].lo, 0x02, 0x01, p[1].hi]
 				&OperationSwap{Depth: 2},
 				// [p[0].lo, 0x02, 0x01, p[1].hi] -> [p[0].lo, 0x02, 0x01]
@@ -962,7 +962,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 			},
 			expected: []Operation{
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstI128{Lo: 0x01, Hi: 0x02},
+				&OperationConstV128{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [p[0].lo, p[1].hi, 0x01, 0x02, 0x01]
 				&OperationPick{Depth: 1},
 				// [p[0].lo, p[1].hi, 0x01, 0x02, 0x01] -> [p[0].lo, p[1].hi, 0x01, 0x02, 0x01, 0x02]
@@ -999,7 +999,7 @@ func TestCompile_Locals_vector(t *testing.T) {
 				&OperationConstI64{Value: 0},
 				&OperationConstI64{Value: 0},
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstI128{Lo: 0x01, Hi: 0x02},
+				&OperationConstV128{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [p[0].lo, p[1].hi, 0x01, 0x02, 0x01]
 				&OperationPick{Depth: 1},
 				// [p[0].lo, p[1].hi, 0x01, 0x02, 0x01] -> [p[0].lo, p[1].hi, 0x01, 0x02, 0x01, 0x02]

--- a/internal/wazeroir/format.go
+++ b/internal/wazeroir/format.go
@@ -181,6 +181,8 @@ func formatOperation(w io.StringWriter, b Operation) {
 			out = "u64"
 		}
 		str = fmt.Sprintf("%s.extend_from.%s", out, in)
+	case *OperationConstI128:
+		str = fmt.Sprintf("v128.const [%#x, %#x]", o.Lo, o.Hi)
 	default:
 		panic("unreachable: a bug in wazeroir implementation")
 	}

--- a/internal/wazeroir/format.go
+++ b/internal/wazeroir/format.go
@@ -181,7 +181,7 @@ func formatOperation(w io.StringWriter, b Operation) {
 			out = "u64"
 		}
 		str = fmt.Sprintf("%s.extend_from.%s", out, in)
-	case *OperationConstI128:
+	case *OperationConstV128:
 		str = fmt.Sprintf("v128.const [%#x, %#x]", o.Lo, o.Hi)
 	default:
 		panic("unreachable: a bug in wazeroir implementation")

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -66,7 +66,6 @@ const (
 	UnsignedTypeI64
 	UnsignedTypeF32
 	UnsignedTypeF64
-	UnsignedTypeI128
 	UnsignedTypeUnknown
 )
 
@@ -80,8 +79,6 @@ func (s UnsignedType) String() (ret string) {
 		ret = "f32"
 	case UnsignedTypeF64:
 		ret = "f64"
-	case UnsignedTypeI128:
-		ret = "i128"
 	case UnsignedTypeUnknown:
 		ret = "unknown"
 	}

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -287,8 +287,8 @@ func (o OperationKind) String() (ret string) {
 		ret = "TableGrow"
 	case OperationKindTableFill:
 		ret = "TableFill"
-	case OperationKindConstI128:
-		ret = "ConstI128"
+	case OperationKindConstV128:
+		ret = "ConstV128"
 	default:
 		panic("BUG")
 	}
@@ -383,7 +383,9 @@ const (
 	OperationKindTableSize
 	OperationKindTableGrow
 	OperationKindTableFill
-	OperationKindConstI128
+	OperationKindConstV128
+	OperationKindI32x4Add
+	OperationKindI64x2Add
 )
 
 type Label struct {
@@ -1148,13 +1150,28 @@ func (o *OperationTableFill) Kind() OperationKind {
 	return OperationKindTableFill
 }
 
-// OperationConstI128 implements Operation.
-
-type OperationConstI128 struct {
+// OperationConstV128 implements Operation.
+type OperationConstV128 struct {
 	Lo, Hi uint64
 }
 
 // Kind implements Operation.Kind.
-func (o *OperationConstI128) Kind() OperationKind {
-	return OperationKindConstI128
+func (o *OperationConstV128) Kind() OperationKind {
+	return OperationKindConstV128
+}
+
+// OperationI32x4Add implements Operation.
+type OperationI32x4Add struct{}
+
+// Kind implements Operation.Kind.
+func (o *OperationI32x4Add) Kind() OperationKind {
+	return OperationKindI32x4Add
+}
+
+// OperationI64x2Add implements Operation.
+type OperationI64x2Add struct{}
+
+// Kind implements Operation.Kind.
+func (o *OperationI64x2Add) Kind() OperationKind {
+	return OperationKindI64x2Add
 }

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -290,8 +290,8 @@ func (o OperationKind) String() (ret string) {
 		ret = "TableGrow"
 	case OperationKindTableFill:
 		ret = "TableFill"
-	case OperationKindConstVec:
-		ret = "ConstVec"
+	case OperationKindConstI128:
+		ret = "ConstI128"
 	default:
 		panic("BUG")
 	}

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -66,6 +66,7 @@ const (
 	UnsignedTypeI64
 	UnsignedTypeF32
 	UnsignedTypeF64
+	UnsignedTypeI128
 	UnsignedTypeUnknown
 )
 
@@ -79,6 +80,8 @@ func (s UnsignedType) String() (ret string) {
 		ret = "f32"
 	case UnsignedTypeF64:
 		ret = "f64"
+	case UnsignedTypeI128:
+		ret = "i128"
 	case UnsignedTypeUnknown:
 		ret = "unknown"
 	}
@@ -287,6 +290,10 @@ func (o OperationKind) String() (ret string) {
 		ret = "TableGrow"
 	case OperationKindTableFill:
 		ret = "TableFill"
+	case OperationKindConstVec:
+		ret = "ConstVec"
+	default:
+		panic("BUG")
 	}
 	return
 }
@@ -379,6 +386,7 @@ const (
 	OperationKindTableSize
 	OperationKindTableGrow
 	OperationKindTableFill
+	OperationKindConstI128
 )
 
 type Label struct {
@@ -1141,4 +1149,15 @@ type OperationTableFill struct {
 // Kind implements Operation.Kind.
 func (o *OperationTableFill) Kind() OperationKind {
 	return OperationKindTableFill
+}
+
+// OperationConstI128 implements Operation.
+
+type OperationConstI128 struct {
+	Lo, Hi uint64
+}
+
+// Kind implements Operation.Kind.
+func (o *OperationConstI128) Kind() OperationKind {
+	return OperationKindConstI128
 }

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -151,6 +151,9 @@ var (
 		in:  []UnsignedType{UnsignedTypeUnknown, UnsignedTypeUnknown, UnsignedTypeI32},
 		out: []UnsignedType{UnsignedTypeUnknown},
 	}
+	signature_None_I128 = &signature{
+		out: []UnsignedType{UnsignedTypeI128},
+	}
 )
 
 // wasmOpcodeSignature returns the signature of given Wasm opcode.
@@ -399,6 +402,13 @@ func (c *compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature
 			return signature_I32I64I32_None, nil
 		default:
 			return nil, fmt.Errorf("unsupported misc instruction in wazeroir: 0x%x", op)
+		}
+	case wasm.OpcodeVecPrefix:
+		switch vecOp := c.body[c.pc+1]; vecOp {
+		case wasm.OpcodeVecV128Const:
+			return signature_None_I128, nil
+		default:
+			return nil, fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported instruction in wazeroir: 0x%x", op)

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -154,6 +154,10 @@ var (
 		in:  []UnsignedType{UnsignedTypeUnknown, UnsignedTypeUnknown, UnsignedTypeI32},
 		out: []UnsignedType{UnsignedTypeUnknown},
 	}
+	signature_I64I64I64I64_I64I64 = &signature{
+		in:  []UnsignedType{UnsignedTypeI64, UnsignedTypeI64, UnsignedTypeI64, UnsignedTypeI64},
+		out: []UnsignedType{UnsignedTypeI64, UnsignedTypeI64},
+	}
 )
 
 // wasmOpcodeSignature returns the signature of given Wasm opcode.
@@ -407,6 +411,8 @@ func (c *compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature
 		switch vecOp := c.body[c.pc+1]; vecOp {
 		case wasm.OpcodeVecV128Const:
 			return signature_None_I64I64, nil
+		case wasm.OpcodeVecI32x4Add, wasm.OpcodeVecI64x2Add:
+			return signature_I64I64I64I64_I64I64, nil
 		default:
 			return nil, fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
 		}

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -438,6 +438,8 @@ func wasmValueTypeToUnsignedType(vt wasm.ValueType) UnsignedType {
 		return UnsignedTypeF32
 	case wasm.ValueTypeF64:
 		return UnsignedTypeF64
+	case wasm.ValueTypeVector:
+		return UnsignedTypeI128
 	}
 	panic("unreachable")
 }

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -444,7 +444,7 @@ func wasmValueTypeToUnsignedType(vt wasm.ValueType) []UnsignedType {
 		return []UnsignedType{UnsignedTypeF32}
 	case wasm.ValueTypeF64:
 		return []UnsignedType{UnsignedTypeF64}
-	case wasm.ValueTypeVector:
+	case wasm.ValueTypeV128:
 		return []UnsignedType{UnsignedTypeI64, UnsignedTypeI64}
 	}
 	panic("unreachable")


### PR DESCRIPTION
This commit implements the `v128.const`, `i32x4.add` and  `i64x2.add` in
interpreter mode and this adds support for the vector value types in the 
locals and globals.

Notably, the vector type values can be passed and returned by exported functions
as well as host functions via two-uint64 encodings as described in https://github.com/tetratelabs/wazero/issues/484#issuecomment-1116866086.

Note: implementation of these instructions on JIT will be done in subsequent PR.

part of #484 