### PR TITLE
Adds coverage logic customized from func-e

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -82,6 +82,16 @@ jobs:
 
       - run: make test
 
+      - name: "Generate coverage report"  # only once (not per OS)
+        if: runner.os == 'Linux'
+        run: make coverage
+
+      - name: "Upload coverage report"  # only on main push and only once (not per OS)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && runner.os == 'Linux'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)
+
   test_scratch:
     name: ${{ matrix.arch }}, Linux (scratch), Go-${{ matrix.go-version }}
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work
 # AssemblyScript
 node_modules
 package-lock.json
+
+# codecov.io
+/coverage.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# Codecov for main is visible here https://app.codecov.io/gh/tetratelabs/wazero
+
+# We use codecov only as a UI, so we disable PR comments.
+# See https://docs.codecov.com/docs/pull-request-comments
+comment: false


### PR DESCRIPTION
This adds coverage the same way as works in func-e, just that there are
slightly different conventions here wrt packages to ignore. Notably, we
should not run coverage using integration tests or examples as they give
false positives.

Once this merges, it is ready for codecov!

```bash
$ make coverage
make coverage
ok  	github.com/tetratelabs/wazero	1.211s	coverage: 20.7% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/api	0.546s	coverage: 0.7% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/assemblyscript	1.096s	coverage: 13.6% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/experimental	1.406s	coverage: 17.8% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
?   	github.com/tetratelabs/wazero/internal/asm	[no test files]
ok  	github.com/tetratelabs/wazero/internal/asm/amd64	0.763s	coverage: 2.8% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/asm/arm64	1.296s	coverage: 2.2% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
?   	github.com/tetratelabs/wazero/internal/buildoptions	[no test files]
ok  	github.com/tetratelabs/wazero/internal/engine/compiler	1.809s	coverage: 29.3% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/engine/interpreter	1.024s	coverage: 5.7% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
?   	github.com/tetratelabs/wazero/internal/ieee754	[no test files]
ok  	github.com/tetratelabs/wazero/internal/leb128	0.358s	coverage: 1.3% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/modgen	2.970s	coverage: 14.4% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/moremath	0.667s	coverage: 0.8% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/sys	0.457s	coverage: 0.6% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/u64	0.865s	coverage: 0.5% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/wasm	1.736s	coverage: 13.9% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/wasm/binary	1.688s	coverage: 6.5% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/wasm/text	1.774s	coverage: 9.0% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/internal/wasmdebug	1.670s	coverage: 0.9% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
?   	github.com/tetratelabs/wazero/internal/wasmruntime	[no test files]
ok  	github.com/tetratelabs/wazero/internal/wazeroir	1.772s	coverage: 7.5% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/sys	1.692s	coverage: 0.5% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
ok  	github.com/tetratelabs/wazero/wasi	1.666s	coverage: 23.3% of statements in ./, ./api/, ./assemblyscript/, ./experimental/, ./internal/asm/, ./internal/asm/amd64/, ./internal/asm/arm64/, ./internal/buildoptions/, ./internal/engine/compiler/, ./internal/engine/interpreter/, ./internal/ieee754/, ./internal/leb128/, ./internal/modgen/, ./internal/moremath/, ./internal/sys/, ./internal/u64/, ./internal/wasm/, ./internal/wasm/binary/, ./internal/wasm/text/, ./internal/wasmdebug/, ./internal/wasmruntime/, ./internal/wazeroir/, ./sys/, ./wasi/
github.com/tetratelabs/wazero/api/wasm.go:40:						ExternTypeName							100.0%
github.com/tetratelabs/wazero/api/wasm.go:105:						ValueTypeName							100.0%
github.com/tetratelabs/wazero/api/wasm.go:340:						EncodeExternref							100.0%
github.com/tetratelabs/wazero/api/wasm.go:346:						DecodeExternref							100.0%
github.com/tetratelabs/wazero/api/wasm.go:351:						EncodeI32							100.0%
github.com/tetratelabs/wazero/api/wasm.go:356:						EncodeI64							100.0%
github.com/tetratelabs/wazero/api/wasm.go:362:						EncodeF32							100.0%
github.com/tetratelabs/wazero/api/wasm.go:368:						DecodeF32							100.0%
github.com/tetratelabs/wazero/api/wasm.go:374:						EncodeF64							100.0%
github.com/tetratelabs/wazero/api/wasm.go:380:						DecodeF64							100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:31:			Instantiate							100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:54:			NewModuleBuilder						100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:73:			WithAbortMessageDisabled					100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:80:			WithTraceToStdout						100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:87:			WithTraceToStderr						100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:94:			Instantiate							100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:125:			abort								100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:154:			trace								100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:201:			formatFloat							100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:211:			seed								100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:221:			readAssemblyScriptString					100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:237:			decodeUTF16							100.0%
github.com/tetratelabs/wazero/assemblyscript/assemblyscript.go:248:			sysCtx								66.7%
github.com/tetratelabs/wazero/builder.go:183:						NewModuleBuilder						100.0%
github.com/tetratelabs/wazero/builder.go:194:						ExportFunction							100.0%
github.com/tetratelabs/wazero/builder.go:200:						ExportFunctions							100.0%
github.com/tetratelabs/wazero/builder.go:208:						ExportMemory							100.0%
github.com/tetratelabs/wazero/builder.go:214:						ExportMemoryWithMax						100.0%
github.com/tetratelabs/wazero/builder.go:220:						ExportGlobalI32							100.0%
github.com/tetratelabs/wazero/builder.go:230:						ExportGlobalI64							100.0%
github.com/tetratelabs/wazero/builder.go:240:						ExportGlobalF32							100.0%
github.com/tetratelabs/wazero/builder.go:249:						ExportGlobalF64							100.0%
github.com/tetratelabs/wazero/builder.go:258:						Compile								81.2%
github.com/tetratelabs/wazero/builder.go:289:						Instantiate							66.7%
github.com/tetratelabs/wazero/config.go:161:						NewRuntimeConfigCompiler					100.0%
github.com/tetratelabs/wazero/config.go:168:						NewRuntimeConfigInterpreter					100.0%
github.com/tetratelabs/wazero/config.go:175:						WithFeatureBulkMemoryOperations					100.0%
github.com/tetratelabs/wazero/config.go:184:						WithFeatureMultiValue						100.0%
github.com/tetratelabs/wazero/config.go:191:						WithFeatureMutableGlobal					100.0%
github.com/tetratelabs/wazero/config.go:198:						WithFeatureNonTrappingFloatToIntConversion			100.0%
github.com/tetratelabs/wazero/config.go:205:						WithFeatureReferenceTypes					100.0%
github.com/tetratelabs/wazero/config.go:214:						WithFeatureSignExtensionOps					100.0%
github.com/tetratelabs/wazero/config.go:221:						WithFeatureSIMD							100.0%
github.com/tetratelabs/wazero/config.go:228:						WithWasmCore1							100.0%
github.com/tetratelabs/wazero/config.go:235:						WithWasmCore2							100.0%
github.com/tetratelabs/wazero/config.go:261:						Close								100.0%
github.com/tetratelabs/wazero/config.go:296:						NewCompileConfig						100.0%
github.com/tetratelabs/wazero/config.go:304:						WithImportRenamer						80.0%
github.com/tetratelabs/wazero/config.go:314:						WithMemorySizer							80.0%
github.com/tetratelabs/wazero/config.go:460:						NewModuleConfig							100.0%
github.com/tetratelabs/wazero/config.go:470:						WithArgs							100.0%
github.com/tetratelabs/wazero/config.go:477:						WithEnv								100.0%
github.com/tetratelabs/wazero/config.go:490:						WithFS								100.0%
github.com/tetratelabs/wazero/config.go:497:						WithName							100.0%
github.com/tetratelabs/wazero/config.go:504:						WithStartFunctions						0.0%
github.com/tetratelabs/wazero/config.go:511:						WithStderr							100.0%
github.com/tetratelabs/wazero/config.go:518:						WithStdin							0.0%
github.com/tetratelabs/wazero/config.go:525:						WithStdout							100.0%
github.com/tetratelabs/wazero/config.go:532:						WithRandSource							100.0%
github.com/tetratelabs/wazero/config.go:539:						WithWorkDirFS							100.0%
github.com/tetratelabs/wazero/config.go:546:						toSysContext							100.0%
github.com/tetratelabs/wazero/config_supported.go:9:					NewRuntimeConfig						100.0%
github.com/tetratelabs/wazero/experimental/fs.go:14:					WithFS								83.3%
github.com/tetratelabs/wazero/experimental/time.go:10:					WithTimeNowUnixNano						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/consts.go:325:				InstructionName							10.0%
github.com/tetratelabs/wazero/internal/asm/amd64/consts.go:680:				RegisterName							32.4%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:56:				isInitializedForEncoding					100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:60:				isJumpNode							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:64:				isBackwardJump							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:68:				isForwardJump							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:72:				isForwardShortJump						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:77:				AssignJumpTarget						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:82:				AssignDestinationConstant					100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:87:				AssignSourceConstant						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:92:				OffsetInBinary							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:101:				String								92.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:169:				String								71.4%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:204:				String								100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:217:				NewAssemblerImpl						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:222:				newNode								100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:235:				addNode								100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:253:				EncodeNode							93.3%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:287:				Assemble							92.9%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:320:				InitializeNodesForEncoding					100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:342:				Encode								66.7%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:371:				maybeNOPPadding							90.9%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:422:				fusedInstructionLength						83.9%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:511:				padNOP								100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:523:				CompileStandAlone						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:528:				CompileConstToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:540:				CompileRegisterToRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:547:				CompileMemoryToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:560:				CompileRegisterToMemory						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:572:				CompileJump							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:577:				CompileJumpToMemory						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:588:				CompileJumpToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:594:				CompileReadInstructionAddress					100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:604:				CompileRegisterToRegisterWithArg				100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:616:				CompileMemoryWithIndexToRegister				100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:633:				CompileRegisterToMemoryWithIndex				100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:649:				CompileRegisterToConst						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:661:				CompileRegisterToNone						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:667:				CompileNoneToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:673:				CompileNoneToMemory						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:684:				CompileConstToMemory						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:698:				CompileMemoryToConst						100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:710:				errorEncodingUnsupported					100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:714:				encodeNoneToNone						85.7%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:736:				EncodeNoneToRegister						89.5%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:827:				EncodeNoneToMemory						85.7%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:870:				instructionLen							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:898:				ResolveForwardRelativeJumps					93.3%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:929:				EncodeRelativeJump						81.8%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:969:				EncodeRegisterToNone						92.3%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1204:				EncodeRegisterToRegister					81.2%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1308:				EncodeRegisterToMemory						77.2%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1455:				EncodeRegisterToConst						85.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1496:				encodeReadInstructionAddress					90.9%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1538:				EncodeMemoryToRegister						95.6%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1687:				EncodeConstToRegister						76.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1888:				EncodeMemoryToConst						0.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1935:				EncodeConstToMemory						82.1%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:1985:				WriteConst							88.9%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:2004:				GetMemoryLocation						77.9%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:2129:				GetRegisterToRegisterModRM					80.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:2195:				register3bits							94.1%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:2236:				FitIn32bit							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:2240:				fitInSigned8bit							100.0%
github.com/tetratelabs/wazero/internal/asm/amd64/impl.go:2244:				IsVectorRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/consts.go:232:				conditionalRegisterStateToRegister				11.1%
github.com/tetratelabs/wazero/internal/asm/arm64/consts.go:271:				RegisterName							17.9%
github.com/tetratelabs/wazero/internal/asm/arm64/consts.go:739:				String								26.7%
github.com/tetratelabs/wazero/internal/asm/arm64/consts.go:775:				InstructionName							13.4%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:40:				AssignJumpTarget						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:45:				AssignDestinationConstant					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:50:				AssignSourceConstant						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:55:				OffsetInBinary							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:65:				String								100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:140:				String								0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:195:				String								0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:222:				NewAssemblerImpl						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:230:				newNode								100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:243:				addNode								81.8%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:263:				Assemble							45.5%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:287:				maybeFlushConstPool						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:331:				setConstPoolCallback						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:335:				addConstPool							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:350:				Bytes								100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:362:				EncodeNode							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:412:				CompileStandAlone						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:417:				CompileConstToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:429:				CompileRegisterToRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:436:				CompileMemoryToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:449:				CompileRegisterToMemory						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:461:				CompileJump							100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:466:				CompileJumpToMemory						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:472:				CompileJumpToRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:478:				CompileReadInstructionAddress					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:488:				CompileMemoryWithRegisterOffsetToRegister			100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:499:				CompileRegisterToMemoryWithRegisterOffset			100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:510:				CompileTwoRegistersToRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:518:				CompileThreeRegistersToRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:530:				CompileTwoRegistersToNone					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:537:				CompileRegisterAndConstToNone					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:548:				CompileLeftShiftedRegisterToRegister				100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:562:				CompileSIMDByteToSIMDByte					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:569:				CompileTwoSIMDBytesToSIMDByteRegister				100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:580:				CompileSIMDByteToRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:587:				CompileConditionalRegisterSet					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:593:				CompileMemoryToVectorRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:601:				CompileVectorRegisterToMemory					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:609:				CompileRegisterToVectorRegister					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:618:				CompileVectorRegisterToVectorRegister				100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:626:				errorEncodingUnsupported					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:632:				EncodeNoneToNone						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:641:				EncodeJumpToRegister						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:669:				EncodeRelativeBranch						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:761:				checkRegisterToRegisterType					100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:777:				EncodeRegisterToRegister					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1284:				EncodeLeftShiftedRegisterToRegister				0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1321:				EncodeTwoRegistersToRegister					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1440:				EncodeThreeRegistersToRegister					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1482:				EncodeTwoRegistersToNone					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1540:				EncodeRegisterAndConstToNone					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1566:				fitInSigned9Bits						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1570:				encodeLoadOrStoreWithRegisterOffset				0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1585:				validateMemoryOffset						85.7%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1601:				encodeLoadOrStoreWithConstOffset				0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1719:				EncodeRegisterToMemory						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1753:				encodeADR							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1805:				EncodeMemoryToRegister						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1848:				const16bitAligned						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1865:				isBitMaskImmediate						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1895:				sequenceOfSetbits						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1903:				getLowestBit							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1908:				addOrSub64BitRegisters						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:1920:				EncodeConstToRegister						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2149:				movk								0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2159:				movz								0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2169:				movn								0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2183:				load64bitConst							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2282:				load16bitAlignedConst						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2304:				loadConstViaBitMaskImmediate					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2362:				getOnesSequenceSize						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2370:				setBitPos							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2382:				EncodeSIMDByteToSIMDByte					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2409:				EncodeSIMDByteToRegister					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2436:				EncodeTwoSIMDBytesToSIMDByteRegister				0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2466:				checkArrangementIndexPair					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2503:				EncodeRegisterToVectorRegister					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2556:				EncodeMemoryToVectorRegister					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2588:				arrangementSizeQ						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2610:				EncodeVectorRegisterToMemory					0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2642:				EncodeVectorRegisterToVectorRegister				50.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2701:				isIntRegister							100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2705:				isVectorRegister						100.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2709:				isConditionalRegister						0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2713:				intRegisterBits							0.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2722:				vectorRegisterBits						75.0%
github.com/tetratelabs/wazero/internal/asm/arm64/impl.go:2731:				registerBits							0.0%
github.com/tetratelabs/wazero/internal/asm/impl.go:22:					SetJumpTargetOnNext						100.0%
github.com/tetratelabs/wazero/internal/asm/impl.go:27:					AddOnGenerateCallBack						100.0%
github.com/tetratelabs/wazero/internal/asm/impl.go:32:					BuildJumpTable							85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/arch_amd64.go:8:			init								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/arch_amd64.go:17:		newArchContextImpl						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/arch_amd64.go:19:		init								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/arch_amd64.go:26:		newCompiler							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:18:	isNilRegister							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:22:	isIntRegister							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:26:	isVectorRegister						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:43:	getRegisterType							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:65:	String								0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:83:	setRegister							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:88:	onRegister							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:92:	onStack								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:96:	onConditionalRegister						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:100:	String								0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:112:	newRuntimeValueLocationStack					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:136:	String								0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:148:	clone								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:170:	pushRuntimeValueLocationOnRegister				100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:179:	pushRuntimeValueLocationOnStack					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:187:	pushRuntimeValueLocationOnConditionalRegister			100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:194:	push								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:209:	pop								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:215:	peek								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:220:	releaseRegister							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:226:	markRegisterUnused						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:232:	markRegisterUsed						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:254:	String								0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:265:	takeFreeRegister						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:282:	takeFreeRegisters						92.3%
github.com/tetratelabs/wazero/internal/engine/compiler/compiler_value_location.go:307:	takeStealTargetFromUsedRegister					90.9%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:213:			createFunction							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:333:			causePanic							40.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:354:			String								30.8%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:383:			String								0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:391:			releaseCode							83.3%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:409:			DeleteCompiledModule						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:414:			CompileModule							92.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:462:			NewModuleEngine							95.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:501:			deleteCodes							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:507:			addCodes							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:513:			getCodes							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:521:			Name								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:526:			CreateFuncElementInstance					0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:540:			InitializeFuncrefGlobals					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:554:			Call								89.3%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:610:			NewEngine							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:614:			newEngine							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:654:			newCallEngine							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:673:			popValue							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:679:			pushValue							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:684:			callFrameTop							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:688:			callFrameAt							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:693:			valueStackTopIndex						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:706:			execWasmFunction						71.4%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:769:			builtinFunctionGrowValueStack					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:783:			builtinFunctionGrowCallFrameStack				88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:800:			builtinFunctionMemoryGrow					85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:815:			builtinFunctionTableGrow					0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:824:			compileHostFunction						66.7%
github.com/tetratelabs/wazero/internal/engine/compiler/engine.go:842:			compileWasmFunction						23.6%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:63:		init								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:124:		String								0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:145:		newAmd64Compiler						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:159:		setLocationStack						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:166:		addStaticData							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:170:		pushRuntimeValueLocationOnRegister				100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:175:		pushVectorRuntimeValueLocationOnRegister			100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:190:		label								100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:201:		compileHostFunction						75.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:213:		compile								92.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:243:		pushFunctionParams						63.6%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:266:		compileUnreachable						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:272:		compileSwap							85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:297:		compileGlobalGet						87.1%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:357:		compileGlobalSet						89.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:399:		compileBr							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:405:		branchInto							90.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:432:		compileBrIf							82.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:553:		compileBrTable							87.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:671:		assignJumpTarget						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:683:		compileLabel							88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:725:		compileCall							58.8%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:759:		compileCallIndirect						77.1%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:870:		compileDrop							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:874:		emitDropRange							95.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:917:		compileSelect							94.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:968:		compilePick							94.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1009:		compileAdd							86.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1045:		compileSub							86.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1081:		compileMul							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1108:		compileMulForInts						91.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1179:		compileMulForFloats						77.8%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1200:		compileClz							83.3%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1263:		compileCtz							81.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1315:		compilePopcnt							88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1334:		compileDiv							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1356:		compileDivForInts						83.3%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1371:		compileRem							92.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1412:		performDivisionOnInts						98.6%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1582:		compileDivForFloats						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1591:		compileAnd							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1602:		compileOr							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1613:		compileXor							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1626:		compileSimpleBinaryOp						81.8%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1651:		compileShl							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1662:		compileShr							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1677:		compileRotl							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1688:		compileRotr							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1700:		compileShiftOp							50.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1751:		compileAbs							88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1769:		compileNeg							83.3%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1794:		compileCeil							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1801:		compileFloor							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1808:		compileTrunc							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1815:		compileNearest							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1846:		compileRoundInstruction						85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1861:		compileMin							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1871:		compileMax							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1892:		compileMinOrMax							90.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:1956:		compileCopysign							89.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2015:		compileSqrt							85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2029:		compileI32WrapFromI64						0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2046:		compileITruncFromF						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2068:		emitUnsignedI32TruncFromFloat					96.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2182:		emitUnsignedI64TruncFromFloat					96.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2296:		emitSignedI32TruncFromFloat					96.2%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2414:		emitSignedI64TruncFromFloat					95.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2523:		compileFConvertFromI						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2555:		emitUnsignedInt64ToFloatConversion				90.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2663:		compileSimpleConversion						80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2683:		compileF32DemoteFromF64						80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2694:		compileF64PromoteFromF32					80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2705:		compileI32ReinterpretFromF32					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2715:		compileI64ReinterpretFromF64					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2725:		compileF32ReinterpretFromI32					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2735:		compileF64ReinterpretFromI64					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2745:		compileExtend							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2756:		compileSignExtend32From8					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2761:		compileSignExtend32From16					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2766:		compileSignExtend64From8					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2771:		compileSignExtend64From16					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2776:		compileSignExtend64From32					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2780:		compileExtendImpl						80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2791:		compileEq							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2796:		compileNe							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2800:		compileEqOrNe							81.2%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2831:		compileEqOrNeForInts						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2850:		compileEqOrNeForFloats						90.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2902:		compileEqz							90.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2925:		compileLt							92.6%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:2972:		compileGt							92.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3017:		compileLe							92.6%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3064:		compileGe							92.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3109:		compileLoad							93.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3170:		compileLoad8							94.4%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3206:		compileLoad16							94.4%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3242:		compileLoad32							90.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3270:		compileMemoryAccessCeilSetup					92.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3302:		compileStore							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3317:		compileStore8							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3322:		compileStore16							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3327:		compileStore32							100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3331:		compileStoreImpl						80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3354:		compileMemoryGrow						83.3%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3369:		compileMemorySize						87.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3388:		compileMemoryInit						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3396:		compileInitImpl							92.1%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3525:		compileDataDrop							87.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3540:		compileLoadDataInstanceAddress					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3554:		compileMemoryCopy						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3562:		compileCopyImpl							95.3%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3738:		compileFillImpl							73.8%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3837:		compileMemoryFill						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3842:		compileTableInit						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3847:		compileTableCopy						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3852:		compileElemDrop							87.5%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3867:		compileLoadElemInstanceAddress					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3881:		compileTableGet							88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3927:		compileTableSet							84.2%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:3975:		compileTableGrow						0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4003:		compileTableSize						0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4029:		compileTableFill						0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4034:		compileRefFunc							85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4059:		compileConstI32							85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4072:		compileConstI64							85.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4086:		compileConstF32							81.8%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4108:		compileConstF64							81.8%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4129:		compileLoadValueOnStackToRegister				88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4159:		maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister	66.7%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4169:		compileLoadConditionalRegisterToGeneralPurposeRegister		100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4175:		compileMoveConditionalToGeneralPurposeRegister			88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4222:		allocateRegister						36.4%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4249:		compileCallFunctionImpl						94.1%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4465:		compileReturnFunction						96.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4574:		compileCallHostFunction						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4578:		compileCallBuiltinFunction					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4584:		compileCallGoFunction						93.3%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4630:		compileReleaseAllRegistersToStack				100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4641:		onValueReleaseRegisterToStack					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4651:		compileReleaseRegisterToStack					90.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4676:		compileExitFromNativeCode					100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4685:		compilePreamble							75.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4706:		compileReservedStackBasePointerInitialization			100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4729:		compileReservedMemoryPointerInitialization			100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4741:		compileMaybeGrowValueStack					90.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4768:		compileModuleContextInitialization				97.2%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_amd64.go:4925:		compileEnsureOnGeneralPurposeRegister				90.0%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_vec_amd64.go:10:		compileConstV128						88.9%
github.com/tetratelabs/wazero/internal/engine/compiler/impl_vec_amd64.go:46:		compileAddV128							0.0%
github.com/tetratelabs/wazero/internal/engine/compiler/mmap.go:13:			mmapCodeSegment							80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/mmap.go:25:			munmapCodeSegment						100.0%
github.com/tetratelabs/wazero/internal/engine/compiler/mmap.go:34:			mmapCodeSegmentAMD64						80.0%
github.com/tetratelabs/wazero/internal/engine/compiler/mmap.go:56:			mmapCodeSegmentARM64						0.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:31:		NewEngine							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:39:		DeleteCompiledModule						100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:43:		deleteCodes							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:49:		addCodes							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:55:		getCodes							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:87:		newCallEngine							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:91:		pushValue							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:95:		popValue							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:109:		peekValues							0.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:122:		drop								85.7%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:140:		pushFrame							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:147:		popFrame							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:176:		functionFromUintptr						0.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:186:		instantiate							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:211:		CompileModule							93.8%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:243:		NewModuleEngine							95.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:283:		lowerIR								14.8%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:603:		Name								100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:608:		CreateFuncElementInstance					0.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:622:		InitializeFuncrefGlobals					100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:636:		Call								90.6%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:692:		callGoFunc							100.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:711:		callNativeFunc							22.8%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:1842:		callNativeFuncWithListener					0.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:1852:		popMemoryOffset							0.0%
github.com/tetratelabs/wazero/internal/engine/interpreter/interpreter.go:1861:		callGoFuncWithStack						100.0%
github.com/tetratelabs/wazero/internal/ieee754/ieee754.go:11:				DecodeFloat32							100.0%
github.com/tetratelabs/wazero/internal/ieee754/ieee754.go:23:				DecodeFloat64							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:35:				EncodeInt32							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:42:				EncodeInt64							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:69:				EncodeUint32							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:76:				EncodeUint64							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:101:				DecodeUint32							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:123:				DecodeUint64							83.3%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:144:				DecodeInt32							100.0%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:177:				DecodeInt33AsInt64						84.6%
github.com/tetratelabs/wazero/internal/leb128/leb128.go:225:				DecodeInt64							85.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:24:				Gen								85.7%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:79:				nextRandom							100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:86:				gen								100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:103:				genTypeSection							83.3%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:114:				newFunctionType							100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:125:				newValueType							85.7%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:142:				genImportSection						96.4%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:200:				genFunctionSection						100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:212:				genTableSection							100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:223:				genMemorySection						100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:233:				genGlobalSection						100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:245:				newConstExpr							93.2%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:311:				genExportSection						93.3%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:343:				genStartSection							92.3%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:368:				genElementSection						93.3%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:403:				genCodeSection							100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:410:				newCode								100.0%
github.com/tetratelabs/wazero/internal/modgen/modgen.go:417:				genDataSection							87.5%
github.com/tetratelabs/wazero/internal/moremath/moremath.go:10:				WasmCompatMin							88.9%
github.com/tetratelabs/wazero/internal/moremath/moremath.go:33:				WasmCompatMax							88.9%
github.com/tetratelabs/wazero/internal/moremath/moremath.go:58:				WasmCompatNearestF32						100.0%
github.com/tetratelabs/wazero/internal/moremath/moremath.go:83:				WasmCompatNearestF64						100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:35:					NewFSContext							100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:55:					nextFD								66.7%
github.com/tetratelabs/wazero/internal/sys/fs.go:63:					Close								83.3%
github.com/tetratelabs/wazero/internal/sys/fs.go:77:					CloseFile							77.8%
github.com/tetratelabs/wazero/internal/sys/fs.go:94:					OpenedFile							100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:100:					OpenFile							80.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:118:					NewFSConfig							100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:127:					setFS								100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:139:					WithFS								100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:145:					WithWorkDirFS							100.0%
github.com/tetratelabs/wazero/internal/sys/fs.go:151:					Preopens							100.0%
github.com/tetratelabs/wazero/internal/u64/u64.go:4:					LeBytes								100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/code.go:13:				decodeCode							45.2%
github.com/tetratelabs/wazero/internal/wasm/binary/code.go:88:				encodeCode							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/const_expr.go:12:			decodeConstantExpression					89.4%
github.com/tetratelabs/wazero/internal/wasm/binary/const_expr.go:97:			encodeConstantExpression					100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/data.go:26:				decodeDataSegment						84.0%
github.com/tetratelabs/wazero/internal/wasm/binary/data.go:80:				encodeDataSegment						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/decoder.go:15:			DecodeModule							78.7%
github.com/tetratelabs/wazero/internal/wasm/binary/element.go:12:			ensureElementKindFuncRef					83.3%
github.com/tetratelabs/wazero/internal/wasm/binary/element.go:23:			decodeElementInitValueVector					80.0%
github.com/tetratelabs/wazero/internal/wasm/binary/element.go:40:			decodeElementConstExprVector					73.3%
github.com/tetratelabs/wazero/internal/wasm/binary/element.go:67:			decodeElementRefType						71.4%
github.com/tetratelabs/wazero/internal/wasm/binary/element.go:100:			decodeElementSegment						73.4%
github.com/tetratelabs/wazero/internal/wasm/binary/element.go:283:			encodeElement							87.5%
github.com/tetratelabs/wazero/internal/wasm/binary/encoder.go:12:			EncodeModule							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/export.go:11:			decodeExport							66.7%
github.com/tetratelabs/wazero/internal/wasm/binary/export.go:38:			encodeExport							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/function.go:33:			encodeFunctionType						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/function.go:58:			decodeFunctionType						82.6%
github.com/tetratelabs/wazero/internal/wasm/binary/global.go:13:			decodeGlobal							71.4%
github.com/tetratelabs/wazero/internal/wasm/binary/global.go:30:			decodeGlobalType						72.7%
github.com/tetratelabs/wazero/internal/wasm/binary/global.go:58:			encodeGlobal							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/import.go:11:			decodeImport							72.2%
github.com/tetratelabs/wazero/internal/wasm/binary/import.go:52:			encodeImport							94.4%
github.com/tetratelabs/wazero/internal/wasm/binary/limits.go:13:			decodeLimitsType						61.1%
github.com/tetratelabs/wazero/internal/wasm/binary/limits.go:47:			encodeLimitsType						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/memory.go:12:			decodeMemory							83.3%
github.com/tetratelabs/wazero/internal/wasm/binary/memory.go:30:			encodeMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:30:				decodeNameSection						87.5%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:79:				decodeFunctionNames						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:101:			decodeLocalNames						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:137:			decodeFunctionIndex						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:145:			decodeFunctionCount						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:159:			encodeNameSectionData						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:174:			encodeFunctionNameData						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:182:			encodeNameMap							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:193:			encodeLocalNameData						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:210:			encodeNameSubsection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:220:			encodeNameAssoc							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/names.go:225:			encodeSizePrefixed						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:12:			decodeTypeSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:27:			decodeImportSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:46:			decodeFunctionSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:61:			decodeTableSection						84.6%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:83:			decodeMemorySection						83.3%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:98:			decodeGlobalSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:113:			decodeExportSection						85.7%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:136:			decodeStartSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:144:			decodeElementSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:159:			decodeCodeSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:174:			decodeDataSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:189:			decodeDataCountSection						75.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:200:			encodeSection							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:209:			encodeTypeSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:222:			encodeImportSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:234:			encodeFunctionSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:247:			encodeCodeSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:260:			encodeTableSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:273:			encodeMemorySection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:283:			encodeGlobalSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:296:			encodeExportSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:308:			encodeStartSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:316:			encodeElementSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/section.go:328:			encodeDataSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/table.go:13:				decodeTable							86.7%
github.com/tetratelabs/wazero/internal/wasm/binary/table.go:43:				encodeTable							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/value.go:27:				encodeValTypes							100.0%
github.com/tetratelabs/wazero/internal/wasm/binary/value.go:48:				decodeValueTypes						91.7%
github.com/tetratelabs/wazero/internal/wasm/binary/value.go:73:				decodeUTF8							88.9%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:15:				NewCallContext							100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:51:				FailIfClosed							100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:59:				Name								100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:64:				WithMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:72:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:77:				Close								100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:82:				CloseWithExitCode						100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:93:				close								100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:107:			Memory								100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:112:			ExportedMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:121:			ExportedFunction						100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:140:			ParamTypes							0.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:145:			ResultTypes							0.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:150:			Call								100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:159:			ParamTypes							100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:164:			ResultTypes							100.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:169:			Call								80.0%
github.com/tetratelabs/wazero/internal/wasm/call_context.go:179:			ExportedGlobal							91.7%
github.com/tetratelabs/wazero/internal/wasm/counts.go:7:				ImportFuncCount							100.0%
github.com/tetratelabs/wazero/internal/wasm/counts.go:13:				ImportTableCount						100.0%
github.com/tetratelabs/wazero/internal/wasm/counts.go:19:				ImportMemoryCount						100.0%
github.com/tetratelabs/wazero/internal/wasm/counts.go:25:				ImportGlobalCount						100.0%
github.com/tetratelabs/wazero/internal/wasm/counts.go:31:				importCount							100.0%
github.com/tetratelabs/wazero/internal/wasm/counts.go:47:				SectionElementCount						95.2%
github.com/tetratelabs/wazero/internal/wasm/features.go:108:				Set								100.0%
github.com/tetratelabs/wazero/internal/wasm/features.go:116:				Get								100.0%
github.com/tetratelabs/wazero/internal/wasm/features.go:121:				Require								100.0%
github.com/tetratelabs/wazero/internal/wasm/features.go:129:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/features.go:145:				featureName							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:29:			validateFunction						100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:37:			validateFunctionWithMaxStackValues				48.9%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1274:			tryPop								100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1293:			pop								66.7%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1302:			popAndVerifyType						100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1313:			push								100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1320:			unreachable							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1325:			resetAtStackLimit						100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1333:			popStackLimit							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1340:			pushStackLimit							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1345:			popParams							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1349:			popResults							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1353:			requireStackValues						95.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1397:			typeMismatchError						93.3%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1419:			typeCountError							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1448:			writeValueTypes							100.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1462:			String								0.0%
github.com/tetratelabs/wazero/internal/wasm/func_validation.go:1500:			DecodeBlockType							57.9%
github.com/tetratelabs/wazero/internal/wasm/global.go:18:				Type								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:23:				Get								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:30:				Set								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:37:				String								80.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:56:				Type								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:61:				Get								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:68:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:78:				Type								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:83:				Get								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:90:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:100:				Type								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:105:				Get								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:112:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:122:				Type								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:127:				Get								100.0%
github.com/tetratelabs/wazero/internal/wasm/global.go:134:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:42:				PopGoFuncParams							100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:59:				PopValues							100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:76:				CallGoFunc							88.6%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:139:				newContextVal							100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:145:				newModuleVal							100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:152:				getFunctionType							100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:224:				kind								100.0%
github.com/tetratelabs/wazero/internal/wasm/gofunc.go:240:				getTypeOf							100.0%
github.com/tetratelabs/wazero/internal/wasm/host.go:14:					NewHostModule							92.9%
github.com/tetratelabs/wazero/internal/wasm/host.go:75:					IsHostModule							100.0%
github.com/tetratelabs/wazero/internal/wasm/host.go:79:					addFuncs							100.0%
github.com/tetratelabs/wazero/internal/wasm/host.go:111:				addMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/host.go:138:				addGlobals							100.0%
github.com/tetratelabs/wazero/internal/wasm/host.go:155:				maybeAddType							100.0%
github.com/tetratelabs/wazero/internal/wasm/host.go:167:				buildHostFunctions						100.0%
github.com/tetratelabs/wazero/internal/wasm/instruction.go:1016:			InstructionName							100.0%
github.com/tetratelabs/wazero/internal/wasm/instruction.go:1065:			MiscInstructionName						100.0%
github.com/tetratelabs/wazero/internal/wasm/instruction.go:1548:			VectorInstructionName						0.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:53:				NewMemoryInstance						100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:65:				Size								100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:72:				IndexByte							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:87:				ReadByte							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:97:				ReadUint16Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:107:				ReadUint32Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:114:				ReadFloat32Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:125:				ReadUint64Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:132:				ReadFloat64Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:143:				Read								100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:153:				WriteByte							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:164:				WriteUint16Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:175:				WriteUint32Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:181:				WriteFloat32Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:188:				WriteUint64Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:195:				WriteFloat64Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:202:				Write								100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:213:				MemoryPagesToBytesNum						100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:218:				Grow								100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:246:				PageSize							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:255:				PagesToUnitOfBytes						100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:274:				memoryBytesNumToPages						100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:279:				size								100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:284:				hasSize								100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:290:				readUint32Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:299:				readUint64Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:308:				writeUint32Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/memory.go:318:				writeUint64Le							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:194:				AssignModuleID							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:201:				TypeOfFunction							83.3%
github.com/tetratelabs/wazero/internal/wasm/module.go:229:				Validate							65.2%
github.com/tetratelabs/wazero/internal/wasm/module.go:275:				validateStartSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:291:				validateGlobals							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:307:				validateFunctions						88.9%
github.com/tetratelabs/wazero/internal/wasm/module.go:359:				declaredFunctionIndexes						100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:390:				funcDesc							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:407:				validateMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:428:				validateImports							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:443:				validateExports							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:474:				validateConstExpression						88.6%
github.com/tetratelabs/wazero/internal/wasm/module.go:545:				validateDataCountSection					100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:553:				buildGlobals							90.9%
github.com/tetratelabs/wazero/internal/wasm/module.go:575:				buildFunctions							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:627:				paramNames							44.4%
github.com/tetratelabs/wazero/internal/wasm/module.go:645:				buildMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:685:				CacheNumInUint64						75.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:702:				EqualsSignature							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:707:				key								100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:730:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:760:				Validate							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:832:				IsPassive							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:898:				AllDeclarations							88.2%
github.com/tetratelabs/wazero/internal/wasm/module.go:966:				SectionIDName							93.8%
github.com/tetratelabs/wazero/internal/wasm/module.go:1016:				ValueTypeName							100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:1025:				isReferenceValueType						100.0%
github.com/tetratelabs/wazero/internal/wasm/module.go:1044:				ExternTypeName							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:179:				Index								100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:184:				Name								100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:189:				ModuleName							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:194:				ExportNames							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:199:				ParamNames							0.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:209:				addSections							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:239:				buildDataInstances						50.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:245:				buildElementInstances						50.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:256:				buildExports							90.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:277:				validateData							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:290:				applyData							85.7%
github.com/tetratelabs/wazero/internal/wasm/store.go:304:				getExport							83.3%
github.com/tetratelabs/wazero/internal/wasm/store.go:315:				NewStore							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:334:				Instantiate							84.8%
github.com/tetratelabs/wazero/internal/wasm/store.go:432:				deleteModule							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:447:				requireModuleName						100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:460:				addModule							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:467:				Module								100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:475:				module								100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:481:				resolveImports							94.7%
github.com/tetratelabs/wazero/internal/wasm/store.go:578:				errorMinSizeMismatch						100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:582:				errorNoMax							100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:586:				errorMaxSizeMismatch						100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:590:				errorInvalidImport						100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:596:				executeConstExpression						100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:647:				getFunctionTypeIDs						88.9%
github.com/tetratelabs/wazero/internal/wasm/store.go:662:				getFunctionTypeID						100.0%
github.com/tetratelabs/wazero/internal/wasm/store.go:677:				CloseWithExitCode						87.5%
github.com/tetratelabs/wazero/internal/wasm/store.go:695:				AliasModule							0.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:27:					Args								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:36:					ArgsSize							100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:44:					Environ								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:53:					EnvironSize								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:59:					Stdin								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:65:					Stdout								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:71:					Stderr								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:75:					FS								100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:84:					RandSource							100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:93:					Read								0.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:101:					DefaultSysContext						66.7%
github.com/tetratelabs/wazero/internal/wasm/sys.go:113:					NewSysContext							100.0%
github.com/tetratelabs/wazero/internal/wasm/sys.go:155:					nullTerminatedByteCount						100.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:30:				RefTypeName							80.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:83:				IsActive							100.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:145:				validateTable							100.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:240:				buildTables							100.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:287:				checkSegmentBounds						100.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:294:				verifyImportGlobalI32						100.0%
github.com/tetratelabs/wazero/internal/wasm/table.go:314:				Grow								53.8%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:107:			DecodeModule							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:153:			newModuleParser							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:171:			ensureLParen							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:179:			beginSourceField						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:193:			beginModuleField						83.3%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:242:			parseModuleName							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:252:			parseModule							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:267:			onTypeEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:281:			parseImportModule						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:303:			parseImportName							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:317:			parseImport							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:331:			beginImportDesc							88.9%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:358:			parseImportFuncID						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:372:			addFunctionName							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:388:			parseImportFunc							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:398:			onImportFunc							81.8%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:419:			parseImportFuncEnd						0.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:429:			addLocalNames							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:437:			parseImportEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:450:			endFunc								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:465:			endMemory							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:480:			parseExportName							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:502:			parseExport							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:516:			beginExportDesc							88.9%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:536:			parseExportDesc							94.4%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:568:			parseExportDescEnd						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:581:			parseExportEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:594:			parseStart							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:604:			parseStartEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:616:			parseUnexpectedTrailingCharacters				100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:621:			resolveTypeIndices						88.9%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:640:			resolveFunctionIndices						83.3%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:665:			resolveTypeUses							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:670:			resolveInlinedTypes						93.8%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:701:			requireInlinedMatchesReferencedType				88.9%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:720:			addInlinedTypes							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/decoder.go:748:			errorContext							94.4%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:20:				Error								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:27:				Unwrap								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:31:				unexpectedFieldName						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:35:				expectedField							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:39:				unexpectedToken							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:55:				importAfterModuleDefined					100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:69:				moreThanOneInvalidInSection					100.0%
github.com/tetratelabs/wazero/internal/wasm/text/errors.go:73:				unhandledSection						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:13:			newFuncParser							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:63:			begin								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:90:			parseFunc							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:105:			afterTypeUse							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:119:			sExpressionsUnsupported						50.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:132:			beginFieldOrInstruction						80.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:145:			beginInstruction						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:269:			encodeMemArgOp							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:276:			end								80.0%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:288:			parseF32							83.3%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:302:			parseF64							83.3%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:315:			parseI32							83.3%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:328:			parseI64							83.3%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:342:			parseFuncIndex							87.5%
github.com/tetratelabs/wazero/internal/wasm/text/func_parser.go:357:			parseLocalIndex							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:11:			newIndexNamespace						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:43:			setID								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:54:			requireNoID							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:63:			parseIndex							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:94:			recordUnresolved						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:102:		recordOutOfRange						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:150:		resolve								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:164:		requireIndex							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:171:		requireIndexInRange						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/index_namespace.go:181:		formatErr							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/lexer.go:38:				lex								98.2%
github.com/tetratelabs/wazero/internal/wasm/text/memory_parser.go:10:			newMemoryParser							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/memory_parser.go:51:			begin								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/memory_parser.go:63:			beginMin							90.9%
github.com/tetratelabs/wazero/internal/wasm/text/memory_parser.go:87:			beginMax							90.9%
github.com/tetratelabs/wazero/internal/wasm/text/memory_parser.go:108:			decodePages							75.0%
github.com/tetratelabs/wazero/internal/wasm/text/memory_parser.go:118:			end								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/numbers.go:10:				decodeUint32							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/numbers.go:37:				decodeUint64							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/numbers.go:58:				decodeUint64SlowPath						93.8%
github.com/tetratelabs/wazero/internal/wasm/text/token.go:109:				String								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/token.go:153:				buildIdChars							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/token.go:160:				_idChar								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/token.go:193:				stripDollar							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:10:			newTypeParser							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:66:			begin								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:78:			tryBeginFunc							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:92:			beginFunc							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:113:			parseFunc							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:125:			parseFuncEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:134:			end								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:143:			beginParamOrResult						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:166:			parseMoreParamsOrResult						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:176:			parseMoreResults						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:185:			beginResult							80.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:215:			parseParamID							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:234:			parseParam							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:270:			parseResult							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:298:			errorContext							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/type_parser.go:310:			parseValueType							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:10:			newTypeUseParser						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:106:			begin								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:124:			emptyTypeIndex							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:153:			beginTypeParamOrResult						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:172:			parseType							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:187:			parseTypeEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:200:			beginParamOrResult						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:224:			parseMoreParamsOrResult						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:233:			parseMoreResults						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:242:			beginResult							90.9%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:274:			parseParamID							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:286:			setParamID							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:317:			parseParam							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:357:			parseResult							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:389:			parseEnd							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:397:			errorContext							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:418:			end								100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:437:			inlinedTypeIndex						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:449:			typeFieldIndex							100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:472:			maybeAddInlinedType						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:492:			recordInlinedType						100.0%
github.com/tetratelabs/wazero/internal/wasm/text/typeuse_parser.go:501:			requireInlinedMatchesReferencedType				100.0%
github.com/tetratelabs/wazero/internal/wasmdebug/debug.go:25:				FuncName							100.0%
github.com/tetratelabs/wazero/internal/wasmdebug/debug.go:47:				signature							100.0%
github.com/tetratelabs/wazero/internal/wasmdebug/debug.go:105:				NewErrorBuilder							100.0%
github.com/tetratelabs/wazero/internal/wasmdebug/debug.go:113:				FromRecovered							80.0%
github.com/tetratelabs/wazero/internal/wasmdebug/debug.go:141:				AddFrame							100.0%
github.com/tetratelabs/wazero/internal/wasmruntime/errors.go:38:			New								100.0%
github.com/tetratelabs/wazero/internal/wasmruntime/errors.go:42:			Error								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:40:				ensureContinuation						100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:49:				asBranchTarget							50.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:66:				functionFrame							0.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:74:				get								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:82:				top								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:90:				empty								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:94:				pop								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:104:			push								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:109:			calcLocalIndexToStackHeight					100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:162:			stackDump							0.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:170:			markUnreachable							100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:174:			resetUnreachable						100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:215:			CompileFunctions						95.8%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:254:			compile								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:305:			handleInstruction						34.2%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1753:			nextID								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1759:			applyToStack							84.4%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1831:			stackPop							100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1841:			stackPush							100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1846:			emit								77.8%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1869:			emitDefaultValue						45.5%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1891:			localDepth							75.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1899:			localType							100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1913:			getFrameDropRange						90.9%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1937:			stackLenInUint64						100.0%
github.com/tetratelabs/wazero/internal/wazeroir/compiler.go:1948:			readMemoryImmediate						0.0%
github.com/tetratelabs/wazero/internal/wazeroir/format.go:12:				Format								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/format.go:23:				formatOperation							15.1%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:12:			String								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:31:			String								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:52:			String								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:73:			String								75.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:102:			String								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:126:			String								37.9%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:400:			String								85.7%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:425:			asBranchTarget							100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:429:			asBranchTargetDrop						100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:437:			IsReturnTarget							100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:441:			String								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:455:			String								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:466:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:474:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:482:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:490:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:503:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:511:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:519:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:528:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:534:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:545:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:556:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:562:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:568:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:592:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:601:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:610:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:619:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:628:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:638:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:648:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:657:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:664:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:671:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:678:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:685:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:692:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:699:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:706:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:713:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:720:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:727:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:734:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:741:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:748:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:755:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:762:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:769:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:776:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:783:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:790:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:797:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:804:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:811:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:818:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:825:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:832:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:839:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:846:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:853:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:860:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:867:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:874:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:881:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:888:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:895:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:902:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:909:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:916:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:923:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:930:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:943:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:953:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:960:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:967:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:974:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:981:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:988:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:995:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1001:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1008:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1015:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1022:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1029:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1036:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1047:			Kind								100.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1058:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1065:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1072:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1084:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1094:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1103:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1116:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1126:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1136:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1146:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1156:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1166:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1176:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1193:			shapeName							0.0%
github.com/tetratelabs/wazero/internal/wazeroir/operations.go:1217:			Kind								0.0%
github.com/tetratelabs/wazero/internal/wazeroir/signature.go:168:			wasmOpcodeSignature						48.3%
github.com/tetratelabs/wazero/internal/wazeroir/signature.go:424:			funcTypeToSignature						100.0%
github.com/tetratelabs/wazero/internal/wazeroir/signature.go:435:			wasmValueTypeToUnsignedType					85.7%
github.com/tetratelabs/wazero/sys/sys.go:28:						NewExitError							100.0%
github.com/tetratelabs/wazero/sys/sys.go:33:						ModuleName							0.0%
github.com/tetratelabs/wazero/sys/sys.go:38:						ExitCode							100.0%
github.com/tetratelabs/wazero/sys/sys.go:42:						Error								0.0%
github.com/tetratelabs/wazero/sys/sys.go:47:						Is								100.0%
github.com/tetratelabs/wazero/wasi/errno.go:16:						ErrnoName							66.7%
github.com/tetratelabs/wazero/wasi/wasi.go:39:						InstantiateSnapshotPreview1					100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:444:						snapshotPreview1Functions					100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:524:						ArgsGet								100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:555:						ArgsSizesGet							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:594:						EnvironGet							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:626:						EnvironSizesGet							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:658:						ClockResGet							75.0%
github.com/tetratelabs/wazero/wasi/wasi.go:687:						ClockTimeGet							88.9%
github.com/tetratelabs/wazero/wasi/wasi.go:705:						FdAdvise							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:710:						FdAllocate							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:722:						FdClose								83.3%
github.com/tetratelabs/wazero/wasi/wasi.go:735:						FdDatasync							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:771:						FdFdstatGet							0.0%
github.com/tetratelabs/wazero/wasi/wasi.go:807:						FdPrestatGet							88.9%
github.com/tetratelabs/wazero/wasi/wasi.go:828:						FdFdstatSetFlags						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:834:						FdFdstatSetRights						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:839:						FdFilestatGet							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:844:						FdFilestatSetSize						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:849:						FdFilestatSetTimes						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:854:						FdPread								100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:882:						FdPrestatDirName						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:903:						FdPwrite							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:950:						FdRead								92.9%
github.com/tetratelabs/wazero/wasi/wasi.go:993:						FdReaddir							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:998:						FdRenumber							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1033:					FdSeek								85.7%
github.com/tetratelabs/wazero/wasi/wasi.go:1061:					FdSync								100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1066:					FdTell								100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1119:					FdWrite								89.3%
github.com/tetratelabs/wazero/wasi/wasi.go:1167:					PathCreateDirectory						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1172:					PathFilestatGet							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1177:					PathFilestatSetTimes						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1182:					PathLink							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1231:					PathOpen							88.2%
github.com/tetratelabs/wazero/wasi/wasi.go:1264:					PathReadlink							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1269:					PathRemoveDirectory						100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1274:					PathRename							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1279:					PathSymlink							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1284:					PathUnlinkFile							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1289:					PollOneoff							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1302:					ProcExit							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1307:					ProcRaise							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1312:					SchedYield							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1331:					RandomGet							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1348:					SockRecv							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1353:					SockSend							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1358:					SockShutdown							100.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1368:					timeNowUnixNano							0.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1372:					sysCtx								66.7%
github.com/tetratelabs/wazero/wasi/wasi.go:1380:					sysFSCtx							75.0%
github.com/tetratelabs/wazero/wasi/wasi.go:1396:					openFileEntry							71.4%
github.com/tetratelabs/wazero/wasi/wasi.go:1415:					writeOffsetsAndNullTerminatedValues				100.0%
github.com/tetratelabs/wazero/wasm.go:119:						NewRuntime							100.0%
github.com/tetratelabs/wazero/wasm.go:124:						NewRuntimeWithConfig						100.0%
github.com/tetratelabs/wazero/wasm.go:143:						Module								0.0%
github.com/tetratelabs/wazero/wasm.go:148:						CompileModule							84.0%
github.com/tetratelabs/wazero/wasm.go:198:						InstantiateModuleFromCode					75.0%
github.com/tetratelabs/wazero/wasm.go:209:						InstantiateModule						89.7%
github.com/tetratelabs/wazero/wasm.go:259:						Close								100.0%
github.com/tetratelabs/wazero/wasm.go:264:						CloseWithExitCode						80.0%
total:											(statements)							66.6%

```