### PR TITLE
Follows go style for amd64 constants.

### DIFF
--- a/internal/asm/amd64/consts.go
+++ b/internal/asm/amd64/consts.go
@@ -7,18 +7,30 @@ import "github.com/tetratelabs/wazero/internal/asm"
 // See https://www.lri.fr/~filliatr/ens/compil/x86-64.pdf
 // See https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf
 const (
-	ConditionalRegisterStateE  = asm.ConditionalRegisterStateUnset + 1 + iota // ZF equal to zero
-	ConditionalRegisterStateNE                                                // ˜ZF not equal to zero
-	ConditionalRegisterStateS                                                 // SF negative
-	ConditionalRegisterStateNS                                                // ˜SF non-negative
-	ConditionalRegisterStateG                                                 // ˜(SF xor OF) & ˜ ZF greater (signed >)
-	ConditionalRegisterStateGE                                                // ˜(SF xor OF) greater or equal (signed >=)
-	ConditionalRegisterStateL                                                 // SF xor OF less (signed <)
-	ConditionalRegisterStateLE                                                // (SF xor OF) | ZF less or equal (signed <=)
-	ConditionalRegisterStateA                                                 // ˜CF & ˜ZF above (unsigned >)
-	ConditionalRegisterStateAE                                                // ˜CF above or equal (unsigned >=)
-	ConditionalRegisterStateB                                                 // CF below (unsigned <)
-	ConditionalRegisterStateBE                                                // CF | ZF below or equal (unsigned <=)
+	// ConditionalRegisterStateE is the e (equal to zero) condition code
+	ConditionalRegisterStateE = asm.ConditionalRegisterStateUnset + 1 + iota // ZF equal to zero
+	// ConditionalRegisterStateNE is the ne (not equal to zero) condition code
+	ConditionalRegisterStateNE // ˜ZF not equal to zero
+	// ConditionalRegisterStateS is the s (negative) condition code
+	ConditionalRegisterStateS // SF negative
+	// ConditionalRegisterStateNS is the ns (non-negative) condition code
+	ConditionalRegisterStateNS // ˜SF non-negative
+	// ConditionalRegisterStateG is the g (greater) condition code
+	ConditionalRegisterStateG // ˜(SF xor OF) & ˜ ZF greater (signed >)
+	// ConditionalRegisterStateGE is the ge (greater or equal) condition code
+	ConditionalRegisterStateGE // ˜(SF xor OF) greater or equal (signed >=)
+	// ConditionalRegisterStateL is the l (less) condition code
+	ConditionalRegisterStateL // SF xor OF less (signed <)
+	// ConditionalRegisterStateLE is the le (less or equal) condition code
+	ConditionalRegisterStateLE // (SF xor OF) | ZF less or equal (signed <=)
+	// ConditionalRegisterStateA is the a (above) condition code
+	ConditionalRegisterStateA // ˜CF & ˜ZF above (unsigned >)
+	// ConditionalRegisterStateAE is the ae (above or equal) condition code
+	ConditionalRegisterStateAE // ˜CF above or equal (unsigned >=)
+	// ConditionalRegisterStateB is the b (below) condition code
+	ConditionalRegisterStateB // CF below (unsigned <)
+	// ConditionalRegisterStateBE is the be (below or equal) condition code
+	ConditionalRegisterStateBE // CF | ZF below or equal (unsigned <=)
 )
 
 // AMD64-specific instructions.
