### PR TITLE
compiler: remove embedding of pointers of jump tables

### DIFF
--- a/internal/asm/amd64/assembler.go
+++ b/internal/asm/amd64/assembler.go
@@ -90,9 +90,9 @@ type Assembler interface {
 
 	// CompileStaticConstToRegister adds an instruction where the source operand is asm.StaticConst located in the
 	// memory and the destination is the dstReg.
-	CompileStaticConstToRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register) error
+	CompileStaticConstToRegister(instruction asm.Instruction, c *asm.StaticConst, dstReg asm.Register) error
 
 	// CompileRegisterToStaticConst adds an instruction where the destination operand is asm.StaticConst located in the
 	// memory and the source is the srcReg.
-	CompileRegisterToStaticConst(instruction asm.Instruction, srcReg asm.Register, c asm.StaticConst) error
+	CompileRegisterToStaticConst(instruction asm.Instruction, srcReg asm.Register, c *asm.StaticConst) error
 }

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -224,14 +224,14 @@ type AssemblerImpl struct {
 	// but have it as a field here for testability.
 	MaxDisplacementForConstantPool int
 
-	pool constPool
+	pool *asm.StaticConstPool
 }
 
 // compile-time check to ensure AssemblerImpl implements Assembler.
 var _ Assembler = &AssemblerImpl{}
 
 func NewAssemblerImpl() *AssemblerImpl {
-	return &AssemblerImpl{Buf: bytes.NewBuffer(nil), EnablePadding: true, pool: newConstPool(),
+	return &AssemblerImpl{Buf: bytes.NewBuffer(nil), EnablePadding: true, pool: asm.NewStaticConstPool(),
 		MaxDisplacementForConstantPool: defaultMaxDisplacementForConstantPool}
 }
 

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -39,7 +39,7 @@ type NodeImpl struct {
 	// JumpOrigins hold all the nodes trying to jump into this node. In other words, all the nodes with .JumpTarget == this.
 	JumpOrigins map[*NodeImpl]struct{}
 
-	staticConst asm.StaticConst
+	staticConst *asm.StaticConst
 }
 
 type NodeFlag byte

--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -40,12 +40,8 @@ func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
 		}
 
 		for _, c := range a.pool.Consts {
-			offset := uint64(a.Buf.Len())
-			c.OffsetInBinary = offset
+			c.SetOffsetInBinary(uint64(a.Buf.Len()))
 			a.Buf.Write(c.Raw)
-			for _, callback := range c.OffsetFinalizedCallbacks {
-				callback(offset)
-			}
 		}
 
 		a.pool = asm.NewStaticConstPool() // reset
