### PR TITLE
Extracts platform-specific runtime code into its own package

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	"github.com/tetratelabs/wazero/internal/buildoptions"
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
@@ -396,7 +397,7 @@ func releaseCode(compiledFn *code) {
 
 	// Setting this to nil allows tests to know the correct finalizer function was called.
 	compiledFn.codeSegment = nil
-	if err := munmapCodeSegment(codeSegment); err != nil {
+	if err := platform.MunmapCodeSegment(codeSegment); err != nil {
 		// munmap failure cannot recover, and happen asynchronously on the finalizer thread. While finalizer
 		// functions can return errors, they are ignored. To make these visible for troubleshooting, we panic
 		// with additional context. module+funcidx should be enough, but if not, we can add more later.

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -173,6 +173,7 @@ func TestCompiler_ModuleEngine_Memory(t *testing.T) {
 	enginetest.RunTestModuleEngine_Memory(t, et)
 }
 
+// requireSupportedOSArch is duplicated also in the platform package to ensure no cyclic dependency.
 func requireSupportedOSArch(t *testing.T) {
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		t.Skip()

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/amd64"
 	"github.com/tetratelabs/wazero/internal/buildoptions"
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
@@ -231,7 +232,7 @@ func (c *amd64Compiler) compile() (code []byte, staticData codeStaticData, stack
 		return
 	}
 
-	code, err = mmapCodeSegment(code)
+	code, err = platform.MmapCodeSegment(code)
 	if err != nil {
 		return
 	}

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -125,7 +125,7 @@ func (c *arm64Compiler) compile() (code []byte, staticData codeStaticData, stack
 		return
 	}
 
-	code, err = mmapCodeSegment(original)
+	code, err = mmap.mmapCodeSegment(original)
 	if err != nil {
 		return
 	}

--- a/internal/platform/mmap.go
+++ b/internal/platform/mmap.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package compiler
+package platform
 
 import (
 	"errors"
@@ -8,30 +8,30 @@ import (
 	"syscall"
 )
 
-// mmapCodeSegment copies the code into the executable region and returns the byte slice of the region.
+// MmapCodeSegment copies the code into the executable region and returns the byte slice of the region.
 // See https://man7.org/linux/man-pages/man2/mmap.2.html for mmap API and flags.
-func mmapCodeSegment(code []byte) ([]byte, error) {
+func MmapCodeSegment(code []byte) ([]byte, error) {
 	if len(code) == 0 {
-		panic(errors.New("BUG: mmapCodeSegment with zero length"))
+		panic(errors.New("BUG: MmapCodeSegment with zero length"))
 	}
 	if runtime.GOARCH == "amd64" {
-		return mmapCodeSegmentAMD64(code)
+		return MmapCodeSegmentAMD64(code)
 	} else {
 		return mmapCodeSegmentARM64(code)
 	}
 }
 
-// munmapCodeSegment unmaps the given memory region.
-func munmapCodeSegment(code []byte) error {
+// MunmapCodeSegment unmaps the given memory region.
+func MunmapCodeSegment(code []byte) error {
 	if len(code) == 0 {
-		panic(errors.New("BUG: munmapCodeSegment with zero length"))
+		panic(errors.New("BUG: MunmapCodeSegment with zero length"))
 	}
 	return syscall.Munmap(code)
 }
 
-// mmapCodeSegmentAMD64 gives all read-write-exec permission to the mmap region
+// MmapCodeSegmentAMD64 gives all read-write-exec permission to the mmap region
 // to enter the function. Otherwise, segmentation fault exception is raised.
-func mmapCodeSegmentAMD64(code []byte) ([]byte, error) {
+func MmapCodeSegmentAMD64(code []byte) ([]byte, error) {
 	mmapFunc, err := syscall.Mmap(
 		-1,
 		0,

--- a/internal/platform/mmap_windows.go
+++ b/internal/platform/mmap_windows.go
@@ -1,4 +1,4 @@
-package compiler
+package platform
 
 import (
 	"errors"
@@ -26,7 +26,7 @@ const (
 
 func mmapCodeSegment(code []byte) ([]byte, error) {
 	if len(code) == 0 {
-		panic(errors.New("BUG: mmapCodeSegment with zero length"))
+		panic(errors.New("BUG: MmapCodeSegment with zero length"))
 	}
 	if runtime.GOARCH == "amd64" {
 		return mmapCodeSegmentAMD64(code)
@@ -37,7 +37,7 @@ func mmapCodeSegment(code []byte) ([]byte, error) {
 
 func munmapCodeSegment(code []byte) error {
 	if len(code) == 0 {
-		panic(errors.New("BUG: munmapCodeSegment with zero length"))
+		panic(errors.New("BUG: MunmapCodeSegment with zero length"))
 	}
 	return freeMemory(code)
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,5 @@
+// Package platform includes runtime-specific code needed for the compiler or otherwise.
+//
+// Note: This is a dependency-free alternative to depending on parts of Go's x/sys.
+// See /RATIONALE.md for more context.
+package platform


### PR DESCRIPTION
This moves the platform-specific runtime code (currently only used by
the compiler) into its own package. Specifically, this moves the mmap
logic, and in doing so makes it easier to test, for example new
operating systems.

This also backfills missing RATIONALE about x/sys and hints at a future
possibility to allow a plugin. However, the next step is to get FreeBSD
working natively on the compiler without any additional dependencies.

See #607
