### PR TITLE
SIMD: implements v128 load, store and lane manipulations.

### DIFF
--- a/internal/asm/amd64/assembler.go
+++ b/internal/asm/amd64/assembler.go
@@ -28,6 +28,18 @@ type Assembler interface {
 		dstReg asm.Register,
 	)
 
+	// CompileMemoryWithIndexAndArgToRegister is the same as CompileMemoryWithIndexToRegister except that this
+	// also accepts one argument.
+	CompileMemoryWithIndexAndArgToRegister(
+		instruction asm.Instruction,
+		srcBaseReg asm.Register,
+		srcOffsetConst int64,
+		srcIndex asm.Register,
+		srcScale int16,
+		dstReg asm.Register,
+		arg byte,
+	)
+
 	// CompileRegisterToMemoryWithIndex adds an instruction where source operand is the register `SrcReg`,
 	// and the destination is the memory address specified as `dstBaseReg + dstOffsetConst + dstIndex*dstScale`
 	// Note: dstScale must be one of 1, 2, 4, 8.
@@ -38,6 +50,18 @@ type Assembler interface {
 		dstOffsetConst int64,
 		dstIndex asm.Register,
 		dstScale int16,
+	)
+
+	// CompileRegisterToMemoryWithIndexAndArg is the same as CompileRegisterToMemoryWithIndex except that this
+	// also accepts one argument.
+	CompileRegisterToMemoryWithIndexAndArg(
+		instruction asm.Instruction,
+		srcReg asm.Register,
+		dstBaseReg asm.Register,
+		dstOffsetConst int64,
+		dstIndex asm.Register,
+		dstScale int16,
+		arg byte,
 	)
 
 	// CompileRegisterToConst adds an instruction where source operand is the register `srcRegister`,
@@ -57,15 +81,14 @@ type Assembler interface {
 	CompileNoneToMemory(instruction asm.Instruction, baseReg asm.Register, offset int64)
 
 	// CompileConstToMemory adds an instruction where source operand is the constant `value` and
-	// the destination is the memory address specified as `dstbaseReg+dstOffset`.
-	CompileConstToMemory(instruction asm.Instruction, value int64, dstbaseReg asm.Register, dstOffset int64) asm.Node
+	// the destination is the memory address specified as `dstBaseReg+dstOffset`.
+	CompileConstToMemory(instruction asm.Instruction, value int64, dstBaseReg asm.Register, dstOffset int64) asm.Node
 
 	// CompileMemoryToConst adds an instruction where source operand is the memory address, and
 	// the destination is the constant `value`.
 	CompileMemoryToConst(instruction asm.Instruction, srcBaseReg asm.Register, srcOffset int64, value int64) asm.Node
-}
 
-// Mode represents a Mode for specific instruction.
-// For example, ROUND** instructions' behavior can be modified "Mode" constant.
-// See https://www.felixcloutier.com/x86/roundss for ROUNDSS as an example.
-type Mode = byte
+	// CompileLoadStaticConstToRegister adds an instruction where the source operand is StaticConstant located in the memory
+	// and the destination is the dstReg.
+	CompileLoadStaticConstToRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register) error
+}

--- a/internal/asm/amd64/assembler.go
+++ b/internal/asm/amd64/assembler.go
@@ -88,7 +88,7 @@ type Assembler interface {
 	// the destination is the constant `value`.
 	CompileMemoryToConst(instruction asm.Instruction, srcBaseReg asm.Register, srcOffset int64, value int64) asm.Node
 
-	// CompileLoadStaticConstToRegister adds an instruction where the source operand is StaticConstant located in the memory
-	// and the destination is the dstReg.
+	// CompileLoadStaticConstToRegister adds an instruction where the source operand is asm.StaticConst located in the
+	// memory and the destination is the dstReg.
 	CompileLoadStaticConstToRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register) error
 }

--- a/internal/asm/amd64/consts.go
+++ b/internal/asm/amd64/consts.go
@@ -175,11 +175,11 @@ const (
 	MOVW
 	// MOVWLSX is the MOVSX instruction for a word in 32-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVWLSX
-	// MOVWLZX is the MOVZX instruction for a word in 32-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
+	// MOVWLZX is the MOVZX instruction for a word in 32-bit mode. https://www.felixcloutier.com/x86/movzx
 	MOVWLZX
 	// MOVWQSX is the MOVSX instruction for a word in 64-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVWQSX
-	// MOVWQZX is the MOVZX instruction for a word in 64-bit mode. https://www.felixcloutier.com/x86/movsx:movsxd
+	// MOVWQZX is the MOVZX instruction for a word in 64-bit mode. https://www.felixcloutier.com/x86/movzx
 	MOVWQZX
 	// MULL is the MUL instruction in 32-bit mode. https://www.felixcloutier.com/x86/mul
 	MULL
@@ -303,17 +303,17 @@ const (
 	NOP
 	// UD2 is the UD2 instruction. https://www.felixcloutier.com/x86/ud
 	UD2
-	// MOVDQU is the MOVDQU instruction. https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
+	// MOVDQU is the MOVDQU instruction in 64-bit mode. https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
 	MOVDQU
-	// MOVDQA is the MOVDQA instruction.
+	// MOVDQA is the MOVDQA instruction in 64-bit mode. https://www.felixcloutier.com/x86/movdqa:vmovdqa32:vmovdqa64
 	MOVDQA
 	// PINSRB is the PINSRB instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 	PINSRB
-	// PINSRW is the mode PINSQRW instruction. https://www.felixcloutier.com/x86/pinsrw
+	// PINSRW is the PINSRW instruction. https://www.felixcloutier.com/x86/pinsrw
 	PINSRW
 	// PINSRD is the PINSRD instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 	PINSRD
-	// PINSRQ is the PINSQRQ instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	// PINSRQ is the PINSRQ instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 	PINSRQ
 	// PADDB is the PADDB instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDB
@@ -327,15 +327,15 @@ const (
 	PSUBB
 	// PSUBW is the PSUBW instruction. https://www.felixcloutier.com/x86/psubb:psubw:psubd
 	PSUBW
-	// PSUBL is the PSUBL instruction. https://www.felixcloutier.com/x86/psubb:psubw:psubd
+	// PSUBL is the PSUBD instruction. https://www.felixcloutier.com/x86/psubb:psubw:psubd
 	PSUBL
-	// PSUBQ is the PSUBQ instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+	// PSUBQ is the PSUBQ instruction. https://www.felixcloutier.com/x86/psubq
 	PSUBQ
 	// ADDPS is the ADDPS instruction. https://www.felixcloutier.com/x86/addps
 	ADDPS
 	// ADDPD is the ADDPD instruction. https://www.felixcloutier.com/x86/addpd
 	ADDPD
-	// SUBPS is the SUBPS instruction. https://www.felixcloutier.com/x86/addps
+	// SUBPS is the SUBPS instruction. https://www.felixcloutier.com/x86/subps
 	SUBPS
 	// SUBPD is the SUBPD instruction. https://www.felixcloutier.com/x86/subpd
 	SUBPD

--- a/internal/asm/amd64/consts.go
+++ b/internal/asm/amd64/consts.go
@@ -305,7 +305,15 @@ const (
 	UD2
 	// MOVDQU is the MOVDQU instruction. https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
 	MOVDQU
-	// PINSRQ is the PINSQR instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	// MOVDQA is the MOVDQA instruction.
+	MOVDQA
+	// PINSRB is the PINSRB instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	PINSRB
+	// PINSRW is the mode PINSQRW instruction. https://www.felixcloutier.com/x86/pinsrw
+	PINSRW
+	// PINSRD is the PINSRD instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	PINSRD
+	// PINSRQ is the PINSQRQ instruction. https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 	PINSRQ
 	// PADDB is the PADDB instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDB
@@ -315,10 +323,66 @@ const (
 	PADDL
 	// PADDQ is the PADDQ instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
 	PADDQ
+	// PSUBB is the PSUBB instruction. https://www.felixcloutier.com/x86/psubb:psubw:psubd
+	PSUBB
+	// PSUBW is the PSUBW instruction. https://www.felixcloutier.com/x86/psubb:psubw:psubd
+	PSUBW
+	// PSUBL is the PSUBL instruction. https://www.felixcloutier.com/x86/psubb:psubw:psubd
+	PSUBL
+	// PSUBQ is the PSUBQ instruction. https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+	PSUBQ
 	// ADDPS is the ADDPS instruction. https://www.felixcloutier.com/x86/addps
 	ADDPS
 	// ADDPD is the ADDPD instruction. https://www.felixcloutier.com/x86/addpd
 	ADDPD
+	// SUBPS is the SUBPS instruction. https://www.felixcloutier.com/x86/addps
+	SUBPS
+	// SUBPD is the SUBPD instruction. https://www.felixcloutier.com/x86/subpd
+	SUBPD
+	// PMOVSXBW is the PMOVSXBW instruction https://www.felixcloutier.com/x86/pmovsx
+	PMOVSXBW
+	// PMOVSXWD is the PMOVSXWD instruction https://www.felixcloutier.com/x86/pmovsx
+	PMOVSXWD
+	// PMOVSXDQ is the PMOVSXDQ instruction https://www.felixcloutier.com/x86/pmovsx
+	PMOVSXDQ
+	// PMOVZXBW is the PMOVZXBW instruction https://www.felixcloutier.com/x86/pmovzx
+	PMOVZXBW
+	// PMOVZXWD is the PMOVZXWD instruction https://www.felixcloutier.com/x86/pmovzx
+	PMOVZXWD
+	// PMOVZXDQ is the PMOVZXDQ instruction https://www.felixcloutier.com/x86/pmovzx
+	PMOVZXDQ
+	// PSHUFB is the PSHUFB instruction https://www.felixcloutier.com/x86/pshufb
+	PSHUFB
+	// PSHUFD is the PSHUFD instruction https://www.felixcloutier.com/x86/pshufd
+	PSHUFD
+	// PXOR is the PXOR instruction https://www.felixcloutier.com/x86/pxor
+	PXOR
+	// PEXTRB is the PEXTRB instruction https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+	PEXTRB
+	// PEXTRW is the PEXTRW instruction https://www.felixcloutier.com/x86/pextrw
+	PEXTRW
+	// PEXTRD is the PEXTRD instruction https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+	PEXTRD
+	// PEXTRQ is the PEXTRQ instruction https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+	PEXTRQ
+	// MOVLHPS is the MOVLHPS instruction https://www.felixcloutier.com/x86/movlhps
+	MOVLHPS
+	// INSERTPS is the INSERTPS instruction https://www.felixcloutier.com/x86/insertps
+	INSERTPS
+	// PTEST is the PTEST instruction https://www.felixcloutier.com/x86/ptest
+	PTEST
+	// PCMPEQB is the PCMPEQB instruction https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
+	PCMPEQB
+	// PCMPEQW is the PCMPEQW instruction https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
+	PCMPEQW
+	// PCMPEQD is the PCMPEQD instruction https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
+	PCMPEQD
+	// PCMPEQQ is the PCMPEQQ instruction https://www.felixcloutier.com/x86/pcmpeqq
+	PCMPEQQ
+	// PADDUSB is the PADDUSB instruction https://www.felixcloutier.com/x86/paddusb:paddusw
+	PADDUSB
+	// MOVSD is the MOVSD instruction https://www.felixcloutier.com/x86/movsd
+	MOVSD
 )
 
 // InstructionName returns the name for an instruction
@@ -586,6 +650,12 @@ func InstructionName(instruction asm.Instruction) string {
 		return "UD2"
 	case MOVDQU:
 		return "MOVDQU"
+	case PINSRB:
+		return "PINSRB"
+	case PINSRW:
+		return "PINSRW"
+	case PINSRD:
+		return "PINSRD"
 	case PINSRQ:
 		return "PINSRQ"
 	case PADDB:
@@ -600,6 +670,64 @@ func InstructionName(instruction asm.Instruction) string {
 		return "ADDPS"
 	case ADDPD:
 		return "ADDPD"
+	case PSUBB:
+		return "PSUBB"
+	case PSUBW:
+		return "PSUBW"
+	case PSUBL:
+		return "PSUBL"
+	case PSUBQ:
+		return "PSUBQ"
+	case SUBPS:
+		return "SUBPS"
+	case SUBPD:
+		return "SUBPD"
+	case PMOVSXBW:
+		return "PMOVSXBW"
+	case PMOVSXWD:
+		return "PMOVSXWD"
+	case PMOVSXDQ:
+		return "PMOVSXDQ"
+	case PMOVZXBW:
+		return "PMOVZXBW"
+	case PMOVZXWD:
+		return "PMOVZXWD"
+	case PMOVZXDQ:
+		return "PMOVZXDQ"
+	case PSHUFB:
+		return "PSHUFB"
+	case PSHUFD:
+		return "PSHUFD"
+	case PXOR:
+		return "PXOR"
+	case PEXTRB:
+		return "PEXTRB"
+	case PEXTRW:
+		return "PEXTRW"
+	case PEXTRD:
+		return "PEXTRD"
+	case PEXTRQ:
+		return "PEXTRQ"
+	case INSERTPS:
+		return "INSERTPS"
+	case MOVLHPS:
+		return "MOVLHPS"
+	case PTEST:
+		return "PTEST"
+	case PCMPEQB:
+		return "PCMPEQB"
+	case PCMPEQW:
+		return "PCMPEQW"
+	case PCMPEQD:
+		return "PCMPEQD"
+	case PCMPEQQ:
+		return "PCMPEQQ"
+	case PADDUSB:
+		return "PADDUSB"
+	case MOVDQA:
+		return "MOVDQA"
+	case MOVSD:
+		return "MOVSD"
 	}
 	return "Unknown"
 }

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -211,8 +211,6 @@ func (o OperandTypes) String() string {
 	return fmt.Sprintf("from:%s,to:%s", o.src, o.dst)
 }
 
-const defaultMaxDisplacementForConstantPool = 1 << 30
-
 // AssemblerImpl implements Assembler.
 type AssemblerImpl struct {
 	asm.BaseAssemblerImpl
@@ -1656,7 +1654,7 @@ func (a *AssemblerImpl) encodeReadInstructionAddress(n *NodeImpl) error {
 	opcode := byte(0x8d)
 	rexPrefix |= RexPrefixW
 
-	// https://wiki.osdev.org/X86-64_Instruction_Encoding#64-bit_addressing
+	// https://wiki.osdev.org/X86-64_Instruction_Encoding#32.2F64-bit_addressing
 	modRM := 0b00_000_101 | // Indicate "LEAQ [RIP + 32bit displacement], DstReg" encoding.
 		(dstReg3Bits << 3) // Place the DstReg on ModRM:reg.
 

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -226,6 +226,7 @@ type AssemblerImpl struct {
 	pool constPool
 }
 
+// compile-time check to ensure AssemblerImpl implements Assembler.
 var _ Assembler = &AssemblerImpl{}
 
 func NewAssemblerImpl() *AssemblerImpl {
@@ -1143,6 +1144,7 @@ var registerToRegisterOpcode = map[asm.Instruction]struct {
 	MOVBLSX: {opcode: []byte{0x0f, 0xbe}, isSrc8bit: true},
 	// https://www.felixcloutier.com/x86/movzx
 	MOVBLZX: {opcode: []byte{0x0f, 0xb6}, isSrc8bit: true},
+	// https://www.felixcloutier.com/x86/movzx
 	MOVWLZX: {opcode: []byte{0x0f, 0xb7}, isSrc8bit: true},
 	// https://www.felixcloutier.com/x86/movsx:movsxd
 	MOVBQSX: {opcode: []byte{0x0f, 0xbe}, rPrefix: RexPrefixW, isSrc8bit: true},
@@ -1209,38 +1211,55 @@ var registerToRegisterOpcode = map[asm.Instruction]struct {
 	MOVDQU: {mandatoryPrefix: 0xf3, opcode: []byte{0x0f, 0x6f}, requireSrcFloat: true, requireDstFloat: true},
 	// https://www.felixcloutier.com/x86/movdqa:vmovdqa32:vmovdqa64
 	MOVDQA: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x6f}, requireSrcFloat: true, requireDstFloat: true},
-	PADDB:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfc}, requireSrcFloat: true, requireDstFloat: true},
-	PADDW:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfd}, requireSrcFloat: true, requireDstFloat: true},
-	PADDL:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfe}, requireSrcFloat: true, requireDstFloat: true},
-	PADDQ:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xd4}, requireSrcFloat: true, requireDstFloat: true},
-	PSUBB:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xf8}, requireSrcFloat: true, requireDstFloat: true},
-	PSUBW:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xf9}, requireSrcFloat: true, requireDstFloat: true},
-	PSUBL:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfa}, requireSrcFloat: true, requireDstFloat: true},
-	PSUBQ:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfb}, requireSrcFloat: true, requireDstFloat: true},
-	ADDPS:  {opcode: []byte{0x0f, 0x58}, requireSrcFloat: true, requireDstFloat: true},
-	ADDPD:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x58}, requireSrcFloat: true, requireDstFloat: true},
-	SUBPS:  {opcode: []byte{0x0f, 0x5c}, requireSrcFloat: true, requireDstFloat: true},
-	SUBPD:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x5c}, requireSrcFloat: true, requireDstFloat: true},
-	PXOR:   {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xef}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/paddb:paddw:paddd:paddq
+	PADDB: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfc}, requireSrcFloat: true, requireDstFloat: true},
+	PADDW: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfd}, requireSrcFloat: true, requireDstFloat: true},
+	PADDL: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfe}, requireSrcFloat: true, requireDstFloat: true},
+	PADDQ: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xd4}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/psubb:psubw:psubd
+	PSUBB: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xf8}, requireSrcFloat: true, requireDstFloat: true},
+	PSUBW: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xf9}, requireSrcFloat: true, requireDstFloat: true},
+	PSUBL: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfa}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/psubq
+	PSUBQ: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xfb}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/addps
+	ADDPS: {opcode: []byte{0x0f, 0x58}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/addpd
+	ADDPD: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x58}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/subps
+	SUBPS: {opcode: []byte{0x0f, 0x5c}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/subpd
+	SUBPD: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x5c}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/pxor
+	PXOR: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xef}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/pshufb
 	PSHUFB: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x38, 0x0}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/pshufd
 	PSHUFD: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x70}, requireSrcFloat: true, requireDstFloat: true, needArg: true},
 	// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
 	PEXTRB: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x3a, 0x14}, requireSrcFloat: true, requireDstFloat: false, needArg: true, srcOnModRMReg: true},
-	// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
-	PEXTRW: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xc5}, requireSrcFloat: true, requireDstFloat: false, needArg: true},
 	// https://www.felixcloutier.com/x86/pextrw
+	PEXTRW: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xc5}, requireSrcFloat: true, requireDstFloat: false, needArg: true},
+	// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
 	PEXTRD: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x3a, 0x16}, requireSrcFloat: true, requireDstFloat: false, needArg: true, srcOnModRMReg: true},
 	// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
-	PEXTRQ:   {rPrefix: RexPrefixW, mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x3a, 0x16}, requireSrcFloat: true, requireDstFloat: false, needArg: true, srcOnModRMReg: true},
+	PEXTRQ: {rPrefix: RexPrefixW, mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x3a, 0x16}, requireSrcFloat: true, requireDstFloat: false, needArg: true, srcOnModRMReg: true},
+	// https://www.felixcloutier.com/x86/insertps
 	INSERTPS: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x3a, 0x21}, requireSrcFloat: true, requireDstFloat: true, needArg: true},
-	MOVLHPS:  {opcode: []byte{0x0f, 0x16}, requireSrcFloat: true, requireDstFloat: true},
-	PTEST:    {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x38, 0x17}, requireSrcFloat: true, requireDstFloat: true},
-	PCMPEQB:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x74}, requireSrcFloat: true, requireDstFloat: true},
-	PCMPEQW:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x75}, requireSrcFloat: true, requireDstFloat: true},
-	PCMPEQD:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x76}, requireSrcFloat: true, requireDstFloat: true},
-	PCMPEQQ:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x38, 0x29}, requireSrcFloat: true, requireDstFloat: true},
-	PADDUSB:  {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xdc}, requireSrcFloat: true, requireDstFloat: true},
-	MOVSD:    {mandatoryPrefix: 0xf2, opcode: []byte{0x0f, 0x10}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/movlhps
+	MOVLHPS: {opcode: []byte{0x0f, 0x16}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/ptest
+	PTEST: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x38, 0x17}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/pcmpeqb:pcmpeqw:pcmpeqd
+	PCMPEQB: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x74}, requireSrcFloat: true, requireDstFloat: true},
+	PCMPEQW: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x75}, requireSrcFloat: true, requireDstFloat: true},
+	PCMPEQD: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x76}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/pcmpeqq
+	PCMPEQQ: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0x38, 0x29}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/paddusb:paddusw
+	PADDUSB: {mandatoryPrefix: 0x66, opcode: []byte{0x0f, 0xdc}, requireSrcFloat: true, requireDstFloat: true},
+	// https://www.felixcloutier.com/x86/movsd
+	MOVSD: {mandatoryPrefix: 0xf2, opcode: []byte{0x0f, 0x10}, requireSrcFloat: true, requireDstFloat: true},
 }
 
 var RegisterToRegisterShiftOpcode = map[asm.Instruction]struct {
@@ -1501,25 +1520,21 @@ func (a *AssemblerImpl) EncodeRegisterToMemory(n *NodeImpl) (err error) {
 		// https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
 		mandatoryPrefix = 0xf3
 		opcode = []byte{0x0f, 0x7f}
-	case PEXTRB:
-		// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+	case PEXTRB: // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x3a, 0x14}
 		needArg = true
-	case PEXTRW:
-		// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
+	case PEXTRW: // https://www.felixcloutier.com/x86/pextrw
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x3a, 0x15}
 		needArg = true
-	case PEXTRD:
-		// https://www.felixcloutier.com/x86/pextrw
+	case PEXTRD: // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x3a, 0x16}
 		needArg = true
-	case PEXTRQ:
-		// https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
-		rexPrefix |= RexPrefixW
+	case PEXTRQ: // https://www.felixcloutier.com/x86/pextrb:pextrd:pextrq
 		mandatoryPrefix = 0x66
+		rexPrefix |= RexPrefixW // REX.W
 		opcode = []byte{0x0f, 0x3a, 0x16}
 		needArg = true
 	default:
@@ -1772,46 +1787,37 @@ func (a *AssemblerImpl) EncodeMemoryToRegister(n *NodeImpl) (err error) {
 		// https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
 		mandatoryPrefix = 0xf3
 		opcode = []byte{0x0f, 0x6f}
-	case PMOVSXBW:
-		// https://www.felixcloutier.com/x86/pmovsx
+	case PMOVSXBW: // https://www.felixcloutier.com/x86/pmovsx
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x38, 0x20}
-	case PMOVSXWD:
-		// https://www.felixcloutier.com/x86/pmovsx
+	case PMOVSXWD: // https://www.felixcloutier.com/x86/pmovsx
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x38, 0x23}
-	case PMOVSXDQ:
-		// https://www.felixcloutier.com/x86/pmovsx
+	case PMOVSXDQ: // https://www.felixcloutier.com/x86/pmovsx
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x38, 0x25}
-	case PMOVZXBW:
-		// https://www.felixcloutier.com/x86/pmovzx
+	case PMOVZXBW: // https://www.felixcloutier.com/x86/pmovzx
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x38, 0x30}
-	case PMOVZXWD:
+	case PMOVZXWD: // https://www.felixcloutier.com/x86/pmovzx
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x38, 0x33}
-		// https://www.felixcloutier.com/x86/pmovzx
-	case PMOVZXDQ:
+	case PMOVZXDQ: // https://www.felixcloutier.com/x86/pmovzx
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x38, 0x35}
-	case PINSRB:
-		// https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	case PINSRB: // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x3a, 0x20}
 		needArg = true
-	case PINSRW:
-		// https://www.felixcloutier.com/x86/pinsrw
+	case PINSRW: // https://www.felixcloutier.com/x86/pinsrw
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0xc4}
 		needArg = true
-	case PINSRD:
-		// https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	case PINSRD: // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x3a, 0x22}
 		needArg = true
-	case PINSRQ:
-		// https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
+	case PINSRQ: // https://www.felixcloutier.com/x86/pinsrb:pinsrd:pinsrq
 		rexPrefix |= RexPrefixW
 		mandatoryPrefix = 0x66
 		opcode = []byte{0x0f, 0x3a, 0x22}
@@ -2340,10 +2346,10 @@ type RexPrefix = byte
 const (
 	RexPrefixNone    RexPrefix = 0x0000_0000 // Indicates that the instruction doesn't need RexPrefix.
 	RexPrefixDefault RexPrefix = 0b0100_0000
-	RexPrefixW                 = 0b0000_1000 | RexPrefixDefault
-	RexPrefixR                 = 0b0000_0100 | RexPrefixDefault
-	RexPrefixX                 = 0b0000_0010 | RexPrefixDefault
-	RexPrefixB                 = 0b0000_0001 | RexPrefixDefault
+	RexPrefixW                 = 0b0000_1000 | RexPrefixDefault // REX.W
+	RexPrefixR                 = 0b0000_0100 | RexPrefixDefault // REX.R
+	RexPrefixX                 = 0b0000_0010 | RexPrefixDefault // REX.X
+	RexPrefixB                 = 0b0000_0001 | RexPrefixDefault // REX.B
 )
 
 // registerSpecifierPosition represents the position in the instruction bytes where an operand register is placed.

--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -13,9 +13,8 @@ type constPool struct {
 	consts                 []asm.StaticConst
 	poolSizeInBytes        int
 
-	// offsetFinalizedCallbacks holds the callbacks keyed on the constants.
-	// These callbacks are called when the offsets of the constants in the binary
-	// have been determined.
+	// offsetFinalizedCallbacks are functions called when the offsets of the
+	// constants in the binary have been determined.
 	offsetFinalizedCallbacks map[string][]func(offsetOfConstInBinary int)
 }
 
@@ -64,7 +63,7 @@ func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
 			}
 		}
 
-		a.pool = newConstPool()
+		a.pool = newConstPool() // reset
 	}
 }
 

