### PR TITLE
ir: fixes a range for drop operation on vector values

### DIFF
--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -167,7 +167,7 @@ func (c *arm64Compiler) markRegisterUnused(regs ...asm.Register) {
 	}
 }
 
-func (c *arm64Compiler) String() (ret string) { return }
+func (c *arm64Compiler) String() (ret string) { return c.locationStack.String() }
 
 // pushFunctionParams pushes any function parameters onto the stack, setting appropriate register types.
 func (c *arm64Compiler) pushFunctionParams() {

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -306,8 +306,10 @@ func (c *compiler) handleInstruction() error {
 	op := c.body[c.pc]
 	if buildoptions.IsDebugMode {
 		var instName string
-		if op == wasm.OpcodeVecPrefix || op == wasm.OpcodeMiscPrefix {
+		if op == wasm.OpcodeVecPrefix {
 			instName = wasm.VectorInstructionName(c.body[c.pc+1])
+		} else if op == wasm.OpcodeMiscPrefix {
+			instName = wasm.MiscInstructionName(c.body[c.pc+1])
 		} else {
 			instName = wasm.InstructionName(op)
 		}

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -729,6 +729,8 @@ operatorSwitch:
 	case wasm.OpcodeDrop:
 		r := &InclusiveRange{Start: 0, End: 0}
 		if peekValueType == UnsignedTypeV128 {
+			// InclusiveRange is the range in uint64 representation, so dropping a vector value on top
+			// should be translated as drop [0..1] inclusively.
 			r.End++
 		}
 		c.emit(


### PR DESCRIPTION
Fixes the second bug found by wazero-fuzz. Previously, Drop instructions on the
vector values were wrongly translated and resulted in panic both on amd64 and arm64,
though that is not covered by spectes and practically doesn't appear in the real world program. 


Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>