### PR TITLE
arm64: implement SIMD Integer arithmetics

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -798,7 +798,7 @@ func (a *AssemblerImpl) EncodeNoneToRegister(n *NodeImpl) (err error) {
 	modRM := 0b11_000_000 | // Specifying that opeand is register.
 		regBits
 	if n.Instruction == JMP {
-		// JMP's Opcode is defined as "FF /4" meaning that we have to have "4"
+		// JMP's opcode is defined as "FF /4" meaning that we have to have "4"
 		// in 4-6th bits in the ModRM byte. https://www.felixcloutier.com/x86/jmp
 		modRM |= 0b00_100_000
 	} else if n.Instruction == NEGQ {

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -48,17 +48,6 @@ type Assembler interface {
 		srcReg, dstReg asm.Register,
 	)
 
-	// CompileSIMDByteToSIMDByte adds an instruction where source and destination operand is the SIMD register
-	// specified as `srcReg.B8` and `dstReg.B8` where `.B8` part of register is called "arrangement".
-	// See https://stackoverflow.com/questions/57294672/what-is-arrangement-specifier-16b-8b-in-arm-assembly-language-instructions
-	//
-	// TODO: implement this in CompileVectorRegisterToVectorRegister.
-	CompileSIMDByteToSIMDByte(instruction asm.Instruction, srcReg, dstReg asm.Register)
-
-	// CompileTwoSIMDBytesToSIMDByteRegister adds an instruction where source operand is two SIMD registers specified as `srcReg1.B8`,
-	// and `srcReg2.B8` and the destination is the one SIMD register `dstReg.B8`.
-	CompileTwoSIMDBytesToSIMDByteRegister(instruction asm.Instruction, srcReg1, srcReg2, dstReg asm.Register)
-
 	// CompileSIMDByteToRegister adds an instruction where source operand is the SIMD register specified as `srcReg.B8`,
 	// and the destination is the register `dstReg`.
 	CompileSIMDByteToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register)

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -48,10 +48,6 @@ type Assembler interface {
 		srcReg, dstReg asm.Register,
 	)
 
-	// CompileSIMDByteToRegister adds an instruction where source operand is the SIMD register specified as `srcReg.B8`,
-	// and the destination is the register `dstReg`.
-	CompileSIMDByteToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register)
-
 	// CompileConditionalRegisterSet adds an instruction to set 1 on dstReg if the condition satisfies,
 	// otherwise set 0.
 	CompileConditionalRegisterSet(cond asm.ConditionalRegisterState, dstReg asm.Register)

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -702,8 +702,8 @@ const (
 	INSGEN
 	// INSELEM is the INS(element) instruction https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/INS--element---Insert-vector-element-from-another-vector-element-?lang=en
 	INSELEM
-	// VUADDLV is the UADDLV(vector) instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/UADDLV--vector-
-	VUADDLV
+	// UADDLV is the UADDLV(vector) instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/UADDLV--vector-
+	UADDLV
 	// VADD is the ADD(vector) instruction. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/ADD--vector-
 	VADD
 	// VFADDS is the FADD(vector) instruction, for single precision. https://developer.arm.com/documentation/dui0802/a/A64-Advanced-SIMD-Vector-Instructions/FADD--vector-
@@ -1186,8 +1186,8 @@ func InstructionName(i asm.Instruction) string {
 		return "VBIT"
 	case VCNT:
 		return "VCNT"
-	case VUADDLV:
-		return "VUADDLV"
+	case UADDLV:
+		return "UADDLV"
 	case VMOV:
 		return "VMOV"
 	case INSELEM:

--- a/internal/asm/arm64/consts.go
+++ b/internal/asm/arm64/consts.go
@@ -535,7 +535,7 @@ const (
 	FCVTSD
 	// FCVTZSD is the FCVTZS instruction, for double precision. https://developer.arm.com/documentation/dui0802/a/A64-Floating-point-Instructions/FCVTZS--scalar--integer-
 	FCVTZSD
-	// FCVTZSD is the FCVTZS instruction, for double precision in 64-bit mode. https://developer.arm.com/documentation/dui0802/a/A64-Floating-point-Instructions/FCVTZS--scalar--integer-
+	// FCVTZSDW is the FCVTZS instruction, for double precision in 64-bit mode. https://developer.arm.com/documentation/dui0802/a/A64-Floating-point-Instructions/FCVTZS--scalar--integer-
 	FCVTZSDW
 	// FCVTZSS is the FCVTZS instruction, for single precision. https://developer.arm.com/documentation/dui0802/a/A64-Floating-point-Instructions/FCVTZS--scalar--integer-
 	FCVTZSS
@@ -816,6 +816,46 @@ const (
 	// VFRINTN is the FRINTN(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/FRINTN--vector---Floating-point-Round-to-Integral--to-nearest-with-ties-to-even--vector--?lang=en
 	// Note: prefixed by V to distinguish from the non-vector variant.
 	VFRINTN
+	// VMUL is the MUL(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/MUL--vector---Multiply--vector--?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VMUL
+	// VNEG is the NEG(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/NEG--vector---Negate--vector--?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VNEG
+	// VABS is the ABS(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/ABS--Absolute-value--vector--?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VABS
+	// VSQADD is the SQADD(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/SQADD--Signed-saturating-Add-?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VSQADD
+	// VUQADD is the UQADD(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/UQADD--Unsigned-saturating-Add-?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VUQADD
+	// VSQSUB is the SQSUB(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/SQSUB--Signed-saturating-Subtract-?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VSQSUB
+	// VUQSUB is the UQSUB(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/UQSUB--Unsigned-saturating-Subtract-?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VUQSUB
+	// SMIN is the SMIN instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/SMIN--Signed-Minimum--vector--?lang=en
+	SMIN
+	// SMAX is the SMAX instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/SMAX--Signed-Maximum--vector--?lang=en
+	SMAX
+	// UMIN is the UMIN instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/UMIN--Unsigned-Minimum--vector--?lang=en
+	UMIN
+	// UMAX is the UMAX instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/UMAX--Unsigned-Maximum--vector--?lang=en
+	UMAX
+	// URHADD is the URHADD instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/URHADD--Unsigned-Rounding-Halving-Add-?lang=en
+	URHADD
+	// REV64 is the REV64 instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/REV64--Reverse-elements-in-64-bit-doublewords--vector--?lang=en
+	REV64
+	// XTN is the XTN instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/XTN--XTN2--Extract-Narrow-?lang=en
+	XTN
+	// VUMLAL is the UMLAL(vector) instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/UMLAL--UMLAL2--vector---Unsigned-Multiply-Add-Long--vector--?lang=en
+	// Note: prefixed by V to distinguish from the non-vector variant.
+	VUMLAL
+	// SHLL is the SHLL instruction https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/SHLL--SHLL2--Shift-Left-Long--by-element-size--?lang=en
+	SHLL
 
 	// instructionEnd is always placed at the bottom of this iota definition to be used in the test.
 	instructionEnd
@@ -1254,6 +1294,38 @@ func InstructionName(i asm.Instruction) string {
 		return "VFRINTZ"
 	case VFRINTN:
 		return "VFRINTN"
+	case VMUL:
+		return "VMUL"
+	case VNEG:
+		return "VNEG"
+	case VABS:
+		return "VABS"
+	case VSQADD:
+		return "VSQADD"
+	case VUQADD:
+		return "VUQADD"
+	case SMIN:
+		return "SMIN"
+	case SMAX:
+		return "SMAX"
+	case UMIN:
+		return "UMIN"
+	case UMAX:
+		return "UMAX"
+	case URHADD:
+		return "URHADD"
+	case VSQSUB:
+		return "VSQSUB"
+	case VUQSUB:
+		return "VUQSUB"
+	case REV64:
+		return "REV64"
+	case XTN:
+		return "XTN"
+	case VUMLAL:
+		return "VUMLAL"
+	case SHLL:
+		return "SHLL"
 	}
 	panic(fmt.Errorf("unknown instruction %d", i))
 }

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -95,16 +95,8 @@ func TestNodeImpl_String(t *testing.T) {
 			exp: "MOVD 0x123, R8",
 		},
 		{
-			in:  &NodeImpl{Instruction: VCNT, Types: OperandTypesSIMDByteToSIMDByte, SrcReg: RegV1, DstReg: RegV2},
-			exp: "VCNT V1.B8, V2.B8",
-		},
-		{
 			in:  &NodeImpl{Instruction: VUADDLV, Types: OperandTypesSIMDByteToRegister, SrcReg: RegV1, DstReg: RegV2},
 			exp: "VUADDLV V1.B8, V2",
-		},
-		{
-			in:  &NodeImpl{Instruction: VBIT, Types: OperandTypesTwoSIMDBytesToSIMDByteRegister, SrcReg: RegV1, SrcReg2: RegV2, DstReg: RegV3},
-			exp: "VBIT (V1.B8, V2.B8), V3.B8",
 		},
 		{
 			in: &NodeImpl{Instruction: VMOV, Types: OperandTypesMemoryToVectorRegister,
@@ -340,29 +332,6 @@ func Test_CompileLeftShiftedRegisterToRegister(t *testing.T) {
 	require.Equal(t, RegR5, actualNode.DstReg)
 	require.Equal(t, OperandTypeLeftShiftedRegister, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
-}
-
-func Test_CompileSIMDByteToSIMDByte(t *testing.T) {
-	a := NewAssemblerImpl(RegR10)
-	a.CompileSIMDByteToSIMDByte(VCNT, RegV0, RegV2)
-	actualNode := a.Current
-	require.Equal(t, VCNT, actualNode.Instruction)
-	require.Equal(t, RegV0, actualNode.SrcReg)
-	require.Equal(t, RegV2, actualNode.DstReg)
-	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.src)
-	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.dst)
-}
-
-func Test_CompileTwoSIMDBytesToSIMDByteRegister(t *testing.T) {
-	a := NewAssemblerImpl(RegR10)
-	a.CompileTwoSIMDBytesToSIMDByteRegister(VBIT, RegV0, RegV10, RegV2)
-	actualNode := a.Current
-	require.Equal(t, VBIT, actualNode.Instruction)
-	require.Equal(t, RegV0, actualNode.SrcReg)
-	require.Equal(t, RegV10, actualNode.SrcReg2)
-	require.Equal(t, RegV2, actualNode.DstReg)
-	require.Equal(t, OperandTypeTwoSIMDBytes, actualNode.Types.src)
-	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.dst)
 }
 
 func Test_CompileSIMDByteToRegister(t *testing.T) {
@@ -889,6 +858,126 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 		exp                []byte
 	}{
 		{
+			inst: XTN,
+			name: "xtn v10.2s, v2.2d",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement2D,
+			exp:  []byte{0x4a, 0x28, 0xa1, 0xe},
+		},
+		{
+			inst: XTN,
+			name: "xtn v10.4h, v2.4s",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement4S,
+			exp:  []byte{0x4a, 0x28, 0x61, 0xe},
+		},
+		{
+			inst: XTN,
+			name: "xtn v10.8b, v2.8h",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement8H,
+			exp:  []byte{0x4a, 0x28, 0x21, 0xe},
+		},
+		{
+			inst: REV64,
+			name: "rev64 v10.16b, v2.16b",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement16B,
+			exp:  []byte{0x4a, 0x8, 0x20, 0x4e},
+		},
+		{
+			inst: REV64,
+			name: "rev64 v10.4s, v2.4s",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement4S,
+			exp:  []byte{0x4a, 0x8, 0xa0, 0x4e},
+		},
+		{
+			inst: VCNT,
+			name: "cnt v10.16b, v2.16b",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement16B,
+			exp:  []byte{0x4a, 0x58, 0x20, 0x4e},
+		},
+		{
+			inst: VCNT,
+			name: "cnt v10.8b, v2.8b",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement8B,
+			exp:  []byte{0x4a, 0x58, 0x20, 0xe},
+		},
+		{
+			inst: VNEG,
+			name: "neg v10.16b, v2.16b",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement16B,
+			exp:  []byte{0x4a, 0xb8, 0x20, 0x6e},
+		},
+		{
+			inst: VNEG,
+			name: "neg v10.8h, v2.18h",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement8H,
+			exp:  []byte{0x4a, 0xb8, 0x60, 0x6e},
+		},
+		{
+			inst: VNEG,
+			name: "neg v10.4s, v2.4s",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement4S,
+			exp:  []byte{0x4a, 0xb8, 0xa0, 0x6e},
+		},
+		{
+			inst: VNEG,
+			name: "neg v10.2d, v2.2d",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement2D,
+			exp:  []byte{0x4a, 0xb8, 0xe0, 0x6e},
+		},
+		{
+			inst: VABS,
+			name: "abs v10.16b, v2.16b",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement16B,
+			exp:  []byte{0x4a, 0xb8, 0x20, 0x4e},
+		},
+		{
+			inst: VABS,
+			name: "abs v10.8h, v2.18h",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement8H,
+			exp:  []byte{0x4a, 0xb8, 0x60, 0x4e},
+		},
+		{
+			inst: VABS,
+			name: "abs v10.4s, v2.4s",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement4S,
+			exp:  []byte{0x4a, 0xb8, 0xa0, 0x4e},
+		},
+		{
+			inst: VABS,
+			name: "abs v10.2d, v2.2d",
+			x1:   RegV2,
+			x2:   RegV10,
+			arr:  VectorArrangement2D,
+			exp:  []byte{0x4a, 0xb8, 0xe0, 0x4e},
+		},
+		{
 			inst: ZIP1,
 			name: "zip1 v10.16b, v10.16b, v2.16b",
 			x1:   RegV2,
@@ -1103,14 +1192,6 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 			exp:  []byte{0x4a, 0x4, 0x7f, 0x4f},
 			arr:  VectorArrangement2D,
 			c:    1,
-		},
-		{
-			name: "sshll v10.8h, v2.8b, #0",
-			x1:   RegV2,
-			x2:   RegV10,
-			inst: SSHLLIMM,
-			exp:  []byte{0x4a, 0xa4, 0x8, 0xf},
-			arr:  VectorArrangement8B,
 		},
 		{
 			name: "sshll v10.8h, v2.8b, #7",
@@ -1639,6 +1720,30 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 			inst: VFRINTN,
 			exp:  []byte{0x3e, 0x8b, 0x61, 0x4e},
 			arr:  VectorArrangement2D,
+		},
+		{
+			x1:   RegV25,
+			x2:   RegV30,
+			name: "shll v30.8h, v25.8b, #8",
+			inst: SHLL,
+			exp:  []byte{0x3e, 0x3b, 0x21, 0x2e},
+			arr:  VectorArrangement8B,
+		},
+		{
+			x1:   RegV25,
+			x2:   RegV30,
+			name: "shll v30.4s, v25.4h, #16",
+			inst: SHLL,
+			exp:  []byte{0x3e, 0x3b, 0x61, 0x2e},
+			arr:  VectorArrangement4H,
+		},
+		{
+			x1:   RegV25,
+			x2:   RegV30,
+			name: "shll v30.2d, v25.2s, #32",
+			inst: SHLL,
+			exp:  []byte{0x3e, 0x3b, 0xa1, 0x2e},
+			arr:  VectorArrangement2S,
 		},
 	}
 
@@ -2177,6 +2282,281 @@ func TestAssemblerImpl_encodeTwoVectorRegistersToVectorRegister(t *testing.T) {
 				VectorArrangement: VectorArrangement2D,
 			},
 			exp: []byte{0x9e, 0xf4, 0x6b, 0x4e},
+		},
+		{
+			name: "mul v30.4s, v4.4s, v11.4s",
+			n: &NodeImpl{
+				Instruction:       VMUL,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement4S,
+			},
+			exp: []byte{0x9e, 0x9c, 0xab, 0x4e},
+		},
+		{
+			name: "mul v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       VMUL,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x9c, 0x2b, 0x4e},
+		},
+		{
+			name: "sqadd v30.2d, v4.2d, v11.2d",
+			n: &NodeImpl{
+				Instruction:       VSQADD,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement2D,
+			},
+			exp: []byte{0x9e, 0xc, 0xeb, 0x4e},
+		},
+		{
+			name: "sqadd v30.8h, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       VSQADD,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0xc, 0x6b, 0x4e},
+		},
+		{
+			name: "uqadd v30.4s, v4.4s, v11.4s",
+			n: &NodeImpl{
+				Instruction:       VUQADD,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement4S,
+			},
+			exp: []byte{0x9e, 0xc, 0xab, 0x6e},
+		},
+		{
+			name: "uqadd v30.8h, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       VUQADD,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0xc, 0x6b, 0x6e},
+		},
+		{
+			name: "smax v30.4s, v4.4s, v11.4s",
+			n: &NodeImpl{
+				Instruction:       SMAX,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement4S,
+			},
+			exp: []byte{0x9e, 0x64, 0xab, 0x4e},
+		},
+		{
+			name: "smax v30.8h, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       SMAX,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0x64, 0x6b, 0x4e},
+		},
+		{
+			name: "smin v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       SMIN,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x6c, 0x2b, 0x4e},
+		},
+		{
+			name: "smin v30.4s, v4.4s, v11.4s",
+			n: &NodeImpl{
+				Instruction:       SMIN,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement4S,
+			},
+			exp: []byte{0x9e, 0x6c, 0xab, 0x4e},
+		},
+		{
+			name: "umin v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       UMIN,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x6c, 0x2b, 0x6e},
+		},
+		{
+			name: "umin v30.4s, v4.4s, v11.4s",
+			n: &NodeImpl{
+				Instruction:       UMIN,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement4S,
+			},
+			exp: []byte{0x9e, 0x6c, 0xab, 0x6e},
+		},
+		{
+			name: "umax v30.4s, v4.4s, v11.4s",
+			n: &NodeImpl{
+				Instruction:       UMAX,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement4S,
+			},
+			exp: []byte{0x9e, 0x64, 0xab, 0x6e},
+		},
+		{
+			name: "umax v30.8h, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       UMAX,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0x64, 0x6b, 0x6e},
+		},
+		{
+			name: "umax v30.8h, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       URHADD,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0x14, 0x6b, 0x6e},
+		},
+		{
+			name: "umax v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       URHADD,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x14, 0x2b, 0x6e},
+		},
+		{
+			name: "sqsub v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       VSQSUB,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x2c, 0x2b, 0x4e},
+		},
+		{
+			name: "sqsub v308hb, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       VSQSUB,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0x2c, 0x6b, 0x4e},
+		},
+		{
+			name: "uqsub v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       VUQSUB,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x2c, 0x2b, 0x6e},
+		},
+		{
+			name: "uqsub v308hb, v4.8h, v11.8h",
+			n: &NodeImpl{
+				Instruction:       VUQSUB,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8H,
+			},
+			exp: []byte{0x9e, 0x2c, 0x6b, 0x6e},
+		},
+		{
+			name: "umlal v0.2d, v6.2s, v2.2s",
+			n: &NodeImpl{
+				Instruction:       VUMLAL,
+				DstReg:            RegV0,
+				SrcReg:            RegV2,
+				SrcReg2:           RegV6,
+				VectorArrangement: VectorArrangement2S,
+			},
+			exp: []byte{0xc0, 0x80, 0xa2, 0x2e},
+		},
+		{
+			name: "umlal v0.4s, v6.4h, v2.4h",
+			n: &NodeImpl{
+				Instruction:       VUMLAL,
+				DstReg:            RegV0,
+				SrcReg:            RegV2,
+				SrcReg2:           RegV6,
+				VectorArrangement: VectorArrangement4H,
+			},
+			exp: []byte{0xc0, 0x80, 0x62, 0x2e},
+		},
+		{
+			name: "umlal v0.8h, v6.8b, v2.8b",
+			n: &NodeImpl{
+				Instruction:       VUMLAL,
+				DstReg:            RegV0,
+				SrcReg:            RegV2,
+				SrcReg2:           RegV6,
+				VectorArrangement: VectorArrangement8B,
+			},
+			exp: []byte{0xc0, 0x80, 0x22, 0x2e},
+		},
+		{
+			name: "bit v30.16b, v4.16b, v11.16b",
+			n: &NodeImpl{
+				Instruction:       VBIT,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement16B,
+			},
+			exp: []byte{0x9e, 0x1c, 0xab, 0x6e},
+		},
+		{
+			name: "bit v30.8b, v4.8b, v11.8b",
+			n: &NodeImpl{
+				Instruction:       VBIT,
+				DstReg:            RegV30,
+				SrcReg:            RegV11,
+				SrcReg2:           RegV4,
+				VectorArrangement: VectorArrangement8B,
+			},
+			exp: []byte{0x9e, 0x1c, 0xab, 0x2e},
 		},
 	}
 

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -95,10 +95,6 @@ func TestNodeImpl_String(t *testing.T) {
 			exp: "MOVD 0x123, R8",
 		},
 		{
-			in:  &NodeImpl{Instruction: VUADDLV, Types: OperandTypesSIMDByteToRegister, SrcReg: RegV1, DstReg: RegV2},
-			exp: "VUADDLV V1.B8, V2",
-		},
-		{
 			in: &NodeImpl{Instruction: VMOV, Types: OperandTypesMemoryToVectorRegister,
 				SrcReg: RegR1, DstReg: RegV29, VectorArrangement: VectorArrangement2S},
 			exp: "VMOV [R1], V29.2S",
@@ -331,17 +327,6 @@ func Test_CompileLeftShiftedRegisterToRegister(t *testing.T) {
 	require.Equal(t, int64(10), actualNode.SrcConst)
 	require.Equal(t, RegR5, actualNode.DstReg)
 	require.Equal(t, OperandTypeLeftShiftedRegister, actualNode.Types.src)
-	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
-}
-
-func Test_CompileSIMDByteToRegister(t *testing.T) {
-	a := NewAssemblerImpl(RegR10)
-	a.CompileSIMDByteToRegister(VUADDLV, RegV0, RegV10)
-	actualNode := a.Current
-	require.Equal(t, VUADDLV, actualNode.Instruction)
-	require.Equal(t, RegV0, actualNode.SrcReg)
-	require.Equal(t, RegV10, actualNode.DstReg)
-	require.Equal(t, OperandTypeSIMDByte, actualNode.Types.src)
 	require.Equal(t, OperandTypeRegister, actualNode.Types.dst)
 }
 
@@ -1744,6 +1729,30 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 			inst: SHLL,
 			exp:  []byte{0x3e, 0x3b, 0xa1, 0x2e},
 			arr:  VectorArrangement2S,
+		},
+		{
+			x1:   RegV25,
+			x2:   RegV30,
+			name: "uaddlv h30, v25.16b",
+			inst: UADDLV,
+			exp:  []byte{0x3e, 0x3b, 0x30, 0x6e},
+			arr:  VectorArrangement16B,
+		},
+		{
+			x1:   RegV25,
+			x2:   RegV30,
+			name: "uaddlv s30, v25.8h",
+			inst: UADDLV,
+			exp:  []byte{0x3e, 0x3b, 0x70, 0x6e},
+			arr:  VectorArrangement8H,
+		},
+		{
+			x1:   RegV25,
+			x2:   RegV30,
+			name: "uaddlv d30, v25.4s",
+			inst: UADDLV,
+			exp:  []byte{0x3e, 0x3b, 0xb0, 0x6e},
+			arr:  VectorArrangement4S,
 		},
 	}
 

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -3385,11 +3385,6 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 }
 
 func TestCompiler_compileV128AvgrU(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name        string
 		shape       wazeroir.Shape
@@ -3540,11 +3535,6 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 }
 
 func TestCompiler_compileV128Mul(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name        string
 		shape       wazeroir.Shape
@@ -3635,11 +3625,6 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 }
 
 func TestCompiler_compileV128Neg(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name   string
 		shape  wazeroir.Shape
@@ -3737,11 +3722,6 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 }
 
 func TestCompiler_compileV128Abs(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name   string
 		shape  wazeroir.Shape
@@ -3915,10 +3895,6 @@ func TestCompiler_compileV128Div(t *testing.T) {
 }
 
 func TestCompiler_compileV128Min(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
 
 	tests := []struct {
 		name        string
@@ -4109,11 +4085,6 @@ func TestCompiler_compileV128Min(t *testing.T) {
 }
 
 func TestCompiler_compileV128Max(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name        string
 		shape       wazeroir.Shape
@@ -4317,11 +4288,6 @@ func TestCompiler_compileV128Max(t *testing.T) {
 }
 
 func TestCompiler_compileV128AddSat(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name        string
 		shape       wazeroir.Shape
@@ -4434,11 +4400,6 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 }
 
 func TestCompiler_compileV128SubSat(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name        string
 		shape       wazeroir.Shape
@@ -4551,11 +4512,6 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 }
 
 func TestCompiler_compileV128Popcnt(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		// TODO: implement on amd64.
-		t.Skip()
-	}
-
 	tests := []struct {
 		name   string
 		v, exp [16]byte

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -1651,7 +1651,7 @@ func (c *arm64Compiler) compilePopcnt(o *wazeroir.OperationPopcnt) error {
 	//    MOVD    $10, R0 ;; Load 10.
 	//    FMOVD   R0, F0
 	//    VCNT    V0.B8, V0.B8
-	//    VUADDLV V0.B8, V0
+	//    UADDLV  V0.B8, V0
 	//
 	var movInst asm.Instruction
 	if o.Type == wazeroir.UnsignedInt32 {
@@ -1662,7 +1662,8 @@ func (c *arm64Compiler) compilePopcnt(o *wazeroir.OperationPopcnt) error {
 	c.assembler.CompileRegisterToRegister(movInst, reg, freg)
 	c.assembler.CompileVectorRegisterToVectorRegister(arm64.VCNT, freg, freg,
 		arm64.VectorArrangement16B, arm64.VectorIndexNone, arm64.VectorIndexNone)
-	c.assembler.CompileSIMDByteToRegister(arm64.VUADDLV, freg, freg)
+	c.assembler.CompileVectorRegisterToVectorRegister(arm64.UADDLV, freg, freg, arm64.VectorArrangement8B,
+		arm64.VectorIndexNone, arm64.VectorIndexNone)
 
 	c.assembler.CompileRegisterToRegister(movInst, freg, reg)
 

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -1660,7 +1660,8 @@ func (c *arm64Compiler) compilePopcnt(o *wazeroir.OperationPopcnt) error {
 		movInst = arm64.FMOVD
 	}
 	c.assembler.CompileRegisterToRegister(movInst, reg, freg)
-	c.assembler.CompileSIMDByteToSIMDByte(arm64.VCNT, freg, freg)
+	c.assembler.CompileVectorRegisterToVectorRegister(arm64.VCNT, freg, freg,
+		arm64.VectorArrangement16B, arm64.VectorIndexNone, arm64.VectorIndexNone)
 	c.assembler.CompileSIMDByteToRegister(arm64.VUADDLV, freg, freg)
 
 	c.assembler.CompileRegisterToRegister(movInst, freg, reg)
@@ -2189,7 +2190,8 @@ func (c *arm64Compiler) compileCopysign(o *wazeroir.OperationCopysign) error {
 	// * https://github.com/golang/go/blob/739328c694d5e608faa66d17192f0a59f6e01d04/src/cmd/compile/internal/arm64/ssa.go#L972
 	//
 	// "vbit vreg.8b, x2vreg.8b, x1vreg.8b" == "inserting 64th bit of x2 into x1".
-	c.assembler.CompileTwoSIMDBytesToSIMDByteRegister(arm64.VBIT, freg, x2.register, x1.register)
+	c.assembler.CompileTwoVectorRegistersToVectorRegister(arm64.VBIT,
+		freg, x2.register, x1.register, arm64.VectorArrangement16B)
 
 	c.markRegisterUnused(x2.register)
 	c.pushRuntimeValueLocationOnRegister(x1.register, x1.valueType)

--- a/internal/integration_test/asm/arm64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/arm64_debug/debug_assembler.go
@@ -232,19 +232,6 @@ func (ta *testAssembler) CompileLeftShiftedRegisterToRegister(
 	ta.a.CompileLeftShiftedRegisterToRegister(instruction, shiftedSourceReg, shiftNum, srcReg, dstReg)
 }
 
-func (ta *testAssembler) CompileSIMDByteToSIMDByte(instruction asm.Instruction, srcReg, dstReg asm.Register) {
-	ta.goasm.CompileSIMDByteToSIMDByte(instruction, srcReg, dstReg)
-	ta.a.CompileSIMDByteToSIMDByte(instruction, srcReg, dstReg)
-}
-
-func (ta *testAssembler) CompileTwoSIMDBytesToSIMDByteRegister(
-	instruction asm.Instruction,
-	srcReg1, srcReg2, dstReg asm.Register,
-) {
-	ta.goasm.CompileTwoSIMDBytesToSIMDByteRegister(instruction, srcReg1, srcReg2, dstReg)
-	ta.a.CompileTwoSIMDBytesToSIMDByteRegister(instruction, srcReg1, srcReg2, dstReg)
-}
-
 func (ta *testAssembler) CompileSIMDByteToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register) {
 	ta.goasm.CompileSIMDByteToRegister(instruction, srcReg, dstReg)
 	ta.a.CompileSIMDByteToRegister(instruction, srcReg, dstReg)

--- a/internal/integration_test/asm/arm64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/arm64_debug/debug_assembler.go
@@ -232,11 +232,6 @@ func (ta *testAssembler) CompileLeftShiftedRegisterToRegister(
 	ta.a.CompileLeftShiftedRegisterToRegister(instruction, shiftedSourceReg, shiftNum, srcReg, dstReg)
 }
 
-func (ta *testAssembler) CompileSIMDByteToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register) {
-	ta.goasm.CompileSIMDByteToRegister(instruction, srcReg, dstReg)
-	ta.a.CompileSIMDByteToRegister(instruction, srcReg, dstReg)
-}
-
 func (ta *testAssembler) CompileConditionalRegisterSet(cond asm.ConditionalRegisterState, dstReg asm.Register) {
 	ta.goasm.CompileConditionalRegisterSet(cond, dstReg)
 	ta.a.CompileConditionalRegisterSet(cond, dstReg)

--- a/internal/integration_test/asm/arm64_debug/golang_asm.go
+++ b/internal/integration_test/asm/arm64_debug/golang_asm.go
@@ -282,22 +282,6 @@ func simdRegisterForScalarFloatRegister(freg int16) int16 {
 	return freg + (arm64.REG_F31 - arm64.REG_F0) + 1
 }
 
-// CompileSIMDByteToRegister implements the same method as documented on arm64.Assembler.
-func (a *assemblerGoAsmImpl) CompileSIMDByteToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register) {
-	srcFloatReg, dstFlaotReg := castAsGolangAsmRegister[srcReg], castAsGolangAsmRegister[dstReg]
-	srcVReg, dstVReg := simdRegisterForScalarFloatRegister(srcFloatReg), simdRegisterForScalarFloatRegister(dstFlaotReg)
-
-	// * https://github.com/twitchyliquid64/golang-asm/blob/v0.15.1/obj/link.go#L172-L177
-	// * https://github.com/golang/go/blob/739328c694d5e608faa66d17192f0a59f6e01d04/src/cmd/compile/internal/arm64/ssa.go#L972
-	inst := a.NewProg()
-	inst.As = castAsGolangAsmInstruction[instruction]
-	inst.To.Type = obj.TYPE_REG
-	inst.To.Reg = dstVReg
-	inst.From.Type = obj.TYPE_REG
-	inst.From.Reg = srcVReg&31 + arm64.REG_ARNG + (arm64.ARNG_8B&15)<<5
-	a.AddInstruction(inst)
-}
-
 // CompileMemoryToVectorRegister implements the same method as documented on arm64.Assembler.
 func (a *assemblerGoAsmImpl) CompileMemoryToVectorRegister(
 	_ asm.Instruction, _ asm.Register, _ asm.ConstantValue, _ asm.Register, _ asm_arm64.VectorArrangement,
@@ -679,7 +663,7 @@ var castAsGolangAsmInstruction = [...]obj.As{
 	asm_arm64.UDIVW:    arm64.AUDIVW,
 	asm_arm64.VBIT:     arm64.AVBIT,
 	asm_arm64.VCNT:     arm64.AVCNT,
-	asm_arm64.VUADDLV:  arm64.AVUADDLV,
+	asm_arm64.UADDLV:   arm64.AVUADDLV,
 	asm_arm64.VMOV:     arm64.AVMOV,
 	asm_arm64.VADD:     arm64.AVADD,
 	asm_arm64.VSUB:     arm64.AVSUB,

--- a/internal/integration_test/asm/arm64_debug/golang_asm.go
+++ b/internal/integration_test/asm/arm64_debug/golang_asm.go
@@ -282,40 +282,6 @@ func simdRegisterForScalarFloatRegister(freg int16) int16 {
 	return freg + (arm64.REG_F31 - arm64.REG_F0) + 1
 }
 
-// CompileTwoSIMDBytesToSIMDByteRegister implements the same method as documented on arm64.Assembler.
-func (a *assemblerGoAsmImpl) CompileTwoSIMDBytesToSIMDByteRegister(instruction asm.Instruction, srcReg1, srcReg2, dstReg asm.Register) {
-	src1FloatReg, src2FloatReg, dstFloatReg := castAsGolangAsmRegister[srcReg1], castAsGolangAsmRegister[srcReg2], castAsGolangAsmRegister[dstReg]
-	src1VReg, src2VReg, dstVReg := simdRegisterForScalarFloatRegister(src1FloatReg), simdRegisterForScalarFloatRegister(src2FloatReg), simdRegisterForScalarFloatRegister(dstFloatReg)
-
-	// * https://github.com/twitchyliquid64/golang-asm/blob/v0.15.1/obj/link.go#L172-L177
-	// * https://github.com/golang/go/blob/739328c694d5e608faa66d17192f0a59f6e01d04/src/cmd/compile/internal/arm64/ssa.go#L972
-	inst := a.NewProg()
-	inst.As = castAsGolangAsmInstruction[instruction]
-	inst.To.Type = obj.TYPE_REG
-	inst.To.Reg = dstVReg&31 + arm64.REG_ARNG + (arm64.ARNG_8B&15)<<5
-	inst.From.Type = obj.TYPE_REG
-	inst.From.Reg = src1VReg&31 + arm64.REG_ARNG + (arm64.ARNG_8B&15)<<5
-	inst.Reg = src2VReg&31 + arm64.REG_ARNG + (arm64.ARNG_8B&15)<<5
-	a.AddInstruction(inst)
-
-}
-
-// CompileSIMDByteToSIMDByte implements the same method as documented on arm64.Assembler.
-func (a *assemblerGoAsmImpl) CompileSIMDByteToSIMDByte(instruction asm.Instruction, srcReg, dstReg asm.Register) {
-	srcFloatReg, dstFloatReg := castAsGolangAsmRegister[srcReg], castAsGolangAsmRegister[dstReg]
-	srcVReg, dstVReg := simdRegisterForScalarFloatRegister(srcFloatReg), simdRegisterForScalarFloatRegister(dstFloatReg)
-
-	// * https://github.com/twitchyliquid64/golang-asm/blob/v0.15.1/obj/link.go#L172-L177
-	// * https://github.com/golang/go/blob/739328c694d5e608faa66d17192f0a59f6e01d04/src/cmd/compile/internal/arm64/ssa.go#L972
-	inst := a.NewProg()
-	inst.As = castAsGolangAsmInstruction[instruction]
-	inst.To.Type = obj.TYPE_REG
-	inst.To.Reg = dstVReg&31 + arm64.REG_ARNG + (arm64.ARNG_8B&15)<<5
-	inst.From.Type = obj.TYPE_REG
-	inst.From.Reg = srcVReg&31 + arm64.REG_ARNG + (arm64.ARNG_8B&15)<<5
-	a.AddInstruction(inst)
-}
-
 // CompileSIMDByteToRegister implements the same method as documented on arm64.Assembler.
 func (a *assemblerGoAsmImpl) CompileSIMDByteToRegister(instruction asm.Instruction, srcReg, dstReg asm.Register) {
 	srcFloatReg, dstFlaotReg := castAsGolangAsmRegister[srcReg], castAsGolangAsmRegister[dstReg]

--- a/internal/integration_test/asm/arm64_debug/impl_test.go
+++ b/internal/integration_test/asm/arm64_debug/impl_test.go
@@ -765,51 +765,6 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 	}
 }
 
-func TestAssemblerImpl_EncodeSIMDByteToRegister(t *testing.T) {
-	t.Run("error", func(t *testing.T) {
-		tests := []struct {
-			n      *arm64.NodeImpl
-			expErr string
-		}{
-			{
-				n:      &arm64.NodeImpl{Instruction: arm64.ADR, Types: arm64.OperandTypesSIMDByteToRegister},
-				expErr: "ADR is unsupported for from:simd-byte,to:register type",
-			},
-		}
-
-		for _, tt := range tests {
-			tc := tt
-			a := arm64.NewAssemblerImpl(asm.NilRegister)
-			err := a.EncodeSIMDByteToRegister(tc.n)
-			require.EqualError(t, err, tc.expErr)
-		}
-	})
-
-	const inst = arm64.VUADDLV
-	t.Run(arm64.InstructionName(inst), func(t *testing.T) {
-		floatRegs := []asm.Register{arm64.RegV0, arm64.RegV10, arm64.RegV21, arm64.RegV31}
-		for _, src := range floatRegs {
-			for _, dst := range floatRegs {
-				src, dst := src, dst
-				t.Run(fmt.Sprintf("src=%s,dst=%s", arm64.RegisterName(src), arm64.RegisterName(dst)), func(t *testing.T) {
-					goasm := newGoasmAssembler(t, asm.NilRegister)
-					goasm.CompileSIMDByteToRegister(inst, src, dst)
-					expected, err := goasm.Assemble()
-					require.NoError(t, err)
-
-					a := arm64.NewAssemblerImpl(arm64.RegR27)
-					err = a.EncodeSIMDByteToRegister(&arm64.NodeImpl{Instruction: inst, SrcReg: src, DstReg: dst})
-					require.NoError(t, err)
-
-					actual := a.Bytes()
-					require.Equal(t, expected, actual)
-
-				})
-			}
-		}
-	})
-}
-
 func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		tests := []struct {

--- a/internal/integration_test/spectest/v2/spec_test.go
+++ b/internal/integration_test/spectest/v2/spec_test.go
@@ -26,10 +26,7 @@ func TestCompiler(t *testing.T) {
 
 	spectest.Run(t, testcases, compiler.NewEngine, enabledFeatures, func(jsonname string) bool {
 		switch path.Base(jsonname) {
-		case "simd_i16x8_arith.json", "simd_i64x2_arith.json", "simd_i32x4_arith.json", "simd_i8x16_arith.json",
-			"simd_i16x8_sat_arith.json", "simd_i8x16_sat_arith.json",
-			"simd_i16x8_arith2.json", "simd_i8x16_arith2.json", "simd_i32x4_arith2.json", "simd_i64x2_arith2.json",
-			"simd_f64x2_pmin_pmax.json", "simd_f32x4_pmin_pmax.json", "simd_int_to_int_extend.json",
+		case "simd_f64x2_pmin_pmax.json", "simd_f32x4_pmin_pmax.json", "simd_int_to_int_extend.json",
 			"simd_i64x2_extmul_i32x4.json", "simd_i32x4_extmul_i16x8.json", "simd_i16x8_extmul_i8x16.json",
 			"simd_i16x8_q15mulr_sat_s.json", "simd_i16x8_extadd_pairwise_i8x16.json", "simd_i32x4_extadd_pairwise_i16x8.json",
 			"simd_i32x4_dot_i16x8.json", "simd_i32x4_trunc_sat_f32x4.json",


### PR DESCRIPTION
This implements SIMD integer arithmetic instructions for arm64 backend.
Notably, now the engine passes  `simd_**_arith`, `simd_**_arith2`, and
`simd_**_sat_arith` spectests.


part of #484 