### PR TITLE
ir: correctly ignores unreachable br_table instructions

### DIFF
--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -655,6 +655,11 @@ operatorSwitch:
 		}
 		c.pc += n
 
+		if c.unreachableState.on {
+			// If it is currently in unreachable, br_table is no-op.
+			break operatorSwitch
+		}
+
 		// Read the branch targets.
 		targets := make([]*BranchTargetDrop, numTargets)
 		for i := range targets {

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -2504,7 +2504,6 @@ func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 				CodeSection: []*wasm.Code{{Body: []byte{
 					wasm.OpcodeBr, 0, // Return the function -> the followings are unreachable.
 					wasm.OpcodeBlock, 0,
-					wasm.OpcodeI32Const, 1,
 					wasm.OpcodeBrTable, 1, 1, 1,
 					wasm.OpcodeEnd, // End the block.
 					wasm.OpcodeEnd, // End the function.

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -2458,8 +2458,8 @@ func TestCompile_Vec(t *testing.T) {
 	}
 }
 
-// TestCompile_unreachable_br_brif ensures that unreachable br and br_if instructions are correctly ignored.
-func TestCompile_unreachable_br_brif(t *testing.T) {
+// TestCompile_unreachable_Br_BrIf_BrTable ensures that unreachable br/br_if/br_table instructions are correctly ignored.
+func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 	tests := []struct {
 		name     string
 		mod      *wasm.Module
@@ -2490,6 +2490,22 @@ func TestCompile_unreachable_br_brif(t *testing.T) {
 					wasm.OpcodeBlock, 0,
 					wasm.OpcodeI32Const, 1,
 					wasm.OpcodeBrIf, 1,
+					wasm.OpcodeEnd, // End the block.
+					wasm.OpcodeEnd, // End the function.
+				}}},
+			},
+			expected: []Operation{&OperationBr{Target: &BranchTarget{}}},
+		},
+		{
+			name: "br_table",
+			mod: &wasm.Module{
+				TypeSection:     []*wasm.FunctionType{{}},
+				FunctionSection: []wasm.Index{0},
+				CodeSection: []*wasm.Code{{Body: []byte{
+					wasm.OpcodeBr, 0, // Return the function -> the followings are unreachable.
+					wasm.OpcodeBlock, 0,
+					wasm.OpcodeI32Const, 1,
+					wasm.OpcodeBrTable, 1, 1, 1,
 					wasm.OpcodeEnd, // End the block.
 					wasm.OpcodeEnd, // End the function.
 				}}},


### PR DESCRIPTION
Found via wazero-fuzz, though in practice this will unlikely happen:

```wat
(module
  (type (;0;) (func (param i32)))
  (func (;0;) (type 0) (param i32)
    local.get 0
    local.tee 0
    local.tee 0
    br_table 0 (;@0;) 0 (;@0;)
    block (result i32)  ;; label = @1
      local.get 0
      br_table 1 (;@0;) 1 (;@0;)
      i32.const 0
    end
    drop)
  (export "r" (func 0)))
```

Similar to #682 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>