--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -1,0 +1,124 @@
+package amd64
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/tetratelabs/wazero/internal/asm"
+)
+
+type constPool struct {
+	firstUseOffsetInBinary *asm.NodeOffsetInBinary
+	consts                 []asm.StaticConst
+	poolSizeInBytes        int
+
+	// offsetFinalizedCallbacks holds the callbacks keyed on the constants.
+	// These callbacks are called when the offsets of the constants in the binary
+	// have been determined.
+	offsetFinalizedCallbacks map[string][]func(offsetOfConstInBinary int)
+}
+
+func newConstPool() constPool {
+	return constPool{offsetFinalizedCallbacks: map[string][]func(offsetOfConstInBinary int){}}
+}
+
+func (p *constPool) addConst(c asm.StaticConst) {
+	key := asm.StaticConstKey(c)
+	if _, ok := p.offsetFinalizedCallbacks[key]; !ok {
+		p.consts = append(p.consts, c)
+		p.poolSizeInBytes += len(c)
+		p.offsetFinalizedCallbacks[key] = []func(int){}
+	}
+}
+
+func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
+	if a.pool.firstUseOffsetInBinary == nil {
+		return
+	}
+
+	if isEndOfFunction ||
+		// Conservative strategy.
+		((a.pool.poolSizeInBytes+a.Buf.Len())-int(*a.pool.firstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
+		if !isEndOfFunction {
+			// Adds the jump instruction to skip the constants if this is not the end of function.
+			//
+			// TODO: consider NOP padding for this jump, though this rarely happens as most functions should be
+			// small enough to fit all consts after the end of function.
+			if a.pool.poolSizeInBytes >= math.MaxInt8-2 {
+				// long jump
+				a.Buf.WriteByte(0xe9)
+				a.WriteConst(int64(a.pool.poolSizeInBytes), 32)
+			} else {
+				// short jump
+				a.Buf.WriteByte(0xeb)
+				a.WriteConst(int64(a.pool.poolSizeInBytes), 8)
+			}
+		}
+
+		for _, c := range a.pool.consts {
+			offset := a.Buf.Len()
+			a.Buf.Write(c)
+			for _, callback := range a.pool.offsetFinalizedCallbacks[asm.StaticConstKey(c)] {
+				callback(offset)
+			}
+		}
+
+		a.pool = newConstPool()
+	}
+}
+
+func (a *AssemblerImpl) encodeStaticConstToRegister(n *NodeImpl) (err error) {
+	if n.Instruction != MOVDQU {
+		err = errorEncodingUnsupported(n)
+		return
+	}
+
+	a.pool.addConst(n.staticConst)
+
+	dstReg3Bits, rexPrefix, err := register3bits(n.DstReg, registerSpecifierPositionModRMFieldReg)
+	if err != nil {
+		return err
+	}
+
+	var inst []byte // mandatory prefix
+	key := asm.StaticConstKey(n.staticConst)
+	a.pool.offsetFinalizedCallbacks[key] = append(a.pool.offsetFinalizedCallbacks[key],
+		func(offsetOfConstInBinary int) {
+			bin := a.Buf.Bytes()
+			displacement := offsetOfConstInBinary - int(n.OffsetInBinary()) - len(inst)
+			binary.LittleEndian.PutUint32(bin[n.OffsetInBinary()+uint64(len(inst)-4):], uint32(int32(displacement)))
+		})
+
+	nodeOffset := uint64(a.Buf.Len())
+	a.pool.firstUseOffsetInBinary = &nodeOffset
+
+	// https://wiki.osdev.org/X86-64_Instruction_Encoding#64-bit_addressing
+	modRM := 0b00_000_101 | // Indicate "MOVDQU [RIP + 32bit displacement], DstReg" encoding.
+		(dstReg3Bits << 3) // Place the DstReg on ModRM:reg.
+
+	// https://www.felixcloutier.com/x86/movdqu:vmovdqu8:vmovdqu16:vmovdqu32:vmovdqu64
+	inst = append(inst, 0xf3) // mandatory prefix
+	if rexPrefix != RexPrefixNone {
+		inst = append(inst, rexPrefix)
+	}
+	inst = append(inst, 0x0f, 0x6f, modRM,
+		0x0, 0x0, 0x0, 0x0, // Preserve 4 bytes for displacement.
+	)
+
+	a.Buf.Write(inst)
+	return
+}
+
+// CompileLoadStaticConstToRegister implements Assembler.CompileLoadStaticConstToRegister.
+func (a *AssemblerImpl) CompileLoadStaticConstToRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register) (err error) {
+	if len(c)%2 != 0 {
+		err = fmt.Errorf("the length of a static constant must be even but was %d", len(c))
+		return
+	}
+
+	n := a.newNode(instruction, OperandTypesStaticConstToRegister)
+	n.DstReg = dstReg
+	n.staticConst = c
+	return
+}

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -22,7 +22,7 @@ func TestConstPool_addConst(t *testing.T) {
 
 func TestAssemblerImpl_CompileLoadStaticConstToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
-	t.Run("odd bytes", func(t *testing.T) {
+	t.Run("odd count of bytes", func(t *testing.T) {
 		err := a.CompileLoadStaticConstToRegister(MOVDQU, []byte{1}, RegAX)
 		require.Error(t, err)
 	})
@@ -41,7 +41,7 @@ func TestAssemblerImpl_CompileLoadStaticConstToRegister(t *testing.T) {
 func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 	t.Run("no consts", func(t *testing.T) {
 		a := NewAssemblerImpl()
-		// Invoking maybeFlushConstants before encoding consts usage should be fine.
+		// Invoking maybeFlushConstants before encoding consts usage should not panic.
 		a.maybeFlushConstants(false)
 		a.maybeFlushConstants(true)
 	})

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -1,0 +1,171 @@
+package amd64
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestConstPool_addConst(t *testing.T) {
+	p := newConstPool()
+	cons := []byte{1, 2, 3, 4}
+
+	for i := 0; i < 2; i++ {
+		p.addConst(cons)
+		require.Equal(t, 1, len(p.consts))
+		require.Equal(t, len(cons), p.poolSizeInBytes)
+		_, ok := p.offsetFinalizedCallbacks[asm.StaticConstKey(cons)]
+		require.True(t, ok)
+	}
+}
+
+func TestAssemblerImpl_CompileLoadStaticConstToRegister(t *testing.T) {
+	a := NewAssemblerImpl()
+	t.Run("odd bytes", func(t *testing.T) {
+		err := a.CompileLoadStaticConstToRegister(MOVDQU, []byte{1}, RegAX)
+		require.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		cons := []byte{1, 2, 3, 4}
+		err := a.CompileLoadStaticConstToRegister(MOVDQU, cons, RegAX)
+		require.NoError(t, err)
+		actualNode := a.Current
+		require.Equal(t, MOVDQU, actualNode.Instruction)
+		require.Equal(t, OperandTypeStaticConst, actualNode.Types.src)
+		require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
+		require.Equal(t, cons, actualNode.staticConst)
+	})
+}
+
+func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
+	t.Run("no consts", func(t *testing.T) {
+		a := NewAssemblerImpl()
+		// Invoking maybeFlushConstants before encoding consts usage should be fine.
+		a.maybeFlushConstants(false)
+		a.maybeFlushConstants(true)
+	})
+
+	largeData := make([]byte, 256)
+
+	tests := []struct {
+		name                    string
+		endOfFunction           bool
+		dummyBodyBeforeFlush    []byte
+		firstUseOffsetInBinary  uint64
+		consts                  []asm.StaticConst
+		expectedOffsetForConsts []int
+		exp                     []byte
+		maxDisplacement         int
+	}{
+		{
+			name:                    "end of function",
+			endOfFunction:           true,
+			dummyBodyBeforeFlush:    []byte{'?', '?', '?', '?'},
+			consts:                  []asm.StaticConst{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
+			expectedOffsetForConsts: []int{4, 4 + 8}, // 4 = len(dummyBodyBeforeFlush)
+			firstUseOffsetInBinary:  0,
+			exp:                     []byte{'?', '?', '?', '?', 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13},
+			maxDisplacement:         1 << 31,
+		},
+		{
+			name:                   "not flush",
+			endOfFunction:          false,
+			dummyBodyBeforeFlush:   []byte{'?', '?', '?', '?'},
+			consts:                 []asm.StaticConst{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
+			firstUseOffsetInBinary: 0,
+			exp:                    []byte{'?', '?', '?', '?'},
+			maxDisplacement:        1 << 31,
+		},
+		{
+			name:                    "not end of function but flush - short jump",
+			endOfFunction:           false,
+			dummyBodyBeforeFlush:    []byte{'?', '?', '?', '?'},
+			consts:                  []asm.StaticConst{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
+			expectedOffsetForConsts: []int{4 + 2, 4 + 2 + 8}, // 4 = len(dummyBodyBeforeFlush), 2 = the size of jump
+			firstUseOffsetInBinary:  0,
+			exp: []byte{'?', '?', '?', '?',
+				0xeb, 0x0c, // short jump with offset = len(consts[0]) + len(consts[1]) = 12 = 0xc.
+				1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13},
+			maxDisplacement: 0,
+		},
+		{
+			name:                    "not end of function but flush - long jump",
+			endOfFunction:           false,
+			dummyBodyBeforeFlush:    []byte{'?', '?', '?', '?'},
+			consts:                  []asm.StaticConst{largeData},
+			expectedOffsetForConsts: []int{4 + 5}, // 4 = len(dummyBodyBeforeFlush), 5 = the size of jump
+			firstUseOffsetInBinary:  0,
+			exp: append([]byte{'?', '?', '?', '?',
+				0xe9, 0x0, 0x1, 0x0, 0x0, // short jump with offset = 256 = 0x0, 0x1, 0x0, 0x0 (in Little Endian).
+			}, largeData...),
+			maxDisplacement: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAssemblerImpl()
+			a.MaxDisplacementForConstantPool = tc.maxDisplacement
+			a.Buf.Write(tc.dummyBodyBeforeFlush)
+
+			for i, c := range tc.consts {
+				a.pool.addConst(c)
+				key := asm.StaticConstKey(c)
+				i := i
+				a.pool.offsetFinalizedCallbacks[key] = append(a.pool.offsetFinalizedCallbacks[key], func(offsetOfConstInBinary int) {
+					require.Equal(t, tc.expectedOffsetForConsts[i], offsetOfConstInBinary)
+				})
+			}
+
+			a.pool.firstUseOffsetInBinary = &tc.firstUseOffsetInBinary
+			a.maybeFlushConstants(tc.endOfFunction)
+
+			require.Equal(t, tc.exp, a.Buf.Bytes())
+		})
+	}
+}
+
+func TestAssemblerImpl_encodeStaticConstToRegister(t *testing.T) {
+	consts := []asm.StaticConst{
+		{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11},
+		{0x22, 0x22, 0x22, 0x22},
+		{0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33},
+	}
+	a := NewAssemblerImpl()
+
+	a.CompileStandAlone(UD2) // insert any dummy instruction before MOVDQUs.
+	err := a.CompileLoadStaticConstToRegister(MOVDQU, consts[0], RegX12)
+	require.NoError(t, err)
+	err = a.CompileLoadStaticConstToRegister(MOVDQU, consts[1], RegX0)
+	require.NoError(t, err)
+	err = a.CompileLoadStaticConstToRegister(MOVDQU, consts[0], RegX0)
+	require.NoError(t, err)
+	err = a.CompileLoadStaticConstToRegister(MOVDQU, consts[2], RegX12)
+	require.NoError(t, err)
+
+	actual, err := a.Assemble()
+	require.NoError(t, err)
+
+	require.Equal(t, []byte{
+		0x0f, 0x0b, // dummy instruction.
+		// 0x2: movdqu xmm12, xmmword ptr [rip + 0x19]
+		// where rip = 0x0b, therefore [rip + 0x19] = [0x24] = consts[0].
+		0xf3, 0x44, 0x0f, 0x6f, 0x25, 0x19, 0x00, 0x00, 0x00,
+		// 0x0b: movdqu xmm0, xmmword ptr [rip + 0x19]
+		// where rip = 0x13, therefore [rip + 0x19] = [0x2c] = consts[1].
+		0xf3, 0x0f, 0x6f, 0x05, 0x19, 0x00, 0x00, 0x00,
+		// 0x13: movdqu xmm0, xmmword ptr [rip + 0x9]
+		// where rip = 0x1b, therefore [rip + 0x9] = [0x24] = consts[0].
+		0xf3, 0x0f, 0x6f, 0x05, 0x09, 0x00, 0x00, 0x00,
+		// 0x1b: movdqu xmm12, xmmword ptr [rip + 0xc]
+		// where rip = 0x24, therefore [rip + 0xc] = [0x30] = consts[2].
+		0xf3, 0x44, 0x0f, 0x6f, 0x25, 0x0c, 0x00, 0x00, 0x00,
+		// 0x24: consts[0]
+		0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+		// 0x2c: consts[1]
+		0x22, 0x22, 0x22, 0x22,
+		// 0x30: consts[2]
+		0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
+	}, actual)
+}

--- a/internal/asm/amd64/impl_test.go
+++ b/internal/asm/amd64/impl_test.go
@@ -509,6 +509,33 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			},
 			exp: []byte{0xf3, 0x45, 0xf, 0x6f, 0xfa},
 		},
+		{
+			n: &NodeImpl{
+				Instruction: MOVDQA,
+				Types:       OperandTypesRegisterToRegister,
+				SrcReg:      RegX3,
+				DstReg:      RegX10,
+			},
+			exp: []byte{0x66, 0x44, 0xf, 0x6f, 0xd3},
+		},
+		{
+			n: &NodeImpl{
+				Instruction: MOVDQA,
+				Types:       OperandTypesRegisterToRegister,
+				SrcReg:      RegX10,
+				DstReg:      RegX3,
+			},
+			exp: []byte{0x66, 0x41, 0xf, 0x6f, 0xda},
+		},
+		{
+			n: &NodeImpl{
+				Instruction: MOVDQA,
+				Types:       OperandTypesRegisterToRegister,
+				SrcReg:      RegX10,
+				DstReg:      RegX15,
+			},
+			exp: []byte{0x66, 0x45, 0xf, 0x6f, 0xfa},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -67,22 +67,28 @@ type Assembler interface {
 	// otherwise set 0.
 	CompileConditionalRegisterSet(cond asm.ConditionalRegisterState, dstReg asm.Register)
 
-	// CompileMemoryToVectorRegister adds an instruction where source operands is the memory address specified by `sourceBaseReg+sourceOffsetConst`
-	// and the destination is `destinationReg` vector register.
-	CompileMemoryToVectorRegister(instruction asm.Instruction, srcBaseReg asm.Register, srcOffset asm.ConstantValue, dstReg asm.Register, arrangement VectorArrangement)
+	// CompileMemoryToVectorRegister adds an instruction where source operands is the memory address specified by
+	// `srcBaseReg+srcOffset` and the destination is `dstReg` vector register.
+	CompileMemoryToVectorRegister(instruction asm.Instruction, srcBaseReg asm.Register, srcOffset asm.ConstantValue,
+		dstReg asm.Register, arrangement VectorArrangement)
 
-	// CompileMemoryWithRegisterOffsetToVectorRegister is the same as CompileMemoryToVectorRegister except that the offset is specified by the `srcOffsetRegister` register.
-	CompileMemoryWithRegisterOffsetToVectorRegister(instruction asm.Instruction, srcBaseReg, srcOffsetRegister asm.Register, dstReg asm.Register, arrangement VectorArrangement)
+	// CompileMemoryWithRegisterOffsetToVectorRegister is the same as CompileMemoryToVectorRegister except that the
+	// offset is specified by the `srcOffsetRegister` register.
+	CompileMemoryWithRegisterOffsetToVectorRegister(instruction asm.Instruction, srcBaseReg,
+		srcOffsetRegister asm.Register, dstReg asm.Register, arrangement VectorArrangement)
 
-	// CompileVectorRegisterToMemory adds an instruction where source operand is `sourceRegister` vector register and the destination is the
-	// memory address specified by `destinationBaseRegister+destinationOffsetConst`.
-	CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstBaseReg asm.Register, dstOffset asm.ConstantValue, arrangement VectorArrangement)
+	// CompileVectorRegisterToMemory adds an instruction where source operand is `srcReg` vector register and the
+	// destination is the memory address specified by `dstBaseReg+dstOffset`.
+	CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstBaseReg asm.Register,
+		dstOffset asm.ConstantValue, arrangement VectorArrangement)
 
-	// CompileVectorRegisterToMemoryWithRegisterOffset is the same as CompileVectorRegisterToMemory except that the offset is specified by the `dstOffsetRegister` register.
-	CompileVectorRegisterToMemoryWithRegisterOffset(instruction asm.Instruction, srcReg, dstBaseReg, dstOffsetRegister asm.Register, arrangement VectorArrangement)
+	// CompileVectorRegisterToMemoryWithRegisterOffset is the same as CompileVectorRegisterToMemory except that the
+	// offset is specified by the `dstOffsetRegister` register.
+	CompileVectorRegisterToMemoryWithRegisterOffset(instruction asm.Instruction, srcReg, dstBaseReg,
+		dstOffsetRegister asm.Register, arrangement VectorArrangement)
 
-	// CompileRegisterToVectorRegister adds an instruction where source operand is `sourceRegister` general purpose register
-	// and the destination is the `dstReg` vector register. The destination vector's arrangement and index of element can be
+	// CompileRegisterToVectorRegister adds an instruction where source operand is `srcReg` general purpose register and
+	// the destination is the `dstReg` vector register. The destination vector's arrangement and index of element can be
 	// given by `arrangement` and `index`, but not all the instructions will use them.
 	CompileRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
 		arrangement VectorArrangement, index VectorIndex)
@@ -93,16 +99,20 @@ type Assembler interface {
 	CompileVectorRegisterToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
 		arrangement VectorArrangement, index VectorIndex)
 
-	// CompileVectorRegisterToVectorRegister adds an instruction where both source and destination operands are vector registers.
-	// The vector's arrangement can be specified `arrangement`, and the source and destination element's index are given by
-	// `srcIndex` and `dstIndex` respectively, but not all the instructions will use them.
-	CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement VectorArrangement, srcIndex, dstIndex VectorIndex)
+	// CompileVectorRegisterToVectorRegister adds an instruction where both source and destination operands are vector
+	// registers. The vector's arrangement can be specified `arrangement`, and the source and destination element's
+	// index are given by `srcIndex` and `dstIndex` respectively, but not all the instructions will use them.
+	CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
+		arrangement VectorArrangement, srcIndex, dstIndex VectorIndex)
 
-	// CompileVectorRegisterToVectorRegisterWithConst is the same as CompileVectorRegisterToVectorRegister but the additional constant can be provided.
+	// CompileVectorRegisterToVectorRegisterWithConst is the same as CompileVectorRegisterToVectorRegister but the
+	// additional constant can be provided.
 	// For example, the const can be used to specify the shift amount for USHLL instruction.
-	CompileVectorRegisterToVectorRegisterWithConst(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement VectorArrangement, c asm.ConstantValue)
+	CompileVectorRegisterToVectorRegisterWithConst(instruction asm.Instruction, srcReg, dstReg asm.Register,
+		arrangement VectorArrangement, c asm.ConstantValue)
 
-	// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
-	// and the destination is the dstReg.
-	CompileLoadStaticConstToVectorRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register, arrangement VectorArrangement)
+	// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in
+	// the memory and the destination is the dstReg.
+	CompileLoadStaticConstToVectorRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register,
+		arrangement VectorArrangement)
 }

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -66,13 +66,43 @@ type Assembler interface {
 	// CompileConditionalRegisterSet adds an instruction to set 1 on dstReg if the condition satisfies,
 	// otherwise set 0.
 	CompileConditionalRegisterSet(cond asm.ConditionalRegisterState, dstReg asm.Register)
-	// CompileMemoryToVectorRegister TODO
-	CompileMemoryToVectorRegister(instruction asm.Instruction, srcOffsetReg, dstReg asm.Register, arrangement VectorArrangement)
-	// CompileVectorRegisterToMemory TODO
-	CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstOffsetReg asm.Register, arrangement VectorArrangement)
-	// CompileRegisterToVectorRegister TODO
+
+	// CompileMemoryToVectorRegister adds an instruction where source operands is the memory address specified by `sourceBaseReg+sourceOffsetConst`
+	// and the destination is `destinationReg` vector register.
+	CompileMemoryToVectorRegister(instruction asm.Instruction, srcBaseReg asm.Register, srcOffset asm.ConstantValue, dstReg asm.Register, arrangement VectorArrangement)
+
+	// CompileMemoryWithRegisterOffsetToVectorRegister is the same as CompileMemoryToVectorRegister except that the offset is specified by the `srcOffsetRegister` register.
+	CompileMemoryWithRegisterOffsetToVectorRegister(instruction asm.Instruction, srcBaseReg, srcOffsetRegister asm.Register, dstReg asm.Register, arrangement VectorArrangement)
+
+	// CompileVectorRegisterToMemory adds an instruction where source operand is `sourceRegister` vector register and the destination is the
+	// memory address specified by `destinationBaseRegister+destinationOffsetConst`.
+	CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstBaseReg asm.Register, dstOffset asm.ConstantValue, arrangement VectorArrangement)
+
+	// CompileVectorRegisterToMemoryWithRegisterOffset is the same as CompileVectorRegisterToMemory except that the offset is specified by the `dstOffsetRegister` register.
+	CompileVectorRegisterToMemoryWithRegisterOffset(instruction asm.Instruction, srcReg, dstBaseReg, dstOffsetRegister asm.Register, arrangement VectorArrangement)
+
+	// CompileRegisterToVectorRegister adds an instruction where source operand is `sourceRegister` general purpose register
+	// and the destination is the `dstReg` vector register. The destination vector's arrangement and index of element can be
+	// given by `arrangement` and `index`, but not all the instructions will use them.
 	CompileRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
 		arrangement VectorArrangement, index VectorIndex)
