### PR TITLE
benchmarks: reduces heft of WasmEdge install

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -155,7 +155,7 @@ jobs:
       # Unlike the other CGO libraries, WasmEdge requires offline installation.
       - name: Install WasmEdge
         run: |
-          wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | sudo bash -s -- -p /usr/local -e all -v ${WASMEDGE_VERSION}
+          wget -qO- https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | sudo bash -s -- -p /usr/local -e none -v ${WASMEDGE_VERSION}
         # The version here is coupled to internal/integration_test/go.mod, but it
         # isn't always the same as sometimes the Go layer has a broken release.
         env:


### PR DESCRIPTION
default installs too many things we don't need and causes flakes. This could be refactored
later to use GH release assets to get the libraries instead, but this should help for now.

See https://github.com/tetratelabs/wazero/runs/6929850638?check_suite_focus=true