### PR TITLE
Implements clock ID support for getting time/res in wasi

### DIFF
--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -1410,11 +1410,7 @@ const (
 	clockIDMonotonic = 1
 )
 
-// time does not provide a means to directly reference the monotonic time value it computes with time.Now.
-// We retrieve a time.Now on initialization to use as a base which we compute values against which ensures
-// subsequent readings from clock_time_get return montonically increasing values with correct deltas.
-// time.Now always returns a time with a monotonic reading for dates between 1885-2157. This code should
-// probably be revisited around 2155 to check if the time is actually monotonic before returning.
+// monotonicClockBase uses time.Now to ensure a monotonic clock reading on all platforms via time.Since.
 var monotonicClockBase = time.Now()
 
 func timeNowUnixNano() uint64 {

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -1413,6 +1413,7 @@ const (
 // time does not provide a means to directly reference the monotonic time value it computes with time.Now.
 // We retrieve a time.Now on initialization to use as a base which we compute values against which ensures
 // subsequent readings from clock_time_get return montonically increasing values with correct deltas.
+// time.Now always returns a Time with a monotonic reading.
 var monotonicClockBase = time.Now()
 
 func timeNowUnixNano() uint64 {

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -659,10 +659,9 @@ func (a *snapshotPreview1) EnvironSizesGet(ctx context.Context, m api.Module, re
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_res_getid-clockid---errno-timestamp
 // See https://linux.die.net/man/3/clock_getres
 func (a *snapshotPreview1) ClockResGet(ctx context.Context, m api.Module, id uint32, resultResolution uint32) Errno {
-	// A clock's resolution is hardware and OS dependent so requires a system call to retrieve an accurate value.
-	// Go does not provide a function for getting resolution, so without CGO we don't have an easy way to get an actual
-	// value. For now, we return fixed values with an assumption that realtime clocks are often lower precision than
-	// monotonic clocks. In the future, this could be improved by having OS+arch specific assembly to make syscalls.
+	// We choose arbitrary resolutions here because there's no perfect alternative. For example, according to the
+	// source in time.go, windows monotonic resolution can be 15ms. This chooses arbitrarily 1us for wall time and
+	// 1ns for monotonic. See RATIONALE.md for more context.
 
 	var resolution uint64 // ns
 	switch id {

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -663,15 +663,6 @@ func (a *snapshotPreview1) ClockResGet(ctx context.Context, m api.Module, id uin
 	// Go does not provide a function for getting resolution, so without CGO we don't have an easy way to get an actual
 	// value. For now, we return fixed values with an assumption that realtime clocks are often lower precision than
 	// monotonic clocks. In the future, this could be improved by having OS+arch specific assembly to make syscalls.
-	//
-	// For example, this is how Go implements time.Now for linux-amd64.
-	// https://github.com/golang/go/blob/f19e4001808863d2ebfe9d1975476513d030c381/src/runtime/time_linux_amd64.s
-	// Because retrieving resolution is not generally called often, unlike getting time, it could be appropriate to only
-	// implement the fallback logic that does not use VDSO (executing syscalls in user mode). The syscall for clock_getres
-	// is 229 https://pkg.go.dev/syscall#pkg-constants.
-	// If implementing similar for Windows, mingw is often a good source to find the Windows API calls that correspond
-	// to a POSIX method.
-	// https://github.com/mirror/mingw-w64/blob/6a0e9165008f731bccadfc41a59719cf7c8efc02/mingw-w64-libraries/winpthreads/src/clock.c#L77
 
 	var resolution uint64 // ns
 	switch id {

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -131,7 +131,7 @@ const (
 
 	// importFdFdstatGet is the WebAssembly 1.0 (20191205) Text format import of functionFdFdstatGet.
 	importFdFdstatGet = `(import "wasi_snapshot_preview1" "fd_fdstat_get"
-    (func $wasi.fd_fdstat_get (param $fd i32) (param $result.stat i32) (result (;errno;) i32)))`  //nolint
+    (func $wasi.fd_fdstat_get (param $fd i32) (param $result.stat i32) (result (;errno;) i32)))` //nolint
 
 	// functionFdFdstatSetFlags adjusts the flags associated with a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_flagsfd-fd-flags-fdflags---errno
@@ -663,11 +663,15 @@ func (a *snapshotPreview1) ClockResGet(ctx context.Context, m api.Module, id uin
 	// Go does not provide a function for getting resolution, so without CGO we don't have an easy way to get an actual
 	// value. For now, we return fixed values with an assumption that realtime clocks are often lower precision than
 	// monotonic clocks. In the future, this could be improved by having OS+arch specific assembly to make syscalls.
+	//
 	// For example, this is how Go implements time.Now for linux-amd64.
 	// https://github.com/golang/go/blob/f19e4001808863d2ebfe9d1975476513d030c381/src/runtime/time_linux_amd64.s
 	// Because retrieving resolution is not generally called often, unlike getting time, it could be appropriate to only
 	// implement the fallback logic that does not use VDSO (executing syscalls in user mode). The syscall for clock_getres
 	// is 229 https://pkg.go.dev/syscall#pkg-constants.
+	// If implementing similar for Windows, mingw is often a good source to find the Windows API calls that correspond
+	// to a POSIX method.
+	// https://github.com/mirror/mingw-w64/blob/6a0e9165008f731bccadfc41a59719cf7c8efc02/mingw-w64-libraries/winpthreads/src/clock.c#L77
 
 	var resolution uint64 // ns
 	switch id {

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -1413,7 +1413,6 @@ const (
 // time does not provide a means to directly reference the monotonic time value it computes with time.Now.
 // We retrieve a time.Now on initialization to use as a base which we compute values against which ensures
 // subsequent readings from clock_time_get return montonically increasing values with correct deltas.
-// time.Now always returns a Time with a monotonic reading.
 var monotonicClockBase = time.Now()
 
 func timeNowUnixNano() uint64 {

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -131,7 +131,7 @@ const (
 
 	// importFdFdstatGet is the WebAssembly 1.0 (20191205) Text format import of functionFdFdstatGet.
 	importFdFdstatGet = `(import "wasi_snapshot_preview1" "fd_fdstat_get"
-    (func $wasi.fd_fdstat_get (param $fd i32) (param $result.stat i32) (result (;errno;) i32)))` //nolint
+    (func $wasi.fd_fdstat_get (param $fd i32) (param $result.stat i32) (result (;errno;) i32)))`  //nolint
 
 	// functionFdFdstatSetFlags adjusts the flags associated with a file descriptor.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_flagsfd-fd-flags-fdflags---errno

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -1404,6 +1404,7 @@ const (
 	fdStderr = 2
 )
 
+// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clockid-enumu32
 const (
 	clockIDRealtime  = 0
 	clockIDMonotonic = 1

--- a/wasi/wasi.go
+++ b/wasi/wasi.go
@@ -1413,6 +1413,8 @@ const (
 // time does not provide a means to directly reference the monotonic time value it computes with time.Now.
 // We retrieve a time.Now on initialization to use as a base which we compute values against which ensures
 // subsequent readings from clock_time_get return montonically increasing values with correct deltas.
+// time.Now always returns a time with a monotonic reading for dates between 1885-2157. This code should
+// probably be revisited around 2155 to check if the time is actually monotonic before returning.
 var monotonicClockBase = time.Now()
 
 func timeNowUnixNano() uint64 {


### PR DESCRIPTION
Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>

#### Supported clock IDs

We only support clock IDs REALTIME and MONOTONIC, while some runtimes support all IDs, not all. The next version of WASI removes the other IDs anyways

https://github.com/WebAssembly/WASI/pull/197
https://github.com/bytecodealliance/wasmtime/blob/8b48ce7fb79c7e36748e2e1a90be3bdf7d65cbce/crates/wasi-common/src/snapshots/preview_1.rs#L249

#### Mockable

Monotonic is not mockable, unlike realtime. I had first toyed with the idea of having the mock return `time.Time` instead of the unixnow value itself to support both but realized that there is no way to create a static monotonic `time.Time` in Go anyways. So allowing that would probably require instead to use the current function but provide it the `clockID` parameter. This didn't feel very useful so I left it out but happy to add it if it seems to make sense.

#### clock_time_get

`precision` is ignored, I looked at the other implementations and they seem to all ignore it. This is understandable since despite the WASI docs saying this is meant to be similar to POSIX `clock_gettime`, that function doesn't accept a precision. I suppose the main target of the parameter is mobile, not server-side. Let me know if it makes sense to commit to that understanding and remove the `TODO`

https://github.com/WasmEdge/WasmEdge/blob/bee4ad9831dec02d3224b9005d69cf30e3e973f6/lib/host/wasi/clock-linux.cpp#L26
https://github.com/wasmerio/wasmer/blob/3604debecc753c1a13701559035d75b30b77d912/lib/wasi/src/syscalls/unix/mod.rs#L36
https://github.com/bytecodealliance/cap-std/blob/024a7491b28de27d4a2dc6eea9e4372ac6001508/cap-time-ext/src/monotonic_clock.rs#L30

#### clock_get_res

`clock_get_res` should return a "real" resolution of a clock, which reflects the actual hardware and OS running the code. As such, it requires a syscall, but Go doesn't provide any function for doing this.

The other runtimes use libc or direct syscall

https://github.com/bytecodealliance/cap-std/blob/024a7491b28de27d4a2dc6eea9e4372ac6001508/cap-time-ext/src/monotonic_clock.rs#L2
https://github.com/WasmEdge/WasmEdge/blob/f77e67dfb298576b41eb7874df4f399a0de0e808/test/host/wasi/wasi.cpp#L17
https://github.com/wasmerio/wasmer/blob/3604debecc753c1a13701559035d75b30b77d912/lib/wasi/src/syscalls/unix/mod.rs#L3

For now, we just return a static value, 1 micro for realtime, and 1 nano for monotonic time, assuming realtime tends to have lower precision than monotonic. I couldn't find any actual usage in stdlib of tinygo or assemblyscript to better inform this decision.