### PR TITLE
Enable comparative benchmark builds on darwin/aarch64 (ie Apple Silicon)

### DIFF
--- a/internal/integration_test/vs/wasmer/wasmer.go
+++ b/internal/integration_test/vs/wasmer/wasmer.go
@@ -1,4 +1,4 @@
-//go:build amd64 && cgo && !windows
+//go:build cgo && !windows
 
 package wasmer
 

--- a/internal/integration_test/vs/wasmer/wasmer_test.go
+++ b/internal/integration_test/vs/wasmer/wasmer_test.go
@@ -1,4 +1,4 @@
-//go:build amd64 && cgo && !windows
+//go:build cgo && !windows
 
 package wasmer
 

--- a/internal/integration_test/vs/wasmtime/go.mod
+++ b/internal/integration_test/vs/wasmtime/go.mod
@@ -3,7 +3,7 @@ module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmtime
 go 1.17
 
 require (
-	github.com/bytecodealliance/wasmtime-go v0.36.0
+	github.com/bytecodealliance/wasmtime-go v0.39.0
 	github.com/tetratelabs/wazero v0.0.0
 )
 

--- a/internal/integration_test/vs/wasmtime/go.sum
+++ b/internal/integration_test/vs/wasmtime/go.sum
@@ -1,2 +1,2 @@
-github.com/bytecodealliance/wasmtime-go v0.36.0 h1:B6thr7RMM9xQmouBtUqm1RpkJjuLS37m6nxX+iwsQSc=
-github.com/bytecodealliance/wasmtime-go v0.36.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.39.0 h1:35AXy5+py5ZXRSpfoxqh+dWJ7nJnIrW1avjDfaJinxU=
+github.com/bytecodealliance/wasmtime-go v0.39.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=

--- a/internal/integration_test/vs/wasmtime/wasmtime.go
+++ b/internal/integration_test/vs/wasmtime/wasmtime.go
@@ -1,4 +1,4 @@
-//go:build amd64 && cgo
+//go:build cgo
 
 package wasmtime
 

--- a/internal/integration_test/vs/wasmtime/wasmtime_test.go
+++ b/internal/integration_test/vs/wasmtime/wasmtime_test.go
@@ -1,4 +1,4 @@
-//go:build amd64 && cgo
+//go:build cgo
 
 package wasmtime
 


### PR DESCRIPTION
Enable for Wasmer, as confirmed that the version we use has arm64 support.
Enable for Wasmtime after bumping to a version which supports arm64.
Don't enable for wasm-edge as they don't support arm64/darwin.