-	// CompileVectorRegisterToVectorRegister TODO
-	CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement VectorArrangement)
+
+	// CompileVectorRegisterToRegister adds an instruction where destination operand is `dstReg` general purpose register
+	// and the source is the `srcReg` vector register. The source vector's arrangement and index of element can be
+	// given by `arrangement` and `index`, but not all the instructions will use them.
+	CompileVectorRegisterToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
+		arrangement VectorArrangement, index VectorIndex)
+
+	// CompileVectorRegisterToVectorRegister adds an instruction where both source and destination operands are vector registers.
+	// The vector's arrangement can be specified `arrangement`, and the source and destination element's index are given by
+	// `srcIndex` and `dstIndex` respectively, but not all the instructions will use them.
+	CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement VectorArrangement, srcIndex, dstIndex VectorIndex)
+
+	// CompileVectorRegisterToVectorRegisterWithConst is the same as CompileVectorRegisterToVectorRegister but the additional constant can be provided.
+	// For example, the const can be used to specify the shift amount for USHLL instruction.
+	CompileVectorRegisterToVectorRegisterWithConst(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement VectorArrangement, c asm.ConstantValue)
+
+	// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
+	// and the destination is the dstReg.
+	CompileLoadStaticConstToVectorRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register, arrangement VectorArrangement)
 }

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -673,36 +673,65 @@ const (
 	UCVTFWS
 	// UDIV is the UDIV instruction .https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
 	UDIV
-	// UDVIW is the UDIV instruction, in 64-bit mode.https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
+	// UDIVW is the UDIV instruction, in 64-bit mode.https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
 	UDIVW
-
-	// Vector instructions.
 
 	// VBIT is the BIT instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/BIT--vector-
 	VBIT
 	// VCNT is the CNT instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/CNT--vector-
 	VCNT
-	// VMOV is the MOV instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector-
+	// VMOV has different semantics depending on the types of operands:
+	//  * MOV(vector) if the operands are vectors and indexes are not specified. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector-
+	//  * MOV(vector, element) if the operands are vectors and indexes are specified. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector--element-
+	//  * INS(vector, element) if the src is a general purpose and the dst is a vector. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/INS--vector---general-
+	//  * UMOV(vector) if the dst is a general purpose and the src is a vector. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/UMOV--vector-
+	//  * LDR(SIMD&FP) if the src is memory and dst is a vector: https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/LDR--immediate--SIMD-FP---Load-SIMD-FP-Register--immediate-offset--
+	//  * LDR (literal, SIMD&FP) if the src is static const and dst is a vector: https://developer.arm.com/documentation/dui0801/h/A64-Floating-point-Instructions/LDR--literal--SIMD-and-FP-
+	//  * STR(SIMD&FP) if the dst is memory and src is a vector: https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/STR--immediate--SIMD-FP---Store-SIMD-FP-register--immediate-offset--
 	VMOV
 	// VUADDLV is the UADDLV instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/UADDLV--vector-
 	VUADDLV
-	// VLD1 is the LD1 instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/LD1--vector--single-structure-
-	VLD1
-	// VST1 is the ST1 instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/ST1--vector--single-structure-
-	VST1
-	// VADD is the ADD instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/ADD--vector-
+	// VADD is the ADD(vector) instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/ADD--vector-
 	VADD
-	// VFADDS is the FADD instruction, for single precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FADD--vector-
+	// VFADDS is the FADD(vector) instruction, for single precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FADD--vector-
 	VFADDS
-	// VFADDD is the FADD instruction, for double precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FADD--vector-
+	// VFADDD is the FADD(vector) instruction, for double precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FADD--vector-
 	VFADDD
+	// VSUB is the SUB(vector) instruction.  https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/SUB--vector-
+	VSUB
+	// VFSUBS is the FSUB(vector) instruction, for single precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FSUB--vector-
+	VFSUBS
+	// VFSUBD is the FSUB(vector) instruction, for double precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FSUB--vector-
+	VFSUBD
+	// SSHLL is the SSHLL instruction. https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/SSHLL--SSHLL2--vector-
+	SSHLL
+	// USHLL is the USHLL instruction. https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/SSHLL--SSHLL2--vector-
+	USHLL
+	// LD1R is the LD1R instruction. https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/LD1R--Load-one-single-element-structure-and-Replicate-to-all-lanes--of-one-register--
+	LD1R
+	// SMOV is the SMOV instruction. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/SMOV--vector-
+	SMOV
+	// DUP is the DUP instruction. https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/DUP--element---Duplicate-vector-element-to-vector-or-scalar-
+	DUP
+	// UMAXP is the UMAXP instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/UMAXP--vector-
+	UMAXP
+	// UMINV is the UMINV instruction. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/UMINV--vector-
+	UMINV
+	// CMEQ is the CMEQ instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/CMEQ--vector--register-
+	CMEQ
+	// ADDP is the ADDP instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/ADDP--vector-
+	ADDP
+	// TBL1 is the TBL instruction whose source is one vector. https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/TBL--Table-vector-Lookup-
+	TBL1
+	// TBL2 is the TBL instruction whose source is two vectors. https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/TBL--Table-vector-Lookup-
+	TBL2
 )
 
 // VectorArrangement is the arrangement of data within a vector register.
 type VectorArrangement byte
 
 const (
-	// VectorArrangmentNone is an arrangement indicating no data is stored.
+	// VectorArrangementNone is an arrangement indicating no data is stored.
 	VectorArrangementNone VectorArrangement = iota
 	// VectorArrangement8B is an arrangement of 8 bytes (64-bit vector)
 	VectorArrangement8B
@@ -728,12 +757,14 @@ const (
 
 	// VectorArrangementB is a size specifier of byte
 	VectorArrangementB
-	// VectorArrangementH is a size specifier of halfword
+	// VectorArrangementH is a size specifier of word (16-bit)
 	VectorArrangementH
-	// VectorArrangementS is a size specifier of word
+	// VectorArrangementS is a size specifier of double word (32-bit)
 	VectorArrangementS
-	// VectorArrangementD is a size specifier of doubleword
+	// VectorArrangementD is a size specifier of quad word (64-bit)
 	VectorArrangementD
+	// VectorArrangementQ is a size specifier of the entire vector (128-bit)
+	VectorArrangementQ
 )
 
 func (v VectorArrangement) String() (ret string) {
@@ -762,14 +793,21 @@ func (v VectorArrangement) String() (ret string) {
 		ret = "S"
 	case VectorArrangementD:
 		ret = "D"
+	case VectorArrangementQ:
+		ret = "Q"
+	case VectorArrangementNone:
+		ret = "none"
 	default:
-		ret = "unknown"
+		panic(v)
 	}
 	return
 }
 
 // VectorIndex is the index of an element of a vector register
 type VectorIndex byte
+
+// VectorIndexNone indicates no vector index specified.
+const VectorIndexNone VectorIndex = ^VectorIndex(0)
 
 // InstructionName returns the name of the given instruction
 func InstructionName(i asm.Instruction) string {
@@ -1014,16 +1052,36 @@ func InstructionName(i asm.Instruction) string {
 		return "VUADDLV"
 	case VMOV:
 		return "VMOV"
-	case VST1:
-		return "VST1"
-	case VLD1:
-		return "VLD1"
 	case VADD:
 		return "VADD"
 	case VFADDS:
 		return "VFADDS"
 	case VFADDD:
 		return "VFADDD"
+	case VSUB:
+		return "VSUB"
+	case VFSUBS:
+		return "VFSUBS"
+	case VFSUBD:
+		return "VFSUBD"
+	case SSHLL:
+		return "SSHLL"
+	case USHLL:
+		return "USHLL"
+	case LD1R:
+		return "LD1R"
+	case SMOV:
+		return "SMOV"
+	case DUP:
+		return "DUP"
+	case UMAXP:
+		return "UMAXP"
+	case UMINV:
+		return "UMINV"
+	case CMEQ:
+		return "CMEQ"
+	case ADDP:
+		return "ADDP"
 	}
-	return "UNKNOWN"
+	panic("unknown instruction")
 }

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -671,9 +671,9 @@ const (
 	UCVTFWD
 	// UCVTFWS is the UCVTF instruction, for single precision in 64-bit mode. https://developer.arm.com/documentation/dui0802/a/A64-Floating-point-Instructions/UCVTF--scalar--integer-
 	UCVTFWS
-	// UDIV is the UDIV instruction .https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
+	// UDIV is the UDIV instruction. https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
 	UDIV
-	// UDIVW is the UDIV instruction, in 64-bit mode.https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
+	// UDIVW is the UDIV instruction, in 64-bit mode. https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/UDIV
 	UDIVW
 
 	// VBIT is the BIT instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/BIT--vector-
@@ -681,15 +681,15 @@ const (
 	// VCNT is the CNT instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/CNT--vector-
 	VCNT
 	// VMOV has different semantics depending on the types of operands:
-	//  * MOV(vector) if the operands are vectors and indexes are not specified. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector-
-	//  * MOV(vector, element) if the operands are vectors and indexes are specified. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector--element-
-	//  * INS(vector, element) if the src is a general purpose and the dst is a vector. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/INS--vector---general-
-	//  * UMOV(vector) if the dst is a general purpose and the src is a vector. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/UMOV--vector-
-	//  * LDR(SIMD&FP) if the src is memory and dst is a vector: https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/LDR--immediate--SIMD-FP---Load-SIMD-FP-Register--immediate-offset--
-	//  * LDR (literal, SIMD&FP) if the src is static const and dst is a vector: https://developer.arm.com/documentation/dui0801/h/A64-Floating-point-Instructions/LDR--literal--SIMD-and-FP-
-	//  * STR(SIMD&FP) if the dst is memory and src is a vector: https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/STR--immediate--SIMD-FP---Store-SIMD-FP-register--immediate-offset--
+	//	* MOV(vector) if the operands are vectors and indexes are not specified. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector-
+	//	* MOV(vector, element) if the operands are vectors and indexes are specified. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/MOV--vector--element-
+	//	* INS(vector, element) if the src is a general purpose and the dst is a vector. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/INS--vector---general-
+	//	* UMOV(vector) if the dst is a general purpose and the src is a vector. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/UMOV--vector-
+	//	* LDR(SIMD&FP) if the src is memory and dst is a vector: https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/LDR--immediate--SIMD-FP---Load-SIMD-FP-Register--immediate-offset--
+	//	* LDR (literal, SIMD&FP) if the src is static const and dst is a vector: https://developer.arm.com/documentation/dui0801/h/A64-Floating-point-Instructions/LDR--literal--SIMD-and-FP-
+	//	* STR(SIMD&FP) if the dst is memory and src is a vector: https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/STR--immediate--SIMD-FP---Store-SIMD-FP-register--immediate-offset--
 	VMOV
-	// VUADDLV is the UADDLV instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/UADDLV--vector-
+	// VUADDLV is the UADDLV(vector) instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/UADDLV--vector-
 	VUADDLV
 	// VADD is the ADD(vector) instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/ADD--vector-
 	VADD
@@ -703,23 +703,23 @@ const (
 	VFSUBS
 	// VFSUBD is the FSUB(vector) instruction, for double precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FSUB--vector-
 	VFSUBD
-	// SSHLL is the SSHLL instruction. https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/SSHLL--SSHLL2--vector-
+	// SSHLL is the SSHLL(vector) instruction. https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/SSHLL--SSHLL2--vector-
 	SSHLL
-	// USHLL is the USHLL instruction. https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/SSHLL--SSHLL2--vector-
+	// USHLL is the USHLL(vector) instruction. https://developer.arm.com/documentation/dui0801/h/A64-SIMD-Vector-Instructions/SSHLL--SSHLL2--vector-
 	USHLL
 	// LD1R is the LD1R instruction. https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/LD1R--Load-one-single-element-structure-and-Replicate-to-all-lanes--of-one-register--
 	LD1R
-	// SMOV is the SMOV instruction. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/SMOV--vector-
+	// SMOV is the SMOV(vector) instruction. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/SMOV--vector-
 	SMOV
-	// DUP is the DUP instruction. https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/DUP--element---Duplicate-vector-element-to-vector-or-scalar-
+	// DUP is the DUP(element) instruction. https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/DUP--element---Duplicate-vector-element-to-vector-or-scalar-
 	DUP
-	// UMAXP is the UMAXP instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/UMAXP--vector-
+	// UMAXP is the UMAXP(vector) instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/UMAXP--vector-
 	UMAXP
-	// UMINV is the UMINV instruction. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/UMINV--vector-
+	// UMINV is the UMINV(vector) instruction. https://developer.arm.com/documentation/100069/0610/A64-SIMD-Vector-Instructions/UMINV--vector-
 	UMINV
-	// CMEQ is the CMEQ instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/CMEQ--vector--register-
+	// CMEQ is the CMEQ(vector, register) instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/CMEQ--vector--register-
 	CMEQ
-	// ADDP is the ADDP instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/ADDP--vector-
+	// ADDP is the ADDP(vector) instruction. https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/ADDP--vector-
 	ADDP
 	// TBL1 is the TBL instruction whose source is one vector. https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/TBL--Table-vector-Lookup-
 	TBL1
@@ -807,7 +807,7 @@ func (v VectorArrangement) String() (ret string) {
 type VectorIndex byte
 
 // VectorIndexNone indicates no vector index specified.
-const VectorIndexNone VectorIndex = ^VectorIndex(0)
+const VectorIndexNone = ^VectorIndex(0)
 
 // InstructionName returns the name of the given instruction
 func InstructionName(i asm.Instruction) string {

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -228,9 +228,8 @@ type constPool struct {
 	firstUseOffsetInBinary *asm.NodeOffsetInBinary
 	consts                 []asm.StaticConst
 	constSizeInBytes       int
-	// offsetFinalizedCallbacks holds the callbacks keyed on the constants.
-	// These callbacks are called when the offsets of the constants in the binary
-	// have been determined.
+	// offsetFinalizedCallbacks are functions called when the offsets of the
+	// constants in the binary have been determined.
 	offsetFinalizedCallbacks map[string][]func(offsetOfConstInBinary int)
 }
 
@@ -345,7 +344,7 @@ func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
 			}
 		}
 
-		// arm64 instructions are must be 4-byte (32-bit) aligned, so we must pad the zero consts here.
+		// arm64 instructions are 4-byte (32-bit) aligned, so we must pad the zero consts here.
 		if pad := a.Buf.Len() % 4; pad != 0 {
 			a.Buf.Write(make([]byte, 4-pad))
 		}
@@ -719,7 +718,7 @@ func errorEncodingUnsupported(n *NodeImpl) error {
 	return fmt.Errorf("%s is unsupported for %s type", InstructionName(n.Instruction), n.Types)
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeNoneToNone is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeNoneToNone(n *NodeImpl) (err error) {
 	if n.Instruction != NOP {
@@ -728,7 +727,7 @@ func (a *AssemblerImpl) EncodeNoneToNone(n *NodeImpl) (err error) {
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeJumpToRegister is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeJumpToRegister(n *NodeImpl) (err error) {
 	// "Unconditional branch (register)" in https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions
@@ -756,7 +755,7 @@ func (a *AssemblerImpl) EncodeJumpToRegister(n *NodeImpl) (err error) {
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeRelativeBranch is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeRelativeBranch(n *NodeImpl) (err error) {
 	switch n.Instruction {
@@ -864,7 +863,7 @@ func checkRegisterToRegisterType(src, dst asm.Register, requireSrcInt, requireDs
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeRegisterToRegister is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeRegisterToRegister(n *NodeImpl) (err error) {
 	switch inst := n.Instruction; inst {
@@ -1371,7 +1370,7 @@ func (a *AssemblerImpl) EncodeRegisterToRegister(n *NodeImpl) (err error) {
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeLeftShiftedRegisterToRegister is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeLeftShiftedRegisterToRegister(n *NodeImpl) (err error) {
 
@@ -1408,7 +1407,7 @@ func (a *AssemblerImpl) EncodeLeftShiftedRegisterToRegister(n *NodeImpl) (err er
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeTwoRegistersToRegister is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeTwoRegistersToRegister(n *NodeImpl) (err error) {
 	switch inst := n.Instruction; inst {
@@ -1527,7 +1526,7 @@ func (a *AssemblerImpl) EncodeTwoRegistersToRegister(n *NodeImpl) (err error) {
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeThreeRegistersToRegister is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeThreeRegistersToRegister(n *NodeImpl) (err error) {
 	switch n.Instruction {
@@ -1569,7 +1568,7 @@ func (a *AssemblerImpl) EncodeThreeRegistersToRegister(n *NodeImpl) (err error) 
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeTwoRegistersToNone is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeTwoRegistersToNone(n *NodeImpl) (err error) {
 	switch n.Instruction {
@@ -1627,7 +1626,7 @@ func (a *AssemblerImpl) EncodeTwoRegistersToNone(n *NodeImpl) (err error) {
 	return
 }
 
-// Exported for inter-op testing with golang-asm.
+// EncodeRegisterAndConstToNone is exported for inter-op testing with golang-asm.
 // TODO: unexport after golang-asm complete removal.
 func (a *AssemblerImpl) EncodeRegisterAndConstToNone(n *NodeImpl) (err error) {
 	if n.Instruction != CMP {
@@ -2593,6 +2592,7 @@ func checkArrangementIndexPair(arr VectorArrangement, index VectorIndex) (err er
 	}
 	return
 }
+
 func (a *AssemblerImpl) EncodeVectorRegisterToRegister(n *NodeImpl) (err error) {
 	if err = checkArrangementIndexPair(n.VectorArrangement, n.SrcVectorIndex); err != nil {
 		return
@@ -3030,8 +3030,7 @@ func (a *AssemblerImpl) EncodeVectorRegisterToVectorRegister(n *NodeImpl) (err e
 	case VFADDS, VFADDD, VFSUBS, VFSUBD:
 		var sz, b byte
 		switch n.Instruction {
-		case VFADDS:
-		case VFADDD:
+		case VFADDS, VFADDD:
 			sz = 0b1
 		case VFSUBS:
 			b = 0b1

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -3030,7 +3030,8 @@ func (a *AssemblerImpl) EncodeVectorRegisterToVectorRegister(n *NodeImpl) (err e
 	case VFADDS, VFADDD, VFSUBS, VFSUBD:
 		var sz, b byte
 		switch n.Instruction {
-		case VFADDS, VFADDD:
+		case VFADDS:
+		case VFADDD:
 			sz = 0b1
 		case VFSUBS:
 			b = 0b1

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -51,6 +51,15 @@ type NodeOffsetInBinary = uint64
 // ConstantValue represents a constant value used in an instruction.
 type ConstantValue = int64
 
+// StaticConst represents an arbitrary constant bytes which are pooled and emitted by assembler into the binary.
+// These constants can be referenced by instructions.
+type StaticConst = []byte
+
+// StaticConstKey returns a string whose underlying bytes equal the original const.
+func StaticConstKey(c StaticConst) string {
+	return string(c)
+}
+
 // AssemblerBase is the common interface for assemblers among multiple architectures.
 //
 // Note: some of them can be implemented in an arch-independent way, but not all can be

--- a/internal/engine/compiler/compiler.go
+++ b/internal/engine/compiler/compiler.go
@@ -404,9 +404,45 @@ type compiler interface {
 	//
 	// https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/valid/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-fill-x
 	compileTableFill(*wazeroir.OperationTableFill) error
-	// compileConstV128 adds instructions to push a constant V128 value onto the stack.
+	// compileV128Const adds instructions to push a constant V128 value onto the stack.
 	// See wasm.OpcodeVecV128Const
-	compileConstV128(*wazeroir.OperationConstV128) error
-	// compileAddV128 adds instruction to add two vector values whose shape is specified as `o.Shape`.
-	compileAddV128(o *wazeroir.OperationAddV128) error
+	compileV128Const(*wazeroir.OperationV128Const) error
+	// compileV128Add adds instruction to add two vector values whose shape is specified as `o.Shape`.
+	// See wasm.OpcodeVecI8x16Add wasm.OpcodeVecI16x8Add wasm.OpcodeVecI32x4Add wasm.OpcodeVecI64x2Add wasm.OpcodeVecF32x4Add wasm.OpcodeVecF64x2Add
+	compileV128Add(o *wazeroir.OperationV128Add) error
+	// compileV128Sub adds instruction to subtract two vector values whose shape is specified as `o.Shape`.
+	// See wasm.OpcodeVecI8x16Sub wasm.OpcodeVecI16x8Sub wasm.OpcodeVecI32x4Sub wasm.OpcodeVecI64x2Sub wasm.OpcodeVecF32x4Sub wasm.OpcodeVecF64x2Sub
+	compileV128Sub(o *wazeroir.OperationV128Sub) error
+	// compileV128Load adds instruction to perform vector load kind instructions.
+	// See wasm.OpcodeVecV128Load* instructions.
+	compileV128Load(o *wazeroir.OperationV128Load) error
+	// compileV128LoadLane adds instructions which are equivalent to wasm.OpcodeVecV128LoadXXLane instructions.
+	// See wasm.OpcodeVecV128Load8LaneName wasm.OpcodeVecV128Load16LaneName wasm.OpcodeVecV128Load32LaneName wasm.OpcodeVecV128Load64LaneName
+	compileV128LoadLane(o *wazeroir.OperationV128LoadLane) error
+	// compileV128Store adds instructions which are equivalent to wasm.OpcodeVecV128StoreName.
+	compileV128Store(o *wazeroir.OperationV128Store) error
+	// compileV128StoreLane adds instructions which are equivalent to wasm.OpcodeVecV128StoreXXLane instructions.
+	// See wasm.OpcodeVecV128Load8LaneName wasm.OpcodeVecV128Load16LaneName wasm.OpcodeVecV128Load32LaneName wasm.OpcodeVecV128Load64LaneName.
+	compileV128StoreLane(o *wazeroir.OperationV128StoreLane) error
+	// compileV128ExtractLane adds instructions which are equivalent to wasm.OpcodeVecXXXXExtractLane instructions.
+	// See wasm.OpcodeVecI8x16ExtractLaneSName wasm.OpcodeVecI8x16ExtractLaneUName wasm.OpcodeVecI16x8ExtractLaneSName wasm.OpcodeVecI16x8ExtractLaneUName
+	// wasm.OpcodeVecI32x4ExtractLaneName wasm.OpcodeVecI64x2ExtractLaneName wasm.OpcodeVecF32x4ExtractLaneName wasm.OpcodeVecF64x2ExtractLaneName.
+	compileV128ExtractLane(o *wazeroir.OperationV128ExtractLane) error
+	// compileV128ReplaceLane adds instructions which are equivalent to wasm.OpcodeVecXXXXReplaceLane instructions.
+	// See wasm.OpcodeVecI8x16ReplaceLaneName wasm.OpcodeVecI16x8ReplaceLaneName wasm.OpcodeVecI32x4ReplaceLaneName wasm.OpcodeVecI64x2ReplaceLaneName
+	// wasm.OpcodeVecF32x4ReplaceLaneName wasm.OpcodeVecF64x2ReplaceLaneName.
+	compileV128ReplaceLane(o *wazeroir.OperationV128ReplaceLane) error
+	// compileV128Splat adds instructions which are equivalent to wasm.OpcodeVecXXXSplat instructions.
+	// See wasm.OpcodeVecI8x16SplatName wasm.OpcodeVecI16x8SplatName wasm.OpcodeVecI32x4SplatName wasm.OpcodeVecI64x2SplatName
+	// wasm.OpcodeVecF32x4SplatName wasm.OpcodeVecF64x2SplatName.
+	compileV128Splat(o *wazeroir.OperationV128Splat) error
+	// compileV128Shuffle adds instructions which are equivalent to wasm.OpcodeVecV128i8x16ShuffleName instruction.
+	compileV128Shuffle(o *wazeroir.OperationV128Shuffle) error
+	// compileV128Swizzle adds instructions which are equivalent to wasm.OpcodeVecI8x16SwizzleName instruction.
+	compileV128Swizzle(o *wazeroir.OperationV128Swizzle) error
+	// compileV128Swizzle adds instructions which are equivalent to wasm.OpcodeVecV128AnyTrueName instruction.
+	compileV128AnyTrue(o *wazeroir.OperationV128AnyTrue) error
+	// compileV128AllTrue adds instructions which are equivalent to wasm.OpcodeVecXXXAllTrue instructions.
+	// See wasm.OpcodeVecI8x16AllTrueName wasm.OpcodeVecI16x8AllTrueName wasm.OpcodeVecI32x4AllTrueName wasm.OpcodeVecI64x2AllTrueName.
+	compileV128AllTrue(o *wazeroir.OperationV128AllTrue) error
 }

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -78,7 +78,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 	// For testing. Arbitrary number is fine.
 	loadTargetValue := uint64(0x12_34_56_78_9a_bc_ef_fe)
 	baseOffset := uint32(100)
-	arg := &wazeroir.MemoryImmediate{Offset: 361}
+	arg := &wazeroir.MemoryArg{Offset: 361}
 	offset := baseOffset + arg.Offset
 
 	tests := []struct {
@@ -277,7 +277,7 @@ func TestCompiler_compileStore(t *testing.T) {
 	// For testing. Arbitrary number is fine.
 	storeTargetValue := uint64(math.MaxUint64)
 	baseOffset := uint32(100)
-	arg := &wazeroir.MemoryImmediate{Offset: 361}
+	arg := &wazeroir.MemoryArg{Offset: 361}
 	offset := arg.Offset + baseOffset
 
 	tests := []struct {
@@ -444,7 +444,7 @@ func TestCompiler_MemoryOutOfBounds(t *testing.T) {
 					err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: base})
 					require.NoError(t, err)
 
-					arg := &wazeroir.MemoryImmediate{Offset: offset}
+					arg := &wazeroir.MemoryArg{Offset: offset}
 
 					switch targetSizeInByte {
 					case 1:

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -17,7 +17,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 		wazeroir.OperationKindConstI64,
 		wazeroir.OperationKindConstF32,
 		wazeroir.OperationKindConstF64,
-		wazeroir.OperationKindConstV128,
+		wazeroir.OperationKindV128Const,
 	} {
 		op := op
 		t.Run(op.String(), func(t *testing.T) {
@@ -51,8 +51,8 @@ func TestCompiler_compileConsts(t *testing.T) {
 						err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: math.Float32frombits(uint32(val))})
 					case wazeroir.OperationKindConstF64:
 						err = compiler.compileConstF64(&wazeroir.OperationConstF64{Value: math.Float64frombits(val)})
-					case wazeroir.OperationKindConstV128:
-						err = compiler.compileConstV128(&wazeroir.OperationConstV128{Lo: val, Hi: ^val})
+					case wazeroir.OperationKindV128Const:
+						err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: val, Hi: ^val})
 					}
 					require.NoError(t, err)
 
@@ -60,7 +60,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 					loc := compiler.runtimeValueLocationStack().peek()
 					require.True(t, loc.onRegister())
 
-					if op == wazeroir.OperationKindConstV128 {
+					if op == wazeroir.OperationKindV128Const {
 						require.Equal(t, runtimeValueTypeV128Hi, loc.valueType)
 					}
 
@@ -76,7 +76,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 
 					// Compiler status must be returned.
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-					if op == wazeroir.OperationKindConstV128 {
+					if op == wazeroir.OperationKindV128Const {
 						require.Equal(t, uint64(2), env.stackPointer()) // a vector value consists of two uint64.
 					} else {
 						require.Equal(t, uint64(1), env.stackPointer())
@@ -87,7 +87,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 						require.Equal(t, uint32(val), env.stackTopAsUint32())
 					case wazeroir.OperationKindConstI64, wazeroir.OperationKindConstF64:
 						require.Equal(t, val, env.stackTopAsUint64())
-					case wazeroir.OperationKindConstV128:
+					case wazeroir.OperationKindV128Const:
 						lo, hi := env.stackTopAsV128()
 						require.Equal(t, val, lo)
 						require.Equal(t, ^val, hi)

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -620,8 +620,6 @@ func TestCompiler_compileSwap_v128(t *testing.T) {
 			if tc.x1OnRegister {
 				err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: x1Lo, Hi: x1Hi})
 				require.NoError(t, err)
-				env.stack()[0] = 0xff
-				env.stack()[1] = 0xff
 			} else {
 				lo := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack() // lo
 				lo.valueType = runtimeValueTypeV128Lo

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -180,7 +180,7 @@ func TestCompiler_compilePick_v128(t *testing.T) {
 
 			// Set up the stack before picking.
 			if tc.isPickTargetOnRegister {
-				err = compiler.compileConstV128(&wazeroir.OperationConstV128{
+				err = compiler.compileV128Const(&wazeroir.OperationV128Const{
 					Lo: pickTargetLo, Hi: pickTargetHi,
 				})
 				require.NoError(t, err)
@@ -618,8 +618,10 @@ func TestCompiler_compileSwap_v128(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.x1OnRegister {
-				err = compiler.compileConstV128(&wazeroir.OperationConstV128{Lo: x1Lo, Hi: x1Hi})
+				err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: x1Lo, Hi: x1Hi})
 				require.NoError(t, err)
+				env.stack()[0] = 0xff
+				env.stack()[1] = 0xff
 			} else {
 				lo := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack() // lo
 				lo.valueType = runtimeValueTypeV128Lo
@@ -632,7 +634,7 @@ func TestCompiler_compileSwap_v128(t *testing.T) {
 			_ = compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack() // Dummy value!
 
 			if tc.x2OnRegister {
-				err = compiler.compileConstV128(&wazeroir.OperationConstV128{Lo: x2Lo, Hi: x2Hi})
+				err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: x2Lo, Hi: x2Hi})
 				require.NoError(t, err)
 			} else {
 				lo := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack() // lo

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -116,9 +116,10 @@ func newRuntimeValueLocationStack() *runtimeValueLocationStack {
 // runtimeValueLocationStack represents the wazeroir virtual stack
 // where each item holds the location information about where it exists
 // on the physical machine at runtime.
+//
 // Notably this is only used in the compilation phase, not runtime,
 // and we change the state of this struct at every wazeroir operation we compile.
-// In this way, we can see where the operands of a operation (for example,
+// In this way, we can see where the operands of an operation (for example,
 // two variables for wazeroir add operation.) exist and check the necessity for
 // moving the variable to registers to perform actual CPU instruction
 // to achieve wazeroir's add operation.
@@ -190,7 +191,7 @@ func (v *runtimeValueLocationStack) pushRuntimeValueLocationOnConditionalRegiste
 	return
 }
 
-// push pushes to a given runtimeValueLocation onto the stack.
+// push a runtimeValueLocation onto the stack.
 func (v *runtimeValueLocationStack) push(loc *runtimeValueLocation) {
 	loc.stackPointer = v.sp
 	if v.sp >= uint64(len(v.stack)) {

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -212,6 +212,12 @@ func (v *runtimeValueLocationStack) pop() (loc *runtimeValueLocation) {
 	return
 }
 
+func (v *runtimeValueLocationStack) popV128() (loc *runtimeValueLocation) {
+	v.sp -= 2
+	loc = v.stack[v.sp]
+	return
+}
+
 func (v *runtimeValueLocationStack) peek() (loc *runtimeValueLocation) {
 	loc = v.stack[v.sp-1]
 	return

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -15,7 +15,6 @@ func TestCompiler_compileV128Add(t *testing.T) {
 }
 
 func TestCompiler_compileV128Sub(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		shape       wazeroir.Shape

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -1,0 +1,1759 @@
+package compiler
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
+)
+
+func TestCompiler_compileV128Add(t *testing.T) {
+	// TODO
+}
+
+func TestCompiler_compileV128Sub(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		shape       wazeroir.Shape
+		x1, x2, exp [16]byte
+	}{
+		{
+			name:  "i8x16",
+			shape: wazeroir.ShapeI8x16,
+			x1:    [16]byte{0: 1, 2: 10, 10: 10},
+			x2:    [16]byte{0: 10, 4: 5, 10: 5},
+			exp:   [16]byte{0: i8ToU8(-9), 2: 10, 4: i8ToU8(-5), 10: 5},
+		},
+		// TODO: add more cases.
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.x1[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.x1[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.x2[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.x2[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Sub(&wazeroir.OperationV128Sub{Shape: tc.shape})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
+
+			lo, hi := env.stackTopAsV128()
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestCompiler_compileV128Load(t *testing.T) {
+	tests := []struct {
+		name       string
+		memSetupFn func(buf []byte)
+		loadType   wazeroir.LoadV128Type
+		offset     uint32
+		exp        [16]byte
+	}{
+		{
+			name: "v128 offset=0", loadType: wazeroir.LoadV128Type128, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+			},
+			exp: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		},
+		{
+			name: "v128 offset=2", loadType: wazeroir.LoadV128Type128, offset: 2,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
+			},
+			exp: [16]byte{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},
+		},
+		{
+			name: "8x8s offset=0", loadType: wazeroir.LoadV128Type8x8s, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 0xff, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0, 0xff, 0xff, 3, 0, 0xff, 0xff, 5, 0, 0xff, 0xff, 7, 0, 0xff, 0xff,
+			},
+		},
+		{
+			name: "8x8s offset=3", loadType: wazeroir.LoadV128Type8x8s, offset: 3,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 0xff, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				0xff, 0xff, 5, 0, 0xff, 0xff, 7, 0, 0xff, 0xff, 9, 0, 10, 0, 11, 0,
+			},
+		},
+		{
+			name: "8x8u offset=0", loadType: wazeroir.LoadV128Type8x8u, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 0xff, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0, 0xff, 0, 3, 0, 0xff, 0, 5, 0, 0xff, 0, 7, 0, 0xff, 0,
+			},
+		},
+		{
+			name: "8x8i offset=3", loadType: wazeroir.LoadV128Type8x8u, offset: 3,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 0xff, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				0xff, 0, 5, 0, 0xff, 0, 7, 0, 0xff, 0, 9, 0, 10, 0, 11, 0,
+			},
+		},
+		{
+			name: "16x4s offset=0", loadType: wazeroir.LoadV128Type16x4s, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 0xff, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0xff, 0xff, 0xff,
+				3, 0xff, 0xff, 0xff,
+				5, 0xff, 0xff, 0xff,
+				7, 0xff, 0xff, 0xff,
+			},
+		},
+		{
+			name: "16x4s offset=3", loadType: wazeroir.LoadV128Type16x4s, offset: 3,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 0xff, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				0xff, 5, 0, 0,
+				6, 0xff, 0xff, 0xff,
+				0xff, 9, 0, 0,
+				10, 11, 0, 0,
+			},
+		},
+		{
+			name: "16x4u offset=0", loadType: wazeroir.LoadV128Type16x4u, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 0xff, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0xff, 0, 0,
+				3, 0xff, 0, 0,
+				5, 0xff, 0, 0,
+				7, 0xff, 0, 0,
+			},
+		},
+		{
+			name: "16x4u offset=3", loadType: wazeroir.LoadV128Type16x4u, offset: 3,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 0xff, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				0xff, 5, 0, 0,
+				6, 0xff, 0, 0,
+				0xff, 9, 0, 0,
+				10, 11, 0, 0,
+			},
+		},
+		{
+			name: "32x2s offset=0", loadType: wazeroir.LoadV128Type32x2s, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0xff, 3, 0xff, 0xff, 0xff, 0xff, 0xff,
+				5, 6, 7, 0xff, 0xff, 0xff, 0xff, 0xff,
+			},
+		},
+		{
+			name: "32x2s offset=2", loadType: wazeroir.LoadV128Type32x2s, offset: 2,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				3, 0xff, 5, 6, 0, 0, 0, 0,
+				7, 0xff, 9, 0xff, 0xff, 0xff, 0xff, 0xff,
+			},
+		},
+		{
+			name: "32x2u offset=0", loadType: wazeroir.LoadV128Type32x2u, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 10,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0xff, 3, 0xff, 0, 0, 0, 0,
+				5, 6, 7, 0xff, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "32x2u offset=2", loadType: wazeroir.LoadV128Type32x2u, offset: 2,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				3, 0xff, 5, 6, 0, 0, 0, 0,
+				7, 0xff, 9, 0xff, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "32zero offset=0", loadType: wazeroir.LoadV128Type32zero, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0xff, 3, 0xff, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "32zero offset=3", loadType: wazeroir.LoadV128Type32zero, offset: 3,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 0xff, 8, 9, 0xff,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				0xff, 5, 6, 0xff, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "64zero offset=0", loadType: wazeroir.LoadV128Type64zero, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				1, 0xff, 3, 0xff, 5, 6, 7, 0xff,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "64zero offset=2", loadType: wazeroir.LoadV128Type64zero, offset: 2,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+					11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				})
+			},
+			exp: [16]byte{
+				3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "8splat offset=0", loadType: wazeroir.LoadV128Type8Splat, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		},
+		{
+			name: "8splat offset=1", loadType: wazeroir.LoadV128Type8Splat, offset: 1,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name: "16splat offset=0", loadType: wazeroir.LoadV128Type16Splat, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{1, 0xff, 1, 0xff, 1, 0xff, 1, 0xff, 1, 0xff, 1, 0xff, 1, 0xff, 1, 0xff},
+		},
+		{
+			name: "16splat offset=5", loadType: wazeroir.LoadV128Type16Splat, offset: 5,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7, 6, 7},
+		},
+		{
+			name: "32splat offset=0", loadType: wazeroir.LoadV128Type32Splat, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{1, 0xff, 3, 0xff, 1, 0xff, 3, 0xff, 1, 0xff, 3, 0xff, 1, 0xff, 3, 0xff},
+		},
+		{
+			name: "32splat offset=1", loadType: wazeroir.LoadV128Type32Splat, offset: 1,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{0xff, 3, 0xff, 5, 0xff, 3, 0xff, 5, 0xff, 3, 0xff, 5, 0xff, 3, 0xff, 5},
+		},
+		{
+			name: "64splat offset=0", loadType: wazeroir.LoadV128Type64Splat, offset: 0,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 1, 0xff, 3, 0xff, 5, 6, 7, 0xff},
+		},
+		{
+			name: "64splat offset=1", loadType: wazeroir.LoadV128Type64Splat, offset: 1,
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff,
+				})
+			},
+			exp: [16]byte{0xff, 3, 0xff, 5, 6, 7, 0xff, 9, 0xff, 3, 0xff, 5, 6, 7, 0xff, 9},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			tc.memSetupFn(env.memory())
+
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: tc.offset})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Load(&wazeroir.OperationV128Load{
+				Type: tc.loadType, Arg: &wazeroir.MemoryArg{},
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+			loadedLocation := compiler.runtimeValueLocationStack().peek()
+			require.True(t, loadedLocation.onRegister())
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, uint64(2), env.stackPointer())
+			lo, hi := env.stackTopAsV128()
+
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestCompiler_compileV128LoadLane(t *testing.T) {
+	originalVecLo, originalVecHi := uint64(0), uint64(0)
+	tests := []struct {
+		name                string
+		memSetupFn          func(buf []byte)
+		laneIndex, laneSize byte
+		offset              uint32
+		exp                 [16]byte
+	}{
+		{
+			name: "8_lane offset=0 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff,
+				})
+			},
+			laneSize:  8,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "8_lane offset=1 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff,
+				})
+			},
+			laneSize:  8,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "8_lane offset=1 laneIndex=5",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff,
+				})
+			},
+			laneSize:  8,
+			laneIndex: 5,
+			offset:    1,
+			exp:       [16]byte{0, 0, 0, 0, 0, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "16_lane offset=0 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa,
+				})
+			},
+			laneSize:  16,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "16_lane offset=1 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa,
+				})
+			},
+			laneSize:  16,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0xff, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "16_lane offset=1 laneIndex=5",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa,
+				})
+			},
+			laneSize:  16,
+			laneIndex: 5,
+			offset:    1,
+			exp:       [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 1, 0, 0, 0, 0},
+		},
+		{
+			name: "32_lane offset=0 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa, 0x9, 0x8,
+				})
+			},
+			laneSize:  32,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 0xff, 1, 0xa, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "32_lane offset=1 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa, 0x9, 0x8,
+				})
+			},
+			laneSize:  32,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0xff, 1, 0xa, 0x9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "32_lane offset=1 laneIndex=3",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa, 0x9, 0x8,
+				})
+			},
+			laneSize:  32,
+			laneIndex: 3,
+			offset:    1,
+			exp:       [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 1, 0xa, 0x9},
+		},
+
+		{
+			name: "64_lane offset=0 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa, 0x9, 0x8, 0x1, 0x2, 0x3, 0x4,
+				})
+			},
+			laneSize:  64,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 0xff, 1, 0xa, 0x9, 0x8, 0x1, 0x2, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "64_lane offset=1 laneIndex=0",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa, 0x9, 0x8, 0x1, 0x2, 0x3, 0x4,
+				})
+			},
+			laneSize:  64,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0xff, 1, 0xa, 0x9, 0x8, 0x1, 0x2, 0x3, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "64_lane offset=3 laneIndex=1",
+			memSetupFn: func(buf []byte) {
+				copy(buf, []byte{
+					1, 0xff, 1, 0xa, 0x9, 0x8, 0x1, 0x2, 0x3, 0x4, 0xa,
+				})
+			},
+			laneSize:  64,
+			laneIndex: 1,
+			offset:    3,
+			exp:       [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xa, 0x9, 0x8, 0x1, 0x2, 0x3, 0x4, 0xa},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			tc.memSetupFn(env.memory())
+
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: tc.offset})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: originalVecLo,
+				Hi: originalVecHi,
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128LoadLane(&wazeroir.OperationV128LoadLane{
+				LaneIndex: tc.laneIndex, LaneSize: tc.laneSize, Arg: &wazeroir.MemoryArg{},
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+			loadedLocation := compiler.runtimeValueLocationStack().peek()
+			require.True(t, loadedLocation.onRegister())
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, uint64(2), env.stackPointer())
+			lo, hi := env.stackTopAsV128()
+
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestCompiler_compileV128Store(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset uint32
+	}{
+		{name: "offset=1", offset: 1},
+		{name: "offset=5", offset: 5},
+		{name: "offset=10", offset: 10},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: tc.offset})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: ^uint64(0), Hi: ^uint64(0)})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Store(&wazeroir.OperationV128Store{Arg: &wazeroir.MemoryArg{}})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(0), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, uint64(0), env.stackPointer())
+
+			mem := env.memory()
+			require.Equal(t, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				mem[tc.offset:tc.offset+16])
+		})
+	}
+}
+
+func TestCompiler_compileV128StoreLane(t *testing.T) {
+	vecBytes := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	tests := []struct {
+		name                string
+		laneIndex, laneSize byte
+		offset              uint32
+		exp                 [16]byte
+	}{
+		{
+			name:      "8_lane offset=0 laneIndex=0",
+			laneSize:  8,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "8_lane offset=1 laneIndex=0",
+			laneSize:  8,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "8_lane offset=3 laneIndex=5",
+			laneSize:  8,
+			laneIndex: 5,
+			offset:    3,
+			exp:       [16]byte{0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "16_lane offset=0 laneIndex=0",
+			laneSize:  16,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "16_lane offset=1 laneIndex=0",
+			laneSize:  16,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "16_lane offset=5 laneIndex=7",
+			laneSize:  16,
+			laneIndex: 7,
+			offset:    5,
+			exp:       [16]byte{0, 0, 0, 0, 0, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+
+		{
+			name:      "32_lane offset=0 laneIndex=0",
+			laneSize:  32,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "32_lane offset=1 laneIndex=0",
+			laneSize:  32,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "32_lane offset=5 laneIndex=3",
+			laneSize:  32,
+			laneIndex: 3,
+			offset:    5,
+			exp:       [16]byte{0, 0, 0, 0, 0, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0},
+		},
+
+		{
+			name:      "64_lane offset=0 laneIndex=0",
+			laneSize:  64,
+			laneIndex: 0,
+			offset:    0,
+			exp:       [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "64_lane offset=1 laneIndex=0",
+			laneSize:  64,
+			laneIndex: 0,
+			offset:    1,
+			exp:       [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:      "64_lane offset=5 laneIndex=3",
+			laneSize:  64,
+			laneIndex: 1,
+			offset:    6,
+			exp:       [16]byte{0, 0, 0, 0, 0, 0, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: tc.offset})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(vecBytes[:8]),
+				Hi: binary.LittleEndian.Uint64(vecBytes[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128StoreLane(&wazeroir.OperationV128StoreLane{
+				LaneIndex: tc.laneIndex, LaneSize: tc.laneSize, Arg: &wazeroir.MemoryArg{},
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(0), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, tc.exp[:], env.memory()[:16])
+		})
+	}
+}
+
+func TestCompiler_compileV128ExtractLane(t *testing.T) {
+	tests := []struct {
+		name      string
+		vecBytes  [16]byte
+		shape     wazeroir.Shape
+		signed    bool
+		laneIndex byte
+		exp       uint64
+	}{
+		{
+			name:      "i8x16 unsigned index=0",
+			vecBytes:  [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			shape:     wazeroir.ShapeI8x16,
+			signed:    false,
+			laneIndex: 0,
+			exp:       uint64(byte(1)),
+		},
+		{
+			name:      "i8x16 unsigned index=15",
+			vecBytes:  [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xff},
+			shape:     wazeroir.ShapeI8x16,
+			signed:    false,
+			laneIndex: 15,
+			exp:       uint64(byte(0xff)),
+		},
+		{
+			name:      "i8x16 signed index=0",
+			vecBytes:  [16]byte{0xf1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			shape:     wazeroir.ShapeI8x16,
+			signed:    true,
+			laneIndex: 0,
+			exp:       uint64(0xff_ff_ff_f1),
+		},
+		{
+			name:      "i8x16 signed index=1",
+			vecBytes:  [16]byte{0xf0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			shape:     wazeroir.ShapeI8x16,
+			signed:    true,
+			laneIndex: 1,
+			exp:       uint64(2),
+		},
+		{
+			name:      "i16x8 unsigned index=0",
+			vecBytes:  [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			shape:     wazeroir.ShapeI16x8,
+			signed:    false,
+			laneIndex: 0,
+			exp:       uint64(uint16(0x2<<8 | 0x1)),
+		},
+		{
+			name:      "i16x8 unsigned index=7",
+			vecBytes:  [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xff},
+			shape:     wazeroir.ShapeI16x8,
+			signed:    false,
+			laneIndex: 7,
+			exp:       uint64(uint16(0xff<<8 | 15)),
+		},
+		{
+			name:      "i16x8 signed index=0",
+			vecBytes:  [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			shape:     wazeroir.ShapeI16x8,
+			signed:    true,
+			laneIndex: 0,
+			exp:       uint64(uint16(0x2<<8 | 0x1)),
+		},
+		{
+			name:      "i16x8 signed index=7",
+			vecBytes:  [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xf1},
+			shape:     wazeroir.ShapeI16x8,
+			signed:    true,
+			laneIndex: 7,
+			exp:       uint64(uint32(0xffff<<16) | uint32(uint16(0xf1<<8|15))),
+		},
+		{
+			name:      "i32x4 index=0",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeI32x4,
+			laneIndex: 0,
+			exp:       uint64(uint32(0x04_03_02_01)),
+		},
+		{
+			name:      "i32x4 index=3",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeI32x4,
+			laneIndex: 3,
+			exp:       uint64(uint32(0x16_15_14_13)),
+		},
+		{
+			name:      "i64x4 index=0",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeI64x2,
+			laneIndex: 0,
+			exp:       uint64(0x08_07_06_05_04_03_02_01),
+		},
+		{
+			name:      "i64x4 index=1",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeI64x2,
+			laneIndex: 1,
+			exp:       uint64(0x16_15_14_13_12_11_10_09),
+		},
+		{
+			name:      "f32x4 index=0",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeF32x4,
+			laneIndex: 0,
+			exp:       uint64(uint32(0x04_03_02_01)),
+		},
+		{
+			name:      "f32x4 index=3",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeF32x4,
+			laneIndex: 3,
+			exp:       uint64(uint32(0x16_15_14_13)),
+		},
+		{
+			name:      "f64x4 index=0",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeF64x2,
+			laneIndex: 0,
+			exp:       uint64(0x08_07_06_05_04_03_02_01),
+		},
+		{
+			name:      "f64x4 index=1",
+			vecBytes:  [16]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16},
+			shape:     wazeroir.ShapeF64x2,
+			laneIndex: 1,
+			exp:       uint64(0x16_15_14_13_12_11_10_09),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.vecBytes[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.vecBytes[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128ExtractLane(&wazeroir.OperationV128ExtractLane{
+				LaneIndex: tc.laneIndex,
+				Signed:    tc.signed,
+				Shape:     tc.shape,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			vt := compiler.runtimeValueLocationStack().peek().valueType
+			switch tc.shape {
+			case wazeroir.ShapeI8x16, wazeroir.ShapeI16x8, wazeroir.ShapeI32x4:
+				require.Equal(t, runtimeValueTypeI32, vt)
+			case wazeroir.ShapeI64x2:
+				require.Equal(t, runtimeValueTypeI64, vt)
+			case wazeroir.ShapeF32x4:
+				require.Equal(t, runtimeValueTypeF32, vt)
+			case wazeroir.ShapeF64x2:
+				require.Equal(t, runtimeValueTypeF64, vt)
+			}
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			switch tc.shape {
+			case wazeroir.ShapeI8x16, wazeroir.ShapeI16x8, wazeroir.ShapeI32x4, wazeroir.ShapeF32x4:
+				require.Equal(t, uint32(tc.exp), env.stackTopAsUint32())
+			case wazeroir.ShapeI64x2, wazeroir.ShapeF64x2:
+				require.Equal(t, tc.exp, env.stackTopAsUint64())
+			}
+		})
+	}
+}
+
+func TestCompiler_compileV128ReplaceLane(t *testing.T) {
+	tests := []struct {
+		name               string
+		originValueSetupFn func(*testing.T, compilerImpl)
+		shape              wazeroir.Shape
+		laneIndex          byte
+		exp                [16]byte
+		lo, hi             uint64
+	}{
+		{
+			name:      "i8x16 index=0",
+			shape:     wazeroir.ShapeI8x16,
+			laneIndex: 5,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xff})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{5: 0xff},
+		},
+		{
+			name:      "i8x16 index=3",
+			shape:     wazeroir.ShapeI8x16,
+			laneIndex: 5,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xff << 8})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{},
+		},
+		{
+			name:      "i8x16 index=5",
+			shape:     wazeroir.ShapeI8x16,
+			laneIndex: 5,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xff})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{5: 0xff},
+		},
+		{
+			name:      "i16x8 index=0",
+			shape:     wazeroir.ShapeI16x8,
+			laneIndex: 0,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xee_ff})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{0: 0xff, 1: 0xee},
+		},
+		{
+			name:      "i16x8 index=3",
+			shape:     wazeroir.ShapeI16x8,
+			laneIndex: 3,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xaa_00})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{7: 0xaa},
+		},
+		{
+			name:      "i16x8 index=7",
+			shape:     wazeroir.ShapeI16x8,
+			laneIndex: 3,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xaa_bb << 16})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{},
+		},
+		{
+			name:      "i32x4 index=0",
+			shape:     wazeroir.ShapeI32x4,
+			laneIndex: 0,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xaa_bb_cc_dd})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{0: 0xdd, 1: 0xcc, 2: 0xbb, 3: 0xaa},
+		},
+		{
+			name:      "i32x4 index=3",
+			shape:     wazeroir.ShapeI32x4,
+			laneIndex: 3,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xaa_bb_cc_dd})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{12: 0xdd, 13: 0xcc, 14: 0xbb, 15: 0xaa},
+		},
+		{
+			name:      "i64x2 index=0",
+			shape:     wazeroir.ShapeI64x2,
+			laneIndex: 0,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI64(&wazeroir.OperationConstI64{Value: 0xaa_bb_cc_dd_01_02_03_04})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{0: 0x04, 1: 0x03, 2: 0x02, 3: 0x01, 4: 0xdd, 5: 0xcc, 6: 0xbb, 7: 0xaa},
+		},
+		{
+			name:      "i64x2 index=1",
+			shape:     wazeroir.ShapeI64x2,
+			laneIndex: 1,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI64(&wazeroir.OperationConstI64{Value: 0xaa_bb_cc_dd_01_02_03_04})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{8: 0x04, 9: 0x03, 10: 0x02, 11: 0x01, 12: 0xdd, 13: 0xcc, 14: 0xbb, 15: 0xaa},
+		},
+		{
+			name:      "f32x4 index=0",
+			shape:     wazeroir.ShapeF32x4,
+			laneIndex: 0,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF32(&wazeroir.OperationConstF32{Value: math.Float32frombits(0xaa_bb_cc_dd)})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{0: 0xdd, 1: 0xcc, 2: 0xbb, 3: 0xaa},
+		},
+		{
+			name:      "f32x4 index=1",
+			shape:     wazeroir.ShapeF32x4,
+			laneIndex: 1,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF32(&wazeroir.OperationConstF32{Value: math.Float32frombits(0xaa_bb_cc_dd)})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{4: 0xdd, 5: 0xcc, 6: 0xbb, 7: 0xaa},
+		},
+		{
+			name:      "f32x4 index=2",
+			shape:     wazeroir.ShapeF32x4,
+			laneIndex: 2,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF32(&wazeroir.OperationConstF32{Value: math.Float32frombits(0xaa_bb_cc_dd)})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{8: 0xdd, 9: 0xcc, 10: 0xbb, 11: 0xaa},
+		},
+		{
+			name:      "f32x4 index=3",
+			shape:     wazeroir.ShapeF32x4,
+			laneIndex: 3,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF32(&wazeroir.OperationConstF32{Value: math.Float32frombits(0xaa_bb_cc_dd)})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{12: 0xdd, 13: 0xcc, 14: 0xbb, 15: 0xaa},
+		},
+		{
+			name:      "f64x2 index=0",
+			shape:     wazeroir.ShapeF64x2,
+			laneIndex: 0,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF64(&wazeroir.OperationConstF64{Value: math.Float64frombits(0xaa_bb_cc_dd_01_02_03_04)})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{0: 0x04, 1: 0x03, 2: 0x02, 3: 0x01, 4: 0xdd, 5: 0xcc, 6: 0xbb, 7: 0xaa},
+		},
+		{
+			name:      "f64x2 index=1",
+			shape:     wazeroir.ShapeF64x2,
+			laneIndex: 1,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF64(&wazeroir.OperationConstF64{Value: math.Float64frombits(0xaa_bb_cc_dd_01_02_03_04)})
+				require.NoError(t, err)
+			},
+			exp: [16]byte{8: 0x04, 9: 0x03, 10: 0x02, 11: 0x01, 12: 0xdd, 13: 0xcc, 14: 0xbb, 15: 0xaa},
+		},
+		{
+			name:      "f64x2 index=0 / lo,hi = 1.0",
+			shape:     wazeroir.ShapeF64x2,
+			laneIndex: 0,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF64(&wazeroir.OperationConstF64{Value: math.Float64frombits(0.0)})
+				require.NoError(t, err)
+			},
+			lo:  math.Float64bits(1.0),
+			hi:  math.Float64bits(1.0),
+			exp: [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		},
+		{
+			name:      "f64x2 index=1 / lo,hi = 1.0",
+			shape:     wazeroir.ShapeF64x2,
+			laneIndex: 1,
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF64(&wazeroir.OperationConstF64{Value: math.Float64frombits(0.0)})
+				require.NoError(t, err)
+			},
+			lo:  math.Float64bits(1.0),
+			hi:  math.Float64bits(1.0),
+			exp: [16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: tc.lo, Hi: tc.hi})
+			require.NoError(t, err)
+
+			tc.originValueSetupFn(t, compiler)
+
+			err = compiler.compileV128ReplaceLane(&wazeroir.OperationV128ReplaceLane{
+				LaneIndex: tc.laneIndex,
+				Shape:     tc.shape,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			lo, hi := env.stackTopAsV128()
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestCompiler_compileV128Splat(t *testing.T) {
+	tests := []struct {
+		name               string
+		originValueSetupFn func(*testing.T, compilerImpl)
+		shape              wazeroir.Shape
+		exp                [16]byte
+	}{
+		{
+			name: "i8x16",
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0x1})
+				require.NoError(t, err)
+			},
+			shape: wazeroir.ShapeI8x16,
+			exp:   [16]byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1},
+		},
+		{
+			name: "i16x8",
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xff_11})
+				require.NoError(t, err)
+			},
+			shape: wazeroir.ShapeI16x8,
+			exp:   [16]byte{0x11, 0xff, 0x11, 0xff, 0x11, 0xff, 0x11, 0xff, 0x11, 0xff, 0x11, 0xff, 0x11, 0xff, 0x11, 0xff},
+		},
+		{
+			name: "i32x4",
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI32(&wazeroir.OperationConstI32{Value: 0xff_11_ee_22})
+				require.NoError(t, err)
+			},
+			shape: wazeroir.ShapeI32x4,
+			exp:   [16]byte{0x22, 0xee, 0x11, 0xff, 0x22, 0xee, 0x11, 0xff, 0x22, 0xee, 0x11, 0xff, 0x22, 0xee, 0x11, 0xff},
+		},
+		{
+			name: "i64x2",
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstI64(&wazeroir.OperationConstI64{Value: 0xff_00_ee_00_11_00_22_00})
+				require.NoError(t, err)
+			},
+			shape: wazeroir.ShapeI64x2,
+			exp:   [16]byte{0x00, 0x22, 0x00, 0x11, 0x00, 0xee, 0x00, 0xff, 0x00, 0x22, 0x00, 0x11, 0x00, 0xee, 0x00, 0xff},
+		},
+		{
+			name: "f32x4",
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF32(&wazeroir.OperationConstF32{Value: math.Float32frombits(0xff_11_ee_22)})
+				require.NoError(t, err)
+			},
+			shape: wazeroir.ShapeF32x4,
+			exp:   [16]byte{0x22, 0xee, 0x11, 0xff, 0x22, 0xee, 0x11, 0xff, 0x22, 0xee, 0x11, 0xff, 0x22, 0xee, 0x11, 0xff},
+		},
+		{
+			name: "f64x2",
+			originValueSetupFn: func(t *testing.T, c compilerImpl) {
+				err := c.compileConstF64(&wazeroir.OperationConstF64{Value: math.Float64frombits(0xff_00_ee_00_11_00_22_00)})
+				require.NoError(t, err)
+			},
+			shape: wazeroir.ShapeF64x2,
+			exp:   [16]byte{0x00, 0x22, 0x00, 0x11, 0x00, 0xee, 0x00, 0xff, 0x00, 0x22, 0x00, 0x11, 0x00, 0xee, 0x00, 0xff},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			tc.originValueSetupFn(t, compiler)
+
+			err = compiler.compileV128Splat(&wazeroir.OperationV128Splat{Shape: tc.shape})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			lo, hi := env.stackTopAsV128()
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestCompiler_compileV128AnyTrue(t *testing.T) {
+	tests := []struct {
+		name   string
+		lo, hi uint64
+		exp    uint32
+	}{
+		{name: "lo == 0 && hi == 0", lo: 0, hi: 0, exp: 0},
+		{name: "lo != 0", lo: 1, exp: 1},
+		{name: "hi != 0", hi: 1, exp: 1},
+		{name: "lo != 0 && hi != 0", lo: 1, hi: 1, exp: 1},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: tc.lo, Hi: tc.hi})
+			require.NoError(t, err)
+
+			err = compiler.compileV128AnyTrue(&wazeroir.OperationV128AnyTrue{})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
+			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, tc.exp, env.stackTopAsUint32())
+		})
+	}
+}
+
+func TestCompiler_compileV128AllTrue(t *testing.T) {
+	tests := []struct {
+		name   string
+		shape  wazeroir.Shape
+		lo, hi uint64
+		exp    uint32
+	}{
+		{
+			name:  "i8x16 - true",
+			shape: wazeroir.ShapeI8x16,
+			lo:    0xffff_ffff_ffff_ffff,
+			hi:    0x0101_0101_0101_0101,
+			exp:   1,
+		},
+		{
+			name:  "i8x16 - false on lo",
+			shape: wazeroir.ShapeI8x16,
+			lo:    0xffff_ffff_ffff_ffff,
+			hi:    0x1111_1111_0011_1111,
+			exp:   0,
+		},
+		{
+			name:  "i8x16 - false on hi",
+			shape: wazeroir.ShapeI8x16,
+			lo:    0xffff_00ff_ffff_ffff,
+			hi:    0x1111_1111_1111_1111,
+			exp:   0,
+		},
+		{
+			name:  "i16x8 - true",
+			shape: wazeroir.ShapeI16x8,
+			lo:    0x1000_0100_0010_0001,
+			hi:    0x0101_0101_0101_0101,
+			exp:   1,
+		},
+		{
+			name:  "i16x8 - false on hi",
+			shape: wazeroir.ShapeI16x8,
+			lo:    0x1000_0100_0010_0001,
+			hi:    0x1111_1111_0000_1111,
+			exp:   0,
+		},
+		{
+			name:  "i16x8 - false on lo",
+			shape: wazeroir.ShapeI16x8,
+			lo:    0xffff_0000_ffff_ffff,
+			hi:    0x1111_1111_1111_1111,
+			exp:   0,
+		},
+		{
+			name:  "i32x4 - true",
+			shape: wazeroir.ShapeI32x4,
+			lo:    0x1000_0000_0010_0000,
+			hi:    0x0000_0001_0000_1000,
+			exp:   1,
+		},
+		{
+			name:  "i32x4 - true",
+			shape: wazeroir.ShapeI32x4,
+			lo:    0x0000_1111_1111_0000,
+			hi:    0x0000_0001_1000_0000,
+			exp:   1,
+		},
+		{
+			name:  "i32x4 - false on lo",
+			shape: wazeroir.ShapeI32x4,
+			lo:    0x1111_1111_0000_0000,
+			hi:    0x1111_1111_1111_1111,
+			exp:   0,
+		},
+		{
+			name:  "i32x4 - false on lo",
+			shape: wazeroir.ShapeI32x4,
+			lo:    0x0000_0000_1111_1111,
+			hi:    0x1111_1111_1111_1111,
+			exp:   0,
+		},
+		{
+			name:  "i32x4 - false on hi",
+			shape: wazeroir.ShapeI32x4,
+			lo:    0x1111_1111_1111_1111,
+			hi:    0x1111_1111_0000_0000,
+			exp:   0,
+		},
+		{
+			name:  "i32x4 - false on hi",
+			shape: wazeroir.ShapeI32x4,
+			lo:    0x1111_1111_1111_1111,
+			hi:    0x0000_0000_1111_1111,
+			exp:   0,
+		},
+
+		{
+			name:  "i64x2 - true",
+			shape: wazeroir.ShapeI64x2,
+			lo:    0x1000_0000_0000_0000,
+			hi:    0x0000_0001_0000_0000,
+			exp:   1,
+		},
+		{
+			name:  "i64x2 - true",
+			shape: wazeroir.ShapeI64x2,
+			lo:    0x0000_0000_0010_0000,
+			hi:    0x0000_0000_0000_0100,
+			exp:   1,
+		},
+		{
+			name:  "i64x2 - true",
+			shape: wazeroir.ShapeI64x2,
+			lo:    0x0000_0000_0000_1000,
+			hi:    0x1000_0000_0000_0000,
+			exp:   1,
+		},
+		{
+			name:  "i64x2 - false on lo",
+			shape: wazeroir.ShapeI64x2,
+			lo:    0,
+			hi:    0x1111_1111_1111_1111,
+			exp:   0,
+		},
+		{
+			name:  "i64x2 - false on hi",
+			shape: wazeroir.ShapeI64x2,
+			lo:    0x1111_1111_1111_1111,
+			hi:    0,
+			exp:   0,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{Lo: tc.lo, Hi: tc.hi})
+			require.NoError(t, err)
+
+			err = compiler.compileV128AllTrue(&wazeroir.OperationV128AllTrue{Shape: tc.shape})
+			require.NoError(t, err)
+
+			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
+			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, tc.exp, env.stackTopAsUint32())
+		})
+	}
+}
+func i8ToU8(v int8) byte {
+	return byte(v)
+}
+
+func TestCompiler_compileV128Swizzle(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		indexVec, baseVec [16]byte
+		expVec            [16]byte
+	}{
+		{
+			name:     "1",
+			baseVec:  [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
+			indexVec: [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			expVec:   [16]byte{16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
+		},
+		{
+			name: "2",
+			baseVec: [16]byte{i8ToU8(-16), i8ToU8(-15), i8ToU8(-14), i8ToU8(-13), i8ToU8(-12),
+				i8ToU8(-11), i8ToU8(-10), i8ToU8(-9), i8ToU8(-8), i8ToU8(-7), i8ToU8(-6), i8ToU8(-5),
+				i8ToU8(-4), i8ToU8(-3), i8ToU8(-2), i8ToU8(-1)},
+			indexVec: [16]byte{i8ToU8(-8), i8ToU8(-7), i8ToU8(-6), i8ToU8(-5), i8ToU8(-4),
+				i8ToU8(-3), i8ToU8(-2), i8ToU8(-1), 16, 17, 18, 19, 20, 21, 22, 23},
+			expVec: [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "3",
+			baseVec:  [16]byte{100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115},
+			indexVec: [16]byte{15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+			expVec:   [16]byte{115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100},
+		},
+		{
+			name:    "4",
+			baseVec: [16]byte{100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115},
+			indexVec: [16]byte{
+				9, 16, 10, 17, 11, 18, 12, 19, 13, 20, 14, 21, 15, 22, 16, 23,
+			},
+			expVec: [16]byte{109, 0, 110, 0, 111, 0, 112, 0, 113, 0, 114, 0, 115, 0, 0, 0},
+		},
+		{
+			name:     "5",
+			baseVec:  [16]byte{0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73},
+			indexVec: [16]byte{9, 16, 10, 17, 11, 18, 12, 19, 13, 20, 14, 21, 15, 22, 16, 23},
+			expVec:   [16]byte{0x6d, 0, 0x6e, 0, 0x6f, 0, 0x70, 0, 0x71, 0, 0x72, 0, 0x73, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.baseVec[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.baseVec[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.indexVec[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.indexVec[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Swizzle(&wazeroir.OperationV128Swizzle{})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
+
+			lo, hi := env.stackTopAsV128()
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.expVec, actual)
+		})
+	}
+}
+
+func TestCompiler_compileV128Shuffle(t *testing.T) {
+	tests := []struct {
+		name             string
+		lanes, w, v, exp [16]byte
+	}{
+		{
+			name:  "v only",
+			lanes: [16]byte{1, 1, 1, 1, 0, 0, 0, 0, 10, 10, 10, 10, 0, 0, 0, 0},
+			v:     [16]byte{0: 0xa, 1: 0xb, 10: 0xc},
+			w:     [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			exp: [16]byte{
+				0xb, 0xb, 0xb, 0xb,
+				0xa, 0xa, 0xa, 0xa,
+				0xc, 0xc, 0xc, 0xc,
+				0xa, 0xa, 0xa, 0xa,
+			},
+		},
+		{
+			name:  "w only",
+			lanes: [16]byte{17, 17, 17, 17, 16, 16, 16, 16, 26, 26, 26, 26, 16, 16, 16, 16},
+			v:     [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			w:     [16]byte{0: 0xa, 1: 0xb, 10: 0xc},
+			exp: [16]byte{
+				0xb, 0xb, 0xb, 0xb,
+				0xa, 0xa, 0xa, 0xa,
+				0xc, 0xc, 0xc, 0xc,
+				0xa, 0xa, 0xa, 0xa,
+			},
+		},
+		{
+			name:  "mix",
+			lanes: [16]byte{0, 17, 2, 19, 4, 21, 6, 23, 8, 25, 10, 27, 12, 29, 14, 31},
+			v: [16]byte{
+				0x1, 0xff, 0x2, 0xff, 0x3, 0xff, 0x4, 0xff,
+				0x5, 0xff, 0x6, 0xff, 0x7, 0xff, 0x8, 0xff,
+			},
+			w: [16]byte{
+				0xff, 0x11, 0xff, 0x12, 0xff, 0x13, 0xff, 0x14,
+				0xff, 0x15, 0xff, 0x16, 0xff, 0x17, 0xff, 0x18,
+			},
+			exp: [16]byte{
+				0x1, 0x11, 0x2, 0x12, 0x3, 0x13, 0x4, 0x14,
+				0x5, 0x15, 0x6, 0x16, 0x7, 0x17, 0x8, 0x18,
+			},
+		},
+		{
+			name:  "mix",
+			lanes: [16]byte{0, 17, 2, 19, 4, 21, 6, 23, 8, 25, 10, 27, 12, 29, 14, 31},
+			v: [16]byte{
+				0x1, 0xff, 0x2, 0xff, 0x3, 0xff, 0x4, 0xff,
+				0x5, 0xff, 0x6, 0xff, 0x7, 0xff, 0x8, 0xff,
+			},
+			w: [16]byte{
+				0xff, 0x11, 0xff, 0x12, 0xff, 0x13, 0xff, 0x14,
+				0xff, 0x15, 0xff, 0x16, 0xff, 0x17, 0xff, 0x18,
+			},
+			exp: [16]byte{
+				0x1, 0x11, 0x2, 0x12, 0x3, 0x13, 0x4, 0x14,
+				0x5, 0x15, 0x6, 0x16, 0x7, 0x17, 0x8, 0x18,
+			},
+		},
+	}
+	/*
+	 */
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := newCompilerEnvironment()
+			compiler := env.requireNewCompiler(t, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.v[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.v[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+				Lo: binary.LittleEndian.Uint64(tc.w[:8]),
+				Hi: binary.LittleEndian.Uint64(tc.w[8:]),
+			})
+			require.NoError(t, err)
+
+			err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: tc.lanes})
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
+
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
+
+			// Generate and run the code under test.
+			code, _, _, err := compiler.compile()
+			require.NoError(t, err)
+			env.exec(code)
+
+			lo, hi := env.stackTopAsV128()
+			var actual [16]byte
+			binary.LittleEndian.PutUint64(actual[:8], lo)
+			binary.LittleEndian.PutUint64(actual[8:], hi)
+			require.Equal(t, tc.exp, actual)
+		})
+	}
+}

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -1040,10 +1040,34 @@ func compileWasmFunction(_ wasm.Features, ir *wazeroir.CompilationResult) (*code
 			err = compiler.compileTableSize(o)
 		case *wazeroir.OperationTableFill:
 			err = compiler.compileTableFill(o)
-		case *wazeroir.OperationConstV128:
-			err = compiler.compileConstV128(o)
-		case *wazeroir.OperationAddV128:
-			err = compiler.compileAddV128(o)
+		case *wazeroir.OperationV128Const:
+			err = compiler.compileV128Const(o)
+		case *wazeroir.OperationV128Add:
+			err = compiler.compileV128Add(o)
+		case *wazeroir.OperationV128Sub:
+			err = compiler.compileV128Sub(o)
+		case *wazeroir.OperationV128Load:
+			err = compiler.compileV128Load(o)
+		case *wazeroir.OperationV128LoadLane:
+			err = compiler.compileV128LoadLane(o)
+		case *wazeroir.OperationV128Store:
+			err = compiler.compileV128Store(o)
+		case *wazeroir.OperationV128StoreLane:
+			err = compiler.compileV128StoreLane(o)
+		case *wazeroir.OperationV128ExtractLane:
+			err = compiler.compileV128ExtractLane(o)
+		case *wazeroir.OperationV128ReplaceLane:
+			err = compiler.compileV128ReplaceLane(o)
+		case *wazeroir.OperationV128Splat:
+			err = compiler.compileV128Splat(o)
+		case *wazeroir.OperationV128Shuffle:
+			err = compiler.compileV128Shuffle(o)
+		case *wazeroir.OperationV128Swizzle:
+			err = compiler.compileV128Swizzle(o)
+		case *wazeroir.OperationV128AnyTrue:
+			err = compiler.compileV128AnyTrue(o)
+		case *wazeroir.OperationV128AllTrue:
+			err = compiler.compileV128AllTrue(o)
 		default:
 			err = errors.New("unsupported")
 		}

--- a/internal/engine/compiler/impl_vec_amd64.go
+++ b/internal/engine/compiler/impl_vec_amd64.go
@@ -6,8 +6,8 @@ import (
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
-// compileConstV128 implements compiler.compileConstV128 for amd64 architecture.
-func (c *amd64Compiler) compileConstV128(o *wazeroir.OperationConstV128) error {
+// compileV128Const implements compiler.compileV128Const for amd64 architecture.
+func (c *amd64Compiler) compileV128Const(o *wazeroir.OperationV128Const) error {
 	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
 
 	result, err := c.allocateRegister(registerTypeVector)
@@ -42,16 +42,14 @@ func (c *amd64Compiler) compileConstV128(o *wazeroir.OperationConstV128) error {
 	return nil
 }
 
-// compileAddV128 implements compiler.compileAddV128 for amd64 architecture.
-func (c *amd64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
-	c.locationStack.pop() // skip higher 64-bits.
-	x2 := c.locationStack.pop()
+// compileV128Add implements compiler.compileV128Add for amd64 architecture.
+func (c *amd64Compiler) compileV128Add(o *wazeroir.OperationV128Add) error {
+	x2 := c.locationStack.popV128()
 	if err := c.compileEnsureOnGeneralPurposeRegister(x2); err != nil {
 		return err
 	}
 
-	c.locationStack.pop() // skip higher 64-bits.
-	x1 := c.locationStack.pop()
+	x1 := c.locationStack.popV128()
 	if err := c.compileEnsureOnGeneralPurposeRegister(x1); err != nil {
 		return err
 	}
@@ -74,5 +72,521 @@ func (c *amd64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
 
 	c.pushVectorRuntimeValueLocationOnRegister(x1.register)
 	c.locationStack.markRegisterUnused(x2.register)
+	return nil
+}
+
+// compileV128Sub implements compiler.compileV128Sub for amd64 architecture.
+func (c *amd64Compiler) compileV128Sub(o *wazeroir.OperationV128Sub) error {
+	x2 := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x2); err != nil {
+		return err
+	}
+
+	x1 := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x1); err != nil {
+		return err
+	}
+	var inst asm.Instruction
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		inst = amd64.PSUBB
+	case wazeroir.ShapeI16x8:
+		inst = amd64.PSUBW
+	case wazeroir.ShapeI32x4:
+		inst = amd64.PSUBL
+	case wazeroir.ShapeI64x2:
+		inst = amd64.PSUBQ
+	case wazeroir.ShapeF32x4:
+		inst = amd64.SUBPS
+	case wazeroir.ShapeF64x2:
+		inst = amd64.SUBPD
+	}
+	c.assembler.CompileRegisterToRegister(inst, x2.register, x1.register)
+
+	c.pushVectorRuntimeValueLocationOnRegister(x1.register)
+	c.locationStack.markRegisterUnused(x2.register)
+	return nil
+}
+
+// compileV128Load implements compiler.compileV128Load for amd64 architecture.
+func (c *amd64Compiler) compileV128Load(o *wazeroir.OperationV128Load) error {
+	result, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	switch o.Type {
+	case wazeroir.LoadV128Type128:
+		err = c.compileV128LoadImpl(amd64.MOVDQU, o.Arg.Offset, 16, result)
+	case wazeroir.LoadV128Type8x8s:
+		err = c.compileV128LoadImpl(amd64.PMOVSXBW, o.Arg.Offset, 8, result)
+	case wazeroir.LoadV128Type8x8u:
+		err = c.compileV128LoadImpl(amd64.PMOVZXBW, o.Arg.Offset, 8, result)
+	case wazeroir.LoadV128Type16x4s:
+		err = c.compileV128LoadImpl(amd64.PMOVSXWD, o.Arg.Offset, 8, result)
+	case wazeroir.LoadV128Type16x4u:
+		err = c.compileV128LoadImpl(amd64.PMOVZXWD, o.Arg.Offset, 8, result)
+	case wazeroir.LoadV128Type32x2s:
+		err = c.compileV128LoadImpl(amd64.PMOVSXDQ, o.Arg.Offset, 8, result)
+	case wazeroir.LoadV128Type32x2u:
+		err = c.compileV128LoadImpl(amd64.PMOVZXDQ, o.Arg.Offset, 8, result)
+	case wazeroir.LoadV128Type8Splat:
+		reg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, 1)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithIndexToRegister(amd64.MOVBQZX, amd64ReservedRegisterForMemory, -1,
+			reg, 1, reg)
+		// pinsrb   $0, reg, result
+		// pxor	    tmpVReg, tmpVReg
+		// pshufb   tmpVReg, result
+		c.locationStack.markRegisterUsed(result)
+		tmpVReg, err := c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRB, reg, result, 0)
+		c.assembler.CompileRegisterToRegister(amd64.PXOR, tmpVReg, tmpVReg)
+		c.assembler.CompileRegisterToRegister(amd64.PSHUFB, tmpVReg, result)
+	case wazeroir.LoadV128Type16Splat:
+		reg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, 2)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithIndexToRegister(amd64.MOVWQZX, amd64ReservedRegisterForMemory, -2,
+			reg, 1, reg)
+		// pinsrw $0, reg, result
+		// pinsrw $1, reg, result
+		// pshufd $0, result, result (result = result[0,0,0,0])
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRW, reg, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRW, reg, result, 1)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, result, result, 0)
+	case wazeroir.LoadV128Type32Splat:
+		reg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, 4)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithIndexToRegister(amd64.MOVLQZX, amd64ReservedRegisterForMemory, -4,
+			reg, 1, reg)
+		// pinsrd $0, reg, result
+		// pshufd $0, result, result (result = result[0,0,0,0])
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRD, reg, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, result, result, 0)
+	case wazeroir.LoadV128Type64Splat:
+		reg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithIndexToRegister(amd64.MOVQ, amd64ReservedRegisterForMemory, -8,
+			reg, 1, reg)
+		// pinsrq $0, reg, result
+		// pinsrq $1, reg, result
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRQ, reg, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRQ, reg, result, 1)
+	case wazeroir.LoadV128Type32zero:
+		err = c.compileV128LoadImpl(amd64.MOVL, o.Arg.Offset, 4, result)
+	case wazeroir.LoadV128Type64zero:
+		err = c.compileV128LoadImpl(amd64.MOVQ, o.Arg.Offset, 8, result)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	c.pushVectorRuntimeValueLocationOnRegister(result)
+	return nil
+}
+
+func (c *amd64Compiler) compileV128LoadImpl(inst asm.Instruction, offset uint32, targetSizeInBytes int64, dst asm.Register) error {
+	offsetReg, err := c.compileMemoryAccessCeilSetup(offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+	c.assembler.CompileMemoryWithIndexToRegister(inst, amd64ReservedRegisterForMemory, -targetSizeInBytes,
+		offsetReg, 1, dst)
+	return nil
+}
+
+// compileV128LoadLane implements compiler.compileV128LoadLane for amd64.
+func (c *amd64Compiler) compileV128LoadLane(o *wazeroir.OperationV128LoadLane) error {
+	targetVector := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(targetVector); err != nil {
+		return err
+	}
+
+	var insertInst asm.Instruction
+	switch o.LaneSize {
+	case 8:
+		insertInst = amd64.PINSRB
+	case 16:
+		insertInst = amd64.PINSRW
+	case 32:
+		insertInst = amd64.PINSRD
+	case 64:
+		insertInst = amd64.PINSRQ
+	}
+
+	targetSizeInBytes := int64(o.LaneSize / 8)
+	offsetReg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+	c.assembler.CompileMemoryWithIndexAndArgToRegister(insertInst, amd64ReservedRegisterForMemory, -targetSizeInBytes,
+		offsetReg, 1, targetVector.register, o.LaneIndex)
+
+	c.pushVectorRuntimeValueLocationOnRegister(targetVector.register)
+	return nil
+}
+
+// compileV128Store implements compiler.compileV128Store for amd64.
+func (c *amd64Compiler) compileV128Store(o *wazeroir.OperationV128Store) error {
+	val := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(val); err != nil {
+		return err
+	}
+
+	const targetSizeInBytes = 16
+	offsetReg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+
+	c.assembler.CompileRegisterToMemoryWithIndex(amd64.MOVDQU, val.register,
+		amd64ReservedRegisterForMemory, -targetSizeInBytes, offsetReg, 1)
+
+	c.locationStack.markRegisterUnused(val.register, offsetReg)
+	return nil
+}
+
+// compileV128StoreLane implements compiler.compileV128StoreLane for amd64.
+func (c *amd64Compiler) compileV128StoreLane(o *wazeroir.OperationV128StoreLane) error {
+	var storeInst asm.Instruction
+	switch o.LaneSize {
+	case 8:
+		storeInst = amd64.PEXTRB
+	case 16:
+		storeInst = amd64.PEXTRW
+	case 32:
+		storeInst = amd64.PEXTRD
+	case 64:
+		storeInst = amd64.PEXTRQ
+	}
+
+	val := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(val); err != nil {
+		return err
+	}
+
+	targetSizeInBytes := int64(o.LaneSize / 8)
+	offsetReg, err := c.compileMemoryAccessCeilSetup(o.Arg.Offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+
+	c.assembler.CompileRegisterToMemoryWithIndexAndArg(storeInst, val.register,
+		amd64ReservedRegisterForMemory, -targetSizeInBytes, offsetReg, 1, o.LaneIndex)
+
+	c.locationStack.markRegisterUnused(val.register, offsetReg)
+	return nil
+}
+
+// compileV128ExtractLane implements compiler.compileV128ExtractLane for amd64.
+func (c *amd64Compiler) compileV128ExtractLane(o *wazeroir.OperationV128ExtractLane) error {
+	val := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(val); err != nil {
+		return err
+	}
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PEXTRB, val.register, result, o.LaneIndex)
+		if o.Signed {
+			c.assembler.CompileRegisterToRegister(amd64.MOVBQSX, result, result)
+		} else {
+			c.assembler.CompileRegisterToRegister(amd64.MOVBLZX, result, result)
+		}
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI32)
+		c.locationStack.markRegisterUnused(val.register)
+	case wazeroir.ShapeI16x8:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PEXTRW, val.register, result, o.LaneIndex)
+		if o.Signed {
+			c.assembler.CompileRegisterToRegister(amd64.MOVWLSX, result, result)
+		} else {
+			c.assembler.CompileRegisterToRegister(amd64.MOVWLZX, result, result)
+		}
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI32)
+		c.locationStack.markRegisterUnused(val.register)
+	case wazeroir.ShapeI32x4:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PEXTRD, val.register, result, o.LaneIndex)
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI32)
+		c.locationStack.markRegisterUnused(val.register)
+	case wazeroir.ShapeI64x2:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PEXTRQ, val.register, result, o.LaneIndex)
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI64)
+		c.locationStack.markRegisterUnused(val.register)
+	case wazeroir.ShapeF32x4:
+		if o.LaneIndex != 0 {
+			c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, val.register, val.register, o.LaneIndex)
+		}
+		c.pushRuntimeValueLocationOnRegister(val.register, runtimeValueTypeF32)
+	case wazeroir.ShapeF64x2:
+		if o.LaneIndex != 0 {
+			// This case we can assume LaneIndex == 1.
+			// We have to modify the val.register as, for example:
+			//    0b11 0b10 0b01 0b00
+			//     |    |    |    |
+			//   [x3,  x2,  x1,  x0] -> [x0,  x0,  x3,  x2]
+			// where val.register = [x3, x2, x1, x0] and each xN = 32bits.
+			// Then, we interpret the register as float64, therefore, the float64 value is obtained as [x3, x2].
+			arg := byte(0b00_00_11_10)
+			c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, val.register, val.register, arg)
+		}
+		c.pushRuntimeValueLocationOnRegister(val.register, runtimeValueTypeF64)
+	}
+
+	return nil
+}
+
+// compileV128ReplaceLane implements compiler.compileV128ReplaceLane for amd64.
+func (c *amd64Compiler) compileV128ReplaceLane(o *wazeroir.OperationV128ReplaceLane) error {
+	origin := c.locationStack.pop()
+	if err := c.compileEnsureOnGeneralPurposeRegister(origin); err != nil {
+		return err
+	}
+
+	vector := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(vector); err != nil {
+		return err
+	}
+
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRB, origin.register, vector.register, o.LaneIndex)
+	case wazeroir.ShapeI16x8:
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRW, origin.register, vector.register, o.LaneIndex)
+	case wazeroir.ShapeI32x4:
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRD, origin.register, vector.register, o.LaneIndex)
+	case wazeroir.ShapeI64x2:
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRQ, origin.register, vector.register, o.LaneIndex)
+	case wazeroir.ShapeF32x4:
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.INSERTPS, origin.register, vector.register,
+			// In INSERTPS instruction, the destination index is encoded at 4 and 5 bits of the argument.
+			// See https://www.felixcloutier.com/x86/insertps
+			o.LaneIndex<<4,
+		)
+	case wazeroir.ShapeF64x2:
+		if o.LaneIndex == 0 {
+			c.assembler.CompileRegisterToRegister(amd64.MOVSD, origin.register, vector.register)
+		} else {
+			c.assembler.CompileRegisterToRegister(amd64.MOVLHPS, origin.register, vector.register)
+		}
+	}
+
+	c.pushVectorRuntimeValueLocationOnRegister(vector.register)
+	c.locationStack.markRegisterUnused(origin.register)
+	return nil
+}
+
+// compileV128Splat implements compiler.compileV128Splat for amd64.
+func (c *amd64Compiler) compileV128Splat(o *wazeroir.OperationV128Splat) (err error) {
+	origin := c.locationStack.pop()
+	if err = c.compileEnsureOnGeneralPurposeRegister(origin); err != nil {
+		return
+	}
+
+	var result asm.Register
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return err
+		}
+		c.locationStack.markRegisterUsed(result)
+
+		tmp, err := c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRB, origin.register, result, 0)
+		c.assembler.CompileRegisterToRegister(amd64.PXOR, tmp, tmp)
+		c.assembler.CompileRegisterToRegister(amd64.PSHUFB, tmp, result)
+	case wazeroir.ShapeI16x8:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return err
+		}
+		c.locationStack.markRegisterUsed(result)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRW, origin.register, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRW, origin.register, result, 1)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, result, result, 0)
+	case wazeroir.ShapeI32x4:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return err
+		}
+		c.locationStack.markRegisterUsed(result)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRD, origin.register, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, result, result, 0)
+	case wazeroir.ShapeI64x2:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return err
+		}
+		c.locationStack.markRegisterUsed(result)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRQ, origin.register, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PINSRQ, origin.register, result, 1)
+	case wazeroir.ShapeF32x4:
+		result = origin.register
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.INSERTPS, origin.register, result, 0)
+		c.assembler.CompileRegisterToRegisterWithArg(amd64.PSHUFD, result, result, 0)
+	case wazeroir.ShapeF64x2:
+		result = origin.register
+		c.assembler.CompileRegisterToRegister(amd64.MOVQ, origin.register, result)
+		c.assembler.CompileRegisterToRegister(amd64.MOVLHPS, origin.register, result)
+	}
+
+	c.locationStack.markRegisterUnused(origin.register)
+	c.pushVectorRuntimeValueLocationOnRegister(result)
+	return nil
+}
+
+// compileV128Shuffle implements compiler.compileV128Shuffle for amd64.
+func (c *amd64Compiler) compileV128Shuffle(o *wazeroir.OperationV128Shuffle) error {
+	w := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(w); err != nil {
+		return err
+	}
+
+	v := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return err
+	}
+
+	tmp, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	consts := [32]byte{}
+	for i, lane := range o.Lanes {
+		if lane < 16 {
+			consts[i+16] = 0x80
+			consts[i] = lane
+		} else {
+			consts[i+16] = lane - 16
+			consts[i] = 0x80
+		}
+	}
+
+	err = c.assembler.CompileLoadStaticConstToRegister(amd64.MOVDQU, consts[:16], tmp)
+	if err != nil {
+		return err
+	}
+	c.assembler.CompileRegisterToRegister(amd64.PSHUFB, tmp, v.register)
+	err = c.assembler.CompileLoadStaticConstToRegister(amd64.MOVDQU, consts[16:], tmp)
+	if err != nil {
+		return err
+	}
+	c.assembler.CompileRegisterToRegister(amd64.PSHUFB, tmp, w.register)
+	c.assembler.CompileRegisterToRegister(amd64.ORPS, v.register, w.register)
+
+	c.pushVectorRuntimeValueLocationOnRegister(w.register)
+	c.locationStack.markRegisterUnused(v.register)
+	return nil
+}
+
+var swizzleConst = [16]byte{
+	0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
+	0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70,
+}
+
+// compileV128Swizzle implements compiler.compileV128Swizzle for amd64.
+func (c *amd64Compiler) compileV128Swizzle(*wazeroir.OperationV128Swizzle) error {
+	indexVec := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(indexVec); err != nil {
+		return err
+	}
+
+	baseVec := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(baseVec); err != nil {
+		return err
+	}
+
+	tmp, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	err = c.assembler.CompileLoadStaticConstToRegister(amd64.MOVDQU, swizzleConst[:], tmp)
+	if err != nil {
+		return err
+	}
+
+	c.assembler.CompileRegisterToRegister(amd64.PADDUSB, tmp, indexVec.register)
+	c.assembler.CompileRegisterToRegister(amd64.PSHUFB, indexVec.register, baseVec.register)
+
+	c.pushVectorRuntimeValueLocationOnRegister(baseVec.register)
+	c.locationStack.markRegisterUnused(indexVec.register)
+	return nil
+}
+
+// compileV128AnyTrue implements compiler.compileV128AnyTrue for amd64.
+func (c *amd64Compiler) compileV128AnyTrue(*wazeroir.OperationV128AnyTrue) error {
+	v := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return err
+	}
+
+	c.assembler.CompileRegisterToRegister(amd64.PTEST, v.register, v.register)
+
+	c.locationStack.pushRuntimeValueLocationOnConditionalRegister(amd64.ConditionalRegisterStateNE)
+	c.locationStack.markRegisterUnused(v.register)
+	return nil
+}
+
+// compileV128AllTrue implements compiler.compileV128AllTrue for amd64.
+func (c *amd64Compiler) compileV128AllTrue(o *wazeroir.OperationV128AllTrue) error {
+	v := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return err
+	}
+
+	tmp, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	var cmpInst asm.Instruction
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		cmpInst = amd64.PCMPEQB
+	case wazeroir.ShapeI16x8:
+		cmpInst = amd64.PCMPEQW
+	case wazeroir.ShapeI32x4:
+		cmpInst = amd64.PCMPEQD
+	case wazeroir.ShapeI64x2:
+		cmpInst = amd64.PCMPEQQ
+	}
+
+	c.assembler.CompileRegisterToRegister(amd64.PXOR, tmp, tmp)
+	c.assembler.CompileRegisterToRegister(cmpInst, v.register, tmp)
+	c.assembler.CompileRegisterToRegister(amd64.PTEST, tmp, tmp)
+	c.locationStack.markRegisterUnused(v.register, tmp)
+	c.locationStack.pushRuntimeValueLocationOnConditionalRegister(amd64.ConditionalRegisterStateE)
 	return nil
 }

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -1,0 +1,64 @@
+package compiler
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/asm/amd64"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
+)
+
+// TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction ensures that flushing constant table in the middle of
+// function works well by intentionally setting amd64.AssemblerImpl MaxDisplacementForConstantPool = 0.
+func TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
+	env := newCompilerEnvironment()
+	compiler := env.requireNewCompiler(t, newCompiler,
+		&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
+
+	lanes := [16]byte{1, 1, 1, 1, 0, 0, 0, 0, 10, 10, 10, 10, 0, 0, 0, 0}
+	v := [16]byte{0: 0xa, 1: 0xb, 10: 0xc}
+	w := [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	exp := [16]byte{
+		0xb, 0xb, 0xb, 0xb,
+		0xa, 0xa, 0xa, 0xa,
+		0xc, 0xc, 0xc, 0xc,
+		0xa, 0xa, 0xa, 0xa,
+	}
+
+	err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+		Lo: binary.LittleEndian.Uint64(v[:8]),
+		Hi: binary.LittleEndian.Uint64(v[8:]),
+	})
+	require.NoError(t, err)
+
+	err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+		Lo: binary.LittleEndian.Uint64(w[:8]),
+		Hi: binary.LittleEndian.Uint64(w[8:]),
+	})
+	require.NoError(t, err)
+
+	err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: lanes})
+	require.NoError(t, err)
+
+	assembler := compiler.(*amd64Compiler).assembler.(*amd64.AssemblerImpl)
+	assembler.MaxDisplacementForConstantPool = 0 // Ensures that constant table for shuffle will be flushed immediately.
+
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
+
+	// Generate and run the code under test.
+	code, _, _, err := compiler.compile()
+	require.NoError(t, err)
+	env.exec(code)
+
+	lo, hi := env.stackTopAsV128()
+	var actual [16]byte
+	binary.LittleEndian.PutUint64(actual[:8], lo)
+	binary.LittleEndian.PutUint64(actual[8:], hi)
+	require.Equal(t, exp, actual)
+}

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -1,12 +1,14 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/arm64"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
-func (c *arm64Compiler) compileConstV128(o *wazeroir.OperationConstV128) error {
+func (c *arm64Compiler) compileV128Const(o *wazeroir.OperationV128Const) error {
 	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
 
 	result, err := c.allocateRegister(registerTypeVector)
@@ -33,20 +35,18 @@ func (c *arm64Compiler) compileConstV128(o *wazeroir.OperationConstV128) error {
 	// "ins Vn.D[1], intReg"
 	c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, intReg, result, arm64.VectorArrangementD, 1)
 
-	c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeV128Lo)
-	c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeV128Hi)
+	c.pushVectorRuntimeValueLocationOnRegister(result)
 	return nil
 }
 
