### PR TITLE
Renames asm packages to match folder name

### DIFF
--- a/internal/asm/amd64/assembler.go
+++ b/internal/asm/amd64/assembler.go
@@ -1,4 +1,4 @@
-package asm_amd64
+package amd64
 
 import (
 	"github.com/tetratelabs/wazero/internal/asm"

--- a/internal/asm/amd64/consts.go
+++ b/internal/asm/amd64/consts.go
@@ -1,4 +1,4 @@
-package asm_amd64
+package amd64
 
 import "github.com/tetratelabs/wazero/internal/asm"
 

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -1,4 +1,4 @@
-package asm_amd64
+package amd64
 
 import (
 	"bytes"

--- a/internal/asm/amd64/impl_test.go
+++ b/internal/asm/amd64/impl_test.go
@@ -1,4 +1,4 @@
-package asm_amd64
+package amd64
 
 import (
 	"strconv"

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -1,4 +1,4 @@
-package asm_arm64
+package arm64
 
 import (
 	"github.com/tetratelabs/wazero/internal/asm"

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -1,4 +1,4 @@
-package asm_arm64
+package arm64
 
 import (
 	"github.com/tetratelabs/wazero/internal/asm"

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1,4 +1,4 @@
-package asm_arm64
+package arm64
 
 import (
 	"bytes"

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -1,4 +1,4 @@
-package asm_arm64
+package arm64
 
 import (
 	"testing"


### PR DESCRIPTION
Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>

I was looking into possibly bringing in func-e's linting config. There are currently tons of failures so may proceed with that very gradually. One easy one that particularly spams the console is not liking package names with underscores. Here we are already aliasing in all the imports anyways so it seems OK to let the packages match the folder name.