### PR TITLE
Fix fdRead: handle io.Reader corner cases

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -458,7 +458,7 @@ effectively it is boolean as this case coerces to `EIO`. If we track a "last
 error" on a file descriptor, it could be complicated for a couple reasons
 including whether the error is transient or permanent, or if the error would
 apply to any FD operation, or just read. Finally, there may never be a
-subsequent error as perhaps the bytes leading up to the error are enough to
+subsequent read as perhaps the bytes leading up to the error are enough to
 satisfy the processor.
 
 This decision boils down to whether or not to track an error bit per file

--- a/wasi_snapshot_preview1/fs.go
+++ b/wasi_snapshot_preview1/fs.go
@@ -411,12 +411,14 @@ var fdRead = wasm.NewGoFunc(
 			if errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {
-				if n != 0 { // Let callers process the n > 0 bytes returned before considering the error err.
-					break
+				// See "Why ignore the error returned by io.Reader when n > 1?"
+				// in /RATIONALE.md
+				if n != 0 {
+					break // Allow the caller to process the bytes.
 				}
 				return ErrnoIo
-			} else if n < len(b) { // Partial read, don't read into the next buffer.
-				break
+			} else if n < len(b) {
+				break // Partial read, don't read into the next buffer.
 			}
 		}
 		if !mod.Memory().WriteUint32Le(ctx, resultSize, nread) {

--- a/wasi_snapshot_preview1/fs.go
+++ b/wasi_snapshot_preview1/fs.go
@@ -411,7 +411,12 @@ var fdRead = wasm.NewGoFunc(
 			if errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {
+				if n != 0 { // Let callers process the n > 0 bytes returned before considering the error err.
+					break
+				}
 				return ErrnoIo
+			} else if n < len(b) { // Partial read, don't read into the next buffer.
+				break
 			}
 		}
 		if !mod.Memory().WriteUint32Le(ctx, resultSize, nread) {


### PR DESCRIPTION
These are to handle corner cases described in [`io.Reader`](https://pkg.go.dev/io#Reader).

For a partial read `readv` really shouldn't continue reading into the following buffer.

And according to [`io.Reader`](https://pkg.go.dev/io#Reader), callers should handle any read bytes before considering the error.