### PR TITLE
ir: correctly ignores unreachable br_table instructions (part2)

### DIFF
--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -657,6 +657,15 @@ operatorSwitch:
 
 		if c.unreachableState.on {
 			// If it is currently in unreachable, br_table is no-op.
+			// But before proceeding to the next instruction, we must advance the pc
+			// according to the number of br_table targets.
+			for i := uint32(0); i <= numTargets; i++ { // inclusive as we also need to read the index of default target.
+				_, n, err := leb128.DecodeUint32(r)
+				if err != nil {
+					return fmt.Errorf("error reading target %d in br_table: %w", i, err)
+				}
+				c.pc += n
+			}
 			break operatorSwitch
 		}
 

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -2504,7 +2504,7 @@ func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 				CodeSection: []*wasm.Code{{Body: []byte{
 					wasm.OpcodeBr, 0, // Return the function -> the followings are unreachable.
 					wasm.OpcodeBlock, 0,
-					wasm.OpcodeBrTable, 1, 1, 1,
+					wasm.OpcodeBrTable, 2, 2, 3,
 					wasm.OpcodeEnd, // End the block.
 					wasm.OpcodeEnd, // End the function.
 				}}},


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>