-func (c *arm64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
-	c.locationStack.pop() // skip higher 64-bits.
-	x1Low := c.locationStack.pop()
-	if err := c.compileEnsureOnGeneralPurposeRegister(x1Low); err != nil {
+func (c *arm64Compiler) compileV128Add(o *wazeroir.OperationV128Add) error {
+	x2 := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x2); err != nil {
 		return err
 	}
-	c.locationStack.pop() // skip higher 64-bits.
-	x2Low := c.locationStack.pop()
-	if err := c.compileEnsureOnGeneralPurposeRegister(x2Low); err != nil {
+
+	x1 := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x1); err != nil {
 		return err
 	}
 
@@ -73,12 +73,566 @@ func (c *arm64Compiler) compileAddV128(o *wazeroir.OperationAddV128) error {
 		arr = arm64.VectorArrangement2D
 	}
 
-	c.assembler.CompileVectorRegisterToVectorRegister(inst, x1Low.register, x2Low.register, arr)
+	c.assembler.CompileVectorRegisterToVectorRegister(inst, x1.register, x2.register, arr,
+		arm64.VectorIndexNone, arm64.VectorIndexNone)
 
-	resultReg := x2Low.register
-	c.pushRuntimeValueLocationOnRegister(resultReg, runtimeValueTypeV128Lo)
-	c.pushRuntimeValueLocationOnRegister(resultReg, runtimeValueTypeV128Hi)
-
-	c.markRegisterUnused(x1Low.register)
+	c.pushVectorRuntimeValueLocationOnRegister(x2.register)
+	c.markRegisterUnused(x1.register)
 	return nil
+}
+
+// compileV128Sub implements compiler.compileV128Sub for arm64.
+func (c *arm64Compiler) compileV128Sub(o *wazeroir.OperationV128Sub) (err error) {
+	x2 := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x2); err != nil {
+		return err
+	}
+
+	x1 := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(x1); err != nil {
+		return err
+	}
+
+	fmt.Println(arm64.RegisterName(x1.register))
+	fmt.Println(arm64.RegisterName(x2.register))
+
+	var arr arm64.VectorArrangement
+	var inst asm.Instruction
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		inst = arm64.VSUB
+		arr = arm64.VectorArrangement16B
+	case wazeroir.ShapeI16x8:
+		inst = arm64.VSUB
+		arr = arm64.VectorArrangement8H
+	case wazeroir.ShapeI32x4:
+		inst = arm64.VSUB
+		arr = arm64.VectorArrangement4S
+	case wazeroir.ShapeI64x2:
+		inst = arm64.VSUB
+		arr = arm64.VectorArrangement2D
+	case wazeroir.ShapeF32x4:
+		inst = arm64.VFSUBS
+		arr = arm64.VectorArrangement4S
+	case wazeroir.ShapeF64x2:
+		inst = arm64.VFSUBD
+		arr = arm64.VectorArrangement2D
+	}
+
+	c.assembler.CompileVectorRegisterToVectorRegister(inst, x2.register, x1.register, arr,
+		arm64.VectorIndexNone, arm64.VectorIndexNone)
+
+	c.pushVectorRuntimeValueLocationOnRegister(x1.register)
+	c.markRegisterUnused(x2.register)
+	return
+}
+
+// compileV128Load implements compiler.compileV128Load for arm64.
+func (c *arm64Compiler) compileV128Load(o *wazeroir.OperationV128Load) (err error) {
+	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	result, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	switch o.Type {
+	case wazeroir.LoadV128Type128:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 16)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementQ,
+		)
+	case wazeroir.LoadV128Type8x8s:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.SSHLL, result, result,
+			arm64.VectorArrangement8B, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	case wazeroir.LoadV128Type8x8u:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.USHLL, result, result,
+			arm64.VectorArrangement8B, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	case wazeroir.LoadV128Type16x4s:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.SSHLL, result, result,
+			arm64.VectorArrangement4H, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	case wazeroir.LoadV128Type16x4u:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.USHLL, result, result,
+			arm64.VectorArrangement4H, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	case wazeroir.LoadV128Type32x2s:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.SSHLL, result, result,
+			arm64.VectorArrangement2S, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	case wazeroir.LoadV128Type32x2u:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.USHLL, result, result,
+			arm64.VectorArrangement2S, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	case wazeroir.LoadV128Type8Splat:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 1)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegister(arm64.ADD, arm64ReservedRegisterForMemory, offset)
+		c.assembler.CompileMemoryToVectorRegister(arm64.LD1R, offset, 0, result, arm64.VectorArrangement16B)
+	case wazeroir.LoadV128Type16Splat:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 2)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegister(arm64.ADD, arm64ReservedRegisterForMemory, offset)
+		c.assembler.CompileMemoryToVectorRegister(arm64.LD1R, offset, 0, result, arm64.VectorArrangement8H)
+	case wazeroir.LoadV128Type32Splat:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 4)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegister(arm64.ADD, arm64ReservedRegisterForMemory, offset)
+		c.assembler.CompileMemoryToVectorRegister(arm64.LD1R, offset, 0, result, arm64.VectorArrangement4S)
+	case wazeroir.LoadV128Type64Splat:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 8)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileRegisterToRegister(arm64.ADD, arm64ReservedRegisterForMemory, offset)
+		c.assembler.CompileMemoryToVectorRegister(arm64.LD1R, offset, 0, result, arm64.VectorArrangement2D)
+	case wazeroir.LoadV128Type32zero:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 16)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementS,
+		)
+	case wazeroir.LoadV128Type64zero:
+		offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, 16)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileMemoryWithRegisterOffsetToVectorRegister(arm64.VMOV,
+			arm64ReservedRegisterForMemory, offset, result, arm64.VectorArrangementD,
+		)
+	}
+
+	c.pushVectorRuntimeValueLocationOnRegister(result)
+	return
+}
+
+// compileV128LoadLane implements compiler.compileV128LoadLane for arm64.
+func (c *arm64Compiler) compileV128LoadLane(o *wazeroir.OperationV128LoadLane) (err error) {
+	targetVector := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(targetVector); err != nil {
+		return
+	}
+
+	targetSizeInBytes := int64(o.LaneSize / 8)
+	source, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+
+	var loadInst asm.Instruction
+	var arr arm64.VectorArrangement
+	switch o.LaneSize {
+	case 8:
+		arr = arm64.VectorArrangementB
+		loadInst = arm64.MOVB
+	case 16:
+		arr = arm64.VectorArrangementH
+		loadInst = arm64.MOVH
+	case 32:
+		loadInst = arm64.MOVW
+		arr = arm64.VectorArrangementS
+	case 64:
+		loadInst = arm64.MOVD
+		arr = arm64.VectorArrangementD
+	}
+
+	c.assembler.CompileMemoryWithRegisterOffsetToRegister(loadInst, arm64ReservedRegisterForMemory, source, source)
+	c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, source, targetVector.register, arr, arm64.VectorIndex(o.LaneIndex))
+
+	c.pushVectorRuntimeValueLocationOnRegister(targetVector.register)
+	c.locationStack.markRegisterUnused(source)
+	return
+}
+
+// compileV128Store implements compiler.compileV128Store for arm64.
+func (c *arm64Compiler) compileV128Store(o *wazeroir.OperationV128Store) (err error) {
+	v := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return
+	}
+
+	const targetSizeInBytes = 16
+	offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+
+	c.assembler.CompileVectorRegisterToMemoryWithRegisterOffset(arm64.VMOV,
+		v.register, arm64ReservedRegisterForMemory, offset, arm64.VectorArrangementQ)
+
+	c.markRegisterUnused(v.register)
+	return
+}
+
+// compileV128StoreLane implements compiler.compileV128StoreLane for arm64.
+func (c *arm64Compiler) compileV128StoreLane(o *wazeroir.OperationV128StoreLane) (err error) {
+	var arr arm64.VectorArrangement
+	var storeInst asm.Instruction
+	switch o.LaneSize {
+	case 8:
+		storeInst = arm64.MOVB
+		arr = arm64.VectorArrangementB
+	case 16:
+		storeInst = arm64.MOVH
+		arr = arm64.VectorArrangementH
+	case 32:
+		storeInst = arm64.MOVW
+		arr = arm64.VectorArrangementS
+	case 64:
+		storeInst = arm64.MOVD
+		arr = arm64.VectorArrangementD
+	}
+
+	v := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return
+	}
+
+	targetSizeInBytes := int64(o.LaneSize / 8)
+	offset, err := c.compileMemoryAccessOffsetSetup(o.Arg.Offset, targetSizeInBytes)
+	if err != nil {
+		return err
+	}
+
+	c.assembler.CompileVectorRegisterToRegister(arm64.VMOV, v.register, arm64ReservedRegisterForTemporary, arr,
+		arm64.VectorIndex(o.LaneIndex))
+
+	c.assembler.CompileRegisterToMemoryWithRegisterOffset(storeInst,
+		arm64ReservedRegisterForTemporary, arm64ReservedRegisterForMemory, offset)
+
+	c.locationStack.markRegisterUnused(v.register)
+	return
+}
+
+// compileV128ExtractLane implements compiler.compileV128ExtractLane for arm64.
+func (c *arm64Compiler) compileV128ExtractLane(o *wazeroir.OperationV128ExtractLane) (err error) {
+	v := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return
+	}
+
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		var inst asm.Instruction
+		if o.Signed {
+			inst = arm64.SMOV
+		} else {
+			inst = arm64.VMOV
+		}
+		c.assembler.CompileVectorRegisterToRegister(inst, v.register, result,
+			arm64.VectorArrangementB, arm64.VectorIndex(o.LaneIndex))
+
+		c.locationStack.markRegisterUnused(v.register)
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI32)
+	case wazeroir.ShapeI16x8:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		var inst asm.Instruction
+		if o.Signed {
+			inst = arm64.SMOV
+		} else {
+			inst = arm64.VMOV
+		}
+		c.assembler.CompileVectorRegisterToRegister(inst, v.register, result,
+			arm64.VectorArrangementH, arm64.VectorIndex(o.LaneIndex))
+
+		c.locationStack.markRegisterUnused(v.register)
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI32)
+	case wazeroir.ShapeI32x4:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileVectorRegisterToRegister(arm64.VMOV, v.register, result,
+			arm64.VectorArrangementS, arm64.VectorIndex(o.LaneIndex))
+
+		c.locationStack.markRegisterUnused(v.register)
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI32)
+	case wazeroir.ShapeI64x2:
+		result, err := c.allocateRegister(registerTypeGeneralPurpose)
+		if err != nil {
+			return err
+		}
+		c.assembler.CompileVectorRegisterToRegister(arm64.VMOV, v.register, result,
+			arm64.VectorArrangementD, arm64.VectorIndex(o.LaneIndex))
+
+		c.locationStack.markRegisterUnused(v.register)
+		c.pushRuntimeValueLocationOnRegister(result, runtimeValueTypeI64)
+	case wazeroir.ShapeF32x4:
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.VMOV, v.register, v.register,
+			arm64.VectorArrangementS, arm64.VectorIndex(o.LaneIndex), 0)
+		c.pushRuntimeValueLocationOnRegister(v.register, runtimeValueTypeF32)
+	case wazeroir.ShapeF64x2:
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.VMOV, v.register, v.register,
+			arm64.VectorArrangementD, arm64.VectorIndex(o.LaneIndex), 0)
+		c.pushRuntimeValueLocationOnRegister(v.register, runtimeValueTypeF64)
+	}
+	return
+}
+
+// compileV128ReplaceLane implements compiler.compileV128ReplaceLane for arm64.
+func (c *arm64Compiler) compileV128ReplaceLane(o *wazeroir.OperationV128ReplaceLane) (err error) {
+	origin := c.locationStack.pop()
+	if err = c.compileEnsureOnGeneralPurposeRegister(origin); err != nil {
+		return
+	}
+
+	vector := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(vector); err != nil {
+		return
+	}
+
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, origin.register, vector.register,
+			arm64.VectorArrangementB, arm64.VectorIndex(o.LaneIndex))
+	case wazeroir.ShapeI16x8:
+		c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, origin.register, vector.register,
+			arm64.VectorArrangementH, arm64.VectorIndex(o.LaneIndex))
+	case wazeroir.ShapeI32x4:
+		c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, origin.register, vector.register,
+			arm64.VectorArrangementS, arm64.VectorIndex(o.LaneIndex))
+	case wazeroir.ShapeI64x2:
+		c.assembler.CompileRegisterToVectorRegister(arm64.VMOV, origin.register, vector.register,
+			arm64.VectorArrangementD, arm64.VectorIndex(o.LaneIndex))
+	case wazeroir.ShapeF32x4:
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.VMOV, origin.register, vector.register,
+			arm64.VectorArrangementS, 0, arm64.VectorIndex(o.LaneIndex))
+	case wazeroir.ShapeF64x2:
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.VMOV, origin.register, vector.register,
+			arm64.VectorArrangementD, 0, arm64.VectorIndex(o.LaneIndex))
+	}
+
+	c.locationStack.markRegisterUnused(origin.register)
+	c.pushVectorRuntimeValueLocationOnRegister(vector.register)
+	return
+}
+
+// compileV128Splat implements compiler.compileV128Splat for arm64.
+func (c *arm64Compiler) compileV128Splat(o *wazeroir.OperationV128Splat) (err error) {
+	origin := c.locationStack.pop()
+	if err = c.compileEnsureOnGeneralPurposeRegister(origin); err != nil {
+		return
+	}
+
+	var result asm.Register
+	switch o.Shape {
+	case wazeroir.ShapeI8x16:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return
+		}
+		c.assembler.CompileRegisterToVectorRegister(arm64.DUP, origin.register, result,
+			arm64.VectorArrangementB, arm64.VectorIndexNone)
+	case wazeroir.ShapeI16x8:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return
+		}
+		c.assembler.CompileRegisterToVectorRegister(arm64.DUP, origin.register, result,
+			arm64.VectorArrangementH, arm64.VectorIndexNone)
+	case wazeroir.ShapeI32x4:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return
+		}
+		c.assembler.CompileRegisterToVectorRegister(arm64.DUP, origin.register, result,
+			arm64.VectorArrangementS, arm64.VectorIndexNone)
+	case wazeroir.ShapeI64x2:
+		result, err = c.allocateRegister(registerTypeVector)
+		if err != nil {
+			return
+		}
+		c.assembler.CompileRegisterToVectorRegister(arm64.DUP, origin.register, result,
+			arm64.VectorArrangementD, arm64.VectorIndexNone)
+	case wazeroir.ShapeF32x4:
+		result = origin.register
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.DUP, origin.register, result,
+			arm64.VectorArrangementS, 0, arm64.VectorIndexNone)
+	case wazeroir.ShapeF64x2:
+		result = origin.register
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.DUP, origin.register, result,
+			arm64.VectorArrangementD, 0, arm64.VectorIndexNone)
+	}
+
+	c.locationStack.markRegisterUnused(origin.register)
+	c.pushVectorRuntimeValueLocationOnRegister(result)
+	return
+}
+
+// compileV128Shuffle implements compiler.compileV128Shuffle for arm64.
+func (c *arm64Compiler) compileV128Shuffle(o *wazeroir.OperationV128Shuffle) (err error) {
+	w := c.locationStack.popV128()
+	v := c.locationStack.popV128()
+	if err := c.compileEnsureOnGeneralPurposeRegister(v); err != nil {
+		return err
+	}
+
+	r1 := v.register
+	var r2 asm.Register
+	if r1 < arm64.RegV30 {
+		r2 = v.register + 1
+	} else {
+		r2 = v.register - 1
+	}
+
+	if w.onRegister() {
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.VMOV, w.register, r2,
+			arm64.VectorArrangement16B, arm64.VectorIndexNone, arm64.VectorIndexNone)
+		c.markRegisterUnused(w.register)
+	} else { // on stack
+		w.setRegister(r2)
+		c.compileLoadValueOnStackToRegister(w)
+	}
+
+	c.locationStack.markRegisterUsed(r1, r2)
+
+	result, err := c.allocateRegister(registerTypeVector)
+	if err != nil {
+		return err
+	}
+
+	c.assembler.CompileLoadStaticConstToVectorRegister(arm64.VMOV, o.Lanes[:], result, arm64.VectorArrangementQ)
+
+	var origin asm.Register
+	if r1 < r2 {
+		origin = r1
+	} else {
+		origin = r2
+	}
+	c.assembler.CompileVectorRegisterToVectorRegister(arm64.TBL2, origin, result, arm64.VectorArrangement16B,
+		arm64.VectorIndexNone, arm64.VectorIndexNone)
+
+	c.locationStack.markRegisterUnused(r1, r2)
+	c.pushVectorRuntimeValueLocationOnRegister(result)
+	return
+}
+
+// compileV128Swizzle implements compiler.compileV128Swizzle for arm64.
+func (c *arm64Compiler) compileV128Swizzle(o *wazeroir.OperationV128Swizzle) (err error) {
+	indexVec := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(indexVec); err != nil {
+		return
+	}
+	baseVec := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(baseVec); err != nil {
+		return
+	}
+
+	c.assembler.CompileVectorRegisterToVectorRegister(arm64.TBL1, baseVec.register, indexVec.register,
+		arm64.VectorArrangement16B, arm64.VectorIndexNone, arm64.VectorIndexNone)
+
+	c.markRegisterUnused(baseVec.register)
+	c.pushVectorRuntimeValueLocationOnRegister(indexVec.register)
+	return
+}
+
+// compileV128AnyTrue implements compiler.compileV128AnyTrue for arm64.
+func (c *arm64Compiler) compileV128AnyTrue(*wazeroir.OperationV128AnyTrue) (err error) {
+	vector := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(vector); err != nil {
+		return
+	}
+
+	v := vector.register
+	c.assembler.CompileVectorRegisterToVectorRegister(arm64.UMAXP, v, v,
+		arm64.VectorArrangement16B, arm64.VectorIndexNone, arm64.VectorIndexNone)
+	c.assembler.CompileVectorRegisterToRegister(arm64.VMOV, v, arm64ReservedRegisterForTemporary,
+		arm64.VectorArrangementD, 0)
+	c.assembler.CompileTwoRegistersToNone(arm64.CMP, arm64.RegRZR, arm64ReservedRegisterForTemporary)
+	c.locationStack.pushRuntimeValueLocationOnConditionalRegister(arm64.CondNE)
+
+	c.locationStack.markRegisterUnused(v)
+	return
+}
+
+// compileV128AllTrue implements compiler.compileV128AllTrue for arm64.
+func (c *arm64Compiler) compileV128AllTrue(o *wazeroir.OperationV128AllTrue) (err error) {
+	vector := c.locationStack.popV128()
+	if err = c.compileEnsureOnGeneralPurposeRegister(vector); err != nil {
+		return
+	}
+
+	v := vector.register
+	if o.Shape == wazeroir.ShapeI64x2 {
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.CMEQ, arm64.RegRZR, v,
+			arm64.VectorArrangementNone, arm64.VectorIndexNone, arm64.VectorIndexNone)
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.ADDP, v, v,
+			arm64.VectorArrangementD, arm64.VectorIndexNone, arm64.VectorIndexNone)
+		c.assembler.CompileTwoRegistersToNone(arm64.FCMPD, v, v)
+		c.locationStack.pushRuntimeValueLocationOnConditionalRegister(arm64.CondEQ)
+	} else {
+		var arr arm64.VectorArrangement
+		switch o.Shape {
+		case wazeroir.ShapeI8x16:
+			arr = arm64.VectorArrangement16B
+		case wazeroir.ShapeI16x8:
+			arr = arm64.VectorArrangement8H
+		case wazeroir.ShapeI32x4:
+			arr = arm64.VectorArrangement4S
+		}
+
+		c.assembler.CompileVectorRegisterToVectorRegister(arm64.UMINV, v, v,
+			arr, arm64.VectorIndexNone, arm64.VectorIndexNone)
+		c.assembler.CompileVectorRegisterToRegister(arm64.VMOV, v, arm64ReservedRegisterForTemporary,
+			arm64.VectorArrangementD, 0)
+		c.assembler.CompileTwoRegistersToNone(arm64.CMP, arm64.RegRZR, arm64ReservedRegisterForTemporary)
+		c.locationStack.pushRuntimeValueLocationOnConditionalRegister(arm64.CondNE)
+	}
+	c.markRegisterUnused(v)
+	return
 }

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -1,8 +1,6 @@
 package compiler
 
 import (
-	"fmt"
-
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/arm64"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -92,9 +90,6 @@ func (c *arm64Compiler) compileV128Sub(o *wazeroir.OperationV128Sub) (err error)
 	if err := c.compileEnsureOnGeneralPurposeRegister(x1); err != nil {
 		return err
 	}
-
-	fmt.Println(arm64.RegisterName(x1.register))
-	fmt.Println(arm64.RegisterName(x2.register))
 
 	var arr arm64.VectorArrangement
 	var inst asm.Instruction

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -1,0 +1,65 @@
+package compiler
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/asm/arm64"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
+)
+
+// TestArm64Compiler_V128Shuffle_ConstTable_MiddleOfFunction ensures that flushing constant table in the middle of
+// function works well by intentionally setting arm64.AssemblerImpl MaxDisplacementForConstantPool = 0.
+func TestArm64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
+	env := newCompilerEnvironment()
+	compiler := env.requireNewCompiler(t, newCompiler,
+		&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
+
+	lanes := [16]byte{1, 1, 1, 1, 0, 0, 0, 0, 10, 10, 10, 10, 0, 0, 0, 0}
+	v := [16]byte{0: 0xa, 1: 0xb, 10: 0xc}
+	w := [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	exp := [16]byte{
+		0xb, 0xb, 0xb, 0xb,
+		0xa, 0xa, 0xa, 0xa,
+		0xc, 0xc, 0xc, 0xc,
+		0xa, 0xa, 0xa, 0xa,
+	}
+
+	err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+		Lo: binary.LittleEndian.Uint64(v[:8]),
+		Hi: binary.LittleEndian.Uint64(v[8:]),
+	})
+	require.NoError(t, err)
+
+	err = compiler.compileV128Const(&wazeroir.OperationV128Const{
+		Lo: binary.LittleEndian.Uint64(w[:8]),
+		Hi: binary.LittleEndian.Uint64(w[8:]),
+	})
+	require.NoError(t, err)
+
+	err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: lanes})
+	require.NoError(t, err)
+
+	assembler := compiler.(*arm64Compiler).assembler.(*arm64.AssemblerImpl)
+	assembler.MaxDisplacementForConstantPool = 0 // Ensures that constant table for shuffle will be flushed immediately.
+
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
+
+	// Generate and run the code under test.
+	code, _, _, err := compiler.compile()
+	require.NoError(t, err)
+
+	env.exec(code)
+
+	lo, hi := env.stackTopAsV128()
+	var actual [16]byte
+	binary.LittleEndian.PutUint64(actual[:8], lo)
+	binary.LittleEndian.PutUint64(actual[8:], hi)
+	require.Equal(t, exp, actual)
+}

