### PR TITLE
Improves godoc formatting

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -119,7 +119,8 @@ func ValueTypeName(t ValueType) string {
 
 // Module return functions exported in a module, post-instantiation.
 //
-// Notes:
+// Notes
+//
 //	* Closing the wazero.Runtime closes any Module it instantiated.
 //	* This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
 //
@@ -239,7 +240,8 @@ type MutableGlobal interface {
 
 // Memory allows restricted access to a module's memory. Notably, this does not allow growing.
 //
-// Notes:
+// Notes
+//
 //	* All functions accept a context.Context, which when nil, default to context.Background.
 //	* This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
 //	* This includes all value types available in WebAssembly 1.0 (20191205) and all are encoded little-endian.

--- a/assemblyscript/assemblyscript.go
+++ b/assemblyscript/assemblyscript.go
@@ -1,6 +1,7 @@
 // Package assemblyscript contains Go-defined special functions imported by AssemblyScript under the module name "env".
 //
 // Note: Some code will only import "env.abort", but even that isn't imported when "import wasi" is used in the source.
+//
 // See https://www.assemblyscript.org/concepts.html#special-imports
 package assemblyscript
 
@@ -19,15 +20,15 @@ import (
 )
 
 // Instantiate instantiates a module implementing special functions defined by AssemblyScript:
-// * "env.abort" - exits with 255 with an abort message written to wazero.ModuleConfig WithStderr.
-// * "env.trace" - no output unless.
-// * "env.seed" - uses wazero.ModuleConfig WithRandSource as the source of seed values.
+//	* "env.abort" - exits with 255 with an abort message written to wazero.ModuleConfig WithStderr.
+//	* "env.trace" - no output unless.
+//	* "env.seed" - uses wazero.ModuleConfig WithRandSource as the source of seed values.
 //
-// Note: To customize behavior, use NewModuleBuilder instead.
-// Note: If the AssemblyScript program is configured to use WASI, by calling "import wasi" in any file, these
-// functions will not be used.
-// See NewModuleBuilder
-// See wasi.InstantiateSnapshotPreview1
+// Notes:
+//	* To customize behavior, use NewModuleBuilder instead.
+//	* A program compiled to use WASI, via "import wasi" in any file, won't import these functions.
+//
+// See NewModuleBuilder and wasi.InstantiateSnapshotPreview1
 func Instantiate(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	return NewModuleBuilder(r).Instantiate(ctx)
 }

--- a/assemblyscript/assemblyscript.go
+++ b/assemblyscript/assemblyscript.go
@@ -24,7 +24,8 @@ import (
 //	* "env.trace" - no output unless.
 //	* "env.seed" - uses wazero.ModuleConfig WithRandSource as the source of seed values.
 //
-// Notes:
+// Notes
+//
 //	* To customize behavior, use NewModuleBuilder instead.
 //	* A program compiled to use WASI, via "import wasi" in any file, won't import these functions.
 //

--- a/builder.go
+++ b/builder.go
@@ -35,7 +35,8 @@ import (
 //
 //	env2, _ := r.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().WithName("env.2"))
 //
-// Notes:
+// Notes
+//
 //	* ModuleBuilder is mutable. WithXXX functions return the same instance for chaining.
 //	* WithXXX methods do not return errors, to allow chaining. Any validation errors are deferred until Build.
 //	* Insertion order is not retained. Anything defined by this builder is sorted lexicographically on Build.
@@ -45,7 +46,8 @@ type ModuleBuilder interface {
 	// ExportFunction adds a function written in Go, which a WebAssembly module can import.
 	// If a function is already exported with the same name, this overwrites it.
 	//
-	// Parameters:
+	// Parameters
+	//
 	//	* name - the name to export. Ex "random_get"
 	//	* goFunc - the `func` to export.
 	//
@@ -93,7 +95,8 @@ type ModuleBuilder interface {
 	// ExportMemory adds linear memory, which a WebAssembly module can import and become available via api.Memory.
 	// If a memory is already exported with the same name, this overwrites it.
 	//
-	// Parameters:
+	// Parameters
+	//
 	//	* name - the name to export. Ex "memory" for wasi.ModuleSnapshotPreview1
 	//	* minPages - the possibly zero initial size in pages (65536 bytes per page).
 	//
@@ -101,7 +104,8 @@ type ModuleBuilder interface {
 	//	// (memory (export "memory") 1)
 	//	builder.ExportMemory(1)
 	//
-	// Notes:
+	// Notes
+	//
 	//	* This is allowed to grow to (4GiB) limited by api.MemorySizer. To bound it, use ExportMemoryWithMax.
 	//	* Version 1.0 (20191205) of the WebAssembly spec allows at most one memory per module.
 	//
@@ -170,7 +174,8 @@ type ModuleBuilder interface {
 
 	// Instantiate is a convenience that calls Build, then Runtime.InstantiateModule, using default configuration.
 	//
-	// Notes:
+	// Notes
+	//
 	//	* Closing the wazero.Runtime closes any api.Module it instantiated.
 	//	* Fields in the builder are copied during instantiation: Later changes do not affect the instantiated result.
 	//	* To avoid using configuration defaults, use Compile instead.

--- a/builder.go
+++ b/builder.go
@@ -36,16 +36,18 @@ import (
 //	env2, _ := r.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().WithName("env.2"))
 //
 // Notes:
-// * ModuleBuilder is mutable. WithXXX functions return the same instance for chaining.
-// * WithXXX methods do not return errors, to allow chaining. Any validation errors are deferred until Build.
-// * Insertion order is not retained. Anything defined by this builder is sorted lexicographically on Build.
+//	* ModuleBuilder is mutable. WithXXX functions return the same instance for chaining.
+//	* WithXXX methods do not return errors, to allow chaining. Any validation errors are deferred until Build.
+//	* Insertion order is not retained. Anything defined by this builder is sorted lexicographically on Build.
 type ModuleBuilder interface {
 	// Note: until golang/go#5860, we can't use example tests to embed code in interface godocs.
 
 	// ExportFunction adds a function written in Go, which a WebAssembly module can import.
+	// If a function is already exported with the same name, this overwrites it.
 	//
-	// * name - the name to export. Ex "random_get"
-	// * goFunc - the `func` to export.
+	// Parameters:
+	//	* name - the name to export. Ex "random_get"
+	//	* goFunc - the `func` to export.
 	//
 	// Noting a context exception described later, all parameters or result types must match WebAssembly 1.0 (20191205) value
 	// types. This means uint32, uint64, float32 or float64. Up to one result can be returned.
@@ -82,7 +84,6 @@ type ModuleBuilder interface {
 	//		results, err := fn(ctx, offset, byteCount)
 	//	--snip--
 	//
-	// Note: If a function is already exported with the same name, this overwrites it.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#host-functions%E2%91%A2
 	ExportFunction(name string, goFunc interface{}) ModuleBuilder
 
@@ -90,17 +91,20 @@ type ModuleBuilder interface {
 	ExportFunctions(nameToGoFunc map[string]interface{}) ModuleBuilder
 
 	// ExportMemory adds linear memory, which a WebAssembly module can import and become available via api.Memory.
+	// If a memory is already exported with the same name, this overwrites it.
 	//
-	// * name - the name to export. Ex "memory" for wasi.ModuleSnapshotPreview1
-	// * minPages - the possibly zero initial size in pages (65536 bytes per page).
+	// Parameters:
+	//	* name - the name to export. Ex "memory" for wasi.ModuleSnapshotPreview1
+	//	* minPages - the possibly zero initial size in pages (65536 bytes per page).
 	//
 	// For example, the WebAssembly 1.0 Text Format below is the equivalent of this builder method:
 	//	// (memory (export "memory") 1)
 	//	builder.ExportMemory(1)
 	//
-	// Note: This is allowed to grow to RuntimeConfig.WithMemoryLimitPages (4GiB). To bound it, use ExportMemoryWithMax.
-	// Note: If a memory is already exported with the same name, this overwrites it.
-	// Note: Version 1.0 (20191205) of the WebAssembly spec allows at most one memory per module.
+	// Notes:
+	//	* This is allowed to grow to (4GiB) limited by api.MemorySizer. To bound it, use ExportMemoryWithMax.
+	//	* Version 1.0 (20191205) of the WebAssembly spec allows at most one memory per module.
+	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-section%E2%91%A0
 	ExportMemory(name string, minPages uint32) ModuleBuilder
 
@@ -110,50 +114,52 @@ type ModuleBuilder interface {
 	//	// (memory (export "memory") 1 1)
 	//	builder.ExportMemoryWithMax(1, 1)
 	//
-	// Note: maxPages must be at least minPages and no larger than RuntimeConfig.WithMemoryLimitPages
+	// Note: api.MemorySizer determines the capacity.
 	ExportMemoryWithMax(name string, minPages, maxPages uint32) ModuleBuilder
 
 	// ExportGlobalI32 exports a global constant of type api.ValueTypeI32.
+	// If a global is already exported with the same name, this overwrites it.
 	//
 	// For example, the WebAssembly 1.0 Text Format below is the equivalent of this builder method:
 	//	// (global (export "canvas_width") i32 (i32.const 1024))
 	//	builder.ExportGlobalI32("canvas_width", 1024)
 	//
-	// Note: If a global is already exported with the same name, this overwrites it.
 	// Note: The maximum value of v is math.MaxInt32 to match constraints of initialization in binary format.
-	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#value-types%E2%91%A0
-	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaltype
+	//
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#value-types%E2%91%A0 and
+	// https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaltype
 	ExportGlobalI32(name string, v int32) ModuleBuilder
 
 	// ExportGlobalI64 exports a global constant of type api.ValueTypeI64.
+	// If a global is already exported with the same name, this overwrites it.
 	//
 	// For example, the WebAssembly 1.0 Text Format below is the equivalent of this builder method:
 	//	// (global (export "start_epoch") i64 (i64.const 1620216263544))
 	//	builder.ExportGlobalI64("start_epoch", 1620216263544)
 	//
-	// Note: If a global is already exported with the same name, this overwrites it.
 	// Note: The maximum value of v is math.MaxInt64 to match constraints of initialization in binary format.
-	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#value-types%E2%91%A0
-	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaltype
+	//
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#value-types%E2%91%A0 and
+	// https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaltype
 	ExportGlobalI64(name string, v int64) ModuleBuilder
 
 	// ExportGlobalF32 exports a global constant of type api.ValueTypeF32.
+	// If a global is already exported with the same name, this overwrites it.
 	//
 	// For example, the WebAssembly 1.0 Text Format below is the equivalent of this builder method:
 	//	// (global (export "math/pi") f32 (f32.const 3.1415926536))
 	//	builder.ExportGlobalF32("math/pi", 3.1415926536)
 	//
-	// Note: If a global is already exported with the same name, this overwrites it.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaltype
 	ExportGlobalF32(name string, v float32) ModuleBuilder
 
 	// ExportGlobalF64 exports a global constant of type api.ValueTypeF64.
+	// If a global is already exported with the same name, this overwrites it.
 	//
 	// For example, the WebAssembly 1.0 Text Format below is the equivalent of this builder method:
 	//	// (global (export "math/pi") f64 (f64.const 3.14159265358979323846264338327950288419716939937510582097494459))
 	//	builder.ExportGlobalF64("math/pi", 3.14159265358979323846264338327950288419716939937510582097494459)
 	//
-	// Note: If a global is already exported with the same name, this overwrites it.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#syntax-globaltype
 	ExportGlobalF64(name string, v float64) ModuleBuilder
 
@@ -164,9 +170,10 @@ type ModuleBuilder interface {
 
 	// Instantiate is a convenience that calls Build, then Runtime.InstantiateModule, using default configuration.
 	//
-	// Note: Closing the wazero.Runtime closes any api.Module it instantiated.
-	// Note: Fields in the builder are copied during instantiation: Later changes do not affect the instantiated result.
-	// Note: To avoid using configuration defaults, use Compile instead.
+	// Notes:
+	//	* Closing the wazero.Runtime closes any api.Module it instantiated.
+	//	* Fields in the builder are copied during instantiation: Later changes do not affect the instantiated result.
+	//	* To avoid using configuration defaults, use Compile instead.
 	Instantiate(context.Context) (api.Module, error)
 }
 

--- a/config.go
+++ b/config.go
@@ -26,25 +26,26 @@ type RuntimeConfig interface {
 	// ("bulk-memory-operations"). This defaults to false as the feature was not finished in WebAssembly 1.0.
 	//
 	// Here are the notable effects:
-	// * Adds `memory.fill`, `memory.init`, `memory.copy` and `data.drop` instructions.
-	// * Adds `table.init`, `table.copy` and `elem.drop` instructions.
-	// * Introduces a "passive" form of element and data segments.
-	// * Stops checking "active" element and data segment boundaries at compile-time, meaning they can error at runtime.
+	//	* Adds `memory.fill`, `memory.init`, `memory.copy` and `data.drop` instructions.
+	//	* Adds `table.init`, `table.copy` and `elem.drop` instructions.
+	//	* Introduces a "passive" form of element and data segments.
+	//	* Stops checking "active" element and data segment boundaries at compile-time, meaning they can error at runtime.
 	//
 	// Note: "bulk-memory-operations" is mixed with the "reference-types" proposal
 	// due to the WebAssembly Working Group merging them "mutually dependent".
 	// Therefore, enabling this feature results in enabling WithFeatureReferenceTypes, and vice-versa.
+	//
 	// See https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md
-	// See https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md
-	// See https://github.com/WebAssembly/spec/pull/1287
+	// https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md and
+	// https://github.com/WebAssembly/spec/pull/1287
 	WithFeatureBulkMemoryOperations(bool) RuntimeConfig
 
 	// WithFeatureMultiValue enables multiple values ("multi-value"). This defaults to false as the feature was not
 	// finished in WebAssembly 1.0 (20191205).
 	//
 	// Here are the notable effects:
-	// * Function (`func`) types allow more than one result
-	// * Block types (`block`, `loop` and `if`) can be arbitrary function types
+	//	* Function (`func`) types allow more than one result
+	//	* Block types (`block`, `loop` and `if`) can be arbitrary function types
 	//
 	// See https://github.com/WebAssembly/spec/blob/main/proposals/multi-value/Overview.md
 	WithFeatureMultiValue(bool) RuntimeConfig
@@ -60,47 +61,48 @@ type RuntimeConfig interface {
 	// ("nontrapping-float-to-int-conversion"). This defaults to false as the feature was not in WebAssembly 1.0.
 	//
 	// The only effect of enabling is allowing the following instructions, which return 0 on NaN instead of panicking.
-	// * `i32.trunc_sat_f32_s`
-	// * `i32.trunc_sat_f32_u`
-	// * `i32.trunc_sat_f64_s`
-	// * `i32.trunc_sat_f64_u`
-	// * `i64.trunc_sat_f32_s`
-	// * `i64.trunc_sat_f32_u`
-	// * `i64.trunc_sat_f64_s`
-	// * `i64.trunc_sat_f64_u`
+	//	* `i32.trunc_sat_f32_s`
+	//	* `i32.trunc_sat_f32_u`
+	//	* `i32.trunc_sat_f64_s`
+	//	* `i32.trunc_sat_f64_u`
+	//	* `i64.trunc_sat_f32_s`
+	//	* `i64.trunc_sat_f32_u`
+	//	* `i64.trunc_sat_f64_s`
+	//	* `i64.trunc_sat_f64_u`
 	//
 	// See https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md
 	WithFeatureNonTrappingFloatToIntConversion(bool) RuntimeConfig
 
 	// WithFeatureReferenceTypes enables various instructions and features related to table and new reference types.
 	//
-	// * Introduction of new value types: `funcref` and `externref`.
-	// * Support for the following new instructions:
-	//   * `ref.null`
-	//   * `ref.func`
-	//   * `ref.is_null`
-	//   * `table.fill`
-	//   * `table.get`
-	//   * `table.grow`
-	//   * `table.set`
-	//   * `table.size`
-	// * Support for multiple tables per module:
-	//   * `call_indirect`, `table.init`, `table.copy` and `elem.drop` instructions can take non-zero table index.
-	//   * Element segments can take non-zero table index.
+	//	* Introduction of new value types: `funcref` and `externref`.
+	//	* Support for the following new instructions:
+	//	 * `ref.null`
+	//	 * `ref.func`
+	//	 * `ref.is_null`
+	//	 * `table.fill`
+	//	 * `table.get`
+	//	 * `table.grow`
+	//	 * `table.set`
+	//	 * `table.size`
+	//	* Support for multiple tables per module:
+	//	 * `call_indirect`, `table.init`, `table.copy` and `elem.drop` instructions can take non-zero table index.
+	//	 * Element segments can take non-zero table index.
 	//
 	// Note: "reference-types" is mixed with the "bulk-memory-operations" proposal
 	// due to the WebAssembly Working Group merging them "mutually dependent".
 	// Therefore, enabling this feature results in enabling WithFeatureBulkMemoryOperations, and vice-versa.
+	//
 	// See https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md
-	// See https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md
-	// See https://github.com/WebAssembly/spec/pull/1287
+	// https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md and
+	// https://github.com/WebAssembly/spec/pull/1287
 	WithFeatureReferenceTypes(enabled bool) RuntimeConfig
 
 	// WithFeatureSignExtensionOps enables sign extension instructions ("sign-extension-ops"). This defaults to false
 	// as the feature was not in WebAssembly 1.0.
 	//
 	// Here are the notable effects:
-	// * Adds instructions `i32.extend8_s`, `i32.extend16_s`, `i64.extend8_s`, `i64.extend16_s` and `i64.extend32_s`
+	//	* Adds instructions `i32.extend8_s`, `i32.extend16_s`, `i64.extend8_s`, `i64.extend16_s` and `i64.extend32_s`
 	//
 	// See https://github.com/WebAssembly/spec/blob/main/proposals/sign-extension-ops/Overview.md
 	WithFeatureSignExtensionOps(bool) RuntimeConfig
@@ -155,7 +157,8 @@ var engineLessConfig = &runtimeConfig{
 // Note: While this is technically AOT, this does not imply any action on your
 // part. wazero automatically performs ahead-of-time compilation as needed when
 // Runtime.CompileModule is invoked.
-// Note: This panics at runtime the runtime.GOOS or runtime.GOARCH does not
+//
+// Warning: This panics at runtime if the runtime.GOOS or runtime.GOARCH does not
 // support Compiler. Use NewRuntimeConfig to safely detect and fallback to
 // NewRuntimeConfigInterpreter if needed.
 func NewRuntimeConfigCompiler() RuntimeConfig {
@@ -240,10 +243,11 @@ func (c *runtimeConfig) WithWasmCore2() RuntimeConfig {
 
 // CompiledModule is a WebAssembly 1.0 module ready to be instantiated (Runtime.InstantiateModule) as an api.Module.
 //
-// Note: Closing the wazero.Runtime closes any CompiledModule it compiled.
-// Note: In WebAssembly language, this is a decoded, validated, and possibly also compiled module. wazero avoids using
+// In WebAssembly terminology, this is a decoded, validated, and possibly also compiled module. wazero avoids using
 // the name "Module" for both before and after instantiation as the name conflation has caused confusion.
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#semantic-phases%E2%91%A0
+//
+// Note: Closing the wazero.Runtime closes any CompiledModule it compiled.
 type CompiledModule interface {
 	// Close releases all the allocated resources for this CompiledModule.
 	//
@@ -275,15 +279,13 @@ func (c *compiledCode) Close(_ context.Context) error {
 type CompileConfig interface {
 
 	// WithImportRenamer can rename imports or break them into different modules. No default.
+	// A nil function is invalid and ignored.
 	//
-	// Note: A nil function is invalid and ignored.
 	// Note: This is currently not relevant for ModuleBuilder as it has no means to define imports.
 	WithImportRenamer(api.ImportRenamer) CompileConfig
 
 	// WithMemorySizer are the allocation parameters used for a Wasm memory.
-	// The default is to set cap=min and max=65536 if unset.
-	//
-	// Note: A nil function is invalid and ignored.
+	// The default is to set cap=min and max=65536 if unset. A nil function is invalid and ignored.
 	WithMemorySizer(api.MemorySizer) CompileConfig
 }
 
@@ -324,14 +326,14 @@ func (c *compileConfig) WithMemorySizer(memorySizer api.MemorySizer) CompileConf
 // system. Using this, resources such as STDIN can be isolated, so that the same module can be safely instantiated
 // multiple times.
 //
-// Note: While wazero supports Windows as a platform, host functions using ModuleConfig follow a UNIX dialect.
+// While wazero supports Windows as a platform, host functions using ModuleConfig follow a UNIX dialect.
 // See RATIONALE.md for design background and relationship to WebAssembly System Interfaces (WASI).
 //
 // Note: ModuleConfig is immutable. Each WithXXX function returns a new instance including the corresponding change.
 type ModuleConfig interface {
 
 	// WithArgs assigns command-line arguments visible to an imported function that reads an arg vector (argv). Defaults to
-	// none.
+	// none. Runtime.InstantiateModule errs if any arg is empty.
 	//
 	// These values are commonly read by the functions like "args_get" in "wasi_snapshot_preview1" although they could be
 	// read by functions imported from other modules.
@@ -341,12 +343,12 @@ type ModuleConfig interface {
 	// argument to the same value set via WithName.
 	//
 	// Note: This does not default to os.Args as that violates sandboxing.
-	// Note: Runtime.InstantiateModule errs if any value is empty.
-	// See https://linux.die.net/man/3/argv
-	// See https://en.wikipedia.org/wiki/Null-terminated_string
+	//
+	// See https://linux.die.net/man/3/argv and https://en.wikipedia.org/wiki/Null-terminated_string
 	WithArgs(...string) ModuleConfig
 
 	// WithEnv sets an environment variable visible to a Module that imports functions. Defaults to none.
+	// Runtime.InstantiateModule errs if the key is empty or contains a NULL(0) or equals("") character.
 	//
 	// Validation is the same as os.Setenv on Linux and replaces any existing value. Unlike exec.Cmd Env, this does not
 	// default to the current process environment as that would violate sandboxing. This also does not preserve order.
@@ -358,12 +360,11 @@ type ModuleConfig interface {
 	// example, neither WebAssembly nor WebAssembly System Interfaces (WASI) define concerns processes have, such as
 	// case-sensitivity on environment keys. For portability, define entries with case-insensitively unique keys.
 	//
-	// Note: Runtime.InstantiateModule errs if the key is empty or contains a NULL(0) or equals("") character.
-	// See https://linux.die.net/man/3/environ
-	// See https://en.wikipedia.org/wiki/Null-terminated_string
+	// See https://linux.die.net/man/3/environ and https://en.wikipedia.org/wiki/Null-terminated_string
 	WithEnv(key, value string) ModuleConfig
 
 	// WithFS assigns the file system to use for any paths beginning at "/". Defaults to not found.
+	// Note: This sets WithWorkDirFS to the same file-system unless already set.
 	//
 	// Ex. This sets a read-only, embedded file-system to serve files under the root ("/") and working (".") directories:
 	//
@@ -376,7 +377,6 @@ type ModuleConfig interface {
 	//	// "index.html" is accessible as both "/index.html" and "./index.html" because we didn't use WithWorkDirFS.
 	//	config := wazero.NewModuleConfig().WithFS(rooted)
 	//
-	// Note: This sets WithWorkDirFS to the same file-system unless already set.
 	WithFS(fs.FS) ModuleConfig
 
 	// WithName configures the module name. Defaults to what was decoded or overridden via CompileConfig.WithModuleName.
@@ -392,8 +392,10 @@ type ModuleConfig interface {
 	// This writer is most commonly used by the functions like "fd_write" in "wasi_snapshot_preview1" although it could
 	// be used by functions imported from other modules.
 	//
-	// Note: The caller is responsible to close any io.Writer they supply: It is not closed on api.Module Close.
-	// Note: This does not default to os.Stderr as that both violates sandboxing and prevents concurrent modules.
+	// Notes:
+	//	* The caller is responsible to close any io.Writer they supply: It is not closed on api.Module Close.
+	//	* This does not default to os.Stderr as that both violates sandboxing and prevents concurrent modules.
+	//
 	// See https://linux.die.net/man/3/stderr
 	WithStderr(io.Writer) ModuleConfig
 
@@ -402,8 +404,10 @@ type ModuleConfig interface {
 	// This reader is most commonly used by the functions like "fd_read" in "wasi_snapshot_preview1" although it could
 	// be used by functions imported from other modules.
 	//
-	// Note: The caller is responsible to close any io.Reader they supply: It is not closed on api.Module Close.
-	// Note: This does not default to os.Stdin as that both violates sandboxing and prevents concurrent modules.
+	// Notes:
+	//	* The caller is responsible to close any io.Reader they supply: It is not closed on api.Module Close.
+	//	* This does not default to os.Stdin as that both violates sandboxing and prevents concurrent modules.
+	//
 	// See https://linux.die.net/man/3/stdin
 	WithStdin(io.Reader) ModuleConfig
 
@@ -412,8 +416,10 @@ type ModuleConfig interface {
 	// This writer is most commonly used by the functions like "fd_write" in "wasi_snapshot_preview1" although it could
 	// be used by functions imported from other modules.
 	//
-	// Note: The caller is responsible to close any io.Writer they supply: It is not closed on api.Module Close.
-	// Note: This does not default to os.Stdout as that both violates sandboxing and prevents concurrent modules.
+	// Notes:
+	//	* The caller is responsible to close any io.Writer they supply: It is not closed on api.Module Close.
+	//	* This does not default to os.Stdout as that both violates sandboxing and prevents concurrent modules.
+	//
 	// See https://linux.die.net/man/3/stdout
 	WithStdout(io.Writer) ModuleConfig
 

--- a/config.go
+++ b/config.go
@@ -392,7 +392,8 @@ type ModuleConfig interface {
 	// This writer is most commonly used by the functions like "fd_write" in "wasi_snapshot_preview1" although it could
 	// be used by functions imported from other modules.
 	//
-	// Notes:
+	// Notes
+	//
 	//	* The caller is responsible to close any io.Writer they supply: It is not closed on api.Module Close.
 	//	* This does not default to os.Stderr as that both violates sandboxing and prevents concurrent modules.
 	//
@@ -404,7 +405,8 @@ type ModuleConfig interface {
 	// This reader is most commonly used by the functions like "fd_read" in "wasi_snapshot_preview1" although it could
 	// be used by functions imported from other modules.
 	//
-	// Notes:
+	// Notes
+	//
 	//	* The caller is responsible to close any io.Reader they supply: It is not closed on api.Module Close.
 	//	* This does not default to os.Stdin as that both violates sandboxing and prevents concurrent modules.
 	//
@@ -416,7 +418,8 @@ type ModuleConfig interface {
 	// This writer is most commonly used by the functions like "fd_write" in "wasi_snapshot_preview1" although it could
 	// be used by functions imported from other modules.
 	//
-	// Notes:
+	// Notes
+	//
 	//	* The caller is responsible to close any io.Writer they supply: It is not closed on api.Module Close.
 	//	* This does not default to os.Stdout as that both violates sandboxing and prevents concurrent modules.
 	//

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -9,6 +9,7 @@ import (
 // FunctionListenerFactoryKey is a context.Context Value key. Its associated value should be a FunctionListenerFactory.
 //
 // Note: This is interpreter-only for now!
+//
 // See https://github.com/tetratelabs/wazero/issues/451
 type FunctionListenerFactoryKey struct{}
 

--- a/sys/sys.go
+++ b/sys/sys.go
@@ -18,8 +18,9 @@ import (
 //
 // Note: While possible the reason of this was "proc_exit" from "wasi_snapshot_preview1", it could be from other host
 // functions, for example an AssemblyScript's abort handler, or any arbitrary caller of CloseWithExitCode.
-// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
-// See https://www.assemblyscript.org/concepts.html#special-imports
+//
+// See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit and
+// https://www.assemblyscript.org/concepts.html#special-imports
 type ExitError struct {
 	moduleName string
 	exitCode   uint32
@@ -39,6 +40,7 @@ func (e *ExitError) ExitCode() uint32 {
 	return e.exitCode
 }
 
+// Error implements the error interface.
 func (e *ExitError) Error() string {
 	return fmt.Sprintf("module %q closed with exit_code(%d)", e.moduleName, e.exitCode)
 }

--- a/wasi/errno.go
+++ b/wasi/errno.go
@@ -6,10 +6,12 @@ import (
 
 // Errno are the error codes returned by WASI functions.
 //
-// Note: This is not always an error, as ErrnoSuccess is a valid code.
-// Note: Codes are defined even when not relevant to WASI for use in higher-level libraries or alignment with POSIX.
-// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-errno-enumu16
-// See https://linux.die.net/man/3/errno
+// Notes:
+//	* This is not always an error, as ErrnoSuccess is a valid code.
+//	* Codes are defined even when not relevant to WASI for use in higher-level libraries or alignment with POSIX.
+//
+// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-errno-enumu16 and
+// https://linux.die.net/man/3/errno
 type Errno = uint32 // alias for parity with wasm.ValueType
 
 // ErrnoName returns the POSIX error code name, except ErrnoSuccess, which is not an error. Ex. Errno2big -> "E2BIG"

--- a/wasi/errno.go
+++ b/wasi/errno.go
@@ -6,7 +6,8 @@ import (
 
 // Errno are the error codes returned by WASI functions.
 //
-// Notes:
+// Notes
+//
 //	* This is not always an error, as ErrnoSuccess is a valid code.
 //	* Codes are defined even when not relevant to WASI for use in higher-level libraries or alignment with POSIX.
 //

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -19,7 +19,8 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// ModuleSnapshotPreview1 is the module name WASI functions are exported into
+// ModuleSnapshotPreview1 is the module name WASI functions are exported into.
+//
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
 const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 
@@ -34,8 +35,9 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
 //	mod, _ := r.InstantiateModuleFromCode(ctx, source)
 //
-// Note: All WASI functions return a single Errno result, ErrnoSuccess on success.
-// Note: Closing the wazero.Runtime closes this instance of WASI as well.
+// Notes:
+//	* All WASI functions return a single Errno result, ErrnoSuccess on success.
+//	* Closing the wazero.Runtime closes this instance of WASI as well.
 func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Closer, error) {
 	_, fns := snapshotPreview1Functions(ctx)
 	return r.NewModuleBuilder(ModuleSnapshotPreview1).ExportFunctions(fns).Instantiate(ctx)

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -35,7 +35,8 @@ const ModuleSnapshotPreview1 = "wasi_snapshot_preview1"
 //	_, _ = wasi.InstantiateSnapshotPreview1(ctx, r)
 //	mod, _ := r.InstantiateModuleFromCode(ctx, source)
 //
-// Notes:
+// Notes
+//
 //	* All WASI functions return a single Errno result, ErrnoSuccess on success.
 //	* Closing the wazero.Runtime closes this instance of WASI as well.
 func InstantiateSnapshotPreview1(ctx context.Context, r wazero.Runtime) (api.Closer, error) {

--- a/wasm.go
+++ b/wasm.go
@@ -38,18 +38,21 @@ type Runtime interface {
 	Module(moduleName string) api.Module
 
 	// CompileModule decodes the WebAssembly text or binary source or errs if invalid.
-	// Any pre-compilation done after decoding the source is dependent on RuntimeConfig or CompileConfig.
+	// When the context is nil, it defaults to context.Background.
 	//
 	// There are two main reasons to use CompileModule instead of InstantiateModuleFromCode:
-	//  * Improve performance when the same module is instantiated multiple times under different names
-	//  * Reduce the amount of errors that can occur during InstantiateModule.
+	//	* Improve performance when the same module is instantiated multiple times under different names
+	//	* Reduce the amount of errors that can occur during InstantiateModule.
 	//
-	// Note: When the context is nil, it defaults to context.Background.
-	// Note: The resulting module name defaults to what was binary from the custom name section.
+	// Notes:
+	//	* The resulting module name defaults to what was binary from the custom name section.
+	//	* Any pre-compilation done after decoding the source is dependent on RuntimeConfig or CompileConfig.
+	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#name-section%E2%91%A0
 	CompileModule(ctx context.Context, source []byte, config CompileConfig) (CompiledModule, error)
 
 	// InstantiateModuleFromCode instantiates a module from the WebAssembly text or binary source or errs if invalid.
+	// When the context is nil, it defaults to context.Background.
 	//
 	// Ex.
 	//	ctx := context.Background()
@@ -58,13 +61,14 @@ type Runtime interface {
 	//
 	//	module, _ := r.InstantiateModuleFromCode(ctx, source)
 	//
-	// Note: When the context is nil, it defaults to context.Background.
-	// Note: This is a convenience utility that chains CompileModule with InstantiateModule. To instantiate the same
-	// source multiple times, use CompileModule as InstantiateModule avoids redundant decoding and/or compilation.
-	// Note: To avoid using configuration defaults, use InstantiateModule instead.
+	// Notes:
+	//	* This is a convenience utility that chains CompileModule with InstantiateModule. To instantiate the same
+	//	source multiple times, use CompileModule as InstantiateModule avoids redundant decoding and/or compilation.
+	//	* To avoid using configuration defaults, use InstantiateModule instead.
 	InstantiateModuleFromCode(ctx context.Context, source []byte) (api.Module, error)
 
 	// InstantiateModule instantiates the module namespace or errs if the configuration was invalid.
+	// When the context is nil, it defaults to context.Background.
 	//
 	// Ex.
 	//	ctx := context.Background()
@@ -75,9 +79,9 @@ type Runtime interface {
 	//	module, _ := r.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().WithName("prod"))
 	//
 	// While CompiledModule is pre-validated, there are a few situations which can cause an error:
-	//  * The module name is already in use.
-	//  * The module has a table element initializer that resolves to an index outside the Table minimum size.
-	//  * The module has a start function, and it failed to execute.
+	//	* The module name is already in use.
+	//	* The module has a table element initializer that resolves to an index outside the Table minimum size.
+	//	* The module has a start function, and it failed to execute.
 	//
 	// Configuration can also define different args depending on the importing module.
 	//
@@ -95,10 +99,10 @@ type Runtime interface {
 	//	module, _ := r.InstantiateModule(ctx, compiled, config.WithName("rotate").WithArgs("rotate", "angle=90", "dir=cw"))
 	//
 	// Note: Config is copied during instantiation: Later changes to config do not affect the instantiated result.
-	// Note: When the context is nil, it defaults to context.Background.
 	InstantiateModule(ctx context.Context, compiled CompiledModule, config ModuleConfig) (api.Module, error)
 
 	// CloseWithExitCode closes all the modules that have been initialized in this Runtime with the provided exit code.
+	// When the context is nil, it defaults to context.Background.
 	// An error is returned if any module returns an error when closed.
 	//
 	// Ex.

--- a/wasm.go
+++ b/wasm.go
@@ -44,7 +44,8 @@ type Runtime interface {
 	//	* Improve performance when the same module is instantiated multiple times under different names
 	//	* Reduce the amount of errors that can occur during InstantiateModule.
 	//
-	// Notes:
+	// Notes
+	//
 	//	* The resulting module name defaults to what was binary from the custom name section.
 	//	* Any pre-compilation done after decoding the source is dependent on RuntimeConfig or CompileConfig.
 	//
@@ -61,7 +62,8 @@ type Runtime interface {
 	//
 	//	module, _ := r.InstantiateModuleFromCode(ctx, source)
 	//
-	// Notes:
+	// Notes
+	//
 	//	* This is a convenience utility that chains CompileModule with InstantiateModule. To instantiate the same
 	//	source multiple times, use CompileModule as InstantiateModule avoids redundant decoding and/or compilation.
 	//	* To avoid using configuration defaults, use InstantiateModule instead.


### PR DESCRIPTION
I researched what is available for improving godoc. Notably, this does
the following on every non-internal go file (tests excluded).

* consolidates links where there's a better single one
* wraps See where there are multiple relevant links
* reduces use of Note: where possible
* Uses preformatting for bullets similar to gob
* Uses titles where appropriate

I looked into it and while there are many ways to re-render godoc into
markdown, there are limited options on what to do in godoc itself. There
are tricks implicitly used where preformatting (tab indent) is used to
avoid having to add extra lines everywhere. This is done in gob, for
example.

See https://go.dev/src/encoding/gob/doc.go
See https://github.com/fluhus/godoc-tricks/blob/master/doc.go
See #426