### PR TITLE
adds image syncer

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -162,7 +162,8 @@ jobs:
       - name: Set up QEMU
         if: ${{ matrix.arch != 'amd64' }}
         uses: docker/setup-qemu-action@v2
-        with:
+        with:  # Avoid docker.io rate-limits; built with internal-images.yml
+          image: ghcr.io/tetratelabs/wazero-internal:binfmt
           platforms: ${{ matrix.arch }}
 
       - name: Build scratch container

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -1,0 +1,41 @@
+# yamllint --format github .github/workflows/internal-images.yml
+---
+name: internal-images
+
+# Refresh the tags once a day. This limits impact of rate-limited images. See RATIONALE.md
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:  # Allows manual refresh
+
+# This builds images and pushes them to ghcr.io/tetratelabs/wazero-internal:$tag
+# Using these avoid docker.io rate-limits particularly on pull requests.
+jobs:
+  copy-images:
+    runs-on: ubuntu-20.04  # Hard-coding an LTS means maintenance, but only once each 2 years!
+    strategy:
+      matrix:
+        # Be precise in tag versions to improve reproducibility
+        include:
+          - source: tonistiigi/binfmt:qemu-v6.2.0  # for docker/setup-qemu-action
+            target_tag: binfmt
+
+    steps:
+      # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
+      - name: "Login into GitHub Container Registry"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          # GHCR_TOKEN=<hex token value>
+          #   - pushes Docker images to ghcr.io
+          #   - create via https://github.com/settings/tokens
+          #   - assign via https://github.com/organizations/tetratelabs/settings/secrets/actions
+          #   - needs repo:status, public_repo, write:packages, delete:packages
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Pull and push
+        run: |  # This will only push a single architecture, which is fine as we currently only support amd64
+          docker pull ${{ matrix.source }}
+          docker tag ${{ matrix.source }} ghcr.io/tetratelabs/wazero-internal:${{ matrix.target_tag }}
+          docker push ghcr.io/tetratelabs/wazero-internal:${{ matrix.target_tag }}

--- a/.github/workflows/spectest.yaml
+++ b/.github/workflows/spectest.yaml
@@ -121,7 +121,8 @@ jobs:
       - name: Set up QEMU
         if: ${{ matrix.arch != 'amd64' }}
         uses: docker/setup-qemu-action@v2
-        with:
+        with:  # Avoid docker.io rate-limits; built with internal-images.yml
+          image: ghcr.io/tetratelabs/wazero-internal:binfmt
           platforms: ${{ matrix.arch }}
 
       - name: Build scratch container


### PR DESCRIPTION
This adds an image sync script similar to what we had in func-e as the amount of matrix jobs that use qemu are hitting problems.

Ex several jobs have failed today pulling the binfmt image.
```
Run docker/setup-qemu-action@v2
Docker info
Pulling binfmt Docker image
  /usr/bin/docker pull tonistiigi/binfmt:latest
  Error response from daemon: unauthorized: authentication required
  Error: The process '/usr/bin/docker' failed with exit code 1
```