--- a/internal/integration_test/asm/amd64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/amd64_debug/debug_assembler.go
@@ -191,10 +191,10 @@ func (ta *testAssembler) CompileReadInstructionAddress(
 func (ta *testAssembler) CompileRegisterToRegisterWithArg(
 	instruction asm.Instruction,
 	from, to asm.Register,
-	mode asm_amd64.Mode,
+	arg byte,
 ) {
-	ta.goasm.CompileRegisterToRegisterWithArg(instruction, from, to, mode)
-	ta.a.CompileRegisterToRegisterWithArg(instruction, from, to, mode)
+	ta.goasm.CompileRegisterToRegisterWithArg(instruction, from, to, arg)
+	ta.a.CompileRegisterToRegisterWithArg(instruction, from, to, arg)
 }
 
 // CompileMemoryWithIndexToRegister implements the same method as documented on asm_amd64.Assembler.
@@ -210,6 +210,20 @@ func (ta *testAssembler) CompileMemoryWithIndexToRegister(
 	ta.a.CompileMemoryWithIndexToRegister(instruction, srcBaseReg, srcOffsetConst, srcIndex, srcScale, dstReg)
 }
 
+// CompileMemoryWithIndexAndArgToRegister implements the same method as documented on asm_amd64.Assembler.
+func (ta *testAssembler) CompileMemoryWithIndexAndArgToRegister(
+	instruction asm.Instruction,
+	srcBaseReg asm.Register,
+	srcOffsetConst int64,
+	srcIndex asm.Register,
+	srcScale int16,
+	dstReg asm.Register,
+	arg byte,
+) {
+	ta.goasm.CompileMemoryWithIndexAndArgToRegister(instruction, srcBaseReg, srcOffsetConst, srcIndex, srcScale, dstReg, arg)
+	ta.a.CompileMemoryWithIndexAndArgToRegister(instruction, srcBaseReg, srcOffsetConst, srcIndex, srcScale, dstReg, arg)
+}
+
 // CompileRegisterToMemoryWithIndex implements the same method as documented on asm_amd64.Assembler.
 func (ta *testAssembler) CompileRegisterToMemoryWithIndex(
 	instruction asm.Instruction,
@@ -220,6 +234,19 @@ func (ta *testAssembler) CompileRegisterToMemoryWithIndex(
 ) {
 	ta.goasm.CompileRegisterToMemoryWithIndex(instruction, srcReg, dstBaseReg, dstOffsetConst, dstIndex, dstScale)
 	ta.a.CompileRegisterToMemoryWithIndex(instruction, srcReg, dstBaseReg, dstOffsetConst, dstIndex, dstScale)
+}
+
+// CompileRegisterToMemoryWithIndexAndArg implements the same method as documented on asm_amd64.Assembler.
+func (ta *testAssembler) CompileRegisterToMemoryWithIndexAndArg(
+	instruction asm.Instruction,
+	srcReg, dstBaseReg asm.Register,
+	dstOffsetConst int64,
+	dstIndex asm.Register,
+	dstScale int16,
+	arg byte,
+) {
+	ta.goasm.CompileRegisterToMemoryWithIndexAndArg(instruction, srcReg, dstBaseReg, dstOffsetConst, dstIndex, dstScale, arg)
+	ta.a.CompileRegisterToMemoryWithIndexAndArg(instruction, srcReg, dstBaseReg, dstOffsetConst, dstIndex, dstScale, arg)
 }
 
 // CompileRegisterToConst implements the same method as documented on asm_amd64.Assembler.
@@ -272,4 +299,9 @@ func (ta *testAssembler) CompileMemoryToConst(
 	ret := ta.goasm.CompileMemoryToConst(instruction, srcBaseReg, srcOffset, value)
 	ret2 := ta.a.CompileMemoryToConst(instruction, srcBaseReg, srcOffset, value)
 	return &testNode{goasm: ret.(*golang_asm.GolangAsmNode), n: ret2.(*asm_amd64.NodeImpl)}
+}
+
+// CompileLoadStaticConstToRegister implements Assembler.CompileLoadStaticConstToRegister.
+func (ta *testAssembler) CompileLoadStaticConstToRegister(asm.Instruction, []byte, asm.Register) (err error) {
+	panic("CompileLoadStaticConstToRegister cannot be supported by golang-asm")
 }

--- a/internal/integration_test/asm/amd64_debug/golang_asm.go
+++ b/internal/integration_test/asm/amd64_debug/golang_asm.go
@@ -62,6 +62,34 @@ func (a *assemblerGoAsmImpl) CompileMemoryWithIndexToRegister(
 	a.AddInstruction(p)
 }
 
+// CompileMemoryWithIndexAndArgToRegister implements the same method as documented on amd64.Assembler.
+func (a *assemblerGoAsmImpl) CompileMemoryWithIndexAndArgToRegister(
+	inst asm.Instruction,
+	sourceBaseReg asm.Register,
+	sourceOffsetConst asm.ConstantValue,
+	sourceIndexReg asm.Register,
+	sourceScale int16,
+	destinationReg asm.Register,
+	arg byte,
+) {
+	p := a.NewProg()
+	p.As = castAsGolangAsmInstruction[inst]
+	p.To.Type = obj.TYPE_REG
+	p.To.Reg = castAsGolangAsmRegister[destinationReg]
+	p.RestArgs = append(p.RestArgs,
+		obj.Addr{
+			Reg:    castAsGolangAsmRegister[sourceBaseReg],
+			Offset: sourceOffsetConst,
+			Index:  castAsGolangAsmRegister[sourceIndexReg],
+			Scale:  sourceScale,
+			Type:   obj.TYPE_MEM,
+		})
+
+	p.From.Type = obj.TYPE_CONST
+	p.From.Offset = int64(arg)
+	a.AddInstruction(p)
+}
+
 // CompileRegisterToMemoryWithIndex implements the same method as documented on amd64.Assembler.
 func (a *assemblerGoAsmImpl) CompileRegisterToMemoryWithIndex(
 	inst asm.Instruction,
@@ -74,6 +102,30 @@ func (a *assemblerGoAsmImpl) CompileRegisterToMemoryWithIndex(
 	p.As = castAsGolangAsmInstruction[inst]
 	p.From.Type = obj.TYPE_REG
 	p.From.Reg = castAsGolangAsmRegister[srcReg]
+	p.To.Type = obj.TYPE_MEM
+	p.To.Reg = castAsGolangAsmRegister[dstBaseReg]
+	p.To.Offset = dstOffsetConst
+	p.To.Index = castAsGolangAsmRegister[dstIndexReg]
+	p.To.Scale = dstScale
+	a.AddInstruction(p)
+}
+
+// CompileRegisterToMemoryWithIndexAndArg implements the same method as documented on amd64.Assembler.
+func (a *assemblerGoAsmImpl) CompileRegisterToMemoryWithIndexAndArg(
+	inst asm.Instruction,
+	srcReg, dstBaseReg asm.Register,
+	dstOffsetConst asm.ConstantValue,
+	dstIndexReg asm.Register,
+	dstScale int16,
+	arg byte,
+) {
+	p := a.NewProg()
+	p.As = castAsGolangAsmInstruction[inst]
+	p.From.Type = obj.TYPE_CONST
+	p.From.Offset = int64(arg)
+	p.RestArgs = append(p.RestArgs,
+		obj.Addr{Reg: castAsGolangAsmRegister[srcReg], Type: obj.TYPE_REG})
+
 	p.To.Type = obj.TYPE_MEM
 	p.To.Reg = castAsGolangAsmRegister[dstBaseReg]
 	p.To.Offset = dstOffsetConst
@@ -261,12 +313,13 @@ func (a *assemblerGoAsmImpl) CompileRegisterToRegisterWithArg(
 	from, to asm.Register,
 	arg byte,
 ) {
+
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
-	p.From.Type = obj.TYPE_CONST
-	p.From.Offset = int64(arg)
 	p.To.Type = obj.TYPE_REG
 	p.To.Reg = castAsGolangAsmRegister[to]
+	p.From.Type = obj.TYPE_CONST
+	p.From.Offset = int64(arg)
 	p.RestArgs = append(p.RestArgs,
 		obj.Addr{Reg: castAsGolangAsmRegister[from], Type: obj.TYPE_REG})
 	a.AddInstruction(p)
@@ -326,6 +379,11 @@ func (a *assemblerGoAsmImpl) CompileReadInstructionAddress(
 		code[readInstructionAddress.Pc+2] &= 0b01111111
 		return nil
 	})
+}
+
+// CompileLoadStaticConstToRegister implements Assembler.CompileLoadStaticConstToRegister.
+func (a *assemblerGoAsmImpl) CompileLoadStaticConstToRegister(instruction asm.Instruction, c []byte, dstReg asm.Register) (err error) {
+	panic("CompileLoadStaticConstToRegister cannot be supported by golangasm")
 }
 
 // castAsGolangAsmRegister maps the registers to golang-asm specific register values.
@@ -497,6 +555,9 @@ var castAsGolangAsmInstruction = [...]obj.As{
 	amd64.XORPD:     x86.AXORPD,
 	amd64.XORPS:     x86.AXORPS,
 	amd64.XORQ:      x86.AXORQ,
+	amd64.PINSRB:    x86.APINSRB,
+	amd64.PINSRW:    x86.APINSRW,
+	amd64.PINSRD:    x86.APINSRD,
 	amd64.PINSRQ:    x86.APINSRQ,
 	amd64.PADDB:     x86.APADDB,
 	amd64.PADDW:     x86.APADDW,
@@ -504,4 +565,32 @@ var castAsGolangAsmInstruction = [...]obj.As{
 	amd64.PADDQ:     x86.APADDQ,
 	amd64.ADDPS:     x86.AADDPS,
 	amd64.ADDPD:     x86.AADDPD,
+	amd64.PSUBB:     x86.APSUBB,
+	amd64.PSUBW:     x86.APSUBW,
+	amd64.PSUBL:     x86.APSUBL,
+	amd64.PSUBQ:     x86.APSUBQ,
+	amd64.SUBPS:     x86.ASUBPS,
+	amd64.SUBPD:     x86.ASUBPD,
+	amd64.PMOVSXBW:  x86.APMOVSXBW,
+	amd64.PMOVSXWD:  x86.APMOVSXWD,
+	amd64.PMOVSXDQ:  x86.APMOVSXDQ,
+	amd64.PMOVZXBW:  x86.APMOVZXBW,
+	amd64.PMOVZXWD:  x86.APMOVZXWD,
+	amd64.PMOVZXDQ:  x86.APMOVZXDQ,
+	amd64.PSHUFB:    x86.APSHUFB,
+	amd64.PSHUFD:    x86.APSHUFD,
+	amd64.PXOR:      x86.APXOR,
+	amd64.PEXTRB:    x86.APEXTRB,
+	amd64.PEXTRW:    x86.APEXTRW,
+	amd64.PEXTRD:    x86.APEXTRD,
+	amd64.PEXTRQ:    x86.APEXTRQ,
+	amd64.MOVLHPS:   x86.AMOVLHPS,
+	amd64.INSERTPS:  x86.AINSERTPS,
+	amd64.PTEST:     x86.APTEST,
+	amd64.PCMPEQB:   x86.APCMPEQB,
+	amd64.PCMPEQW:   x86.APCMPEQW,
+	amd64.PCMPEQD:   x86.APCMPEQL,
+	amd64.PCMPEQQ:   x86.APCMPEQQ,
+	amd64.PADDUSB:   x86.APADDUSB,
+	amd64.MOVSD:     x86.AMOVSD,
 }

--- a/internal/integration_test/asm/amd64_debug/golang_asm.go
+++ b/internal/integration_test/asm/amd64_debug/golang_asm.go
@@ -313,7 +313,6 @@ func (a *assemblerGoAsmImpl) CompileRegisterToRegisterWithArg(
 	from, to asm.Register,
 	arg byte,
 ) {
-
 	p := a.NewProg()
 	p.As = castAsGolangAsmInstruction[inst]
 	p.To.Type = obj.TYPE_REG

--- a/internal/integration_test/asm/amd64_debug/impl_test.go
+++ b/internal/integration_test/asm/amd64_debug/impl_test.go
@@ -816,8 +816,20 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		{instruction: amd64.PADDQ, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.ADDPS, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.ADDPD, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PSUBB, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PSUBW, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PSUBL, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PSUBQ, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.SUBPS, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.SUBPD, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.PINSRQ, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 1},
 		{instruction: amd64.PINSRQ, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 0},
+		{instruction: amd64.PINSRD, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 1},
+		{instruction: amd64.PINSRD, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 0},
+		{instruction: amd64.PINSRW, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 1},
+		{instruction: amd64.PINSRW, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 0},
+		{instruction: amd64.PINSRB, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 1},
+		{instruction: amd64.PINSRB, srcRegs: intRegisters, DstRegs: floatRegisters, arg: 0},
 		{instruction: amd64.ADDL, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.ADDQ, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.ADDSD, srcRegs: floatRegisters, DstRegs: floatRegisters},
@@ -852,6 +864,7 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		{instruction: amd64.MAXSS, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.MINSS, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.MOVBLSX, srcRegs: intRegisters, DstRegs: intRegisters},
+		{instruction: amd64.MOVWLZX, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.MOVBLZX, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.MOVBQSX, srcRegs: intRegisters, DstRegs: intRegisters},
 		{instruction: amd64.MOVLQSX, srcRegs: intRegisters, DstRegs: intRegisters},
@@ -905,6 +918,24 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		{instruction: amd64.XORPD, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.XORPS, srcRegs: floatRegisters, DstRegs: floatRegisters},
 		{instruction: amd64.XORQ, srcRegs: intRegisters, DstRegs: intRegisters},
+		{instruction: amd64.PXOR, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PSHUFB, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PSHUFD, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0},
+		{instruction: amd64.PSHUFD, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 1},
+		{instruction: amd64.PEXTRB, srcRegs: floatRegisters, DstRegs: intRegisters, arg: 0},
+		{instruction: amd64.PEXTRW, srcRegs: floatRegisters, DstRegs: intRegisters, arg: 1},
+		{instruction: amd64.PEXTRD, srcRegs: floatRegisters, DstRegs: intRegisters, arg: 1},
+		{instruction: amd64.PEXTRQ, srcRegs: floatRegisters, DstRegs: intRegisters, arg: 1},
+		{instruction: amd64.MOVLHPS, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.INSERTPS, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 0},
+		{instruction: amd64.INSERTPS, srcRegs: floatRegisters, DstRegs: floatRegisters, arg: 1},
+		{instruction: amd64.PTEST, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PCMPEQB, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PCMPEQW, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PCMPEQD, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PCMPEQQ, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.PADDUSB, srcRegs: floatRegisters, DstRegs: floatRegisters},
+		{instruction: amd64.MOVSD, srcRegs: floatRegisters, DstRegs: floatRegisters},
 	}
 
 	for _, tt := range tests {
@@ -961,11 +992,16 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 							// TODO: remove golang-asm dependency in tests.
 							goasm, err := newGolangAsmAssembler()
 							require.NoError(t, err)
-							if tc.instruction == amd64.ROUNDSD || tc.instruction == amd64.ROUNDSS || tc.instruction == amd64.PINSRQ {
+
+							switch tc.instruction {
+							case amd64.ROUNDSD, amd64.ROUNDSS, amd64.PINSRQ, amd64.PINSRD, amd64.PINSRW,
+								amd64.PINSRB, amd64.PSHUFD, amd64.PEXTRB, amd64.PEXTRW, amd64.PEXTRD, amd64.PEXTRQ,
+								amd64.INSERTPS:
 								goasm.CompileRegisterToRegisterWithArg(tc.instruction, srcReg, DstReg, tc.arg)
-							} else {
+							default:
 								goasm.CompileRegisterToRegister(tc.instruction, srcReg, DstReg)
 							}
+
 							bs, err := goasm.Assemble()
 							require.NoError(t, err)
 
@@ -975,12 +1011,119 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 								Arg: tc.arg,
 							})
 							require.NoError(t, err)
-							// fmt.Printf("modRM: want: 0b%b, got: 0b%b\n", bs[1], a.Buf.Bytes()[1])
 							require.Equal(t, bs, a.Buf.Bytes())
 						})
 					}
 				})
 			}
