### PR TITLE
amd64: do not load/store higher bits of 32-bit int/float

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -1501,6 +1501,7 @@ var registerToRegisterMOVOpcodes = map[asm.Instruction]struct {
 		// https://www.felixcloutier.com/x86/movd:movq
 		i2f: registerToRegisterMOVOpcode{opcode: []byte{0x0f, 0x6e}, mandatoryPrefix: 0x66, srcOnModRMReg: false},
 		f2i: registerToRegisterMOVOpcode{opcode: []byte{0x0f, 0x7e}, mandatoryPrefix: 0x66, srcOnModRMReg: true},
+		f2f: registerToRegisterMOVOpcode{opcode: []byte{0x0f, 0x7e}, mandatoryPrefix: 0x66},
 	},
 	MOVQ: {
 		// https://www.felixcloutier.com/x86/mov
@@ -1521,9 +1522,6 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		var opcode registerToRegisterMOVOpcode
 		srcIsFloat, dstIsFloat := IsVectorRegister(n.srcReg), IsVectorRegister(n.dstReg)
 		if srcIsFloat && dstIsFloat {
-			if inst == MOVL {
-				return errors.New("MOVL for float to float is undefined")
-			}
 			opcode = op.f2f
 		} else if srcIsFloat && !dstIsFloat {
 			opcode = op.f2i

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -1501,7 +1501,6 @@ var registerToRegisterMOVOpcodes = map[asm.Instruction]struct {
 		// https://www.felixcloutier.com/x86/movd:movq
 		i2f: registerToRegisterMOVOpcode{opcode: []byte{0x0f, 0x6e}, mandatoryPrefix: 0x66, srcOnModRMReg: false},
 		f2i: registerToRegisterMOVOpcode{opcode: []byte{0x0f, 0x7e}, mandatoryPrefix: 0x66, srcOnModRMReg: true},
-		f2f: registerToRegisterMOVOpcode{opcode: []byte{0x0f, 0x7e}, mandatoryPrefix: 0x66},
 	},
 	MOVQ: {
 		// https://www.felixcloutier.com/x86/mov
@@ -1522,6 +1521,9 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		var opcode registerToRegisterMOVOpcode
 		srcIsFloat, dstIsFloat := IsVectorRegister(n.srcReg), IsVectorRegister(n.dstReg)
 		if srcIsFloat && dstIsFloat {
+			if inst == MOVL {
+				return errors.New("MOVL for float to float is undefined")
+			}
 			opcode = op.f2f
 		} else if srcIsFloat && !dstIsFloat {
 			opcode = op.f2i

--- a/internal/asm/amd64/impl_2_test.go
+++ b/internal/asm/amd64/impl_2_test.go
@@ -605,9 +605,6 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			{
 				n:      &nodeImpl{instruction: ADDL, types: operandTypesRegisterToRegister, srcReg: RegAX},
 				expErr: "invalid register [nil]",
-			}, {
-				n:      &nodeImpl{instruction: MOVL, types: operandTypesRegisterToRegister, srcReg: RegX0, dstReg: RegX1},
-				expErr: "MOVL for float to float is undefined",
 			},
 		}
 

--- a/internal/asm/amd64/impl_2_test.go
+++ b/internal/asm/amd64/impl_2_test.go
@@ -606,6 +606,10 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 				n:      &nodeImpl{instruction: ADDL, types: operandTypesRegisterToRegister, srcReg: RegAX},
 				expErr: "invalid register [nil]",
 			},
+			{
+				n:      &nodeImpl{instruction: MOVL, types: operandTypesRegisterToRegister, srcReg: RegX0, dstReg: RegX1},
+				expErr: "MOVL for float to float is undefined",
+			},
 		}
 
 		for _, tc := range tests {

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -527,6 +527,7 @@ func TestCompiler_compileSelect(t *testing.T) {
 					require.NoError(t, err)
 
 					x1 := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+					x1.valueType = runtimeValueTypeI64
 					env.stack()[x1.stackPointer] = x1Value
 					if tc.x1OnRegister {
 						err = compiler.compileEnsureOnRegister(x1)
@@ -534,6 +535,7 @@ func TestCompiler_compileSelect(t *testing.T) {
 					}
 
 					x2 := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+					x2.valueType = runtimeValueTypeI64
 					env.stack()[x2.stackPointer] = x2Value
 					if tc.x2OnRegister {
 						err = compiler.compileEnsureOnRegister(x2)

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -959,7 +959,7 @@ func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
 		var inst asm.Instruction
 		if o.IsTargetVector {
 			inst = amd64.MOVDQU
-		} else if pickTarget.valueType == runtimeValueTypeI32 {
+		} else if pickTarget.valueType == runtimeValueTypeI32 { // amd64 cannot copy single-precisions between registers.
 			inst = amd64.MOVL
 		} else {
 			inst = amd64.MOVQ
@@ -970,7 +970,7 @@ func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
 		var inst asm.Instruction
 		if o.IsTargetVector {
 			inst = amd64.MOVDQU
-		} else if pickTarget.valueType == runtimeValueTypeI32 {
+		} else if pickTarget.valueType == runtimeValueTypeI32 || pickTarget.valueType == runtimeValueTypeF32 {
 			inst = amd64.MOVL
 		} else {
 			inst = amd64.MOVQ

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4357,9 +4357,12 @@ func (c *amd64Compiler) compileLoadValueOnStackToRegister(loc *runtimeValueLocat
 		inst = amd64.MOVDQU
 	case runtimeValueTypeV128Hi:
 		panic("BUG: V128Hi must be be loaded to a register along with V128Lo")
-	default:
+	case runtimeValueTypeI32, runtimeValueTypeF32:
+		inst = amd64.MOVL
+	case runtimeValueTypeI64, runtimeValueTypeF64:
 		inst = amd64.MOVQ
 	}
+
 	// Copy the value from the stack.
 	c.assembler.CompileMemoryToRegister(inst,
 		// Note: stack pointers are ensured not to exceed 2^27 so this offset never exceeds 32-bit range.
@@ -4893,7 +4896,9 @@ func (c *amd64Compiler) compileReleaseRegisterToStack(loc *runtimeValueLocation)
 		inst = amd64.MOVDQU
 	case runtimeValueTypeV128Hi:
 		panic("BUG: V128Hi must be released to the stack along with V128Lo")
-	default:
+	case runtimeValueTypeI32, runtimeValueTypeF32:
+		inst = amd64.MOVL
+	case runtimeValueTypeI64, runtimeValueTypeF64:
 		inst = amd64.MOVQ
 	}
 

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -303,6 +303,8 @@ func (c *amd64Compiler) compileGlobalGet(o *wazeroir.OperationGlobalGet) error {
 		if err != nil {
 			return err
 		}
+	default:
+		panic("BUG: unknown runtime value type")
 	}
 
 	// Using the register holding the pointer to the target instance, move its value into a register.
@@ -4380,6 +4382,8 @@ func (c *amd64Compiler) compileLoadValueOnStackToRegister(loc *runtimeValueLocat
 		inst = amd64.MOVL
 	case runtimeValueTypeI64, runtimeValueTypeF64:
 		inst = amd64.MOVQ
+	default:
+		panic("BUG: unknown runtime value type")
 	}
 
 	// Copy the value from the stack.
@@ -4919,6 +4923,8 @@ func (c *amd64Compiler) compileReleaseRegisterToStack(loc *runtimeValueLocation)
 		inst = amd64.MOVL
 	case runtimeValueTypeI64, runtimeValueTypeF64:
 		inst = amd64.MOVQ
+	default:
+		panic("BUG: unknown runtime value type")
 	}
 
 	c.assembler.CompileRegisterToMemory(inst, loc.register,

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -959,7 +959,7 @@ func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
 		var inst asm.Instruction
 		if o.IsTargetVector {
 			inst = amd64.MOVDQU
-		} else if pickTarget.valueType == runtimeValueTypeI32 || pickTarget.valueType == runtimeValueTypeF32 {
+		} else if pickTarget.valueType == runtimeValueTypeI32 {
 			inst = amd64.MOVL
 		} else {
 			inst = amd64.MOVQ
@@ -970,7 +970,7 @@ func (c *amd64Compiler) compilePick(o *wazeroir.OperationPick) error {
 		var inst asm.Instruction
 		if o.IsTargetVector {
 			inst = amd64.MOVDQU
-		} else if pickTarget.valueType == runtimeValueTypeI32 || pickTarget.valueType == runtimeValueTypeF32 {
+		} else if pickTarget.valueType == runtimeValueTypeI32 {
 			inst = amd64.MOVL
 		} else {
 			inst = amd64.MOVQ

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -273,6 +273,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 							compiler.pushRuntimeValueLocationOnRegister(tc.x1Reg, runtimeValueTypeI64)
 						} else {
 							loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+							loc.valueType = runtimeValueTypeI64
 							env.stack()[loc.stackPointer] = uint64(x1Value)
 						}
 						if tc.x2Reg != asm.NilRegister {
@@ -280,6 +281,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 							compiler.pushRuntimeValueLocationOnRegister(tc.x2Reg, runtimeValueTypeI64)
 						} else {
 							loc := compiler.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+							loc.valueType = runtimeValueTypeI64
 							env.stack()[loc.stackPointer] = uint64(x2Value)
 						}
 


### PR DESCRIPTION
Previously, regardless of the value types, i've been using MOVQ to load/store the value from/to stack.
That was unnecessarily costly as i32 and f32 values don't need to move higher 32-bits.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>