### PR TITLE
Makes fake clocks increment and fixes mutability bug

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -425,6 +425,14 @@ of requiring configuration to opt-into real clocks.
 
 See https://gruss.cc/files/fantastictimers.pdf for an example attacks.
 
+## Why does fake time increase on reading?
+
+Both the fake nanotime and walltime increase by 1ms on reading. Particularly in
+the case of nanotime, this prevents spinning. For example, when Go compiles
+`time.Sleep` using `GOOS=js GOARCH=wasm`, nanotime is used in a loop. If that
+never increases, the gouroutine is mistaken for being busy. This would be worse
+if a compiler implement sleep using nanotime, yet doesn't check for spinning!
+
 ## Why not `time.Clock`?
 
 wazero can't use `time.Clock` as a plugin for clock implementation as it is

--- a/internal/platform/time_test.go
+++ b/internal/platform/time_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 )
 
+func Test_NewFakeWalltime(t *testing.T) {
+	wt := NewFakeWalltime()
+
+	// Base should be the same as FakeEpochNanos
+	sec, nsec := (*wt)(context.Background())
+	ft := time.UnixMicro(FakeEpochNanos / time.Microsecond.Nanoseconds()).UTC()
+	require.Equal(t, ft, time.Unix(sec, int64(nsec)).UTC())
+
+	// next reading should increase by 1ms
+	sec, nsec = (*wt)(context.Background())
+	require.Equal(t, ft.Add(time.Millisecond), time.Unix(sec, int64(nsec)).UTC())
+}
+
+func Test_NewFakeNanotime(t *testing.T) {
+	nt := NewFakeNanotime()
+
+	require.Equal(t, int64(0), (*nt)(context.Background()))
+
+	// next reading should increase by 1ms
+	require.Equal(t, int64(time.Millisecond), (*nt)(context.Background()))
+}
+
 func Test_Walltime(t *testing.T) {
 	now := time.Now().Unix()
 	sec, nsec := Walltime(context.Background())

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -121,6 +121,20 @@ func NewFSConfig() *FSConfig {
 	}
 }
 
+// Clone makes a deep copy of this FS config.
+func (c *FSConfig) Clone() *FSConfig {
+	ret := *c // copy except maps which share a ref
+	ret.preopens = make(map[uint32]*FileEntry, len(c.preopens))
+	for key, value := range c.preopens {
+		ret.preopens[key] = value
+	}
+	ret.preopenPaths = make(map[string]uint32, len(c.preopenPaths))
+	for key, value := range c.preopenPaths {
+		ret.preopenPaths[key] = value
+	}
+	return &ret
+}
+
 // setFS maps a path to a file-system. This is only used for base paths: "/" and ".".
 func (c *FSConfig) setFS(path string, fs fs.FS) {
 	// Check to see if this key already exists and update it.
@@ -135,15 +149,15 @@ func (c *FSConfig) setFS(path string, fs fs.FS) {
 }
 
 func (c *FSConfig) WithFS(fs fs.FS) *FSConfig {
-	ret := *c // copy
+	ret := c.Clone()
 	ret.setFS("/", fs)
-	return &ret
+	return ret
 }
 
 func (c *FSConfig) WithWorkDirFS(fs fs.FS) *FSConfig {
-	ret := *c // copy
+	ret := c.Clone()
 	ret.setFS(".", fs)
-	return &ret
+	return ret
 }
 
 func (c *FSConfig) Preopens() (map[uint32]*FileEntry, error) {

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -57,3 +57,20 @@ func (f *testFile) Close() error                       { return f.closeErr }
 func (f *testFile) Stat() (fs.FileInfo, error)         { return nil, nil }
 func (f *testFile) Read(_ []byte) (int, error)         { return 0, nil }
 func (f *testFile) Seek(_ int64, _ int) (int64, error) { return 0, nil }
+
+func TestFSConfig_Clone(t *testing.T) {
+	fsc := NewFSConfig()
+	cloned := fsc.Clone()
+
+	fsc.preopens[2] = nil
+	fsc.preopenPaths["2"] = 2
+
+	cloned.preopens[1] = nil
+	cloned.preopenPaths["1"] = 1
+
+	// Ensure the maps are not shared
+	require.Equal(t, map[uint32]*FileEntry{2: nil}, fsc.preopens)
+	require.Equal(t, map[string]uint32{"2": 2}, fsc.preopenPaths)
+	require.Equal(t, map[uint32]*FileEntry{1: nil}, cloned.preopens)
+	require.Equal(t, map[string]uint32{"1": 1}, cloned.preopenPaths)
+}

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -136,8 +136,6 @@ func DefaultContext() *Context {
 }
 
 var _ = DefaultContext() // Force panic on bug.
-var wt sys.Walltime = platform.FakeWalltime
-var nt sys.Nanotime = platform.FakeNanotime
 
 // NewContext is a factory function which helps avoid needing to know defaults or exporting all fields.
 // Note: max is exposed for testing. max is only used for env/args validation.
@@ -192,7 +190,7 @@ func NewContext(
 		sysCtx.walltime = walltime
 		sysCtx.walltimeResolution = walltimeResolution
 	} else {
-		sysCtx.walltime = &wt
+		sysCtx.walltime = platform.NewFakeWalltime()
 		sysCtx.walltimeResolution = sys.ClockResolution(time.Microsecond.Nanoseconds())
 	}
 
@@ -203,7 +201,7 @@ func NewContext(
 		sysCtx.nanotime = nanotime
 		sysCtx.nanotimeResolution = nanotimeResolution
 	} else {
-		sysCtx.nanotime = &nt
+		sysCtx.nanotime = platform.NewFakeNanotime()
 		sysCtx.nanotimeResolution = sys.ClockResolution(time.Nanosecond)
 	}
 


### PR DESCRIPTION
This ensures fake clocks increment so that compilers that implement
sleep with them don't spin.

This also fixes a mutability bug in config where we weren't really doing
clone properly because map references are shared.