+		})
+	}
+}
+
+func TestAssemblerImpl_CompileMemoryWithIndexAndArgToRegister(t *testing.T) {
+	tests := []struct {
+		name        string
+		instruction asm.Instruction
+	}{
+		{name: "PINSRB", instruction: amd64.PINSRB},
+		{name: "PINSRW", instruction: amd64.PINSRW},
+		{name: "PINSRD", instruction: amd64.PINSRD},
+		{name: "PINSRQ", instruction: amd64.PINSRQ},
+	}
+
+	dstRegs := []asm.Register{amd64.RegX0, amd64.RegX13}
+	indexRegs := []asm.Register{amd64.RegR12, amd64.RegAX, amd64.RegBP, amd64.RegSI}
+	offsets := []int64{0, 1, math.MaxInt32}
+	args := []byte{0, 1}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			for _, dstReg := range dstRegs {
+				for _, indexReg := range indexRegs {
+					for _, offset := range offsets {
+						for _, arg := range args {
+							dstReg, indexReg, offset, arg := dstReg, indexReg, offset, arg
+							t.Run(fmt.Sprintf("dst=%s,index=%s,offset=%d,arg=%d",
+								amd64.RegisterName(dstReg), amd64.RegisterName(indexReg), offset, arg), func(t *testing.T) {
+
+								goasm, err := newGolangAsmAssembler()
+								require.NoError(t, err)
+
+								a := amd64.NewAssemblerImpl()
+								for _, assembler := range []amd64.Assembler{goasm, a} {
+									assembler.CompileMemoryWithIndexAndArgToRegister(tc.instruction,
+										amd64.RegAX, offset, amd64.RegCX, 1, dstReg, arg)
+								}
+
+								actual, err := a.Assemble()
+								require.NoError(t, err)
+								expected, err := goasm.Assemble()
+								require.NoError(t, err)
+
+								require.Equal(t, expected, actual)
+							})
+						}
+
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func TestAssemblerImpl_CompileRegisterToMemoryWithIndexAndArg(t *testing.T) {
+	tests := []struct {
+		name        string
+		instruction asm.Instruction
+	}{
+		{name: "PEXTRB", instruction: amd64.PEXTRB},
+		{name: "PEXTRW", instruction: amd64.PEXTRW},
+		{name: "PEXTRD", instruction: amd64.PEXTRD},
+		{name: "PEXTRQ", instruction: amd64.PEXTRQ},
+	}
+
+	srcRegs := []asm.Register{amd64.RegX0, amd64.RegX13}
+	indexRegs := []asm.Register{amd64.RegR12, amd64.RegAX, amd64.RegBP, amd64.RegSI}
+	offsets := []int64{0, 1, math.MaxInt32}
+	args := []byte{0, 1}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			for _, srcReg := range srcRegs {
+				for _, indexReg := range indexRegs {
+					for _, offset := range offsets {
+						for _, arg := range args {
+							srcReg, indexReg, offset, arg := srcReg, indexReg, offset, arg
+							t.Run(fmt.Sprintf("src=%s,index=%s,offset=%d,arg=%d",
+								amd64.RegisterName(srcReg), amd64.RegisterName(indexReg), offset, arg), func(t *testing.T) {
+
+								goasm, err := newGolangAsmAssembler()
+								require.NoError(t, err)
+
+								a := amd64.NewAssemblerImpl()
+								for _, assembler := range []amd64.Assembler{goasm, a} {
+									assembler.CompileRegisterToMemoryWithIndexAndArg(tc.instruction, srcReg,
+										amd64.RegCX, offset, indexReg, 1, arg)
+								}
+
+								actual, err := a.Assemble()
+								require.NoError(t, err)
+								expected, err := goasm.Assemble()
+								require.NoError(t, err)
+
+								require.Equal(t, expected, actual)
+							})
+						}
+
+					}
+				}
+			}
+
 		})
 	}
 }
@@ -1256,7 +1399,7 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 		a := amd64.NewAssemblerImpl()
 		require.EqualError(t, a.EncodeMemoryToRegister(n), "JMP is unsupported for from:memory,to:register type")
 	})
