### PR TITLE
Narrows compiler support to operating systems currently known to work

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.arch != 'amd64' }}
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.arch }}
 

--- a/.github/workflows/spectest.yaml
+++ b/.github/workflows/spectest.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.arch != 'amd64' }}
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.arch }}
 

--- a/config_supported.go
+++ b/config_supported.go
@@ -1,4 +1,14 @@
-//go:build amd64 || arm64
+// Note: The build constraints here are about the compiler, which is more
+// narrow than the architectures supported by the assembler.
+//
+// For example, the internal/platform package has dependencies such as
+// syscall.Mprotect when not on Windows. Go's SDK only supports this on darwin
+// and linux. Constraints here may loosen as the platform package supports
+// other runtime.GOOS, or a plugin becomes available to accomplish the same.
+//
+// Meanwhile, users who know their runtime.GOOS can operate with the compiler
+// may choose to use NewRuntimeConfigCompiler explicitly.
+//go:build (amd64 || arm64) && (darwin || linux || windows)
 
 package wazero
 

--- a/config_supported.go
+++ b/config_supported.go
@@ -1,10 +1,7 @@
 // Note: The build constraints here are about the compiler, which is more
 // narrow than the architectures supported by the assembler.
 //
-// For example, the internal/platform package has dependencies such as
-// syscall.Mprotect when not on Windows. Go's SDK only supports this on darwin
-// and linux. Constraints here may loosen as the platform package supports
-// other runtime.GOOS, or a plugin becomes available to accomplish the same.
+// Constraints here must match platform.IsSupported.
 //
 // Meanwhile, users who know their runtime.GOOS can operate with the compiler
 // may choose to use NewRuntimeConfigCompiler explicitly.

--- a/config_unsupported.go
+++ b/config_unsupported.go
@@ -1,4 +1,5 @@
-//go:build !amd64 && !arm64
+// This is the opposite constraint of config_supported.go
+//go:build !(amd64 || arm64) || !(darwin || linux || windows)
 
 package wazero
 

--- a/internal/engine/compiler/arch.go
+++ b/internal/engine/compiler/arch.go
@@ -1,13 +1,8 @@
 package compiler
 
-var (
-	// newArchContext returns a new archContext which is architecture-specific type to be embedded in callEngine.
-	// This must be initialized in init() function in architecture-specific arch_*.go file which is guarded by build tag.
-	newArchContext func() archContext
-)
-
-// IsSupported returns whether the compiler is supported on this architecture.
-const IsSupported = isSupported
+// newArchContext returns a new archContext which is architecture-specific type to be embedded in callEngine.
+// This must be initialized in init() function in architecture-specific arch_*.go file which is guarded by build tag.
+var newArchContext func() archContext
 
 // nativecall is used by callEngine.execWasmFunction and the entrypoint to enter the compiled native code.
 // codeSegment is the pointer to the initial instruction of the compiled native code.

