### PR TITLE
compiler: always allocate register to save conditional values

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -296,6 +296,9 @@ func (a *AssemblerImpl) EncodeNode(n *nodeImpl) (err error) {
 	default:
 		err = fmt.Errorf("encoder undefined for [%s] operand type", n.types)
 	}
+	if err != nil {
+		err = fmt.Errorf("%w: %s", err, n) // Ensure the error is debuggable by including the string value of the node.
+	}
 	return
 }
 

--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -191,9 +191,10 @@ func TestAssemblerImpl_newNode(t *testing.T) {
 func TestAssemblerImpl_encodeNode(t *testing.T) {
 	a := NewAssembler()
 	err := a.EncodeNode(&nodeImpl{
-		types: operandTypes{operandTypeBranch, operandTypeRegister},
+		instruction: ADDPD,
+		types:       operandTypesRegisterToMemory,
 	})
-	require.EqualError(t, err, "encoder undefined for [from:branch,to:register] operand type")
+	require.EqualError(t, err, "ADDPD is unsupported for from:register,to:memory type: ADDPD nil, [nil + 0x0]")
 }
 
 func TestAssemblerImpl_padNOP(t *testing.T) {

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -385,7 +385,7 @@ func (a *AssemblerImpl) encodeNode(n *nodeImpl) (err error) {
 		err = fmt.Errorf("encoder undefined for [%s] operand type", n.types)
 	}
 	if err != nil {
-		err = fmt.Errorf("%w: %s", err, n) // Ensure the error is debuggable by including the string value.
+		err = fmt.Errorf("%w: %s", err, n) // Ensure the error is debuggable by including the string value of the node.
 	}
 	return
 }

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -1,0 +1,50 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
+)
+
+// TestCompiler_conditional_value_saving ensure that saving conditional register works correctly even if there's
+// no free registers available.
+func TestCompiler_conditional_value_saving(t *testing.T) {
+	env := newCompilerEnvironment()
+	compiler := env.requireNewCompiler(t, newCompiler, nil)
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
+
+	// Generate constants to occupy all the unreserved GP registers.
+	for i := 0; i < len(unreservedGeneralPurposeRegisters); i++ {
+		err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: 100})
+		require.NoError(t, err)
+	}
+
+	// Ensures that no free registers are available.
+	_, ok := compiler.runtimeValueLocationStack().takeFreeRegister(registerTypeGeneralPurpose)
+	require.False(t, ok)
+
+	// Generate conditional flag via floating point comparisons
+	err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: 1.0})
+	require.NoError(t, err)
+	err = compiler.compileConstF32(&wazeroir.OperationConstF32{Value: 2.0})
+	require.NoError(t, err)
+	err = compiler.compileLe(&wazeroir.OperationLe{Type: wazeroir.SignedTypeFloat32})
+	require.NoError(t, err)
+
+	// Ensures that we have conditional value at top of stack.
+	l := compiler.runtimeValueLocationStack().peek()
+	require.True(t, l.onConditionalRegister())
+
+	// On function return, the conditional value must be saved to a general purpose reg, and then written to stack.
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
+
+	// Generate and run the code under test.
+	code, _, err := compiler.compile()
+	require.NoError(t, err)
+	env.exec(code)
+
+	require.Equal(t, uint32(1), env.stackTopAsUint32()) // expect 1 as the result of 1.0 < 2.0.
+}

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -164,7 +164,7 @@ func (j *compilerEnv) requireNewCompiler(t *testing.T, fn newTestCompiler, ir *w
 	return ret
 }
 