-	intRegs := []asm.Register{amd64.RegAX, amd64.RegBP, amd64.RegSI, amd64.RegDI, amd64.RegR10}
+	intRegs := []asm.Register{amd64.RegAX, amd64.RegBP, amd64.RegDI, amd64.RegR10}
 	floatRegs := []asm.Register{amd64.RegX0, amd64.RegX8}
 	scales := []byte{1, 4}
 	tests := []struct {
@@ -1285,6 +1428,12 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 		{instruction: amd64.SUBSS, isFloatInst: true},
 		{instruction: amd64.UCOMISD, isFloatInst: true},
 		{instruction: amd64.UCOMISS, isFloatInst: true},
+		{instruction: amd64.PMOVSXBW, isFloatInst: true},
+		{instruction: amd64.PMOVSXWD, isFloatInst: true},
+		{instruction: amd64.PMOVSXDQ, isFloatInst: true},
+		{instruction: amd64.PMOVZXBW, isFloatInst: true},
+		{instruction: amd64.PMOVZXWD, isFloatInst: true},
+		{instruction: amd64.PMOVZXDQ, isFloatInst: true},
 	}
 
 	for _, tt := range tests {

--- a/internal/integration_test/asm/arm64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/arm64_debug/debug_assembler.go
@@ -255,16 +255,18 @@ func (ta *testAssembler) CompileConditionalRegisterSet(cond asm.ConditionalRegis
 	ta.a.CompileConditionalRegisterSet(cond, dstReg)
 }
 
-func (ta *testAssembler) CompileMemoryToVectorRegister(instruction asm.Instruction, srcOffsetReg, dstReg asm.Register,
+func (ta *testAssembler) CompileMemoryToVectorRegister(instruction asm.Instruction, srcOffsetReg asm.Register,
+	c asm.ConstantValue, dstReg asm.Register,
 	arrangement arm64.VectorArrangement) {
-	ta.goasm.CompileMemoryToVectorRegister(instruction, srcOffsetReg, dstReg, arrangement)
-	ta.a.CompileMemoryToVectorRegister(instruction, srcOffsetReg, dstReg, arrangement)
+	ta.goasm.CompileMemoryToVectorRegister(instruction, srcOffsetReg, c, dstReg, arrangement)
+	ta.a.CompileMemoryToVectorRegister(instruction, srcOffsetReg, c, dstReg, arrangement)
 }
 
 func (ta *testAssembler) CompileVectorRegisterToMemory(instruction asm.Instruction, srcReg, dstOffsetReg asm.Register,
+	c asm.ConstantValue,
 	arrangement arm64.VectorArrangement) {
-	ta.goasm.CompileVectorRegisterToMemory(instruction, srcReg, dstOffsetReg, arrangement)
-	ta.a.CompileVectorRegisterToMemory(instruction, srcReg, dstOffsetReg, arrangement)
+	ta.goasm.CompileVectorRegisterToMemory(instruction, srcReg, dstOffsetReg, c, arrangement)
+	ta.a.CompileVectorRegisterToMemory(instruction, srcReg, dstOffsetReg, c, arrangement)
 }
 
 func (ta *testAssembler) CompileRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
@@ -274,7 +276,36 @@ func (ta *testAssembler) CompileRegisterToVectorRegister(instruction asm.Instruc
 }
 
 func (ta *testAssembler) CompileVectorRegisterToVectorRegister(instruction asm.Instruction, srcReg, dstReg asm.Register,
-	arrangement arm64.VectorArrangement) {
-	ta.goasm.CompileVectorRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement)
-	ta.a.CompileVectorRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement)
+	arrangement arm64.VectorArrangement, srcIndex, dstIndex arm64.VectorIndex) {
+	ta.goasm.CompileVectorRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement, srcIndex, dstIndex)
+	ta.a.CompileVectorRegisterToVectorRegister(instruction, srcReg, dstReg, arrangement, srcIndex, dstIndex)
+}
+
+func (ta *testAssembler) CompileVectorRegisterToVectorRegisterWithConst(instruction asm.Instruction, srcReg, dstReg asm.Register,
+	arrangement arm64.VectorArrangement, c asm.ConstantValue) {
+	ta.goasm.CompileVectorRegisterToVectorRegisterWithConst(instruction, srcReg, dstReg, arrangement, c)
+	ta.a.CompileVectorRegisterToVectorRegisterWithConst(instruction, srcReg, dstReg, arrangement, c)
+}
+
+func (ta *testAssembler) CompileMemoryWithRegisterOffsetToVectorRegister(instruction asm.Instruction, srcBaseReg, srcOffsetRegister asm.Register, dstReg asm.Register, arrangement arm64.VectorArrangement) {
+	ta.goasm.CompileMemoryWithRegisterOffsetToVectorRegister(instruction, srcBaseReg, srcOffsetRegister, dstReg, arrangement)
+	ta.a.CompileMemoryWithRegisterOffsetToVectorRegister(instruction, srcBaseReg, srcOffsetRegister, dstReg, arrangement)
+}
+
+func (ta *testAssembler) CompileVectorRegisterToMemoryWithRegisterOffset(instruction asm.Instruction, srcReg, dstBaseReg, dstOffsetRegister asm.Register, arrangement arm64.VectorArrangement) {
+	ta.goasm.CompileVectorRegisterToMemoryWithRegisterOffset(instruction, srcReg, dstBaseReg, dstOffsetRegister, arrangement)
+	ta.a.CompileVectorRegisterToMemoryWithRegisterOffset(instruction, srcReg, dstBaseReg, dstOffsetRegister, arrangement)
+}
+
+func (ta *testAssembler) CompileVectorRegisterToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register, arrangement arm64.VectorArrangement, index arm64.VectorIndex) {
+	ta.goasm.CompileVectorRegisterToRegister(instruction, srcReg, dstReg, arrangement, index)
+	ta.a.CompileVectorRegisterToRegister(instruction, srcReg, dstReg, arrangement, index)
+}
+
+// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
+// and the destination is the dstReg.
+func (ta *testAssembler) CompileLoadStaticConstToVectorRegister(instruction asm.Instruction,
+	c asm.StaticConst, dstReg asm.Register, arrangement arm64.VectorArrangement) {
+	ta.goasm.CompileLoadStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
+	ta.a.CompileLoadStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
 }

--- a/internal/integration_test/asm/arm64_debug/impl_test.go
+++ b/internal/integration_test/asm/arm64_debug/impl_test.go
@@ -1395,8 +1395,6 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 						expected, err := goasm.Assemble()
 						require.NoError(t, err)
 
-						fmt.Println(hex.EncodeToString(expected))
-
 						actual, err := a.Assemble()
 						require.NoError(t, err)
 						require.Equal(t, expected, actual, hex.EncodeToString(expected))

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -27,7 +27,27 @@ func TestCompiler(t *testing.T) {
 	spectest.Run(t, testcases, compiler.NewEngine, enabledFeatures, func(jsonname string) bool {
 		// TODO: remove after SIMD proposal
 		if strings.Contains(jsonname, "simd") {
-			return path.Base(jsonname) == "simd_const.json"
+			switch path.Base(jsonname) {
+			case "simd_address.json":
+			case "simd_const.json":
+			case "simd_align.json":
+			case "simd_load16_lane.json":
+			case "simd_load32_lane.json":
+			case "simd_load64_lane.json":
+			case "simd_load8_lane.json":
+			case "simd_lane.json":
+			case "simd_load_extend.json":
+			case "simd_load_splat.json":
+			case "simd_load_zero.json":
+			case "simd_store.json":
+			case "simd_store16_lane.json":
+			case "simd_store32_lane.json":
+			case "simd_store64_lane.json":
+			case "simd_store8_lane.json":
+			default:
+				return false
+			}
+			return true
 		}
 		return true
 	})
@@ -37,7 +57,27 @@ func TestInterpreter(t *testing.T) {
 	spectest.Run(t, testcases, interpreter.NewEngine, enabledFeatures, func(jsonname string) bool {
 		// TODO: remove after SIMD proposal
 		if strings.Contains(jsonname, "simd") {
-			return path.Base(jsonname) == "simd_const.json"
+			switch path.Base(jsonname) {
+			case "simd_address.json":
+			case "simd_const.json":
+			case "simd_align.json":
+			case "simd_load16_lane.json":
+			case "simd_load32_lane.json":
+			case "simd_load64_lane.json":
+			case "simd_load8_lane.json":
+			case "simd_lane.json":
+			case "simd_load_extend.json":
+			case "simd_load_splat.json":
+			case "simd_load_zero.json":
+			case "simd_store.json":
+			case "simd_store16_lane.json":
+			case "simd_store32_lane.json":
+			case "simd_store64_lane.json":
+			case "simd_store8_lane.json":
+			default:
+				return false
+			}
+			return true
 		}
 		return true
 	})

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -45,7 +45,7 @@ func TestCompiler(t *testing.T) {
 			case "simd_store64_lane.json":
 			case "simd_store8_lane.json":
 			default:
-				return false
+				return false // others not supported, yet!
 			}
 			return true
 		}

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -15,7 +15,7 @@ import (
 
 //go:embed testdata/*.wasm
 //go:embed testdata/*.json
-var testcases embed.FS //nolint:unused
+var testcases embed.FS
 
 const enabledFeatures = wasm.Features20220419
 

--- a/internal/wasm/instruction.go
+++ b/internal/wasm/instruction.go
@@ -330,12 +330,12 @@ const (
 	// Loads and stores.
 
 	OpcodeVecV128Load        OpcodeVec = 0x00
-	OpcodeVecV128Load8x8_s   OpcodeVec = 0x01
-	OpcodeVecV128Load8x8_u   OpcodeVec = 0x02
-	OpcodeVecV128Load16x4_s  OpcodeVec = 0x03
-	OpcodeVecV128Load16x4_u  OpcodeVec = 0x04
-	OpcodeVecV128Load32x2_s  OpcodeVec = 0x05
-	OpcodeVecV128Load32x2_u  OpcodeVec = 0x06
+	OpcodeVecV128Load8x8s    OpcodeVec = 0x01
+	OpcodeVecV128Load8x8u    OpcodeVec = 0x02
+	OpcodeVecV128Load16x4s   OpcodeVec = 0x03
+	OpcodeVecV128Load16x4u   OpcodeVec = 0x04
+	OpcodeVecV128Load32x2s   OpcodeVec = 0x05
+	OpcodeVecV128Load32x2u   OpcodeVec = 0x06
 	OpcodeVecV128Load8Splat  OpcodeVec = 0x07
 	OpcodeVecV128Load16Splat OpcodeVec = 0x08
 	OpcodeVecV128Load32Splat OpcodeVec = 0x09
@@ -593,21 +593,21 @@ const (
 
 	// f64 misc.
 
-	OpcodeVecF64x4Ceil    OpcodeVec = 0x74
-	OpcodeVecF64x4Floor   OpcodeVec = 0x75
-	OpcodeVecF64x4Trunc   OpcodeVec = 0x7a
-	OpcodeVecF64x4Nearest OpcodeVec = 0x94
-	OpcodeVecF64x4Abs     OpcodeVec = 0xec
-	OpcodeVecF64x4Neg     OpcodeVec = 0xed
-	OpcodeVecF64x4Sqrt    OpcodeVec = 0xef
-	OpcodeVecF64x4Add     OpcodeVec = 0xf0
-	OpcodeVecF64x4Sub     OpcodeVec = 0xf1
-	OpcodeVecF64x4Mul     OpcodeVec = 0xf2
-	OpcodeVecF64x4Div     OpcodeVec = 0xf3
-	OpcodeVecF64x4Min     OpcodeVec = 0xf4
-	OpcodeVecF64x4Max     OpcodeVec = 0xf5
-	OpcodeVecF64x4Pmin    OpcodeVec = 0xf6
-	OpcodeVecF64x4Pmax    OpcodeVec = 0xf7
+	OpcodeVecF64x2Ceil    OpcodeVec = 0x74
+	OpcodeVecF64x2Floor   OpcodeVec = 0x75
+	OpcodeVecF64x2Trunc   OpcodeVec = 0x7a
+	OpcodeVecF64x2Nearest OpcodeVec = 0x94
+	OpcodeVecF64x2Abs     OpcodeVec = 0xec
+	OpcodeVecF64x2Neg     OpcodeVec = 0xed
+	OpcodeVecF64x2Sqrt    OpcodeVec = 0xef
+	OpcodeVecF64x2Add     OpcodeVec = 0xf0
+	OpcodeVecF64x2Sub     OpcodeVec = 0xf1
+	OpcodeVecF64x2Mul     OpcodeVec = 0xf2
+	OpcodeVecF64x2Div     OpcodeVec = 0xf3
+	OpcodeVecF64x2Min     OpcodeVec = 0xf4
+	OpcodeVecF64x2Max     OpcodeVec = 0xf5
+	OpcodeVecF64x2Pmin    OpcodeVec = 0xf6
+	OpcodeVecF64x2Pmax    OpcodeVec = 0xf7
 
 	// conversions.
 
@@ -1068,12 +1068,12 @@ func MiscInstructionName(oc OpcodeMisc) string {
 
 const (
 	OpcodeVecV128LoadName                  = "v128.load"
-	OpcodeVecV128Load8x8_sName             = "v128.load8x8_s"
-	OpcodeVecV128Load8x8_uName             = "v128.load8x8_u"
-	OpcodeVecV128Load16x4_sName            = "v128.load16x4_s"
-	OpcodeVecV128Load16x4_uName            = "v128.load16x4_u"
-	OpcodeVecV128Load32x2_sName            = "v128.load32x2_s"
-	OpcodeVecV128Load32x2_uName            = "v128.load32x2_u"
+	OpcodeVecV128Load8x8SName              = "v128.load8x8_s"
+	OpcodeVecV128Load8x8UName              = "v128.load8x8_u"
+	OpcodeVecV128Load16x4SName             = "v128.load16x4_s"
+	OpcodeVecV128Load16x4UName             = "v128.load16x4_u"
+	OpcodeVecV128Load32x2SName             = "v128.load32x2_s"
+	OpcodeVecV128Load32x2UName             = "v128.load32x2_u"
 	OpcodeVecV128Load8SplatName            = "v128.load8_splat"
 	OpcodeVecV128Load16SplatName           = "v128.load16_splat"
 	OpcodeVecV128Load32SplatName           = "v128.load32_splat"
@@ -1096,7 +1096,7 @@ const (
 	OpcodeVecI8x16ReplaceLaneName          = "i8x16.replace_lane"
 	OpcodeVecI16x8ExtractLaneSName         = "i16x4.extract_lane_s"
 	OpcodeVecI16x8ExtractLaneUName         = "i16x4.extract_lane_u"
-	OpcodeVecI16x8ReplaceLaneName          = "i16x4.replace"
+	OpcodeVecI16x8ReplaceLaneName          = "i16x4.replace_lane"
 	OpcodeVecI32x4ExtractLaneName          = "i32x4.extract_lane"
 	OpcodeVecI32x4ReplaceLaneName          = "i32x4.replace_lane"
 	OpcodeVecI64x2ExtractLaneName          = "i64x2.extract_lane"
@@ -1278,21 +1278,21 @@ const (
 	OpcodeVecF32x4MaxName                  = "f32x4.max"
 	OpcodeVecF32x4PminName                 = "f32x4.pmin"
 	OpcodeVecF32x4PmaxName                 = "f32x4.pmax"
-	OpcodeVecF64x4CeilName                 = "f64x2.ceil"
-	OpcodeVecF64x4FloorName                = "f64x2.floor"
-	OpcodeVecF64x4TruncName                = "f64x2.trunc"
-	OpcodeVecF64x4NearestName              = "f64x2.nearest"
-	OpcodeVecF64x4AbsName                  = "f64x2.abs"
-	OpcodeVecF64x4NegName                  = "f64x2.neg"
-	OpcodeVecF64x4SqrtName                 = "f64x2.sqrt"
-	OpcodeVecF64x4AddName                  = "f64x2.add"
-	OpcodeVecF64x4SubName                  = "f64x2.sub"
-	OpcodeVecF64x4MulName                  = "f64x2.mul"
-	OpcodeVecF64x4DivName                  = "f64x2.div"
-	OpcodeVecF64x4MinName                  = "f64x2.min"
-	OpcodeVecF64x4MaxName                  = "f64x2.max"
-	OpcodeVecF64x4PminName                 = "f64x2.pmin"
-	OpcodeVecF64x4PmaxName                 = "f64x2.pmax"
+	OpcodeVecF64x2CeilName                 = "f64x2.ceil"
+	OpcodeVecF64x2FloorName                = "f64x2.floor"
+	OpcodeVecF64x2TruncName                = "f64x2.trunc"
+	OpcodeVecF64x2NearestName              = "f64x2.nearest"
+	OpcodeVecF64x2AbsName                  = "f64x2.abs"
+	OpcodeVecF64x2NegName                  = "f64x2.neg"
+	OpcodeVecF64x2SqrtName                 = "f64x2.sqrt"
+	OpcodeVecF64x2AddName                  = "f64x2.add"
+	OpcodeVecF64x2SubName                  = "f64x2.sub"
+	OpcodeVecF64x2MulName                  = "f64x2.mul"
+	OpcodeVecF64x2DivName                  = "f64x2.div"
+	OpcodeVecF64x2MinName                  = "f64x2.min"
+	OpcodeVecF64x2MaxName                  = "f64x2.max"
+	OpcodeVecF64x2PminName                 = "f64x2.pmin"
+	OpcodeVecF64x2PmaxName                 = "f64x2.pmax"
 	OpcodeVecI32x4TruncSatF32x4SName       = "i32x4.trunc_sat_f32x4_s"
 	OpcodeVecI32x4TruncSatF32x4UName       = "i32x4.trunc_sat_f32x4_u"
 	OpcodeVecF32x4ConvertI32x4SName        = "f32x4.convert_i32x4_s"
@@ -1307,12 +1307,12 @@ const (
 
 var vectorInstructionName = map[OpcodeVec]string{
 	OpcodeVecV128Load:                  OpcodeVecV128LoadName,
-	OpcodeVecV128Load8x8_s:             OpcodeVecV128Load8x8_sName,
-	OpcodeVecV128Load8x8_u:             OpcodeVecV128Load8x8_uName,
-	OpcodeVecV128Load16x4_s:            OpcodeVecV128Load16x4_sName,
-	OpcodeVecV128Load16x4_u:            OpcodeVecV128Load16x4_uName,
-	OpcodeVecV128Load32x2_s:            OpcodeVecV128Load32x2_sName,
-	OpcodeVecV128Load32x2_u:            OpcodeVecV128Load32x2_uName,
+	OpcodeVecV128Load8x8s:              OpcodeVecV128Load8x8SName,
+	OpcodeVecV128Load8x8u:              OpcodeVecV128Load8x8UName,
+	OpcodeVecV128Load16x4s:             OpcodeVecV128Load16x4SName,
+	OpcodeVecV128Load16x4u:             OpcodeVecV128Load16x4UName,
+	OpcodeVecV128Load32x2s:             OpcodeVecV128Load32x2SName,
+	OpcodeVecV128Load32x2u:             OpcodeVecV128Load32x2UName,
 	OpcodeVecV128Load8Splat:            OpcodeVecV128Load8SplatName,
 	OpcodeVecV128Load16Splat:           OpcodeVecV128Load16SplatName,
 	OpcodeVecV128Load32Splat:           OpcodeVecV128Load32SplatName,
@@ -1517,21 +1517,21 @@ var vectorInstructionName = map[OpcodeVec]string{
 	OpcodeVecF32x4Max:                  OpcodeVecF32x4MaxName,
 	OpcodeVecF32x4Pmin:                 OpcodeVecF32x4PminName,
 	OpcodeVecF32x4Pmax:                 OpcodeVecF32x4PmaxName,
-	OpcodeVecF64x4Ceil:                 OpcodeVecF64x4CeilName,
-	OpcodeVecF64x4Floor:                OpcodeVecF64x4FloorName,
-	OpcodeVecF64x4Trunc:                OpcodeVecF64x4TruncName,
-	OpcodeVecF64x4Nearest:              OpcodeVecF64x4NearestName,
-	OpcodeVecF64x4Abs:                  OpcodeVecF64x4AbsName,
-	OpcodeVecF64x4Neg:                  OpcodeVecF64x4NegName,
-	OpcodeVecF64x4Sqrt:                 OpcodeVecF64x4SqrtName,
-	OpcodeVecF64x4Add:                  OpcodeVecF64x4AddName,
-	OpcodeVecF64x4Sub:                  OpcodeVecF64x4SubName,
-	OpcodeVecF64x4Mul:                  OpcodeVecF64x4MulName,
-	OpcodeVecF64x4Div:                  OpcodeVecF64x4DivName,
-	OpcodeVecF64x4Min:                  OpcodeVecF64x4MinName,
-	OpcodeVecF64x4Max:                  OpcodeVecF64x4MaxName,
-	OpcodeVecF64x4Pmin:                 OpcodeVecF64x4PminName,
-	OpcodeVecF64x4Pmax:                 OpcodeVecF64x4PmaxName,
+	OpcodeVecF64x2Ceil:                 OpcodeVecF64x2CeilName,
+	OpcodeVecF64x2Floor:                OpcodeVecF64x2FloorName,
+	OpcodeVecF64x2Trunc:                OpcodeVecF64x2TruncName,
+	OpcodeVecF64x2Nearest:              OpcodeVecF64x2NearestName,
+	OpcodeVecF64x2Abs:                  OpcodeVecF64x2AbsName,
+	OpcodeVecF64x2Neg:                  OpcodeVecF64x2NegName,
+	OpcodeVecF64x2Sqrt:                 OpcodeVecF64x2SqrtName,
+	OpcodeVecF64x2Add:                  OpcodeVecF64x2AddName,
+	OpcodeVecF64x2Sub:                  OpcodeVecF64x2SubName,
+	OpcodeVecF64x2Mul:                  OpcodeVecF64x2MulName,
+	OpcodeVecF64x2Div:                  OpcodeVecF64x2DivName,
+	OpcodeVecF64x2Min:                  OpcodeVecF64x2MinName,
+	OpcodeVecF64x2Max:                  OpcodeVecF64x2MaxName,
+	OpcodeVecF64x2Pmin:                 OpcodeVecF64x2PminName,
+	OpcodeVecF64x2Pmax:                 OpcodeVecF64x2PmaxName,
 	OpcodeVecI32x4TruncSatF32x4S:       OpcodeVecI32x4TruncSatF32x4SName,
 	OpcodeVecI32x4TruncSatF32x4U:       OpcodeVecI32x4TruncSatF32x4UName,
 	OpcodeVecF32x4ConvertI32x4S:        OpcodeVecF32x4ConvertI32x4SName,

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -798,7 +798,7 @@ operatorSwitch:
 			&OperationGlobalSet{Index: *index},
 		)
 	case wasm.OpcodeI32Load:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32LoadName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32LoadName)
 		if err != nil {
 			return err
 		}
@@ -806,7 +806,7 @@ operatorSwitch:
 			&OperationLoad{Type: UnsignedTypeI32, Arg: imm},
 		)
 	case wasm.OpcodeI64Load:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64LoadName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64LoadName)
 		if err != nil {
 			return err
 		}
@@ -814,7 +814,7 @@ operatorSwitch:
 			&OperationLoad{Type: UnsignedTypeI64, Arg: imm},
 		)
 	case wasm.OpcodeF32Load:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeF32LoadName)
+		imm, err := c.readMemoryArg(wasm.OpcodeF32LoadName)
 		if err != nil {
 			return err
 		}
@@ -822,7 +822,7 @@ operatorSwitch:
 			&OperationLoad{Type: UnsignedTypeF32, Arg: imm},
 		)
 	case wasm.OpcodeF64Load:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeF64LoadName)
+		imm, err := c.readMemoryArg(wasm.OpcodeF64LoadName)
 		if err != nil {
 			return err
 		}
@@ -830,7 +830,7 @@ operatorSwitch:
 			&OperationLoad{Type: UnsignedTypeF64, Arg: imm},
 		)
 	case wasm.OpcodeI32Load8S:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32Load8SName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32Load8SName)
 		if err != nil {
 			return err
 		}
@@ -838,7 +838,7 @@ operatorSwitch:
 			&OperationLoad8{Type: SignedInt32, Arg: imm},
 		)
 	case wasm.OpcodeI32Load8U:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32Load8UName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32Load8UName)
 		if err != nil {
 			return err
 		}