--- a/internal/engine/compiler/arch_amd64.go
+++ b/internal/engine/compiler/arch_amd64.go
@@ -4,8 +4,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
-const isSupported = true
-
 // init initializes variables for the amd64 architecture
 func init() {
 	newArchContext = newArchContextImpl

--- a/internal/engine/compiler/arch_arm64.go
+++ b/internal/engine/compiler/arch_arm64.go
@@ -6,8 +6,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
-const isSupported = true
-
 // init initializes variables for the arm64 architecture
 func init() {
 	newArchContext = newArchContextImpl
@@ -17,7 +15,7 @@ func init() {
 type archContext struct {
 	// compilerCallReturnAddress holds the absolute return address for nativecall.
 	// The value is set whenever nativecall is executed and done in compiler_arm64.s
-	// Native code can return back to the ce.execWasmFunction's main loop back by
+	// Native code can return to the ce.execWasmFunction's main loop back by
 	// executing "ret" instruction with this value. See arm64Compiler.exit.
 	// Note: this is only used by Compiler code so mark this as nolint.
 	compilerCallReturnAddress uint64 //nolint

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -175,7 +176,7 @@ func TestCompiler_ModuleEngine_Memory(t *testing.T) {
 
 // requireSupportedOSArch is duplicated also in the platform package to ensure no cyclic dependency.
 func requireSupportedOSArch(t *testing.T) {
-	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+	if !platform.IsSupported() {
 		t.Skip()
 	}
 }

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/engine/compiler"
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
@@ -47,7 +47,7 @@ var tests = map[string]func(t *testing.T, r wazero.Runtime){
 }
 
 func TestEngineCompiler(t *testing.T) {
-	if !compiler.IsSupported {
+	if !platform.IsSupported() {
 		t.Skip()
 	}
 	runAllTests(t, tests, wazero.NewRuntimeConfigCompiler())

--- a/internal/integration_test/engine/hammer_test.go
+++ b/internal/integration_test/engine/hammer_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/engine/compiler"
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/hammer"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
@@ -19,7 +19,7 @@ var hammers = map[string]func(t *testing.T, r wazero.Runtime){
 }
 
 func TestEngineCompiler_hammer(t *testing.T) {
-	if !compiler.IsSupported {
+	if !platform.IsSupported() {
 		t.Skip()
 	}
 	runAllTests(t, hammers, wazero.NewRuntimeConfigCompiler())

--- a/internal/platform/mmap.go
+++ b/internal/platform/mmap.go
@@ -1,10 +1,9 @@
-//go:build !windows
+// This uses syscall.Mprotect. Go's SDK only supports this on darwin and linux.
+//go:build darwin || linux
 
 package platform
 
-import (
-	"syscall"
-)
+import "syscall"
 
 func munmapCodeSegment(code []byte) error {
 	return syscall.Munmap(code)

--- a/internal/platform/mmap_test.go
+++ b/internal/platform/mmap_test.go
@@ -3,7 +3,6 @@ package platform
 import (
 	"crypto/rand"
 	"io"
-	"runtime"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -12,7 +11,9 @@ import (
 var testCode, _ = io.ReadAll(io.LimitReader(rand.Reader, 8*1024))
 
 func Test_MmapCodeSegment(t *testing.T) {
-	requireSupportedOSArch(t)
+	if !IsSupported() {
+		t.Skip()
+	}
 
 	newCode, err := MmapCodeSegment(testCode)
 	require.NoError(t, err)
@@ -29,7 +30,9 @@ func Test_MmapCodeSegment(t *testing.T) {
 }
 
 func Test_MunmapCodeSegment(t *testing.T) {
-	requireSupportedOSArch(t)
+	if !IsSupported() {
+		t.Skip()
+	}
 
 	// Errors if never mapped
 	require.Error(t, MunmapCodeSegment(testCode))
@@ -47,11 +50,4 @@ func Test_MunmapCodeSegment(t *testing.T) {
 		})
 		require.EqualError(t, captured, "BUG: MunmapCodeSegment with zero length")
 	})
-}
-
-// requireSupportedOSArch is duplicated also in the compiler package to ensure no cyclic dependency.
-func requireSupportedOSArch(t *testing.T) {
-	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
-		t.Skip()
-	}
 }

--- a/internal/platform/mmap_unsupported.go
+++ b/internal/platform/mmap_unsupported.go
@@ -1,0 +1,22 @@
+//go:build !(darwin || linux || windows)
+
+package platform
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var errUnsupported = fmt.Errorf("mmap unsupported on GOOS=%s. Use interpreter instead.", runtime.GOOS)
+
+func munmapCodeSegment(code []byte) error {
+	panic(errUnsupported)
+}
+
+func mmapCodeSegmentAMD64(code []byte) ([]byte, error) {
+	panic(errUnsupported)
+}
+
+func mmapCodeSegmentARM64(code []byte) ([]byte, error) {
+	panic(errUnsupported)
+}

--- a/internal/platform/mmap_windows.go
+++ b/internal/platform/mmap_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package platform
 
 import (

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -9,6 +9,26 @@ import (
 	"runtime"
 )
 
+// IsSupported is exported for tests and includes constraints here and also the assembler.
+func IsSupported() bool {
+	if _, ok := map[string]struct{}{
+		"darwin":  {},
+		"windows": {},
+		"linux":   {},
+	}[runtime.GOOS]; !ok {
+		return false
+	}
+
+	if _, ok := map[string]struct{}{
+		"amd64": {},
+		"arm64": {},
+	}[runtime.GOARCH]; !ok {
+		return false
+	}
+
+	return true
+}
+
 // MmapCodeSegment copies the code into the executable region and returns the byte slice of the region.
 //
 // See https://man7.org/linux/man-pages/man2/mmap.2.html for mmap API and flags.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -11,18 +11,15 @@ import (
 
 // IsSupported is exported for tests and includes constraints here and also the assembler.
 func IsSupported() bool {
-	if _, ok := map[string]struct{}{
-		"darwin":  {},
-		"windows": {},
-		"linux":   {},
-	}[runtime.GOOS]; !ok {
+	switch runtime.GOOS {
+	case "darwin", "windows", "linux":
+	default:
 		return false
 	}
 
-	if _, ok := map[string]struct{}{
-		"amd64": {},
-		"arm64": {},
-	}[runtime.GOARCH]; !ok {
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+	default:
 		return false
 	}
 


### PR DESCRIPTION
This narrows to what the `internal/platform` package supports, which is
currently bound by Go SDK source that include `Mprotect` or windows.

Ex. `zsyscall_linux_amd64.go` includes `Mprotect`, but
`zsyscall_freebsd_amd64.go` does not.

This should prevent errors like below, by allowing `wazero.NewRuntime()`
to properly fallback to the interpreter.

```
.../mmap.go:74:16: undefined: syscall.Mprotect
```

A later change will implement FreeBSD. This is just here to ensure users
don't crash on unexpected OS.

See #607