### PR TITLE
filecache: include GOOS/GOARCH in the key

### DIFF
--- a/internal/compilationcache/file_cache.go
+++ b/internal/compilationcache/file_cache.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime"
 	"sync"
 )
 
@@ -40,7 +41,7 @@ type fileReadCloser struct {
 }
 
 func (fc *fileCache) path(key Key) string {
-	return path.Join(fc.dirPath, hex.EncodeToString(key[:]))
+	return path.Join(fc.dirPath, runtime.GOARCH+"-"+runtime.GOOS+"-"+hex.EncodeToString(key[:]))
 }
 
 func (fc *fileCache) Get(key Key) (content io.ReadCloser, ok bool, err error) {

--- a/internal/compilationcache/file_cache_test.go
+++ b/internal/compilationcache/file_cache_test.go
@@ -2,8 +2,11 @@ package compilationcache
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -132,4 +135,12 @@ func TestFileCache_Get(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, ok)
 	})
+}
+
+func TestFileCache_path(t *testing.T) {
+	fc := &fileCache{dirPath: "/tmp/.wazero"}
+	actual := fc.path(Key{1, 2, 3, 4, 5})
+	require.Contains(t, actual, fmt.Sprintf("%s-%s-", runtime.GOARCH, runtime.GOOS))
+	require.True(t, strings.HasPrefix(actual, fc.dirPath))
+	require.True(t, strings.HasSuffix(actual, "0102030405000000000000000000000000000000000000000000000000000000"))
 }


### PR DESCRIPTION
This allows us to avoid crashes with `GOARCH=amd64 make test` after running `make test` on M1 Mac

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>