### PR TITLE
Small cleanups to godoc

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -10,7 +10,9 @@ import (
 // ExternType classifies imports and exports with their respective types.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#import-section%E2%91%A0
+//
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
+//
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#external-types%E2%91%A0
 type ExternType = byte
 
@@ -36,6 +38,7 @@ const (
 // ExternTypeName returns the name of the WebAssembly 1.0 (20191205) Text Format field of the given type.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#imports⑤
+//
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#exports%E2%91%A4
 func ExternTypeName(et ExternType) string {
 	switch et {
@@ -121,7 +124,9 @@ func ValueTypeName(t ValueType) string {
 // Module return functions exported in a module, post-instantiation.
 //
 // Note: Closing the wazero.Runtime closes any Module it instantiated.
+//
 // Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
+//
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#external-types%E2%91%A0
 type Module interface {
 	fmt.Stringer

--- a/assemblyscript/assemblyscript.go
+++ b/assemblyscript/assemblyscript.go
@@ -24,10 +24,11 @@ import (
 // * "env.seed" - uses wazero.ModuleConfig WithRandSource as the source of seed values.
 //
 // Note: To customize behavior, use NewModuleBuilder instead.
+//
 // Note: If the AssemblyScript program is configured to use WASI, by calling "import wasi" in any file, these
 // functions will not be used.
-// See NewModuleBuilder
-// See wasi.InstantiateSnapshotPreview1
+//
+// See NewModuleBuilder and wasi.InstantiateSnapshotPreview1
 func Instantiate(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	return NewModuleBuilder(r).Instantiate(ctx)
 }

--- a/builder.go
+++ b/builder.go
@@ -36,8 +36,11 @@ import (
 //	env2, _ := r.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().WithName("env.2"))
 //
 // Notes:
+//
 // * ModuleBuilder is mutable. WithXXX functions return the same instance for chaining.
+//
 // * WithXXX methods do not return errors, to allow chaining. Any validation errors are deferred until Build.
+//
 // * Insertion order is not retained. Anything defined by this builder is sorted lexicographically on Build.
 type ModuleBuilder interface {
 	// Note: until golang/go#5860, we can't use example tests to embed code in interface godocs.

--- a/config.go
+++ b/config.go
@@ -155,6 +155,7 @@ var engineLessConfig = &runtimeConfig{
 // Note: While this is technically AOT, this does not imply any action on your
 // part. wazero automatically performs ahead-of-time compilation as needed when
 // Runtime.CompileModule is invoked.
+//
 // Note: This panics at runtime the runtime.GOOS or runtime.GOARCH does not
 // support Compiler. Use NewRuntimeConfig to safely detect and fallback to
 // NewRuntimeConfigInterpreter if needed.
@@ -241,6 +242,7 @@ func (c *runtimeConfig) WithWasmCore2() RuntimeConfig {
 // CompiledModule is a WebAssembly 1.0 module ready to be instantiated (Runtime.InstantiateModule) as an api.Module.
 //
 // Note: Closing the wazero.Runtime closes any CompiledModule it compiled.
+//
 // Note: In WebAssembly language, this is a decoded, validated, and possibly also compiled module. wazero avoids using
 // the name "Module" for both before and after instantiation as the name conflation has caused confusion.
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#semantic-phases%E2%91%A0

--- a/config_supported.go
+++ b/config_supported.go
@@ -4,7 +4,8 @@ package wazero
 
 const CompilerSupported = true
 
-// NewRuntimeConfig returns NewRuntimeConfigCompiler
+// NewRuntimeConfig returns a RuntimeConfig using the compiler if it is supported in this
+// environment, or interpreter otherwise.
 func NewRuntimeConfig() RuntimeConfig {
 	return NewRuntimeConfigCompiler()
 }

--- a/config_unsupported.go
+++ b/config_unsupported.go
@@ -4,7 +4,8 @@ package wazero
 
 const CompilerSupported = false
 
-// NewRuntimeConfig returns NewRuntimeConfigInterpreter
+// NewRuntimeConfig returns a RuntimeConfig using the compiler if it is supported in this
+// environment, or interpreter otherwise.
 func NewRuntimeConfig() RuntimeConfig {
 	return NewRuntimeConfigInterpreter()
 }

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -35,6 +35,7 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //	mod, _ := r.InstantiateModuleFromCode(ctx, source)
 //
 // Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
+//
 // Note: Closing the wazero.Runtime closes this instance of WASI as well.
 func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	_, fns := snapshotPreview1Functions(ctx)


### PR DESCRIPTION
Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>

Godoc compresses subsequent lines into one without adding empty lines. This causes lists to look like a blob of text.

- Adds empty lines between list items (e.g. https://pkg.go.dev/github.com/tetratelabs/wazero#CompiledModule). Unfortunately this causes each item to be a paragraph, not a line break, but there is no alternative from what I could find. This is better than blob of text though I think
- Documents the API for `NewRuntimeConfig`, not the behavior (which is arch specific). https://pkg.go.dev/github.com/tetratelabs/wazero#NewRuntimeConfig