### PR TITLE
Adds tests for sign bit preservation for moremath rounding functions.

### DIFF
--- a/internal/moremath/moremath.go
+++ b/internal/moremath/moremath.go
@@ -57,7 +57,7 @@ func WasmCompatMax(x, y float64) float64 {
 // See https://llvm.org/docs/LangRef.html#llvm-rint-intrinsic.
 func WasmCompatNearestF32(f float32) float32 {
 	// TODO: look at https://github.com/bytecodealliance/wasmtime/pull/2171 and reconsider this algorithm
-	if f != -0 && f != 0 {
+	if f != 0 {
 		ceil := float32(math.Ceil(float64(f)))
 		floor := float32(math.Floor(float64(f)))
 		distToCeil := math.Abs(float64(f - ceil))
@@ -82,7 +82,7 @@ func WasmCompatNearestF32(f float32) float32 {
 // See https://llvm.org/docs/LangRef.html#llvm-rint-intrinsic.
 func WasmCompatNearestF64(f float64) float64 {
 	// TODO: look at https://github.com/bytecodealliance/wasmtime/pull/2171 and reconsider this algorithm
-	if f != -0 && f != 0 {
+	if f != 0 {
 		ceil := math.Ceil(f)
 		floor := math.Floor(f)
 		distToCeil := math.Abs(f - ceil)

--- a/internal/moremath/moremath_test.go
+++ b/internal/moremath/moremath_test.go
@@ -39,6 +39,17 @@ func TestWasmCompatNearestF32(t *testing.T) {
 	// This is the diff from math.Round.
 	require.Equal(t, WasmCompatNearestF32(-4.5), float32(-4.0))
 	require.Equal(t, float32(math.Round(-4.5)), float32(-5.0))
+
+	// Prevent constant folding by using two variables. -float32(0) is not actually negative.
+	// https://github.com/golang/go/issues/2196
+	zero := float32(0)
+	negZero := -zero
+
+	// Sign bit preserved for +/- zero
+	require.False(t, math.Signbit(float64(zero)))
+	require.False(t, math.Signbit(float64(WasmCompatNearestF32(zero))))
+	require.True(t, math.Signbit(float64(negZero)))
+	require.True(t, math.Signbit(float64(WasmCompatNearestF32(negZero))))
 }
 
 func TestWasmCompatNearestF64(t *testing.T) {
@@ -47,4 +58,15 @@ func TestWasmCompatNearestF64(t *testing.T) {
 	// This is the diff from math.Round.
 	require.Equal(t, WasmCompatNearestF64(-4.5), -4.0)
 	require.Equal(t, math.Round(-4.5), -5.0)
+
+	// Prevent constant folding by using two variables. -float64(0) is not actually negative.
+	// https://github.com/golang/go/issues/2196
+	zero := float64(0)
+	negZero := -zero
+
+	// Sign bit preserved for +/- zero
+	require.False(t, math.Signbit(zero))
+	require.False(t, math.Signbit(WasmCompatNearestF64(zero)))
+	require.True(t, math.Signbit(negZero))
+	require.True(t, math.Signbit(WasmCompatNearestF64(negZero)))
 }


### PR DESCRIPTION
Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>

I was randomly looking at this file where GoLand was flagging the `f != -0 && f != 0`. 

In Go, the `-0` literal is actually positive zero

https://github.com/golang/go/issues/2196

So GoLand suggested simplifying since the code repeats the same check twice effectively.

I added tests to verify the desired behavior of preserving sign bit for negative zero is happening. If the intention of `f != -0` was a performance optimization for that case, we don't have it, but negative zero should be rare enough to not worry about it I guess.