@@ -27,148 +39,289 @@ const (
 // Note: Naming conventions intentionally match the Go assembler: https://go.dev/doc/asm
 // See https://www.felixcloutier.com/x86/index.html
 const (
+	// NONE is not a real instruction but represents the lack of an instruction
 	NONE asm.Instruction = iota
+	// ADDL is the ADD instruction in 32-bit mode. https://www.felixcloutier.com/x86/add
 	ADDL
+	// ADDQ is the ADD instruction in 64-bit mode. https://www.felixcloutier.com/x86/add
 	ADDQ
+	// ADDSD is the ADDSD instruction. https://www.felixcloutier.com/x86/addsd
 	ADDSD
+	// ADDSS is the ADDSS instruction. https://www.felixcloutier.com/x86/addss
 	ADDSS
+	// ANDL is the AND instruction in 32-bit mode. https://www.felixcloutier.com/x86/and
 	ANDL
+	// ANDPD is the ANDPD instruction. https://www.felixcloutier.com/x86/andpd
 	ANDPD
+	// ANDPS is the ANDPS instruction. https://www.felixcloutier.com/x86/andps
 	ANDPS
+	// ANDQ is the AND instruction in 64-bit mode. https://www.felixcloutier.com/x86/and
 	ANDQ
+	// BSRL is the BSR instruction in 32-bit mode. https://www.felixcloutier.com/x86/bsr
 	BSRL
+	// BSRQ is the BSR instruction in 64-bit mode. https://www.felixcloutier.com/x86/bsr
 	BSRQ
+	// CDQ is the CDQ instruction. https://www.felixcloutier.com/x86/cwd:cdq:cqo
 	CDQ
+	// CMOVQCS is the CMOVC (move if carry) instruction in 64-bit mode. https://www.felixcloutier.com/x86/cmovcc
 	CMOVQCS
+	// CMPL is the CMP instruction in 32-bit mode. https://www.felixcloutier.com/x86/cmp
 	CMPL
+	// CMPQ is the CMP instruction in 64-bit mode. https://www.felixcloutier.com/x86/cmp
 	CMPQ
+	// COMISD is the COMISD instruction. https://www.felixcloutier.com/x86/comisd
 	COMISD
+	// COMISS is the COMISS instruction. https://www.felixcloutier.com/x86/comiss
 	COMISS
+	// CQO is the CQO instruction. https://www.felixcloutier.com/x86/cwd:cdq:cqo
 	CQO
+	// CVTSD2SS is the CVTSD2SS instruction. https://www.felixcloutier.com/x86/cvtsd2ss
 	CVTSD2SS
+	// CVTSL2SD is the CVTSI2SD instruction in 32-bit mode. https://www.felixcloutier.com/x86/cvtsi2sd
 	CVTSL2SD
+	// CVTSL2SS is the CVTSI2SS instruction in 32-bit mode. https://www.felixcloutier.com/x86/cvtsi2ss
 	CVTSL2SS
+	// CVTSL2SD is the CVTSI2SD instruction in 64-bit mode. https://www.felixcloutier.com/x86/cvtsi2sd
 	CVTSQ2SD
+	// CVTSL2SS is the CVTSI2SS instruction in 64-bit mode. https://www.felixcloutier.com/x86/cvtsi2ss
 	CVTSQ2SS
+	// CVTSS2SD is the CVTSS2SD instruction. https://www.felixcloutier.com/x86/cvtss2sd
 	CVTSS2SD
+	// CVTTSD2SL is the CVTTSD2SI instruction in 32-bit mode. https://www.felixcloutier.com/x86/cvttsd2si
 	CVTTSD2SL
+	// CVTTSD2SQ is the CVTTSD2SI instruction in 64-bit mode. https://www.felixcloutier.com/x86/cvttsd2si
 	CVTTSD2SQ
+	// CVTTSS2SL is the CVTTSS2SI instruction in 32-bit mode. https://www.felixcloutier.com/x86/cvttss2si
 	CVTTSS2SL
+	// CVTTSS2SQ is the CVTTSS2SI instruction in 64-bit mode. https://www.felixcloutier.com/x86/cvttss2si
 	CVTTSS2SQ
+	// DECQ is the DEC instruction in 64-bit mode. https://www.felixcloutier.com/x86/dec
 	DECQ
+	// DIVL is the DIV instruction in 32-bit mode. https://www.felixcloutier.com/x86/div
 	DIVL
+	// DIVQ is the DIV instruction in 64-bit mode. https://www.felixcloutier.com/x86/div
 	DIVQ
+	// DIVSD is the DIVSD instruction. https://www.felixcloutier.com/x86/divsd
 	DIVSD
+	// DIVSS is the DIVSS instruction. https://www.felixcloutier.com/x86/divss
 	DIVSS
+	// IDIVL is the IDIV instruction in 32-bit mode. https://www.felixcloutier.com/x86/idiv
 	IDIVL
+	// IDIVQ is the IDIV instruction in 64-bit mode. https://www.felixcloutier.com/x86/idiv
 	IDIVQ
+	// INCQ is the INC instruction in 64-bit mode. https://www.felixcloutier.com/x86/inc
 	INCQ
+	// JCC is the JAE (jump if above or equal) instruction. https://www.felixcloutier.com/x86/jcc
 	JCC
+	// JCS is the JB (jump if below) instruction. https://www.felixcloutier.com/x86/jcc
 	JCS
+	// JEQ is the JE (jump if equal) instruction. https://www.felixcloutier.com/x86/jcc
 	JEQ
+	// JGE is the JGE (jump if greater or equal) instruction. https://www.felixcloutier.com/x86/jcc
 	JGE
+	// JGT is the JG (jump if greater) instruction. https://www.felixcloutier.com/x86/jcc
 	JGT
+	// JHI is the JNBE (jump if not below or equal) instruction. https://www.felixcloutier.com/x86/jcc
 	JHI
+	// JLE is the JLE (jump if less or equal) instruction. https://www.felixcloutier.com/x86/jcc
 	JLE
+	// JLS is the JNA (jump if not above) instruction. https://www.felixcloutier.com/x86/jcc
 	JLS
+	// JLT is the JL (jump if less) instruction. https://www.felixcloutier.com/x86/jcc
 	JLT
+	// JMI is the JS (jump if sign) instruction. https://www.felixcloutier.com/x86/jcc
 	JMI
+	// JNE is the JNE (jump if not equal) instruction. https://www.felixcloutier.com/x86/jcc
 	JNE
+	// JPC is the JPO (jump if parity odd) instruction. https://www.felixcloutier.com/x86/jcc
 	JPC
+	// JPL is the JNS (jump if not sign) instruction. https://www.felixcloutier.com/x86/jcc
 	JPL
+	// JPS is the JPE (jump if parity even) instruction. https://www.felixcloutier.com/x86/jcc
 	JPS
+	// LEAQ is the LEA instruction in 64-bit mode. https://www.felixcloutier.com/x86/lea
 	LEAQ
+	// LZCNTL is the LZCNT instruction in 32-bit mode. https://www.felixcloutier.com/x86/lzcnt
 	LZCNTL
+	// LZCNTQ is the LZCNT instruction in 64-bit mode. https://www.felixcloutier.com/x86/lzcnt
 	LZCNTQ
+	// MAXSD is the MAXSD instruction. https://www.felixcloutier.com/x86/maxsd
 	MAXSD
+	// MAXSS is the MAXSS instruction. https://www.felixcloutier.com/x86/maxss
 	MAXSS
+	// MINSD is the MINSD instruction. https://www.felixcloutier.com/x86/minsd
 	MINSD
+	// MINSS is the MINSS instruction. https://www.felixcloutier.com/x86/minss
 	MINSS
+	// MOVB is the MOV instruction for a single byte. https://www.felixcloutier.com/x86/mov
 	MOVB
+	// MOVBLSX is the MOVSX instruction for single byte in 32-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVBLSX
+	// MOVBLZX is the MOVZX instruction for single-byte in 32-bit mode. https://www.felixcloutier.com/x86/movzx
 	MOVBLZX
+	// MOVBQSX is the MOVSX instruction for single byte in 64-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVBQSX
+	// MOVBQZX is the MOVZX instruction for single-byte in 64-bit mode. https://www.felixcloutier.com/x86/movzx
 	MOVBQZX
+	// MOVL is the MOV instruction for a word.
 	MOVL
+	// MOVLQSX is the MOVSXD instruction. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVLQSX
+	// MOVLQZX is the MOVZX instruction for a word to a doubleword. https://www.felixcloutier.com/x86/movzx
 	MOVLQZX
+	// MOVQ is the MOV instruction for a doubleword. https://www.felixcloutier.com/x86/mov
 	MOVQ
+	// MOVW is the MOV instruction for a word. https://www.felixcloutier.com/x86/mov
 	MOVW
+	// MOVWLSX is the MOVSX instruction for a word in 32-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVWLSX
+	// MOVWLZX is the MOVZX instruction for a word in 32-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVWLZX
+	// MOVWQSX is the MOVSX instruction for a word in 64-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVWQSX
+	// MOVWQZX is the MOVZX instruction for a word in 64-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVWQZX
+	// MULL is the MUL instruction in 32-bit mode. https://www.felixcloutier.com/x86/mul
 	MULL
+	// MULQ is the MUL instruction in 64-bit mode. https://www.felixcloutier.com/x86/mul
 	MULQ
+	// MULSD is the MULSD instruction. https://www.felixcloutier.com/x86/mulsd
 	MULSD
+	// MULSS is the MULSS instruction. https://www.felixcloutier.com/x86/mulss
 	MULSS
+	// NEGQ is the NEG instruction in 64-bit mode. https://www.felixcloutier.com/x86/neg
 	NEGQ
+	// ORL is the OR instruction in 32-bit mode. https://www.felixcloutier.com/x86/or
 	ORL
+	// ORPD is the ORPD instruction. https://www.felixcloutier.com/x86/orpd
 	ORPD
+	// ORPS is the ORPS instruction. https://www.felixcloutier.com/x86/orps
 	ORPS
+	// ORQ is the OR instruction in 64-bit mode. https://www.felixcloutier.com/x86/or
 	ORQ
+	// POPCNTL is the POPCNT instruction in 32-bit mode. https://www.felixcloutier.com/x86/popcnt
 	POPCNTL
+	// POPCNTQ is the POPCNT instruction in 64-bit mode. https://www.felixcloutier.com/x86/popcnt
 	POPCNTQ
+	// PSLLL is the PSLLW instruction. https://www.felixcloutier.com/x86/psllw:pslld:psllq
 	PSLLL
+	// PSLLQ is the PSLLQ instruction. https://www.felixcloutier.com/x86/psllw:pslld:psllq
 	PSLLQ
+	// PSRLL is the PSRLW instruction. https://www.felixcloutier.com/x86/psrlw:psrld:psrlq
 	PSRLL
+	// PSRLQ is the PSRLQ instruction. https://www.felixcloutier.com/x86/psrlw:psrld:psrlq
 	PSRLQ
+	// ROLL is the ROL instruction in 32-bit mode. https://www.felixcloutier.com/x86/rcl:rcr:rol:ror
 	ROLL
+	// ROLQ is the ROL instruction in 64-bit mode. https://www.felixcloutier.com/x86/rcl:rcr:rol:ror
 	ROLQ
+	// RORL is the ROR instruction in 32-bit mode. https://www.felixcloutier.com/x86/rcl:rcr:rol:ror
 	RORL
+	// RORQ is the ROR instruction in 64-bit mode. https://www.felixcloutier.com/x86/rcl:rcr:rol:ror
 	RORQ
+	// ROUNDSD is the ROUNDSD instruction. https://www.felixcloutier.com/x86/roundsd
 	ROUNDSD
+	// ROUNDSS is the ROUNDSS instruction. https://www.felixcloutier.com/x86/roundss
 	ROUNDSS
+	// SARL is the SAR instruction in 32-bit mode. https://www.felixcloutier.com/x86/sal:sar:shl:shr
 	SARL
+	// SARQ is the SAR instruction in 64-bit mode. https://www.felixcloutier.com/x86/sal:sar:shl:shr
 	SARQ
+	// SETCC is the SETAE (set if above or equal) instruction. https://www.felixcloutier.com/x86/setcc
 	SETCC
+	// SETCS is the SETB (set if below) instruction. https://www.felixcloutier.com/x86/setcc
 	SETCS
+	// SETEQ is the SETE (set if equal) instruction. https://www.felixcloutier.com/x86/setcc
 	SETEQ
+	// SETGE is the SETGE (set if greater or equal) instruction. https://www.felixcloutier.com/x86/setcc
 	SETGE
+	// SETGT is the SETG (set if greater) instruction. https://www.felixcloutier.com/x86/setcc
 	SETGT
+	// SETHI is the SETNBE (set if not below or equal) instruction. https://www.felixcloutier.com/x86/setcc
 	SETHI
+	// SETLE is the SETLE (set if less or equal) instruction. https://www.felixcloutier.com/x86/setcc
 	SETLE
+	// SETLS is the SETNA (set if not above) instruction. https://www.felixcloutier.com/x86/setcc
 	SETLS
+	// SETLT is the SETL (set if less) instruction. https://www.felixcloutier.com/x86/setcc
 	SETLT
+	// SETMI is the SETS (set if sign) instruction. https://www.felixcloutier.com/x86/setcc
 	SETMI
+	// SETNE is the SETNE (set if not equal) instruction. https://www.felixcloutier.com/x86/setcc
 	SETNE
+	// SETPC is the SETNP (set if not parity) instruction. https://www.felixcloutier.com/x86/setcc
 	SETPC
+	// SETPL is the SETNS (set if not sign) instruction. https://www.felixcloutier.com/x86/setcc
 	SETPL
+	// SETPS is the SETP (set if parity) instruction. https://www.felixcloutier.com/x86/setcc
 	SETPS
+	// SHLL is the SHL instruction in 32-bit mode. https://www.felixcloutier.com/x86/sal:sar:shl:shr
 	SHLL
+	// SHLQ is the SHL instruction in 64-bit mode. https://www.felixcloutier.com/x86/sal:sar:shl:shr
 	SHLQ
+	// SHRL is the SHR instruction in 32-bit mode. https://www.felixcloutier.com/x86/sal:sar:shl:shr
 	SHRL
+	// SHRQ is the SHR instruction in 64-bit mode. https://www.felixcloutier.com/x86/sal:sar:shl:shr
 	SHRQ
+	// SQRTSD is the SQRTSD instruction. https://www.felixcloutier.com/x86/sqrtsd
 	SQRTSD
+	// SQRTSS is the SQRTSS instruction. https://www.felixcloutier.com/x86/sqrtss
 	SQRTSS
+	// SUBL is the SUB instruction in 32-bit mode. https://www.felixcloutier.com/x86/sub
 	SUBL
+	// SUBQ is the SUB instruction in 64-bit mode. https://www.felixcloutier.com/x86/sub
 	SUBQ
+	// SUBSD is the SUBSD instruction. https://www.felixcloutier.com/x86/subsd
 	SUBSD
+	// SUBSS is the SUBSS instruction. https://www.felixcloutier.com/x86/subss
 	SUBSS
+	// TESTL is the TEST instruction in 32-bit mode. https://www.felixcloutier.com/x86/test
 	TESTL
+	// TESTQ is the TEST instruction in 64-bit mode. https://www.felixcloutier.com/x86/test
 	TESTQ
+	// TZCNTL is the TZCNT instruction in 32-bit mode. https://www.felixcloutier.com/x86/tzcnt
 	TZCNTL
+	// TZCNTQ is the TZCNT instruction in 64-bit mode. https://www.felixcloutier.com/x86/tzcnt
 	TZCNTQ
+	// UCOMISD is the UCOMISD instruction. https://www.felixcloutier.com/x86/ucomisd
 	UCOMISD
+	// UCOMISS is the UCOMISS instruction. https://www.felixcloutier.com/x86/ucomisd
 	UCOMISS
+	// XORL is the XOR instruction in 32-bit mode. https://www.felixcloutier.com/x86/xor
 	XORL
+	// XORPD is the XORPD instruction. https://www.felixcloutier.com/x86/xorpd
 	XORPD
+	// XORPS is the XORPS instruction. https://www.felixcloutier.com/x86/xorps
 	XORPS
+	// XORQ is the XOR instruction in 64-bit mode. https://www.felixcloutier.com/x86/xor
 	XORQ
+	// RET is the RET instruction. https://www.felixcloutier.com/x86/ret
 	RET
+	// JMP is the JMP instruction. https://www.felixcloutier.com/x86/jmp
 	JMP
+	// NOP is the NOP instruction. https://www.felixcloutier.com/x86/nop
 	NOP
+	// UD2 is the UD2 instruction. https://www.felixcloutier.com/x86/ud
 	UD2
+	// MOVDQU is the MOVDQU instruction. https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
 	MOVDQU
+	// PINSRQ is the PINSQR instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 	PINSRQ
+	// PADDB is the PADDB instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDB
+	// PADDW is the PADDW instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDW
+	// PADDL is the PADDD instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDL
+	// PADDQ is the PADDQ instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDQ
+	// ADDPS is the ADDPS instruction. https://www.felixcloutier.com/x86/addps
 	ADDPS
+	// ADDPD is the ADDPD instruction. https://www.felixcloutier.com/x86/addpd
 	ADDPD
 )
 
+// InstructionName returns the name for an instruction
 func InstructionName(instruction asm.Instruction) string {
 	switch instruction {
 	case ADDL:
@@ -451,111 +604,144 @@ func InstructionName(instruction asm.Instruction) string {
 	return "Unknown"
 }
 
-// Arm64-specific registers.
+// Amd64-specific registers.
 //
 // Note: naming convention intentionally matches the Go assembler: https://go.dev/doc/asm
 // See https://www.lri.fr/~filliatr/ens/compil/x86-64.pdf
 // See https://cs.brown.edu/courses/cs033/docs/guides/x64_cheatsheet.pdf
 const (
-	REG_AX = asm.NilRegister + 1 + iota
-	REG_CX
-	REG_DX
-	REG_BX
-	REG_SP
-	REG_BP
-	REG_SI
-	REG_DI
-	REG_R8
-	REG_R9
-	REG_R10
-	REG_R11
-	REG_R12
-	REG_R13
-	REG_R14
-	REG_R15
-	REG_X0
-	REG_X1
-	REG_X2
-	REG_X3
-	REG_X4
-	REG_X5
-	REG_X6
-	REG_X7
-	REG_X8
-	REG_X9
-	REG_X10
-	REG_X11
-	REG_X12
-	REG_X13
-	REG_X14
-	REG_X15
+	// RegAX is the ax register
+	RegAX = asm.NilRegister + 1 + iota
+	// RegCX is the cx register
+	RegCX
+	// RegDX is the dx register
+	RegDX
+	// RegBX is the bx register
+	RegBX
+	// RegSP is the sp register
+	RegSP
+	// RegBP is the bp register
+	RegBP
+	// RegSI is the si register
+	RegSI
+	// RegDI is the di register
+	RegDI
+	// RegR8 is the r8 register
+	RegR8
+	// RegR9 is the r9 register
+	RegR9
+	// RegR10 is the r10 register
+	RegR10
+	// RegR11 is the r11 register
+	RegR11
+	// RegR12 is the r12 register
+	RegR12
+	// RegR13 is the r13 register
+	RegR13
+	// RegR14 is the r14 register
+	RegR14
+	// RegR15 is the r15 register
+	RegR15
+	// RegX0 is the x0 register
+	RegX0
+	// RegX1 is the x1 register
+	RegX1
+	// RegX2 is the x2 register
+	RegX2
+	// RegX3 is the x3 register
+	RegX3
+	// RegX4 is the x4 register
+	RegX4
+	// RegX5 is the x5 register
+	RegX5
+	// RegX6 is the x6 register
+	RegX6
+	// RegX7 is the x7 register
+	RegX7
+	// RegX8 is the x8 register
+	RegX8
+	// RegX9 is the x9 register
+	RegX9
+	// RegX10 is the x10 register
+	RegX10
+	// RegX11 is the x11 register
+	RegX11
+	// RegX12 is the x12 register
+	RegX12
+	// RegX13 is the x13 register
+	RegX13
+	// RegX14 is the x14 register
+	RegX14
+	// Regx15 is the x15 register
+	RegX15
 )
 
+// RegisterName returns the name for a register
 func RegisterName(reg asm.Register) string {
 	switch reg {
-	case REG_AX:
+	case RegAX:
 		return "AX"
-	case REG_CX:
+	case RegCX:
 		return "CX"
-	case REG_DX:
+	case RegDX:
 		return "DX"
-	case REG_BX:
+	case RegBX:
 		return "BX"
-	case REG_SP:
+	case RegSP:
 		return "SP"
-	case REG_BP:
+	case RegBP:
 		return "BP"
-	case REG_SI:
+	case RegSI:
 		return "SI"
-	case REG_DI:
+	case RegDI:
 		return "DI"
-	case REG_R8:
+	case RegR8:
 		return "R8"
-	case REG_R9:
+	case RegR9:
 		return "R9"
-	case REG_R10:
+	case RegR10:
 		return "R10"
-	case REG_R11:
+	case RegR11:
 		return "R11"
-	case REG_R12:
+	case RegR12:
 		return "R12"
-	case REG_R13:
+	case RegR13:
 		return "R13"
-	case REG_R14:
+	case RegR14:
 		return "R14"
-	case REG_R15:
+	case RegR15:
 		return "R15"
-	case REG_X0:
+	case RegX0:
 		return "X0"
-	case REG_X1:
+	case RegX1:
 		return "X1"
-	case REG_X2:
+	case RegX2:
 		return "X2"
-	case REG_X3:
+	case RegX3:
 		return "X3"
-	case REG_X4:
+	case RegX4:
 		return "X4"
-	case REG_X5:
+	case RegX5:
 		return "X5"
-	case REG_X6:
+	case RegX6:
 		return "X6"
-	case REG_X7:
+	case RegX7:
 		return "X7"
-	case REG_X8:
+	case RegX8:
 		return "X8"
-	case REG_X9:
+	case RegX9:
 		return "X9"
-	case REG_X10:
+	case RegX10:
 		return "X10"
-	case REG_X11:
+	case RegX11:
 		return "X11"
-	case REG_X12:
+	case RegX12:
 		return "X12"
-	case REG_X13:
+	case RegX13:
 		return "X13"
-	case REG_X14:
+	case RegX14:
 		return "X14"
-	case REG_X15:
+	case RegX15:
 		return "X15"
 	default:
 		return "nil"

--- a/internal/asm/amd64/impl_test.go
+++ b/internal/asm/amd64/impl_test.go
@@ -38,67 +38,67 @@ func TestNodeImpl_String(t *testing.T) {
 			exp: "NOP",
 		},
 		{
-			in:  &NodeImpl{Instruction: SETCC, Types: OperandTypesNoneToRegister, DstReg: REG_AX},
+			in:  &NodeImpl{Instruction: SETCC, Types: OperandTypesNoneToRegister, DstReg: RegAX},
 			exp: "SETCC AX",
 		},
 		{
-			in:  &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToMemory, DstReg: REG_AX, DstConst: 100},
+			in:  &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToMemory, DstReg: RegAX, DstConst: 100},
 			exp: "JMP [AX + 0x64]",
 		},
 		{
-			in:  &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToMemory, DstReg: REG_AX, DstConst: 100, DstMemScale: 8, DstMemIndex: REG_R11},
+			in:  &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToMemory, DstReg: RegAX, DstConst: 100, DstMemScale: 8, DstMemIndex: RegR11},
 			exp: "JMP [AX + 0x64 + R11*0x8]",
 		},
 		{
-			in:  &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToBranch, JumpTarget: &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToMemory, DstReg: REG_AX, DstConst: 100}},
+			in:  &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToBranch, JumpTarget: &NodeImpl{Instruction: JMP, Types: OperandTypesNoneToMemory, DstReg: RegAX, DstConst: 100}},
 			exp: "JMP {JMP [AX + 0x64]}",
 		},
 		{
-			in:  &NodeImpl{Instruction: IDIVQ, Types: OperandTypesRegisterToNone, SrcReg: REG_DX},
+			in:  &NodeImpl{Instruction: IDIVQ, Types: OperandTypesRegisterToNone, SrcReg: RegDX},
 			exp: "IDIVQ DX",
 		},
 		{
-			in:  &NodeImpl{Instruction: ADDL, Types: OperandTypesRegisterToRegister, SrcReg: REG_DX, DstReg: REG_R14},
+			in:  &NodeImpl{Instruction: ADDL, Types: OperandTypesRegisterToRegister, SrcReg: RegDX, DstReg: RegR14},
 			exp: "ADDL DX, R14",
 		},
 		{
 			in: &NodeImpl{Instruction: MOVQ, Types: OperandTypesRegisterToMemory,
-				SrcReg: REG_DX, DstReg: REG_R14, DstConst: 100},
+				SrcReg: RegDX, DstReg: RegR14, DstConst: 100},
 			exp: "MOVQ DX, [R14 + 0x64]",
 		},
 		{
 			in: &NodeImpl{Instruction: MOVQ, Types: OperandTypesRegisterToMemory,
-				SrcReg: REG_DX, DstReg: REG_R14, DstConst: 100, DstMemIndex: REG_CX, DstMemScale: 4},
+				SrcReg: RegDX, DstReg: RegR14, DstConst: 100, DstMemIndex: RegCX, DstMemScale: 4},
 			exp: "MOVQ DX, [R14 + 0x64 + CX*0x4]",
 		},
 		{
 			in: &NodeImpl{Instruction: CMPL, Types: OperandTypesRegisterToConst,
-				SrcReg: REG_DX, DstConst: 100},
+				SrcReg: RegDX, DstConst: 100},
 			exp: "CMPL DX, 0x64",
 		},
 		{
 			in: &NodeImpl{Instruction: MOVL, Types: OperandTypesMemoryToRegister,
-				SrcReg: REG_DX, SrcConst: 1, DstReg: REG_AX},
+				SrcReg: RegDX, SrcConst: 1, DstReg: RegAX},
 			exp: "MOVL [DX + 0x1], AX",
 		},
 		{
 			in: &NodeImpl{Instruction: MOVL, Types: OperandTypesMemoryToRegister,
-				SrcReg: REG_DX, SrcConst: 1, SrcMemIndex: REG_R12, SrcMemScale: 2,
-				DstReg: REG_AX},
+				SrcReg: RegDX, SrcConst: 1, SrcMemIndex: RegR12, SrcMemScale: 2,
+				DstReg: RegAX},
 			exp: "MOVL [DX + 1 + R12*0x2], AX",
 		},
 		{
 			in: &NodeImpl{Instruction: CMPQ, Types: OperandTypesMemoryToConst,
-				SrcReg: REG_DX, SrcConst: 1, SrcMemIndex: REG_R12, SrcMemScale: 2,
+				SrcReg: RegDX, SrcConst: 1, SrcMemIndex: RegR12, SrcMemScale: 2,
 				DstConst: 123},
 			exp: "CMPQ [DX + 1 + R12*0x2], 0x7b",
 		},
 		{
-			in:  &NodeImpl{Instruction: MOVQ, Types: OperandTypesConstToMemory, SrcConst: 123, DstReg: REG_AX, DstConst: 100, DstMemScale: 8, DstMemIndex: REG_R11},
+			in:  &NodeImpl{Instruction: MOVQ, Types: OperandTypesConstToMemory, SrcConst: 123, DstReg: RegAX, DstConst: 100, DstMemScale: 8, DstMemIndex: RegR11},
 			exp: "MOVQ 0x7b, [AX + 0x64 + R11*0x8]",
 		},
 		{
-			in:  &NodeImpl{Instruction: MOVQ, Types: OperandTypesConstToRegister, SrcConst: 123, DstReg: REG_AX},
+			in:  &NodeImpl{Instruction: MOVQ, Types: OperandTypesConstToRegister, SrcConst: 123, DstReg: RegAX},
 			exp: "MOVQ 0x7b, AX",
 		},
 	} {
@@ -186,45 +186,45 @@ func TestAssemblerImpl_CompileStandAlone(t *testing.T) {
 
 func TestAssemblerImpl_CompileConstToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileConstToRegister(MOVQ, 1000, REG_AX)
+	a.CompileConstToRegister(MOVQ, 1000, RegAX)
 	actualNode := a.Current
 	require.Equal(t, MOVQ, actualNode.Instruction)
 	require.Equal(t, int64(1000), actualNode.SrcConst)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, OperandTypeConst, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileRegisterToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileRegisterToRegister(MOVQ, REG_BX, REG_AX)
+	a.CompileRegisterToRegister(MOVQ, RegBX, RegAX)
 	actualNode := a.Current
 	require.Equal(t, MOVQ, actualNode.Instruction)
-	require.Equal(t, REG_BX, actualNode.SrcReg)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileMemoryToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileMemoryToRegister(MOVQ, REG_BX, 100, REG_AX)
+	a.CompileMemoryToRegister(MOVQ, RegBX, 100, RegAX)
 	actualNode := a.Current
 	require.Equal(t, MOVQ, actualNode.Instruction)
-	require.Equal(t, REG_BX, actualNode.SrcReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
 	require.Equal(t, int64(100), actualNode.SrcConst)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileRegisterToMemory(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileRegisterToMemory(MOVQ, REG_BX, REG_AX, 100)
+	a.CompileRegisterToMemory(MOVQ, RegBX, RegAX, 100)
 	actualNode := a.Current
 	require.Equal(t, MOVQ, actualNode.Instruction)
-	require.Equal(t, REG_BX, actualNode.SrcReg)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, int64(100), actualNode.DstConst)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.src)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.dst)
@@ -241,20 +241,20 @@ func TestAssemblerImpl_CompileJump(t *testing.T) {
 
 func TestAssemblerImpl_CompileJumpToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileJumpToRegister(JNE, REG_AX)
+	a.CompileJumpToRegister(JNE, RegAX)
 	actualNode := a.Current
 	require.Equal(t, JNE, actualNode.Instruction)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, OperandTypeNone, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileJumpToMemory(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileJumpToMemory(JNE, REG_AX, 100)
+	a.CompileJumpToMemory(JNE, RegAX, 100)
 	actualNode := a.Current
 	require.Equal(t, JNE, actualNode.Instruction)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, int64(100), actualNode.DstConst)
 	require.Equal(t, OperandTypeNone, actualNode.Types.src)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.dst)
@@ -262,10 +262,10 @@ func TestAssemblerImpl_CompileJumpToMemory(t *testing.T) {
 
 func TestAssemblerImpl_CompileReadInstructionAddress(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileReadInstructionAddress(REG_R10, RET)
+	a.CompileReadInstructionAddress(RegR10, RET)
 	actualNode := a.Current
 	require.Equal(t, LEAQ, actualNode.Instruction)
-	require.Equal(t, REG_R10, actualNode.DstReg)
+	require.Equal(t, RegR10, actualNode.DstReg)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 	require.Equal(t, RET, actualNode.readInstructionAddressBeforeTargetInstruction)
@@ -273,11 +273,11 @@ func TestAssemblerImpl_CompileReadInstructionAddress(t *testing.T) {
 
 func TestAssemblerImpl_CompileRegisterToRegisterWithArg(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileRegisterToRegisterWithArg(MOVQ, REG_BX, REG_AX, 123)
+	a.CompileRegisterToRegisterWithArg(MOVQ, RegBX, RegAX, 123)
 	actualNode := a.Current
 	require.Equal(t, MOVQ, actualNode.Instruction)
-	require.Equal(t, REG_BX, actualNode.SrcReg)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, byte(123), actualNode.Arg)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
@@ -285,23 +285,23 @@ func TestAssemblerImpl_CompileRegisterToRegisterWithArg(t *testing.T) {
 
 func TestAssemblerImpl_CompileMemoryWithIndexToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileMemoryWithIndexToRegister(MOVQ, REG_BX, 100, REG_R10, 8, REG_AX)
+	a.CompileMemoryWithIndexToRegister(MOVQ, RegBX, 100, RegR10, 8, RegAX)
 	actualNode := a.Current
 	require.Equal(t, MOVQ, actualNode.Instruction)
-	require.Equal(t, REG_BX, actualNode.SrcReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
 	require.Equal(t, int64(100), actualNode.SrcConst)
-	require.Equal(t, REG_R10, actualNode.SrcMemIndex)
+	require.Equal(t, RegR10, actualNode.SrcMemIndex)
 	require.Equal(t, byte(8), actualNode.SrcMemScale)
-	require.Equal(t, REG_AX, actualNode.DstReg)
+	require.Equal(t, RegAX, actualNode.DstReg)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileRegisterToConst(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileRegisterToConst(MOVQ, REG_BX, 123)
+	a.CompileRegisterToConst(MOVQ, RegBX, 123)
 	actualNode := a.Current
-	require.Equal(t, REG_BX, actualNode.SrcReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
 	require.Equal(t, int64(123), actualNode.DstConst)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.src)
 	require.Equal(t, OperandTypeConst, actualNode.Types.dst)
@@ -309,27 +309,27 @@ func TestAssemblerImpl_CompileRegisterToConst(t *testing.T) {
 
 func TestAssemblerImpl_CompileRegisterToNone(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileRegisterToNone(MOVQ, REG_BX)
+	a.CompileRegisterToNone(MOVQ, RegBX)
 	actualNode := a.Current
-	require.Equal(t, REG_BX, actualNode.SrcReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.src)
 	require.Equal(t, OperandTypeNone, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileNoneToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileNoneToRegister(MOVQ, REG_BX)
+	a.CompileNoneToRegister(MOVQ, RegBX)
 	actualNode := a.Current
-	require.Equal(t, REG_BX, actualNode.DstReg)
+	require.Equal(t, RegBX, actualNode.DstReg)
 	require.Equal(t, OperandTypeNone, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
 func TestAssemblerImpl_CompileNoneToMemory(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileNoneToMemory(MOVQ, REG_BX, 1234)
+	a.CompileNoneToMemory(MOVQ, RegBX, 1234)
 	actualNode := a.Current
-	require.Equal(t, REG_BX, actualNode.DstReg)
+	require.Equal(t, RegBX, actualNode.DstReg)
 	require.Equal(t, int64(1234), actualNode.DstConst)
 	require.Equal(t, OperandTypeNone, actualNode.Types.src)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.dst)
@@ -337,9 +337,9 @@ func TestAssemblerImpl_CompileNoneToMemory(t *testing.T) {
 
 func TestAssemblerImpl_CompileConstToMemory(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileConstToMemory(MOVQ, -9999, REG_BX, 1234)
+	a.CompileConstToMemory(MOVQ, -9999, RegBX, 1234)
 	actualNode := a.Current
-	require.Equal(t, REG_BX, actualNode.DstReg)
+	require.Equal(t, RegBX, actualNode.DstReg)
 	require.Equal(t, int64(-9999), actualNode.SrcConst)
 	require.Equal(t, int64(1234), actualNode.DstConst)
 	require.Equal(t, OperandTypeConst, actualNode.Types.src)
@@ -348,9 +348,9 @@ func TestAssemblerImpl_CompileConstToMemory(t *testing.T) {
 
 func TestAssemblerImpl_CompileMemoryToConst(t *testing.T) {
 	a := NewAssemblerImpl()
-	a.CompileMemoryToConst(MOVQ, REG_BX, 1234, -9999)
+	a.CompileMemoryToConst(MOVQ, RegBX, 1234, -9999)
 	actualNode := a.Current
-	require.Equal(t, REG_BX, actualNode.SrcReg)
+	require.Equal(t, RegBX, actualNode.SrcReg)
 	require.Equal(t, int64(1234), actualNode.SrcConst)
 	require.Equal(t, int64(-9999), actualNode.DstConst)
 	require.Equal(t, OperandTypeMemory, actualNode.Types.src)
@@ -393,8 +393,8 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesMemoryToRegister,
-				SrcReg:      REG_AX,
-				DstReg:      REG_X3,
+				SrcReg:      RegAX,
+				DstReg:      RegX3,
 				SrcConst:    10,
 			},
 			exp: []byte{0xf3, 0xf, 0x6f, 0x58, 0xa},
@@ -403,8 +403,8 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesMemoryToRegister,
-				SrcReg:      REG_R13,
-				DstReg:      REG_X3,
+				SrcReg:      RegR13,
+				DstReg:      RegX3,
 				SrcConst:    10,
 			},
 			exp: []byte{0xf3, 0x41, 0xf, 0x6f, 0x5d, 0xa},
@@ -434,8 +434,8 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesRegisterToMemory,
-				SrcReg:      REG_X3,
-				DstReg:      REG_AX,
+				SrcReg:      RegX3,
+				DstReg:      RegAX,
 				SrcConst:    10,
 			},
 			exp: []byte{0xf3, 0xf, 0x7f, 0x18},
@@ -444,8 +444,8 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesRegisterToMemory,
-				SrcReg:      REG_X3,
-				DstReg:      REG_R13,
+				SrcReg:      RegX3,
+				DstReg:      RegR13,
 				SrcConst:    10,
 			},
 			exp: []byte{0xf3, 0x41, 0xf, 0x7f, 0x5d, 0x0},
@@ -475,8 +475,8 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesRegisterToRegister,
-				SrcReg:      REG_X3,
-				DstReg:      REG_X10,
+				SrcReg:      RegX3,
+				DstReg:      RegX10,
 			},
 			exp: []byte{0xf3, 0x44, 0xf, 0x6f, 0xd3},
 		},
@@ -484,8 +484,8 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesRegisterToRegister,
-				SrcReg:      REG_X10,
-				DstReg:      REG_X3,
+				SrcReg:      RegX10,
+				DstReg:      RegX3,
 			},
 			exp: []byte{0xf3, 0x41, 0xf, 0x6f, 0xda},
 		},
@@ -493,8 +493,8 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			n: &NodeImpl{
 				Instruction: MOVDQU,
 				Types:       OperandTypesRegisterToRegister,
-				SrcReg:      REG_X10,
-				DstReg:      REG_X15,
+				SrcReg:      RegX10,
+				DstReg:      RegX15,
 			},
 			exp: []byte{0xf3, 0x45, 0xf, 0x6f, 0xfa},
 		},

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -88,19 +88,19 @@ func init() {
 
 var (
 	// amd64ReservedRegisterForCallEngine: pointer to callEngine (i.e. *callEngine as uintptr)
-	amd64ReservedRegisterForCallEngine = amd64.REG_R13
+	amd64ReservedRegisterForCallEngine = amd64.RegR13
 	// amd64ReservedRegisterForStackBasePointerAddress: stack base pointer's address (callEngine.stackBasePointer) in the current function call.
-	amd64ReservedRegisterForStackBasePointerAddress = amd64.REG_R14
+	amd64ReservedRegisterForStackBasePointerAddress = amd64.RegR14
 	// amd64ReservedRegisterForMemory: pointer to the memory slice's data (i.e. &memory.Buffer[0] as uintptr).
-	amd64ReservedRegisterForMemory = amd64.REG_R15
+	amd64ReservedRegisterForMemory = amd64.RegR15
 )
 
 var (
 	amd64UnreservedVectorRegisters = []asm.Register{ // nolint
-		amd64.REG_X0, amd64.REG_X1, amd64.REG_X2, amd64.REG_X3,
-		amd64.REG_X4, amd64.REG_X5, amd64.REG_X6, amd64.REG_X7,
-		amd64.REG_X8, amd64.REG_X9, amd64.REG_X10, amd64.REG_X11,
-		amd64.REG_X12, amd64.REG_X13, amd64.REG_X14, amd64.REG_X15,
+		amd64.RegX0, amd64.RegX1, amd64.RegX2, amd64.RegX3,
+		amd64.RegX4, amd64.RegX5, amd64.RegX6, amd64.RegX7,
+		amd64.RegX8, amd64.RegX9, amd64.RegX10, amd64.RegX11,
+		amd64.RegX12, amd64.RegX13, amd64.RegX14, amd64.RegX15,
 	}
 	// Note that we never invoke "call" instruction,
 	// so we don't need to care about the calling convention.
@@ -108,9 +108,9 @@ var (
 	// in Go-allocated variables, and reuse these registers
 	// in compiled functions and write them back before returns.
 	amd64UnreservedGeneralPurposeRegisters = []asm.Register{ // nolint
-		amd64.REG_AX, amd64.REG_CX, amd64.REG_DX, amd64.REG_BX,
-		amd64.REG_SI, amd64.REG_DI, amd64.REG_R8, amd64.REG_R9,
-		amd64.REG_R10, amd64.REG_R11, amd64.REG_R12,
+		amd64.RegAX, amd64.RegCX, amd64.RegDX, amd64.RegBX,
+		amd64.RegSI, amd64.RegDI, amd64.RegR8, amd64.RegR9,
+		amd64.RegR10, amd64.RegR11, amd64.RegR12,
 	}
 )
 
@@ -118,7 +118,7 @@ var (
 	// amd64CallingConventionModuleInstanceAddressRegister holds *wasm.ModuleInstance of the
 	// next executing function instance. The value is set and used when making function calls
 	// or function returns in the ModuleContextInitialization. See compileModuleContextInitialization.
-	amd64CallingConventionModuleInstanceAddressRegister = amd64.REG_R12
+	amd64CallingConventionModuleInstanceAddressRegister = amd64.RegR12
 )
 
 func (c *amd64Compiler) String() string {
@@ -1107,8 +1107,8 @@ func (c *amd64Compiler) compileMul(o *wazeroir.OperationMul) (err error) {
 // See https://www.felixcloutier.com/x86/mul#description for detail semantics.
 func (c *amd64Compiler) compileMulForInts(is32Bit bool, mulInstruction asm.Instruction) error {
 	const (
-		resultRegister   = amd64.REG_AX
-		reservedRegister = amd64.REG_DX
+		resultRegister   = amd64.RegAX
+		reservedRegister = amd64.RegDX
 	)
 
 	x2 := c.locationStack.pop()
@@ -1360,9 +1360,9 @@ func (c *amd64Compiler) compileDivForInts(is32Bit bool, signed bool) error {
 	// Now we have the quotient of the division result in the AX register,
 	// so we record it.
 	if is32Bit {
-		c.pushRuntimeValueLocationOnRegister(amd64.REG_AX, runtimeValueTypeI32)
+		c.pushRuntimeValueLocationOnRegister(amd64.RegAX, runtimeValueTypeI32)
 	} else {
-		c.pushRuntimeValueLocationOnRegister(amd64.REG_AX, runtimeValueTypeI64)
+		c.pushRuntimeValueLocationOnRegister(amd64.RegAX, runtimeValueTypeI64)
 	}
 	return nil
 }
@@ -1391,7 +1391,7 @@ func (c *amd64Compiler) compileRem(o *wazeroir.OperationRem) (err error) {
 
 	// Now we have the remainder of the division result in the DX register,
 	// so we record it.
-	c.pushRuntimeValueLocationOnRegister(amd64.REG_DX, vt)
+	c.pushRuntimeValueLocationOnRegister(amd64.RegDX, vt)
 	return
 }
 
@@ -1411,8 +1411,8 @@ func (c *amd64Compiler) compileRem(o *wazeroir.OperationRem) (err error) {
 // where AX holds the quotient while DX the remainder of the division result.
 func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error {
 	const (
-		quotientRegister  = amd64.REG_AX
-		remainderRegister = amd64.REG_DX
+		quotientRegister  = amd64.RegAX
+		remainderRegister = amd64.RegDX
 	)
 
 	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
@@ -1551,7 +1551,7 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		c.assembler.CompileRegisterToNone(amd64.IDIVL, x2.register)
 	} else if is32Bit && !signed {
 		// Zeros DX register to have 64 bit dividend over DX and AX registers.
-		c.assembler.CompileRegisterToRegister(amd64.XORQ, amd64.REG_DX, amd64.REG_DX)
+		c.assembler.CompileRegisterToRegister(amd64.XORQ, amd64.RegDX, amd64.RegDX)
 		c.assembler.CompileRegisterToNone(amd64.DIVL, x2.register)
 	} else if !is32Bit && signed {
 		// Emits sign-extension to have 128 bit dividend over DX and AX registers.
@@ -1559,7 +1559,7 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		c.assembler.CompileRegisterToNone(amd64.IDIVQ, x2.register)
 	} else if !is32Bit && !signed {
 		// Zeros DX register to have 128 bit dividend over DX and AX registers.
-		c.assembler.CompileRegisterToRegister(amd64.XORQ, amd64.REG_DX, amd64.REG_DX)
+		c.assembler.CompileRegisterToRegister(amd64.XORQ, amd64.RegDX, amd64.RegDX)
 		c.assembler.CompileRegisterToNone(amd64.DIVQ, x2.register)
 	}
 
@@ -1703,7 +1703,7 @@ func (c *amd64Compiler) compileShiftOp(instruction asm.Instruction, is32Bit bool
 	x2 := c.locationStack.pop()
 
 	// Ensures that x2 (holding shift counts) is placed on the CX register.
-	const shiftCountRegister = amd64.REG_CX
+	const shiftCountRegister = amd64.RegCX
 	if (x2.onRegister() && x2.register != shiftCountRegister) || x2.onStack() {
 		// If another value lives on the CX register, we release it to the stack.
 		c.onValueReleaseRegisterToStack(shiftCountRegister)

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -24,37 +24,37 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 				}{
 					{
 						name:  "x1:ax,x2:random_reg",
-						x1Reg: amd64.REG_AX,
-						x2Reg: amd64.REG_R10,
+						x1Reg: amd64.RegAX,
+						x2Reg: amd64.RegR10,
 					},
 					{
 						name:  "x1:ax,x2:stack",
-						x1Reg: amd64.REG_AX,
+						x1Reg: amd64.RegAX,
 						x2Reg: asm.NilRegister,
 					},
 					{
 						name:  "x1:random_reg,x2:ax",
-						x1Reg: amd64.REG_R10,
-						x2Reg: amd64.REG_AX,
+						x1Reg: amd64.RegR10,
+						x2Reg: amd64.RegAX,
 					},
 					{
 						name:  "x1:stack,x2:ax",
 						x1Reg: asm.NilRegister,
-						x2Reg: amd64.REG_AX,
+						x2Reg: amd64.RegAX,
 					},
 					{
 						name:  "x1:random_reg,x2:random_reg",
-						x1Reg: amd64.REG_R10,
-						x2Reg: amd64.REG_R9,
+						x1Reg: amd64.RegR10,
+						x2Reg: amd64.RegR9,
 					},
 					{
 						name:  "x1:stack,x2:random_reg",
 						x1Reg: asm.NilRegister,
-						x2Reg: amd64.REG_R9,
+						x2Reg: amd64.RegR9,
 					},
 					{
 						name:  "x1:random_reg,x2:stack",
-						x1Reg: amd64.REG_R9,
+						x1Reg: amd64.RegR9,
 						x2Reg: asm.NilRegister,
 					},
 					{
@@ -78,8 +78,8 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// Pretend there was an existing value on the DX register. We expect compileMul to save this to the stack.
 						// Here, we put it just before two operands as ["any value used by DX", x1, x2]
 						// but in reality, it can exist in any position of stack.
-						compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(dxValue), amd64.REG_DX)
-						prevOnDX := compiler.pushRuntimeValueLocationOnRegister(amd64.REG_DX, runtimeValueTypeI32)
+						compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(dxValue), amd64.RegDX)
+						prevOnDX := compiler.pushRuntimeValueLocationOnRegister(amd64.RegDX, runtimeValueTypeI32)
 
 						// Setup values.
 						if tc.x1Reg != asm.NilRegister {
@@ -147,37 +147,37 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 				}{
 					{
 						name:  "x1:ax,x2:random_reg",
-						x1Reg: amd64.REG_AX,
-						x2Reg: amd64.REG_R10,
+						x1Reg: amd64.RegAX,
+						x2Reg: amd64.RegR10,
 					},
 					{
 						name:  "x1:ax,x2:stack",
-						x1Reg: amd64.REG_AX,
+						x1Reg: amd64.RegAX,
 						x2Reg: asm.NilRegister,
 					},
 					{
 						name:  "x1:random_reg,x2:ax",
-						x1Reg: amd64.REG_R10,
-						x2Reg: amd64.REG_AX,
+						x1Reg: amd64.RegR10,
+						x2Reg: amd64.RegAX,
 					},
 					{
 						name:  "x1:stack,x2:ax",
 						x1Reg: asm.NilRegister,
-						x2Reg: amd64.REG_AX,
+						x2Reg: amd64.RegAX,
 					},
 					{
 						name:  "x1:random_reg,x2:random_reg",
-						x1Reg: amd64.REG_R10,
-						x2Reg: amd64.REG_R9,
+						x1Reg: amd64.RegR10,
+						x2Reg: amd64.RegR9,
 					},
 					{
 						name:  "x1:stack,x2:random_reg",
 						x1Reg: asm.NilRegister,
-						x2Reg: amd64.REG_R9,
+						x2Reg: amd64.RegR9,
 					},
 					{
 						name:  "x1:random_reg,x2:stack",
-						x1Reg: amd64.REG_R9,
+						x1Reg: amd64.RegR9,
 						x2Reg: asm.NilRegister,
 					},
 					{
@@ -200,8 +200,8 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// Pretend there was an existing value on the DX register. We expect compileMul to save this to the stack.
 						// Here, we put it just before two operands as ["any value used by DX", x1, x2]
 						// but in reality, it can exist in any position of stack.
-						compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(dxValue), amd64.REG_DX)
-						prevOnDX := compiler.pushRuntimeValueLocationOnRegister(amd64.REG_DX, runtimeValueTypeI64)
+						compiler.assembler.CompileConstToRegister(amd64.MOVQ, int64(dxValue), amd64.RegDX)
+						prevOnDX := compiler.pushRuntimeValueLocationOnRegister(amd64.RegDX, runtimeValueTypeI64)
 
 						// Setup values.
 						if tc.x1Reg != asm.NilRegister {
@@ -278,7 +278,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		require.NoError(t, err)
 
 		// Set the acquisition target instruction to the one after JMP.
-		compiler.assembler.CompileReadInstructionAddress(amd64.REG_AX, amd64.JMP)
+		compiler.assembler.CompileReadInstructionAddress(amd64.RegAX, amd64.JMP)
 
 		// If generate the code without JMP after readInstructionAddress,
 		// the call back added must return error.
@@ -293,7 +293,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
 
-		const destinationRegister = amd64.REG_AX
+		const destinationRegister = amd64.RegAX
 		// Set the acquisition target instruction to the one after RET,
 		// and read the absolute address into destinationRegister.
 		compiler.assembler.CompileReadInstructionAddress(destinationRegister, amd64.RET)

--- a/internal/integration_test/asm/amd64_debug/golang_asm.go
+++ b/internal/integration_test/asm/amd64_debug/golang_asm.go
@@ -287,7 +287,7 @@ func (a *assemblerGoAsmImpl) CompileReadInstructionAddress(
 	// after return instruction.
 	readInstructionAddress.From.Offset = 0xffff
 	// Since the assembler cannot directly emit "LEA destination [RIP + offset]", we use the some hack here:
-	// We intentionally use x86.REG_BP here so that the resulting instruction sequence becomes
+	// We intentionally use x86.RegBP here so that the resulting instruction sequence becomes
 	// exactly the same as "LEA destination [RIP + offset]" except the most significant bit of the third byte.
 	// We do the rewrite in onGenerateCallbacks which is invoked after the assembler emitted the code.
 	readInstructionAddress.From.Reg = x86.REG_BP
@@ -330,38 +330,38 @@ func (a *assemblerGoAsmImpl) CompileReadInstructionAddress(
 
 // castAsGolangAsmRegister maps the registers to golang-asm specific register values.
 var castAsGolangAsmRegister = [...]int16{
-	amd64.REG_AX:  x86.REG_AX,
-	amd64.REG_CX:  x86.REG_CX,
-	amd64.REG_DX:  x86.REG_DX,
-	amd64.REG_BX:  x86.REG_BX,
-	amd64.REG_SP:  x86.REG_SP,
-	amd64.REG_BP:  x86.REG_BP,
-	amd64.REG_SI:  x86.REG_SI,
-	amd64.REG_DI:  x86.REG_DI,
-	amd64.REG_R8:  x86.REG_R8,
-	amd64.REG_R9:  x86.REG_R9,
-	amd64.REG_R10: x86.REG_R10,
-	amd64.REG_R11: x86.REG_R11,
-	amd64.REG_R12: x86.REG_R12,
-	amd64.REG_R13: x86.REG_R13,
-	amd64.REG_R14: x86.REG_R14,
-	amd64.REG_R15: x86.REG_R15,
-	amd64.REG_X0:  x86.REG_X0,
-	amd64.REG_X1:  x86.REG_X1,
-	amd64.REG_X2:  x86.REG_X2,
-	amd64.REG_X3:  x86.REG_X3,
-	amd64.REG_X4:  x86.REG_X4,
-	amd64.REG_X5:  x86.REG_X5,
-	amd64.REG_X6:  x86.REG_X6,
-	amd64.REG_X7:  x86.REG_X7,
-	amd64.REG_X8:  x86.REG_X8,
-	amd64.REG_X9:  x86.REG_X9,
-	amd64.REG_X10: x86.REG_X10,
-	amd64.REG_X11: x86.REG_X11,
-	amd64.REG_X12: x86.REG_X12,
-	amd64.REG_X13: x86.REG_X13,
-	amd64.REG_X14: x86.REG_X14,
-	amd64.REG_X15: x86.REG_X15,
+	amd64.RegAX:  x86.REG_AX,
+	amd64.RegCX:  x86.REG_CX,
+	amd64.RegDX:  x86.REG_DX,
+	amd64.RegBX:  x86.REG_BX,
+	amd64.RegSP:  x86.REG_SP,
+	amd64.RegBP:  x86.REG_BP,
+	amd64.RegSI:  x86.REG_SI,
+	amd64.RegDI:  x86.REG_DI,
+	amd64.RegR8:  x86.REG_R8,
+	amd64.RegR9:  x86.REG_R9,
+	amd64.RegR10: x86.REG_R10,
+	amd64.RegR11: x86.REG_R11,
+	amd64.RegR12: x86.REG_R12,
+	amd64.RegR13: x86.REG_R13,
+	amd64.RegR14: x86.REG_R14,
+	amd64.RegR15: x86.REG_R15,
+	amd64.RegX0:  x86.REG_X0,
+	amd64.RegX1:  x86.REG_X1,
+	amd64.RegX2:  x86.REG_X2,
+	amd64.RegX3:  x86.REG_X3,
+	amd64.RegX4:  x86.REG_X4,
+	amd64.RegX5:  x86.REG_X5,
+	amd64.RegX6:  x86.REG_X6,
+	amd64.RegX7:  x86.REG_X7,
+	amd64.RegX8:  x86.REG_X8,
+	amd64.RegX9:  x86.REG_X9,
+	amd64.RegX10: x86.REG_X10,
+	amd64.RegX11: x86.REG_X11,
+	amd64.RegX12: x86.REG_X12,
+	amd64.RegX13: x86.REG_X13,
+	amd64.RegX14: x86.REG_X14,
+	amd64.RegX15: x86.REG_X15,
 }
 
 // castAsGolangAsmRegister maps the instructions to golang-asm specific instruction values.

--- a/internal/integration_test/asm/amd64_debug/impl_test.go
+++ b/internal/integration_test/asm/amd64_debug/impl_test.go
@@ -96,7 +96,7 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 				name: "JMP to register",
 				setupFn: func(assembler amd64.Assembler) {
 					for i := 0; i < 128; i++ {
-						assembler.CompileJumpToRegister(amd64.JMP, amd64.REG_AX)
+						assembler.CompileJumpToRegister(amd64.JMP, amd64.RegAX)
 					}
 				},
 			},
@@ -104,7 +104,7 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 				name: "JMP to memory",
 				setupFn: func(assembler amd64.Assembler) {
 					for i := 0; i < 128; i++ {
-						assembler.CompileJumpToMemory(amd64.JMP, amd64.REG_AX, 10)
+						assembler.CompileJumpToMemory(amd64.JMP, amd64.RegAX, 10)
 					}
 				},
 			},
@@ -112,7 +112,7 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 				name: "JMP to memory large offset",
 				setupFn: func(assembler amd64.Assembler) {
 					for i := 0; i < 128; i++ {
-						assembler.CompileJumpToMemory(amd64.JMP, amd64.REG_AX, math.MaxInt32)
+						assembler.CompileJumpToMemory(amd64.JMP, amd64.RegAX, math.MaxInt32)
 					}
 				},
 			},
@@ -190,121 +190,121 @@ func TestAssemblerImpl_Assemble_NOPPadding_fusedJumps(t *testing.T) {
 		{
 			name: "CMPL(register to const)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToConst(amd64.CMPL, amd64.REG_AX, math.MaxInt16)
+				assembler.CompileRegisterToConst(amd64.CMPL, amd64.RegAX, math.MaxInt16)
 			},
 		},
 		{
 			name: "CMPL(memory to const)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileMemoryToConst(amd64.CMPL, amd64.REG_AX, 1, 10)
+				assembler.CompileMemoryToConst(amd64.CMPL, amd64.RegAX, 1, 10)
 			},
 		},
 		{
 			name: "CMPL(register to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.CMPL, amd64.REG_R14, amd64.REG_R10)
+				assembler.CompileRegisterToRegister(amd64.CMPL, amd64.RegR14, amd64.RegR10)
 			},
 		},
 		{
 			name: "CMPQ(register to const)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToConst(amd64.CMPQ, amd64.REG_AX, math.MaxInt16)
+				assembler.CompileRegisterToConst(amd64.CMPQ, amd64.RegAX, math.MaxInt16)
 			},
 		},
 		{
 			name: "CMPQ(register to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.CMPQ, amd64.REG_R14, amd64.REG_R10)
+				assembler.CompileRegisterToRegister(amd64.CMPQ, amd64.RegR14, amd64.RegR10)
 			},
 		},
 		{
 			name: "TESTL",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.TESTL, amd64.REG_AX, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.TESTL, amd64.RegAX, amd64.RegAX)
 			},
 		},
 		{
 			name: "TESTQ",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.TESTQ, amd64.REG_AX, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.TESTQ, amd64.RegAX, amd64.RegAX)
 			},
 		},
 		{
 			name: "ADDL (register to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.ADDL, amd64.REG_R10, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.ADDL, amd64.RegR10, amd64.RegAX)
 			},
 		},
 		{
 			name: "ADDL(memory to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileMemoryToRegister(amd64.ADDL, amd64.REG_R10, 1234, amd64.REG_AX)
+				assembler.CompileMemoryToRegister(amd64.ADDL, amd64.RegR10, 1234, amd64.RegAX)
 			},
 		},
 		{
 			name: "ADDQ (register to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.ADDQ, amd64.REG_R10, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.ADDQ, amd64.RegR10, amd64.RegAX)
 			},
 		},
 		{
 			name: "ADDQ(memory to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileMemoryToRegister(amd64.ADDQ, amd64.REG_R10, 1234, amd64.REG_AX)
+				assembler.CompileMemoryToRegister(amd64.ADDQ, amd64.RegR10, 1234, amd64.RegAX)
 			},
 		},
 		{
 			name: "ADDQ(const to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileConstToRegister(amd64.ADDQ, 1234, amd64.REG_R10)
+				assembler.CompileConstToRegister(amd64.ADDQ, 1234, amd64.RegR10)
 			},
 		},
 		{
 			name: "SUBL",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.SUBL, amd64.REG_R10, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.SUBL, amd64.RegR10, amd64.RegAX)
 			},
 		},
 		{
 			name: "SUBQ (register to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.SUBQ, amd64.REG_R10, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.SUBQ, amd64.RegR10, amd64.RegAX)
 			},
 		},
 		{
 			name: "SUBQ (memory to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileMemoryToRegister(amd64.SUBQ, amd64.REG_R10, math.MaxInt16, amd64.REG_AX)
+				assembler.CompileMemoryToRegister(amd64.SUBQ, amd64.RegR10, math.MaxInt16, amd64.RegAX)
 			},
 		},
 		{
 			name: "ANDL",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.ANDL, amd64.REG_R10, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.ANDL, amd64.RegR10, amd64.RegAX)
 			},
 		},
 		{
 			name: "ANDQ (register to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileRegisterToRegister(amd64.ANDQ, amd64.REG_R10, amd64.REG_AX)
+				assembler.CompileRegisterToRegister(amd64.ANDQ, amd64.RegR10, amd64.RegAX)
 			},
 		},
 		{
 			name: "ANDQ (const to register)",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileConstToRegister(amd64.ANDQ, -123, amd64.REG_R10)
+				assembler.CompileConstToRegister(amd64.ANDQ, -123, amd64.RegR10)
 			},
 		},
 		{
 			name: "INCQ",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileNoneToMemory(amd64.INCQ, amd64.REG_R10, 123)
+				assembler.CompileNoneToMemory(amd64.INCQ, amd64.RegR10, 123)
 			},
 		},
 		{
 			name: "DECQ",
 			setupFn: func(assembler amd64.Assembler) {
-				assembler.CompileNoneToMemory(amd64.DECQ, amd64.REG_R10, 0)
+				assembler.CompileNoneToMemory(amd64.DECQ, amd64.RegR10, 0)
 			},
 		},
 	} {
@@ -346,20 +346,20 @@ func TestAssemblerImpl_Assemble_NOPPadding_fusedJumps(t *testing.T) {
 }
 
 var intRegisters = []asm.Register{
-	amd64.REG_AX, amd64.REG_CX, amd64.REG_DX, amd64.REG_BX, amd64.REG_SP, amd64.REG_BP, amd64.REG_SI, amd64.REG_DI,
-	amd64.REG_R8, amd64.REG_R9, amd64.REG_R10, amd64.REG_R11, amd64.REG_R12, amd64.REG_R13, amd64.REG_R14, amd64.REG_R15,
+	amd64.RegAX, amd64.RegCX, amd64.RegDX, amd64.RegBX, amd64.RegSP, amd64.RegBP, amd64.RegSI, amd64.RegDI,
+	amd64.RegR8, amd64.RegR9, amd64.RegR10, amd64.RegR11, amd64.RegR12, amd64.RegR13, amd64.RegR14, amd64.RegR15,
 }
 
 var floatRegisters = []asm.Register{
-	amd64.REG_X0, amd64.REG_X1, amd64.REG_X2, amd64.REG_X3, amd64.REG_X4, amd64.REG_X5, amd64.REG_X6, amd64.REG_X7,
-	amd64.REG_X8, amd64.REG_X9, amd64.REG_X10, amd64.REG_X11, amd64.REG_X12, amd64.REG_X13, amd64.REG_X14, amd64.REG_X15,
+	amd64.RegX0, amd64.RegX1, amd64.RegX2, amd64.RegX3, amd64.RegX4, amd64.RegX5, amd64.RegX6, amd64.RegX7,
+	amd64.RegX8, amd64.RegX9, amd64.RegX10, amd64.RegX11, amd64.RegX12, amd64.RegX13, amd64.RegX14, amd64.RegX15,
 }
 
 func TestAssemblerImpl_EncodeNoneToRegister(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		a := amd64.NewAssemblerImpl()
 		err := a.EncodeNoneToRegister(&amd64.NodeImpl{Instruction: amd64.ADDL,
-			Types: amd64.OperandTypesNoneToRegister, DstReg: amd64.REG_AX})
+			Types: amd64.OperandTypesNoneToRegister, DstReg: amd64.RegAX})
 		require.Error(t, err)
 
 		t.Run("error", func(t *testing.T) {
@@ -368,7 +368,7 @@ func TestAssemblerImpl_EncodeNoneToRegister(t *testing.T) {
 				expErr string
 			}{
 				{
-					n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesNoneToRegister, DstReg: amd64.REG_AX},
+					n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesNoneToRegister, DstReg: amd64.RegAX},
 					expErr: "ADDL is unsupported for from:none,to:register type",
 				},
 				{
@@ -421,7 +421,7 @@ func TestAssemblerImpl_EncodeNoneToMemory(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesNoneToMemory, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesNoneToMemory, DstReg: amd64.RegAX},
 				expErr: "ADDL is unsupported for from:none,to:memory type",
 			},
 		} {
@@ -700,7 +700,7 @@ func TestAssemblerImpl_EncodeRegisterToNone(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToNone, SrcReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToNone, SrcReg: amd64.RegAX},
 				expErr: "ADDL is unsupported for from:register,to:none type",
 			},
 			{
@@ -750,18 +750,18 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.JMP, Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.JMP, Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegAX},
 				expErr: "JMP is unsupported for from:register,to:register type",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToRegister, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToRegister, DstReg: amd64.RegAX},
 				expErr: "invalid register [nil]",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX},
 				expErr: "invalid register [nil]",
 			}, {
-				n:      &amd64.NodeImpl{Instruction: amd64.MOVL, Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_X1},
+				n:      &amd64.NodeImpl{Instruction: amd64.MOVL, Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegX1},
 				expErr: "MOVL for float to float is undefined",
 			},
 		} {
@@ -774,8 +774,8 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		}
 	})
 
