### PR TITLE
Makes CacheNumInUint64 lazy and stops crashing in assemblyscript

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -324,6 +324,8 @@ func (b *moduleBuilder) Compile(ctx context.Context, cConfig CompileConfig) (Com
 	module, err := wasm.NewHostModule(b.moduleName, b.nameToGoFunc, b.funcToNames, b.nameToMemory, b.nameToGlobal, b.r.enabledFeatures)
 	if err != nil {
 		return nil, err
+	} else if err = module.Validate(b.r.enabledFeatures); err != nil {
+		return nil, err
 	}
 
 	c := &compiledModule{module: module, compiledEngine: b.r.store.Engine}

--- a/builder_test.go
+++ b/builder_test.go
@@ -51,7 +51,7 @@ func TestNewModuleBuilder_Compile(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{GoFunc: &fnUint32_uint32}},
@@ -70,7 +70,7 @@ func TestNewModuleBuilder_Compile(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{GoFunc: &fnUint32_uint32}},
@@ -90,7 +90,7 @@ func TestNewModuleBuilder_Compile(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{GoFunc: &fnUint64_uint32}},
@@ -110,8 +110,8 @@ func TestNewModuleBuilder_Compile(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0, 1},
 				CodeSection:     []*wasm.Code{{GoFunc: &fnUint32_uint32}, {GoFunc: &fnUint64_uint32}},
@@ -134,8 +134,8 @@ func TestNewModuleBuilder_Compile(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0, 1},
 				CodeSection:     []*wasm.Code{{GoFunc: &fnUint32_uint32}, {GoFunc: &fnUint64_uint32}},
@@ -159,8 +159,8 @@ func TestNewModuleBuilder_Compile(t *testing.T) {
 			},
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
-					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
+					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0, 1},
 				CodeSection:     []*wasm.Code{{GoFunc: &fnUint32_uint32}, {GoFunc: &fnUint64_uint32}},
@@ -448,6 +448,9 @@ func TestNewModuleBuilder_Instantiate_Errors(t *testing.T) {
 // requireHostModuleEquals is redefined from internal/wasm/host_test.go to avoid an import cycle extracting it.
 func requireHostModuleEquals(t *testing.T, expected, actual *wasm.Module) {
 	// `require.Equal(t, expected, actual)` fails reflect pointers don't match, so brute compare:
+	for _, tp := range expected.TypeSection {
+		tp.CacheNumInUint64()
+	}
 	require.Equal(t, expected.TypeSection, actual.TypeSection)
 	require.Equal(t, expected.ImportSection, actual.ImportSection)
 	require.Equal(t, expected.FunctionSection, actual.FunctionSection)

--- a/emscripten/emscripten.go
+++ b/emscripten/emscripten.go
@@ -51,8 +51,7 @@ type functionExporter struct{}
 
 // ExportFunctions implements FunctionExporter.ExportFunctions
 func (e *functionExporter) ExportFunctions(builder wazero.ModuleBuilder) {
-	builder.ExportFunction("emscripten_notify_memory_growth", emscriptenNotifyMemoryGrowth,
-		"emscripten_notify_memory_growth", "memory_index")
+	builder.ExportFunction(notifyMemoryGrowth.Name, notifyMemoryGrowth)
 }
 
 // emscriptenNotifyMemoryGrowth is called when wasm is compiled with
@@ -70,7 +69,12 @@ func (e *functionExporter) ExportFunctions(builder wazero.ModuleBuilder) {
 //
 // See https://github.com/emscripten-core/emscripten/blob/3.1.16/system/lib/standalone/standalone.c#L118
 // and https://emscripten.org/docs/api_reference/emscripten.h.html#abi-functions
-var emscriptenNotifyMemoryGrowth = &wasm.Func{
-	Type: &wasm.FunctionType{Params: []wasm.ValueType{wasm.ValueTypeI32}},
-	Code: &wasm.Code{Body: []byte{wasm.OpcodeEnd}},
+const functionNotifyMemoryGrowth = "emscripten_notify_memory_growth"
+
+var notifyMemoryGrowth = &wasm.Func{
+	ExportNames: []string{functionNotifyMemoryGrowth},
+	Name:        functionNotifyMemoryGrowth,
+	ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
+	ParamNames:  []string{"memory_index"},
+	Code:        &wasm.Code{Body: []byte{wasm.OpcodeEnd}},
 }

--- a/internal/integration_test/bench/codec_test.go
+++ b/internal/integration_test/bench/codec_test.go
@@ -21,12 +21,12 @@ func newExample() *wasm.Module {
 	f32, i32, i64 := wasm.ValueTypeF32, wasm.ValueTypeI32, wasm.ValueTypeI64
 	return &wasm.Module{
 		TypeSection: []*wasm.FunctionType{
-			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
-			{ParamNumInUint64: 0, ResultNumInUint64: 0},
-			{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
-			{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}, ParamNumInUint64: 1, ResultNumInUint64: 1},
-			{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
-			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
+			{ParamNumInUint64: 0},
+			{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
+			{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}},
+			{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}},
+			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}},
 		},
 		ImportSection: []*wasm.Import{
 			{

--- a/internal/integration_test/bench/codec_test.go
+++ b/internal/integration_test/bench/codec_test.go
@@ -22,7 +22,7 @@ func newExample() *wasm.Module {
 	return &wasm.Module{
 		TypeSection: []*wasm.FunctionType{
 			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
-			{ParamNumInUint64: 0},
+			{},
 			{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
 			{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}},
 			{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}},

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -30,14 +30,8 @@ func TestDecodeModule(t *testing.T) {
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					{},
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
-						ParamNumInUint64:  2,
-						ResultNumInUint64: 1,
-					},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32},
-						ParamNumInUint64:  4,
-						ResultNumInUint64: 1,
-					},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 			},
 		},
@@ -45,14 +39,8 @@ func TestDecodeModule(t *testing.T) {
 			name: "type and import section",
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
-						ParamNumInUint64:  2,
-						ResultNumInUint64: 1,
-					},
-					{Params: []wasm.ValueType{f32, f32}, Results: []wasm.ValueType{f32},
-						ParamNumInUint64:  2,
-						ResultNumInUint64: 1,
-					},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{f32, f32}, Results: []wasm.ValueType{f32}},
 				},
 				ImportSection: []*wasm.Import{
 					{

--- a/internal/wasm/binary/function.go
+++ b/internal/wasm/binary/function.go
@@ -96,7 +96,5 @@ func decodeFunctionType(enabledFeatures wasm.Features, r *bytes.Reader) (*wasm.F
 		Params:  paramTypes,
 		Results: resultTypes,
 	}
-
-	ret.CacheNumInUint64()
 	return ret, nil
 }

--- a/internal/wasm/binary/function_test.go
+++ b/internal/wasm/binary/function_test.go
@@ -23,52 +23,52 @@ func TestFunctionType(t *testing.T) {
 		},
 		{
 			name:     "one param no result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32}},
 			expected: []byte{0x60, 1, i32, 0},
 		},
 		{
 			name:     "no param one result",
-			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32}, ResultNumInUint64: 1},
+			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32}},
 			expected: []byte{0x60, 0, 1, i32},
 		},
 		{
 			name:     "one param one result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32}},
 			expected: []byte{0x60, 1, i64, 1, i32},
 		},
 		{
 			name:     "two params no result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, ParamNumInUint64: 2},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 2, i32, i64, 0},
 		},
 		{
 			name:     "two param one result",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32}},
 			expected: []byte{0x60, 2, i32, i64, 1, i32},
 		},
 		{
 			name:     "no param two results",
-			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}, ResultNumInUint64: 2},
+			input:    &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 0, 2, i32, i64},
 		},
 		{
 			name:     "one param two results",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32, i64}, ParamNumInUint64: 1, ResultNumInUint64: 2},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 1, i64, 2, i32, i64},
 		},
 		{
 			name:     "two param two results",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32, i64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32, i64}},
 			expected: []byte{0x60, 2, i32, i64, 2, i32, i64},
 		},
 		{
 			name:     "two param two results with funcrefs",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, funcRef}, Results: []wasm.ValueType{funcRef, i64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, funcRef}, Results: []wasm.ValueType{funcRef, i64}},
 			expected: []byte{0x60, 2, i32, funcRef, 2, funcRef, i64},
 		},
 		{
 			name:     "two param two results with externrefs",
-			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, externRef}, Results: []wasm.ValueType{externRef, i64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			input:    &wasm.FunctionType{Params: []wasm.ValueType{i32, externRef}, Results: []wasm.ValueType{externRef, i64}},
 			expected: []byte{0x60, 2, i32, externRef, 2, externRef, i64},
 		},
 	}

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -148,17 +148,6 @@ func newModuleVal(m api.Module) reflect.Value {
 	return val
 }
 