@@ -846,7 +846,7 @@ operatorSwitch:
 			&OperationLoad8{Type: SignedUint32, Arg: imm},
 		)
 	case wasm.OpcodeI32Load16S:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32Load16SName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32Load16SName)
 		if err != nil {
 			return err
 		}
@@ -854,7 +854,7 @@ operatorSwitch:
 			&OperationLoad16{Type: SignedInt32, Arg: imm},
 		)
 	case wasm.OpcodeI32Load16U:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32Load16UName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32Load16UName)
 		if err != nil {
 			return err
 		}
@@ -862,7 +862,7 @@ operatorSwitch:
 			&OperationLoad16{Type: SignedUint32, Arg: imm},
 		)
 	case wasm.OpcodeI64Load8S:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Load8SName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Load8SName)
 		if err != nil {
 			return err
 		}
@@ -870,7 +870,7 @@ operatorSwitch:
 			&OperationLoad8{Type: SignedInt64, Arg: imm},
 		)
 	case wasm.OpcodeI64Load8U:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Load8UName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Load8UName)
 		if err != nil {
 			return err
 		}
@@ -878,7 +878,7 @@ operatorSwitch:
 			&OperationLoad8{Type: SignedUint64, Arg: imm},
 		)
 	case wasm.OpcodeI64Load16S:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Load16SName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Load16SName)
 		if err != nil {
 			return err
 		}
@@ -886,7 +886,7 @@ operatorSwitch:
 			&OperationLoad16{Type: SignedInt64, Arg: imm},
 		)
 	case wasm.OpcodeI64Load16U:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Load16UName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Load16UName)
 		if err != nil {
 			return err
 		}
@@ -894,7 +894,7 @@ operatorSwitch:
 			&OperationLoad16{Type: SignedUint64, Arg: imm},
 		)
 	case wasm.OpcodeI64Load32S:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Load32SName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Load32SName)
 		if err != nil {
 			return err
 		}
@@ -902,7 +902,7 @@ operatorSwitch:
 			&OperationLoad32{Signed: true, Arg: imm},
 		)
 	case wasm.OpcodeI64Load32U:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Load32UName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Load32UName)
 		if err != nil {
 			return err
 		}
@@ -910,7 +910,7 @@ operatorSwitch:
 			&OperationLoad32{Signed: false, Arg: imm},
 		)
 	case wasm.OpcodeI32Store:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32StoreName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32StoreName)
 		if err != nil {
 			return err
 		}
@@ -918,7 +918,7 @@ operatorSwitch:
 			&OperationStore{Type: UnsignedTypeI32, Arg: imm},
 		)
 	case wasm.OpcodeI64Store:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64StoreName)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64StoreName)
 		if err != nil {
 			return err
 		}
@@ -926,7 +926,7 @@ operatorSwitch:
 			&OperationStore{Type: UnsignedTypeI64, Arg: imm},
 		)
 	case wasm.OpcodeF32Store:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeF32StoreName)
+		imm, err := c.readMemoryArg(wasm.OpcodeF32StoreName)
 		if err != nil {
 			return err
 		}
@@ -934,7 +934,7 @@ operatorSwitch:
 			&OperationStore{Type: UnsignedTypeF32, Arg: imm},
 		)
 	case wasm.OpcodeF64Store:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeF64StoreName)
+		imm, err := c.readMemoryArg(wasm.OpcodeF64StoreName)
 		if err != nil {
 			return err
 		}
@@ -942,7 +942,7 @@ operatorSwitch:
 			&OperationStore{Type: UnsignedTypeF64, Arg: imm},
 		)
 	case wasm.OpcodeI32Store8:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32Store8Name)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32Store8Name)
 		if err != nil {
 			return err
 		}
@@ -950,7 +950,7 @@ operatorSwitch:
 			&OperationStore8{Type: UnsignedInt32, Arg: imm},
 		)
 	case wasm.OpcodeI32Store16:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI32Store16Name)
+		imm, err := c.readMemoryArg(wasm.OpcodeI32Store16Name)
 		if err != nil {
 			return err
 		}
@@ -958,7 +958,7 @@ operatorSwitch:
 			&OperationStore16{Type: UnsignedInt32, Arg: imm},
 		)
 	case wasm.OpcodeI64Store8:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Store8Name)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Store8Name)
 		if err != nil {
 			return err
 		}
@@ -966,7 +966,7 @@ operatorSwitch:
 			&OperationStore8{Type: UnsignedInt64, Arg: imm},
 		)
 	case wasm.OpcodeI64Store16:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Store16Name)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Store16Name)
 		if err != nil {
 			return err
 		}
@@ -974,7 +974,7 @@ operatorSwitch:
 			&OperationStore16{Type: UnsignedInt64, Arg: imm},
 		)
 	case wasm.OpcodeI64Store32:
-		imm, err := c.readMemoryImmediate(wasm.OpcodeI64Store32Name)
+		imm, err := c.readMemoryArg(wasm.OpcodeI64Store32Name)
 		if err != nil {
 			return err
 		}
@@ -1720,26 +1720,380 @@ operatorSwitch:
 		}
 	case wasm.OpcodeVecPrefix:
 		c.pc++
-		switch miscOp := c.body[c.pc]; miscOp {
+		switch vecOp := c.body[c.pc]; vecOp {
 		case wasm.OpcodeVecV128Const:
 			c.pc++
 			lo := binary.LittleEndian.Uint64(c.body[c.pc : c.pc+8])
 			c.pc += 8
 			hi := binary.LittleEndian.Uint64(c.body[c.pc : c.pc+8])
 			c.emit(
-				&OperationConstV128{Lo: lo, Hi: hi},
+				&OperationV128Const{Lo: lo, Hi: hi},
 			)
 			c.pc += 7
+		case wasm.OpcodeVecI8x16Add:
+			c.emit(
+				&OperationV128Add{Shape: ShapeI8x16},
+			)
+		case wasm.OpcodeVecI16x8Add:
+			c.emit(
+				&OperationV128Add{Shape: ShapeI16x8},
+			)
 		case wasm.OpcodeVecI32x4Add:
 			c.emit(
-				&OperationAddV128{Shape: ShapeI32x4},
+				&OperationV128Add{Shape: ShapeI32x4},
 			)
 		case wasm.OpcodeVecI64x2Add:
 			c.emit(
-				&OperationAddV128{Shape: ShapeI64x2},
+				&OperationV128Add{Shape: ShapeI64x2},
+			)
+		case wasm.OpcodeVecI8x16Sub:
+			c.emit(
+				&OperationV128Sub{Shape: ShapeI8x16},
+			)
+		case wasm.OpcodeVecI16x8Sub:
+			c.emit(
+				&OperationV128Sub{Shape: ShapeI16x8},
+			)
+		case wasm.OpcodeVecI32x4Sub:
+			c.emit(
+				&OperationV128Sub{Shape: ShapeI32x4},
+			)
+		case wasm.OpcodeVecI64x2Sub:
+			c.emit(
+				&OperationV128Sub{Shape: ShapeI64x2},
+			)
+		case wasm.OpcodeVecV128Load:
+			arg, err := c.readMemoryArg(wasm.OpcodeI32LoadName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type128, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load8x8s:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load8x8SName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type8x8s, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load8x8u:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load8x8UName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type8x8u, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load16x4s:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load16x4SName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type16x4s, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load16x4u:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load16x4UName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type16x4u, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load32x2s:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load32x2SName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type32x2s, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load32x2u:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load32x2UName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type32x2u, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load8Splat:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load8SplatName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type8Splat, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load16Splat:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load16SplatName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type16Splat, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load32Splat:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load32SplatName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type32Splat, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load64Splat:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load64SplatName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type64Splat, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load32zero:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load32zeroName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type32zero, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load64zero:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load64zeroName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Load{Type: LoadV128Type64zero, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load8Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load8LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128LoadLane{LaneIndex: laneIndex, LaneSize: 8, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load16Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load16LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128LoadLane{LaneIndex: laneIndex, LaneSize: 16, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load32Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load32LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128LoadLane{LaneIndex: laneIndex, LaneSize: 32, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Load64Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Load64LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128LoadLane{LaneIndex: laneIndex, LaneSize: 64, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Store:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128StoreName)
+			if err != nil {
+				return err
+			}
+			c.emit(
+				&OperationV128Store{Arg: arg},
+			)
+		case wasm.OpcodeVecV128Store8Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Store8LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128StoreLane{LaneIndex: laneIndex, LaneSize: 8, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Store16Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Store16LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128StoreLane{LaneIndex: laneIndex, LaneSize: 16, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Store32Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Store32LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128StoreLane{LaneIndex: laneIndex, LaneSize: 32, Arg: arg},
+			)
+		case wasm.OpcodeVecV128Store64Lane:
+			arg, err := c.readMemoryArg(wasm.OpcodeVecV128Store64LaneName)
+			if err != nil {
+				return err
+			}
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128StoreLane{LaneIndex: laneIndex, LaneSize: 64, Arg: arg},
+			)
+		case wasm.OpcodeVecI8x16ExtractLaneS:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeI8x16, Signed: true},
+			)
+		case wasm.OpcodeVecI8x16ExtractLaneU:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeI8x16, Signed: false},
+			)
+		case wasm.OpcodeVecI16x8ExtractLaneS:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeI16x8, Signed: true},
+			)
+		case wasm.OpcodeVecI16x8ExtractLaneU:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeI16x8, Signed: false},
+			)
+		case wasm.OpcodeVecI32x4ExtractLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeI32x4},
+			)
+		case wasm.OpcodeVecI64x2ExtractLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeI64x2},
+			)
+		case wasm.OpcodeVecF32x4ExtractLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeF32x4},
+			)
+		case wasm.OpcodeVecF64x2ExtractLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ExtractLane{LaneIndex: laneIndex, Shape: ShapeF64x2},
+			)
+		case wasm.OpcodeVecI8x16ReplaceLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ReplaceLane{LaneIndex: laneIndex, Shape: ShapeI8x16},
+			)
+		case wasm.OpcodeVecI16x8ReplaceLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ReplaceLane{LaneIndex: laneIndex, Shape: ShapeI16x8},
+			)
+		case wasm.OpcodeVecI32x4ReplaceLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ReplaceLane{LaneIndex: laneIndex, Shape: ShapeI32x4},
+			)
+		case wasm.OpcodeVecI64x2ReplaceLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ReplaceLane{LaneIndex: laneIndex, Shape: ShapeI64x2},
+			)
+		case wasm.OpcodeVecF32x4ReplaceLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ReplaceLane{LaneIndex: laneIndex, Shape: ShapeF32x4},
+			)
+		case wasm.OpcodeVecF64x2ReplaceLane:
+			c.pc++
+			laneIndex := c.body[c.pc]
+			c.emit(
+				&OperationV128ReplaceLane{LaneIndex: laneIndex, Shape: ShapeF64x2},
+			)
+		case wasm.OpcodeVecI8x16Splat:
+			c.emit(
+				&OperationV128Splat{Shape: ShapeI8x16},
+			)
+		case wasm.OpcodeVecI16x8Splat:
+			c.emit(
+				&OperationV128Splat{Shape: ShapeI16x8},
+			)
+		case wasm.OpcodeVecI32x4Splat:
+			c.emit(
+				&OperationV128Splat{Shape: ShapeI32x4},
+			)
+		case wasm.OpcodeVecI64x2Splat:
+			c.emit(
+				&OperationV128Splat{Shape: ShapeI64x2},
+			)
+		case wasm.OpcodeVecF32x4Splat:
+			c.emit(
+				&OperationV128Splat{Shape: ShapeF32x4},
+			)
+		case wasm.OpcodeVecF64x2Splat:
+			c.emit(
+				&OperationV128Splat{Shape: ShapeF64x2},
+			)
+		case wasm.OpcodeVecI8x16Swizzle:
+			c.emit(
+				&OperationV128Swizzle{},
+			)
+		case wasm.OpcodeVecV128i8x16Shuffle:
+			c.pc++
+			op := &OperationV128Shuffle{}
+			copy(op.Lanes[:], c.body[c.pc:c.pc+16])
+			c.emit(op)
+			c.pc += 15
+		case wasm.OpcodeVecV128AnyTrue:
+			c.emit(
+				&OperationV128AnyTrue{},
+			)
+		case wasm.OpcodeVecI8x16AllTrue:
+			c.emit(
+				&OperationV128AllTrue{Shape: ShapeI8x16},
+			)
+		case wasm.OpcodeVecI16x8AllTrue:
+			c.emit(
+				&OperationV128AllTrue{Shape: ShapeI16x8},
+			)
+		case wasm.OpcodeVecI32x4AllTrue:
+			c.emit(
+				&OperationV128AllTrue{Shape: ShapeI32x4},
+			)
+		case wasm.OpcodeVecI64x2AllTrue:
+			c.emit(
+				&OperationV128AllTrue{Shape: ShapeI64x2},
 			)
 		default:
-			return fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
+			return fmt.Errorf("unsupported vector instruction in wazeroir: %s", wasm.VectorInstructionName(vecOp))
 		}
 	default:
 		return fmt.Errorf("unsupported instruction in wazeroir: 0x%x", op)
@@ -1882,7 +2236,7 @@ func (c *compiler) emitDefaultValue(t wasm.ValueType) {
 		c.emit(&OperationConstF64{Value: 0})
 	case wasm.ValueTypeV128:
 		c.stackPush(UnsignedTypeV128)
-		c.emit(&OperationConstV128{Hi: 0, Lo: 0})
+		c.emit(&OperationV128Const{Hi: 0, Lo: 0})
 	}
 }
 
@@ -1945,7 +2299,7 @@ func (c *compiler) stackLenInUint64(ceil int) (ret int) {
 	return
 }
 
-func (c *compiler) readMemoryImmediate(tag string) (*MemoryImmediate, error) {
+func (c *compiler) readMemoryArg(tag string) (*MemoryArg, error) {
 	r := bytes.NewReader(c.body[c.pc+1:])
 	alignment, num, err := leb128.DecodeUint32(r)
 	if err != nil {
@@ -1957,5 +2311,5 @@ func (c *compiler) readMemoryImmediate(tag string) (*MemoryImmediate, error) {
 		return nil, fmt.Errorf("reading offset for %s: %w", tag, err)
 	}
 	c.pc += num
-	return &MemoryImmediate{Offset: offset, Alignment: alignment}, nil
+	return &MemoryArg{Offset: offset, Alignment: alignment}, nil
 }

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -931,7 +931,7 @@ func TestCompile_Locals(t *testing.T) {
 				}},
 			},
 			expected: []Operation{
-				&OperationConstV128{Lo: 0, Hi: 0},
+				&OperationV128Const{Lo: 0, Hi: 0},
 				&OperationPick{Depth: 1, IsTargetVector: true}, // [p[0].low, p[0].high] -> [p[0].low, p[0].high, p[0].low, p[0].high]
 				&OperationDrop{Depth: &InclusiveRange{Start: 0, End: 3}},
 				&OperationBr{Target: &BranchTarget{}}, // return!
@@ -952,7 +952,7 @@ func TestCompile_Locals(t *testing.T) {
 			},
 			expected: []Operation{
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstV128{Lo: 0x01, Hi: 0x02},
+				&OperationV128Const{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [0x01, 0x02, p[0].lo, p[1].hi]
 				&OperationSwap{Depth: 3, IsTargetVector: true},
 				// [0x01, 0x02, p[0].lo, p[1].hi] -> [0x02, 0x01]
@@ -997,9 +997,9 @@ func TestCompile_Locals(t *testing.T) {
 				}},
 			},
 			expected: []Operation{
-				&OperationConstV128{Lo: 0, Hi: 0},
+				&OperationV128Const{Lo: 0, Hi: 0},
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstV128{Lo: 0x01, Hi: 0x02},
+				&OperationV128Const{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [0x01, 0x02, p[0].lo, p[1].hi]
 				&OperationSwap{Depth: 3, IsTargetVector: true},
 				// [p[0].lo, 0x02, 0x01, p[1].hi] -> [0x02, 0x01]
@@ -1023,7 +1023,7 @@ func TestCompile_Locals(t *testing.T) {
 			},
 			expected: []Operation{
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstV128{Lo: 0x01, Hi: 0x02},
+				&OperationV128Const{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [p[0].lo, p[1].hi, 0x01, 0x02, 0x01, 0x02]
 				&OperationPick{Depth: 1, IsTargetVector: true},
 				// [p[0].lo, p[1].hi, 0x01, 0x02, 0x01, 0x02] -> [0x01, 0x02, 0x01, 0x02, p[0].lo, p[1].hi]
@@ -1071,9 +1071,9 @@ func TestCompile_Locals(t *testing.T) {
 				}},
 			},
 			expected: []Operation{
-				&OperationConstV128{Lo: 0, Hi: 0},
+				&OperationV128Const{Lo: 0, Hi: 0},
 				// [p[0].lo, p[1].hi] -> [p[0].lo, p[1].hi, 0x01, 0x02]
-				&OperationConstV128{Lo: 0x01, Hi: 0x02},
+				&OperationV128Const{Lo: 0x01, Hi: 0x02},
 				// [p[0].lo, p[1].hi, 0x01, 0x02] -> [p[0].lo, p[1].hi, 0x01, 0x02, 0x01, 0x02]
 				&OperationPick{Depth: 1, IsTargetVector: true},
 				// [p[0].lo, p[1].hi, 0x01, 0x02, 0x01, 0x2] -> [0x01, 0x02, 0x01, 0x02, p[0].lo, p[1].hi]

--- a/internal/wazeroir/format.go
+++ b/internal/wazeroir/format.go
@@ -181,9 +181,9 @@ func formatOperation(w io.StringWriter, b Operation) {
 			out = "u64"
 		}
 		str = fmt.Sprintf("%s.extend_from.%s", out, in)
-	case *OperationConstV128:
+	case *OperationV128Const:
 		str = fmt.Sprintf("v128.const [%#x, %#x]", o.Lo, o.Hi)
-	case *OperationAddV128:
+	case *OperationV128Add:
 		str = fmt.Sprintf("v128.add (shape=%s)", shapeName(o.Shape))
 	default:
 		panic("unreachable: a bug in wazeroir implementation")

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -1,8 +1,6 @@
 package wazeroir
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type UnsignedInt byte
 

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -413,6 +413,8 @@ const (
 	OperationKindTableGrow
 	OperationKindTableFill
 
+	// Vector value related instructions are prefixed by V128.
+
 	OperationKindV128Const
 	OperationKindV128Add
 	OperationKindV128Sub

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -158,6 +158,61 @@ var (
 		in:  []UnsignedType{UnsignedTypeV128, UnsignedTypeV128},
 		out: []UnsignedType{UnsignedTypeV128},
 	}
+	signature_I32_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeI32},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_I32V128_None = &signature{
+		in: []UnsignedType{UnsignedTypeI32, UnsignedTypeV128},
+	}
+	signature_I32V128_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeI32, UnsignedTypeV128},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_V128I32_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128, UnsignedTypeI32},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_V128I64_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128, UnsignedTypeI64},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_V128F32_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128, UnsignedTypeF32},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_V128F64_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128, UnsignedTypeF64},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_V128_I32 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128},
+		out: []UnsignedType{UnsignedTypeI32},
+	}
+	signature_V128_I64 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128},
+		out: []UnsignedType{UnsignedTypeI64},
+	}
+	signature_V128_F32 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128},
+		out: []UnsignedType{UnsignedTypeF32},
+	}
+	signature_V128_F64 = &signature{
+		in:  []UnsignedType{UnsignedTypeV128},
+		out: []UnsignedType{UnsignedTypeF64},
+	}
+	signature_I64_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeI64},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_F32_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeF32},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
+	signature_F64_V128 = &signature{
+		in:  []UnsignedType{UnsignedTypeF64},
+		out: []UnsignedType{UnsignedTypeV128},
+	}
 )
 
 // wasmOpcodeSignature returns the signature of given Wasm opcode.
@@ -411,10 +466,62 @@ func (c *compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature
 		switch vecOp := c.body[c.pc+1]; vecOp {
 		case wasm.OpcodeVecV128Const:
 			return signature_None_V128, nil
-		case wasm.OpcodeVecI32x4Add, wasm.OpcodeVecI64x2Add:
+		case wasm.OpcodeVecI8x16Add, wasm.OpcodeVecI16x8Add, wasm.OpcodeVecI32x4Add, wasm.OpcodeVecI64x2Add,
+			wasm.OpcodeVecI8x16Sub, wasm.OpcodeVecI16x8Sub, wasm.OpcodeVecI32x4Sub, wasm.OpcodeVecI64x2Sub:
 			return signature_V128V128_V128, nil
+		case wasm.OpcodeVecV128Load, wasm.OpcodeVecV128Load8x8s, wasm.OpcodeVecV128Load8x8u,
+			wasm.OpcodeVecV128Load16x4s, wasm.OpcodeVecV128Load16x4u, wasm.OpcodeVecV128Load32x2s,
+			wasm.OpcodeVecV128Load32x2u, wasm.OpcodeVecV128Load8Splat, wasm.OpcodeVecV128Load16Splat,
+			wasm.OpcodeVecV128Load32Splat, wasm.OpcodeVecV128Load64Splat, wasm.OpcodeVecV128Load32zero,
+			wasm.OpcodeVecV128Load64zero:
+			return signature_I32_V128, nil
+		case wasm.OpcodeVecV128Load8Lane, wasm.OpcodeVecV128Load16Lane,
+			wasm.OpcodeVecV128Load32Lane, wasm.OpcodeVecV128Load64Lane:
+			return signature_I32V128_V128, nil
+		case wasm.OpcodeVecV128Store,
+			wasm.OpcodeVecV128Store8Lane,
+			wasm.OpcodeVecV128Store16Lane,
+			wasm.OpcodeVecV128Store32Lane,
+			wasm.OpcodeVecV128Store64Lane:
+			return signature_I32V128_None, nil
+		case wasm.OpcodeVecI8x16ExtractLaneS,
+			wasm.OpcodeVecI8x16ExtractLaneU,
+			wasm.OpcodeVecI16x8ExtractLaneS,
+			wasm.OpcodeVecI16x8ExtractLaneU,
+			wasm.OpcodeVecI32x4ExtractLane:
+			return signature_V128_I32, nil
+		case wasm.OpcodeVecI64x2ExtractLane:
+			return signature_V128_I64, nil
+		case wasm.OpcodeVecF32x4ExtractLane:
+			return signature_V128_F32, nil
+		case wasm.OpcodeVecF64x2ExtractLane:
+			return signature_V128_F64, nil
+		case wasm.OpcodeVecI8x16ReplaceLane, wasm.OpcodeVecI16x8ReplaceLane, wasm.OpcodeVecI32x4ReplaceLane:
+			return signature_V128I32_V128, nil
+		case wasm.OpcodeVecI64x2ReplaceLane:
+			return signature_V128I64_V128, nil
+		case wasm.OpcodeVecF32x4ReplaceLane:
+			return signature_V128F32_V128, nil
+		case wasm.OpcodeVecF64x2ReplaceLane:
+			return signature_V128F64_V128, nil
+		case wasm.OpcodeVecI8x16Splat,
+			wasm.OpcodeVecI16x8Splat,
+			wasm.OpcodeVecI32x4Splat:
+			return signature_I32_V128, nil
+		case wasm.OpcodeVecI64x2Splat:
+			return signature_I64_V128, nil
+		case wasm.OpcodeVecF32x4Splat:
+			return signature_F32_V128, nil
+		case wasm.OpcodeVecF64x2Splat:
+			return signature_F64_V128, nil
+		case wasm.OpcodeVecV128i8x16Shuffle, wasm.OpcodeVecI8x16Swizzle:
+			return signature_V128V128_V128, nil
+		case wasm.OpcodeVecI8x16AllTrue, wasm.OpcodeVecI16x8AllTrue, wasm.OpcodeVecI32x4AllTrue, wasm.OpcodeVecI64x2AllTrue:
+			return signature_V128_I32, nil
+		case wasm.OpcodeVecV128AnyTrue:
+			return signature_V128_I32, nil
 		default:
-			return nil, fmt.Errorf("unsupported vector instruction in wazeroir: 0x%x", op)
+			return nil, fmt.Errorf("unsupported vector instruction in wazeroir: %s", wasm.VectorInstructionName(vecOp))
 		}
 	default:
 		return nil, fmt.Errorf("unsupported instruction in wazeroir: 0x%x", op)


### PR DESCRIPTION
This implements various SIMD instructions related to
load, store, and lane manipulations for all engines.

Notablely, now our engines pass the following specification tests:

* simd_address.wast
* simd_const.wast
* simd_align.wast
* simd_laod16_lane.wast
* simd_laod32_lane.wast
* simd_laod64_lane.wast
* simd_laod8_lane.wast
* simd_lane.wast
* simd_load_extend.wast
* simd_load_splat.wast
* simd_load_zero.wast
* simd_store.wast
* simd_store16_lane.wast
* simd_store32_lane.wast
* simd_store64_lane.wast
* simd_store8_lane.wast

part of #484 