### PR TITLE
Replaces Memory.IndexByte with stronger documentation on Read

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -254,18 +254,18 @@ type Memory interface {
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
 	Size(context.Context) uint32
 
-	// Grow increases memory by the delta in pages (65536 bytes per page). The return val is the previous memory size in
-	// pages, or false if the delta was ignored as it exceeds max memory.
+	// Grow increases memory by the delta in pages (65536 bytes per page).
+	// The return val is the previous memory size in pages, or false if the
+	// delta was ignored as it exceeds max memory.
 	//
-	// Note: This is the same as the "memory.grow" instruction defined in the WebAssembly Core Specification, except
-	// returns false instead of -1 on failure
+	// Notes
 	//
-	// See MemorySizer and https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem
+	//	* This is the same as the "memory.grow" instruction defined in the
+	//	  WebAssembly Core Specification, except returns false instead of -1.
+	//	* When this returns true, any shared views via Read must be refreshed.
+	//
+	// See MemorySizer Read and https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem
 	Grow(ctx context.Context, deltaPages uint32) (previousPages uint32, ok bool)
-
-	// IndexByte returns the index of the first instance of c in the underlying buffer at the offset or returns false if
-	// not found or out of range.
-	IndexByte(ctx context.Context, offset uint32, c byte) (uint32, bool)
 
 	// ReadByte reads a single byte from the underlying buffer at the offset or returns false if out of range.
 	ReadByte(ctx context.Context, offset uint32) (byte, bool)
@@ -293,21 +293,37 @@ type Memory interface {
 	// See math.Float64bits
 	ReadFloat64Le(ctx context.Context, offset uint32) (float64, bool)
 
-	// Read reads byteCount bytes from the underlying buffer at the offset or returns false if out of range.
+	// Read reads byteCount bytes from the underlying buffer at the offset or
+	// returns false if out of range.
 	//
-	// This returns a view of the underlying memory, not a copy. This means any writes to the slice returned are visible
-	// to Wasm, and any updates from Wasm are visible reading the returned slice.
+	// For example, to search for a NUL-terminated string:
+	//	buf, _ = memory.Read(ctx, offset, byteCount)
+	//	n := bytes.IndexByte(data, 0)
+	//	if n < 0 {
+	//		// Not found!
+	//	}
+	//
+	// Write-through
+	//
+	// This returns a view of the underlying memory, not a copy. This means any
+	// writes to the slice returned are visible to Wasm, and any updates from
+	// Wasm are visible reading the returned slice.
 	//
 	// For example:
 	//	buf, _ = memory.Read(ctx, offset, byteCount)
-	//	buf[1] = 'a' // writes through to memory, meaning Wasm code see 'a' at that position.
+	//	buf[1] = 'a' // writes through to memory, meaning Wasm code see 'a'.
 	//
-	// If you don't desire this behavior, make a copy of the returned slice before affecting it.
+	// If you don't intend-write through, make a copy of the returned slice.
 	//
-	// Note: The returned slice is no longer shared on a capacity change. For example, `buf = append(buf, 'a')` might result
-	// in a slice that is no longer shared. The same exists Wasm side. For example, if Wasm changes its memory capacity,
-	// ex via "memory.grow"), the host slice is no longer shared. Those who need a stable view must set Wasm memory
-	// min=max, or use wazero.RuntimeConfig WithMemoryCapacityPages to ensure max is always allocated.
+	// When to refresh Read
+	//
+	// The returned slice disconnects on any capacity change. For example,
+	// `buf = append(buf, 'a')` might result in a slice that is no longer
+	// shared. The same exists Wasm side. For example, if Wasm changes its
+	// memory capacity, ex via "memory.grow"), the host slice is no longer
+	// shared. Those who need a stable view must set Wasm memory min=max, or
+	// use wazero.RuntimeConfig WithMemoryCapacityPages to ensure max is always
+	// allocated.
 	Read(ctx context.Context, offset, byteCount uint32) ([]byte, bool)
 
 	// WriteByte writes a single byte to the underlying buffer at the offset in or returns false if out of range.

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -298,7 +298,7 @@ type Memory interface {
 	//
 	// For example, to search for a NUL-terminated string:
 	//	buf, _ = memory.Read(ctx, offset, byteCount)
-	//	n := bytes.IndexByte(data, 0)
+	//	n := bytes.IndexByte(buf, 0)
 	//	if n < 0 {
 	//		// Not found!
 	//	}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -66,21 +65,6 @@ func (m *MemoryInstance) Size(_ context.Context) uint32 {
 	// Note: If you use the context.Context param, don't forget to coerce nil to context.Background()!
 
 	return m.size()
-}
-
-// IndexByte implements the same method as documented on api.Memory.
-func (m *MemoryInstance) IndexByte(_ context.Context, offset uint32, c byte) (uint32, bool) {
-	// Note: If you use the context.Context param, don't forget to coerce nil to context.Background()!
-
-	if offset >= uint32(len(m.Buffer)) {
-		return 0, false
-	}
-	b := m.Buffer[offset:]
-	if result := bytes.IndexByte(b, c); result == -1 {
-		return 0, false
-	} else {
-		return uint32(result) + offset, true
-	}
 }
 
 // ReadByte implements the same method as documented on api.Memory.
@@ -280,9 +264,11 @@ func (m *MemoryInstance) size() uint32 {
 	return uint32(len(m.Buffer)) // We don't lock here because size can't become smaller.
 }
 
-// hasSize returns true if Len is sufficient for sizeInBytes at the given offset.
-func (m *MemoryInstance) hasSize(offset uint32, sizeInBytes uint32) bool {
-	return uint64(offset)+uint64(sizeInBytes) <= uint64(len(m.Buffer)) // uint64 prevents overflow on add
+// hasSize returns true if Len is sufficient for byteCount at the given offset.
+//
+// Note: This is always fine, because memory can grow, but never shrink.
+func (m *MemoryInstance) hasSize(offset uint32, byteCount uint32) bool {
+	return uint64(offset)+uint64(byteCount) <= uint64(len(m.Buffer)) // uint64 prevents overflow on add
 }
 
 // readUint32Le implements ReadUint32Le without using a context. This is extracted as both ints and floats are stored in

--- a/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/wasi_snapshot_preview1/wasi_bench_test.go
@@ -25,11 +25,11 @@ func Test_EnvironGet(t *testing.T) {
 	sys, err := newSysContext(nil, []string{"a=b", "b=cd"}, nil)
 	require.NoError(t, err)
 
-	m := newModule(make([]byte, 20), sys)
+	mod := newModule(make([]byte, 20), sys)
 	environGet := (&wasi{}).EnvironGet
 
-	require.Equal(t, ErrnoSuccess, environGet(testCtx, m, 11, 1))
-	require.Equal(t, m.Memory(), testMem)
+	require.Equal(t, ErrnoSuccess, environGet(testCtx, mod, 11, 1))
+	require.Equal(t, mod.Memory(), testMem)
 }
 
 func Benchmark_EnvironGet(b *testing.B) {
@@ -38,7 +38,7 @@ func Benchmark_EnvironGet(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	m := newModule([]byte{
+	mod := newModule([]byte{
 		0,                // environBuf is after this
 		'a', '=', 'b', 0, // null terminated "a=b",
 		'b', '=', 'c', 'd', 0, // null terminated "b=cd"
@@ -51,7 +51,7 @@ func Benchmark_EnvironGet(b *testing.B) {
 	environGet := (&wasi{}).EnvironGet
 	b.Run("EnvironGet", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if environGet(testCtx, m, 0, 4) != ErrnoSuccess {
+			if environGet(testCtx, mod, 0, 4) != ErrnoSuccess {
 				b.Fatal()
 			}
 		}

--- a/wasi_snapshot_preview1/wasi_test.go
+++ b/wasi_snapshot_preview1/wasi_test.go
@@ -1140,7 +1140,7 @@ func TestSnapshotPreview1_FdRead(t *testing.T) {
 	)
 
 	// TestSnapshotPreview1_FdRead uses a matrix because setting up test files is complicated and has to be clean each time.
-	type fdReadFn func(ctx context.Context, m api.Module, fd, iovs, iovsCount, resultSize uint32) Errno
+	type fdReadFn func(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno
 	tests := []struct {
 		name   string
 		fdRead func(api.Module, api.Function) fdReadFn
@@ -1149,7 +1149,7 @@ func TestSnapshotPreview1_FdRead(t *testing.T) {
 			return a.FdRead
 		}},
 		{functionFdRead, func(mod api.Module, fn api.Function) fdReadFn {
-			return func(ctx context.Context, m api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
+			return func(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
 				results, err := fn.Call(testCtx, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultSize))
 				require.NoError(t, err)
 				return Errno(results[0])
@@ -1329,7 +1329,7 @@ func TestSnapshotPreview1_FdSeek(t *testing.T) {
 	defer mod.Close(testCtx)
 
 	// TestSnapshotPreview1_FdSeek uses a matrix because setting up test files is complicated and has to be clean each time.
-	type fdSeekFn func(ctx context.Context, m api.Module, fd uint32, offset uint64, whence, resultNewOffset uint32) Errno
+	type fdSeekFn func(ctx context.Context, mod api.Module, fd uint32, offset uint64, whence, resultNewOffset uint32) Errno
 	seekFns := []struct {
 		name   string
 		fdSeek func() fdSeekFn
@@ -1338,7 +1338,7 @@ func TestSnapshotPreview1_FdSeek(t *testing.T) {
 			return a.FdSeek
 		}},
 		{functionFdSeek, func() fdSeekFn {
-			return func(ctx context.Context, m api.Module, fd uint32, offset uint64, whence, resultNewoffset uint32) Errno {
+			return func(ctx context.Context, mod api.Module, fd uint32, offset uint64, whence, resultNewoffset uint32) Errno {
 				results, err := fn.Call(ctx, uint64(fd), offset, uint64(whence), uint64(resultNewoffset))
 				require.NoError(t, err)
 				return Errno(results[0])
@@ -1532,7 +1532,7 @@ func TestSnapshotPreview1_FdWrite(t *testing.T) {
 	)
 
 	// TestSnapshotPreview1_FdWrite uses a matrix because setting up test files is complicated and has to be clean each time.
-	type fdWriteFn func(ctx context.Context, m api.Module, fd, iovs, iovsCount, resultSize uint32) Errno
+	type fdWriteFn func(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno
 	tests := []struct {
 		name    string
 		fdWrite func(api.Module, api.Function) fdWriteFn
@@ -1541,7 +1541,7 @@ func TestSnapshotPreview1_FdWrite(t *testing.T) {
 			return a.FdWrite
 		}},
 		{functionFdWrite, func(mod api.Module, fn api.Function) fdWriteFn {
-			return func(ctx context.Context, m api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
+			return func(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
 				results, err := fn.Call(ctx, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultSize))
 				require.NoError(t, err)
 				return Errno(results[0])


### PR DESCRIPTION
Memory.IndexByte is unneeded with better understanding of write-through
on Memory.Read. Removing this also helps usher folks into the myriad of
Go utilities that are compatable with []byte.

This also reduces the complexity of WASI which didn't need to re-buffer
random reads (also due to above).