-	intRegisters := []asm.Register{amd64.REG_AX, amd64.REG_R8}
-	floatRegisters := []asm.Register{amd64.REG_X0, amd64.REG_X8}
+	intRegisters := []asm.Register{amd64.RegAX, amd64.RegR8}
+	floatRegisters := []asm.Register{amd64.RegX0, amd64.RegX8}
 	allRegisters := append(intRegisters, floatRegisters...)
 	for _, tc := range []struct {
 		instruction      asm.Instruction
@@ -841,10 +841,10 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		{instruction: amd64.ORQ, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.POPCNTL, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.POPCNTQ, srcRegs: intRegisters, DstRegs: intRegisters},
-		{instruction: amd64.ROLL, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.ROLQ, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.RORL, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.RORQ, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
+		{instruction: amd64.ROLL, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.ROLQ, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.RORL, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.RORQ, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
 		{instruction: amd64.ROUNDSD, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0x00},
 		{instruction: amd64.ROUNDSS, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0x00},
 		{instruction: amd64.ROUNDSD, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0x01},
@@ -855,12 +855,12 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		{instruction: amd64.ROUNDSS, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0x03},
 		{instruction: amd64.ROUNDSD, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0x04},
 		{instruction: amd64.ROUNDSS, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0x04},
-		{instruction: amd64.SARL, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.SARQ, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.SHLL, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.SHLQ, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.SHRL, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
-		{instruction: amd64.SHRQ, srcRegs: []asm.Register{amd64.REG_CX}, DstRegs: intRegisters},
+		{instruction: amd64.SARL, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.SARQ, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.SHLL, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.SHLQ, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.SHRL, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
+		{instruction: amd64.SHRQ, srcRegs: []asm.Register{amd64.RegCX}, DstRegs: intRegisters},
 		{instruction: amd64.SQRTSD, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.SQRTSS, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.SUBL, srcRegs: intRegisters, DstRegs: intRegisters},
@@ -886,39 +886,39 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 				a := amd64.NewAssemblerImpl()
 				if _, isShiftOp := amd64.RegisterToRegisterShiftOpcode[tc.instruction]; isShiftOp {
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_CX, DstReg: amd64.REG_X0}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegCX, DstReg: amd64.RegX0}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_X0}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegX0}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_CX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegCX}))
 				} else if srcFloat && dstFloat && !isMOV { // Float to Float
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegAX}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_AX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegAX}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_X0}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegX0}))
 				} else if srcFloat && !dstFloat && !isMOV { // Float to Int
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_X1}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegX1}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_X1}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegX1}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegAX}))
 				} else if !srcFloat && dstFloat && !isMOV { // Int to Float
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_AX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegAX}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegAX}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_X0}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegX0}))
 				} else if !isMOV { // Int to Int
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_X0}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegX0}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_X0, DstReg: amd64.REG_AX}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegX0, DstReg: amd64.RegAX}))
 					require.Error(t, a.EncodeRegisterToRegister(&amd64.NodeImpl{Instruction: tc.instruction,
-						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.REG_AX, DstReg: amd64.REG_X0}))
+						Types: amd64.OperandTypesRegisterToRegister, SrcReg: amd64.RegAX, DstReg: amd64.RegX0}))
 				}
 			})
 			for _, srcReg := range tc.srcRegs {
@@ -964,13 +964,13 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.JMP,
 					Types:  amd64.OperandTypesRegisterToMemory,
-					SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX},
+					SrcReg: amd64.RegAX, DstReg: amd64.RegAX},
 				expErr: "JMP is unsupported for from:register,to:memory type",
 			},
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.SHLQ,
 					Types:  amd64.OperandTypesRegisterToMemory,
