### PR TITLE
ir: correctly ignore unreachable br/br_if

### DIFF
--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -587,6 +587,11 @@ operatorSwitch:
 		}
 		c.pc += n
 
+		if c.unreachableState.on {
+			// If it is currently in unreachable, br is no-op.
+			break operatorSwitch
+		}
+
 		targetFrame := c.controlFrames.get(int(targetIndex))
 		targetFrame.ensureContinuation()
 		dropOp := &OperationDrop{Depth: c.getFrameDropRange(targetFrame, false)}
@@ -606,6 +611,11 @@ operatorSwitch:
 			return fmt.Errorf("read the target for br_if: %w", err)
 		}
 		c.pc += n
+
+		if c.unreachableState.on {
+			// If it is currently in unreachable, br-if is no-op.
+			break operatorSwitch
+		}
 
 		targetFrame := c.controlFrames.get(int(targetIndex))
 		targetFrame.ensureContinuation()


### PR DESCRIPTION
This is the first bug found by wazero-fuzz repository:

```wat
(module
  (type (func))
  (func (type 0)
    br 0 ;; return the function, therefore the following instructions are unreachable.
    block
      br 1 ;; <------------ this is unreachable and must be ignored, not causing panic :D 
    end))
```


Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>