### PR TITLE
Read unsigned leb128 for the index of ref.func in global initializer

### DIFF
--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -554,6 +554,8 @@ func (m *Module) buildGlobals(importedGlobals []*GlobalInstance) (globals []*Glo
 	for _, gs := range m.GlobalSection {
 		g := &GlobalInstance{Type: gs.Type}
 		switch v := executeConstExpression(importedGlobals, gs.Init).(type) {
+		case uint32:
+			g.Val = uint64(v)
 		case int32:
 			g.Val = uint64(uint32(v))
 		case int64:

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -627,10 +627,10 @@ func executeConstExpression(importedGlobals []*GlobalInstance, expr *ConstantExp
 			v = GlobalInstanceNullFuncRefValue
 		}
 	case OpcodeRefFunc:
-		// For ref.func const expresssion, we temporarily store the index as value,
+		// For ref.func const expression, we temporarily store the index as value,
 		// and if this is the const expr for global, the value will be further downed to
 		// opaque pointer of the engine-specific compiled function.
-		v, _, _ = leb128.DecodeInt32(r)
+		v, _, _ = leb128.DecodeUint32(r)
 	case OpcodeVecV128Const:
 		v = [2]uint64{binary.LittleEndian.Uint64(expr.Data[0:8]), binary.LittleEndian.Uint64(expr.Data[8:16])}
 	}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -511,7 +511,7 @@ func TestExecuteConstExpression(t *testing.T) {
 					Opcode: OpcodeRefNull,
 					Data:   []byte{RefTypeFuncref},
 				},
-				exp: int64(GlobalInstanceNullFuncRefValue),
+				exp: GlobalInstanceNullFuncRefValue,
 			},
 			{
 				name: "ref.func",
@@ -519,7 +519,15 @@ func TestExecuteConstExpression(t *testing.T) {
 					Opcode: OpcodeRefFunc,
 					Data:   []byte{1},
 				},
-				exp: int32(1),
+				exp: uint32(1),
+			},
+			{
+				name: "ref.func",
+				expr: &ConstantExpression{
+					Opcode: OpcodeRefFunc,
+					Data:   []byte{0x5d},
+				},
+				exp: uint32(93),
 			},
 		}
 


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>