### PR TITLE
compiler(arm64): allow large type IDs during compilation

### DIFF
--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
-
 	"github.com/tetratelabs/wazero/internal/asm"
+	"math"
 )
 
 type NodeImpl struct {
@@ -1583,10 +1582,10 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithRegisterOffset(
 // In theory, offset can be any, but for simplicity of our homemade assembler, we limit the offset range
 // that can be encoded enough for supporting compiler.
 func validateMemoryOffset(offset int64) (err error) {
-	if offset > 255 && offset%8 != 0 {
-		// This is because we only have large offsets for load/store with Wasm value stack, and its offset
-		// is always multiplied by 8 (== the size of uint64, the type of value stack in Go).
-		err = fmt.Errorf("large memory offset (>255) must be a multiple of 8 but got %d", offset)
+	if offset > 255 && offset%4 != 0 {
+		// This is because we only have large offsets for load/store with Wasm value stack or reading type IDs, and its offset
+		// is always multiplied by 4.
+		err = fmt.Errorf("large memory offset (>255) must be a multiple of 4 but got %d", offset)
 	} else if offset < -256 { // 9-bit signed integer's minimum = 2^8.
 		err = fmt.Errorf("negative memory offset must be larget than or equal -256 but got %d", offset)
 	} else if offset > 1<<31-1 {

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -477,9 +477,9 @@ func Test_validateMemoryOffset(t *testing.T) {
 		offset int64
 		expErr string
 	}{
-		{offset: 0}, {offset: -256}, {offset: 255}, {offset: 123 * 8},
+		{offset: 0}, {offset: -256}, {offset: 255}, {offset: 123 * 8}, {offset: 123 * 4},
 		{offset: -257, expErr: "negative memory offset must be larget than or equal -256 but got -257"},
-		{offset: 257, expErr: "large memory offset (>255) must be a multiple of 8 but got 257"},
+		{offset: 257, expErr: "large memory offset (>255) must be a multiple of 4 but got 257"},
 	}
 
 	for _, tt := range tests {

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -822,7 +822,7 @@ func (c *amd64Compiler) compileCallIndirect(o *wazeroir.OperationCallIndirect) e
 	c.assembler.CompileMemoryToRegister(amd64.MOVQ,
 		amd64ReservedRegisterForCallEngine, callEngineModuleContextTypeIDsElement0AddressOffset,
 		tmp2)
-	c.assembler.CompileMemoryToRegister(amd64.MOVQ, tmp2, int64(o.TypeIndex)*4, tmp2)
+	c.assembler.CompileMemoryToRegister(amd64.MOVL, tmp2, int64(o.TypeIndex)*4, tmp2)
 
 	// Jump if the type matches.
 	c.assembler.CompileMemoryToRegister(amd64.CMPL, tmp, functionInstanceTypeIDOffset, tmp2)


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>