-// CompilerImpl is the interface used for architecture-independent unit tests in this file.
+// CompilerImpl is the interface used for architecture-independent unit tests in this pkg.
 // This is currently implemented by amd64 and arm64.
 type compilerImpl interface {
 	compiler

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -244,7 +244,7 @@ func (c *amd64Compiler) compileSwap(o *wazeroir.OperationSwap) error {
 
 // compileGlobalGet implements compiler.compileGlobalGet for the amd64 architecture.
 func (c *amd64Compiler) compileGlobalGet(o *wazeroir.OperationGlobalGet) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -348,7 +348,7 @@ func (c *amd64Compiler) compileGlobalSet(o *wazeroir.OperationGlobalSet) error {
 
 // compileBr implements compiler.compileBr for the amd64 architecture.
 func (c *amd64Compiler) compileBr(o *wazeroir.OperationBr) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 	return c.branchInto(o.Target)
@@ -927,7 +927,7 @@ func (c *amd64Compiler) compileSelect() error {
 
 // compilePick implements compiler.compilePick for the amd64 architecture.
 func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -1378,7 +1378,7 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		remainderRegister = amd64.RegDX
 	)
 
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -1669,7 +1669,7 @@ func (c *amd64Compiler) compileRotr(o *wazeroir.OperationRotr) (err error) {
 // compileShiftOp adds instructions for shift operations (SHR, SHL, ROTR, ROTL)
 // where we have to place the second value (shift counts) on the CX register.
 func (c *amd64Compiler) compileShiftOp(instruction asm.Instruction, is32Bit bool) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -3396,7 +3396,7 @@ func (c *amd64Compiler) compileStoreImpl(offsetConst uint32, inst asm.Instructio
 
 // compileMemoryGrow implements compiler.compileMemoryGrow for the amd64 architecture.
 func (c *amd64Compiler) compileMemoryGrow() error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -3413,7 +3413,7 @@ func (c *amd64Compiler) compileMemoryGrow() error {
 
 // compileMemorySize implements compiler.compileMemorySize for the amd64 architecture.
 func (c *amd64Compiler) compileMemorySize() error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -4021,7 +4021,7 @@ func (c *amd64Compiler) compileTableSet(o *wazeroir.OperationTableSet) error {
 
 // compileTableGrow implements compiler.compileTableGrow for the amd64 architecture.
 func (c *amd64Compiler) compileTableGrow(o *wazeroir.OperationTableGrow) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -4107,7 +4107,7 @@ func (c *amd64Compiler) compileRefFunc(o *wazeroir.OperationRefFunc) error {
 
 // compileConstI32 implements compiler.compileConstI32 for the amd64 architecture.
 func (c *amd64Compiler) compileConstI32(o *wazeroir.OperationConstI32) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -4122,7 +4122,7 @@ func (c *amd64Compiler) compileConstI32(o *wazeroir.OperationConstI32) error {
 
 // compileConstI64 implements compiler.compileConstI64 for the amd64 architecture.
 func (c *amd64Compiler) compileConstI64(o *wazeroir.OperationConstI64) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -4138,7 +4138,7 @@ func (c *amd64Compiler) compileConstI64(o *wazeroir.OperationConstI64) error {
 
 // compileConstF32 implements compiler.compileConstF32 for the amd64 architecture.
 func (c *amd64Compiler) compileConstF32(o *wazeroir.OperationConstF32) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -4162,7 +4162,7 @@ func (c *amd64Compiler) compileConstF32(o *wazeroir.OperationConstF32) error {
 
 // compileConstF64 implements compiler.compileConstF64 for the amd64 architecture.
 func (c *amd64Compiler) compileConstF64(o *wazeroir.OperationConstF64) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -4207,14 +4207,14 @@ func (c *amd64Compiler) compileLoadValueOnStackToRegister(loc *runtimeValueLocat
 	}
 }
 
-// maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister moves the top value on the stack
+// maybeCompileMoveTopConditionalToGeneralPurposeRegister moves the top value on the stack
 // if the value is located on a conditional register.
 //
 // This is usually called at the beginning of methods on compiler interface where we possibly
 // compile instructions without saving the conditional register value.
-// The compile* functions without calling this function is saving the conditional
+// The compileXXX functions without calling this function is saving the conditional
 // value to the stack or register by invoking compileEnsureOnRegister for the top.
-func (c *amd64Compiler) maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister() (err error) {
+func (c *amd64Compiler) maybeCompileMoveTopConditionalToGeneralPurposeRegister() (err error) {
 	if c.locationStack.sp > 0 {
 		if loc := c.locationStack.peek(); loc.onConditionalRegister() {
 			if err = c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc); err != nil {
@@ -4228,7 +4228,7 @@ func (c *amd64Compiler) maybeCompileMoveTopConditionalToFreeGeneralPurposeRegist
 // loadConditionalRegisterToGeneralPurposeRegister saves the conditional register value
 // to a general purpose register.
 func (c *amd64Compiler) compileLoadConditionalRegisterToGeneralPurposeRegister(loc *runtimeValueLocation) error {
-	reg, err := c.allocateRegister(loc.getRegisterType())
+	reg, err := c.allocateRegister(registerTypeGeneralPurpose)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -244,7 +244,9 @@ func (c *amd64Compiler) compileSwap(o *wazeroir.OperationSwap) error {
 
 // compileGlobalGet implements compiler.compileGlobalGet for the amd64 architecture.
 func (c *amd64Compiler) compileGlobalGet(o *wazeroir.OperationGlobalGet) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	intReg, err := c.allocateRegister(registerTypeGeneralPurpose)
 	if err != nil {
@@ -346,7 +348,9 @@ func (c *amd64Compiler) compileGlobalSet(o *wazeroir.OperationGlobalSet) error {
 
 // compileBr implements compiler.compileBr for the amd64 architecture.
 func (c *amd64Compiler) compileBr(o *wazeroir.OperationBr) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 	return c.branchInto(o.Target)
 }
 
@@ -917,7 +921,9 @@ func (c *amd64Compiler) compileSelect() error {
 
 // compilePick implements compiler.compilePick for the amd64 architecture.
 func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	// TODO: if we track the type of values on the stack,
 	// we could optimize the instruction according to the bit size of the value.
@@ -1366,7 +1372,9 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		remainderRegister = amd64.RegDX
 	)
 
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	// Ensures that previous values on these registers are saved to memory.
 	c.onValueReleaseRegisterToStack(quotientRegister)
@@ -1655,7 +1663,9 @@ func (c *amd64Compiler) compileRotr(o *wazeroir.OperationRotr) (err error) {
 // compileShiftOp adds instructions for shift operations (SHR, SHL, ROTR, ROTL)
 // where we have to place the second value (shift counts) on the CX register.
 func (c *amd64Compiler) compileShiftOp(instruction asm.Instruction, is32Bit bool) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	x2 := c.locationStack.pop()
 
@@ -3380,7 +3390,9 @@ func (c *amd64Compiler) compileStoreImpl(offsetConst uint32, inst asm.Instructio
 
 // compileMemoryGrow implements compiler.compileMemoryGrow for the amd64 architecture.
 func (c *amd64Compiler) compileMemoryGrow() error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	if err := c.compileCallBuiltinFunction(builtinFunctionIndexMemoryGrow); err != nil {
 		return err
@@ -3395,7 +3407,9 @@ func (c *amd64Compiler) compileMemoryGrow() error {
 
 // compileMemorySize implements compiler.compileMemorySize for the amd64 architecture.
 func (c *amd64Compiler) compileMemorySize() error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	reg, err := c.allocateRegister(registerTypeGeneralPurpose)
 	if err != nil {
@@ -4001,7 +4015,9 @@ func (c *amd64Compiler) compileTableSet(o *wazeroir.OperationTableSet) error {
 
 // compileTableGrow implements compiler.compileTableGrow for the amd64 architecture.
 func (c *amd64Compiler) compileTableGrow(o *wazeroir.OperationTableGrow) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	// Pushes the table index.
 	if err := c.compileConstI32(&wazeroir.OperationConstI32{Value: o.TableIndex}); err != nil {
@@ -4085,7 +4101,9 @@ func (c *amd64Compiler) compileRefFunc(o *wazeroir.OperationRefFunc) error {
 
 // compileConstI32 implements compiler.compileConstI32 for the amd64 architecture.
 func (c *amd64Compiler) compileConstI32(o *wazeroir.OperationConstI32) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	reg, err := c.allocateRegister(registerTypeGeneralPurpose)
 	if err != nil {
@@ -4098,7 +4116,9 @@ func (c *amd64Compiler) compileConstI32(o *wazeroir.OperationConstI32) error {
 
 // compileConstI64 implements compiler.compileConstI64 for the amd64 architecture.
 func (c *amd64Compiler) compileConstI64(o *wazeroir.OperationConstI64) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	reg, err := c.allocateRegister(registerTypeGeneralPurpose)
 	if err != nil {
@@ -4112,7 +4132,9 @@ func (c *amd64Compiler) compileConstI64(o *wazeroir.OperationConstI64) error {
 
 // compileConstF32 implements compiler.compileConstF32 for the amd64 architecture.
 func (c *amd64Compiler) compileConstF32(o *wazeroir.OperationConstF32) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	reg, err := c.allocateRegister(registerTypeVector)
 	if err != nil {
@@ -4134,7 +4156,9 @@ func (c *amd64Compiler) compileConstF32(o *wazeroir.OperationConstF32) error {
 
 // compileConstF64 implements compiler.compileConstF64 for the amd64 architecture.
 func (c *amd64Compiler) compileConstF64(o *wazeroir.OperationConstF64) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	reg, err := c.allocateRegister(registerTypeVector)
 	if err != nil {
@@ -4184,20 +4208,26 @@ func (c *amd64Compiler) compileLoadValueOnStackToRegister(loc *runtimeValueLocat
 // compile instructions without saving the conditional register value.
 // The compile* functions without calling this function is saving the conditional
 // value to the stack or register by invoking compileEnsureOnRegister for the top.
-func (c *amd64Compiler) maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister() {
+func (c *amd64Compiler) maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister() (err error) {
 	if c.locationStack.sp > 0 {
 		if loc := c.locationStack.peek(); loc.onConditionalRegister() {
-			c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc)
+			if err = c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc); err != nil {
+				return err
+			}
 		}
 	}
+	return
 }
 
 // loadConditionalRegisterToGeneralPurposeRegister saves the conditional register value
 // to a general purpose register.
-func (c *amd64Compiler) compileLoadConditionalRegisterToGeneralPurposeRegister(loc *runtimeValueLocation) {
-	// Get the free register.
-	reg, _ := c.locationStack.takeFreeRegister(registerTypeGeneralPurpose)
+func (c *amd64Compiler) compileLoadConditionalRegisterToGeneralPurposeRegister(loc *runtimeValueLocation) error {
+	reg, err := c.allocateRegister(loc.getRegisterType())
+	if err != nil {
+		return err
+	}
 	c.compileMoveConditionalToGeneralPurposeRegister(loc, reg)
+	return nil
 }
 
 func (c *amd64Compiler) compileMoveConditionalToGeneralPurposeRegister(loc *runtimeValueLocation, reg asm.Register) {
@@ -4950,7 +4980,7 @@ func (c *amd64Compiler) compileModuleContextInitialization() error {
 
 // compileEnsureOnRegister ensures that the given value is located on a
 // general purpose register of an appropriate type.
-func (c *amd64Compiler) compileEnsureOnRegister(loc *runtimeValueLocation) error {
+func (c *amd64Compiler) compileEnsureOnRegister(loc *runtimeValueLocation) (err error) {
 	if loc.onStack() {
 		// Allocate the register.
 		reg, err := c.allocateRegister(loc.getRegisterType())
@@ -4964,7 +4994,7 @@ func (c *amd64Compiler) compileEnsureOnRegister(loc *runtimeValueLocation) error
 
 		c.compileLoadValueOnStackToRegister(loc)
 	} else if loc.onConditionalRegister() {
-		c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc)
+		err = c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc)
 	}
-	return nil
+	return
 }

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -476,7 +476,7 @@ func (c *arm64Compiler) compileSwap(o *wazeroir.OperationSwap) error {
 
 // compileGlobalGet implements compiler.compileGlobalGet for the arm64 architecture.
 func (c *arm64Compiler) compileGlobalGet(o *wazeroir.OperationGlobalGet) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -627,7 +627,7 @@ func (c *arm64Compiler) compileReadGlobalAddress(globalIndex uint32) (destinatio
 
 // compileBr implements compiler.compileBr for the arm64 architecture.
 func (c *arm64Compiler) compileBr(o *wazeroir.OperationBr) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 	return c.compileBranchInto(o.Target)
@@ -1255,7 +1255,7 @@ func (c *arm64Compiler) compileDropRange(r *wazeroir.InclusiveRange) error {
 
 	// Below, we might end up moving a non-top value first which
 	// might result in changing the flag value.
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -1360,7 +1360,7 @@ func (c *arm64Compiler) compileSelect() error {
 
 // compilePick implements compiler.compilePick for the arm64 architecture.
 func (c *arm64Compiler) compilePick(o *wazeroir.OperationPick) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -2839,7 +2839,7 @@ func (c *arm64Compiler) compileMemoryAccessOffsetSetup(offsetArg uint32, targetS
 
 // compileMemoryGrow implements compileMemoryGrow variants for arm64 architecture.
 func (c *arm64Compiler) compileMemoryGrow() error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -2855,7 +2855,7 @@ func (c *arm64Compiler) compileMemoryGrow() error {
 
 // compileMemorySize implements compileMemorySize variants for arm64 architecture.
 func (c *arm64Compiler) compileMemorySize() error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -2959,7 +2959,7 @@ func (c *arm64Compiler) compileConstI64(o *wazeroir.OperationConstI64) error {
 // is32bit is true if the target value is originally 32-bit const, false otherwise.
 // value holds the (zero-extended for 32-bit case) load target constant.
 func (c *arm64Compiler) compileIntConstant(is32bit bool, value uint64) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -3003,7 +3003,7 @@ func (c *arm64Compiler) compileConstF64(o *wazeroir.OperationConstF64) error {
 // is32bit is true if the target value is originally 32-bit const, false otherwise.
 // value holds the (zero-extended for 32-bit case) bit representation of load target float constant.
 func (c *arm64Compiler) compileFloatConstant(is32bit bool, value uint64) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -3845,7 +3845,7 @@ func (c *arm64Compiler) compileTableSet(o *wazeroir.OperationTableSet) error {
 
 // compileTableGrow implements compiler.compileTableGrow for the arm64 architecture.
 func (c *arm64Compiler) compileTableGrow(o *wazeroir.OperationTableGrow) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -3962,14 +3962,14 @@ func (c *arm64Compiler) compileEnsureOnRegister(loc *runtimeValueLocation) (err 
 	return
 }
 
-// maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister moves the top value on the stack
+// maybeCompileMoveTopConditionalToGeneralPurposeRegister moves the top value on the stack
 // if the value is located on a conditional register.
 //
 // This is usually called at the beginning of methods on compiler interface where we possibly
 // compile instructions without saving the conditional register value.
 // compile* functions without calling this function is saving the conditional
 // value to the stack or register by invoking ensureOnGeneralPurposeRegister for the top.
-func (c *arm64Compiler) maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister() (err error) {
+func (c *arm64Compiler) maybeCompileMoveTopConditionalToGeneralPurposeRegister() (err error) {
 	if c.locationStack.sp > 0 {
 		if loc := c.locationStack.peek(); loc.onConditionalRegister() {
 			err = c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc)

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -4054,16 +4054,18 @@ func (c *arm64Compiler) allocateRegister(t registerType) (reg asm.Register, err 
 // compileReleaseAllRegistersToStack adds instructions to store all the values located on
 // either general purpose or conditional registers onto the memory stack.
 // See releaseRegisterToStack.
-func (c *arm64Compiler) compileReleaseAllRegistersToStack() error {
+func (c *arm64Compiler) compileReleaseAllRegistersToStack() (err error) {
 	for i := uint64(0); i < c.locationStack.sp; i++ {
 		if loc := c.locationStack.stack[i]; loc.onRegister() {
 			c.compileReleaseRegisterToStack(loc)
 		} else if loc.onConditionalRegister() {
-			c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc)
+			if err = c.compileLoadConditionalRegisterToGeneralPurposeRegister(loc); err != nil {
+				return
+			}
 			c.compileReleaseRegisterToStack(loc)
 		}
 	}
-	return nil
+	return
 }
 
 // releaseRegisterToStack adds an instruction to write the value on a register back to memory stack region.

--- a/internal/engine/compiler/impl_vec_amd64.go
+++ b/internal/engine/compiler/impl_vec_amd64.go
@@ -10,7 +10,7 @@ import (
 
 // compileV128Const implements compiler.compileV128Const for amd64 architecture.
 func (c *amd64Compiler) compileV128Const(o *wazeroir.OperationV128Const) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 

--- a/internal/engine/compiler/impl_vec_amd64.go
+++ b/internal/engine/compiler/impl_vec_amd64.go
@@ -10,7 +10,9 @@ import (
 
 // compileV128Const implements compiler.compileV128Const for amd64 architecture.
 func (c *amd64Compiler) compileV128Const(o *wazeroir.OperationV128Const) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	result, err := c.allocateRegister(registerTypeVector)
 	if err != nil {

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -8,7 +8,7 @@ import (
 
 // compileV128Const implements compiler.compileV128Const for arm64.
 func (c *arm64Compiler) compileV128Const(o *wazeroir.OperationV128Const) error {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 
@@ -128,7 +128,7 @@ func (c *arm64Compiler) compileV128Sub(o *wazeroir.OperationV128Sub) (err error)
 
 // compileV128Load implements compiler.compileV128Load for arm64.
 func (c *arm64Compiler) compileV128Load(o *wazeroir.OperationV128Load) (err error) {
-	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+	if err := c.maybeCompileMoveTopConditionalToGeneralPurposeRegister(); err != nil {
 		return err
 	}
 	result, err := c.allocateRegister(registerTypeVector)

--- a/internal/engine/compiler/impl_vec_arm64.go
+++ b/internal/engine/compiler/impl_vec_arm64.go
@@ -8,7 +8,9 @@ import (
 
 // compileV128Const implements compiler.compileV128Const for arm64.
 func (c *arm64Compiler) compileV128Const(o *wazeroir.OperationV128Const) error {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 
 	result, err := c.allocateRegister(registerTypeVector)
 	if err != nil {
@@ -126,7 +128,9 @@ func (c *arm64Compiler) compileV128Sub(o *wazeroir.OperationV128Sub) (err error)
 
 // compileV128Load implements compiler.compileV128Load for arm64.
 func (c *arm64Compiler) compileV128Load(o *wazeroir.OperationV128Load) (err error) {
-	c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister()
+	if err := c.maybeCompileMoveTopConditionalToFreeGeneralPurposeRegister(); err != nil {
+		return err
+	}
 	result, err := c.allocateRegister(registerTypeVector)
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously I had the assumption that we have always free registers for conditional value 
saving in compileLoadConditionalRegisterToGeneralPurposeRegister, but that is not the case 
when the conditional flag was created by floating-point comparison instructions.

Fixes #665 




Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>