### PR TITLE
Set floor on Go 1.18

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,7 +14,7 @@ on:
       - 'netlify.toml'
 
 env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.17"  # 1.xx == latest patch of 1.xx
+  GO_VERSION: "1.18"  # 1.xx == latest patch of 1.xx
 
 defaults:
   run:  # use bash for all operating systems unless overridden
@@ -27,8 +27,8 @@ jobs:
     strategy:
       matrix:  # use latest available versions and be consistent on all workflows!
         go-version:
-        - "1.17" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+        - "1.18" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+        - "1.19"
 
     steps:
       - uses: actions/setup-go@v3
@@ -63,8 +63,8 @@ jobs:
       matrix:  # use latest available versions and be consistent on all workflows!
         os: [ubuntu-20.04, macos-12, windows-2022]
         go-version:
-        - "1.17" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+        - "1.18" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+        - "1.19"
 
     steps:
       - uses: actions/setup-go@v3
@@ -99,8 +99,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:
         go-version:
-          - "1.17" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-          - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+          - "1.18" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+          - "1.19"
 
     steps:
       - uses: actions/setup-go@v3
@@ -131,8 +131,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:
         go-version:
-        - "1.17"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+        - "1.18"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+        - "1.19"
         arch:
         - "amd64"
         - "arm64"

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       matrix:  # use latest available versions and be consistent on all workflows!
         go-version:
-          - "1.17"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-          - "1.18"
+          - "1.18"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
+          - "1.19"
 
     steps:
       - name: Checkout

--- a/.github/workflows/spectest.yaml
+++ b/.github/workflows/spectest.yaml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:
         go-version:
-        - "1.17"
-        - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+        - "1.18"
+        - "1.19"
         spec-version:
         - "v1"
         - "v2"
@@ -54,8 +54,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:
         go-version:
-          - "1.17"
-          - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+          - "1.18"
+          - "1.19"
         spec-version:
           - "v1"
           - "v2"
@@ -89,8 +89,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:
         go-version:
-        - "1.17"
-        - "1.19.0-rc.2" # TODO: use 1.19.0 after the release.
+        - "1.18"
+        - "1.19"
         arch:
         - "arm64"
         - "riscv64"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
 module github.com/tetratelabs/wazero
 
 // This should be the minimum supported Go version per https://go.dev/doc/devel/release (1 version behind latest)
-go 1.17
+go 1.18


### PR DESCRIPTION
Now that Go 1.19 has been released officially, it's time to
set our floor version of Go to 1.18 following our support policy.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>