### PR TITLE
Vector values support in ahead-of-time compiler

### DIFF
--- a/internal/asm/amd64/assembler.go
+++ b/internal/asm/amd64/assembler.go
@@ -12,9 +12,9 @@ type Assembler interface {
 	// and returns the corresponding Node in the assembled linked list.
 	CompileJumpToMemory(jmpInstruction asm.Instruction, baseReg asm.Register, offset asm.ConstantValue)
 
-	// CompileRegisterToRegisterWithMode adds an instruction where source and destination
-	// are `from` and `to` registers and the instruction's "Mode" is specified by `Mode`.
-	CompileRegisterToRegisterWithMode(instruction asm.Instruction, from, to asm.Register, mode Mode)
+	// CompileRegisterToRegisterWithArg adds an instruction where source and destination
+	// are `from` and `to` registers.
+	CompileRegisterToRegisterWithArg(instruction asm.Instruction, from, to asm.Register, arg byte)
 
 	// CompileMemoryWithIndexToRegister adds an instruction where source operand is the memory address
 	// specified as `srcBaseReg + srcOffsetConst + srcIndex*srcScale` and destination is the register `DstReg`.

--- a/internal/asm/amd64/consts.go
+++ b/internal/asm/amd64/consts.go
@@ -159,6 +159,14 @@ const (
 	JMP
 	NOP
 	UD2
+	MOVDQU
+	PINSRQ
+	PADDB
+	PADDW
+	PADDL
+	PADDQ
+	ADDPS
+	ADDPD
 )
 
 func InstructionName(instruction asm.Instruction) string {
@@ -423,6 +431,22 @@ func InstructionName(instruction asm.Instruction) string {
 		return "NOP"
 	case UD2:
 		return "UD2"
+	case MOVDQU:
+		return "MOVDQU"
+	case PINSRQ:
+		return "PINSRQ"
+	case PADDB:
+		return "PADDB"
+	case PADDW:
+		return "PADDW"
+	case PADDL:
+		return "PADDL"
+	case PADDQ:
+		return "PADDQ"
+	case ADDPS:
+		return "ADDPS"
+	case ADDPD:
+		return "ADDPD"
 	}
 	return "Unknown"
 }
@@ -433,7 +457,7 @@ func InstructionName(instruction asm.Instruction) string {
 // See https://www.lri.fr/~filliatr/ens/compil/x86-64.pdf
 // See https://cs.brown.edu/courses/cs033/docs/guides/x64_cheatsheet.pdf
 const (
-	REG_AX asm.Register = asm.NilRegister + 1 + iota
+	REG_AX = asm.NilRegister + 1 + iota
 	REG_CX
 	REG_DX
 	REG_BX

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -51,6 +51,8 @@ type Assembler interface {
 	// CompileSIMDByteToSIMDByte adds an instruction where source and destination operand is the SIMD register
 	// specified as `srcReg.B8` and `dstReg.B8` where `.B8` part of register is called "arrangement".
 	// See https://stackoverflow.com/questions/57294672/what-is-arrangement-specifier-16b-8b-in-arm-assembly-language-instructions
+	//
+	// TODO: implement this in CompileVectorRegisterToVectorRegister.
 	CompileSIMDByteToSIMDByte(instruction asm.Instruction, srcReg, dstReg asm.Register)
 
 	// CompileTwoSIMDBytesToSIMDByteRegister adds an instruction where source operand is two SIMD registers specified as `srcReg1.B8`,
@@ -64,4 +66,13 @@ type Assembler interface {
 	// CompileConditionalRegisterSet adds an instruction to set 1 on dstReg if the condition satisfies,
 	// otherwise set 0.
 	CompileConditionalRegisterSet(cond asm.ConditionalRegisterState, dstReg asm.Register)
+	// CompileMemoryToVectorRegister TODO
+	CompileMemoryToVectorRegister(instruction asm.Instruction, srcOffsetReg, dstReg asm.Register, arrangement VectorArrangement)
+	// CompileVectorRegisterToMemory TODO
+	CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstOffsetReg asm.Register, arrangement VectorArrangement)
+	// CompileRegisterToVectorRegister TODO
+	CompileRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
+		arrangement VectorArrangement, index VectorIndex)
+	// CompileVectorRegisterToVectorRegister TODO
+	CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement VectorArrangement)
 }

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -69,38 +69,38 @@ const (
 
 	// Scalar floating point registers.
 
-	REG_F0
-	REG_F1
-	REG_F2
-	REG_F3
-	REG_F4
-	REG_F5
-	REG_F6
-	REG_F7
-	REG_F8
-	REG_F9
-	REG_F10
-	REG_F11
-	REG_F12
-	REG_F13
-	REG_F14
-	REG_F15
-	REG_F16
-	REG_F17
-	REG_F18
-	REG_F19
-	REG_F20
-	REG_F21
-	REG_F22
-	REG_F23
-	REG_F24
-	REG_F25
-	REG_F26
-	REG_F27
-	REG_F28
-	REG_F29
-	REG_F30
-	REG_F31
+	REG_V0
+	REG_V1
+	REG_V2
+	REG_V3
+	REG_V4
+	REG_V5
+	REG_V6
+	REG_V7
+	REG_V8
+	REG_V9
+	REG_V10
+	REG_V11
+	REG_V12
+	REG_V13
+	REG_V14
+	REG_V15
+	REG_V16
+	REG_V17
+	REG_V18
+	REG_V19
+	REG_V20
+	REG_V21
+	REG_V22
+	REG_V23
+	REG_V24
+	REG_V25
+	REG_V26
+	REG_V27
+	REG_V28
+	REG_V29
+	REG_V30
+	REG_V31
 
 	// Floating point status register.
 
@@ -236,70 +236,70 @@ func RegisterName(r asm.Register) string {
 		return "R30"
 	case REGZERO:
 		return "ZERO"
-	case REG_F0:
-		return "F0"
-	case REG_F1:
-		return "F1"
-	case REG_F2:
-		return "F2"
-	case REG_F3:
-		return "F3"
-	case REG_F4:
-		return "F4"
-	case REG_F5:
-		return "F5"
-	case REG_F6:
-		return "F6"
-	case REG_F7:
-		return "F7"
-	case REG_F8:
-		return "F8"
-	case REG_F9:
-		return "F9"
-	case REG_F10:
-		return "F10"
-	case REG_F11:
-		return "F11"
-	case REG_F12:
-		return "F12"
-	case REG_F13:
-		return "F13"
-	case REG_F14:
-		return "F14"
-	case REG_F15:
-		return "F15"
-	case REG_F16:
-		return "F16"
-	case REG_F17:
-		return "F17"
-	case REG_F18:
-		return "F18"
-	case REG_F19:
-		return "F19"
-	case REG_F20:
-		return "F20"
-	case REG_F21:
-		return "F21"
-	case REG_F22:
-		return "F22"
-	case REG_F23:
-		return "F23"
-	case REG_F24:
-		return "F24"
-	case REG_F25:
-		return "F25"
-	case REG_F26:
-		return "F26"
-	case REG_F27:
-		return "F27"
-	case REG_F28:
-		return "F28"
-	case REG_F29:
-		return "F29"
-	case REG_F30:
-		return "F30"
-	case REG_F31:
-		return "F31"
+	case REG_V0:
+		return "V0"
+	case REG_V1:
+		return "V1"
+	case REG_V2:
+		return "V2"
+	case REG_V3:
+		return "V3"
+	case REG_V4:
+		return "V4"
+	case REG_V5:
+		return "V5"
+	case REG_V6:
+		return "V6"
+	case REG_V7:
+		return "V7"
+	case REG_V8:
+		return "V8"
+	case REG_V9:
+		return "V9"
+	case REG_V10:
+		return "V10"
+	case REG_V11:
+		return "V11"
+	case REG_V12:
+		return "V12"
+	case REG_V13:
+		return "V13"
+	case REG_V14:
+		return "V14"
+	case REG_V15:
+		return "V15"
+	case REG_V16:
+		return "V16"
+	case REG_V17:
+		return "V17"
+	case REG_V18:
+		return "V18"
+	case REG_V19:
+		return "V19"
+	case REG_V20:
+		return "V20"
+	case REG_V21:
+		return "V21"
+	case REG_V22:
+		return "V22"
+	case REG_V23:
+		return "V23"
+	case REG_V24:
+		return "V24"
+	case REG_V25:
+		return "V25"
+	case REG_V26:
+		return "V26"
+	case REG_V27:
+		return "V27"
+	case REG_V28:
+		return "V28"
+	case REG_V29:
+		return "V29"
+	case REG_V30:
+		return "V30"
+	case REG_V31:
+		return "V31"
 	case REG_FPSR:
 		return "FPSR"
 	case REG_COND_EQ:
@@ -461,10 +461,70 @@ const (
 	UDIV
 	UDIVW
 	UXTW
+
+	// Vector instructions.
 	VBIT
 	VCNT
+	VMOV
 	VUADDLV
+	VLD1
+	VST1
+	VADD
+	VFADDS
+	VFADDD
 )
+
+type VectorArrangement byte
+
+const (
+	VectorArrangementNone VectorArrangement = iota
+	VectorArrangement8B
+	VectorArrangement16B
+	VectorArrangement4H
+	VectorArrangement8H
+	VectorArrangement2S
+	VectorArrangement4S
+	VectorArrangement1D
+	VectorArrangement2D
+	VectorArrangementB
+	VectorArrangementH
+	VectorArrangementS
+	VectorArrangementD
+)
+
+func (v VectorArrangement) String() (ret string) {
+	switch v {
+	case VectorArrangement8B:
+		ret = "8B"
+	case VectorArrangement16B:
+		ret = "16B"
+	case VectorArrangement4H:
+		ret = "4H"
+	case VectorArrangement8H:
+		ret = "8H"
+	case VectorArrangement2S:
+		ret = "2S"
+	case VectorArrangement4S:
+		ret = "4S"
+	case VectorArrangement1D:
+		ret = "1D"
+	case VectorArrangement2D:
+		ret = "2D"
+	case VectorArrangementB:
+		ret = ""
+	case VectorArrangementH:
+		ret = "H"
+	case VectorArrangementS:
+		ret = "S"
+	case VectorArrangementD:
+		ret = "D"
+	default:
+		ret = "unknown"
+	}
+	return
+}
+
+type VectorIndex byte
 
 func InstructionName(i asm.Instruction) string {
 	switch i {
@@ -710,6 +770,18 @@ func InstructionName(i asm.Instruction) string {
 		return "VCNT"
 	case VUADDLV:
 		return "VUADDLV"
+	case VMOV:
+		return "VMOV"
+	case VST1:
+		return "VST1"
+	case VLD1:
+		return "VLD1"
+	case VADD:
+		return "VADD"
+	case VFADDS:
+		return "VFADDS"
+	case VFADDD:
+		return "VFADDD"
 	}
 	return "UNKNOWN"
 }

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -511,7 +511,7 @@ func (v VectorArrangement) String() (ret string) {
 	case VectorArrangement2D:
 		ret = "2D"
 	case VectorArrangementB:
-		ret = ""
+		ret = "B"
 	case VectorArrangementH:
 		ret = "H"
 	case VectorArrangementS:

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/tetratelabs/wazero/internal/asm"
 	"math"
+
+	"github.com/tetratelabs/wazero/internal/asm"
 )
 
 type NodeImpl struct {

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -2531,7 +2531,7 @@ func (a *AssemblerImpl) EncodeRegisterToVectorRegister(n *NodeImpl) (err error) 
 			imm5 |= byte(n.VectorIndex) << 1
 		case VectorArrangementH:
 			imm5 |= 0b10
-			imm5 |= byte(n.VectorIndex) << 02
+			imm5 |= byte(n.VectorIndex) << 2
 		case VectorArrangementS:
 			imm5 |= 0b100
 			imm5 |= byte(n.VectorIndex) << 3
@@ -2539,7 +2539,7 @@ func (a *AssemblerImpl) EncodeRegisterToVectorRegister(n *NodeImpl) (err error) 
 			imm5 |= 0b1000
 			imm5 |= byte(n.VectorIndex) << 4
 		default:
-			return fmt.Errorf("unsupported arragement for VMOV: %s", n.VectorArrangement)
+			return fmt.Errorf("unsupported arrangement for VMOV: %s", n.VectorArrangement)
 		}
 		a.Buf.Write([]byte{
 			(srcRegBits << 5) | dstVectorRegBits,

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -1,6 +1,7 @@
 package arm64
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/asm"
@@ -48,8 +49,8 @@ func TestNodeImpl_String(t *testing.T) {
 			exp: "BNE {NOP}",
 		},
 		{
-			in:  &NodeImpl{Instruction: ADD, Types: OperandTypesRegisterToRegister, SrcReg: REG_F0, DstReg: REG_F10},
-			exp: "ADD F0, F10",
+			in:  &NodeImpl{Instruction: ADD, Types: OperandTypesRegisterToRegister, SrcReg: REG_V0, DstReg: REG_V10},
+			exp: "ADD V0, V10",
 		},
 		{
 			in: &NodeImpl{Instruction: ADD, Types: OperandTypesLeftShiftedRegisterToRegister,
@@ -94,16 +95,36 @@ func TestNodeImpl_String(t *testing.T) {
 			exp: "MOVD 0x123, R8",
 		},
 		{
-			in:  &NodeImpl{Instruction: VCNT, Types: OperandTypesSIMDByteToSIMDByte, SrcReg: REG_F1, DstReg: REG_F2},
-			exp: "VCNT F1.B8, F2.B8",
+			in:  &NodeImpl{Instruction: VCNT, Types: OperandTypesSIMDByteToSIMDByte, SrcReg: REG_V1, DstReg: REG_V2},
+			exp: "VCNT V1.B8, V2.B8",
 		},
 		{
-			in:  &NodeImpl{Instruction: VUADDLV, Types: OperandTypesSIMDByteToRegister, SrcReg: REG_F1, DstReg: REG_F2},
-			exp: "VUADDLV F1.B8, F2",
+			in:  &NodeImpl{Instruction: VUADDLV, Types: OperandTypesSIMDByteToRegister, SrcReg: REG_V1, DstReg: REG_V2},
+			exp: "VUADDLV V1.B8, V2",
 		},
 		{
-			in:  &NodeImpl{Instruction: VBIT, Types: OperandTypesTwoSIMDBytesToSIMDByteRegister, SrcReg: REG_F1, SrcReg2: REG_F2, DstReg: REG_F3},
-			exp: "VBIT (F1.B8, F2.B8), F3.B8",
+			in:  &NodeImpl{Instruction: VBIT, Types: OperandTypesTwoSIMDBytesToSIMDByteRegister, SrcReg: REG_V1, SrcReg2: REG_V2, DstReg: REG_V3},
+			exp: "VBIT (V1.B8, V2.B8), V3.B8",
+		},
+		{
+			in: &NodeImpl{Instruction: VLD1, Types: OperandTypesMemoryToVectorRegister,
+				SrcReg: REG_R1, DstReg: REG_V29, VectorArrangement: VectorArrangement2S},
+			exp: "VLD1 [R1], V29.2S",
+		},
+		{
+			in: &NodeImpl{Instruction: VST1, Types: OperandTypesVectorRegisterToMemory,
+				DstReg: REG_R1, SrcReg: REG_V29, VectorArrangement: VectorArrangement2S},
+			exp: "VST1 V29.2S, [R1]",
+		},
+		{
+			in: &NodeImpl{Instruction: VMOV, Types: OperandTypesRegisterToVectorRegister,
+				SrcReg: REG_R1, DstReg: REG_V29, VectorArrangement: VectorArrangement2D, VectorIndex: 1},
+			exp: "VMOV R1, V29.2D[1]",
+		},
+		{
+			in: &NodeImpl{Instruction: VCNT, Types: OperandTypesVectorRegisterToVectorRegister,
+				SrcReg: REG_V3, DstReg: REG_V29, VectorArrangement: VectorArrangement2D, VectorIndex: 1},
+			exp: "VCNT V3.V3, V29.V3",
 		},
 	} {
 		require.Equal(t, tc.exp, tc.in.String())
@@ -318,34 +339,34 @@ func Test_CompileLeftShiftedRegisterToRegister(t *testing.T) {
 
 func Test_CompileSIMDByteToSIMDByte(t *testing.T) {
 	a := NewAssemblerImpl(REG_R10)
-	a.CompileSIMDByteToSIMDByte(VCNT, REG_F0, REG_F2)
+	a.CompileSIMDByteToSIMDByte(VCNT, REG_V0, REG_V2)
 	actualNode := a.Current
 	require.Equal(t, VCNT, actualNode.Instruction)
-	require.Equal(t, REG_F0, actualNode.SrcReg)
-	require.Equal(t, REG_F2, actualNode.DstReg)
+	require.Equal(t, REG_V0, actualNode.SrcReg)
+	require.Equal(t, REG_V2, actualNode.DstReg)
 	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.src)
 	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.dst)
 }
 
 func Test_CompileTwoSIMDBytesToSIMDByteRegister(t *testing.T) {
 	a := NewAssemblerImpl(REG_R10)
-	a.CompileTwoSIMDBytesToSIMDByteRegister(VBIT, REG_F0, REG_F10, REG_F2)
+	a.CompileTwoSIMDBytesToSIMDByteRegister(VBIT, REG_V0, REG_V10, REG_V2)
 	actualNode := a.Current
 	require.Equal(t, VBIT, actualNode.Instruction)
-	require.Equal(t, REG_F0, actualNode.SrcReg)
-	require.Equal(t, REG_F10, actualNode.SrcReg2)
-	require.Equal(t, REG_F2, actualNode.DstReg)
+	require.Equal(t, REG_V0, actualNode.SrcReg)
+	require.Equal(t, REG_V10, actualNode.SrcReg2)
+	require.Equal(t, REG_V2, actualNode.DstReg)
 	require.Equal(t, OperandTypeTwoSIMDBytes, actualNode.Types.src)
 	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.dst)
 }
 
 func Test_CompileSIMDByteToRegister(t *testing.T) {
 	a := NewAssemblerImpl(REG_R10)
-	a.CompileSIMDByteToRegister(VUADDLV, REG_F0, REG_F10)
+	a.CompileSIMDByteToRegister(VUADDLV, REG_V0, REG_V10)
 	actualNode := a.Current
 	require.Equal(t, VUADDLV, actualNode.Instruction)
-	require.Equal(t, REG_F0, actualNode.SrcReg)
-	require.Equal(t, REG_F10, actualNode.DstReg)
+	require.Equal(t, REG_V0, actualNode.SrcReg)
+	require.Equal(t, REG_V10, actualNode.DstReg)
 	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
@@ -361,6 +382,55 @@ func Test_CompileConditionalRegisterSet(t *testing.T) {
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
+func Test_CompileMemoryToVectorRegister(t *testing.T) {
+	a := NewAssemblerImpl(REG_R10)
+	a.CompileMemoryToVectorRegister(VMOV, REG_R10, REG_V3, VectorArrangement1D)
+	actualNode := a.Current
+	require.Equal(t, VMOV, actualNode.Instruction)
+	require.Equal(t, REG_R10, actualNode.SrcReg)
+	require.Equal(t, REG_V3, actualNode.DstReg)
+	require.Equal(t, OperandTypeMemory, actualNode.Types.src)
+	require.Equal(t, OperandTypeVectorRegister, actualNode.Types.dst)
+	require.Equal(t, VectorArrangement1D, actualNode.VectorArrangement)
+}
+
+func Test_CompileVectorRegisterToMemory(t *testing.T) {
+	a := NewAssemblerImpl(REG_R10)
+	a.CompileVectorRegisterToMemory(VMOV, REG_V3, REG_R10, VectorArrangement1D)
+	actualNode := a.Current
+	require.Equal(t, VMOV, actualNode.Instruction)
+	require.Equal(t, REG_V3, actualNode.SrcReg)
+	require.Equal(t, REG_R10, actualNode.DstReg)
+	require.Equal(t, OperandTypeVectorRegister, actualNode.Types.src)
+	require.Equal(t, OperandTypeMemory, actualNode.Types.dst)
+	require.Equal(t, VectorArrangement1D, actualNode.VectorArrangement)
+}
+
+func Test_CompileRegisterToVectorRegister(t *testing.T) {
+	a := NewAssemblerImpl(REG_R10)
+	a.CompileRegisterToVectorRegister(VMOV, REG_V3, REG_R10, VectorArrangement1D, 10)
+	actualNode := a.Current
+	require.Equal(t, VMOV, actualNode.Instruction)
+	require.Equal(t, REG_V3, actualNode.SrcReg)
+	require.Equal(t, REG_R10, actualNode.DstReg)
+	require.Equal(t, OperandTypeRegister, actualNode.Types.src)
+	require.Equal(t, OperandTypeVectorRegister, actualNode.Types.dst)
+	require.Equal(t, VectorArrangement1D, actualNode.VectorArrangement)
+	require.Equal(t, VectorIndex(10), actualNode.VectorIndex)
+}
+
+func Test_CompileVectorRegisterToVectorRegister(t *testing.T) {
+	a := NewAssemblerImpl(REG_R10)
+	a.CompileVectorRegisterToVectorRegister(VMOV, REG_V3, REG_V10, VectorArrangement1D)
+	actualNode := a.Current
+	require.Equal(t, VMOV, actualNode.Instruction)
+	require.Equal(t, REG_V3, actualNode.SrcReg)
+	require.Equal(t, REG_V10, actualNode.DstReg)
+	require.Equal(t, OperandTypeVectorRegister, actualNode.Types.src)
+	require.Equal(t, OperandTypeVectorRegister, actualNode.Types.dst)
+	require.Equal(t, VectorArrangement1D, actualNode.VectorArrangement)
+}
+
 func Test_checkRegisterToRegisterType(t *testing.T) {
 	for _, tc := range []struct {
 		src, dst                     asm.Register
@@ -372,20 +442,20 @@ func Test_checkRegisterToRegisterType(t *testing.T) {
 		{src: REG_R10, dst: REG_R30, requireSrcInt: false, requireDstInt: false, expErr: "src requires float register but got R10"},
 		{src: REG_R10, dst: REG_R30, requireSrcInt: true, requireDstInt: false, expErr: "dst requires float register but got R30"},
 
-		{src: REG_R10, dst: REG_F30, requireSrcInt: true, requireDstInt: false, expErr: ""},
-		{src: REG_R10, dst: REG_F30, requireSrcInt: false, requireDstInt: true, expErr: "src requires float register but got R10"},
-		{src: REG_R10, dst: REG_F30, requireSrcInt: false, requireDstInt: false, expErr: "src requires float register but got R10"},
-		{src: REG_R10, dst: REG_F30, requireSrcInt: true, requireDstInt: true, expErr: "dst requires int register but got F30"},
+		{src: REG_R10, dst: REG_V30, requireSrcInt: true, requireDstInt: false, expErr: ""},
+		{src: REG_R10, dst: REG_V30, requireSrcInt: false, requireDstInt: true, expErr: "src requires float register but got R10"},
+		{src: REG_R10, dst: REG_V30, requireSrcInt: false, requireDstInt: false, expErr: "src requires float register but got R10"},
+		{src: REG_R10, dst: REG_V30, requireSrcInt: true, requireDstInt: true, expErr: "dst requires int register but got V30"},
 
-		{src: REG_F10, dst: REG_R30, requireSrcInt: false, requireDstInt: true, expErr: ""},
-		{src: REG_F10, dst: REG_R30, requireSrcInt: true, requireDstInt: true, expErr: "src requires int register but got F10"},
-		{src: REG_F10, dst: REG_R30, requireSrcInt: true, requireDstInt: false, expErr: "src requires int register but got F10"},
-		{src: REG_F10, dst: REG_R30, requireSrcInt: false, requireDstInt: false, expErr: "dst requires float register but got R30"},
+		{src: REG_V10, dst: REG_R30, requireSrcInt: false, requireDstInt: true, expErr: ""},
+		{src: REG_V10, dst: REG_R30, requireSrcInt: true, requireDstInt: true, expErr: "src requires int register but got V10"},
+		{src: REG_V10, dst: REG_R30, requireSrcInt: true, requireDstInt: false, expErr: "src requires int register but got V10"},
+		{src: REG_V10, dst: REG_R30, requireSrcInt: false, requireDstInt: false, expErr: "dst requires float register but got R30"},
 
-		{src: REG_F10, dst: REG_F30, requireSrcInt: false, requireDstInt: false, expErr: ""},
-		{src: REG_F10, dst: REG_F30, requireSrcInt: true, requireDstInt: false, expErr: "src requires int register but got F10"},
-		{src: REG_F10, dst: REG_F30, requireSrcInt: true, requireDstInt: true, expErr: "src requires int register but got F10"},
-		{src: REG_F10, dst: REG_F30, requireSrcInt: false, requireDstInt: true, expErr: "dst requires int register but got F30"},
+		{src: REG_V10, dst: REG_V30, requireSrcInt: false, requireDstInt: false, expErr: ""},
+		{src: REG_V10, dst: REG_V30, requireSrcInt: true, requireDstInt: false, expErr: "src requires int register but got V10"},
+		{src: REG_V10, dst: REG_V30, requireSrcInt: true, requireDstInt: true, expErr: "src requires int register but got V10"},
+		{src: REG_V10, dst: REG_V30, requireSrcInt: false, requireDstInt: true, expErr: "dst requires int register but got V30"},
 	} {
 		actual := checkRegisterToRegisterType(tc.src, tc.dst, tc.requireSrcInt, tc.requireDstInt)
 		if tc.expErr != "" {
@@ -411,5 +481,36 @@ func Test_validateMemoryOffset(t *testing.T) {
 		} else {
 			require.EqualError(t, actual, tc.expErr)
 		}
+	}
+}
+
+func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
+	x1, x2 := REG_V2, REG_V10
+	for _, tc := range []struct {
+		inst asm.Instruction
+		exp  []byte
+	}{
+		// These are not supported in golang-asm, so test it here instead of integration tests.
+		{inst: VFADDD, exp: []byte{
+			0x4a, 0xd4, 0x6a, 0x4e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		}},
+		{inst: VFADDS, exp: []byte{
+			0x4a, 0xd4, 0x2a, 0x4e, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+		}},
+	} {
+		tc := tc
+		t.Run(InstructionName(tc.inst), func(t *testing.T) {
+			a := NewAssemblerImpl(asm.NilRegister)
+			err := a.EncodeVectorRegisterToVectorRegister(&NodeImpl{
+				Instruction: tc.inst,
+				SrcReg:      x1,
+				DstReg:      x2,
+			})
+			require.NoError(t, err)
+			actual, err := a.Assemble()
+			require.NoError(t, err)
+
+			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
+		})
 	}
 }

--- a/internal/engine/compiler/RATIONALE.md
+++ b/internal/engine/compiler/RATIONALE.md
@@ -37,10 +37,10 @@ marked as executable via mmap system call.
 
 Assuming that we have a native code as `[]byte`, it is straightforward to enter
 the native code region via Go assembly code. In this package, we have the
-function without body called `compilercall`
+function without body called `nativecall`
 
 ```go
-func compilercall(codeSegment, engine, memory uintptr)
+func nativecall(codeSegment, engine, memory uintptr)
 ```
 
 where we pass `codeSegment uintptr` as a first argument. This pointer is to the
@@ -51,10 +51,10 @@ first instruction to be executed. The pointer can be easily derived from
 code := []byte{}
 /* ...Compilation ...*/
 codeSegment := uintptr(unsafe.Pointer(&code[0]))
-compilercall(codeSegment, ...)
+nativecall(codeSegment, ...)
 ```
 
-And `compilercall` is actually implemented in [arch_amd64.s](./arch_amd64.s)
+And `nativecall` is actually implemented in [arch_amd64.s](./arch_amd64.s)
 as a convenience layer to comply with the Go's official calling convention.
 We delegate the task to jump into the code segment to the Go assembler code.
 

--- a/internal/engine/compiler/arch.go
+++ b/internal/engine/compiler/arch.go
@@ -6,9 +6,9 @@ var (
 	newArchContext func() archContext
 )
 
-// compilercall is used by callEngine.execWasmFunction and the entrypoint to enter the compiled native code.
+// nativecall is used by callEngine.execWasmFunction and the entrypoint to enter the compiled native code.
 // codeSegment is the pointer to the initial instruction of the compiled native code.
 // ce is "*callEngine" as uintptr.
 //
 // Note: this is implemented in per-arch Go assembler file. For example, arch_amd64.s implements this for amd64.
-func compilercall(codeSegment, ce uintptr, moduleInstanceAddress uintptr)
+func nativecall(codeSegment, ce uintptr, moduleInstanceAddress uintptr)

--- a/internal/engine/compiler/arch_amd64.go
+++ b/internal/engine/compiler/arch_amd64.go
@@ -17,8 +17,8 @@ type archContext struct{}
 func newArchContextImpl() (ret archContext) { return }
 
 func init() {
-	unreservedGeneralPurposeIntRegisters = amd64UnreservedGeneralPurposeIntRegisters
-	unreservedGeneralPurposeFloatRegisters = amd64UnreservedGeneralPurposeFloatRegisters
+	unreservedGeneralPurposeRegisters = amd64UnreservedGeneralPurposeRegisters
+	unreservedVectorRegisters = amd64UnreservedVectorRegisters
 }
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.

--- a/internal/engine/compiler/arch_amd64.s
+++ b/internal/engine/compiler/arch_amd64.s
@@ -1,8 +1,8 @@
 #include "funcdata.h"
 #include "textflag.h"
 
-// compilercall(codeSegment, ce, moduleInstanceAddress)
-TEXT ·compilercall(SB),NOSPLIT|NOFRAME,$0-24
+// nativecall(codeSegment, ce, moduleInstanceAddress)
+TEXT ·nativecall(SB),NOSPLIT|NOFRAME,$0-24
         MOVQ ce+8(FP),R13                     // Load the address of *callEngine. into amd64ReservedRegisterForCallEngine.
         MOVQ moduleInstanceAddress+16(FP),R12 // Load the address of *wasm.ModuleInstance into amd64CallingConventionModuleInstanceAddressRegister.
         MOVQ codeSegment+0(FP),AX             // Load the address of native code.

--- a/internal/engine/compiler/arch_arm64.go
+++ b/internal/engine/compiler/arch_arm64.go
@@ -13,8 +13,8 @@ func init() {
 
 // archContext is embedded in callEngine in order to store architecture-specific data.
 type archContext struct {
-	// compilerCallReturnAddress holds the absolute return address for compilercall.
-	// The value is set whenever compilercall is executed and done in compiler_arm64.s
+	// compilerCallReturnAddress holds the absolute return address for nativecall.
+	// The value is set whenever nativecall is executed and done in compiler_arm64.s
 	// Native code can return back to the ce.execWasmFunction's main loop back by
 	// executing "ret" instruction with this value. See arm64Compiler.exit.
 	// Note: this is only used by Compiler code so mark this as nolint.
@@ -42,8 +42,8 @@ func newArchContextImpl() archContext {
 }
 
 func init() {
-	unreservedGeneralPurposeIntRegisters = arm64UnreservedGeneralPurposeIntRegisters
-	unreservedGeneralPurposeFloatRegisters = arm64UnreservedGeneralPurposeFloatRegisters
+	unreservedGeneralPurposeRegisters = arm64UnreservedGeneralPurposeRegisters
+	unreservedVectorRegisters = arm64UnreservedVectorRegisters
 }
 
 // newCompiler returns a new compiler interface which can be used to compile the given function instance.

--- a/internal/engine/compiler/arch_arm64.s
+++ b/internal/engine/compiler/arch_arm64.s
@@ -1,8 +1,8 @@
 #include "funcdata.h"
 #include "textflag.h"
 
-// compilercall(codeSegment, ce, moduleInstanceAddress)
-TEXT ·compilercall(SB),NOSPLIT|NOFRAME,$0-24
+// nativecall(codeSegment, ce, moduleInstanceAddress)
+TEXT ·nativecall(SB),NOSPLIT|NOFRAME,$0-24
         // Load the address of *callEngine into arm64ReservedRegisterForCallEngine.
         MOVD ce+8(FP),R0
         // In arm64, return address is stored in R30 after jumping into the code.

--- a/internal/engine/compiler/arch_other.s
+++ b/internal/engine/compiler/arch_other.s
@@ -1,3 +1,3 @@
 //go:build !arm64 && !amd64
 
-TEXT ·compilercall(SB),$0-16
+TEXT ·nativecall(SB),$0-16

--- a/internal/engine/compiler/compiler.go
+++ b/internal/engine/compiler/compiler.go
@@ -23,7 +23,7 @@ type compiler interface {
 	// Return true if the compiler decided to skip the entire label.
 	// See wazeroir.OperationLabel
 	compileLabel(o *wazeroir.OperationLabel) (skipThisLabel bool)
-	// compileUnreachable adds instructions to return to engine with compilerCallStatusCodeUnreachable status.
+	// compileUnreachable adds instructions to return to engine with nativeCallStatusCodeUnreachable status.
 	// See wasm.OpcodeUnreachable
 	compileUnreachable() error
 	// compileSwap adds instruction to swap the stack top value with the target in the Wasm value stack.
@@ -65,8 +65,8 @@ type compiler interface {
 	// Note: This is called indirect function call in the sense that the target function is indirectly
 	// determined by the current state (top value) of the stack.
 	// Therefore, two checks are performed at runtime before entering the target function:
-	// 1) If "offset" exceeds the length of table, the function exits with compilerCallStatusCodeInvalidTableAccess.
-	// 2) If the type of the function table[offset] doesn't match the specified function type, the function exits with compilerCallStatusCodeTypeMismatchOnIndirectCall.
+	// 1) If "offset" exceeds the length of table, the function exits with nativeCallStatusCodeInvalidTableAccess.
+	// 2) If the type of the function table[offset] doesn't match the specified function type, the function exits with nativeCallStatusCodeTypeMismatchOnIndirectCall.
 	// Otherwise, we successfully enter the target function.
 	//
 	// See wasm.CallIndirect
@@ -203,7 +203,7 @@ type compiler interface {
 	// Please refer to [1] and [2] for when we encounter undefined behavior in the WebAssembly specification.
 	// To summarize, if the source float value is NaN or doesn't fit in the destination range of integers (incl. +=Inf),
 	// then the runtime behavior is undefined. In wazero, we exit the function in these undefined cases with
-	// compilerCallStatusCodeInvalidFloatToIntConversion or compilerCallStatusIntegerOverflow status code.
+	// nativeCallStatusCodeInvalidFloatToIntConversion or nativeCallStatusIntegerOverflow status code.
 	// [1] https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefop-trunc-umathrmtruncmathsfu_m-n-z for unsigned integers.
 	// [2] https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefop-trunc-smathrmtruncmathsfs_m-n-z for signed integers.
 	// See OpcodeI32TruncF32S OpcodeI32TruncF32U OpcodeI32TruncF64S OpcodeI32TruncF64U
@@ -270,35 +270,35 @@ type compiler interface {
 	// See wasm.OpcodeI32Load wasm.OpcodeI64Load wasm.OpcodeF32Load wasm.OpcodeF64Load
 	compileLoad(o *wazeroir.OperationLoad) error
 	// compileLoad8 adds instructions to perform load8 instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds if out-of-bounds access happens.
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds if out-of-bounds access happens.
 	// See wasm.OpcodeI32Load8S wasm.OpcodeI32Load8U wasm.OpcodeI64Load8S wasm.OpcodeI64Load8U
 	compileLoad8(o *wazeroir.OperationLoad8) error
 	// compileLoad16 adds instructions to perform load16 instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds if out-of-bounds access happens.
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds if out-of-bounds access happens.
 	// See wasm.OpcodeI32Load16S wasm.OpcodeI32Load16U wasm.OpcodeI64Load16S wasm.OpcodeI64Load16U
 	compileLoad16(o *wazeroir.OperationLoad16) error
 	// compileLoad32 adds instructions to perform load32 instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds
 	// if out-of-bounds access happens.
 	// See wasm.OpcodeI64Load32S wasm.OpcodeI64Load32U
 	compileLoad32(o *wazeroir.OperationLoad32) error
 	// compileStore adds instructions to perform store instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds
 	// if out-of-bounds access happens.
 	// See wasm.OpcodeI32Store wasm.OpcodeI64Store wasm.OpcodeF32Store wasm.OpcodeF64Store
 	compileStore(o *wazeroir.OperationStore) error
 	// compileStore8 adds instructions to perform store8 instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds
 	// if out-of-bounds access happens.
 	// See wasm.OpcodeI32Store8S wasm.OpcodeI32Store8U wasm.OpcodeI64Store8S wasm.OpcodeI64Store8U
 	compileStore8(o *wazeroir.OperationStore8) error
 	// compileStore16 adds instructions to perform store16 instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds
 	// if out-of-bounds access happens.
 	// See wasm.OpcodeI32Store16S wasm.OpcodeI32Store16U wasm.OpcodeI64Store16S wasm.OpcodeI64Store16U
 	compileStore16(o *wazeroir.OperationStore16) error
 	// compileStore32 adds instructions to perform store32 instruction in WebAssembly.
-	// The resulting code checks the memory boundary at runtime, and exit the function with compilerCallStatusCodeMemoryOutOfBounds
+	// The resulting code checks the memory boundary at runtime, and exit the function with nativeCallStatusCodeMemoryOutOfBounds
 	// if out-of-bounds access happens.
 	// See wasm.OpcodeI64Store32S wasm.OpcodeI64Store32U
 	compileStore32(o *wazeroir.OperationStore32) error
@@ -375,7 +375,7 @@ type compiler interface {
 	// wasm.FeatureReferenceTypes.
 	//
 	// Note: in wazero, we express any reference types (funcref or externref) as opaque pointers which is uint64.
-	// Thefore, the compilers implementations emit instructions to push the address of *function onto the stack.
+	// Therefore, the compilers implementations emit instructions to push the address of *function onto the stack.
 	//
 	// https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/valid/instructions.html#xref-syntax-instructions-syntax-instr-ref-mathsf-ref-func-x
 	compileRefFunc(*wazeroir.OperationRefFunc) error
@@ -404,4 +404,9 @@ type compiler interface {
 	//
 	// https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/valid/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-fill-x
 	compileTableFill(*wazeroir.OperationTableFill) error
+	// compileConstV128 adds instructions to push a constant V128 value onto the stack.
+	// See wasm.OpcodeVecV128Const
+	compileConstV128(*wazeroir.OperationConstV128) error
+	// compileAddV128 adds instruction to add two vector values whose shape is specified as `o.Shape`.
+	compileAddV128(o *wazeroir.OperationAddV128) error
 }

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -33,7 +33,7 @@ func TestCompiler_compileReinterpret(t *testing.T) {
 							require.NoError(t, err)
 
 							if originOnStack {
-								loc := compiler.valueLocationStack().pushValueLocationOnStack()
+								loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
 								env.stack()[loc.stackPointer] = v
 								env.setStackPointer(1)
 							}
@@ -218,12 +218,12 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 					env.exec(code)
 
 					// Check the result.
-					expStatus := compilerCallStatusCodeReturned
+					expStatus := nativeCallStatusCodeReturned
 					if math.IsNaN(v) {
 						if tc.nonTrapping {
 							v = 0
 						} else {
-							expStatus = compilerCallStatusCodeInvalidFloatToIntConversion
+							expStatus = nativeCallStatusCodeInvalidFloatToIntConversion
 						}
 					}
 					if tc.inputType == wazeroir.Float32 && tc.outputType == wazeroir.SignedInt32 {
@@ -237,10 +237,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxInt32
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsInt32())
 						}
 					} else if tc.inputType == wazeroir.Float32 && tc.outputType == wazeroir.SignedInt64 {
@@ -254,10 +254,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxInt64
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsInt64())
 						}
 					} else if tc.inputType == wazeroir.Float64 && tc.outputType == wazeroir.SignedInt32 {
@@ -269,10 +269,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									v = math.MaxInt32
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, int32(math.Trunc(v)), env.stackTopAsInt32())
 						}
 					} else if tc.inputType == wazeroir.Float64 && tc.outputType == wazeroir.SignedInt64 {
@@ -285,10 +285,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxInt64
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsInt64())
 						}
 					} else if tc.inputType == wazeroir.Float32 && tc.outputType == wazeroir.SignedUint32 {
@@ -302,10 +302,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxUint32
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsUint32())
 						}
 					} else if tc.inputType == wazeroir.Float64 && tc.outputType == wazeroir.SignedUint32 {
@@ -318,10 +318,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxUint32
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsUint32())
 						}
 					} else if tc.inputType == wazeroir.Float32 && tc.outputType == wazeroir.SignedUint64 {
@@ -335,10 +335,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxUint64
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsUint64())
 						}
 					} else if tc.inputType == wazeroir.Float64 && tc.outputType == wazeroir.SignedUint64 {
@@ -351,10 +351,10 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 									exp = math.MaxUint64
 								}
 							} else {
-								expStatus = compilerCallStatusIntegerOverflow
+								expStatus = nativeCallStatusIntegerOverflow
 							}
 						}
-						if expStatus == compilerCallStatusCodeReturned {
+						if expStatus == nativeCallStatusCodeReturned {
 							require.Equal(t, exp, env.stackTopAsUint64())
 						}
 					}

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -33,12 +33,12 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			require.NoError(t, err)
 
 			// At this point, the top of stack must be the retrieved global on a register.
-			global := compiler.valueLocationStack().peek()
+			global := compiler.runtimeValueLocationStack().peek()
 			require.True(t, global.onRegister())
-			require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 			switch tp {
 			case wasm.ValueTypeF32, wasm.ValueTypeF64:
-				require.True(t, isFloatRegister(global.register))
+				require.True(t, isVectorRegister(global.register))
 			case wasm.ValueTypeI32, wasm.ValueTypeI64:
 				require.True(t, isIntRegister(global.register))
 			}
@@ -58,6 +58,49 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			require.Equal(t, uint64(1), env.stackPointer())
 		})
 	}
+}
+
+func TestCompiler_compileGlobalGet_v128(t *testing.T) {
+	const v128Type = wasm.ValueTypeV128
+	env := newCompilerEnvironment()
+	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+		Signature: &wasm.FunctionType{},
+		Globals:   []*wasm.GlobalType{nil, {ValType: v128Type}},
+	})
+
+	// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
+	globals := []*wasm.GlobalInstance{nil, {Val: 12345, ValHi: 6789, Type: &wasm.GlobalType{ValType: v128Type}}}
+	env.addGlobals(globals...)
+
+	// Emit the code.
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
+	op := &wazeroir.OperationGlobalGet{Index: 1}
+	err = compiler.compileGlobalGet(op)
+	require.NoError(t, err)
+
+	// At this point, the top of stack must be the retrieved global on a register.
+	global := compiler.runtimeValueLocationStack().peek()
+	require.True(t, global.onRegister())
+	require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+	require.True(t, isVectorRegister(global.register))
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
+
+	// Generate the code under test.
+	code, _, _, err := compiler.compile()
+	require.NoError(t, err)
+
+	// Run the code assembled above.
+	env.exec(code)
+
+	require.Equal(t, uint64(2), env.stackPointer())
+	require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
+
+	// Since we call global.get, the top of the stack must be the global value.
+	actual := globals[1]
+	require.Equal(t, actual.Val, env.stack()[0])
+	require.Equal(t, actual.ValHi, env.stack()[1])
 }
 
 func TestCompiler_compileGlobalSet(t *testing.T) {
@@ -82,18 +125,22 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			require.NoError(t, err)
 
 			// Place the set target value.
-			loc := compiler.valueLocationStack().pushValueLocationOnStack()
+			loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
 			switch tp {
-			case wasm.ValueTypeI32, wasm.ValueTypeI64, wasm.ValueTypeExternref, wasm.ValueTypeFuncref:
-				loc.setRegisterType(generalPurposeRegisterTypeInt)
-			case wasm.ValueTypeF32, wasm.ValueTypeF64:
-				loc.setRegisterType(generalPurposeRegisterTypeFloat)
+			case wasm.ValueTypeI32:
+				loc.valueType = runtimeValueTypeI32
+			case wasm.ValueTypeI64, wasm.ValueTypeExternref, wasm.ValueTypeFuncref:
+				loc.valueType = runtimeValueTypeI64
+			case wasm.ValueTypeF32:
+				loc.valueType = runtimeValueTypeF32
+			case wasm.ValueTypeF64:
+				loc.valueType = runtimeValueTypeF64
 			}
 			env.stack()[loc.stackPointer] = valueToSet
 
 			op := &wazeroir.OperationGlobalSet{Index: 1}
 			err = compiler.compileGlobalSet(op)
-			require.Equal(t, uint64(0), compiler.valueLocationStack().sp)
+			require.Equal(t, uint64(0), compiler.runtimeValueLocationStack().sp)
 			require.NoError(t, err)
 
 			err = compiler.compileReturnFunction()
@@ -105,9 +152,56 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			env.exec(code)
 
 			// The global value should be set to valueToSet.
-			require.Equal(t, valueToSet, env.getGlobal(op.Index))
+			actual := env.globals()[op.Index]
+			require.Equal(t, valueToSet, actual.Val)
 			// Plus we consumed the top of the stack, the stack pointer must be decremented.
 			require.Equal(t, uint64(0), env.stackPointer())
 		})
 	}
+}
+
+func TestCompiler_compileGlobalSet_v128(t *testing.T) {
+	const v128Type = wasm.ValueTypeV128
+	const valueToSetLo, valueToSetHi uint64 = 0xffffff, 1
+
+	env := newCompilerEnvironment()
+	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+		Signature: &wasm.FunctionType{},
+		Globals:   []*wasm.GlobalType{nil, {ValType: v128Type}},
+	})
+
+	// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
+	env.addGlobals(nil, &wasm.GlobalInstance{Val: 0, ValHi: 0, Type: &wasm.GlobalType{ValType: v128Type}})
+
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
+
+	// Place the set target value.
+	lo := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+	lo.valueType = runtimeValueTypeV128Lo
+	env.stack()[lo.stackPointer] = valueToSetLo
+	hi := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+	hi.valueType = runtimeValueTypeV128Hi
+	env.stack()[hi.stackPointer] = valueToSetHi
+
+	op := &wazeroir.OperationGlobalSet{Index: 1}
+	err = compiler.compileGlobalSet(op)
+	require.Equal(t, uint64(0), compiler.runtimeValueLocationStack().sp)
+	require.NoError(t, err)
+
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
+
+	// Generate the code under test.
+	code, _, _, err := compiler.compile()
+	require.NoError(t, err)
+	env.exec(code)
+
+	require.Equal(t, uint64(0), env.stackPointer())
+	require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
+
+	// The global value should be set to valueToSet.
+	actual := env.globals()[op.Index]
+	require.Equal(t, valueToSetLo, actual.Val)
+	require.Equal(t, valueToSetHi, actual.ValHi)
 }

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -223,10 +223,10 @@ func TestCompiler_compileMemoryCopy(t *testing.T) {
 					exp[tc.sourceOffset:tc.sourceOffset+tc.size])
 
 				// Check the status code and the destination memory region.
-				require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 				require.Equal(t, exp, mem[:checkCeil])
 			} else {
-				require.Equal(t, compilerCallStatusCodeMemoryOutOfBounds, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeMemoryOutOfBounds, env.compilerStatus())
 			}
 		})
 	}
@@ -302,10 +302,10 @@ func TestCompiler_compileMemoryFill(t *testing.T) {
 				}
 
 				// Check the status code and the destination memory region.
-				require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 				require.Equal(t, exp, mem[:checkCeil])
 			} else {
-				require.Equal(t, compilerCallStatusCodeMemoryOutOfBounds, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeMemoryOutOfBounds, env.compilerStatus())
 			}
 		})
 	}
@@ -343,7 +343,7 @@ func TestCompiler_compileDataDrop(t *testing.T) {
 			// Run code.
 			env.exec(code)
 
-			require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 
 			// Check if the target data instance is dropped from the dataInstances slice.
 			for j := 0; j < len(origins); j++ {
@@ -432,7 +432,7 @@ func TestCompiler_compileMemoryInit(t *testing.T) {
 				}
 				require.Equal(t, exp[:20], mem[:20])
 			} else {
-				require.Equal(t, compilerCallStatusCodeMemoryOutOfBounds, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeMemoryOutOfBounds, env.compilerStatus())
 			}
 		})
 	}
@@ -480,7 +480,7 @@ func TestCompiler_compileElemDrop(t *testing.T) {
 			// Run code.
 			env.exec(code)
 
-			require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 
 			for j := 0; j < len(insts); j++ {
 				if i == j {
@@ -572,10 +572,10 @@ func TestCompiler_compileTableCopy(t *testing.T) {
 					exp[tc.sourceOffset:tc.sourceOffset+tc.size])
 
 				// Check the status code and the destination memory region.
-				require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 				require.Equal(t, exp, table)
 			} else {
-				require.Equal(t, compilerCallStatusCodeInvalidTableAccess, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			}
 		})
 	}
@@ -655,7 +655,7 @@ func TestCompiler_compileTableInit(t *testing.T) {
 			env.exec(code)
 
 			if !tc.expOutOfBounds {
-				require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 				exp := make([]wasm.Reference, tableSize)
 				for i := 0; i < tableSize; i++ {
 					exp[i] = uintptr(i)
@@ -665,7 +665,7 @@ func TestCompiler_compileTableInit(t *testing.T) {
 				}
 				require.Equal(t, exp, table)
 			} else {
-				require.Equal(t, compilerCallStatusCodeInvalidTableAccess, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			}
 		})
 	}
@@ -768,9 +768,9 @@ func TestCompiler_compileTableSet(t *testing.T) {
 			env.exec(code)
 
 			if tc.expError {
-				require.Equal(t, compilerCallStatusCodeInvalidTableAccess, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			} else {
-				require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 				require.Equal(t, uint64(0), env.stackPointer())
 
 				if tc.expExtern {
@@ -895,9 +895,9 @@ func TestCompiler_compileTableGet(t *testing.T) {
 			env.exec(code)
 
 			if tc.expError {
-				require.Equal(t, compilerCallStatusCodeInvalidTableAccess, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			} else {
-				require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 				require.Equal(t, uint64(1), env.stackPointer())
 				require.Equal(t, uint64(tc.exp), env.stackTopAsUint64())
 			}
@@ -938,7 +938,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 			// Run code.
 			env.exec(code)
 
-			require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 			require.Equal(t, uint64(1), env.stackPointer())
 			require.Equal(t, uintptr(unsafe.Pointer(me.functions[i])), uintptr(env.stackTopAsUint64()))
 		})

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -38,14 +38,14 @@ func TestCompiler_VerifyOffsetValue(t *testing.T) {
 	require.Equal(t, int(unsafe.Offsetof(ce.functionsElement0Address)), callEngineModuleContextFunctionsElement0AddressOffset)
 	require.Equal(t, int(unsafe.Offsetof(ce.typeIDsElement0Address)), callEngineModuleContextTypeIDsElement0AddressOffset)
 	require.Equal(t, int(unsafe.Offsetof(ce.dataInstancesElement0Address)), callEngineModuleContextDataInstancesElement0AddressOffset)
-	require.Equal(t, int(unsafe.Offsetof(ce.elementInstancesElemen0Address)), callEngineModuleContextElementInstancesElement0AddressOffset)
+	require.Equal(t, int(unsafe.Offsetof(ce.elementInstancesElement0Address)), callEngineModuleContextElementInstancesElement0AddressOffset)
 
 	// Offsets for callEngine.valueStackContext
 	require.Equal(t, int(unsafe.Offsetof(ce.stackPointer)), callEngineValueStackContextStackPointerOffset)
 	require.Equal(t, int(unsafe.Offsetof(ce.stackBasePointer)), callEngineValueStackContextStackBasePointerOffset)
 
 	// Offsets for callEngine.exitContext.
-	require.Equal(t, int(unsafe.Offsetof(ce.statusCode)), callEngineExitContextCompilerCallStatusCodeOffset)
+	require.Equal(t, int(unsafe.Offsetof(ce.statusCode)), callEngineExitContextnativeCallStatusCodeOffset)
 	require.Equal(t, int(unsafe.Offsetof(ce.builtinFunctionCallIndex)), callEngineExitContextBuiltinFunctionCallAddressOffset)
 
 	// Size and offsets for callFrame.

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -176,7 +176,6 @@ func (c *amd64Compiler) pushVectorRuntimeValueLocationOnRegister(reg asm.Registe
 	c.locationStack.pushRuntimeValueLocationOnRegister(reg, runtimeValueTypeV128Lo)
 	c.locationStack.pushRuntimeValueLocationOnRegister(reg, runtimeValueTypeV128Hi)
 	c.locationStack.markRegisterUsed(reg)
-	return
 }
 
 type amd64LabelInfo struct {

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -79,21 +79,21 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// Here, we put it just before two operands as ["any value used by DX", x1, x2]
 						// but in reality, it can exist in any position of stack.
 						compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(dxValue), amd64.REG_DX)
-						prevOnDX := compiler.pushValueLocationOnRegister(amd64.REG_DX)
+						prevOnDX := compiler.pushRuntimeValueLocationOnRegister(amd64.REG_DX, runtimeValueTypeI32)
 
 						// Setup values.
 						if tc.x1Reg != asm.NilRegister {
 							compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(x1Value), tc.x1Reg)
-							compiler.pushValueLocationOnRegister(tc.x1Reg)
+							compiler.pushRuntimeValueLocationOnRegister(tc.x1Reg, runtimeValueTypeI32)
 						} else {
-							loc := compiler.valueLocationStack().pushValueLocationOnStack()
+							loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
 							env.stack()[loc.stackPointer] = uint64(x1Value)
 						}
 						if tc.x2Reg != asm.NilRegister {
 							compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(x2Value), tc.x2Reg)
-							compiler.pushValueLocationOnRegister(tc.x2Reg)
+							compiler.pushRuntimeValueLocationOnRegister(tc.x2Reg, runtimeValueTypeI32)
 						} else {
-							loc := compiler.valueLocationStack().pushValueLocationOnStack()
+							loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
 							env.stack()[loc.stackPointer] = uint64(x2Value)
 						}
 
@@ -107,9 +107,9 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						}
 						require.NoError(t, err)
 
-						require.Equal(t, generalPurposeRegisterTypeInt, compiler.valueLocationStack().peek().regType)
-						require.Equal(t, uint64(2), compiler.valueLocationStack().sp)
-						require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
+						require.Equal(t, registerTypeGeneralPurpose, compiler.runtimeValueLocationStack().peek().getRegisterType())
+						require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+						require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 						// At this point, the previous value on the DX register is saved to the stack.
 						require.True(t, prevOnDX.onStack())
 
@@ -201,21 +201,21 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// Here, we put it just before two operands as ["any value used by DX", x1, x2]
 						// but in reality, it can exist in any position of stack.
 						compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(dxValue), amd64.REG_DX)
-						prevOnDX := compiler.pushValueLocationOnRegister(amd64.REG_DX)
+						prevOnDX := compiler.pushRuntimeValueLocationOnRegister(amd64.REG_DX, runtimeValueTypeI64)
 
 						// Setup values.
 						if tc.x1Reg != asm.NilRegister {
 							compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(x1Value), tc.x1Reg)
-							compiler.pushValueLocationOnRegister(tc.x1Reg)
+							compiler.pushRuntimeValueLocationOnRegister(tc.x1Reg, runtimeValueTypeI64)
 						} else {
-							loc := compiler.valueLocationStack().pushValueLocationOnStack()
+							loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
 							env.stack()[loc.stackPointer] = uint64(x1Value)
 						}
 						if tc.x2Reg != asm.NilRegister {
 							compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(x2Value), tc.x2Reg)
-							compiler.pushValueLocationOnRegister(tc.x2Reg)
+							compiler.pushRuntimeValueLocationOnRegister(tc.x2Reg, runtimeValueTypeI64)
 						} else {
-							loc := compiler.valueLocationStack().pushValueLocationOnStack()
+							loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
 							env.stack()[loc.stackPointer] = uint64(x2Value)
 						}
 
@@ -229,9 +229,9 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						}
 						require.NoError(t, err)
 
-						require.Equal(t, generalPurposeRegisterTypeInt, compiler.valueLocationStack().peek().regType)
-						require.Equal(t, uint64(2), compiler.valueLocationStack().sp)
-						require.Equal(t, 1, len(compiler.valueLocationStack().usedRegisters))
+						require.Equal(t, registerTypeGeneralPurpose, compiler.runtimeValueLocationStack().peek().getRegisterType())
+						require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+						require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 						// At this point, the previous value on the DX register is saved to the stack.
 						require.True(t, prevOnDX.onStack())
 
@@ -321,14 +321,14 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		// Run code.
 		env.exec(code)
 
-		require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+		require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 		require.Equal(t, uint64(1), env.stackPointer())
 		require.Equal(t, expectedReturnValue, env.stackTopAsUint32())
 	})
 }
 
-// compile implements compilerImpl.valueLocationStack for the amd64 architecture.
-func (c *amd64Compiler) valueLocationStack() *valueLocationStack {
+// compile implements compilerImpl.runtimeValueLocationStack for the amd64 architecture.
+func (c *amd64Compiler) runtimeValueLocationStack() *runtimeValueLocationStack {
 	return c.locationStack
 }
 
@@ -342,11 +342,11 @@ func (c *amd64Compiler) setStackPointerCeil(v uint64) {
 	c.stackPointerCeil = v
 }
 
-// compile implements compilerImpl.setValueLocationStack for the amd64 architecture.
-func (c *amd64Compiler) setValueLocationStack(s *valueLocationStack) {
+// compile implements compilerImpl.setRuntimeValueLocationStack for the amd64 architecture.
+func (c *amd64Compiler) setRuntimeValueLocationStack(s *runtimeValueLocationStack) {
 	c.locationStack = s
 }
 
-func (a *amd64Compiler) compileNOP() {
-	a.assembler.CompileStandAlone(amd64.NOP)
+func (c *amd64Compiler) compileNOP() {
+	c.assembler.CompileStandAlone(amd64.NOP)
 }

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -25,7 +25,7 @@ func TestArm64Compiler_readInstructionAddress(t *testing.T) {
 
 	// If we fail to branch, we reach here and exit with unreachable status,
 	// so the assertion would fail.
-	compiler.compileExitFromNativeCode(compilerCallStatusCodeUnreachable)
+	compiler.compileExitFromNativeCode(nativeCallStatusCodeUnreachable)
 
 	// This could be the read instruction target as this is the
 	// right after RET. Therefore, the branch instruction above
@@ -38,11 +38,11 @@ func TestArm64Compiler_readInstructionAddress(t *testing.T) {
 
 	env.exec(code)
 
-	require.Equal(t, compilerCallStatusCodeReturned, env.compilerStatus())
+	require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 }
 
-// compile implements compilerImpl.valueLocationStack for the amd64 architecture.
-func (c *arm64Compiler) valueLocationStack() *valueLocationStack {
+// compile implements compilerImpl.runtimeValueLocationStack for the amd64 architecture.
+func (c *arm64Compiler) runtimeValueLocationStack() *runtimeValueLocationStack {
 	return c.locationStack
 }
 
@@ -56,11 +56,11 @@ func (c *arm64Compiler) setStackPointerCeil(v uint64) {
 	c.stackPointerCeil = v
 }
 
-// compile implements compilerImpl.setValueLocationStack for the amd64 architecture.
-func (c *arm64Compiler) setValueLocationStack(s *valueLocationStack) {
+// compile implements compilerImpl.setRuntimeValueLocationStack for the amd64 architecture.
+func (c *arm64Compiler) setRuntimeValueLocationStack(s *runtimeValueLocationStack) {
 	c.locationStack = s
 }
 
-func (a *arm64Compiler) compileNOP() {
-	a.assembler.CompileStandAlone(arm64.NOP)
+func (c *arm64Compiler) compileNOP() {
+	c.assembler.CompileStandAlone(arm64.NOP)
 }

--- a/internal/engine/compiler/impl_vec_amd64.go
+++ b/internal/engine/compiler/impl_vec_amd64.go
@@ -1,0 +1,78 @@
+package compiler
+
+import (
+	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/asm/amd64"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
+)
+
+// compileConstV128 implements compiler.compileConstV128 for amd64 architecture.
+func (c *amd64Compiler) compileConstV128(o *wazeroir.OperationConstV128) error {
+	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+
+	result, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	// We cannot directly load the value from memory to float regs,
+	// so we move it to int reg temporarily.
+	tmpReg, err := c.allocateRegister(registerTypeGeneralPurpose)
+	if err != nil {
+		return err
+	}
+
+	// Move the lower 64-bits.
+	if o.Lo == 0 {
+		c.assembler.CompileRegisterToRegister(amd64.XORQ, tmpReg, tmpReg)
+	} else {
+		c.assembler.CompileConstToRegister(amd64.MOVQ, int64(o.Lo), tmpReg)
+	}
+	c.assembler.CompileRegisterToRegister(amd64.MOVQ, tmpReg, result)
+
+	if o.Lo != 0 && o.Hi == 0 {
+		c.assembler.CompileRegisterToRegister(amd64.XORQ, tmpReg, tmpReg)
+	} else if o.Hi != 0 {
+		c.assembler.CompileConstToRegister(amd64.MOVQ, int64(o.Hi), tmpReg)
+	}
+	// Move the higher 64-bits with PINSRQ at the second element of 64x2 vector.
+	c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRQ, tmpReg, result, 1)
+
+	c.pushVectorRuntimeValueLocationOnRegister(result)
+	return nil
+}
+
+// compileAddV128 implements compiler.compileAddV128 for amd64 architecture.
+func (c *amd64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
+	c.locationStack.pop() // skip higher 64-bits.
+	x2 := c.locationStack.pop()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x2); err != nil {
+		return err
+	}
+
+	c.locationStack.pop() // skip higher 64-bits.
+	x1 := c.locationStack.pop()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x1); err != nil {
+		return err
+	}
+	var inst asm.Instruction
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		inst = amd64.PADDB
+	case wazeroir.ShapeI16x8:
+		inst = amd64.PADDW
+	case wazeroir.ShapeI32x4:
+		inst = amd64.PADDL
+	case wazeroir.ShapeI64x2:
+		inst = amd64.PADDQ
+	case wazeroir.ShapeF32x4:
+		inst = amd64.ADDPS
+	case wazeroir.ShapeF64x2:
+		inst = amd64.ADDPD
+	}
+	c.assembler.CompileRegisterToRegister(inst, x2.register, x1.register)
+
+	c.pushVectorRuntimeValueLocationOnRegister(x1.register)
+	c.locationStack.markRegisterUnused(x2.register)
+	return nil
+}

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -79,6 +79,6 @@ func (c *arm64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
 	c.pushRuntimeValueLocationOnRegister(resultReg, runtimeValueTypeV128Lo)
 	c.pushRuntimeValueLocationOnRegister(resultReg, runtimeValueTypeV128Hi)
 
-	// TODO: free
+	c.markRegisterUnused(x1Low.register)
 	return nil
 }

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -1,0 +1,84 @@
+package compiler
+
+import (
+	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/asm/arm64"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
+)
+
+func (c *arm64Compiler) compileConstV128(o *wazeroir.OperationConstV128) error {
+	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+
+	result, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	// Moves the lower 64-bits as a scalar float.
+	var intReg = arm64ReservedRegisterForTemporary
+	if o.Lo == 0 {
+		intReg = arm64.REGZERO
+	} else {
+		c.assembler.CompileConstToRegister(arm64.MOVD, int64(o.Lo), arm64ReservedRegisterForTemporary)
+	}
+	c.assembler.CompileRegisterToRegister(arm64.FMOVD, intReg, result)
+
+	// Then, insert the higher bits with VMOV (translated as "ins" instruction).
+	intReg = arm64ReservedRegisterForTemporary
+	if o.Hi == 0 {
+		intReg = arm64.REGZERO
+	} else {
+		c.assembler.CompileConstToRegister(arm64.MOVD, int64(o.Hi), arm64ReservedRegisterForTemporary)
+	}
+	// "ins Vn.D[1], intReg"
+	c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, intReg, result, arm64.VectorArrangementD, 1)
+
+	c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeV128Lo)
+	c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeV128Hi)
+	return nil
+}
+
+func (c *arm64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
+	c.locationStack.pop() // skip higher 64-bits.
+	x1Low := c.locationStack.pop()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x1Low); err != nil {
+		return err
+	}
+	c.locationStack.pop() // skip higher 64-bits.
+	x2Low := c.locationStack.pop()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x2Low); err != nil {
+		return err
+	}
+
+	var arr arm64.VectorArrangement
+	var inst asm.Instruction
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		inst = arm64.VADD
+		arr = arm64.VectorArrangement16B
+	case wazeroir.ShapeI16x8:
+		inst = arm64.VADD
+		arr = arm64.VectorArrangement8H
+	case wazeroir.ShapeI32x4:
+		inst = arm64.VADD
+		arr = arm64.VectorArrangement4S
+	case wazeroir.ShapeI64x2:
+		inst = arm64.VADD
+		arr = arm64.VectorArrangement2D
+	case wazeroir.ShapeF32x4:
+		inst = arm64.VFADDS
+		arr = arm64.VectorArrangement4S
+	case wazeroir.ShapeF64x2:
+		inst = arm64.VFADDD
+		arr = arm64.VectorArrangement2D
+	}
+
+	c.assembler.CompileVectorRegisterToVectorRegister(inst, x1Low.register, x2Low.register, arr)
+
+	resultReg := x2Low.register
+	c.pushRuntimeValueLocationOnRegister(resultReg, runtimeValueTypeV128Lo)
+	c.pushRuntimeValueLocationOnRegister(resultReg, runtimeValueTypeV128Hi)
+
+	// TODO: free
+	return nil
+}

--- a/internal/integration_test/asm/amd64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/amd64_debug/debug_assembler.go
@@ -187,14 +187,14 @@ func (ta *testAssembler) CompileReadInstructionAddress(
 	ta.a.CompileReadInstructionAddress(destinationRegister, beforeAcquisitionTargetInstruction)
 }
 
-// CompileRegisterToRegisterWithMode implements the same method as documented on asm_amd64.Assembler.
-func (ta *testAssembler) CompileRegisterToRegisterWithMode(
+// CompileRegisterToRegisterWithArg implements the same method as documented on asm_amd64.Assembler.
+func (ta *testAssembler) CompileRegisterToRegisterWithArg(
 	instruction asm.Instruction,
 	from, to asm.Register,
 	mode asm_amd64.Mode,
 ) {
-	ta.goasm.CompileRegisterToRegisterWithMode(instruction, from, to, mode)
-	ta.a.CompileRegisterToRegisterWithMode(instruction, from, to, mode)
+	ta.goasm.CompileRegisterToRegisterWithArg(instruction, from, to, mode)
+	ta.a.CompileRegisterToRegisterWithArg(instruction, from, to, mode)
 }
 
 // CompileMemoryWithIndexToRegister implements the same method as documented on asm_amd64.Assembler.

--- a/internal/integration_test/asm/amd64_debug/golang_asm.go
+++ b/internal/integration_test/asm/amd64_debug/golang_asm.go
@@ -8,11 +8,11 @@ import (
 	"github.com/twitchyliquid64/golang-asm/obj/x86"
 
 	"github.com/tetratelabs/wazero/internal/asm"
-	asm_amd64 "github.com/tetratelabs/wazero/internal/asm/amd64"
+	"github.com/tetratelabs/wazero/internal/asm/amd64"
 	"github.com/tetratelabs/wazero/internal/integration_test/asm/golang_asm"
 )
 
-// assemblerGoAsmImpl implements asm_amd64.Assembler for golang-asm library.
+// assemblerGoAsmImpl implements amd64.Assembler for golang-asm library.
 type assemblerGoAsmImpl struct {
 	*golang_asm.GolangAsmBaseAssembler
 }
@@ -22,7 +22,7 @@ func newGolangAsmAssembler() (*assemblerGoAsmImpl, error) {
 	return &assemblerGoAsmImpl{g}, err
 }
 
-// CompileStandAlone implements the same method as documented on asm_amd64.Assembler.
+// CompileStandAlone implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileStandAlone(inst asm.Instruction) asm.Node {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
@@ -30,7 +30,7 @@ func (a *assemblerGoAsmImpl) CompileStandAlone(inst asm.Instruction) asm.Node {
 	return golang_asm.NewGolangAsmNode(p)
 }
 
-// CompileRegisterToRegister implements the same method as documented on asm_amd64.Assembler.
+// CompileRegisterToRegister implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileRegisterToRegister(inst asm.Instruction, from, to asm.Register) {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
@@ -41,7 +41,7 @@ func (a *assemblerGoAsmImpl) CompileRegisterToRegister(inst asm.Instruction, fro
 	a.AddInstruction(p)
 }
 
-// CompileMemoryWithIndexToRegister implements the same method as documented on asm_amd64.Assembler.
+// CompileMemoryWithIndexToRegister implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileMemoryWithIndexToRegister(
 	inst asm.Instruction,
 	sourceBaseReg asm.Register,
@@ -62,7 +62,7 @@ func (a *assemblerGoAsmImpl) CompileMemoryWithIndexToRegister(
 	a.AddInstruction(p)
 }
 
-// CompileRegisterToMemoryWithIndex implements the same method as documented on asm_amd64.Assembler.
+// CompileRegisterToMemoryWithIndex implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileRegisterToMemoryWithIndex(
 	inst asm.Instruction,
 	srcReg, dstBaseReg asm.Register,
@@ -82,12 +82,15 @@ func (a *assemblerGoAsmImpl) CompileRegisterToMemoryWithIndex(
 	a.AddInstruction(p)
 }
 
-// CompileRegisterToMemory implements the same method as documented on asm_amd64.Assembler.
+// CompileRegisterToMemory implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileRegisterToMemory(
 	inst asm.Instruction,
 	sourceRegister, destinationBaseRegister asm.Register,
 	destinationOffsetConst asm.ConstantValue,
 ) {
+	if inst == amd64.MOVDQU {
+		panic("unsupported by golang-asm")
+	}
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
 	p.To.Type = obj.TYPE_MEM
@@ -98,7 +101,7 @@ func (a *assemblerGoAsmImpl) CompileRegisterToMemory(
 	a.AddInstruction(p)
 }
 
-// CompileConstToRegister implements the same method as documented on asm_amd64.Assembler.
+// CompileConstToRegister implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileConstToRegister(
 	inst asm.Instruction,
 	constValue asm.ConstantValue,
@@ -114,7 +117,7 @@ func (a *assemblerGoAsmImpl) CompileConstToRegister(
 	return golang_asm.NewGolangAsmNode(p)
 }
 
-// CompileRegisterToConst implements the same method as documented on asm_amd64.Assembler.
+// CompileRegisterToConst implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileRegisterToConst(
 	inst asm.Instruction,
 	srcRegister asm.Register,
@@ -130,7 +133,7 @@ func (a *assemblerGoAsmImpl) CompileRegisterToConst(
 	return golang_asm.NewGolangAsmNode(p)
 }
 
-// CompileRegisterToNone implements the same method as documented on asm_amd64.Assembler.
+// CompileRegisterToNone implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileRegisterToNone(inst asm.Instruction, register asm.Register) {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
@@ -140,7 +143,7 @@ func (a *assemblerGoAsmImpl) CompileRegisterToNone(inst asm.Instruction, registe
 	a.AddInstruction(p)
 }
 
-// CompileNoneToRegister implements the same method as documented on asm_amd64.Assembler.
+// CompileNoneToRegister implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileNoneToRegister(inst asm.Instruction, register asm.Register) {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
@@ -150,7 +153,7 @@ func (a *assemblerGoAsmImpl) CompileNoneToRegister(inst asm.Instruction, registe
 	a.AddInstruction(p)
 }
 
-// CompileNoneToMemory implements the same method as documented on asm_amd64.Assembler.
+// CompileNoneToMemory implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileNoneToMemory(
 	inst asm.Instruction,
 	baseReg asm.Register,
@@ -165,7 +168,7 @@ func (a *assemblerGoAsmImpl) CompileNoneToMemory(
 	a.AddInstruction(p)
 }
 
-// CompileConstToMemory implements the same method as documented on asm_amd64.Assembler.
+// CompileConstToMemory implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileConstToMemory(
 	inst asm.Instruction,
 	constValue asm.ConstantValue,
@@ -183,13 +186,16 @@ func (a *assemblerGoAsmImpl) CompileConstToMemory(
 	return golang_asm.NewGolangAsmNode(p)
 }
 
-// CompileMemoryToRegister implements the same method as documented on asm_amd64.Assembler.
+// CompileMemoryToRegister implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileMemoryToRegister(
 	inst asm.Instruction,
 	sourceBaseReg asm.Register,
 	sourceOffsetConst asm.ConstantValue,
 	destinationReg asm.Register,
 ) {
+	if inst == amd64.MOVDQU {
+		panic("unsupported by golang-asm")
+	}
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
 	p.From.Type = obj.TYPE_MEM
@@ -200,7 +206,7 @@ func (a *assemblerGoAsmImpl) CompileMemoryToRegister(
 	a.AddInstruction(p)
 }
 
-// CompileMemoryToConst implements the same method as documented on asm_amd64.Assembler.
+// CompileMemoryToConst implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileMemoryToConst(
 	inst asm.Instruction,
 	baseReg asm.Register,
@@ -217,7 +223,7 @@ func (a *assemblerGoAsmImpl) CompileMemoryToConst(
 	return golang_asm.NewGolangAsmNode(p)
 }
 
-// CompileJump implements the same method as documented on asm_amd64.Assembler.
+// CompileJump implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileJump(jmpInstruction asm.Instruction) asm.Node {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[jmpInstruction]
@@ -226,7 +232,7 @@ func (a *assemblerGoAsmImpl) CompileJump(jmpInstruction asm.Instruction) asm.Nod
 	return golang_asm.NewGolangAsmNode(p)
 }
 
-// CompileJumpToRegister implements the same method as documented on asm_amd64.Assembler.
+// CompileJumpToRegister implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileJumpToRegister(jmpInstruction asm.Instruction, reg asm.Register) {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[jmpInstruction]
@@ -235,7 +241,7 @@ func (a *assemblerGoAsmImpl) CompileJumpToRegister(jmpInstruction asm.Instructio
 	a.AddInstruction(p)
 }
 
-// CompileJumpToMemory implements the same method as documented on asm_amd64.Assembler.
+// CompileJumpToMemory implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileJumpToMemory(
 	jmpInstruction asm.Instruction,
 	baseReg asm.Register,
@@ -249,16 +255,16 @@ func (a *assemblerGoAsmImpl) CompileJumpToMemory(
 	a.AddInstruction(p)
 }
 
-// CompileRegisterToRegisterWithMode implements the same method as documented on asm_amd64.Assembler.
-func (a *assemblerGoAsmImpl) CompileRegisterToRegisterWithMode(
+// CompileRegisterToRegisterWithArg implements the same method as documented on amd64.Assembler.
+func (a *assemblerGoAsmImpl) CompileRegisterToRegisterWithArg(
 	inst asm.Instruction,
 	from, to asm.Register,
-	mode asm_amd64.Mode,
+	arg byte,
 ) {
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
 	p.From.Type = obj.TYPE_CONST
-	p.From.Offset = int64(mode)
+	p.From.Offset = int64(arg)
 	p.To.Type = obj.TYPE_REG
 	p.To.Reg = castAsGolangAsmRegister[to]
 	p.RestArgs = append(p.RestArgs,
@@ -266,7 +272,7 @@ func (a *assemblerGoAsmImpl) CompileRegisterToRegisterWithMode(
 	a.AddInstruction(p)
 }
 
-// CompileReadInstructionAddress implements the same method as documented on asm_amd64.Assembler.
+// CompileReadInstructionAddress implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileReadInstructionAddress(
 	destinationRegister asm.Register,
 	beforeAcquisitionTargetInstruction asm.Instruction,
@@ -324,171 +330,178 @@ func (a *assemblerGoAsmImpl) CompileReadInstructionAddress(
 
 // castAsGolangAsmRegister maps the registers to golang-asm specific register values.
 var castAsGolangAsmRegister = [...]int16{
-	asm_amd64.REG_AX:  x86.REG_AX,
-	asm_amd64.REG_CX:  x86.REG_CX,
-	asm_amd64.REG_DX:  x86.REG_DX,
-	asm_amd64.REG_BX:  x86.REG_BX,
-	asm_amd64.REG_SP:  x86.REG_SP,
-	asm_amd64.REG_BP:  x86.REG_BP,
-	asm_amd64.REG_SI:  x86.REG_SI,
-	asm_amd64.REG_DI:  x86.REG_DI,
-	asm_amd64.REG_R8:  x86.REG_R8,
-	asm_amd64.REG_R9:  x86.REG_R9,
-	asm_amd64.REG_R10: x86.REG_R10,
-	asm_amd64.REG_R11: x86.REG_R11,
-	asm_amd64.REG_R12: x86.REG_R12,
-	asm_amd64.REG_R13: x86.REG_R13,
-	asm_amd64.REG_R14: x86.REG_R14,
-	asm_amd64.REG_R15: x86.REG_R15,
-	asm_amd64.REG_X0:  x86.REG_X0,
-	asm_amd64.REG_X1:  x86.REG_X1,
-	asm_amd64.REG_X2:  x86.REG_X2,
-	asm_amd64.REG_X3:  x86.REG_X3,
-	asm_amd64.REG_X4:  x86.REG_X4,
-	asm_amd64.REG_X5:  x86.REG_X5,
-	asm_amd64.REG_X6:  x86.REG_X6,
-	asm_amd64.REG_X7:  x86.REG_X7,
-	asm_amd64.REG_X8:  x86.REG_X8,
-	asm_amd64.REG_X9:  x86.REG_X9,
-	asm_amd64.REG_X10: x86.REG_X10,
-	asm_amd64.REG_X11: x86.REG_X11,
-	asm_amd64.REG_X12: x86.REG_X12,
-	asm_amd64.REG_X13: x86.REG_X13,
-	asm_amd64.REG_X14: x86.REG_X14,
-	asm_amd64.REG_X15: x86.REG_X15,
+	amd64.REG_AX:  x86.REG_AX,
+	amd64.REG_CX:  x86.REG_CX,
+	amd64.REG_DX:  x86.REG_DX,
+	amd64.REG_BX:  x86.REG_BX,
+	amd64.REG_SP:  x86.REG_SP,
+	amd64.REG_BP:  x86.REG_BP,
+	amd64.REG_SI:  x86.REG_SI,
+	amd64.REG_DI:  x86.REG_DI,
+	amd64.REG_R8:  x86.REG_R8,
+	amd64.REG_R9:  x86.REG_R9,
+	amd64.REG_R10: x86.REG_R10,
+	amd64.REG_R11: x86.REG_R11,
+	amd64.REG_R12: x86.REG_R12,
+	amd64.REG_R13: x86.REG_R13,
+	amd64.REG_R14: x86.REG_R14,
+	amd64.REG_R15: x86.REG_R15,
+	amd64.REG_X0:  x86.REG_X0,
+	amd64.REG_X1:  x86.REG_X1,
+	amd64.REG_X2:  x86.REG_X2,
+	amd64.REG_X3:  x86.REG_X3,
+	amd64.REG_X4:  x86.REG_X4,
+	amd64.REG_X5:  x86.REG_X5,
+	amd64.REG_X6:  x86.REG_X6,
+	amd64.REG_X7:  x86.REG_X7,
+	amd64.REG_X8:  x86.REG_X8,
+	amd64.REG_X9:  x86.REG_X9,
+	amd64.REG_X10: x86.REG_X10,
+	amd64.REG_X11: x86.REG_X11,
+	amd64.REG_X12: x86.REG_X12,
+	amd64.REG_X13: x86.REG_X13,
+	amd64.REG_X14: x86.REG_X14,
+	amd64.REG_X15: x86.REG_X15,
 }
 
 // castAsGolangAsmRegister maps the instructions to golang-asm specific instruction values.
 var castAsGolangAsmInstruction = [...]obj.As{
-	asm_amd64.NOP:       obj.ANOP,
-	asm_amd64.RET:       obj.ARET,
-	asm_amd64.JMP:       obj.AJMP,
-	asm_amd64.UD2:       x86.AUD2,
-	asm_amd64.ADDL:      x86.AADDL,
-	asm_amd64.ADDQ:      x86.AADDQ,
-	asm_amd64.ADDSD:     x86.AADDSD,
-	asm_amd64.ADDSS:     x86.AADDSS,
-	asm_amd64.ANDL:      x86.AANDL,
-	asm_amd64.ANDPD:     x86.AANDPD,
-	asm_amd64.ANDPS:     x86.AANDPS,
-	asm_amd64.ANDQ:      x86.AANDQ,
-	asm_amd64.BSRL:      x86.ABSRL,
-	asm_amd64.BSRQ:      x86.ABSRQ,
-	asm_amd64.CDQ:       x86.ACDQ,
-	asm_amd64.CMOVQCS:   x86.ACMOVQCS,
-	asm_amd64.CMPL:      x86.ACMPL,
-	asm_amd64.CMPQ:      x86.ACMPQ,
-	asm_amd64.COMISD:    x86.ACOMISD,
-	asm_amd64.COMISS:    x86.ACOMISS,
-	asm_amd64.CQO:       x86.ACQO,
-	asm_amd64.CVTSD2SS:  x86.ACVTSD2SS,
-	asm_amd64.CVTSL2SD:  x86.ACVTSL2SD,
-	asm_amd64.CVTSL2SS:  x86.ACVTSL2SS,
-	asm_amd64.CVTSQ2SD:  x86.ACVTSQ2SD,
-	asm_amd64.CVTSQ2SS:  x86.ACVTSQ2SS,
-	asm_amd64.CVTSS2SD:  x86.ACVTSS2SD,
-	asm_amd64.CVTTSD2SL: x86.ACVTTSD2SL,
-	asm_amd64.CVTTSD2SQ: x86.ACVTTSD2SQ,
-	asm_amd64.CVTTSS2SL: x86.ACVTTSS2SL,
-	asm_amd64.CVTTSS2SQ: x86.ACVTTSS2SQ,
-	asm_amd64.DECQ:      x86.ADECQ,
-	asm_amd64.DIVL:      x86.ADIVL,
-	asm_amd64.DIVQ:      x86.ADIVQ,
-	asm_amd64.DIVSD:     x86.ADIVSD,
-	asm_amd64.DIVSS:     x86.ADIVSS,
-	asm_amd64.IDIVL:     x86.AIDIVL,
-	asm_amd64.IDIVQ:     x86.AIDIVQ,
-	asm_amd64.INCQ:      x86.AINCQ,
-	asm_amd64.JCC:       x86.AJCC,
-	asm_amd64.JCS:       x86.AJCS,
-	asm_amd64.JEQ:       x86.AJEQ,
-	asm_amd64.JGE:       x86.AJGE,
-	asm_amd64.JGT:       x86.AJGT,
-	asm_amd64.JHI:       x86.AJHI,
-	asm_amd64.JLE:       x86.AJLE,
-	asm_amd64.JLS:       x86.AJLS,
-	asm_amd64.JLT:       x86.AJLT,
-	asm_amd64.JMI:       x86.AJMI,
-	asm_amd64.JNE:       x86.AJNE,
-	asm_amd64.JPC:       x86.AJPC,
-	asm_amd64.JPL:       x86.AJPL,
-	asm_amd64.JPS:       x86.AJPS,
-	asm_amd64.LEAQ:      x86.ALEAQ,
-	asm_amd64.LZCNTL:    x86.ALZCNTL,
-	asm_amd64.LZCNTQ:    x86.ALZCNTQ,
-	asm_amd64.NEGQ:      x86.ANEGQ,
-	asm_amd64.MAXSD:     x86.AMAXSD,
-	asm_amd64.MAXSS:     x86.AMAXSS,
-	asm_amd64.MINSD:     x86.AMINSD,
-	asm_amd64.MINSS:     x86.AMINSS,
-	asm_amd64.MOVB:      x86.AMOVB,
-	asm_amd64.MOVBLSX:   x86.AMOVBLSX,
-	asm_amd64.MOVBLZX:   x86.AMOVBLZX,
-	asm_amd64.MOVBQSX:   x86.AMOVBQSX,
-	asm_amd64.MOVBQZX:   x86.AMOVBQZX,
-	asm_amd64.MOVL:      x86.AMOVL,
-	asm_amd64.MOVLQSX:   x86.AMOVLQSX,
-	asm_amd64.MOVLQZX:   x86.AMOVLQZX,
-	asm_amd64.MOVQ:      x86.AMOVQ,
-	asm_amd64.MOVW:      x86.AMOVW,
-	asm_amd64.MOVWLSX:   x86.AMOVWLSX,
-	asm_amd64.MOVWLZX:   x86.AMOVWLZX,
-	asm_amd64.MOVWQSX:   x86.AMOVWQSX,
-	asm_amd64.MOVWQZX:   x86.AMOVWQZX,
-	asm_amd64.MULL:      x86.AMULL,
-	asm_amd64.MULQ:      x86.AMULQ,
-	asm_amd64.MULSD:     x86.AMULSD,
-	asm_amd64.MULSS:     x86.AMULSS,
-	asm_amd64.ORL:       x86.AORL,
-	asm_amd64.ORPD:      x86.AORPD,
-	asm_amd64.ORPS:      x86.AORPS,
-	asm_amd64.ORQ:       x86.AORQ,
-	asm_amd64.POPCNTL:   x86.APOPCNTL,
-	asm_amd64.POPCNTQ:   x86.APOPCNTQ,
-	asm_amd64.PSLLL:     x86.APSLLL,
-	asm_amd64.PSLLQ:     x86.APSLLQ,
-	asm_amd64.PSRLL:     x86.APSRLL,
-	asm_amd64.PSRLQ:     x86.APSRLQ,
-	asm_amd64.ROLL:      x86.AROLL,
-	asm_amd64.ROLQ:      x86.AROLQ,
-	asm_amd64.RORL:      x86.ARORL,
-	asm_amd64.RORQ:      x86.ARORQ,
-	asm_amd64.ROUNDSD:   x86.AROUNDSD,
-	asm_amd64.ROUNDSS:   x86.AROUNDSS,
-	asm_amd64.SARL:      x86.ASARL,
-	asm_amd64.SARQ:      x86.ASARQ,
-	asm_amd64.SETCC:     x86.ASETCC,
-	asm_amd64.SETCS:     x86.ASETCS,
-	asm_amd64.SETEQ:     x86.ASETEQ,
-	asm_amd64.SETGE:     x86.ASETGE,
-	asm_amd64.SETGT:     x86.ASETGT,
-	asm_amd64.SETHI:     x86.ASETHI,
-	asm_amd64.SETLE:     x86.ASETLE,
-	asm_amd64.SETLS:     x86.ASETLS,
-	asm_amd64.SETLT:     x86.ASETLT,
-	asm_amd64.SETMI:     x86.ASETMI,
-	asm_amd64.SETNE:     x86.ASETNE,
-	asm_amd64.SETPC:     x86.ASETPC,
-	asm_amd64.SETPL:     x86.ASETPL,
-	asm_amd64.SETPS:     x86.ASETPS,
-	asm_amd64.SHLL:      x86.ASHLL,
-	asm_amd64.SHLQ:      x86.ASHLQ,
-	asm_amd64.SHRL:      x86.ASHRL,
-	asm_amd64.SHRQ:      x86.ASHRQ,
-	asm_amd64.SQRTSD:    x86.ASQRTSD,
-	asm_amd64.SQRTSS:    x86.ASQRTSS,
-	asm_amd64.SUBL:      x86.ASUBL,
-	asm_amd64.SUBQ:      x86.ASUBQ,
-	asm_amd64.SUBSD:     x86.ASUBSD,
-	asm_amd64.SUBSS:     x86.ASUBSS,
-	asm_amd64.TESTL:     x86.ATESTL,
-	asm_amd64.TESTQ:     x86.ATESTQ,
-	asm_amd64.TZCNTL:    x86.ATZCNTL,
-	asm_amd64.TZCNTQ:    x86.ATZCNTQ,
-	asm_amd64.UCOMISD:   x86.AUCOMISD,
-	asm_amd64.UCOMISS:   x86.AUCOMISS,
-	asm_amd64.XORL:      x86.AXORL,
-	asm_amd64.XORPD:     x86.AXORPD,
-	asm_amd64.XORPS:     x86.AXORPS,
-	asm_amd64.XORQ:      x86.AXORQ,
+	amd64.NOP:       obj.ANOP,
+	amd64.RET:       obj.ARET,
+	amd64.JMP:       obj.AJMP,
+	amd64.UD2:       x86.AUD2,
+	amd64.ADDL:      x86.AADDL,
+	amd64.ADDQ:      x86.AADDQ,
+	amd64.ADDSD:     x86.AADDSD,
+	amd64.ADDSS:     x86.AADDSS,
+	amd64.ANDL:      x86.AANDL,
+	amd64.ANDPD:     x86.AANDPD,
+	amd64.ANDPS:     x86.AANDPS,
+	amd64.ANDQ:      x86.AANDQ,
+	amd64.BSRL:      x86.ABSRL,
+	amd64.BSRQ:      x86.ABSRQ,
+	amd64.CDQ:       x86.ACDQ,
+	amd64.CMOVQCS:   x86.ACMOVQCS,
+	amd64.CMPL:      x86.ACMPL,
+	amd64.CMPQ:      x86.ACMPQ,
+	amd64.COMISD:    x86.ACOMISD,
+	amd64.COMISS:    x86.ACOMISS,
+	amd64.CQO:       x86.ACQO,
+	amd64.CVTSD2SS:  x86.ACVTSD2SS,
+	amd64.CVTSL2SD:  x86.ACVTSL2SD,
+	amd64.CVTSL2SS:  x86.ACVTSL2SS,
+	amd64.CVTSQ2SD:  x86.ACVTSQ2SD,
+	amd64.CVTSQ2SS:  x86.ACVTSQ2SS,
+	amd64.CVTSS2SD:  x86.ACVTSS2SD,
+	amd64.CVTTSD2SL: x86.ACVTTSD2SL,
+	amd64.CVTTSD2SQ: x86.ACVTTSD2SQ,
+	amd64.CVTTSS2SL: x86.ACVTTSS2SL,
+	amd64.CVTTSS2SQ: x86.ACVTTSS2SQ,
+	amd64.DECQ:      x86.ADECQ,
+	amd64.DIVL:      x86.ADIVL,
+	amd64.DIVQ:      x86.ADIVQ,
+	amd64.DIVSD:     x86.ADIVSD,
+	amd64.DIVSS:     x86.ADIVSS,
+	amd64.IDIVL:     x86.AIDIVL,
+	amd64.IDIVQ:     x86.AIDIVQ,
+	amd64.INCQ:      x86.AINCQ,
+	amd64.JCC:       x86.AJCC,
+	amd64.JCS:       x86.AJCS,
+	amd64.JEQ:       x86.AJEQ,
+	amd64.JGE:       x86.AJGE,
+	amd64.JGT:       x86.AJGT,
+	amd64.JHI:       x86.AJHI,
+	amd64.JLE:       x86.AJLE,
+	amd64.JLS:       x86.AJLS,
+	amd64.JLT:       x86.AJLT,
+	amd64.JMI:       x86.AJMI,
+	amd64.JNE:       x86.AJNE,
+	amd64.JPC:       x86.AJPC,
+	amd64.JPL:       x86.AJPL,
+	amd64.JPS:       x86.AJPS,
+	amd64.LEAQ:      x86.ALEAQ,
+	amd64.LZCNTL:    x86.ALZCNTL,
+	amd64.LZCNTQ:    x86.ALZCNTQ,
+	amd64.NEGQ:      x86.ANEGQ,
+	amd64.MAXSD:     x86.AMAXSD,
+	amd64.MAXSS:     x86.AMAXSS,
+	amd64.MINSD:     x86.AMINSD,
+	amd64.MINSS:     x86.AMINSS,
+	amd64.MOVB:      x86.AMOVB,
+	amd64.MOVBLSX:   x86.AMOVBLSX,
+	amd64.MOVBLZX:   x86.AMOVBLZX,
+	amd64.MOVBQSX:   x86.AMOVBQSX,
+	amd64.MOVBQZX:   x86.AMOVBQZX,
+	amd64.MOVL:      x86.AMOVL,
+	amd64.MOVLQSX:   x86.AMOVLQSX,
+	amd64.MOVLQZX:   x86.AMOVLQZX,
+	amd64.MOVQ:      x86.AMOVQ,
+	amd64.MOVW:      x86.AMOVW,
+	amd64.MOVWLSX:   x86.AMOVWLSX,
+	amd64.MOVWLZX:   x86.AMOVWLZX,
+	amd64.MOVWQSX:   x86.AMOVWQSX,
+	amd64.MOVWQZX:   x86.AMOVWQZX,
+	amd64.MULL:      x86.AMULL,
+	amd64.MULQ:      x86.AMULQ,
+	amd64.MULSD:     x86.AMULSD,
+	amd64.MULSS:     x86.AMULSS,
+	amd64.ORL:       x86.AORL,
+	amd64.ORPD:      x86.AORPD,
+	amd64.ORPS:      x86.AORPS,
+	amd64.ORQ:       x86.AORQ,
+	amd64.POPCNTL:   x86.APOPCNTL,
+	amd64.POPCNTQ:   x86.APOPCNTQ,
+	amd64.PSLLL:     x86.APSLLL,
+	amd64.PSLLQ:     x86.APSLLQ,
+	amd64.PSRLL:     x86.APSRLL,
+	amd64.PSRLQ:     x86.APSRLQ,
+	amd64.ROLL:      x86.AROLL,
+	amd64.ROLQ:      x86.AROLQ,
+	amd64.RORL:      x86.ARORL,
+	amd64.RORQ:      x86.ARORQ,
+	amd64.ROUNDSD:   x86.AROUNDSD,
+	amd64.ROUNDSS:   x86.AROUNDSS,
+	amd64.SARL:      x86.ASARL,
+	amd64.SARQ:      x86.ASARQ,
+	amd64.SETCC:     x86.ASETCC,
+	amd64.SETCS:     x86.ASETCS,
+	amd64.SETEQ:     x86.ASETEQ,
+	amd64.SETGE:     x86.ASETGE,
+	amd64.SETGT:     x86.ASETGT,
+	amd64.SETHI:     x86.ASETHI,
+	amd64.SETLE:     x86.ASETLE,
+	amd64.SETLS:     x86.ASETLS,
+	amd64.SETLT:     x86.ASETLT,
+	amd64.SETMI:     x86.ASETMI,
+	amd64.SETNE:     x86.ASETNE,
+	amd64.SETPC:     x86.ASETPC,
+	amd64.SETPL:     x86.ASETPL,
+	amd64.SETPS:     x86.ASETPS,
+	amd64.SHLL:      x86.ASHLL,
+	amd64.SHLQ:      x86.ASHLQ,
+	amd64.SHRL:      x86.ASHRL,
+	amd64.SHRQ:      x86.ASHRQ,
+	amd64.SQRTSD:    x86.ASQRTSD,
+	amd64.SQRTSS:    x86.ASQRTSS,
+	amd64.SUBL:      x86.ASUBL,
+	amd64.SUBQ:      x86.ASUBQ,
+	amd64.SUBSD:     x86.ASUBSD,
+	amd64.SUBSS:     x86.ASUBSS,
+	amd64.TESTL:     x86.ATESTL,
+	amd64.TESTQ:     x86.ATESTQ,
+	amd64.TZCNTL:    x86.ATZCNTL,
+	amd64.TZCNTQ:    x86.ATZCNTQ,
+	amd64.UCOMISD:   x86.AUCOMISD,
+	amd64.UCOMISS:   x86.AUCOMISS,
+	amd64.XORL:      x86.AXORL,
+	amd64.XORPD:     x86.AXORPD,
+	amd64.XORPS:     x86.AXORPS,
+	amd64.XORQ:      x86.AXORQ,
+	amd64.PINSRQ:    x86.APINSRQ,
+	amd64.PADDB:     x86.APADDB,
+	amd64.PADDW:     x86.APADDW,
+	amd64.PADDL:     x86.APADDL,
+	amd64.PADDQ:     x86.APADDQ,
+	amd64.ADDPS:     x86.AADDPS,
+	amd64.ADDPD:     x86.AADDPD,
 }

--- a/internal/integration_test/asm/arm64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/arm64_debug/debug_assembler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/tetratelabs/wazero/internal/asm"
-	asm_arm64 "github.com/tetratelabs/wazero/internal/asm/arm64"
+	"github.com/tetratelabs/wazero/internal/asm/arm64"
 	"github.com/tetratelabs/wazero/internal/integration_test/asm/golang_asm"
 )
 
@@ -15,12 +15,12 @@ import (
 //
 // TODO: this will be removed after golang-asm removal.
 // Note: this is intentionally exported in order to suppress bunch of "unused" lint errors on this function, testAssembler and testNode.
-func NewDebugAssembler(temporaryRegister asm.Register) (asm_arm64.Assembler, error) {
+func NewDebugAssembler(temporaryRegister asm.Register) (arm64.Assembler, error) {
 	goasm, err := newAssembler(temporaryRegister)
 	if err != nil {
 		return nil, err
 	}
-	a := asm_arm64.NewAssemblerImpl(temporaryRegister)
+	a := arm64.NewAssemblerImpl(temporaryRegister)
 	return &testAssembler{a: a, goasm: goasm}, nil
 }
 
@@ -31,14 +31,14 @@ func NewDebugAssembler(temporaryRegister asm.Register) (asm_arm64.Assembler, err
 // TODO: this will be removed after golang-asm removal.
 type testAssembler struct {
 	goasm *assemblerGoAsmImpl
-	a     *asm_arm64.AssemblerImpl
+	a     *arm64.AssemblerImpl
 }
 
 // testNode implements asm.Node for the usage with testAssembler.
 //
 // TODO: this will be removed after golang-asm removal.
 type testNode struct {
-	n     *asm_arm64.NodeImpl
+	n     *arm64.NodeImpl
 	goasm *golang_asm.GolangAsmNode
 }
 
@@ -71,7 +71,7 @@ func (tn *testNode) OffsetInBinary() asm.NodeOffsetInBinary {
 	return tn.goasm.OffsetInBinary()
 }
 
-// Assemble implements the same method as documented on asm_arm64.Assembler.
+// Assemble implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) Assemble() ([]byte, error) {
 	ret, err := ta.goasm.Assemble()
 	if err != nil {
@@ -91,7 +91,7 @@ func (ta *testAssembler) Assemble() ([]byte, error) {
 	return ret, nil
 }
 
-// SetJumpTargetOnNext implements the same method as documented on asm_arm64.Assembler.
+// SetJumpTargetOnNext implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) SetJumpTargetOnNext(nodes ...asm.Node) {
 	for _, n := range nodes {
 		targetTestNode := n.(*testNode)
@@ -100,7 +100,7 @@ func (ta *testAssembler) SetJumpTargetOnNext(nodes ...asm.Node) {
 	}
 }
 
-// BuildJumpTable implements the same method as documented on asm_arm64.Assembler.
+// BuildJumpTable implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) BuildJumpTable(table []byte, initialInstructions []asm.Node) {
 	ta.goasm.BuildJumpTable(table, initialInstructions)
 	ta.a.BuildJumpTable(table, initialInstructions)
@@ -110,10 +110,10 @@ func (ta *testAssembler) BuildJumpTable(table []byte, initialInstructions []asm.
 func (ta *testAssembler) CompileStandAlone(instruction asm.Instruction) asm.Node {
 	ret := ta.goasm.CompileStandAlone(instruction)
 	ret2 := ta.a.CompileStandAlone(instruction)
-	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*asm_arm64.NodeImpl)}
+	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*arm64.NodeImpl)}
 }
 
-// CompileConstToRegister implements the same method as documented on asm_arm64.Assembler.
+// CompileConstToRegister implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileConstToRegister(
 	instruction asm.Instruction,
 	value asm.ConstantValue,
@@ -121,16 +121,16 @@ func (ta *testAssembler) CompileConstToRegister(
 ) asm.Node {
 	ret := ta.goasm.CompileConstToRegister(instruction, value, destinationReg)
 	ret2 := ta.a.CompileConstToRegister(instruction, value, destinationReg)
-	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*asm_arm64.NodeImpl)}
+	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*arm64.NodeImpl)}
 }
 
-// CompileRegisterToRegister implements the same method as documented on asm_arm64.Assembler.
+// CompileRegisterToRegister implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileRegisterToRegister(instruction asm.Instruction, from, to asm.Register) {
 	ta.goasm.CompileRegisterToRegister(instruction, from, to)
 	ta.a.CompileRegisterToRegister(instruction, from, to)
 }
 
-// CompileMemoryToRegister implements the same method as documented on asm_arm64.Assembler.
+// CompileMemoryToRegister implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileMemoryToRegister(
 	instruction asm.Instruction,
 	sourceBaseReg asm.Register,
@@ -141,7 +141,7 @@ func (ta *testAssembler) CompileMemoryToRegister(
 	ta.a.CompileMemoryToRegister(instruction, sourceBaseReg, sourceOffsetConst, destinationReg)
 }
 
-// CompileRegisterToMemory implements the same method as documented on asm_arm64.Assembler.
+// CompileRegisterToMemory implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileRegisterToMemory(
 	instruction asm.Instruction,
 	sourceRegister, destinationBaseRegister asm.Register,
@@ -151,26 +151,26 @@ func (ta *testAssembler) CompileRegisterToMemory(
 	ta.a.CompileRegisterToMemory(instruction, sourceRegister, destinationBaseRegister, destinationOffsetConst)
 }
 
-// CompileJump implements the same method as documented on asm_arm64.Assembler.
+// CompileJump implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileJump(jmpInstruction asm.Instruction) asm.Node {
 	ret := ta.goasm.CompileJump(jmpInstruction)
 	ret2 := ta.a.CompileJump(jmpInstruction)
-	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*asm_arm64.NodeImpl)}
+	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*arm64.NodeImpl)}
 }
 
-// CompileJumpToMemory implements the same method as documented on asm_arm64.Assembler.
+// CompileJumpToMemory implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileJumpToMemory(jmpInstruction asm.Instruction, baseReg asm.Register) {
 	ta.goasm.CompileJumpToMemory(jmpInstruction, baseReg)
 	ta.a.CompileJumpToMemory(jmpInstruction, baseReg)
 }
 
-// CompileJumpToRegister implements the same method as documented on asm_arm64.Assembler.
+// CompileJumpToRegister implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileJumpToRegister(jmpInstruction asm.Instruction, reg asm.Register) {
 	ta.goasm.CompileJumpToRegister(jmpInstruction, reg)
 	ta.a.CompileJumpToRegister(jmpInstruction, reg)
 }
 
-// CompileReadInstructionAddress implements the same method as documented on asm_arm64.Assembler.
+// CompileReadInstructionAddress implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileReadInstructionAddress(
 	destinationRegister asm.Register,
 	beforeAcquisitionTargetInstruction asm.Instruction,
@@ -253,4 +253,28 @@ func (ta *testAssembler) CompileSIMDByteToRegister(instruction asm.Instruction, 
 func (ta *testAssembler) CompileConditionalRegisterSet(cond asm.ConditionalRegisterState, dstReg asm.Register) {
 	ta.goasm.CompileConditionalRegisterSet(cond, dstReg)
 	ta.a.CompileConditionalRegisterSet(cond, dstReg)
+}
+
+func (ta *testAssembler) CompileMemoryToVectorRegister(instruction asm.Instruction, srcOffsetReg, dstReg asm.Register,
+	arrangement arm64.VectorArrangement) {
+	ta.goasm.CompileMemoryToVectorRegister(instruction, srcOffsetReg, dstReg, arrangement)
+	ta.a.CompileMemoryToVectorRegister(instruction, srcOffsetReg, dstReg, arrangement)
+}
+
+func (ta *testAssembler) CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstOffsetReg asm.Register,
+	arrangement arm64.VectorArrangement) {
+	ta.goasm.CompileVectorRegisterToMemory(instruction, srcReg, dstOffsetReg, arrangement)
+	ta.a.CompileVectorRegisterToMemory(instruction, srcReg, dstOffsetReg, arrangement)
+}
+
+func (ta *testAssembler) CompileRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
+	arrangement arm64.VectorArrangement, index arm64.VectorIndex) {
+	ta.goasm.CompileRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement, index)
+	ta.a.CompileRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement, index)
+}
+
+func (ta *testAssembler) CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
+	arrangement arm64.VectorArrangement) {
+	ta.goasm.CompileVectorRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement)
+	ta.a.CompileVectorRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement)
 }

--- a/internal/integration_test/asm/arm64_debug/impl_test.go
+++ b/internal/integration_test/asm/arm64_debug/impl_test.go
@@ -1468,7 +1468,7 @@ func TestAssemblerImpl_EncodeRegisterToVectorRegister(t *testing.T) {
 					DstReg:      arm64.REG_V3,
 					VectorIndex: 0, VectorArrangement: arm64.VectorArrangement1D,
 				},
-				expErr: "unsupported arragement for VMOV: 1D",
+				expErr: "unsupported arrangement for VMOV: 1D",
 			},
 		} {
 			a := arm64.NewAssemblerImpl(asm.NilRegister)

--- a/internal/integration_test/spectest/v1/spec_test.go
+++ b/internal/integration_test/spectest/v1/spec_test.go
@@ -21,7 +21,6 @@ func TestCompiler(t *testing.T) {
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Skip()
 	}
-
 	spectest.Run(t, testcases, compiler.NewEngine, enabledFeatures, func(string) bool { return true })
 }
 

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -26,7 +26,10 @@ func TestCompiler(t *testing.T) {
 
 	spectest.Run(t, testcases, compiler.NewEngine, enabledFeatures, func(jsonname string) bool {
 		// TODO: remove after SIMD proposal
-		return !strings.Contains(jsonname, "simd")
+		if strings.Contains(jsonname, "simd") {
+			return path.Base(jsonname) == "simd_const.json"
+		}
+		return true
 	})
 }
 

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -22,9 +22,9 @@ type RefType = byte
 
 const (
 	// RefTypeFuncref represents a reference to a function.
-	RefTypeFuncref RefType = ValueTypeFuncref
+	RefTypeFuncref = ValueTypeFuncref
 	// RefTypeExternref represents a reference to a host object, which is not currently supported in wazero.
-	RefTypeExternref RefType = ValueTypeExternref
+	RefTypeExternref = ValueTypeExternref
 )
 
 func RefTypeName(t RefType) (ret string) {
@@ -62,7 +62,7 @@ type ElementSegment struct {
 	// Note: This is only set when Mode is active.
 	OffsetExpr *ConstantExpression
 
-	// TableIndex is the tables's index to which this element segment is applied.
+	// TableIndex is the table's index to which this element segment is applied.
 	// Note: This is used if and only if the Mode is active.
 	TableIndex Index
 
@@ -90,7 +90,7 @@ func (e *ElementSegment) IsActive() bool {
 type TableInstance struct {
 	// References holds references whose type is either RefTypeFuncref or RefTypeExternref (unsupported).
 	//
-	// Currently only function references are supported.
+	// Currently, only function references are supported.
 	References []Reference
 
 	// Min is the minimum (function) elements in this table and cannot grow to accommodate ElementSegment.
@@ -307,7 +307,7 @@ func (m *Module) verifyImportGlobalI32(sectionID SectionID, sectionIdx Index, id
 	return fmt.Errorf("%s[%d] (global.get %d): out of range of imported globals", SectionIDName(sectionID), sectionIdx, idx)
 }
 
-// Grow appends the `initialRef` by `delta` times into the .References slice.
+// Grow appends the `initialRef` by `delta` times into the References slice.
 // Returns -1 if the operation is not valid, otherwise the old length of the table.
 //
 // https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-grow-x
@@ -321,7 +321,7 @@ func (t *TableInstance) Grow(_ context.Context, delta uint32, initialRef Referen
 		return
 	}
 
-	if newLen := int64(currentLen) + int64(delta); // adding as 64bit ints to avoide overflow.
+	if newLen := int64(currentLen) + int64(delta); // adding as 64bit ints to avoid overflow.
 	newLen >= math.MaxUint32 || (t.Max != nil && newLen > int64(*t.Max)) {
 		return 0xffffffff // = -1 in signed 32-bit integer.
 	}

--- a/internal/wazeroir/format.go
+++ b/internal/wazeroir/format.go
@@ -48,9 +48,9 @@ func formatOperation(w io.StringWriter, b Operation) {
 	case *OperationSelect:
 		str = "select"
 	case *OperationPick:
-		str = fmt.Sprintf("pick %d", o.Depth)
+		str = fmt.Sprintf("pick %d (is_vector=%v)", o.Depth, o.IsTargetVector)
 	case *OperationSwap:
-		str = fmt.Sprintf("swap %d", o.Depth)
+		str = fmt.Sprintf("swap %d (is_vector=%v)", o.Depth, o.IsTargetVector)
 	case *OperationGlobalGet:
 		str = fmt.Sprintf("global.get %d", o.Index)
 	case *OperationGlobalSet:
@@ -183,6 +183,8 @@ func formatOperation(w io.StringWriter, b Operation) {
 		str = fmt.Sprintf("%s.extend_from.%s", out, in)
 	case *OperationConstV128:
 		str = fmt.Sprintf("v128.const [%#x, %#x]", o.Lo, o.Hi)
+	case *OperationAddV128:
+		str = fmt.Sprintf("v128.add (shape=%s)", shapeName(o.Shape))
 	default:
 		panic("unreachable: a bug in wazeroir implementation")
 	}

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -23,8 +23,8 @@ var (
 	signature_None_I64 = &signature{
 		out: []UnsignedType{UnsignedTypeI64},
 	}
-	signature_None_I64I64 = &signature{
-		out: []UnsignedType{UnsignedTypeI64, UnsignedTypeI64},
+	signature_None_V128 = &signature{
+		out: []UnsignedType{UnsignedTypeV128},
 	}
 	signature_None_F32 = &signature{
 		out: []UnsignedType{UnsignedTypeF32},
@@ -154,9 +154,9 @@ var (
 		in:  []UnsignedType{UnsignedTypeUnknown, UnsignedTypeUnknown, UnsignedTypeI32},
 		out: []UnsignedType{UnsignedTypeUnknown},
 	}
-	signature_I64I64I64I64_I64I64 = &signature{
-		in:  []UnsignedType{UnsignedTypeI64, UnsignedTypeI64, UnsignedTypeI64, UnsignedTypeI64},
-		out: []UnsignedType{UnsignedTypeI64, UnsignedTypeI64},
+	signature_V128V128_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128, UnsignedTypeV128},
+		out: []UnsignedType{UnsignedTypeV128},
 	}
 )
 
@@ -410,9 +410,9 @@ func (c *compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature
 	case wasm.OpcodeVecPrefix:
 		switch vecOp := c.body[c.pc+1]; vecOp {
 		case wasm.OpcodeVecV128Const:
-			return signature_None_I64I64, nil
+			return signature_None_V128, nil
 		case wasm.OpcodeVecI32x4Add, wasm.OpcodeVecI64x2Add:
-			return signature_I64I64I64I64_I64I64, nil
+			return signature_V128V128_V128, nil
 		default:
 			return nil, fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
 		}
@@ -445,7 +445,7 @@ func wasmValueTypeToUnsignedType(vt wasm.ValueType) []UnsignedType {
 	case wasm.ValueTypeF64:
 		return []UnsignedType{UnsignedTypeF64}
 	case wasm.ValueTypeV128:
-		return []UnsignedType{UnsignedTypeI64, UnsignedTypeI64}
+		return []UnsignedType{UnsignedTypeV128}
 	}
 	panic("unreachable")
 }


### PR DESCRIPTION
This commit adds support for vector values in AOT compilers,
including globals and locals, and implements the following instructions:
* v128.const
* i8x16.add
* i16x8.add
* i32x4.add
* i64x2.add
* f32x4.add
* f64x2.add

Notably, now both interpreter and compiler pass simd_consts.wast spectests.


part of #484 