-					SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX},
+					SrcReg: amd64.RegAX, DstReg: amd64.RegAX},
 				expErr: "shifting instruction SHLQ require CX register as src but got AX",
 			},
 		} {
@@ -987,10 +987,10 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 		for _, instruction := range []asm.Instruction{
 			amd64.CMPL, amd64.CMPQ, amd64.MOVB, amd64.MOVL, amd64.MOVQ, amd64.MOVW,
 		} {
-			regs := []asm.Register{amd64.REG_R12, amd64.REG_AX, amd64.REG_BP, amd64.REG_SI}
+			regs := []asm.Register{amd64.RegR12, amd64.RegAX, amd64.RegBP, amd64.RegSI}
 			srcRegs := regs
 			if instruction == amd64.MOVL || instruction == amd64.MOVQ {
-				srcRegs = append(srcRegs, amd64.REG_X0, amd64.REG_X10)
+				srcRegs = append(srcRegs, amd64.RegX0, amd64.RegX10)
 			}
 
 			for _, srcReg := range srcRegs {
@@ -1044,7 +1044,7 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 		}
 	})
 	t.Run("shift", func(t *testing.T) {
-		regs := []asm.Register{amd64.REG_AX, amd64.REG_R8}
+		regs := []asm.Register{amd64.RegAX, amd64.RegR8}
 		scales := []byte{1, 4}
 		for _, instruction := range []asm.Instruction{
 			amd64.SARL, amd64.SARQ, amd64.SHLL, amd64.SHLQ, amd64.SHRL, amd64.SHRQ,
@@ -1058,13 +1058,13 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 					offset := offset
 					n := &amd64.NodeImpl{Instruction: instruction,
 						Types:  amd64.OperandTypesRegisterToMemory,
-						SrcReg: amd64.REG_CX, DstReg: DstReg, DstConst: offset}
+						SrcReg: amd64.RegCX, DstReg: DstReg, DstConst: offset}
 
 					// Without index.
 					t.Run(n.String(), func(t *testing.T) {
 						goasm, err := newGolangAsmAssembler()
 						require.NoError(t, err)
-						goasm.CompileRegisterToMemory(instruction, amd64.REG_CX, DstReg, offset)
+						goasm.CompileRegisterToMemory(instruction, amd64.RegCX, DstReg, offset)
 						bs, err := goasm.Assemble()
 						require.NoError(t, err)
 
@@ -1082,7 +1082,7 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 							t.Run(n.String(), func(t *testing.T) {
 								goasm, err := newGolangAsmAssembler()
 								require.NoError(t, err)
-								goasm.CompileRegisterToMemoryWithIndex(instruction, amd64.REG_CX, DstReg, offset, indexReg, int16(scale))
+								goasm.CompileRegisterToMemoryWithIndex(instruction, amd64.RegCX, DstReg, offset, indexReg, int16(scale))
 								bs, err := goasm.Assemble()
 								require.NoError(t, err)
 
@@ -1106,7 +1106,7 @@ func TestAssemblerImpl_encodeRegisterToConst(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToConst, SrcReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesRegisterToConst, SrcReg: amd64.RegAX},
 				expErr: "ADDL is unsupported for from:register,to:const type",
 			},
 			{
@@ -1156,7 +1156,7 @@ func TestAssemblerImpl_encodeRegisterToConst(t *testing.T) {
 func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		const targetBeforeInstruction = amd64.RET
-		for _, DstReg := range []asm.Register{amd64.REG_AX, amd64.REG_R8} {
+		for _, DstReg := range []asm.Register{amd64.RegAX, amd64.RegR8} {
 			DstReg := DstReg
 			t.Run(amd64.RegisterName(DstReg), func(t *testing.T) {
 				goasm, err := newGolangAsmAssembler()
@@ -1183,14 +1183,14 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 	})
 	t.Run("not found", func(t *testing.T) {
 		a := amd64.NewAssemblerImpl()
-		a.CompileReadInstructionAddress(amd64.REG_R10, amd64.NOP)
+		a.CompileReadInstructionAddress(amd64.RegR10, amd64.NOP)
 		a.CompileStandAlone(amd64.CDQ)
 		_, err := a.Assemble()
 		require.EqualError(t, err, "BUG: target instruction not found for read instruction address")
 	})
 	t.Run("offset too large", func(t *testing.T) {
 		a := amd64.NewAssemblerImpl()
-		a.CompileReadInstructionAddress(amd64.REG_R10, amd64.RET)
+		a.CompileReadInstructionAddress(amd64.RegR10, amd64.RET)
 		a.CompileStandAlone(amd64.RET)
 		a.CompileStandAlone(amd64.CDQ)
 
@@ -1216,12 +1216,12 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		n := &amd64.NodeImpl{Instruction: amd64.JMP,
 			Types:  amd64.OperandTypesMemoryToRegister,
-			SrcReg: amd64.REG_AX, DstReg: amd64.REG_AX}
+			SrcReg: amd64.RegAX, DstReg: amd64.RegAX}
 		a := amd64.NewAssemblerImpl()
 		require.EqualError(t, a.EncodeMemoryToRegister(n), "JMP is unsupported for from:memory,to:register type")
 	})
-	intRegs := []asm.Register{amd64.REG_AX, amd64.REG_BP, amd64.REG_SI, amd64.REG_DI, amd64.REG_R10}
-	floatRegs := []asm.Register{amd64.REG_X0, amd64.REG_X8}
+	intRegs := []asm.Register{amd64.RegAX, amd64.RegBP, amd64.RegSI, amd64.RegDI, amd64.RegR10}
+	floatRegs := []asm.Register{amd64.RegX0, amd64.RegX8}
 	scales := []byte{1, 4}
 	for _, tc := range []struct {
 		instruction asm.Instruction
@@ -1316,7 +1316,7 @@ func TestAssemblerImpl_encodeConstToRegister(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.RET, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.RET, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.RegAX},
 				expErr: "RET is unsupported for from:const,to:register type",
 			},
 			{
@@ -1324,23 +1324,23 @@ func TestAssemblerImpl_encodeConstToRegister(t *testing.T) {
 				expErr: "invalid register [nil]",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.PSLLL, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.PSLLL, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.RegAX},
 				expErr: "PSLLL needs float register but got AX",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDQ, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.REG_X0},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDQ, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.RegX0},
 				expErr: "ADDQ needs int register but got X0",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.PSLLL, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.REG_X0, SrcConst: 2199023255552},
+				n:      &amd64.NodeImpl{Instruction: amd64.PSLLL, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.RegX0, SrcConst: 2199023255552},
 				expErr: "constant must fit in 32-bit integer for PSLLL, but got 2199023255552",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.SHLQ, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.REG_R10, SrcConst: 32768},
+				n:      &amd64.NodeImpl{Instruction: amd64.SHLQ, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.RegR10, SrcConst: 32768},
 				expErr: "constant must fit in positive 8-bit integer for SHLQ, but got 32768",
 			},
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.PSRLQ, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.REG_X0, SrcConst: 32768},
+				n:      &amd64.NodeImpl{Instruction: amd64.PSRLQ, Types: amd64.OperandTypesConstToRegister, DstReg: amd64.RegX0, SrcConst: 32768},
 				expErr: "constant must fit in signed 8-bit integer for PSRLQ, but got 32768",
 			},
 		} {
@@ -1427,7 +1427,7 @@ func TestAssemblerImpl_EncodeMemoryToConst(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToConst, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToConst, DstReg: amd64.RegAX},
 				expErr: "ADDL is unsupported for from:memory,to:const type",
 			},
 		} {
@@ -1442,7 +1442,7 @@ func TestAssemblerImpl_EncodeMemoryToConst(t *testing.T) {
 
 	const inst = amd64.CMPL
 	t.Run("ok", func(t *testing.T) {
-		for _, reg := range []asm.Register{amd64.REG_AX, amd64.REG_R8} {
+		for _, reg := range []asm.Register{amd64.RegAX, amd64.RegR8} {
 			reg := reg
 			t.Run(amd64.RegisterName(reg), func(t *testing.T) {
 				for _, offset := range []int64{0, 1, -1, 1243, -1234, math.MaxInt32, math.MinInt32, math.MaxInt16, math.MinInt16} {
@@ -1482,19 +1482,19 @@ func TestAssemblerImpl_EncodeConstToMemory(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesConstToMemory, DstReg: amd64.REG_AX},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesConstToMemory, DstReg: amd64.RegAX},
 				expErr: "ADDL is unsupported for from:const,to:memory type",
 			},
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.MOVB, Types: amd64.OperandTypesConstToMemory,
 					SrcConst: math.MaxInt16,
-					DstReg:   amd64.REG_AX, DstConst: 0xff_ff},
+					DstReg:   amd64.RegAX, DstConst: 0xff_ff},
 				expErr: "too large load target const 32767 for MOVB",
 			},
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.MOVL, Types: amd64.OperandTypesConstToMemory,
 					SrcConst: math.MaxInt64,
-					DstReg:   amd64.REG_AX, DstConst: 0xff_ff},
+					DstReg:   amd64.RegAX, DstConst: 0xff_ff},
 				expErr: "too large load target const 9223372036854775807 for MOVL",
 			},
 		} {
@@ -1523,7 +1523,7 @@ func TestAssemblerImpl_EncodeConstToMemory(t *testing.T) {
 				consts = constsMOVQ
 			}
 			t.Run(amd64.InstructionName(inst), func(t *testing.T) {
-				for _, reg := range []asm.Register{amd64.REG_AX, amd64.REG_R8} {
+				for _, reg := range []asm.Register{amd64.RegAX, amd64.RegR8} {
 					reg := reg
 					t.Run(amd64.RegisterName(reg), func(t *testing.T) {
 						for _, offset := range []int64{0, 1, -1, 1243, -1234, math.MaxInt32, math.MinInt32, math.MaxInt16, math.MinInt16} {
@@ -1563,22 +1563,22 @@ func TestNodeImpl_GetMemoryLocation(t *testing.T) {
 			expErr string
 		}{
 			{
-				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToRegister, SrcConst: math.MaxInt64, SrcReg: amd64.REG_AX, DstReg: amd64.REG_R10},
+				n:      &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToRegister, SrcConst: math.MaxInt64, SrcReg: amd64.RegAX, DstReg: amd64.RegR10},
 				expErr: "offset does not fit in 32-bit integer",
 			},
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToRegister,
-					SrcConst: 10, SrcReg: asm.NilRegister, SrcMemIndex: amd64.REG_R12, SrcMemScale: 1, DstReg: amd64.REG_R10},
+					SrcConst: 10, SrcReg: asm.NilRegister, SrcMemIndex: amd64.RegR12, SrcMemScale: 1, DstReg: amd64.RegR10},
 				expErr: "addressing without base register but with index is not implemented",
 			},
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToRegister,
-					SrcConst: 10, SrcReg: amd64.REG_AX, SrcMemIndex: amd64.REG_SP, SrcMemScale: 1, DstReg: amd64.REG_R10},
+					SrcConst: 10, SrcReg: amd64.RegAX, SrcMemIndex: amd64.RegSP, SrcMemScale: 1, DstReg: amd64.RegR10},
 				expErr: "SP cannot be used for SIB index",
 			},
 			{
 				n: &amd64.NodeImpl{Instruction: amd64.ADDL, Types: amd64.OperandTypesMemoryToRegister,
-					SrcConst: 10, SrcReg: amd64.REG_AX, SrcMemIndex: amd64.REG_R9, SrcMemScale: 3, DstReg: amd64.REG_R10},
+					SrcConst: 10, SrcReg: amd64.RegAX, SrcMemIndex: amd64.RegR9, SrcMemScale: 3, DstReg: amd64.RegR10},
 				expErr: "scale in SIB must be one of 1, 2, 4, 8 but got 3",
 			},
 		} {
@@ -1597,7 +1597,7 @@ func TestNodeImpl_GetMemoryLocation(t *testing.T) {
 			t.Run(fmt.Sprintf("%d", offset), func(t *testing.T) {
 				goasm, err := newGolangAsmAssembler()
 				require.NoError(t, err)
-				goasm.CompileRegisterToMemory(amd64.CMPL, amd64.REG_AX, asm.NilRegister, offset)
+				goasm.CompileRegisterToMemory(amd64.CMPL, amd64.RegAX, asm.NilRegister, offset)
 				require.NoError(t, err)
 
 				expectedBytes, err := goasm.Assemble()
@@ -1645,7 +1645,7 @@ func TestNodeImpl_GetMemoryLocation(t *testing.T) {
 				for _, indexReg := range append(intRegisters,
 					// Without index.
 					asm.NilRegister) {
-					if indexReg == amd64.REG_SP {
+					if indexReg == amd64.RegSP {
 						continue
 					}
 					n.SrcMemIndex = indexReg
@@ -1654,7 +1654,7 @@ func TestNodeImpl_GetMemoryLocation(t *testing.T) {
 						t.Run(n.String(), func(t *testing.T) {
 							goasm, err := newGolangAsmAssembler()
 							require.NoError(t, err)
-							goasm.CompileMemoryWithIndexToRegister(amd64.ADDL, srcReg, offset, indexReg, int16(scale), amd64.REG_AX)
+							goasm.CompileMemoryWithIndexToRegister(amd64.ADDL, srcReg, offset, indexReg, int16(scale), amd64.RegAX)
 							expectedBytes, err := goasm.Assemble()
 							require.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>

This resolves `revive` linter errors in the amd64 package related to

- No ALL_CAPS constants (REG_AX -> RegAX)
- Doc on all exported members

All the code changes are automatic with GoLand's renaming functionality. The docs on the instruction names essentially map from go asm to amd64 asm (by reading https://www.felixcloutier.com/x86/index.html) which I think best explains how each instruction works.

@mathetake If this PR / pattern makes sense, I will send one for arm64 too.