@@ -142,7 +138,7 @@ func (a *AssemblerImpl) encodeStaticConstImpl(n *NodeImpl, opcode []byte, rex Re
 	rexPrefix |= rex
 
 	var inst []byte
-	n.staticConst.OffsetFinalizedCallbacks = append(n.staticConst.OffsetFinalizedCallbacks, func(offsetOfConstInBinary uint64) {
+	n.staticConst.AddOffsetFinalizedCallback(func(offsetOfConstInBinary uint64) {
 		bin := a.Buf.Bytes()
 		displacement := int(offsetOfConstInBinary) - int(n.OffsetInBinary()) - len(inst)
 		displacementOffsetInInstruction := n.OffsetInBinary() + uint64(len(inst)-4)

--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -8,36 +8,13 @@ import (
 	"github.com/tetratelabs/wazero/internal/asm"
 )
 
-type constPool struct {
-	firstUseOffsetInBinary *asm.NodeOffsetInBinary
-	consts                 []*asm.StaticConst
-	poolSizeInBytes        int
-
-	// offsetFinalizedCallbacks are functions called when the offsets of the
-	// constants in the binary have been determined.
-	offsetFinalizedCallbacks map[string][]func(offsetOfConstInBinary int)
-}
-
-func newConstPool() constPool {
-	return constPool{offsetFinalizedCallbacks: map[string][]func(offsetOfConstInBinary int){}}
-}
-
-func (p *constPool) addConst(c *asm.StaticConst) {
-	key := c.Key()
-	if _, ok := p.offsetFinalizedCallbacks[key]; !ok {
-		p.consts = append(p.consts, c)
-		p.poolSizeInBytes += len(c.Raw)
-		p.offsetFinalizedCallbacks[key] = []func(int){}
-	}
-}
-
 // defaultMaxDisplacementForConstantPool is the maximum displacement allowed for literal move instructions which access
 // the constant pool. This is set as 2 ^30 conservatively while the actual limit is 2^31 since we actually allow this
 // limit plus max(length(c) for c in the pool) so we must ensure that limit is less than 2^31.
 const defaultMaxDisplacementForConstantPool = 1 << 30
 
 func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
-	if a.pool.firstUseOffsetInBinary == nil {
+	if a.pool.FirstUseOffsetInBinary == nil {
 		return
 	}
 
@@ -45,33 +22,33 @@ func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
 		// If the distance between (the first use in binary) and (end of constant pool) can be larger
 		// than MaxDisplacementForConstantPool, we have to emit the constant pool now, otherwise
 		// a const might be unreachable by a literal move whose maximum offset is +- 2^31.
-		((a.pool.poolSizeInBytes+a.Buf.Len())-int(*a.pool.firstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
+		((a.pool.PoolSizeInBytes+a.Buf.Len())-int(*a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
 		if !isEndOfFunction {
 			// Adds the jump instruction to skip the constants if this is not the end of function.
 			//
 			// TODO: consider NOP padding for this jump, though this rarely happens as most functions should be
 			// small enough to fit all consts after the end of function.
-			if a.pool.poolSizeInBytes >= math.MaxInt8-2 {
+			if a.pool.PoolSizeInBytes >= math.MaxInt8-2 {
 				// long (near-relative) jump: https://www.felixcloutier.com/x86/jmp
 				a.Buf.WriteByte(0xe9)
-				a.WriteConst(int64(a.pool.poolSizeInBytes), 32)
+				a.WriteConst(int64(a.pool.PoolSizeInBytes), 32)
 			} else {
 				// short jump: https://www.felixcloutier.com/x86/jmp
 				a.Buf.WriteByte(0xeb)
-				a.WriteConst(int64(a.pool.poolSizeInBytes), 8)
+				a.WriteConst(int64(a.pool.PoolSizeInBytes), 8)
 			}
 		}
 
-		for _, c := range a.pool.consts {
-			offset := a.Buf.Len()
-			c.OffsetInBinary = uint64(offset)
+		for _, c := range a.pool.Consts {
+			offset := uint64(a.Buf.Len())
+			c.OffsetInBinary = offset
 			a.Buf.Write(c.Raw)
-			for _, callback := range a.pool.offsetFinalizedCallbacks[c.Key()] {
+			for _, callback := range c.OffsetFinalizedCallbacks {
 				callback(offset)
 			}
 		}
 
-		a.pool = newConstPool() // reset
+		a.pool = asm.NewStaticConstPool() // reset
 	}
 }
 
@@ -148,7 +125,7 @@ func (a *AssemblerImpl) encodeStaticConstToRegister(n *NodeImpl) (err error) {
 // encodeStaticConstImpl encodes an instruction where mod:r/m points to the memory location of the static constant n.staticConst,
 // and the other operand is the register given at n.SrcReg or n.DstReg.
 func (a *AssemblerImpl) encodeStaticConstImpl(n *NodeImpl, opcode []byte, rex RexPrefix, mandatoryPrefix byte) (err error) {
-	a.pool.addConst(n.staticConst)
+	a.pool.AddConst(n.staticConst, uint64(a.Buf.Len()))
 
 	var reg asm.Register
 	if n.DstReg != asm.NilRegister {
@@ -165,17 +142,12 @@ func (a *AssemblerImpl) encodeStaticConstImpl(n *NodeImpl, opcode []byte, rex Re
 	rexPrefix |= rex
 
 	var inst []byte
-	key := n.staticConst.Key()
-	a.pool.offsetFinalizedCallbacks[key] = append(a.pool.offsetFinalizedCallbacks[key],
-		func(offsetOfConstInBinary int) {
-			bin := a.Buf.Bytes()
-			displacement := offsetOfConstInBinary - int(n.OffsetInBinary()) - len(inst)
-			displacementOffsetInInstruction := n.OffsetInBinary() + uint64(len(inst)-4)
-			binary.LittleEndian.PutUint32(bin[displacementOffsetInInstruction:], uint32(int32(displacement)))
-		})
-
-	nodeOffset := uint64(a.Buf.Len())
-	a.pool.firstUseOffsetInBinary = &nodeOffset
+	n.staticConst.OffsetFinalizedCallbacks = append(n.staticConst.OffsetFinalizedCallbacks, func(offsetOfConstInBinary uint64) {
+		bin := a.Buf.Bytes()
+		displacement := int(offsetOfConstInBinary) - int(n.OffsetInBinary()) - len(inst)
+		displacementOffsetInInstruction := n.OffsetInBinary() + uint64(len(inst)-4)
+		binary.LittleEndian.PutUint32(bin[displacementOffsetInInstruction:], uint32(int32(displacement)))
+	})
 
 	// https://wiki.osdev.org/X86-64_Instruction_Encoding#32.2F64-bit_addressing
 	modRM := 0b00_000_101 | // Indicate "[RIP + 32bit displacement]" encoding.

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestConstPool_addConst(t *testing.T) {
 	p := newConstPool()
-	cons := []byte{1, 2, 3, 4}
+	cons := asm.NewStaticConst([]byte{1, 2, 3, 4})
 
 	// Loop twice to ensure that the same constant is cached and not added twice.
 	for i := 0; i < 2; i++ {
 		p.addConst(cons)
 		require.Equal(t, 1, len(p.consts))
-		require.Equal(t, len(cons), p.poolSizeInBytes)
-		_, ok := p.offsetFinalizedCallbacks[asm.StaticConstKey(cons)]
+		require.Equal(t, len(cons.Raw), p.poolSizeInBytes)
+		_, ok := p.offsetFinalizedCallbacks[cons.Key()]
 		require.True(t, ok)
 	}
 }
@@ -25,11 +25,11 @@ func TestConstPool_addConst(t *testing.T) {
 func TestAssemblerImpl_CompileStaticConstToRegister(t *testing.T) {
 	a := NewAssemblerImpl()
 	t.Run("odd count of bytes", func(t *testing.T) {
-		err := a.CompileStaticConstToRegister(MOVDQU, []byte{1}, RegAX)
+		err := a.CompileStaticConstToRegister(MOVDQU, asm.NewStaticConst([]byte{1}), RegAX)
 		require.Error(t, err)
 	})
 	t.Run("ok", func(t *testing.T) {
-		cons := []byte{1, 2, 3, 4}
+		cons := asm.NewStaticConst([]byte{1, 2, 3, 4})
 		err := a.CompileStaticConstToRegister(MOVDQU, cons, RegAX)
 		require.NoError(t, err)
 		actualNode := a.Current
@@ -43,11 +43,11 @@ func TestAssemblerImpl_CompileStaticConstToRegister(t *testing.T) {
 func TestAssemblerImpl_CompileRegisterToStaticConst(t *testing.T) {
 	a := NewAssemblerImpl()
 	t.Run("odd count of bytes", func(t *testing.T) {
-		err := a.CompileRegisterToStaticConst(MOVDQU, RegAX, []byte{1})
+		err := a.CompileRegisterToStaticConst(MOVDQU, RegAX, asm.NewStaticConst([]byte{1}))
 		require.Error(t, err)
 	})
 	t.Run("ok", func(t *testing.T) {
-		cons := []byte{1, 2, 3, 4}
+		cons := asm.NewStaticConst([]byte{1, 2, 3, 4})
 		err := a.CompileRegisterToStaticConst(MOVDQU, RegAX, cons)
 		require.NoError(t, err)
 		actualNode := a.Current
@@ -73,7 +73,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 		endOfFunction           bool
 		dummyBodyBeforeFlush    []byte
 		firstUseOffsetInBinary  uint64
-		consts                  []asm.StaticConst
+		consts                  [][]byte
 		expectedOffsetForConsts []int
 		exp                     []byte
 		maxDisplacement         int
@@ -82,7 +82,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			name:                    "end of function",
 			endOfFunction:           true,
 			dummyBodyBeforeFlush:    []byte{'?', '?', '?', '?'},
-			consts:                  []asm.StaticConst{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
+			consts:                  [][]byte{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
 			expectedOffsetForConsts: []int{4, 4 + 8}, // 4 = len(dummyBodyBeforeFlush)
 			firstUseOffsetInBinary:  0,
 			exp:                     []byte{'?', '?', '?', '?', 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13},
@@ -92,7 +92,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			name:                   "not flush",
 			endOfFunction:          false,
 			dummyBodyBeforeFlush:   []byte{'?', '?', '?', '?'},
-			consts:                 []asm.StaticConst{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
+			consts:                 [][]byte{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
 			firstUseOffsetInBinary: 0,
 			exp:                    []byte{'?', '?', '?', '?'},
 			maxDisplacement:        1 << 31, // large displacement will emit the consts at the end of function.
@@ -101,7 +101,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			name:                    "not end of function but flush - short jump",
 			endOfFunction:           false,
 			dummyBodyBeforeFlush:    []byte{'?', '?', '?', '?'},
-			consts:                  []asm.StaticConst{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
+			consts:                  [][]byte{{1, 2, 3, 4, 5, 6, 7, 8}, {10, 11, 12, 13}},
 			expectedOffsetForConsts: []int{4 + 2, 4 + 2 + 8}, // 4 = len(dummyBodyBeforeFlush), 2 = the size of jump
 			firstUseOffsetInBinary:  0,
 			exp: []byte{'?', '?', '?', '?',
@@ -113,7 +113,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			name:                    "not end of function but flush - long jump",
 			endOfFunction:           false,
 			dummyBodyBeforeFlush:    []byte{'?', '?', '?', '?'},
-			consts:                  []asm.StaticConst{largeData},
+			consts:                  [][]byte{largeData},
 			expectedOffsetForConsts: []int{4 + 5}, // 4 = len(dummyBodyBeforeFlush), 5 = the size of jump
 			firstUseOffsetInBinary:  0,
 			exp: append([]byte{'?', '?', '?', '?',
@@ -130,8 +130,9 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			a.Buf.Write(tc.dummyBodyBeforeFlush)
 
 			for i, c := range tc.consts {
-				a.pool.addConst(c)
-				key := asm.StaticConstKey(c)
+				sc := asm.NewStaticConst(c)
+				a.pool.addConst(sc)
+				key := sc.Key()
 				i := i
 				a.pool.offsetFinalizedCallbacks[key] = append(a.pool.offsetFinalizedCallbacks[key], func(offsetOfConstInBinary int) {
 					require.Equal(t, tc.expectedOffsetForConsts[i], offsetOfConstInBinary)
@@ -150,7 +151,7 @@ func TestAssemblerImpl_encodeRegisterToStaticConst(t *testing.T) {
 	tests := []struct {
 		name            string
 		ins             asm.Instruction
-		c               asm.StaticConst
+		c               []byte
 		reg             asm.Register
 		ud2sBeforeConst int
 		exp             []byte
@@ -220,7 +221,7 @@ func TestAssemblerImpl_encodeRegisterToStaticConst(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAssemblerImpl()
 
-			err := a.CompileRegisterToStaticConst(tc.ins, tc.reg, tc.c)
+			err := a.CompileRegisterToStaticConst(tc.ins, tc.reg, asm.NewStaticConst(tc.c))
 			require.NoError(t, err)
 
 			for i := 0; i < tc.ud2sBeforeConst; i++ {
@@ -239,7 +240,7 @@ func TestAssemblerImpl_encodeStaticConstToRegister(t *testing.T) {
 	tests := []struct {
 		name            string
 		ins             asm.Instruction
-		c               asm.StaticConst
+		c               []byte
 		reg             asm.Register
 		ud2sBeforeConst int
 		exp             []byte
@@ -612,7 +613,7 @@ func TestAssemblerImpl_encodeStaticConstToRegister(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAssemblerImpl()
 
-			err := a.CompileStaticConstToRegister(tc.ins, tc.c, tc.reg)
+			err := a.CompileStaticConstToRegister(tc.ins, asm.NewStaticConst(tc.c), tc.reg)
 			require.NoError(t, err)
 
 			for i := 0; i < tc.ud2sBeforeConst; i++ {

--- a/internal/asm/arm64/assembler.go
+++ b/internal/asm/arm64/assembler.go
@@ -96,9 +96,13 @@ type Assembler interface {
 	CompileVectorRegisterToVectorRegisterWithConst(instruction asm.Instruction, srcReg, dstReg asm.Register,
 		arrangement VectorArrangement, c asm.ConstantValue)
 
-	// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in
+	// CompileStaticConstToRegister adds an instruction where the source operand is StaticConstant located in
 	// the memory and the destination is the dstReg.
-	CompileLoadStaticConstToVectorRegister(instruction asm.Instruction, c asm.StaticConst, dstReg asm.Register,
+	CompileStaticConstToRegister(instruction asm.Instruction, c *asm.StaticConst, dstReg asm.Register)
+
+	// CompileStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in
+	// the memory and the destination is the dstReg.
+	CompileStaticConstToVectorRegister(instruction asm.Instruction, c *asm.StaticConst, dstReg asm.Register,
 		arrangement VectorArrangement)
 
 	// CompileTwoVectorRegistersToVectorRegister adds an instruction where source are two vectors and destination is one

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -424,6 +424,8 @@ func (a *AssemblerImpl) EncodeNode(n *NodeImpl) (err error) {
 		err = a.EncodeVectorRegisterToVectorRegister(n)
 	case OperandTypesStaticConstToVectorRegister:
 		err = a.EncodeStaticConstToVectorRegister(n)
+	case OperandTypesTwoVectorRegistersToVectorRegister:
+		err = a.encodeTwoVectorRegistersToVectorRegister(n)
 	default:
 		err = fmt.Errorf("encoder undefined for [%s] operand type", n.Types)
 	}
@@ -1859,7 +1861,7 @@ func (a *AssemblerImpl) encodeADR(n *NodeImpl) (err error) {
 			offset := offsetOfConst - int(adrInstructionOffsetInBinary)
 			adrInstructionBytes[3] |= byte(offset & 0b00000011 << 5)
 			offset >>= 2
-			adrInstructionBytes[0] |= byte(offset << 4)
+			adrInstructionBytes[0] |= byte(offset << 5)
 			offset >>= 3
 			adrInstructionBytes[1] |= byte(offset)
 			offset >>= 8

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -319,14 +319,8 @@ func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
 
 		// Then adding the consts into the binary.
 		for _, c := range a.pool.Consts {
-			offsetOfConst := uint64(a.Buf.Len())
+			c.SetOffsetInBinary(uint64(a.Buf.Len()))
 			a.Buf.Write(c.Raw)
-			c.OffsetInBinary = offsetOfConst
-
-			// Invoke callbacks for `c` with the offset of binary where we store `c`.
-			for _, cb := range c.OffsetFinalizedCallbacks {
-				cb(offsetOfConst)
-			}
 		}
 
 		// arm64 instructions are 4-byte (32-bit) aligned, so we must pad the zero consts here.

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1827,8 +1827,9 @@ func (a *AssemblerImpl) encodeADR(n *NodeImpl) (err error) {
 		a.pool.AddConst(sc, adrInstructionOffsetInBinary)
 		sc.AddOffsetFinalizedCallback(func(offsetOfConst uint64) {
 			adrInstructionBytes := a.Buf.Bytes()[adrInstructionOffsetInBinary : adrInstructionOffsetInBinary+4]
-
 			offset := int(offsetOfConst) - int(adrInstructionOffsetInBinary)
+
+			// See https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADR--Form-PC-relative-address-?lang=en
 			adrInstructionBytes[3] |= byte(offset & 0b00000011 << 5)
 			offset >>= 2
 			adrInstructionBytes[0] |= byte(offset << 5)

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -3441,7 +3441,6 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 		name                   string
 		reg                    asm.Register
 		offsetOfConstInBinary  int
-		c                      []byte
 		expADRInstructionBytes []byte
 	}{
 		{
@@ -3449,23 +3448,21 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 			name:                   "adr x12, #8",
 			reg:                    RegR12,
 			offsetOfConstInBinary:  10,
-			c:                      []byte{1, 2, 3, 4},
-			expADRInstructionBytes: []byte{0x2c, 0x0, 0x0, 0x10},
+			expADRInstructionBytes: []byte{0x4c, 0x0, 0x0, 0x10},
 		},
 		{
 			// #0x7fffd = offsetOfConstInBinary - beforeADRByteNum.
-			name:                   "adr x28, #0x7fffd",
+			name:                   "adr x12, #0x7fffd",
 			reg:                    RegR12,
 			offsetOfConstInBinary:  0x7ffff,
-			c:                      []byte{1, 2, 3, 4},
-			expADRInstructionBytes: []byte{0xfc, 0xff, 0x3f, 0x30},
+			expADRInstructionBytes: []byte{0xec, 0xff, 0x3f, 0x30},
 		},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			sc := asm.NewStaticConst(tc.c)
+			sc := asm.NewStaticConst([]byte{1, 2, 3, 4}) // Arbitrary data is fine.
 
 			a := NewAssemblerImpl(asm.NilRegister)
 
@@ -3487,7 +3484,7 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 			cbs[0](tc.offsetOfConstInBinary)
 
 			actualBytes := a.Buf.Bytes()[beforeADRByteNum : beforeADRByteNum+4]
-			require.Equal(t, actualBytes, tc.expADRInstructionBytes, hex.EncodeToString(actualBytes))
+			require.Equal(t, tc.expADRInstructionBytes, actualBytes, hex.EncodeToString(actualBytes))
 		})
 	}
 }

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -3476,10 +3476,8 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 
 			require.Equal(t, beforeADRByteNum, *a.pool.FirstUseOffsetInBinary)
 
-			require.Equal(t, 1, len(sc.OffsetFinalizedCallbacks))
-
 			// Finalize the ADR instruction bytes.
-			sc.OffsetFinalizedCallbacks[0](tc.offsetOfConstInBinary)
+			sc.SetOffsetInBinary(tc.offsetOfConstInBinary)
 
 			actualBytes := a.Buf.Bytes()[beforeADRByteNum : beforeADRByteNum+4]
 			require.Equal(t, tc.expADRInstructionBytes, actualBytes, hex.EncodeToString(actualBytes))

--- a/internal/asm/arm64/impl_test.go
+++ b/internal/asm/arm64/impl_test.go
@@ -3246,7 +3246,7 @@ func TestAssemblerImpl_EncodeRegisterToVectorRegister(t *testing.T) {
 func TestAssemblerImpl_maybeFlushConstPool(t *testing.T) {
 	tests := []struct {
 		name string
-		c    asm.StaticConst
+		c    []byte
 		exp  []byte
 	}{
 		{
@@ -3335,10 +3335,11 @@ func TestAssemblerImpl_maybeFlushConstPool(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAssemblerImpl(asm.NilRegister)
-			a.addConstPool(tc.c, 0)
+			sc := asm.NewStaticConst(tc.c)
+			a.addConstPool(sc, 0)
 
 			var called bool
-			a.setConstPoolCallback(tc.c, func(int) {
+			a.setConstPoolCallback(sc, func(int) {
 				called = true
 			})
 
@@ -3364,7 +3365,7 @@ func TestAssemblerImpl_EncodeStaticConstToVectorRegister(t *testing.T) {
 				Instruction:       VMOV,
 				DstReg:            RegV8,
 				VectorArrangement: VectorArrangementQ,
-				staticConst:       []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+				staticConst:       asm.NewStaticConst([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
 			},
 			exp: []byte{
 				// 0x0: ldr q8, #8
@@ -3383,7 +3384,7 @@ func TestAssemblerImpl_EncodeStaticConstToVectorRegister(t *testing.T) {
 				Instruction:       VMOV,
 				DstReg:            RegV30,
 				VectorArrangement: VectorArrangementD,
-				staticConst:       []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				staticConst:       asm.NewStaticConst([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 			},
 			exp: []byte{
 				// 0x0: ldr d30, #8
@@ -3402,7 +3403,7 @@ func TestAssemblerImpl_EncodeStaticConstToVectorRegister(t *testing.T) {
 				Instruction:       VMOV,
 				DstReg:            RegV8,
 				VectorArrangement: VectorArrangementS,
-				staticConst:       []byte{1, 2, 3, 4},
+				staticConst:       asm.NewStaticConst([]byte{1, 2, 3, 4}),
 			},
 			exp: []byte{
 				// 0x0: ldr s8, #8

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -53,11 +53,19 @@ type ConstantValue = int64
 
 // StaticConst represents an arbitrary constant bytes which are pooled and emitted by assembler into the binary.
 // These constants can be referenced by instructions.
-type StaticConst = []byte
+type StaticConst struct {
+	Raw            []byte
+	OffsetInBinary uint64
+}
 
-// StaticConstKey returns a string whose underlying bytes equal the original const.
-func StaticConstKey(c StaticConst) string {
-	return string(c)
+// Key returns a string whose underlying bytes equal the original const.
+func (s StaticConst) Key() string {
+	return string(s.Raw)
+}
+
+// NewStaticConst returns the pointer to the new NewStaticConst for given bytes.
+func NewStaticConst(raw []byte) *StaticConst {
+	return &StaticConst{Raw: raw}
 }
 
 // AssemblerBase is the common interface for assemblers among multiple architectures.
@@ -78,10 +86,8 @@ type AssemblerBase interface {
 
 	// BuildJumpTable calculates the offsets between the first instruction `initialInstructions[0]`
 	// and others (e.g. initialInstructions[3]), and wrote the calculated offsets into pre-allocated
-	// `table` slice in little endian.
-	//
-	// TODO: This can be hidden into assembler implementation after golang-asm removal.
-	BuildJumpTable(table []byte, initialInstructions []Node)
+	// `table` StaticConst in little endian.
+	BuildJumpTable(table *StaticConst, initialInstructions []Node)
 
 	// CompileStandAlone adds an instruction to take no arguments.
 	CompileStandAlone(instruction Instruction) Node

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -66,7 +66,7 @@ func NewStaticConst(raw []byte) *StaticConst {
 	return &StaticConst{Raw: raw}
 }
 
-// AddOffsetFinalizedCallback adds a callback into OffsetFinalizedCallbacks.
+// AddOffsetFinalizedCallback adds a callback into offsetFinalizedCallbacks.
 func (s *StaticConst) AddOffsetFinalizedCallback(cb func(offsetOfConstInBinary uint64)) {
 	s.offsetFinalizedCallbacks = append(s.offsetFinalizedCallbacks, cb)
 }

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -71,6 +71,7 @@ func (s *StaticConst) AddOffsetFinalizedCallback(cb func(offsetOfConstInBinary u
 	s.offsetFinalizedCallbacks = append(s.offsetFinalizedCallbacks, cb)
 }
 
+// SetOffsetInBinary finalizes the offset of this StaticConst, and invokes callbacks.
 func (s *StaticConst) SetOffsetInBinary(offset uint64) {
 	s.offsetInBinary = offset
 	for _, cb := range s.offsetFinalizedCallbacks {

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -56,9 +56,9 @@ type ConstantValue = int64
 type StaticConst struct {
 	Raw []byte
 	// OffsetInBinary is the offset of this static const in the result binary.
-	OffsetInBinary uint64
-	// OffsetFinalizedCallbacks holds callbacks which are called when .OffsetInBinary is finalized by assembler implementation.
-	OffsetFinalizedCallbacks []func(offsetOfConstInBinary uint64)
+	offsetInBinary uint64
+	// offsetFinalizedCallbacks holds callbacks which are called when .OffsetInBinary is finalized by assembler implementation.
+	offsetFinalizedCallbacks []func(offsetOfConstInBinary uint64)
 }
 
 // NewStaticConst returns the pointer to the new NewStaticConst for given bytes.
@@ -68,7 +68,14 @@ func NewStaticConst(raw []byte) *StaticConst {
 
 // AddOffsetFinalizedCallback adds a callback into OffsetFinalizedCallbacks.
 func (s *StaticConst) AddOffsetFinalizedCallback(cb func(offsetOfConstInBinary uint64)) {
-	s.OffsetFinalizedCallbacks = append(s.OffsetFinalizedCallbacks, cb)
+	s.offsetFinalizedCallbacks = append(s.offsetFinalizedCallbacks, cb)
+}
+
+func (s *StaticConst) SetOffsetInBinary(offset uint64) {
+	s.offsetInBinary = offset
+	for _, cb := range s.offsetFinalizedCallbacks {
+		cb(offset)
+	}
 }
 
 // StaticConstPool holds a bulk of StaticConst which are yet to be emitted into the binary.

--- a/internal/asm/assembler_test.go
+++ b/internal/asm/assembler_test.go
@@ -1,0 +1,37 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestNewStaticConstPool(t *testing.T) {
+	p := NewStaticConstPool()
+	require.NotNil(t, p.addedConsts)
+}
+
+func TestStaticConst_AddOffsetFinalizedCallback(t *testing.T) {
+	p := NewStaticConstPool()
+	const firstUseOffset uint64 = 100
+
+	// Add first const.
+	c := NewStaticConst([]byte{1})
+	p.AddConst(c, firstUseOffset)
+	require.Equal(t, firstUseOffset, *p.FirstUseOffsetInBinary)
+	require.Equal(t, 1, len(p.Consts))
+	require.Equal(t, 1, len(p.addedConsts))
+
+	// Adding the same *StaticConst doesn't affect the state.
+	p.AddConst(c, firstUseOffset+10000)
+	require.Equal(t, firstUseOffset, *p.FirstUseOffsetInBinary)
+	require.Equal(t, 1, len(p.Consts))
+	require.Equal(t, 1, len(p.addedConsts))
+
+	// Add another const.
+	c2 := NewStaticConst([]byte{1, 2})
+	p.AddConst(c2, firstUseOffset+100)
+	require.Equal(t, firstUseOffset, *p.FirstUseOffsetInBinary) // first use doesn't change!
+	require.Equal(t, 2, len(p.Consts))
+	require.Equal(t, 2, len(p.addedConsts))
+}

--- a/internal/asm/assembler_test.go
+++ b/internal/asm/assembler_test.go
@@ -35,3 +35,12 @@ func TestStaticConst_AddOffsetFinalizedCallback(t *testing.T) {
 	require.Equal(t, 2, len(p.Consts))
 	require.Equal(t, 2, len(p.addedConsts))
 }
+
+func TestStaticConst_SetOffsetInBinary(t *testing.T) {
+	sc := NewStaticConst([]byte{1})
+	const offset uint64 = 100
+	sc.AddOffsetFinalizedCallback(func(offsetOfConstInBinary uint64) {
+		require.Equal(t, offset, offsetOfConstInBinary)
+	})
+	sc.SetOffsetInBinary(offset)
+}

--- a/internal/asm/impl.go
+++ b/internal/asm/impl.go
@@ -29,16 +29,17 @@ func (a *BaseAssemblerImpl) AddOnGenerateCallBack(cb func([]byte) error) {
 }
 
 // BuildJumpTable implements AssemblerBase.BuildJumpTable
-func (a *BaseAssemblerImpl) BuildJumpTable(table []byte, labelInitialInstructions []Node) {
+func (a *BaseAssemblerImpl) BuildJumpTable(table *StaticConst, labelInitialInstructions []Node) {
 	a.AddOnGenerateCallBack(func(code []byte) error {
 		// Compile the offset table for each target.
 		base := labelInitialInstructions[0].OffsetInBinary()
 		for i, nop := range labelInitialInstructions {
-			if uint64(nop.OffsetInBinary())-uint64(base) >= JumpTableMaximumOffset {
+			if nop.OffsetInBinary()-base >= JumpTableMaximumOffset {
 				return fmt.Errorf("too large br_table")
 			}
 			// We store the offset from the beginning of the L0's initial instruction.
-			binary.LittleEndian.PutUint32(table[i*4:(i+1)*4], uint32(nop.OffsetInBinary())-uint32(base))
+			binary.LittleEndian.PutUint32(code[table.OffsetInBinary+uint64(i*4):table.OffsetInBinary+uint64((i+1)*4)],
+				uint32(nop.OffsetInBinary())-uint32(base))
 		}
 		return nil
 	})

--- a/internal/asm/impl.go
+++ b/internal/asm/impl.go
@@ -38,7 +38,7 @@ func (a *BaseAssemblerImpl) BuildJumpTable(table *StaticConst, labelInitialInstr
 				return fmt.Errorf("too large br_table")
 			}
 			// We store the offset from the beginning of the L0's initial instruction.
-			binary.LittleEndian.PutUint32(code[table.OffsetInBinary+uint64(i*4):table.OffsetInBinary+uint64((i+1)*4)],
+			binary.LittleEndian.PutUint32(code[table.offsetInBinary+uint64(i*4):table.offsetInBinary+uint64((i+1)*4)],
 				uint32(nop.OffsetInBinary())-uint32(base))
 		}
 		return nil

--- a/internal/asm/impl.go
+++ b/internal/asm/impl.go
@@ -41,6 +41,7 @@ func (a *BaseAssemblerImpl) BuildJumpTable(table *StaticConst, labelInitialInstr
 			binary.LittleEndian.PutUint32(code[table.OffsetInBinary+uint64(i*4):table.OffsetInBinary+uint64((i+1)*4)],
 				uint32(nop.OffsetInBinary())-uint32(base))
 		}
+		fmt.Println(code[table.OffsetInBinary:])
 		return nil
 	})
 }

--- a/internal/asm/impl.go
+++ b/internal/asm/impl.go
@@ -41,7 +41,6 @@ func (a *BaseAssemblerImpl) BuildJumpTable(table *StaticConst, labelInitialInstr
 			binary.LittleEndian.PutUint32(code[table.OffsetInBinary+uint64(i*4):table.OffsetInBinary+uint64((i+1)*4)],
 				uint32(nop.OffsetInBinary())-uint32(base))
 		}
-		fmt.Println(code[table.OffsetInBinary:])
 		return nil
 	})
 }

--- a/internal/engine/compiler/compiler.go
+++ b/internal/engine/compiler/compiler.go
@@ -14,8 +14,7 @@ type compiler interface {
 	compilePreamble() error
 	// compile generates the byte slice of native code.
 	// stackPointerCeil is the max stack pointer that the target function would reach.
-	// staticData is codeStaticData for the resulting native code.
-	compile() (code []byte, staticData codeStaticData, stackPointerCeil uint64, err error)
+	compile() (code []byte, stackPointerCeil uint64, err error)
 	// compileHostFunction adds the trampoline code from which native code can jump into the host function.
 	// TODO: maybe we wouldn't need to have trampoline for host functions.
 	compileHostFunction() error

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -22,7 +22,7 @@ func TestCompiler_compileHostFunction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and run the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 
@@ -253,7 +253,7 @@ func TestCompiler_compileBrIf(t *testing.T) {
 					require.False(t, skip)
 					compiler.compileExitFromNativeCode(elseLabelExitStatus)
 
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 
 					// The generated code looks like this:
@@ -295,7 +295,7 @@ func TestCompiler_compileBrTable(t *testing.T) {
 		}
 
 		// Generate the code under test and run.
-		code, _, _, err := c.compile()
+		code, _, err := c.compile()
 		require.NoError(t, err)
 		env.exec(code)
 
@@ -472,7 +472,7 @@ func TestCompiler_compileBr(t *testing.T) {
 
 		// Compile and execute the code under test.
 		// Note: we don't invoke "compiler.return()" as the code emitted by compilerBr is enough to exit.
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 		env.exec(code)
 
@@ -509,7 +509,7 @@ func TestCompiler_compileBr(t *testing.T) {
 		err = compiler.compileBr(&wazeroir.OperationBr{Target: &wazeroir.BranchTarget{Label: exitLabel}})
 		require.NoError(t, err)
 
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		// The generated code looks like this:
@@ -554,7 +554,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		compiler.compileExitFromNativeCode(nativeCallStatusCodeUnreachable)
 
 		// Generate the code under test and run.
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 		env.exec(code)
 
@@ -590,7 +590,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		require.NoError(t, err)
 
 		// Generate the code under test and run.
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 		env.exec(code)
 
@@ -630,7 +630,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		require.NoError(t, err)
 
 		// Generate the code under test and run.
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 		env.exec(code)
 
@@ -675,7 +675,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 						err = compiler.compileReturnFunction()
 						require.NoError(t, err)
 
-						c, _, _, err := compiler.compile()
+						c, _, err := compiler.compile()
 						require.NoError(t, err)
 
 						f := &function{
@@ -723,7 +723,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 						require.NoError(t, err)
 
 						// Generate the code under test and run.
-						code, _, _, err := compiler.compile()
+						code, _, err := compiler.compile()
 						require.NoError(t, err)
 						env.exec(code)
 
@@ -777,7 +777,7 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		c, _, _, err := compiler.compile()
+		c, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		f := &function{
@@ -807,7 +807,7 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test and run.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 }
@@ -853,7 +853,7 @@ func TestCompiler_compileCall(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
-					c, _, _, err := compiler.compile()
+					c, _, err := compiler.compile()
 					require.NoError(t, err)
 					index := wasm.Index(i)
 					me.functions = append(me.functions, &function{
@@ -892,7 +892,7 @@ func TestCompiler_compileCall(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -931,7 +931,7 @@ func TestCompiler_returnFunction(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		env.exec(code)
@@ -967,7 +967,7 @@ func TestCompiler_returnFunction(t *testing.T) {
 				err = compiler.compileReturnFunction()
 				require.NoError(t, err)
 
-				c, _, _, err := compiler.compile()
+				c, _, err := compiler.compile()
 				require.NoError(t, err)
 
 				// Compiles and adds to the engine.

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -1,7 +1,6 @@
 package compiler
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 	"unsafe"
@@ -298,7 +297,6 @@ func TestCompiler_compileBrTable(t *testing.T) {
 		// Generate the code under test and run.
 		code, _, err := c.compile()
 		require.NoError(t, err)
-		fmt.Println(hex.EncodeToString(code))
 		env.exec(code)
 
 		// Check the returned value.

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"encoding/hex"
 	"fmt"
 	"testing"
 	"unsafe"
@@ -297,6 +298,7 @@ func TestCompiler_compileBrTable(t *testing.T) {
 		// Generate the code under test and run.
 		code, _, err := c.compile()
 		require.NoError(t, err)
+		fmt.Println(hex.EncodeToString(code))
 		env.exec(code)
 
 		// Check the returned value.

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -78,7 +78,7 @@ func TestCompiler_compileReinterpret(t *testing.T) {
 							require.NoError(t, err)
 
 							// Generate and run the code under test.
-							code, _, _, err := compiler.compile()
+							code, _, err := compiler.compile()
 							require.NoError(t, err)
 							env.exec(code)
 
@@ -121,7 +121,7 @@ func TestCompiler_compileExtend(t *testing.T) {
 					require.NoError(t, err)
 
 					// Generate and run the code under test.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 
@@ -215,7 +215,7 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 					require.NoError(t, err)
 
 					// Generate and run the code under test.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 
@@ -414,7 +414,7 @@ func TestCompiler_compileFConvertFromI(t *testing.T) {
 					require.NoError(t, err)
 
 					// Generate and run the code under test.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 
@@ -485,7 +485,7 @@ func TestCompiler_compileF64PromoteFromF32(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -531,7 +531,7 @@ func TestCompiler_compileF32DemoteFromF64(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -46,7 +46,7 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run the code assembled above.
@@ -88,7 +88,7 @@ func TestCompiler_compileGlobalGet_v128(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 
 	// Run the code assembled above.
@@ -147,7 +147,7 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -193,7 +193,7 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -134,7 +134,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			compiler.compileExitFromNativeCode(nativeCallStatusCodeReturned)
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			env.exec(code)
@@ -200,7 +200,7 @@ func TestCompiler_compileMaybeGrowValueStack(t *testing.T) {
 				compiler.compileExitFromNativeCode(nativeCallStatusCodeReturned)
 
 				// Generate and run the code under test.
-				code, _, _, err := compiler.compile()
+				code, _, err := compiler.compile()
 				require.NoError(t, err)
 				env.exec(code)
 
@@ -231,7 +231,7 @@ func TestCompiler_compileMaybeGrowValueStack(t *testing.T) {
 		env.setValueStackBasePointer(stackBasePointer)
 
 		// Generate and run the code under test.
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 		env.exec(code)
 

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -30,7 +30,7 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and run the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 
@@ -66,7 +66,7 @@ func TestCompiler_compileMemorySize(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and run the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 
@@ -262,7 +262,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -396,7 +396,7 @@ func TestCompiler_compileStore(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Set the value on the left and right neighboring memoryregion,
@@ -464,7 +464,7 @@ func TestCompiler_MemoryOutOfBounds(t *testing.T) {
 					require.NoError(t, compiler.compileReturnFunction())
 
 					// Generate the code under test and run.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -68,7 +68,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 					require.NoError(t, err)
 
 					// Generate the code under test.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 
 					// Run native code.
@@ -184,7 +184,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							require.NoError(t, err)
 
 							// Compile and execute the code under test.
-							code, _, _, err := compiler.compile()
+							code, _, err := compiler.compile()
 							require.NoError(t, err)
 							env.exec(code)
 
@@ -354,7 +354,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								require.NoError(t, err)
 
 								// Compile and execute the code under test.
-								code, _, _, err := compiler.compile()
+								code, _, err := compiler.compile()
 								require.NoError(t, err)
 								env.exec(code)
 
@@ -471,7 +471,7 @@ func TestCompiler_compileShr(t *testing.T) {
 						require.NoError(t, err)
 
 						// Compile and execute the code under test.
-						code, _, _, err := compiler.compile()
+						code, _, err := compiler.compile()
 						require.NoError(t, err)
 						env.exec(code)
 
@@ -633,7 +633,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							require.NoError(t, err)
 
 							// Compile and execute the code under test.
-							code, _, _, err := compiler.compile()
+							code, _, err := compiler.compile()
 							require.NoError(t, err)
 							env.exec(code)
 
@@ -788,7 +788,7 @@ func TestCompiler_compile_Clz_Ctz_Popcnt(t *testing.T) {
 							require.NoError(t, err)
 
 							// Generate and run the code under test.
-							code, _, _, err := compiler.compile()
+							code, _, err := compiler.compile()
 							require.NoError(t, err)
 							env.exec(code)
 
@@ -987,7 +987,7 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					require.NoError(t, err)
 
 					// Generate and run the code under test.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 
@@ -1290,7 +1290,7 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					require.NoError(t, err)
 
 					// Generate and run the code under test.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 
@@ -1419,7 +1419,7 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 							require.NoError(t, err)
 
 							// Compile and execute the code under test.
-							code, _, _, err := compiler.compile()
+							code, _, err := compiler.compile()
 							require.NoError(t, err)
 							env.exec(code)
 

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -65,7 +65,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				require.NoError(t, err)
 
 				// Generate and run the code under test.
-				code, _, _, err := compiler.compile()
+				code, _, err := compiler.compile()
 				require.NoError(t, err)
 				env.exec(code)
 
@@ -138,7 +138,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				require.NoError(t, err)
 
 				// Generate and run the code under test.
-				code, _, _, err := compiler.compile()
+				code, _, err := compiler.compile()
 				require.NoError(t, err)
 				env.exec(code)
 
@@ -208,7 +208,7 @@ func TestCompiler_compileMemoryCopy(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Setup the source memory region.
@@ -287,7 +287,7 @@ func TestCompiler_compileMemoryFill(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Setup the memory region.
@@ -345,7 +345,7 @@ func TestCompiler_compileDataDrop(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -428,7 +428,7 @@ func TestCompiler_compileMemoryInit(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -484,7 +484,7 @@ func TestCompiler_compileElemDrop(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -562,7 +562,7 @@ func TestCompiler_compileTableCopy(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Setup the table.
@@ -662,7 +662,7 @@ func TestCompiler_compileTableInit(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -777,7 +777,7 @@ func TestCompiler_compileTableSet(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -906,7 +906,7 @@ func TestCompiler_compileTableGet(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -950,7 +950,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -54,7 +54,7 @@ func TestCompiler_releaseRegisterToStack(t *testing.T) {
 			compiler.compileExitFromNativeCode(nativeCallStatusCodeReturned)
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run native code after growing the value stack.
@@ -137,7 +137,7 @@ func TestCompiler_compileLoadValueOnStackToRegister(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run native code after growing the value stack, and place the original value.
@@ -212,7 +212,7 @@ func TestCompiler_compilePick_v128(t *testing.T) {
 			require.NoError(t, err)
 
 			// Compile and execute the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -308,7 +308,7 @@ func TestCompiler_compilePick(t *testing.T) {
 			require.NoError(t, err)
 
 			// Compile and execute the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -352,7 +352,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		env.exec(code)
@@ -393,7 +393,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		env.exec(code)
@@ -441,7 +441,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		env.exec(code)
@@ -579,7 +579,7 @@ func TestCompiler_compileSelect(t *testing.T) {
 					require.NoError(t, err)
 
 					// Run code.
-					code, _, _, err := compiler.compile()
+					code, _, err := compiler.compile()
 					require.NoError(t, err)
 					env.exec(code)
 
@@ -650,7 +650,7 @@ func TestCompiler_compileSwap_v128(t *testing.T) {
 			require.NoError(t, compiler.compileReturnFunction())
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.
@@ -723,7 +723,7 @@ func TestCompiler_compileSwap(t *testing.T) {
 			require.NoError(t, compiler.compileReturnFunction())
 
 			// Generate the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			// Run code.

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -93,7 +93,7 @@ func TestCompiler_compileV128Add(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -191,7 +191,7 @@ func TestCompiler_compileV128Sub(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -544,7 +544,7 @@ func TestCompiler_compileV128Load(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -750,7 +750,7 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -802,7 +802,7 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -944,7 +944,7 @@ func TestCompiler_compileV128StoreLane(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1127,7 +1127,7 @@ func TestCompiler_compileV128ExtractLane(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1364,7 +1364,7 @@ func TestCompiler_compileV128ReplaceLane(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1462,7 +1462,7 @@ func TestCompiler_compileV128Splat(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1509,7 +1509,7 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1671,7 +1671,7 @@ func TestCompiler_compileV128AllTrue(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1773,7 +1773,7 @@ func TestCompiler_compileV128Swizzle(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -1883,7 +1883,7 @@ func TestCompiler_compileV128Shuffle(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -2020,7 +2020,7 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 
 			// Generate and run the code under test.
 
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -2056,7 +2056,7 @@ func TestCompiler_compileV128_Not(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and run the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 
@@ -2284,7 +2284,7 @@ func TestCompiler_compileV128_And_Or_Xor_AndNot(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -2378,7 +2378,7 @@ func TestCompiler_compileV128Bitselect(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -2663,7 +2663,7 @@ func TestCompiler_compileV128Shl(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -2939,7 +2939,7 @@ func TestCompiler_compileV128Shr(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3370,7 +3370,7 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3451,7 +3451,7 @@ func TestCompiler_compileV128AvgrU(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3518,7 +3518,7 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3608,7 +3608,7 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3705,7 +3705,7 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3802,7 +3802,7 @@ func TestCompiler_compileV128Abs(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -3878,7 +3878,7 @@ func TestCompiler_compileV128Div(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -4039,7 +4039,7 @@ func TestCompiler_compileV128Min(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -4242,7 +4242,7 @@ func TestCompiler_compileV128Max(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -4383,7 +4383,7 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -4495,7 +4495,7 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -4565,7 +4565,7 @@ func TestCompiler_compileV128Popcnt(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -4745,7 +4745,7 @@ func TestCompiler_compileV128Round(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -5038,7 +5038,7 @@ func TestCompiler_compileV128_Pmax_Pmin(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -5732,7 +5732,7 @@ func TestCompiler_compileV128ExtMul(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -6205,7 +6205,7 @@ func TestCompiler_compileV128Extend(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -6290,7 +6290,7 @@ func TestCompiler_compileV128Q15mulrSatS(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -6363,7 +6363,7 @@ func TestCompiler_compileFloatPromote(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -6447,7 +6447,7 @@ func TestCompiler_compileV128FloatDemote(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -6657,7 +6657,7 @@ func TestCompiler_compileV128ExtAddPairwise(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -6905,7 +6905,7 @@ func TestCompiler_compileV128Narrow(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -7042,7 +7042,7 @@ func TestCompiler_compileV128FConvertFromI(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -7114,7 +7114,7 @@ func TestCompiler_compileV128Dot(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -7266,7 +7266,7 @@ func TestCompiler_compileV128ITruncSatFromF(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -193,7 +193,6 @@ type (
 		// codeSegment is holding the compiled native code as a byte slice.
 		codeSegment []byte
 		// See the doc for codeStaticData type.
-		staticData codeStaticData
 		// stackPointerCeil is the max of the stack pointer this function can reach. Lazily applied via maybeGrowValueStack.
 		stackPointerCeil uint64
 
@@ -202,14 +201,6 @@ type (
 		// sourceModule is the module from which this function is compiled. For logging purpose.
 		sourceModule *wasm.Module
 	}
-
-	// TODO: remove
-	//
-	// staticData holds the read-only data (i.e. outside codeSegment which is marked as executable) per function.
-	// This is used to store jump tables for br_table instructions.
-	// The primary index is the logical separation of multiple data, for example data[0] and data[1]
-	// correspond to different jump tables for different br_table instructions.
-	codeStaticData = [][]byte
 )
 
 // createFunction creates a new function which uses the native code compiled.

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -203,6 +203,8 @@ type (
 		sourceModule *wasm.Module
 	}
 
+	// TODO: remove
+	//
 	// staticData holds the read-only data (i.e. outside codeSegment which is marked as executable) per function.
 	// This is used to store jump tables for br_table instructions.
 	// The primary index is the logical separation of multiple data, for example data[0] and data[1]
@@ -837,7 +839,7 @@ func compileHostFunction(sig *wasm.FunctionType) (*code, error) {
 		return nil, err
 	}
 
-	c, _, _, err := compiler.compile()
+	c, _, err := compiler.compile()
 	if err != nil {
 		return nil, err
 	}
@@ -1156,10 +1158,10 @@ func compileWasmFunction(_ wasm.Features, ir *wazeroir.CompilationResult) (*code
 		}
 	}
 
-	c, staticData, stackPointerCeil, err := compiler.compile()
+	c, stackPointerCeil, err := compiler.compile()
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile: %w", err)
 	}
 
-	return &code{codeSegment: c, stackPointerCeil: stackPointerCeil, staticData: staticData}, nil
+	return &code{codeSegment: c, stackPointerCeil: stackPointerCeil}, nil
 }

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -95,7 +95,6 @@ type amd64Compiler struct {
 	currentLabel string
 	// onStackPointerCeilDeterminedCallBack hold a callback which are called when the max stack pointer is determined BEFORE generating native code.
 	onStackPointerCeilDeterminedCallBack func(stackPointerCeil uint64)
-	staticData                           codeStaticData
 }
 
 func newAmd64Compiler(ir *wazeroir.CompilationResult) (compiler, error) {

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -162,7 +162,7 @@ func (c *amd64Compiler) compileHostFunction() error {
 }
 
 // compile implements compiler.compile for the amd64 architecture.
-func (c *amd64Compiler) compile() (code []byte, staticData codeStaticData, stackPointerCeil uint64, err error) {
+func (c *amd64Compiler) compile() (code []byte, stackPointerCeil uint64, err error) {
 	// c.stackPointerCeil tracks the stack pointer ceiling (max seen) value across all runtimeValueLocationStack(s)
 	// used for all labels (via setLocationStack), excluding the current one.
 	// Hence, we check here if the final block's max one exceeds the current c.stackPointerCeil.

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -32,7 +32,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		c, _, _, err := compiler.compile()
+		c, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		f := &function{
@@ -64,7 +64,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test and run.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 }
@@ -184,7 +184,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						require.NoError(t, compiler.compileReturnFunction())
 
 						// Generate the code under test.
-						code, _, _, err := compiler.compile()
+						code, _, err := compiler.compile()
 						require.NoError(t, err)
 						// Run code.
 						env.exec(code)
@@ -308,7 +308,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						require.NoError(t, compiler.compileReturnFunction())
 
 						// Generate the code under test.
-						code, _, _, err := compiler.compile()
+						code, _, err := compiler.compile()
 						require.NoError(t, err)
 
 						// Run code.
@@ -346,7 +346,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 
 		// If generate the code without JMP after readInstructionAddress,
 		// the call back added must return error.
-		_, _, _, err = compiler.compile()
+		_, _, err = compiler.compile()
 		require.Error(t, err)
 	})
 
@@ -379,7 +379,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		require.NoError(t, err)
 
 		// Generate the code under test.
-		code, _, _, err := compiler.compile()
+		code, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		// Run code.

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -808,7 +808,7 @@ func (c *arm64Compiler) compileBrTable(o *wazeroir.OperationBrTable) error {
 	c.assembler.CompileRegisterToRegister(arm64.MOVWU, tmpReg, index.register)
 	c.assembler.SetJumpTargetOnNext(brDefaultIndex)
 
-	// We prepare the static data which holds the offset of
+	// We prepare the asm.StaticConst which holds the offset of
 	// each target's first instruction (incl. default)
 	// relative to the beginning of label tables.
 	//

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -12,12 +12,13 @@ package compiler
 import (
 	"errors"
 	"fmt"
+	"math"
+
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/arm64"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
-	"math"
 )
 
 type arm64Compiler struct {

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -12,14 +12,12 @@ package compiler
 import (
 	"errors"
 	"fmt"
-	"math"
-	"unsafe"
-
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/arm64"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
+	"math"
 )
 
 type arm64Compiler struct {
@@ -34,9 +32,6 @@ type arm64Compiler struct {
 	stackPointerCeil uint64
 	// onStackPointerCeilDeterminedCallBack hold a callback which are called when the ceil of stack pointer is determined before generating native code.
 	onStackPointerCeilDeterminedCallBack func(stackPointerCeil uint64)
-	// codeStaticData holds br_table offset tables.
-	// See codeStaticData and arm64Compiler.compileBrTable.
-	staticData codeStaticData
 }
 
 func newArm64Compiler(ir *wazeroir.CompilationResult) (compiler, error) {
@@ -100,12 +95,8 @@ func isZeroRegister(r asm.Register) bool {
 	return r == arm64.RegRZR
 }
 
-func (c *arm64Compiler) addStaticData(d []byte) {
-	c.staticData = append(c.staticData, d)
-}
-
 // compile implements compiler.compile for the arm64 architecture.
-func (c *arm64Compiler) compile() (code []byte, staticData codeStaticData, stackPointerCeil uint64, err error) {
+func (c *arm64Compiler) compile() (code []byte, stackPointerCeil uint64, err error) {
 	// c.stackPointerCeil tracks the stack pointer ceiling (max seen) value across all runtimeValueLocationStack(s)
 	// used for all labels (via setLocationStack), excluding the current one.
 	// Hence, we check here if the final block's max one exceeds the current c.stackPointerCeil.
@@ -130,8 +121,6 @@ func (c *arm64Compiler) compile() (code []byte, staticData codeStaticData, stack
 	if err != nil {
 		return
 	}
-
-	staticData = c.staticData
 	return
 }
 
@@ -844,16 +833,10 @@ func (c *arm64Compiler) compileBrTable(o *wazeroir.OperationBrTable) error {
 	// the above example's offsetData would be [0x0, 0x0, 0x0, 0x0, 0x5, 0x0, 0x0, 0x0, 0x8, 0x0, 0x0, 0x0].
 	//
 	// Note: this is similar to how GCC implements Switch statements in C.
-	offsetData := make([]byte, 4*(len(o.Targets)+1))
-	c.addStaticData(offsetData)
+	offsetData := asm.NewStaticConst(make([]byte, 4*(len(o.Targets)+1)))
 
 	// "tmpReg = &offsetData[0]"
-	c.assembler.CompileConstToRegister(
-		arm64.MOVD,
-		// Note: this should be modified to support Clone() functionality per #179.
-		int64(uintptr(unsafe.Pointer(&offsetData[0]))),
-		tmpReg,
-	)
+	c.assembler.CompileStaticConstToRegister(arm64.ADR, offsetData, tmpReg)
 
 	// "index.register = tmpReg + (index.register << 2) (== &offsetData[offset])"
 	c.assembler.CompileLeftShiftedRegisterToRegister(arm64.ADD, index.register, 2, tmpReg, index.register)

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -31,7 +31,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		c, _, _, err := compiler.compile()
+		c, _, err := compiler.compile()
 		require.NoError(t, err)
 
 		f := &function{
@@ -63,7 +63,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test and run.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 }
@@ -94,7 +94,7 @@ func TestArm64Compiler_readInstructionAddress(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 
 	env.exec(code)

--- a/internal/engine/compiler/impl_vec_amd64.go
+++ b/internal/engine/compiler/impl_vec_amd64.go
@@ -495,12 +495,12 @@ func (c *amd64Compiler) compileV128Shuffle(o *wazeroir.OperationV128Shuffle) err
 		}
 	}
 
-	err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, consts[:16], tmp)
+	err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(consts[:16]), tmp)
 	if err != nil {
 		return err
 	}
 	c.assembler.CompileRegisterToRegister(amd64.PSHUFB, tmp, v.register)
-	err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, consts[16:], tmp)
+	err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(consts[16:]), tmp)
 	if err != nil {
 		return err
 	}
@@ -534,7 +534,7 @@ func (c *amd64Compiler) compileV128Swizzle(*wazeroir.OperationV128Swizzle) error
 		return err
 	}
 
-	err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, swizzleConst[:], tmp)
+	err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(swizzleConst[:]), tmp)
 	if err != nil {
 		return err
 	}
@@ -957,7 +957,7 @@ func (c *amd64Compiler) compileV128ShrI8x16Impl(signed bool) error {
 		}
 
 		// Read the initial address of the mask table into gpTmp register.
-		err = c.assembler.CompileStaticConstToRegister(amd64.LEAQ, i8x16LogicalSHRMaskTable[:], gpTmp)
+		err = c.assembler.CompileStaticConstToRegister(amd64.LEAQ, asm.NewStaticConst(i8x16LogicalSHRMaskTable[:]), gpTmp)
 		if err != nil {
 			return err
 		}
@@ -1042,7 +1042,7 @@ func (c *amd64Compiler) compileV128Shl(o *wazeroir.OperationV128Shl) error {
 		}
 
 		// Read the initial address of the mask table into gpTmp register.
-		err = c.assembler.CompileStaticConstToRegister(amd64.LEAQ, i8x16SHLMaskTable[:], gpTmp)
+		err = c.assembler.CompileStaticConstToRegister(amd64.LEAQ, asm.NewStaticConst(i8x16SHLMaskTable[:]), gpTmp)
 		if err != nil {
 			return err
 		}
@@ -1754,7 +1754,7 @@ func (c *amd64Compiler) compileV128Popcnt(*wazeroir.OperationV128Popcnt) error {
 
 	// Read the popcntMask into tmp1, and we have
 	//  tmp1 = [0xf, ..., 0xf]
-	if err := c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, popcntMask[:], tmp1); err != nil {
+	if err := c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(popcntMask[:]), tmp1); err != nil {
 		return err
 	}
 
@@ -1775,7 +1775,7 @@ func (c *amd64Compiler) compileV128Popcnt(*wazeroir.OperationV128Popcnt) error {
 
 	// Read the popcntTable into tmp1, and we have
 	//  tmp1 = [0x00, 0x01, 0x01, 0x02, 0x01, 0x02, 0x02, 0x03, 0x01, 0x02, 0x02, 0x03, 0x02, 0x03, 0x03, 0x04]
-	if err := c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, popcntTable[:], tmp1); err != nil {
+	if err := c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(popcntTable[:]), tmp1); err != nil {
 		return err
 	}
 
@@ -2261,7 +2261,7 @@ func (c *amd64Compiler) compileV128Q15mulrSatS(*wazeroir.OperationV128Q15mulrSat
 	x1r, x2r := x1.register, x2.register
 
 	// See https://github.com/WebAssembly/simd/pull/365 for the following logic.
-	if err := c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, q15mulrSatSMask[:], tmp); err != nil {
+	if err := c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(q15mulrSatSMask[:]), tmp); err != nil {
 		return err
 	}
 
@@ -2300,7 +2300,7 @@ func (c *amd64Compiler) compileV128ExtAddPairwise(o *wazeroir.OperationV128ExtAd
 		}
 
 		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU,
-			allOnesI8x16[:], allOnesReg); err != nil {
+			asm.NewStaticConst(allOnesI8x16[:]), allOnesReg); err != nil {
 			return err
 		}
 
@@ -2329,7 +2329,8 @@ func (c *amd64Compiler) compileV128ExtAddPairwise(o *wazeroir.OperationV128ExtAd
 
 		if o.Signed {
 			// See https://www.felixcloutier.com/x86/pmaddwd
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, allOnesI16x8[:], tmp); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU,
+				asm.NewStaticConst(allOnesI16x8[:]), tmp); err != nil {
 				return err
 			}
 
@@ -2337,7 +2338,8 @@ func (c *amd64Compiler) compileV128ExtAddPairwise(o *wazeroir.OperationV128ExtAd
 			c.pushVectorRuntimeValueLocationOnRegister(vr)
 		} else {
 
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, extAddPairwiseI16x8uMask[:16], tmp); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU,
+				asm.NewStaticConst(extAddPairwiseI16x8uMask[:16]), tmp); err != nil {
 				return err
 			}
 
@@ -2347,7 +2349,8 @@ func (c *amd64Compiler) compileV128ExtAddPairwise(o *wazeroir.OperationV128ExtAd
 			// 	vr[i] = int8(-w1) for i = 0...8
 			c.assembler.CompileRegisterToRegister(amd64.PXOR, tmp, vr)
 
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, allOnesI16x8[:], tmp); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU,
+				asm.NewStaticConst(allOnesI16x8[:]), tmp); err != nil {
 				return err
 			}
 
@@ -2356,7 +2359,8 @@ func (c *amd64Compiler) compileV128ExtAddPairwise(o *wazeroir.OperationV128ExtAd
 			c.assembler.CompileRegisterToRegister(amd64.PMADDWD, tmp, vr)
 
 			// tmp[i] = [0, 0, 1, 0] = int32(math.MaxInt16+1)
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, extAddPairwiseI16x8uMask[16:], tmp); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU,
+				asm.NewStaticConst(extAddPairwiseI16x8uMask[16:]), tmp); err != nil {
 				return err
 			}
 
@@ -2468,7 +2472,7 @@ func (c *amd64Compiler) compileV128FConvertFromI(o *wazeroir.OperationV128FConve
 			}
 
 			// tmp = [0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, fConvertFromIMask[:16], tmp); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, asm.NewStaticConst(fConvertFromIMask[:16]), tmp); err != nil {
 				return err
 			}
 
@@ -2479,7 +2483,8 @@ func (c *amd64Compiler) compileV128FConvertFromI(o *wazeroir.OperationV128FConve
 			c.assembler.CompileRegisterToRegister(amd64.UNPCKLPS, tmp, vr)
 
 			// tmp = [float64(0x1.0p52), float64(0x1.0p52)]
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU, twop52[:], tmp); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVDQU,
+				asm.NewStaticConst(twop52[:]), tmp); err != nil {
 				return err
 			}
 
@@ -2649,7 +2654,7 @@ func (c *amd64Compiler) compileV128ITruncSatFromF(o *wazeroir.OperationV128ITrun
 			c.assembler.CompileRegisterToRegister(amd64.CMPEQPD, tmp, tmp)
 
 			// Load the 2147483647 into tmp2's each lane.
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVUPD, i32sMaxOnF64x2[:], tmp2); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVUPD, asm.NewStaticConst(i32sMaxOnF64x2[:]), tmp2); err != nil {
 				return err
 			}
 
@@ -2671,7 +2676,7 @@ func (c *amd64Compiler) compileV128ITruncSatFromF(o *wazeroir.OperationV128ITrun
 			c.assembler.CompileRegisterToRegister(amd64.MAXPD, tmp, vr)
 
 			// tmp2[i] = float64(math.MaxUint32) = math.MaxUint32
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVUPD, i32uMaxOnF64x2[:], tmp2); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVUPD, asm.NewStaticConst(i32uMaxOnF64x2[:]), tmp2); err != nil {
 				return err
 			}
 
@@ -2683,7 +2688,7 @@ func (c *amd64Compiler) compileV128ITruncSatFromF(o *wazeroir.OperationV128ITrun
 			c.assembler.CompileRegisterToRegisterWithArg(amd64.ROUNDPD, vr, vr, 0x3)
 
 			// tmp2[i] = float64(0x1.0p52)
-			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVUPD, twop52[:], tmp2); err != nil {
+			if err = c.assembler.CompileStaticConstToRegister(amd64.MOVUPD, asm.NewStaticConst(twop52[:]), tmp2); err != nil {
 				return err
 			}
 

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -53,7 +53,7 @@ func TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and run the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 	env.exec(code)
 
@@ -203,7 +203,7 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 
@@ -288,7 +288,7 @@ func TestAmd64Compiler_compileV128Neg_NaNOnTemporary(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 			env.exec(code)
 

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -567,7 +567,7 @@ func (c *arm64Compiler) compileV128Shuffle(o *wazeroir.OperationV128Shuffle) (er
 		return err
 	}
 
-	c.assembler.CompileLoadStaticConstToVectorRegister(arm64.VMOV, o.Lanes[:], result, arm64.VectorArrangementQ)
+	c.assembler.CompileStaticConstToVectorRegister(arm64.VMOV, asm.NewStaticConst(o.Lanes[:]), result, arm64.VectorArrangementQ)
 	c.assembler.CompileVectorRegisterToVectorRegister(arm64.TBL2, vReg, result, arm64.VectorArrangement16B,
 		arm64.VectorIndexNone, arm64.VectorIndexNone)
 
@@ -691,7 +691,7 @@ func (c *arm64Compiler) compileV128BitMask(o *wazeroir.OperationV128BitMask) (er
 		c.assembler.CompileVectorRegisterToVectorRegisterWithConst(arm64.SSHR, v, v, arm64.VectorArrangement16B, 7)
 
 		// Load the bit mask into vecTmp.
-		c.assembler.CompileLoadStaticConstToVectorRegister(arm64.VMOV, i8x16BitmaskConst[:], vecTmp, arm64.VectorArrangementQ)
+		c.assembler.CompileStaticConstToVectorRegister(arm64.VMOV, asm.NewStaticConst(i8x16BitmaskConst[:]), vecTmp, arm64.VectorArrangementQ)
 
 		// Lane-wise logical AND with i8x16BitmaskConst, meaning that we have
 		// v[i] = (1 << i) if vi<0, 0 otherwise.
@@ -725,7 +725,7 @@ func (c *arm64Compiler) compileV128BitMask(o *wazeroir.OperationV128BitMask) (er
 		c.assembler.CompileVectorRegisterToVectorRegisterWithConst(arm64.SSHR, v, v, arm64.VectorArrangement8H, 15)
 
 		// Load the bit mask into vecTmp.
-		c.assembler.CompileLoadStaticConstToVectorRegister(arm64.VMOV, i16x8BitmaskConst[:], vecTmp, arm64.VectorArrangementQ)
+		c.assembler.CompileStaticConstToVectorRegister(arm64.VMOV, asm.NewStaticConst(i16x8BitmaskConst[:]), vecTmp, arm64.VectorArrangementQ)
 
 		// Lane-wise logical AND with i16x8BitmaskConst, meaning that we have
 		// v[i] = (1 << i)     if vi<0, 0 otherwise for i=0..3
@@ -748,7 +748,8 @@ func (c *arm64Compiler) compileV128BitMask(o *wazeroir.OperationV128BitMask) (er
 		c.assembler.CompileVectorRegisterToVectorRegisterWithConst(arm64.SSHR, v, v, arm64.VectorArrangement4S, 32)
 
 		// Load the bit mask into vecTmp.
-		c.assembler.CompileLoadStaticConstToVectorRegister(arm64.VMOV, i32x4BitmaskConst[:], vecTmp, arm64.VectorArrangementQ)
+		c.assembler.CompileStaticConstToVectorRegister(arm64.VMOV,
+			asm.NewStaticConst(i32x4BitmaskConst[:]), vecTmp, arm64.VectorArrangementQ)
 
 		// Lane-wise logical AND with i16x8BitmaskConst, meaning that we have
 		// v[i] = (1 << i)     if vi<0, 0 otherwise for i in [0, 1]

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -53,7 +53,7 @@ func TestArm64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate and run the code under test.
-	code, _, _, err := compiler.compile()
+	code, _, err := compiler.compile()
 	require.NoError(t, err)
 
 	env.exec(code)
@@ -202,7 +202,7 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate and run the code under test.
-			code, _, _, err := compiler.compile()
+			code, _, err := compiler.compile()
 			require.NoError(t, err)
 
 			env.exec(code)

--- a/internal/integration_test/asm/amd64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/amd64_debug/debug_assembler.go
@@ -110,8 +110,7 @@ func (ta *testAssembler) SetJumpTargetOnNext(nodes ...asm.Node) {
 
 // BuildJumpTable implements the same method as documented on asm_amd64.Assembler.
 func (ta *testAssembler) BuildJumpTable(table *asm.StaticConst, initialInstructions []asm.Node) {
-	ta.goasm.BuildJumpTable(table, initialInstructions)
-	ta.a.BuildJumpTable(table, initialInstructions)
+	panic("BuildJumpTable is not supported by golang-asm")
 }
 
 // CompileStandAlone implements the same method as documented on asm_amd64.Assembler.

--- a/internal/integration_test/asm/amd64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/amd64_debug/debug_assembler.go
@@ -109,7 +109,7 @@ func (ta *testAssembler) SetJumpTargetOnNext(nodes ...asm.Node) {
 }
 
 // BuildJumpTable implements the same method as documented on asm_amd64.Assembler.
-func (ta *testAssembler) BuildJumpTable(table []byte, initialInstructions []asm.Node) {
+func (ta *testAssembler) BuildJumpTable(table *asm.StaticConst, initialInstructions []asm.Node) {
 	ta.goasm.BuildJumpTable(table, initialInstructions)
 	ta.a.BuildJumpTable(table, initialInstructions)
 }
@@ -302,11 +302,11 @@ func (ta *testAssembler) CompileMemoryToConst(
 }
 
 // CompileStaticConstToRegister implements Assembler.CompileStaticConstToRegister.
-func (ta *testAssembler) CompileStaticConstToRegister(asm.Instruction, []byte, asm.Register) (err error) {
+func (ta *testAssembler) CompileStaticConstToRegister(asm.Instruction, *asm.StaticConst, asm.Register) (err error) {
 	panic("CompileStaticConstToRegister cannot be supported by golang-asm")
 }
 
 // CompileRegisterToStaticConst implements Assembler.CompileRegisterToStaticConst.
-func (ta *testAssembler) CompileRegisterToStaticConst(asm.Instruction, asm.Register, []byte) (err error) {
+func (ta *testAssembler) CompileRegisterToStaticConst(asm.Instruction, asm.Register, *asm.StaticConst) (err error) {
 	panic("CompileRegisterToStaticConst cannot be supported by golang-asm")
 }

--- a/internal/integration_test/asm/amd64_debug/golang_asm.go
+++ b/internal/integration_test/asm/amd64_debug/golang_asm.go
@@ -381,12 +381,12 @@ func (a *assemblerGoAsmImpl) CompileReadInstructionAddress(
 }
 
 // CompileStaticConstToRegister implements Assembler.CompileStaticConstToRegister.
-func (a *assemblerGoAsmImpl) CompileStaticConstToRegister(instruction asm.Instruction, c []byte, dstReg asm.Register) (err error) {
+func (a *assemblerGoAsmImpl) CompileStaticConstToRegister(asm.Instruction, *asm.StaticConst, asm.Register) (err error) {
 	panic("CompileStaticConstToRegister cannot be supported by golangasm")
 }
 
 // CompileRegisterToStaticConst implements Assembler.CompileRegisterToStaticConst.
-func (ta *assemblerGoAsmImpl) CompileRegisterToStaticConst(asm.Instruction, asm.Register, []byte) (err error) {
+func (a *assemblerGoAsmImpl) CompileRegisterToStaticConst(asm.Instruction, asm.Register, *asm.StaticConst) (err error) {
 	panic("CompileRegisterToStaticConst cannot be supported by golang-asm")
 }
 

--- a/internal/integration_test/asm/arm64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/arm64_debug/debug_assembler.go
@@ -101,7 +101,7 @@ func (ta *testAssembler) SetJumpTargetOnNext(nodes ...asm.Node) {
 }
 
 // BuildJumpTable implements the same method as documented on arm64.Assembler.
-func (ta *testAssembler) BuildJumpTable(table []byte, initialInstructions []asm.Node) {
+func (ta *testAssembler) BuildJumpTable(table *asm.StaticConst, initialInstructions []asm.Node) {
 	ta.goasm.BuildJumpTable(table, initialInstructions)
 	ta.a.BuildJumpTable(table, initialInstructions)
 }
@@ -284,12 +284,16 @@ func (ta *testAssembler) CompileVectorRegisterToRegister(instruction asm.Instruc
 	ta.a.CompileVectorRegisterToRegister(instruction, srcReg, dstReg, arrangement, index)
 }
 
-// CompileStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
-// and the destination is the dstReg.
+// CompileStaticConstToVectorRegister implements the same method as documented on arm64.Assembler.
 func (ta *testAssembler) CompileStaticConstToVectorRegister(instruction asm.Instruction,
-	c asm.StaticConst, dstReg asm.Register, arrangement arm64.VectorArrangement) {
+	c *asm.StaticConst, dstReg asm.Register, arrangement arm64.VectorArrangement) {
 	ta.goasm.CompileStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
 	ta.a.CompileStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
+}
+
+// CompileStaticConstToRegister implements the same method as documented on arm64.Assembler.
+func (ta *testAssembler) CompileStaticConstToRegister(asm.Instruction, *asm.StaticConst, asm.Register) {
+	panic("CompileStaticConstToRegister is not supported by golang-asm")
 }
 
 // CompileTwoVectorRegistersToVectorRegister implements the same method as documented on arm64.Assembler.

--- a/internal/integration_test/asm/arm64_debug/debug_assembler.go
+++ b/internal/integration_test/asm/arm64_debug/debug_assembler.go
@@ -284,12 +284,12 @@ func (ta *testAssembler) CompileVectorRegisterToRegister(instruction asm.Instruc
 	ta.a.CompileVectorRegisterToRegister(instruction, srcReg, dstReg, arrangement, index)
 }
 
-// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
+// CompileStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
 // and the destination is the dstReg.
-func (ta *testAssembler) CompileLoadStaticConstToVectorRegister(instruction asm.Instruction,
+func (ta *testAssembler) CompileStaticConstToVectorRegister(instruction asm.Instruction,
 	c asm.StaticConst, dstReg asm.Register, arrangement arm64.VectorArrangement) {
-	ta.goasm.CompileLoadStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
-	ta.a.CompileLoadStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
+	ta.goasm.CompileStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
+	ta.a.CompileStaticConstToVectorRegister(instruction, c, dstReg, arrangement)
 }
 
 // CompileTwoVectorRegistersToVectorRegister implements the same method as documented on arm64.Assembler.

--- a/internal/integration_test/asm/arm64_debug/golang_asm.go
+++ b/internal/integration_test/asm/arm64_debug/golang_asm.go
@@ -400,7 +400,13 @@ func (a *assemblerGoAsmImpl) CompileVectorRegisterToRegister(instruction asm.Ins
 // CompileStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
 // and the destination is the dstReg.
 func (a *assemblerGoAsmImpl) CompileStaticConstToVectorRegister(asm.Instruction,
-	asm.StaticConst, asm.Register, asm_arm64.VectorArrangement) {
+	*asm.StaticConst, asm.Register, asm_arm64.VectorArrangement) {
+	panic("unsupported in golang-asm")
+}
+
+// CompileStaticConstToRegister adds an instruction where the source operand is StaticConstant located in the memory
+// and the destination is the dstReg.
+func (a *assemblerGoAsmImpl) CompileStaticConstToRegister(asm.Instruction, *asm.StaticConst, asm.Register) {
 	panic("unsupported in golang-asm")
 }
 

--- a/internal/integration_test/asm/arm64_debug/golang_asm.go
+++ b/internal/integration_test/asm/arm64_debug/golang_asm.go
@@ -397,9 +397,9 @@ func (a *assemblerGoAsmImpl) CompileVectorRegisterToRegister(instruction asm.Ins
 	a.AddInstruction(inst)
 }
 
-// CompileLoadStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
+// CompileStaticConstToVectorRegister adds an instruction where the source operand is StaticConstant located in the memory
 // and the destination is the dstReg.
-func (a *assemblerGoAsmImpl) CompileLoadStaticConstToVectorRegister(asm.Instruction,
+func (a *assemblerGoAsmImpl) CompileStaticConstToVectorRegister(asm.Instruction,
 	asm.StaticConst, asm.Register, asm_arm64.VectorArrangement) {
 	panic("unsupported in golang-asm")
 }

--- a/internal/integration_test/asm/arm64_debug/impl_test.go
+++ b/internal/integration_test/asm/arm64_debug/impl_test.go
@@ -1118,29 +1118,6 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 	}
 }
 
-// TestAssemblerImpl_multipleLargeOffset ensures that the const pool flushing strategy matches
-// the one of Go's assembler.
-func TestAssemblerImpl_multipleLargeOffset(t *testing.T) {
-	t.Skip() // TODO
-	goasm := newGoasmAssembler(t, asm.NilRegister)
-	a := arm64.NewAssemblerImpl(arm64.RegR27)
-
-	for _, assembler := range []arm64.Assembler{a, goasm} {
-		for i := 0; i < 10000; i++ {
-			// This will be put into const pool, but the callback won't be set for it.
-			assembler.CompileRegisterToMemory(arm64.MOVD, arm64.RegR11, arm64.RegR12, 0xfff0+int64(i*8))
-			// This will also set the call back for it.
-			assembler.CompileRegisterToMemory(arm64.MOVD, arm64.RegR11, arm64.RegR12, (0xfff0+int64(i*8)<<16+8)%(1<<31))
-		}
-	}
-
-	actual, err := a.Assemble()
-	require.NoError(t, err)
-	expected, err := goasm.Assemble()
-	require.NoError(t, err)
-	require.Equal(t, expected, actual)
-}
-
 func conditionalRegisterToState(r asm.Register) asm.ConditionalRegisterState {
 	switch r {
 	case arm64.RegCondEQ:

--- a/internal/integration_test/asm/arm64_debug/impl_test.go
+++ b/internal/integration_test/asm/arm64_debug/impl_test.go
@@ -1118,9 +1118,10 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 	}
 }
 
-// TestAssemblerImpl_multipleLargeOffest ensures that the const pool flushing strategy matches
+// TestAssemblerImpl_multipleLargeOffset ensures that the const pool flushing strategy matches
 // the one of Go's assembler.
-func TestAssemblerImpl_multipleLargeOffest(t *testing.T) {
+func TestAssemblerImpl_multipleLargeOffset(t *testing.T) {
+	t.Skip() // TODO
 	goasm := newGoasmAssembler(t, asm.NilRegister)
 	a := arm64.NewAssemblerImpl(arm64.RegR27)
 

--- a/internal/integration_test/asm/golang_asm/golang_asm.go
+++ b/internal/integration_test/asm/golang_asm/golang_asm.go
@@ -1,7 +1,6 @@
 package golang_asm
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	goasm "github.com/twitchyliquid64/golang-asm"
@@ -87,22 +86,8 @@ func (a *GolangAsmBaseAssembler) AddOnGenerateCallBack(cb func([]byte) error) {
 }
 
 // BuildJumpTable implements the same method as documented on asm.AssemblerBase.
-func (a *GolangAsmBaseAssembler) BuildJumpTable(table *asm.StaticConst, labelInitialInstructions []asm.Node) {
-	a.AddOnGenerateCallBack(func(code []byte) error {
-		// Compile the offset table for each target.
-		base := labelInitialInstructions[0].OffsetInBinary()
-		for i, nop := range labelInitialInstructions {
-			if nop.OffsetInBinary()-base >= asm.JumpTableMaximumOffset {
-				return fmt.Errorf("too large br_table")
-			}
-			// We store the offset from the beginning of the L0's initial instruction.
-			binary.LittleEndian.PutUint32(
-				code[table.OffsetInBinary+uint64(i*4):table.OffsetInBinary+uint64((i+1)*4)],
-				uint32(nop.OffsetInBinary())-uint32(base),
-			)
-		}
-		return nil
-	})
+func (a *GolangAsmBaseAssembler) BuildJumpTable(*asm.StaticConst, []asm.Node) {
+	panic("BuildJumpTable is not supported by golang-asm")
 }
 
 // AddInstruction is used in architecture specific assembler implementation for golang-asm.


### PR DESCRIPTION
This removes the embedding of pointers of jump tables (uintptr of []byte)
used by BrTable operations. That is the last usage of unsafe.Pointer in
compiler implementations.
Alternatively, we treat jump tables as asm.StaticConst and emit them 
into the constPool already implemented and used by various places.


Notably, now the native code compiled by compilers can be reusable
across multiple processes, meaning that they are independent of 
any runtime pointers.

part of #618

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>