### PR TITLE
compiler: drop higher bits on table index

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -796,7 +796,7 @@ func (ce *callEngine) builtinFunctionMemoryGrow(ctx context.Context, mem *wasm.M
 }
 
 func (ce *callEngine) builtinFunctionTableGrow(ctx context.Context, tables []*wasm.TableInstance) {
-	tableIndex := ce.popValue()
+	tableIndex := uint32(ce.popValue())
 	table := tables[tableIndex] // verified not to be out of range by the func validation at compilation phase.
 	num := ce.popValue()
 	ref := ce.popValue()


### PR DESCRIPTION
as of #743 #742 , store into the value stack only stores lower 32-bits,
so we have to drop the higher 32-bits.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>