-// MustFunctionType returns the function type corresponding to the function
-// signature or panics if invalid.
-func MustFunctionType(fn interface{}) *FunctionType {
-	fnV := reflect.ValueOf(fn)
-	_, ft, err := getFunctionType(&fnV)
-	if err != nil {
-		panic(err)
-	}
-	return ft
-}
-
 // getFunctionType returns the function type corresponding to the function signature or errs if invalid.
 func getFunctionType(fn *reflect.Value) (fk FunctionKind, ft *FunctionType, err error) {
 	p := fn.Type()
@@ -181,8 +170,6 @@ func getFunctionType(fn *reflect.Value) (fk FunctionKind, ft *FunctionType, err 
 	rCount := p.NumOut()
 
 	ft = &FunctionType{Params: make([]ValueType, p.NumIn()-pOffset), Results: make([]ValueType, rCount)}
-	ft.CacheNumInUint64()
-
 	for i := 0; i < len(ft.Params); i++ {
 		pI := p.In(i + pOffset)
 		if t, ok := getTypeOf(pI.Kind()); ok {

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -49,7 +49,7 @@ func TestGetFunctionType(t *testing.T) {
 			name:         "all supported params and i32 result",
 			inputFunc:    func(uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoNoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
 		},
 		{
 			name: "all supported params and all supported results",
@@ -58,28 +58,27 @@ func TestGetFunctionType(t *testing.T) {
 			},
 			expectedKind: FunctionKindGoNoContext,
 			expectedType: &FunctionType{
-				Params:           []ValueType{i32, i64, f32, f64, externref},
-				Results:          []ValueType{i32, i64, f32, f64, externref},
-				ParamNumInUint64: 5, ResultNumInUint64: 5,
+				Params:  []ValueType{i32, i64, f32, f64, externref},
+				Results: []ValueType{i32, i64, f32, f64, externref},
 			},
 		},
 		{
 			name:         "all supported params and i32 result - wasm.Module",
 			inputFunc:    func(api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoModule,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
 		},
 		{
 			name:         "all supported params and i32 result - context.Context",
 			inputFunc:    func(context.Context, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
 		},
 		{
 			name:         "all supported params and i32 result - context.Context and api.Module",
 			inputFunc:    func(context.Context, api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedKind: FunctionKindGoContextModule,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}, ParamNumInUint64: 5, ResultNumInUint64: 1},
+			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -30,8 +30,6 @@ func swap(x, y uint32) (uint32, uint32) {
 }
 
 func TestNewHostModule(t *testing.T) {
-	i32 := ValueTypeI32
-
 	a := wasiAPI{}
 	functionArgsSizesGet := "args_sizes_get"
 	fnArgsSizesGet := reflect.ValueOf(a.ArgsSizesGet)
@@ -65,8 +63,8 @@ func TestNewHostModule(t *testing.T) {
 			},
 			expected: &Module{
 				TypeSection: []*FunctionType{
-					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
-					{Params: []ValueType{i32, i32, i32, i32}, Results: []ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
+					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}},
+					{Params: []ValueType{i32, i32, i32, i32}, Results: []ValueType{i32}},
 				},
 				FunctionSection: []Index{0, 1},
 				CodeSection:     []*Code{{GoFunc: &fnArgsSizesGet}, {GoFunc: &fnFdWrite}},
@@ -90,7 +88,7 @@ func TestNewHostModule(t *testing.T) {
 				functionSwap: swap,
 			},
 			expected: &Module{
-				TypeSection:     []*FunctionType{{Params: []ValueType{i32, i32}, Results: []ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2}},
+				TypeSection:     []*FunctionType{{Params: []ValueType{i32, i32}, Results: []ValueType{i32, i32}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{{GoFunc: &fnSwap}},
 				ExportSection:   []*Export{{Name: "swap", Type: ExternTypeFunc, Index: 0}},
@@ -151,7 +149,7 @@ func TestNewHostModule(t *testing.T) {
 			},
 			expected: &Module{
 				TypeSection: []*FunctionType{
-					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}},
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{{GoFunc: &fnArgsSizesGet}},

--- a/internal/watzero/internal/decoder.go
+++ b/internal/watzero/internal/decoder.go
@@ -143,10 +143,6 @@ func DecodeModule(
 	if names.ModuleName == "" && names.FunctionNames == nil && names.LocalNames == nil {
 		module.NameSection = nil
 	}
-
-	for _, tp := range module.TypeSection {
-		tp.CacheNumInUint64()
-	}
 	return
 }
 

--- a/internal/watzero/internal/decoder_test.go
+++ b/internal/watzero/internal/decoder_test.go
@@ -63,7 +63,7 @@ func TestDecodeModule(t *testing.T) {
 			input: "(module (type (func (param i32 i32) (result i32 i32))))",
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}},
 				},
 			},
 		},
@@ -72,7 +72,7 @@ func TestDecodeModule(t *testing.T) {
 			input: "(module (type (func (param i32) (param i32) (result i32) (result i32))))",
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}},
 				},
 			},
 		},
@@ -362,8 +362,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 				ImportSection: []*wasm.Import{
 					{
@@ -549,7 +549,7 @@ func TestDecodeModule(t *testing.T) {
 			input: "(module (import \"\" \"\" (func (param i32 i32) (param $v i32) (param i64) (param $t f32))))",
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5},
+					{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
 				},
 				ImportSection: []*wasm.Import{{Type: wasm.ExternTypeFunc, DescFunc: 0}},
 				NameSection: &wasm.NameSection{
@@ -569,8 +569,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 9, ResultNumInUint64: 1},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 				ImportSection: []*wasm.Import{
 					{
@@ -598,7 +598,7 @@ func TestDecodeModule(t *testing.T) {
 	(import "foo" "bar" (func (type 0) (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -613,7 +613,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -628,7 +628,7 @@ func TestDecodeModule(t *testing.T) {
 	(import "foo" "bar" (func (type $i32) (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -643,7 +643,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "foo", Name: "bar",
 					Type:     wasm.ExternTypeFunc,
@@ -655,7 +655,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "import func multiple abbreviated results",
 			input: `(module (import "misc" "swap" (func $swap (param i32 i32) (result i32 i32))))`,
 			expected: &wasm.Module{
-				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2}},
+				TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}}},
 				ImportSection: []*wasm.Import{{
 					Module: "misc", Name: "swap",
 					Type:     wasm.ExternTypeFunc,
@@ -856,8 +856,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 9, ResultNumInUint64: 1},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{1, 2},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}, {Body: localGet0End}},
@@ -881,8 +881,8 @@ func TestDecodeModule(t *testing.T) {
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
 					v_v,
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
-					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
+					{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{1, 2},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}, {Body: localGet0End}},
@@ -922,7 +922,7 @@ func TestDecodeModule(t *testing.T) {
 	(func (type 0) (param i32))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -934,7 +934,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -946,7 +946,7 @@ func TestDecodeModule(t *testing.T) {
 	(func (type $i32) (param i32))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -958,7 +958,7 @@ func TestDecodeModule(t *testing.T) {
 	(type $i32 (func (param i32)))
 )`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, ParamNumInUint64: 1}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{codeEnd},
 			},
@@ -1101,7 +1101,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "func param IDs",
 			input: "(module (func $one (param $x i32) (param $y i32) (result i32) local.get 0))",
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}},
 				NameSection: &wasm.NameSection{
@@ -1119,7 +1119,7 @@ func TestDecodeModule(t *testing.T) {
 			(func (param $l i32) (param $r i32) (result i32) local.get 0)
 		)`,
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}},
 				FunctionSection: []wasm.Index{0, 0},
 				CodeSection:     []*wasm.Code{{Body: localGet0End}, {Body: localGet0End}},
 				NameSection: &wasm.NameSection{
@@ -1134,7 +1134,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "func mixed param IDs", // Verifies we can handle less param fields than Params
 			input: "(module (func (param i32 i32) (param $v i32) (param i64) (param $t f32)))",
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32, i32, i64, f32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: end}},
 				NameSection: &wasm.NameSection{
@@ -1148,7 +1148,7 @@ func TestDecodeModule(t *testing.T) {
 			name:  "func multiple abbreviated results",
 			input: "(module (func $swap (param i32 i32) (result i32 i32) local.get 1 local.get 0))",
 			expected: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}, ParamNumInUint64: 2, ResultNumInUint64: 2}},
+				TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32, i32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0x01, wasm.OpcodeLocalGet, 0x00, wasm.OpcodeEnd}}},
 				NameSection: &wasm.NameSection{
@@ -1393,7 +1393,7 @@ func TestDecodeModule(t *testing.T) {
 )`,
 			expected: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{
-					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
+					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection: []*wasm.Code{

--- a/internal/watzero/internal/type_parser_test.go
+++ b/internal/watzero/internal/type_parser_test.go
@@ -9,44 +9,19 @@ import (
 
 var (
 	f32, f64, i32, i64 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32, wasm.ValueTypeI64
-	i32_v              = &wasm.FunctionType{Params: []wasm.ValueType{i32},
-		ParamNumInUint64: 1,
-	}
-	v_i32 = &wasm.FunctionType{Results: []wasm.ValueType{i32},
-		ResultNumInUint64: 1,
-	}
-	v_i32i64 = &wasm.FunctionType{Results: []wasm.ValueType{i32, i64},
-		ResultNumInUint64: 2,
-	}
-	f32_i32 = &wasm.FunctionType{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32},
-		ParamNumInUint64:  1,
-		ResultNumInUint64: 1,
-	}
-	i64_i64 = &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64},
-		ParamNumInUint64:  1,
-		ResultNumInUint64: 1,
-	}
-	i32i64_v = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64},
-		ParamNumInUint64: 2,
-	}
-	i32i32_i32 = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32},
-		ParamNumInUint64:  2,
-		ResultNumInUint64: 1,
-	}
-	i32i64_i32 = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32},
-		ParamNumInUint64:  2,
-		ResultNumInUint64: 1,
-	}
-	i32i32i32i32_i32 = &wasm.FunctionType{
-		Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32},
-		ParamNumInUint64:  4,
-		ResultNumInUint64: 1,
-	}
+	i32_v              = &wasm.FunctionType{Params: []wasm.ValueType{i32}}
+	v_i32              = &wasm.FunctionType{Results: []wasm.ValueType{i32}}
+	v_i32i64           = &wasm.FunctionType{Results: []wasm.ValueType{i32, i64}}
+	f32_i32            = &wasm.FunctionType{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}}
+	i64_i64            = &wasm.FunctionType{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}}
+	i32i64_v           = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}}
+	i32i32_i32         = &wasm.FunctionType{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}}
+	i32i64_i32         = &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{i32}}
+	i32i32i32i32_i32   = &wasm.FunctionType{
+		Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}}
 	i32i32i32i32i32i64i64i32i32_i32 = &wasm.FunctionType{
-		Params:            []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
-		Results:           []wasm.ValueType{i32},
-		ParamNumInUint64:  9,
-		ResultNumInUint64: 1,
+		Params:  []wasm.ValueType{i32, i32, i32, i32, i32, i64, i64, i32, i32},
+		Results: []wasm.ValueType{i32},
 	}
 )
 
@@ -125,7 +100,7 @@ func TestTypeParser(t *testing.T) {
 		{
 			name:     "mixed param abbreviation", // Verifies we can handle less param fields than param types
 			input:    "(type (func (param i32 i32) (param i32) (param i64) (param f32)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
 		},
 
 		// Below are changes to test/core/br.wast from the commit that added "multi-value" support.
@@ -134,58 +109,55 @@ func TestTypeParser(t *testing.T) {
 		{
 			name:     "multi-value - v_i64f32 abbreviated",
 			input:    "(type (func (result i64 f32)))",
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
 		},
 		{
 			name:     "multi-value - i32i64_f32f64 abbreviated",
 			input:    "(type (func (param i32 i64) (result f32 f64)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
 		},
 		{
 			name:     "multi-value - v_i64f32",
 			input:    "(type (func (result i64) (result f32)))",
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
 		},
 		{
 			name:     "multi-value - i32i64_f32f64",
 			input:    "(type (func (param i32) (param i64) (result f32) (result f64)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
 		},
 		{
 			name:     "multi-value - i32i64_f32f64 named",
 			input:    "(type (func (param $x i32) (param $y i64) (result f32) (result f64)))",
-			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}, ParamNumInUint64: 2, ResultNumInUint64: 2},
+			expected: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
 		},
 		{
 			name:     "multi-value - i64i64f32_f32i32 results abbreviated in groups",
 			input:    "(type (func (result i64 i64 f32) (result f32 i32)))",
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32}, ResultNumInUint64: 5},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32}},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 params and results abbreviated in groups",
 			input: "(type (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32)))",
 			expected: &wasm.FunctionType{
-				Params:           []wasm.ValueType{i32, i32, i64, i32},
-				Results:          []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64: 4, ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "(type (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32)))",
 			expected: &wasm.FunctionType{
-				Params:           []wasm.ValueType{i32, i32, i64, i32},
-				Results:          []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64: 4, ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "(type (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32)))",
 			expected: &wasm.FunctionType{
-				Params:           []wasm.ValueType{i32, i32, i64, i32},
-				Results:          []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64: 4, ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 		{
@@ -193,7 +165,7 @@ func TestTypeParser(t *testing.T) {
 			input: "(type (func (result) (result) (result i64 i64) (result) (result f32) (result)))",
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
-			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32}, ResultNumInUint64: 3},
+			expected: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32}},
 		},
 		{
 			name: "multi-value - empty abbreviated params and results",
@@ -204,9 +176,8 @@ func TestTypeParser(t *testing.T) {
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
 			expected: &wasm.FunctionType{
-				Params:           []wasm.ValueType{i32, i32, i64, i32, i32},
-				Results:          []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64: 5, ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 	}
@@ -408,9 +379,6 @@ func parseFunctionType(
 	tp := newTypeParser(enabledFeatures, typeNamespace, setFunc)
 	// typeParser starts after the '(type', so we need to eat it first!
 	_, _, err := lex(skipTokens(2, tp.begin), []byte(input))
-	if parsed != nil {
-		parsed.CacheNumInUint64()
-	}
 	return parsed, tp, err
 }
 

--- a/internal/watzero/internal/typeuse_parser_test.go
+++ b/internal/watzero/internal/typeuse_parser_test.go
@@ -74,7 +74,7 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 		{
 			name:                "mixed param abbreviation", // Verifies we can handle less param fields than param types
 			input:               "((param i32 i32) (param i32) (param i64) (param f32))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}, ParamNumInUint64: 5},
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i32, i32, i64, f32}},
 		},
 
 		// Below are changes to test/core/br.wast from the commit that added "multi-value" support.
@@ -83,73 +83,56 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 		{
 			name:                "multi-value - v_i64f32 abbreviated",
 			input:               "((result i64 f32))",
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
 		},
 		{
-			name:  "multi-value - i32i64_f32f64 abbreviated",
-			input: "((param i32 i64) (result f32 f64))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64},
-				ParamNumInUint64:  2,
-				ResultNumInUint64: 2,
-			},
+			name:                "multi-value - i32i64_f32f64 abbreviated",
+			input:               "((param i32 i64) (result f32 f64))",
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
 		},
 		{
 			name:                "multi-value - v_i64f32",
 			input:               "((result i64) (result f32))",
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}, ResultNumInUint64: 2},
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, f32}},
 		},
 		{
-			name:  "multi-value - i32i64_f32f64",
-			input: "((param i32) (param i64) (result f32) (result f64))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64},
-				ParamNumInUint64:  2,
-				ResultNumInUint64: 2,
-			},
+			name:                "multi-value - i32i64_f32f64",
+			input:               "((param i32) (param i64) (result f32) (result f64))",
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
 		},
 		{
-			name:  "multi-value - i32i64_f32f64 named",
-			input: "((param $x i32) (param $y i64) (result f32) (result f64))",
-			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64},
-				ParamNumInUint64:  2,
-				ResultNumInUint64: 2,
-			},
-			expectedParamNames: wasm.NameMap{&wasm.NameAssoc{Index: 0, Name: "x"}, &wasm.NameAssoc{Index: 1, Name: "y"}},
+			name:                "multi-value - i32i64_f32f64 named",
+			input:               "((param $x i32) (param $y i64) (result f32) (result f64))",
+			expectedInlinedType: &wasm.FunctionType{Params: []wasm.ValueType{i32, i64}, Results: []wasm.ValueType{f32, f64}},
+			expectedParamNames:  wasm.NameMap{&wasm.NameAssoc{Index: 0, Name: "x"}, &wasm.NameAssoc{Index: 1, Name: "y"}},
 		},
 		{
-			name:  "multi-value - i64i64f32_f32i32 results abbreviated in groups",
-			input: "((result i64 i64 f32) (result f32 i32))",
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32},
-				ResultNumInUint64: 5,
-			},
+			name:                "multi-value - i64i64f32_f32i32 results abbreviated in groups",
+			input:               "((result i64 i64 f32) (result f32 i32))",
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32, f32, i32}},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 params and results abbreviated in groups",
 			input: "((param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))",
 			expectedInlinedType: &wasm.FunctionType{
-				Params:            []wasm.ValueType{i32, i32, i64, i32},
-				Results:           []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64:  4,
-				ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "((param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))",
 			expectedInlinedType: &wasm.FunctionType{
-				Params:            []wasm.ValueType{i32, i32, i64, i32},
-				Results:           []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64:  4,
-				ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 		{
 			name:  "multi-value - i32i32i64i32_f32f64f64i32 abbreviated in groups",
 			input: "((param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))",
 			expectedInlinedType: &wasm.FunctionType{
-				Params:            []wasm.ValueType{i32, i32, i64, i32},
-				Results:           []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64:  4,
-				ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 		},
 		{
@@ -157,9 +140,7 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 			input: "((result) (result) (result i64 i64) (result) (result f32) (result))",
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
-			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32},
-				ResultNumInUint64: 3,
-			},
+			expectedInlinedType: &wasm.FunctionType{Results: []wasm.ValueType{i64, i64, f32}},
 		},
 		{
 			name: "multi-value - empty abbreviated params and results",
@@ -170,10 +151,8 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 			// Abbreviations have min length zero, which implies no-op results are ok.
 			// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#abbreviations%E2%91%A2
 			expectedInlinedType: &wasm.FunctionType{
-				Params:            []wasm.ValueType{i32, i32, i64, i32, i32},
-				Results:           []wasm.ValueType{f32, f64, f64, i32},
-				ParamNumInUint64:  5,
-				ResultNumInUint64: 4,
+				Params:  []wasm.ValueType{i32, i32, i64, i32, i32},
+				Results: []wasm.ValueType{f32, f64, f64, i32},
 			},
 			expectedParamNames: wasm.NameMap{&wasm.NameAssoc{Index: 4, Name: "x"}},
 		},
@@ -185,8 +164,6 @@ func TestTypeUseParser_InlinesTypesWhenNotYetAdded(t *testing.T) {
 		return tp, func(t *testing.T) {
 			// We should have inlined the type, and it is the first type use, which means the inlined index is zero
 			require.Zero(t, tp.inlinedTypeIndices[0].inlinedIdx)
-			exp := tp.inlinedTypes[0]
-			exp.CacheNumInUint64()
 			require.Equal(t, []*wasm.FunctionType{tc.expectedInlinedType}, tp.inlinedTypes)
 		}
 	})
@@ -225,9 +202,7 @@ func TestTypeUseParser_UnresolvedType(t *testing.T) {
 			if tc.expectedInlinedType == nil {
 				require.Zero(t, len(tp.inlinedTypes), "expected no inlinedTypes")
 			} else {
-				exp := tp.inlinedTypes[0]
-				exp.CacheNumInUint64()
-				require.Equal(t, tc.expectedInlinedType, exp)
+				require.Equal(t, tc.expectedInlinedType, tp.inlinedTypes[0])
 			}
 		}
 	})
@@ -372,9 +347,6 @@ func TestTypeUseParser_ReuseExistingInlinedType(t *testing.T) {
 		require.NoError(t, parseTypeUse(tp, tc.input, ignoreTypeUse))
 
 		return tp, func(t *testing.T) {
-			for _, it := range tp.inlinedTypes {
-				it.CacheNumInUint64()
-			}
 			// verify it wasn't duplicated
 			require.Equal(t, []*wasm.FunctionType{i32i64_v, tc.expectedInlinedType}, tp.inlinedTypes)
 			// last two inlined types are the same
@@ -420,9 +392,6 @@ func TestTypeUseParser_BeginResets(t *testing.T) {
 		require.NoError(t, parseTypeUse(tp, tc.input, ignoreTypeUse))
 
 		return tp, func(t *testing.T) {
-			for _, it := range tp.inlinedTypes {
-				it.CacheNumInUint64()
-			}
 			// this is the second inlined type
 			require.Equal(t, []*wasm.FunctionType{i32i64_i32, tc.expectedInlinedType}, tp.inlinedTypes)
 		}

--- a/internal/watzero/watzero_test.go
+++ b/internal/watzero/watzero_test.go
@@ -22,7 +22,7 @@ func newExample() *wasm.Module {
 	return &wasm.Module{
 		TypeSection: []*wasm.FunctionType{
 			{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 2, ResultNumInUint64: 1},
-			{ParamNumInUint64: 0, ResultNumInUint64: 0},
+			{},
 			{Params: []wasm.ValueType{i32, i32, i32, i32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 4, ResultNumInUint64: 1},
 			{Params: []wasm.ValueType{i64}, Results: []wasm.ValueType{i64}, ParamNumInUint64: 1, ResultNumInUint64: 1},
 			{Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32}, ParamNumInUint64: 1, ResultNumInUint64: 1},

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -119,7 +119,9 @@ func TestCompile(t *testing.T) {
 			if enabledFeatures == 0 {
 				enabledFeatures = wasm.Features20220419
 			}
-
+			for _, tp := range tc.module.TypeSection {
+				tp.CacheNumInUint64()
+			}
 			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0])
@@ -535,6 +537,9 @@ func TestCompile_MultiValue(t *testing.T) {
 			if enabledFeatures == 0 {
 				enabledFeatures = wasm.Features20220419
 			}
+			for _, tp := range tc.module.TypeSection {
+				tp.CacheNumInUint64()
+			}
 			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0])
@@ -565,7 +570,9 @@ func TestCompile_NonTrappingFloatToIntConversion(t *testing.T) {
 		Types:        []*wasm.FunctionType{f32_i32},
 		TableTypes:   []wasm.RefType{},
 	}
-
+	for _, tp := range module.TypeSection {
+		tp.CacheNumInUint64()
+	}
 	res, err := CompileFunctions(ctx, wasm.FeatureNonTrappingFloatToIntConversion, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
@@ -590,7 +597,9 @@ func TestCompile_SignExtensionOps(t *testing.T) {
 		Types:        []*wasm.FunctionType{i32_i32},
 		TableTypes:   []wasm.RefType{},
 	}
-
+	for _, tp := range module.TypeSection {
+		tp.CacheNumInUint64()
+	}
 	res, err := CompileFunctions(ctx, wasm.FeatureSignExtensionOps, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])

--- a/wasi_snapshot_preview1/fs.go
+++ b/wasi_snapshot_preview1/fs.go
@@ -50,13 +50,21 @@ const (
 // advisory information on a file descriptor.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_advisefd-fd-offset-filesize-len-filesize-advice-advice---errno
-var fdAdvise = stubFunction(i32, i64, i64, i32) // stubbed for GrainLang per #271.
+var fdAdvise = stubFunction(
+	functionFdAdvise,
+	[]wasm.ValueType{i32, i64, i64, i32},
+	[]string{"fd", "offset", "len", "result.advice"},
+)
 
 // fdAllocate is the WASI function named functionFdAllocate which forces the
 // allocation of space in a file.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_allocatefd-fd-offset-filesize-len-filesize---errno
-var fdAllocate = stubFunction(i32, i64, i64) // stubbed for GrainLang per #271.
+var fdAllocate = stubFunction(
+	functionFdAllocate,
+	[]wasm.ValueType{i32, i64, i64},
+	[]string{"fd", "offset", "len"},
+)
 
 // fdClose is the WASI function named functionFdClose which closes a file
 // descriptor.
@@ -73,20 +81,28 @@ var fdAllocate = stubFunction(i32, i64, i64) // stubbed for GrainLang per #271.
 // Note: This is similar to `close` in POSIX.
 // See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#fd_close
 // and https://linux.die.net/man/3/close
-func fdClose(ctx context.Context, mod api.Module, fd uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	if ok := sysCtx.FS(ctx).CloseFile(ctx, fd); !ok {
-		return ErrnoBadf
-	}
+var fdClose = wasm.NewGoFunc(
+	functionFdClose, functionFdClose,
+	[]string{"fd"},
+	func(ctx context.Context, mod api.Module, fd uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		if ok := sysCtx.FS(ctx).CloseFile(ctx, fd); !ok {
+			return ErrnoBadf
+		}
 
-	return ErrnoSuccess
-}
+		return ErrnoSuccess
+	},
+)
 
 // fdDatasync is the WASI function named functionFdDatasync which synchronizes
 // the data of a file to disk.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_datasyncfd-fd---errno
-var fdDatasync = stubFunction(i32) // stubbed for GrainLang per #271.
+var fdDatasync = stubFunction(
+	functionFdDatasync,
+	[]wasm.ValueType{i32},
+	[]string{"fd"},
+)
 
 // fdFdstatGet is the WASI function named functionFdFdstatGet which returns the
 // attributes of a file descriptor.
@@ -125,20 +141,28 @@ var fdDatasync = stubFunction(i32) // stubbed for GrainLang per #271.
 // well as additional fields.
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fdstat
 // and https://linux.die.net/man/3/fsync
-func fdFdstatGet(ctx context.Context, mod api.Module, fd uint32, resultStat uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	if _, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd); !ok {
-		return ErrnoBadf
-	}
-	// TODO: actually write the fdstat!
-	return ErrnoSuccess
-}
+var fdFdstatGet = wasm.NewGoFunc(
+	functionFdFdstatGet, functionFdFdstatGet,
+	[]string{"fd", "result.stat"},
+	func(ctx context.Context, mod api.Module, fd uint32, resultStat uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		if _, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd); !ok {
+			return ErrnoBadf
+		}
+		// TODO: actually write the fdstat!
+		return ErrnoSuccess
+	},
+)
 
 // fdFdstatSetFlags is the WASI function named functionFdFdstatSetFlags which
 // adjusts the flags associated with a file descriptor.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_flagsfd-fd-flags-fdflags---errnoand is stubbed for GrainLang per #271
-var fdFdstatSetFlags = stubFunction(i32, i32) // stubbed for GrainLang per #271.
+var fdFdstatSetFlags = stubFunction(
+	functionFdFdstatSetFlags,
+	[]wasm.ValueType{i32, i32},
+	[]string{"fd", "flags"},
+)
 
 // fdFdstatSetRights is the WASI function named functionFdFdstatSetRights which
 // adjusts the rights associated with a file descriptor.
@@ -146,31 +170,51 @@ var fdFdstatSetFlags = stubFunction(i32, i32) // stubbed for GrainLang per #271.
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_rightsfd-fd-fs_rights_base-rights-fs_rights_inheriting-rights---errno
 //
 // Note: This will never be implemented per https://github.com/WebAssembly/WASI/issues/469#issuecomment-1045251844
-var fdFdstatSetRights = stubFunction(i32, i64, i64) // stubbed for GrainLang per #271.
+var fdFdstatSetRights = stubFunction(
+	functionFdFdstatSetRights,
+	[]wasm.ValueType{i32, i64, i64},
+	[]string{"fd", "fs_rights_base", "fs_rights_inheriting"},
+)
 
 // fdFilestatGet is the WASI function named functionFdFilestatGet which returns
 // the attributes of an open file.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_filestat_getfd-fd---errno-filestat
-var fdFilestatGet = stubFunction(i32, i32) // stubbed for GrainLang per #271.
+var fdFilestatGet = stubFunction(
+	functionFdFilestatGet,
+	[]wasm.ValueType{i32, i32},
+	[]string{"fd", "result.buf"},
+)
 
 // fdFilestatSetSize is the WASI function named functionFdFilestatSetSize which
 // adjusts the size of an open file.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_filestat_set_sizefd-fd-size-filesize---errno
-var fdFilestatSetSize = stubFunction(i32, i64) // stubbed for GrainLang per #271.
+var fdFilestatSetSize = stubFunction(
+	functionFdFilestatSetSize,
+	[]wasm.ValueType{i32, i64},
+	[]string{"fd", "size"},
+)
 
 // fdFilestatSetTimes is the WASI function named functionFdFilestatSetTimes
 // which adjusts the times of an open file.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_filestat_set_timesfd-fd-atim-timestamp-mtim-timestamp-fst_flags-fstflags---errno
-var fdFilestatSetTimes = stubFunction(i32, i64, i64, i32) // stubbed for GrainLang per #271.
+var fdFilestatSetTimes = stubFunction(
+	functionFdFilestatSetTimes,
+	[]wasm.ValueType{i32, i64, i64, i32},
+	[]string{"fd", "atim", "mtim", "fst_flags"},
+)
 
 // fdPread is the WASI function named functionFdPread which reads from a file
 // descriptor, without using and updating the file descriptor's offset.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_preadfd-fd-iovs-iovec_array-offset-filesize---errno-size
-var fdPread = stubFunction(i32, i32, i32, i64, i32) // stubbed for GrainLang per #271.
+var fdPread = stubFunction(
+	functionFdPread,
+	[]wasm.ValueType{i32, i32, i32, i64, i32},
+	[]string{"fd", "iovs", "iovs_len", "offset", "result.nread"},
+)
 
 // fdPrestatGet is the WASI function named functionFdPrestatGet which returns
 // the prestat data of a file descriptor.
@@ -203,24 +247,28 @@ var fdPread = stubFunction(i32, i32, i32, i64, i32) // stubbed for GrainLang per
 //
 // See fdPrestatDirName and
 // https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#prestat
-func fdPrestatGet(ctx context.Context, mod api.Module, fd uint32, resultPrestat uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	entry, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd)
-	if !ok {
-		return ErrnoBadf
-	}
+var fdPrestatGet = wasm.NewGoFunc(
+	functionFdPrestatGet, functionFdPrestatGet,
+	[]string{"fd", "result.prestat"},
+	func(ctx context.Context, mod api.Module, fd uint32, resultPrestat uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		entry, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd)
+		if !ok {
+			return ErrnoBadf
+		}
 
-	// Zero-value 8-bit tag, and 3-byte zero-value paddings, which is uint32le(0) in short.
-	if !mod.Memory().WriteUint32Le(ctx, resultPrestat, uint32(0)) {
-		return ErrnoFault
-	}
-	// Write the length of the directory name at offset 4.
-	if !mod.Memory().WriteUint32Le(ctx, resultPrestat+4, uint32(len(entry.Path))) {
-		return ErrnoFault
-	}
+		// Zero-value 8-bit tag, and 3-byte zero-value paddings, which is uint32le(0) in short.
+		if !mod.Memory().WriteUint32Le(ctx, resultPrestat, uint32(0)) {
+			return ErrnoFault
+		}
+		// Write the length of the directory name at offset 4.
+		if !mod.Memory().WriteUint32Le(ctx, resultPrestat+4, uint32(len(entry.Path))) {
+			return ErrnoFault
+		}
 
-	return ErrnoSuccess
-}
+		return ErrnoSuccess
+	},
+)
 
 // fdPrestatDirName is the WASI function named functionFdPrestatDirName which
 // returns the path of the pre-opened directory of a file descriptor.
@@ -252,30 +300,37 @@ func fdPrestatGet(ctx context.Context, mod api.Module, fd uint32, resultPrestat 
 //
 // See fdPrestatGet
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_prestat_dir_name
-func fdPrestatDirName(ctx context.Context, mod api.Module, fd uint32, pathPtr uint32, pathLen uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	f, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd)
-	if !ok {
-		return ErrnoBadf
-	}
+var fdPrestatDirName = wasm.NewGoFunc(
+	functionFdPrestatDirName, functionFdPrestatDirName,
+	[]string{"fd", "path", "path_len"},
+	func(ctx context.Context, mod api.Module, fd uint32, pathPtr uint32, pathLen uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		f, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd)
+		if !ok {
+			return ErrnoBadf
+		}
 
-	// Some runtimes may have another semantics. See /RATIONALE.md
-	if uint32(len(f.Path)) < pathLen {
-		return ErrnoNametoolong
-	}
+		// Some runtimes may have another semantics. See /RATIONALE.md
+		if uint32(len(f.Path)) < pathLen {
+			return ErrnoNametoolong
+		}
 
-	// TODO: fdPrestatDirName may have to return ErrnoNotdir if the type of the prestat data of `fd` is not a PrestatDir.
-	if !mod.Memory().Write(ctx, pathPtr, []byte(f.Path)[:pathLen]) {
-		return ErrnoFault
-	}
-	return ErrnoSuccess
-}
+		// TODO: fdPrestatDirName may have to return ErrnoNotdir if the type of the prestat data of `fd` is not a PrestatDir.
+		if !mod.Memory().Write(ctx, pathPtr, []byte(f.Path)[:pathLen]) {
+			return ErrnoFault
+		}
+		return ErrnoSuccess
+	},
+)
 
 // fdPwrite is the WASI function named functionFdPwrite which writes to a file
 // descriptor, without using and updating the file descriptor's offset.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_pwritefd-fd-iovs-ciovec_array-offset-filesize---errno-size
-var fdPwrite = stubFunction(i32, i32, i32, i64, i32) // stubbed for GrainLang per #271.
+var fdPwrite = stubFunction(functionFdPwrite,
+	[]wasm.ValueType{i32, i32, i32, i64, i32},
+	[]string{"fd", "iovs", "iovs_len", "offset", "result.nwritten"},
+)
 
 // fdRead is the WASI function named functionFdRead which reads from a file
 // descriptor.
@@ -326,53 +381,65 @@ var fdPwrite = stubFunction(i32, i32, i32, i64, i32) // stubbed for GrainLang pe
 //
 // See fdWrite
 // and https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_read
-func fdRead(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	reader := internalsys.FdReader(ctx, sysCtx, fd)
-	if reader == nil {
-		return ErrnoBadf
-	}
+var fdRead = wasm.NewGoFunc(
+	functionFdRead, functionFdRead,
+	[]string{"fd", "iovs", "iovs_len", "result.size"},
+	func(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		reader := internalsys.FdReader(ctx, sysCtx, fd)
+		if reader == nil {
+			return ErrnoBadf
+		}
 
-	var nread uint32
-	for i := uint32(0); i < iovsCount; i++ {
-		iovPtr := iovs + i*8
-		offset, ok := mod.Memory().ReadUint32Le(ctx, iovPtr)
-		if !ok {
+		var nread uint32
+		for i := uint32(0); i < iovsCount; i++ {
+			iovPtr := iovs + i*8
+			offset, ok := mod.Memory().ReadUint32Le(ctx, iovPtr)
+			if !ok {
+				return ErrnoFault
+			}
+			l, ok := mod.Memory().ReadUint32Le(ctx, iovPtr+4)
+			if !ok {
+				return ErrnoFault
+			}
+			b, ok := mod.Memory().Read(ctx, offset, l)
+			if !ok {
+				return ErrnoFault
+			}
+			n, err := reader.Read(b) // Note: n <= l
+			nread += uint32(n)
+			if errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				return ErrnoIo
+			}
+		}
+		if !mod.Memory().WriteUint32Le(ctx, resultSize, nread) {
 			return ErrnoFault
 		}
-		l, ok := mod.Memory().ReadUint32Le(ctx, iovPtr+4)
-		if !ok {
-			return ErrnoFault
-		}
-		b, ok := mod.Memory().Read(ctx, offset, l)
-		if !ok {
-			return ErrnoFault
-		}
-		n, err := reader.Read(b) // Note: n <= l
-		nread += uint32(n)
-		if errors.Is(err, io.EOF) {
-			break
-		} else if err != nil {
-			return ErrnoIo
-		}
-	}
-	if !mod.Memory().WriteUint32Le(ctx, resultSize, nread) {
-		return ErrnoFault
-	}
-	return ErrnoSuccess
-}
+		return ErrnoSuccess
+	},
+)
 
 // fdReaddir is the WASI function named functionFdReaddir which reads directory
 // entries from a directory.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_readdirfd-fd-buf-pointeru8-buf_len-size-cookie-dircookie---errno-size
-var fdReaddir = stubFunction(i32, i32, i32, i64, i32) // stubbed for GrainLang per #271.
+var fdReaddir = stubFunction(
+	functionFdReaddir,
+	[]wasm.ValueType{i32, i32, i32, i64, i32},
+	[]string{"fd", "buf", "buf_len", "cookie", "result.bufused"},
+)
 
 // fdRenumber is the WASI function named functionFdRenumber which atomically
 // replaces a file descriptor by renumbering another file descriptor.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_renumberfd-fd-to-fd---errno
-var fdRenumber = stubFunction(i32, i32) // stubbed for GrainLang per #271.
+var fdRenumber = stubFunction(
+	functionFdRenumber,
+	[]wasm.ValueType{i32, i32},
+	[]string{"fd", "to"},
+)
 
 // fdSeek is the WASI function named functionFdSeek which moves the offset of a
 // file descriptor.
@@ -411,43 +478,55 @@ var fdRenumber = stubFunction(i32, i32) // stubbed for GrainLang per #271.
 //
 // See io.Seeker
 // and https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_seek
-func fdSeek(ctx context.Context, mod api.Module, fd uint32, offset uint64, whence uint32, resultNewoffset uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	var seeker io.Seeker
-	// Check to see if the file descriptor is available
-	if f, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd); !ok || f.File == nil {
-		return ErrnoBadf
-		// fs.FS doesn't declare io.Seeker, but implementations such as os.File implement it.
-	} else if seeker, ok = f.File.(io.Seeker); !ok {
-		return ErrnoBadf
-	}
+var fdSeek = wasm.NewGoFunc(
+	functionFdSeek, functionFdSeek,
+	[]string{"fd", "offset", "whence", "result.newoffset"},
+	func(ctx context.Context, mod api.Module, fd uint32, offset uint64, whence uint32, resultNewoffset uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		var seeker io.Seeker
+		// Check to see if the file descriptor is available
+		if f, ok := sysCtx.FS(ctx).OpenedFile(ctx, fd); !ok || f.File == nil {
+			return ErrnoBadf
+			// fs.FS doesn't declare io.Seeker, but implementations such as os.File implement it.
+		} else if seeker, ok = f.File.(io.Seeker); !ok {
+			return ErrnoBadf
+		}
 
-	if whence > io.SeekEnd /* exceeds the largest valid whence */ {
-		return ErrnoInval
-	}
-	newOffset, err := seeker.Seek(int64(offset), int(whence))
-	if err != nil {
-		return ErrnoIo
-	}
+		if whence > io.SeekEnd /* exceeds the largest valid whence */ {
+			return ErrnoInval
+		}
+		newOffset, err := seeker.Seek(int64(offset), int(whence))
+		if err != nil {
+			return ErrnoIo
+		}
 
-	if !mod.Memory().WriteUint32Le(ctx, resultNewoffset, uint32(newOffset)) {
-		return ErrnoFault
-	}
+		if !mod.Memory().WriteUint32Le(ctx, resultNewoffset, uint32(newOffset)) {
+			return ErrnoFault
+		}
 
-	return ErrnoSuccess
-}
+		return ErrnoSuccess
+	},
+)
 
 // fdSync is the WASI function named functionFdSync which synchronizes the data
 // and metadata of a file to disk.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_syncfd-fd---errno
-var fdSync = stubFunction(i32) // stubbed for GrainLang per #271.
+var fdSync = stubFunction(
+	functionFdSync,
+	[]wasm.ValueType{i32},
+	[]string{"fd"},
+)
 
 // fdTell is the WASI function named functionFdTell which returns the current
 // offset of a file descriptor.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_tellfd-fd---errno-filesize
-var fdTell = stubFunction(i32, i32) // stubbed for GrainLang per #271.
+var fdTell = stubFunction(
+	functionFdTell,
+	[]wasm.ValueType{i32, i32},
+	[]string{"fd", "result.offset"},
+)
 
 // fdWrite is the WASI function named functionFdWrite which writes to a file
 // descriptor.
@@ -506,65 +585,85 @@ var fdTell = stubFunction(i32, i32) // stubbed for GrainLang per #271.
 // See fdRead
 // https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#ciovec
 // and https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fd_write
-func fdWrite(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	writer := internalsys.FdWriter(ctx, sysCtx, fd)
-	if writer == nil {
-		return ErrnoBadf
-	}
+var fdWrite = wasm.NewGoFunc(
+	functionFdWrite, functionFdWrite,
+	[]string{"fd", "iovs", "iovs_len", "result.size"},
+	func(ctx context.Context, mod api.Module, fd, iovs, iovsCount, resultSize uint32) Errno {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		writer := internalsys.FdWriter(ctx, sysCtx, fd)
+		if writer == nil {
+			return ErrnoBadf
+		}
 
-	var nwritten uint32
-	for i := uint32(0); i < iovsCount; i++ {
-		iovPtr := iovs + i*8
-		offset, ok := mod.Memory().ReadUint32Le(ctx, iovPtr)
-		if !ok {
+		var nwritten uint32
+		for i := uint32(0); i < iovsCount; i++ {
+			iovPtr := iovs + i*8
+			offset, ok := mod.Memory().ReadUint32Le(ctx, iovPtr)
+			if !ok {
+				return ErrnoFault
+			}
+			// Note: emscripten has been known to write zero length iovec. However,
+			// it is not common in other compilers, so we don't optimize for it.
+			l, ok := mod.Memory().ReadUint32Le(ctx, iovPtr+4)
+			if !ok {
+				return ErrnoFault
+			}
+			b, ok := mod.Memory().Read(ctx, offset, l)
+			if !ok {
+				return ErrnoFault
+			}
+			n, err := writer.Write(b)
+			if err != nil {
+				return ErrnoIo
+			}
+			nwritten += uint32(n)
+		}
+		if !mod.Memory().WriteUint32Le(ctx, resultSize, nwritten) {
 			return ErrnoFault
 		}
-		// Note: emscripten has been known to write zero length iovec. However,
-		// it is not common in other compilers, so we don't optimize for it.
-		l, ok := mod.Memory().ReadUint32Le(ctx, iovPtr+4)
-		if !ok {
-			return ErrnoFault
-		}
-		b, ok := mod.Memory().Read(ctx, offset, l)
-		if !ok {
-			return ErrnoFault
-		}
-		n, err := writer.Write(b)
-		if err != nil {
-			return ErrnoIo
-		}
-		nwritten += uint32(n)
-	}
-	if !mod.Memory().WriteUint32Le(ctx, resultSize, nwritten) {
-		return ErrnoFault
-	}
-	return ErrnoSuccess
-}
+		return ErrnoSuccess
+	},
+)
 
 // pathCreateDirectory is the WASI function named functionPathCreateDirectory
 // which creates a directory.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_create_directoryfd-fd-path-string---errno
-var pathCreateDirectory = stubFunction(i32, i32, i32) // stubbed for GrainLang per #271.
+var pathCreateDirectory = stubFunction(
+	functionPathCreateDirectory,
+	[]wasm.ValueType{i32, i32, i32},
+	[]string{"fd", "path", "path_len"},
+)
 
 // pathFilestatGet is the WASI function named functionPathFilestatGet which
 // returns the attributes of a file or directory.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_filestat_getfd-fd-flags-lookupflags-path-string---errno-filestat
-var pathFilestatGet = stubFunction(i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var pathFilestatGet = stubFunction(
+	functionPathFilestatGet,
+	[]wasm.ValueType{i32, i32, i32, i32, i32},
+	[]string{"fd", "flags", "path", "path_len", "result.buf"},
+)
 
 // pathFilestatSetTimes is the WASI function named functionPathFilestatSetTimes
 // which adjusts the timestamps of a file or directory.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_filestat_set_timesfd-fd-flags-lookupflags-path-string-atim-timestamp-mtim-timestamp-fst_flags-fstflags---errno
-var pathFilestatSetTimes = stubFunction(i32, i32, i32, i32, i64, i64, i32) // stubbed for GrainLang per #271.
+var pathFilestatSetTimes = stubFunction(
+	functionPathFilestatSetTimes,
+	[]wasm.ValueType{i32, i32, i32, i32, i64, i64, i32},
+	[]string{"fd", "flags", "path", "path_len", "atim", "mtim", "fst_flags"},
+)
 
 // pathLink is the WASI function named functionPathLink which adjusts the
 // timestamps of a file or directory.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#path_link
-var pathLink = stubFunction(i32, i32, i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var pathLink = stubFunction(
+	functionPathLink,
+	[]wasm.ValueType{i32, i32, i32, i32, i32, i32, i32},
+	[]string{"old_fd", "old_flags", "old_path", "old_path_len", "new_fd", "new_path", "new_path_len"},
+)
 
 // pathOpen is the WASI function named functionPathOpen which opens a file or
 // directory. This returns ErrnoBadf if the fd is invalid.
@@ -620,59 +719,83 @@ var pathLink = stubFunction(i32, i32, i32, i32, i32, i32, i32) // stubbed for Gr
 //	* Rights will never be implemented per https://github.com/WebAssembly/WASI/issues/469#issuecomment-1045251844
 //
 // See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#path_open
-func pathOpen(ctx context.Context, mod api.Module, fd, dirflags, pathPtr, pathLen, oflags uint32, fsRightsBase,
-	fsRightsInheriting uint64, fdflags, resultOpenedFd uint32) (errno Errno) {
-	sysCtx := mod.(*wasm.CallContext).Sys
-	fsc := sysCtx.FS(ctx)
-	if _, ok := fsc.OpenedFile(ctx, fd); !ok {
-		return ErrnoBadf
-	}
-
-	b, ok := mod.Memory().Read(ctx, pathPtr, pathLen)
-	if !ok {
-		return ErrnoFault
-	}
-
-	if newFD, err := fsc.OpenFile(ctx, string(b)); err != nil {
-		switch {
-		case errors.Is(err, fs.ErrNotExist):
-			return ErrnoNoent
-		case errors.Is(err, fs.ErrExist):
-			return ErrnoExist
-		default:
-			return ErrnoIo
+var pathOpen = wasm.NewGoFunc(
+	functionPathOpen, functionPathOpen,
+	[]string{"fd", "dirflags", "path", "path_len", "oflags", "fs_rights_base", "fs_rights_inheriting", "fdflags", "result.opened_fd"},
+	func(ctx context.Context, mod api.Module, fd, dirflags, pathPtr, pathLen, oflags uint32, fsRightsBase,
+		fsRightsInheriting uint64, fdflags, resultOpenedFd uint32) (errno Errno) {
+		sysCtx := mod.(*wasm.CallContext).Sys
+		fsc := sysCtx.FS(ctx)
+		if _, ok := fsc.OpenedFile(ctx, fd); !ok {
+			return ErrnoBadf
 		}
-	} else if !mod.Memory().WriteUint32Le(ctx, resultOpenedFd, newFD) {
-		_ = fsc.CloseFile(ctx, newFD)
-		return ErrnoFault
-	}
-	return ErrnoSuccess
-}
+
+		b, ok := mod.Memory().Read(ctx, pathPtr, pathLen)
+		if !ok {
+			return ErrnoFault
+		}
+
+		if newFD, err := fsc.OpenFile(ctx, string(b)); err != nil {
+			switch {
+			case errors.Is(err, fs.ErrNotExist):
+				return ErrnoNoent
+			case errors.Is(err, fs.ErrExist):
+				return ErrnoExist
+			default:
+				return ErrnoIo
+			}
+		} else if !mod.Memory().WriteUint32Le(ctx, resultOpenedFd, newFD) {
+			_ = fsc.CloseFile(ctx, newFD)
+			return ErrnoFault
+		}
+		return ErrnoSuccess
+	},
+)
 
 // pathReadlink is the WASI function named functionPathReadlink that reads the
 // contents of a symbolic link.
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_readlinkfd-fd-path-string-buf-pointeru8-buf_len-size---errno-size
-var pathReadlink = stubFunction(i32, i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var pathReadlink = stubFunction(
+	functionPathReadlink,
+	[]wasm.ValueType{i32, i32, i32, i32, i32, i32},
+	[]string{"fd", "path", "path_len", "buf", "buf_len", "result.bufused"},
+)
 
 // pathRemoveDirectory is the WASI function named functionPathRemoveDirectory
 // which removes a directory.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_remove_directoryfd-fd-path-string---errno
-var pathRemoveDirectory = stubFunction(i32, i32, i32) // stubbed for GrainLang per #271.
+var pathRemoveDirectory = stubFunction(
+	functionPathRemoveDirectory,
+	[]wasm.ValueType{i32, i32, i32},
+	[]string{"fd", "path", "path_len"},
+)
 
 // pathRename is the WASI function named functionPathRename which renames a
 // file or directory.
-var pathRename = stubFunction(i32, i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var pathRename = stubFunction(
+	functionPathRename,
+	[]wasm.ValueType{i32, i32, i32, i32, i32, i32},
+	[]string{"fd", "old_path", "old_path_len", "new_fd", "new_path", "new_path_len"},
+)
 
 // pathSymlink is the WASI function named functionPathSymlink which creates a
 // symbolic link.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#path_symlink
-var pathSymlink = stubFunction(i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var pathSymlink = stubFunction(
+	functionPathSymlink,
+	[]wasm.ValueType{i32, i32, i32, i32, i32},
+	[]string{"old_path", "old_path_len", "fd", "new_path", "new_path_len"},
+)
 
 // pathUnlinkFile is the WASI function named functionPathUnlinkFile which
 // unlinks a file.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-path_unlink_filefd-fd-path-string---errno
-var pathUnlinkFile = stubFunction(i32, i32, i32) // stubbed for GrainLang per #271.
+var pathUnlinkFile = stubFunction(
+	functionPathUnlinkFile,
+	[]wasm.ValueType{i32, i32, i32},
+	[]string{"fd", "path", "path_len"},
+)

--- a/wasi_snapshot_preview1/poll.go
+++ b/wasi_snapshot_preview1/poll.go
@@ -46,57 +46,61 @@ const (
 //	* This is similar to `poll` in POSIX.
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#poll_oneoff
 // See https://linux.die.net/man/3/poll
-func pollOneoff(ctx context.Context, mod api.Module, in, out, nsubscriptions, resultNevents uint32) Errno {
-	if nsubscriptions == 0 {
-		return ErrnoInval
-	}
-
-	mem := mod.Memory()
-
-	// Ensure capacity prior to the read loop to reduce error handling.
-	inBuf, ok := mem.Read(ctx, in, nsubscriptions*48)
-	if !ok {
-		return ErrnoFault
-	}
-	outBuf, ok := mem.Read(ctx, out, nsubscriptions*32)
-	if !ok {
-		return ErrnoFault
-	}
-
-	// Eagerly write the number of events which will equal subscriptions unless
-	// there's a fault in parsing (not processing).
-	if !mod.Memory().WriteUint32Le(ctx, resultNevents, nsubscriptions) {
-		return ErrnoFault
-	}
-
-	// Loop through all subscriptions and write their output.
-	for sub := uint32(0); sub < nsubscriptions; sub++ {
-		inOffset := sub * 48
-		outOffset := sub * 32
-
-		var errno Errno
-		eventType := inBuf[inOffset+8] // +8 past userdata
-		switch eventType {
-		case eventTypeClock: // handle later
-			// +8 past userdata +8 name alignment
-			errno = processClockEvent(ctx, mod, inBuf[inOffset+8+8:])
-		case eventTypeFdRead, eventTypeFdWrite:
-			// +8 past userdata +4 FD alignment
-			errno = processFDEvent(ctx, mod, eventType, inBuf[inOffset+8+4:])
-		default:
+var pollOneoff = wasm.NewGoFunc(
+	functionPollOneoff, functionPollOneoff,
+	[]string{"in", "out", "nsubscriptions", "result.nevents"},
+	func(ctx context.Context, mod api.Module, in, out, nsubscriptions, resultNevents uint32) Errno {
+		if nsubscriptions == 0 {
 			return ErrnoInval
 		}
 
-		// Write the event corresponding to the processed subscription.
-		// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-event-struct
-		copy(outBuf, inBuf[inOffset:inOffset+8]) // userdata
-		outBuf[outOffset+8] = byte(errno)        // uint16, but safe as < 255
-		outBuf[outOffset+9] = 0
-		binary.LittleEndian.PutUint32(outBuf[outOffset+10:], uint32(eventType))
-		// TODO: When FD events are supported, write outOffset+16
-	}
-	return ErrnoSuccess
-}
+		mem := mod.Memory()
+
+		// Ensure capacity prior to the read loop to reduce error handling.
+		inBuf, ok := mem.Read(ctx, in, nsubscriptions*48)
+		if !ok {
+			return ErrnoFault
+		}
+		outBuf, ok := mem.Read(ctx, out, nsubscriptions*32)
+		if !ok {
+			return ErrnoFault
+		}
+
+		// Eagerly write the number of events which will equal subscriptions unless
+		// there's a fault in parsing (not processing).
+		if !mod.Memory().WriteUint32Le(ctx, resultNevents, nsubscriptions) {
+			return ErrnoFault
+		}
+
+		// Loop through all subscriptions and write their output.
+		for sub := uint32(0); sub < nsubscriptions; sub++ {
+			inOffset := sub * 48
+			outOffset := sub * 32
+
+			var errno Errno
+			eventType := inBuf[inOffset+8] // +8 past userdata
+			switch eventType {
+			case eventTypeClock: // handle later
+				// +8 past userdata +8 name alignment
+				errno = processClockEvent(ctx, mod, inBuf[inOffset+8+8:])
+			case eventTypeFdRead, eventTypeFdWrite:
+				// +8 past userdata +4 FD alignment
+				errno = processFDEvent(ctx, mod, eventType, inBuf[inOffset+8+4:])
+			default:
+				return ErrnoInval
+			}
+
+			// Write the event corresponding to the processed subscription.
+			// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-event-struct
+			copy(outBuf, inBuf[inOffset:inOffset+8]) // userdata
+			outBuf[outOffset+8] = byte(errno)        // uint16, but safe as < 255
+			outBuf[outOffset+9] = 0
+			binary.LittleEndian.PutUint32(outBuf[outOffset+10:], uint32(eventType))
+			// TODO: When FD events are supported, write outOffset+16
+		}
+		return ErrnoSuccess
+	},
+)
 
 // processClockEvent supports only relative name events, as that's what's used
 // to implement sleep in various compilers including Rust, Zig and TinyGo.

--- a/wasi_snapshot_preview1/proc.go
+++ b/wasi_snapshot_preview1/proc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -21,18 +22,22 @@ const (
 //	* exitCode: exit code.
 //
 // See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
-func procExit(ctx context.Context, mod api.Module, exitCode uint32) {
-	// Ensure other callers see the exit code.
-	_ = mod.CloseWithExitCode(ctx, exitCode)
+var procExit = wasm.NewGoFunc(
+	functionProcExit, functionProcExit,
+	[]string{"rval"},
+	func(ctx context.Context, mod api.Module, exitCode uint32) {
+		// Ensure other callers see the exit code.
+		_ = mod.CloseWithExitCode(ctx, exitCode)
 
-	// Prevent any code from executing after this function. For example, LLVM
-	// inserts unreachable instructions after calls to exit.
-	// See: https://github.com/emscripten-core/emscripten/issues/12322
-	panic(sys.NewExitError(mod.Name(), exitCode))
-}
+		// Prevent any code from executing after this function. For example, LLVM
+		// inserts unreachable instructions after calls to exit.
+		// See: https://github.com/emscripten-core/emscripten/issues/12322
+		panic(sys.NewExitError(mod.Name(), exitCode))
+	},
+)
 
 // procRaise is the WASI function named functionProcRaise which sends a signal
 // to the process of the calling thread.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-proc_raisesig-signal---errno
-var procRaise = stubFunction(i32) // stubbed for GrainLang per #271.
+var procRaise = stubFunction(functionProcRaise, []wasm.ValueType{i32}, []string{"sig"})

--- a/wasi_snapshot_preview1/proc_test.go
+++ b/wasi_snapshot_preview1/proc_test.go
@@ -20,10 +20,16 @@ func Test_procExit(t *testing.T) {
 		{
 			name:     "success (exitcode 0)",
 			exitCode: 0,
+			expectedLog: `
+==> wasi_snapshot_preview1.proc_exit(rval=0)
+`,
 		},
 		{
 			name:     "arbitrary non-zero exitcode",
 			exitCode: 42,
+			expectedLog: `
+==> wasi_snapshot_preview1.proc_exit(rval=42)
+`,
 		},
 	}
 
@@ -34,9 +40,9 @@ func Test_procExit(t *testing.T) {
 			defer log.Reset()
 
 			// Since procExit panics, any opcodes afterwards cannot be reached.
-			err := require.CapturePanic(func() { procExit(testCtx, mod, tc.exitCode) })
+			_, err := mod.ExportedFunction(functionProcExit).Call(testCtx, uint64(tc.exitCode))
 			require.Equal(t, tc.exitCode, err.(*sys.ExitError).ExitCode())
-			require.Equal(t, tc.expectedLog, log.String())
+			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
 }

--- a/wasi_snapshot_preview1/random_test.go
+++ b/wasi_snapshot_preview1/random_test.go
@@ -92,10 +92,18 @@ func Test_randomGet_SourceError(t *testing.T) {
 		{
 			name:       "error",
 			randSource: iotest.ErrReader(errors.New("RandSource error")),
+			expectedLog: `
+==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
+<== EIO
+`,
 		},
 		{
 			name:       "incomplete",
 			randSource: bytes.NewReader([]byte{1, 2}),
+			expectedLog: `
+==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
+<== EIO
+`,
 		},
 	}
 
@@ -106,9 +114,8 @@ func Test_randomGet_SourceError(t *testing.T) {
 				WithRandSource(tc.randSource))
 			defer r.Close(testCtx)
 
-			errno := randomGet(testCtx, mod, uint32(1), uint32(5)) // arbitrary offset and length
-			require.Equal(t, ErrnoIo, errno, ErrnoName(errno))
-			require.Equal(t, tc.expectedLog, log.String())
+			requireErrno(t, ErrnoIo, mod, functionRandomGet, uint64(1), uint64(5)) // arbitrary offset and length
+			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
 }

--- a/wasi_snapshot_preview1/sched.go
+++ b/wasi_snapshot_preview1/sched.go
@@ -6,4 +6,4 @@ const functionSchedYield = "sched_yield"
 // yields execution of the calling thread.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sched_yield---errno
-var schedYield = stubFunction() // stubbed for GrainLang per #271.
+var schedYield = stubFunction(functionSchedYield, nil, nil)

--- a/wasi_snapshot_preview1/sock.go
+++ b/wasi_snapshot_preview1/sock.go
@@ -1,5 +1,7 @@
 package wasi_snapshot_preview1
 
+import "github.com/tetratelabs/wazero/internal/wasm"
+
 const (
 	functionSockRecv     = "sock_recv"
 	functionSockSend     = "sock_send"
@@ -10,16 +12,28 @@ const (
 // message from a socket.
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_recvfd-fd-ri_data-iovec_array-ri_flags-riflags---errno-size-roflags
-var sockRecv = stubFunction(i32, i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var sockRecv = stubFunction(
+	functionSockRecv,
+	[]wasm.ValueType{i32, i32, i32, i32, i32, i32},
+	[]string{"fd", "ri_data", "ri_data_count", "ri_flags", "result.ro_datalen", "result.ro_flags"},
+)
 
 // sockSend is the WASI function named functionSockSend which sends a message
 // on a socket.
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_sendfd-fd-si_data-ciovec_array-si_flags-siflags---errno-size
-var sockSend = stubFunction(i32, i32, i32, i32, i32) // stubbed for GrainLang per #271.
+var sockSend = stubFunction(
+	functionSockSend,
+	[]wasm.ValueType{i32, i32, i32, i32, i32},
+	[]string{"fd", "si_data", "si_data_count", "si_flags", "result.so_datalen"},
+)
 
 // sockShutdown is the WASI function named functionSockShutdown which shuts
 // down socket send and receive channels.
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_shutdownfd-fd-how-sdflags---errno
-var sockShutdown = stubFunction(i32, i32) // stubbed for GrainLang per #271.
+var sockShutdown = stubFunction(
+	functionSockShutdown,
+	[]wasm.ValueType{i32, i32},
+	[]string{"fd", "how"},
+)

--- a/wasi_snapshot_preview1/wasi.go
+++ b/wasi_snapshot_preview1/wasi.go
@@ -111,96 +111,51 @@ func (b *builder) Instantiate(ctx context.Context, ns wazero.Namespace) (api.Clo
 func exportFunctions(builder wazero.ModuleBuilder) {
 	// Note:se are ordered per spec for consistency even if the resulting map can't guarantee that.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#functions
-	builder.ExportFunction(functionArgsGet, argsGet,
-		functionArgsGet, "argv", "argv_buf")
-	builder.ExportFunction(functionArgsSizesGet, argsSizesGet,
-		functionArgsSizesGet, "result.argc", "result.argv_buf_size")
-	builder.ExportFunction(functionEnvironGet, environGet,
-		functionEnvironGet, "environ", "environ_buf")
-	builder.ExportFunction(functionEnvironSizesGet, environSizesGet,
-		functionEnvironSizesGet, "result.environc", "result.environBufSize")
-	builder.ExportFunction(functionClockResGet, clockResGet,
-		functionClockResGet, "id", "result.resolution")
-	builder.ExportFunction(functionClockTimeGet, clockTimeGet,
-		functionClockTimeGet, "id", "precision", "result.timestamp")
-	builder.ExportFunction(functionFdAdvise, fdAdvise,
-		functionFdAdvise, "fd", "offset", "len", "result.advice")
-	builder.ExportFunction(functionFdAllocate, fdAllocate,
-		functionFdAllocate, "fd", "offset", "len")
-	builder.ExportFunction(functionFdClose, fdClose,
-		functionFdClose, "fd")
-	builder.ExportFunction(functionFdDatasync, fdDatasync,
-		functionFdDatasync, "fd")
-	builder.ExportFunction(functionFdFdstatGet, fdFdstatGet,
-		functionFdFdstatGet, "fd", "result.stat")
-	builder.ExportFunction(functionFdFdstatSetFlags, fdFdstatSetFlags,
-		functionFdFdstatSetFlags, "fd", "flags")
-	builder.ExportFunction(functionFdFdstatSetRights, fdFdstatSetRights,
-		functionFdFdstatSetRights, "fd", "fs_rights_base", "fs_rights_inheriting")
-	builder.ExportFunction(functionFdFilestatGet, fdFilestatGet,
-		functionFdFilestatGet, "fd", "result.buf")
-	builder.ExportFunction(functionFdFilestatSetSize, fdFilestatSetSize,
-		functionFdFilestatSetSize, "fd", "size")
-	builder.ExportFunction(functionFdFilestatSetTimes, fdFilestatSetTimes,
-		functionFdFilestatSetTimes, "fd", "atim", "mtim", "fst_flags")
-	builder.ExportFunction(functionFdPread, fdPread,
-		functionFdPread, "fd", "iovs", "iovs_len", "offset", "result.nread")
-	builder.ExportFunction(functionFdPrestatGet, fdPrestatGet,
-		functionFdPrestatGet, "fd", "result.prestat")
-	builder.ExportFunction(functionFdPrestatDirName, fdPrestatDirName,
-		functionFdPrestatDirName, "fd", "path", "path_len")
-	builder.ExportFunction(functionFdPwrite, fdPwrite,
-		functionFdPwrite, "fd", "iovs", "iovs_len", "offset", "result.nwritten")
-	builder.ExportFunction(functionFdRead, fdRead,
-		functionFdRead, "fd", "iovs", "iovs_len", "result.size")
-	builder.ExportFunction(functionFdReaddir, fdReaddir,
-		functionFdReaddir, "fd", "buf", "buf_len", "cookie", "result.bufused")
-	builder.ExportFunction(functionFdRenumber, fdRenumber,
-		functionFdRenumber, "fd", "to")
-	builder.ExportFunction(functionFdSeek, fdSeek,
-		functionFdSeek, "fd", "offset", "whence", "result.newoffset")
-	builder.ExportFunction(functionFdSync, fdSync,
-		functionFdSync, "fd")
-	builder.ExportFunction(functionFdTell, fdTell,
-		functionFdTell, "fd", "result.offset")
-	builder.ExportFunction(functionFdWrite, fdWrite,
-		functionFdWrite, "fd", "iovs", "iovs_len", "result.size")
-	builder.ExportFunction(functionPathCreateDirectory, pathCreateDirectory,
-		functionPathCreateDirectory, "fd", "path", "path_len")
-	builder.ExportFunction(functionPathFilestatGet, pathFilestatGet,
-		functionPathFilestatGet, "fd", "flags", "path", "path_len", "result.buf")
-	builder.ExportFunction(functionPathFilestatSetTimes, pathFilestatSetTimes,
-		functionPathFilestatSetTimes, "fd", "flags", "path", "path_len", "atim", "mtim", "fst_flags")
-	builder.ExportFunction(functionPathLink, pathLink,
-		functionPathLink, "old_fd", "old_flags", "old_path", "old_path_len", "new_fd", "new_path", "new_path_len")
-	builder.ExportFunction(functionPathOpen, pathOpen,
-		functionPathOpen, "fd", "dirflags", "path", "path_len", "oflags", "fs_rights_base", "fs_rights_inheriting", "fdflags", "result.opened_fd")
-	builder.ExportFunction(functionPathReadlink, pathReadlink,
-		functionPathReadlink, "fd", "path", "path_len", "buf", "buf_len", "result.bufused")
-	builder.ExportFunction(functionPathRemoveDirectory, pathRemoveDirectory,
-		functionPathRemoveDirectory, "fd", "path", "path_len")
-	builder.ExportFunction(functionPathRename, pathRename,
-		functionPathRename, "fd", "old_path", "old_path_len", "new_fd", "new_path", "new_path_len")
-	builder.ExportFunction(functionPathSymlink, pathSymlink,
-		functionPathSymlink, "old_path", "old_path_len", "fd", "new_path", "new_path_len")
-	builder.ExportFunction(functionPathUnlinkFile, pathUnlinkFile,
-		functionPathUnlinkFile, "fd", "path", "path_len")
-	builder.ExportFunction(functionPollOneoff, pollOneoff,
-		functionPollOneoff, "in", "out", "nsubscriptions", "result.nevents")
-	builder.ExportFunction(functionProcExit, procExit,
-		functionProcExit, "rval")
-	builder.ExportFunction(functionProcRaise, procRaise,
-		functionProcRaise, "sig")
-	builder.ExportFunction(functionSchedYield, schedYield,
-		functionSchedYield)
-	builder.ExportFunction(functionRandomGet, randomGet,
-		functionRandomGet, "buf", "buf_len")
-	builder.ExportFunction(functionSockRecv, sockRecv,
-		functionSockRecv, "fd", "ri_data", "ri_data_count", "ri_flags", "result.ro_datalen", "result.ro_flags")
-	builder.ExportFunction(functionSockSend, sockSend,
-		functionSockSend, "fd", "si_data", "si_data_count", "si_flags", "result.so_datalen")
-	builder.ExportFunction(functionSockShutdown, sockShutdown,
-		functionSockShutdown, "fd", "how")
+	builder.ExportFunction(argsGet.Name, argsGet)
+	builder.ExportFunction(argsSizesGet.Name, argsSizesGet)
+	builder.ExportFunction(environGet.Name, environGet)
+	builder.ExportFunction(environSizesGet.Name, environSizesGet)
+	builder.ExportFunction(clockResGet.Name, clockResGet)
+	builder.ExportFunction(clockTimeGet.Name, clockTimeGet)
+	builder.ExportFunction(fdAdvise.Name, fdAdvise)
+	builder.ExportFunction(fdAllocate.Name, fdAllocate)
+	builder.ExportFunction(fdClose.Name, fdClose)
+	builder.ExportFunction(fdDatasync.Name, fdDatasync)
+	builder.ExportFunction(fdFdstatGet.Name, fdFdstatGet)
+	builder.ExportFunction(fdFdstatSetFlags.Name, fdFdstatSetFlags)
+	builder.ExportFunction(fdFdstatSetRights.Name, fdFdstatSetRights)
+	builder.ExportFunction(fdFilestatGet.Name, fdFilestatGet)
+	builder.ExportFunction(fdFilestatSetSize.Name, fdFilestatSetSize)
+	builder.ExportFunction(fdFilestatSetTimes.Name, fdFilestatSetTimes)
+	builder.ExportFunction(fdPread.Name, fdPread)
+	builder.ExportFunction(fdPrestatGet.Name, fdPrestatGet)
+	builder.ExportFunction(fdPrestatDirName.Name, fdPrestatDirName)
+	builder.ExportFunction(fdPwrite.Name, fdPwrite)
+	builder.ExportFunction(fdRead.Name, fdRead)
+	builder.ExportFunction(fdReaddir.Name, fdReaddir)
+	builder.ExportFunction(fdRenumber.Name, fdRenumber)
+	builder.ExportFunction(fdSeek.Name, fdSeek)
+	builder.ExportFunction(fdSync.Name, fdSync)
+	builder.ExportFunction(fdTell.Name, fdTell)
+	builder.ExportFunction(fdWrite.Name, fdWrite)
+	builder.ExportFunction(pathCreateDirectory.Name, pathCreateDirectory)
+	builder.ExportFunction(pathFilestatGet.Name, pathFilestatGet)
+	builder.ExportFunction(pathFilestatSetTimes.Name, pathFilestatSetTimes)
+	builder.ExportFunction(pathLink.Name, pathLink)
+	builder.ExportFunction(pathOpen.Name, pathOpen)
+	builder.ExportFunction(pathReadlink.Name, pathReadlink)
+	builder.ExportFunction(pathRemoveDirectory.Name, pathRemoveDirectory)
+	builder.ExportFunction(pathRename.Name, pathRename)
+	builder.ExportFunction(pathSymlink.Name, pathSymlink)
+	builder.ExportFunction(pathUnlinkFile.Name, pathUnlinkFile)
+	builder.ExportFunction(pollOneoff.Name, pollOneoff)
+	builder.ExportFunction(procExit.Name, procExit)
+	builder.ExportFunction(procRaise.Name, procRaise)
+	builder.ExportFunction(schedYield.Name, schedYield)
+	builder.ExportFunction(randomGet.Name, randomGet)
+	builder.ExportFunction(sockRecv.Name, sockRecv)
+	builder.ExportFunction(sockSend.Name, sockSend)
+	builder.ExportFunction(sockShutdown.Name, sockShutdown)
 }
 
 func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, values []string, offsets, bytes uint32) Errno {
@@ -225,15 +180,14 @@ func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, va
 	return ErrnoSuccess
 }
 
-// stubFunction returns a function for the given params which returns ErrnoNosys.
-func stubFunction(params ...wasm.ValueType) *wasm.Func {
+// stubFunction stubs for GrainLang per #271.
+func stubFunction(name string, paramTypes []wasm.ValueType, paramNames []string) *wasm.Func {
 	return &wasm.Func{
-		Type: &wasm.FunctionType{
-			Params:            params,
-			Results:           []wasm.ValueType{wasm.ValueTypeI32},
-			ParamNumInUint64:  len(params),
-			ResultNumInUint64: 1,
-		},
-		Code: &wasm.Code{Body: []byte{wasm.OpcodeI32Const, byte(ErrnoNosys), wasm.OpcodeEnd}},
+		Name:        name,
+		ExportNames: []string{name},
+		ParamTypes:  paramTypes,
+		ParamNames:  paramNames,
+		ResultTypes: []wasm.ValueType{i32},
+		Code:        &wasm.Code{Body: []byte{wasm.OpcodeI32Const, byte(ErrnoNosys), wasm.OpcodeEnd}},
 	}
 }

--- a/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/wasi_snapshot_preview1/wasi_bench_test.go
@@ -53,8 +53,13 @@ func Benchmark_EnvironGet(b *testing.B) {
 
 	b.Run("environGet", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if environGet(testCtx, mod, 0, 4) != ErrnoSuccess {
-				b.Fatal()
+			results, err := mod.ExportedFunction(functionEnvironGet).Call(testCtx, uint64(0), uint64(4))
+			if err != nil {
+				b.Fatal(err)
+			}
+			errno := Errno(results[0])
+			if errno != ErrnoSuccess {
+				b.Fatal(ErrnoName(errno))
 			}
 		}
 	})


### PR DESCRIPTION
This makes CacheNumInUint64 lazy so that all tests for function types
don't need to handle it. This also changes the assemblyscript special
functions so they don't crash when attempting to log. Finally, this
refactors `wasm.Func` so that it can enclose the parameter names as it
is more sensible than defining them elsewhere