### PR TITLE
compiler: hold stack base pointers in bytes, not index to the stack slice

### DIFF
--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -965,12 +965,12 @@ func TestCompiler_returnFunction(t *testing.T) {
 				// Set the return address to the beginning of the function so that we can execute the constI32 above.
 				returnAddress: f.codeInitialAddress,
 				// Note: return stack base pointer is set to funcaddr*5 and this is where the const should be pushed.
-				returnStackBasePointer: uint64(funcIndex) * 5,
-				function:               f,
+				returnStackBasePointerInBytes: (uint64(funcIndex) * 5) << 3,
+				function:                      f,
 			}
 			ce.callFrameStack[ce.globalContext.callFrameStackPointer] = frame
 			ce.globalContext.callFrameStackPointer++
-			stackPointerToExpectedValue[frame.returnStackBasePointer] = expValue
+			stackPointerToExpectedValue[frame.returnStackBasePointerInBytes>>3] = expValue
 		}
 
 		require.Equal(t, uint64(callFrameNums), env.callFrameStackPointer())

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -54,7 +54,7 @@ func init() {
 	requireEqual(int(unsafe.Offsetof(ce.elementInstancesElement0Address)), callEngineModuleContextElementInstancesElement0AddressOffset, "callEngineModuleContextElementInstancesElement0AddressOffset")
 
 	// Offsets for callEngine.valueStackContext
-	requireEqual(int(unsafe.Offsetof(ce.stackPointerInBytes)), callEngineValueStackContextStackPointerInBytesOffset, "callEngineValueStackContextStackPointerInBytesOffset")
+	requireEqual(int(unsafe.Offsetof(ce.stackPointer)), callEngineValueStackContextStackPointerOffset, "callEngineValueStackContextStackPointerOffset")
 	requireEqual(int(unsafe.Offsetof(ce.stackBasePointerInBytes)), callEngineValueStackContextStackBasePointerInBytesOffset, "callEngineValueStackContextStackBasePointerInBytesOffset")
 
 	// Offsets for callEngine.exitContext.
@@ -169,7 +169,7 @@ func (j *compilerEnv) builtinFunctionCallAddress() wasm.Index {
 }
 
 func (j *compilerEnv) stackPointer() uint64 {
-	return j.ce.valueStackContext.stackPointerInBytes >> 3
+	return j.ce.valueStackContext.stackPointer
 }
 
 func (j *compilerEnv) stackBasePointer() uint64 {
@@ -177,7 +177,7 @@ func (j *compilerEnv) stackBasePointer() uint64 {
 }
 
 func (j *compilerEnv) setStackPointer(sp uint64) {
-	j.ce.valueStackContext.stackPointerInBytes = sp << 3
+	j.ce.valueStackContext.stackPointer = sp
 }
 
 func (j *compilerEnv) addGlobals(g ...*wasm.GlobalInstance) {
@@ -201,7 +201,7 @@ func (j *compilerEnv) callFrameStackPointer() uint64 {
 }
 
 func (j *compilerEnv) setValueStackBasePointer(sp uint64) {
-	j.ce.valueStackContext.stackBasePointerInBytes = sp * 8
+	j.ce.valueStackContext.stackBasePointerInBytes = sp << 3
 }
 
 func (j *compilerEnv) setCallFrameStackPointerLen(l uint64) {

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -68,7 +68,7 @@ func init() {
 	requireEqual(0, callFrameDataSize&(callFrameDataSize-1), "callFrameDataSize&(callFrameDataSize-1)")
 	requireEqual(math.Ilogb(float64(callFrameDataSize)), callFrameDataSizeMostSignificantSetBit, "callFrameDataSizeMostSignificantSetBit")
 	requireEqual(int(unsafe.Offsetof(frame.returnAddress)), callFrameReturnAddressOffset, "callFrameReturnAddressOffset")
-	requireEqual(int(unsafe.Offsetof(frame.returnStackBasePointer)), callFrameReturnStackBasePointerOffset, "callFrameReturnStackBasePointerOffset")
+	requireEqual(int(unsafe.Offsetof(frame.returnStackBasePointerInBytes)), callFrameReturnStackBasePointerInBytesOffset, "callFrameReturnStackBasePointerInBytesOffset")
 	requireEqual(int(unsafe.Offsetof(frame.function)), callFrameFunctionOffset, "callFrameFunctionOffset")
 
 	// Offsets for code.

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -37,7 +37,7 @@ func init() {
 	var ce callEngine
 	// Offsets for callEngine.globalContext.
 	requireEqual(int(unsafe.Offsetof(ce.valueStackElement0Address)), callEngineGlobalContextValueStackElement0AddressOffset, "callEngineGlobalContextValueStackElement0AddressOffset")
-	requireEqual(int(unsafe.Offsetof(ce.valueStackLen)), callEngineGlobalContextValueStackLenOffset, "callEngineGlobalContextValueStackLenOffset")
+	requireEqual(int(unsafe.Offsetof(ce.valueStackLenInBytes)), callEngineGlobalContextValueStackLenInBytesOffset, "callEngineGlobalContextValueStackLenInBytesOffset")
 	requireEqual(int(unsafe.Offsetof(ce.callFrameStackElementZeroAddress)), callEngineGlobalContextCallFrameStackElement0AddressOffset, "callEngineGlobalContextCallFrameStackElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.callFrameStackLen)), callEngineGlobalContextCallFrameStackLenOffset, "callEngineGlobalContextCallFrameStackLenOffset")
 	requireEqual(int(unsafe.Offsetof(ce.callFrameStackPointer)), callEngineGlobalContextCallFrameStackPointerOffset, "callEngineGlobalContextCallFrameStackPointerOffset")
@@ -54,8 +54,8 @@ func init() {
 	requireEqual(int(unsafe.Offsetof(ce.elementInstancesElement0Address)), callEngineModuleContextElementInstancesElement0AddressOffset, "callEngineModuleContextElementInstancesElement0AddressOffset")
 
 	// Offsets for callEngine.valueStackContext
-	requireEqual(int(unsafe.Offsetof(ce.stackPointer)), callEngineValueStackContextStackPointerOffset, "callEngineValueStackContextStackPointerOffset")
-	requireEqual(int(unsafe.Offsetof(ce.stackBasePointer)), callEngineValueStackContextStackBasePointerOffset, "callEngineValueStackContextStackBasePointerOffset")
+	requireEqual(int(unsafe.Offsetof(ce.stackPointerInBytes)), callEngineValueStackContextStackPointerInBytesOffset, "callEngineValueStackContextStackPointerInBytesOffset")
+	requireEqual(int(unsafe.Offsetof(ce.stackBasePointerInBytes)), callEngineValueStackContextStackBasePointerInBytesOffset, "callEngineValueStackContextStackBasePointerInBytesOffset")
 
 	// Offsets for callEngine.exitContext.
 	requireEqual(int(unsafe.Offsetof(ce.statusCode)), callEngineExitContextNativeCallStatusCodeOffset, "callEngineExitContextNativeCallStatusCodeOffset")
@@ -169,15 +169,15 @@ func (j *compilerEnv) builtinFunctionCallAddress() wasm.Index {
 }
 
 func (j *compilerEnv) stackPointer() uint64 {
-	return j.ce.valueStackContext.stackPointer
+	return j.ce.valueStackContext.stackPointerInBytes >> 3
 }
 
 func (j *compilerEnv) stackBasePointer() uint64 {
-	return j.ce.valueStackContext.stackBasePointer
+	return j.ce.valueStackContext.stackBasePointerInBytes >> 3
 }
 
 func (j *compilerEnv) setStackPointer(sp uint64) {
-	j.ce.valueStackContext.stackPointer = sp
+	j.ce.valueStackContext.stackPointerInBytes = sp << 3
 }
 
 func (j *compilerEnv) addGlobals(g ...*wasm.GlobalInstance) {
@@ -201,7 +201,7 @@ func (j *compilerEnv) callFrameStackPointer() uint64 {
 }
 
 func (j *compilerEnv) setValueStackBasePointer(sp uint64) {
-	j.ce.valueStackContext.stackBasePointer = sp
+	j.ce.valueStackContext.stackBasePointerInBytes = sp * 8
 }
 
 func (j *compilerEnv) setCallFrameStackPointerLen(l uint64) {

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -130,14 +130,14 @@ type (
 
 	// valueStackContext stores the data to access engine.valueStack.
 	valueStackContext struct {
-		// stackPointer on .valueStack field which is accessed by [stackBasePointer] + [stackPointer].
+		// stackPointer on .valueStack field which is accessed by valueStack[stackBasePointer+stackBasePointerInBytes*8].
 		//
 		// Note: stackPointer is not used in assembly since the native code knows exact position of
 		// each variable in the value stack from the info from compilation.
 		// Therefore, only updated when native code exit from the Compiler world and go back to the Go function.
 		stackPointer uint64
 
-		// stackBasePointer is updated whenever we make function calls.
+		// stackBasePointerInBytes is updated whenever we make function calls.
 		// Background: Functions might be compiled as if they use the stack from the bottom.
 		// However, in reality, they have to use it from the middle of the stack depending on
 		// when these function calls are made. So instead of accessing stack via stackPointer alone,

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -79,9 +79,9 @@ type (
 		// valueStackElement0Address is &engine.valueStack[0] as uintptr.
 		// Note: this is updated when growing the stack in builtinFunctionGrowValueStack.
 		valueStackElement0Address uintptr
-		// valueStackLen is len(engine.valueStack[0]).
+		// valueStackLen is len(engine.valueStack[0]) * 8 (bytes).
 		// Note: this is updated when growing the stack in builtinFunctionGrowValueStack.
-		valueStackLen uint64
+		valueStackLenInBytes uint64
 
 		// callFrameStackElementZeroAddress is &engine.callFrameStack[0] as uintptr.
 		// Note: this is updated when growing the stack in builtinFunctionGrowCallFrameStack.
@@ -135,7 +135,7 @@ type (
 		// Note: stackPointer is not used in assembly since the native code knows exact position of
 		// each variable in the value stack from the info from compilation.
 		// Therefore, only updated when native code exit from the Compiler world and go back to the Go function.
-		stackPointer uint64
+		stackPointerInBytes uint64
 
 		// stackBasePointer is updated whenever we make function calls.
 		// Background: Functions might be compiled as if they use the stack from the bottom.
@@ -148,7 +148,7 @@ type (
 		// Note: This is saved on callFrameTop().returnStackBasePointer whenever making function call.
 		// Also, this is changed whenever we make function call or return from functions where we execute jump instruction.
 		// In either case, the caller of "jmp" instruction must set this field properly.
-		stackBasePointer uint64
+		stackBasePointerInBytes uint64
 	}
 
 	// exitContext will be manipulated whenever compiled native code returns into the Go function.
@@ -230,7 +230,7 @@ const (
 
 	// Offsets for callEngine globalContext.
 	callEngineGlobalContextValueStackElement0AddressOffset     = 0
-	callEngineGlobalContextValueStackLenOffset                 = 8
+	callEngineGlobalContextValueStackLenInBytesOffset          = 8
 	callEngineGlobalContextCallFrameStackElement0AddressOffset = 16
 	callEngineGlobalContextCallFrameStackLenOffset             = 24
 	callEngineGlobalContextCallFrameStackPointerOffset         = 32
@@ -247,8 +247,8 @@ const (
 	callEngineModuleContextElementInstancesElement0AddressOffset = 104
 
 	// Offsets for callEngine valueStackContext.
-	callEngineValueStackContextStackPointerOffset     = 112
-	callEngineValueStackContextStackBasePointerOffset = 120
+	callEngineValueStackContextStackPointerInBytesOffset     = 112
+	callEngineValueStackContextStackBasePointerInBytesOffset = 120
 
 	// Offsets for callEngine exitContext.
 	callEngineExitContextNativeCallStatusCodeOffset       = 128
@@ -585,7 +585,7 @@ func (ce *callEngine) recoverOnCall(v interface{}) (err error) {
 	err = builder.FromRecovered(v)
 
 	// Allows the reuse of CallEngine.
-	ce.stackPointer, ce.callFrameStackPointer = 0, 0
+	ce.valueStackLenInBytes, ce.callFrameStackPointer = 0, 0
 	return
 }
 
@@ -652,7 +652,7 @@ func (e *moduleEngine) newCallEngine(source *wasm.FunctionInstance, compiled *fu
 	callFrameStackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.callFrameStack))
 	ce.globalContext = globalContext{
 		valueStackElement0Address:        valueStackHeader.Data,
-		valueStackLen:                    uint64(valueStackHeader.Len),
+		valueStackLenInBytes:             uint64(valueStackHeader.Len) * 8,
 		callFrameStackElementZeroAddress: callFrameStackHeader.Data,
 		callFrameStackLen:                uint64(callFrameStackHeader.Len),
 		callFrameStackPointer:            0,
@@ -661,14 +661,14 @@ func (e *moduleEngine) newCallEngine(source *wasm.FunctionInstance, compiled *fu
 }
 
 func (ce *callEngine) popValue() (ret uint64) {
-	ce.valueStackContext.stackPointer--
+	ce.valueStackContext.stackPointerInBytes -= 8
 	ret = ce.valueStack[ce.valueStackTopIndex()]
 	return
 }
 
 func (ce *callEngine) pushValue(v uint64) {
 	ce.valueStack[ce.valueStackTopIndex()] = v
-	ce.valueStackContext.stackPointer++
+	ce.valueStackContext.stackBasePointerInBytes += 8
 }
 
 func (ce *callEngine) callFrameTop() *callFrame {
@@ -681,7 +681,7 @@ func (ce *callEngine) callFrameAt(depth uint64) *callFrame {
 }
 
 func (ce *callEngine) valueStackTopIndex() uint64 {
-	return ce.valueStackContext.stackBasePointer + ce.valueStackContext.stackPointer
+	return (ce.valueStackContext.stackPointerInBytes + ce.valueStackContext.stackBasePointerInBytes) >> 3
 }
 
 const (
@@ -703,7 +703,7 @@ entry:
 		frame := ce.callFrameTop()
 		if buildoptions.IsDebugMode {
 			fmt.Printf("callframe=%s, stackBasePointer: %d, stackPointer: %d\n",
-				frame.String(), ce.valueStackContext.stackBasePointer, ce.valueStackContext.stackPointer)
+				frame.String(), ce.valueStackContext.stackBasePointerInBytes>>2, ce.valueStackContext.stackPointerInBytes>>2)
 		}
 
 		// Call into the native code.
@@ -758,14 +758,15 @@ entry:
 
 func (ce *callEngine) builtinFunctionGrowValueStack(stackPointerCeil uint64) {
 	// Extends the valueStack's length to currentLen*2+stackPointerCeil.
-	newLen := ce.globalContext.valueStackLen*2 + (stackPointerCeil)
+	newLen := uint64(len(ce.valueStack)) + (stackPointerCeil)
 	newStack := make([]uint64, newLen)
-	top := ce.valueStackContext.stackBasePointer + ce.valueStackContext.stackPointer
+	ce.valueStackTopIndex()
+	top := ce.valueStackTopIndex()
 	copy(newStack[:top], ce.valueStack[:top])
 	ce.valueStack = newStack
 	valueStackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.valueStack))
 	ce.globalContext.valueStackElement0Address = valueStackHeader.Data
-	ce.globalContext.valueStackLen = uint64(valueStackHeader.Len)
+	ce.globalContext.valueStackLenInBytes = uint64(valueStackHeader.Len) * 8
 }
 
 var callStackCeiling = uint64(buildoptions.CallStackCeiling)

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -585,7 +585,7 @@ func (ce *callEngine) recoverOnCall(v interface{}) (err error) {
 	err = builder.FromRecovered(v)
 
 	// Allows the reuse of CallEngine.
-	ce.valueStackLenInBytes, ce.callFrameStackPointer = 0, 0
+	ce.stackPointerInBytes, ce.callFrameStackPointer = 0, 0
 	return
 }
 
@@ -703,7 +703,7 @@ entry:
 		frame := ce.callFrameTop()
 		if buildoptions.IsDebugMode {
 			fmt.Printf("callframe=%s, stackBasePointer: %d, stackPointer: %d\n",
-				frame.String(), ce.valueStackContext.stackBasePointerInBytes>>2, ce.valueStackContext.stackPointerInBytes>>2)
+				frame.String(), ce.valueStackContext.stackBasePointerInBytes>>3, ce.valueStackContext.stackPointerInBytes>>3)
 		}
 
 		// Call into the native code.
@@ -758,7 +758,7 @@ entry:
 
 func (ce *callEngine) builtinFunctionGrowValueStack(stackPointerCeil uint64) {
 	// Extends the valueStack's length to currentLen*2+stackPointerCeil.
-	newLen := uint64(len(ce.valueStack)) + (stackPointerCeil)
+	newLen := uint64(len(ce.valueStack))<<1 + (stackPointerCeil)
 	newStack := make([]uint64, newLen)
 	ce.valueStackTopIndex()
 	top := ce.valueStackTopIndex()
@@ -766,7 +766,7 @@ func (ce *callEngine) builtinFunctionGrowValueStack(stackPointerCeil uint64) {
 	ce.valueStack = newStack
 	valueStackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.valueStack))
 	ce.globalContext.valueStackElement0Address = valueStackHeader.Data
-	ce.globalContext.valueStackLenInBytes = uint64(valueStackHeader.Len) * 8
+	ce.globalContext.valueStackLenInBytes = uint64(valueStackHeader.Len) << 3
 }
 
 var callStackCeiling = uint64(buildoptions.CallStackCeiling)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -295,7 +295,7 @@ func TestCallEngine_builtinFunctionTableGrow(t *testing.T) {
 			// which happens if the previous value on that stack location was 64-bit wide.
 			0xffffffff << 32,
 		},
-		valueStackContext: valueStackContext{stackPointerInBytes: 3 * 8},
+		valueStackContext: valueStackContext{stackPointer: 3},
 	}
 
 	table := &wasm.TableInstance{References: []wasm.Reference{}, Min: 10}
@@ -308,7 +308,7 @@ func TestCallEngine_builtinFunctionTableGrow(t *testing.T) {
 func TestCallEngine_recoverOnCall(t *testing.T) {
 	ce := &callEngine{
 		valueStack:        make([]uint64, 100),
-		valueStackContext: valueStackContext{stackPointerInBytes: 3 * 8},
+		valueStackContext: valueStackContext{stackPointer: 3},
 		globalContext:     globalContext{callFrameStackPointer: 5},
 		callFrameStack: []callFrame{
 			{function: &function{source: &wasm.FunctionInstance{FunctionDefinition: newMockFunctionDefinition("1")}}},

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -295,7 +295,7 @@ func TestCallEngine_builtinFunctionTableGrow(t *testing.T) {
 			// which happens if the previous value on that stack location was 64-bit wide.
 			0xffffffff << 32,
 		},
-		valueStackContext: valueStackContext{stackPointer: 3},
+		valueStackContext: valueStackContext{stackPointerInBytes: 3 * 8},
 	}
 
 	table := &wasm.TableInstance{References: []wasm.Reference{}, Min: 10}
@@ -308,7 +308,7 @@ func TestCallEngine_builtinFunctionTableGrow(t *testing.T) {
 func TestCallEngine_recoverOnCall(t *testing.T) {
 	ce := &callEngine{
 		valueStack:        make([]uint64, 100),
-		valueStackContext: valueStackContext{stackPointer: 3},
+		valueStackContext: valueStackContext{stackPointerInBytes: 3 * 8},
 		globalContext:     globalContext{callFrameStackPointer: 5},
 		callFrameStack: []callFrame{
 			{function: &function{source: &wasm.FunctionInstance{FunctionDefinition: newMockFunctionDefinition("1")}}},
@@ -332,7 +332,7 @@ wasm stack trace:
 
 	// After recover, the stack pointers must be reset, but the underlying slices must be intact
 	// for the subsequent calls.
-	require.Equal(t, uint64(0), ce.stackPointer)
+	require.Equal(t, uint64(0), ce.stackBasePointerInBytes)
 	require.Equal(t, uint64(0), ce.callFrameStackPointer)
 	require.Equal(t, beforeRecoverValueStack, ce.valueStack)
 	require.Equal(t, beforeRecoverCallFrameStack, ce.callFrameStack)

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4608,7 +4608,7 @@ func (c *amd64Compiler) compileCallFunctionImpl(index wasm.Index, functionAddres
 
 		c.assembler.CompileRegisterToMemory(amd64.MOVQ, tmpRegister,
 			// "rb.1" is BELOW the top address. See the above example for detail.
-			callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerOffset),
+			callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerInBytesOffset),
 		)
 	}
 
@@ -4617,7 +4617,7 @@ func (c *amd64Compiler) compileCallFunctionImpl(index wasm.Index, functionAddres
 		// At this point, tmpRegister holds the old stack base pointer. We could get the new frame's
 		// stack base pointer by "old stack base pointer + old stack pointer - # of function params"
 		// See the comments in callEngine.pushCallFrame which does exactly the same calculation in Go.
-		c.assembler.CompileConstToRegister(amd64.ADDQ, offset*8, tmpRegister)
+		c.assembler.CompileConstToRegister(amd64.ADDQ, offset<<3, tmpRegister)
 
 		// Write the calculated value to callEngine.valueStackContext.stackBasePointer.
 		c.assembler.CompileRegisterToMemory(amd64.MOVQ, tmpRegister, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset)
@@ -4791,7 +4791,7 @@ func (c *amd64Compiler) compileReturnFunction() error {
 	// 1) Set callEngine.valueStackContext.stackBasePointer to the value on "rb.caller"
 	c.assembler.CompileMemoryToRegister(amd64.MOVQ,
 		// "rb.caller" is BELOW the top address. See the above example for detail.
-		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerOffset),
+		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerInBytesOffset),
 		tmpRegister,
 	)
 	c.assembler.CompileRegisterToMemory(amd64.MOVQ,

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4604,7 +4604,7 @@ func (c *amd64Compiler) compileCallFunctionImpl(index wasm.Index, functionAddres
 	{
 		// We must save the current stack base pointer (which lives on callEngine.valueStackContext.stackPointer)
 		// to the call frame stack. In the example, this is equivalent to writing the value into "rb.1".
-		c.assembler.CompileMemoryToRegister(amd64.MOVQ, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset, tmpRegister)
+		c.assembler.CompileMemoryToRegister(amd64.MOVQ, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset, tmpRegister)
 
 		c.assembler.CompileRegisterToMemory(amd64.MOVQ, tmpRegister,
 			// "rb.1" is BELOW the top address. See the above example for detail.
@@ -4617,10 +4617,10 @@ func (c *amd64Compiler) compileCallFunctionImpl(index wasm.Index, functionAddres
 		// At this point, tmpRegister holds the old stack base pointer. We could get the new frame's
 		// stack base pointer by "old stack base pointer + old stack pointer - # of function params"
 		// See the comments in callEngine.pushCallFrame which does exactly the same calculation in Go.
-		c.assembler.CompileConstToRegister(amd64.ADDQ, offset, tmpRegister)
+		c.assembler.CompileConstToRegister(amd64.ADDQ, offset*8, tmpRegister)
 
 		// Write the calculated value to callEngine.valueStackContext.stackBasePointer.
-		c.assembler.CompileRegisterToMemory(amd64.MOVQ, tmpRegister, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset)
+		c.assembler.CompileRegisterToMemory(amd64.MOVQ, tmpRegister, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset)
 	}
 
 	// 3) Set rc.next to specify which function is executed on the current call frame (needs to make builtin function calls).
@@ -4795,7 +4795,7 @@ func (c *amd64Compiler) compileReturnFunction() error {
 		tmpRegister,
 	)
 	c.assembler.CompileRegisterToMemory(amd64.MOVQ,
-		tmpRegister, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset)
+		tmpRegister, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset)
 
 	// 2) Load rc.caller.moduleInstanceAddress into amd64CallingConventionModuleInstanceAddressRegister
 	c.assembler.CompileMemoryToRegister(amd64.MOVQ,
@@ -4938,7 +4938,7 @@ func (c *amd64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 	c.assembler.CompileConstToMemory(amd64.MOVB, int64(status), amd64ReservedRegisterForCallEngine, callEngineExitContextNativeCallStatusCodeOffset)
 
 	// Write back the cached SP to the actual eng.stackPointer.
-	c.assembler.CompileConstToMemory(amd64.MOVQ, int64(c.locationStack.sp), amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackPointerOffset)
+	c.assembler.CompileConstToMemory(amd64.MOVQ, int64(c.locationStack.sp), amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackPointerInBytesOffset)
 
 	c.assembler.CompileStandAlone(amd64.RET)
 }
@@ -4970,19 +4970,9 @@ func (c *amd64Compiler) compileReservedStackBasePointerInitialization() {
 		amd64ReservedRegisterForCallEngine, callEngineGlobalContextValueStackElement0AddressOffset,
 		amd64ReservedRegisterForStackBasePointerAddress)
 
-	// Since initializeReservedRegisters is called at the beginning of function
-	// calls (or right after they return), we have free registers at this point.
-	tmpReg, _ := c.locationStack.takeFreeRegister(registerTypeGeneralPurpose)
-
 	// next we move the base pointer (callEngine.stackBasePointer) to the tmp register.
-	c.assembler.CompileMemoryToRegister(amd64.MOVQ,
-		amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset,
-		tmpReg,
-	)
-
-	c.assembler.CompileMemoryWithIndexToRegister(
-		amd64.LEAQ,
-		amd64ReservedRegisterForStackBasePointerAddress, 0, tmpReg, 8,
+	c.assembler.CompileMemoryToRegister(amd64.ADDQ,
+		amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset,
 		amd64ReservedRegisterForStackBasePointerAddress,
 	)
 }
@@ -5002,13 +4992,13 @@ func (c *amd64Compiler) compileReservedMemoryPointerInitialization() {
 func (c *amd64Compiler) compileMaybeGrowValueStack() error {
 	tmpRegister, _ := c.allocateRegister(registerTypeGeneralPurpose)
 
-	c.assembler.CompileMemoryToRegister(amd64.MOVQ, amd64ReservedRegisterForCallEngine, callEngineGlobalContextValueStackLenOffset, tmpRegister)
-	c.assembler.CompileMemoryToRegister(amd64.SUBQ, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset, tmpRegister)
+	c.assembler.CompileMemoryToRegister(amd64.MOVQ, amd64ReservedRegisterForCallEngine, callEngineGlobalContextValueStackLenInBytesOffset, tmpRegister)
+	c.assembler.CompileMemoryToRegister(amd64.SUBQ, amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset, tmpRegister)
 
 	// If stack base pointer + max stack pointer > valueStackLen, we need to grow the stack.
 	cmpWithStackPointerCeil := c.assembler.CompileRegisterToConst(amd64.CMPQ, tmpRegister, 0)
 	c.onStackPointerCeilDeterminedCallBack = func(stackPointerCeil uint64) {
-		cmpWithStackPointerCeil.AssignDestinationConstant(int64(stackPointerCeil))
+		cmpWithStackPointerCeil.AssignDestinationConstant(int64(stackPointerCeil) << 3)
 	}
 
 	// Jump if we have no need to grow.

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4935,10 +4935,12 @@ func (c *amd64Compiler) compileReleaseRegisterToStack(loc *runtimeValueLocation)
 }
 
 func (c *amd64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
-	c.assembler.CompileConstToMemory(amd64.MOVB, int64(status), amd64ReservedRegisterForCallEngine, callEngineExitContextNativeCallStatusCodeOffset)
+	c.assembler.CompileConstToMemory(amd64.MOVB, int64(status),
+		amd64ReservedRegisterForCallEngine, callEngineExitContextNativeCallStatusCodeOffset)
 
 	// Write back the cached SP to the actual eng.stackPointer.
-	c.assembler.CompileConstToMemory(amd64.MOVQ, int64(c.locationStack.sp), amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackPointerInBytesOffset)
+	c.assembler.CompileConstToMemory(amd64.MOVQ, int64(c.locationStack.sp)<<3,
+		amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackPointerInBytesOffset)
 
 	c.assembler.CompileStandAlone(amd64.RET)
 }

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4939,8 +4939,8 @@ func (c *amd64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 		amd64ReservedRegisterForCallEngine, callEngineExitContextNativeCallStatusCodeOffset)
 
 	// Write back the cached SP to the actual eng.stackPointer.
-	c.assembler.CompileConstToMemory(amd64.MOVQ, int64(c.locationStack.sp)<<3,
-		amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackPointerInBytesOffset)
+	c.assembler.CompileConstToMemory(amd64.MOVQ, int64(c.locationStack.sp),
+		amd64ReservedRegisterForCallEngine, callEngineValueStackContextStackPointerOffset)
 
 	c.assembler.CompileStandAlone(amd64.RET)
 }

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -4103,7 +4103,7 @@ func (c *arm64Compiler) compileReservedStackBasePointerRegisterInitialization() 
 		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset,
 		arm64ReservedRegisterForTemporary)
 
-	// Finally, we calculate "callEngineValueStackContextStackBasePointerInBytesOffset + arm64ReservedRegisterForTemporary << 3"
+	// Finally, we calculate "callEngineValueStackContextStackBasePointerInBytesOffset + arm64ReservedRegisterForTemporary"
 	c.assembler.CompileRegisterToRegister(arm64.ADD, arm64ReservedRegisterForTemporary, arm64ReservedRegisterForStackBasePointerAddress)
 }
 

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -378,9 +378,9 @@ func (c *arm64Compiler) compileReturnFunction() error {
 // compileExitFromNativeCode adds instructions to give the control back to ce.exec with the given status code.
 func (c *arm64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 	// Write the current stack pointer to the ce.stackPointer.
-	c.assembler.CompileConstToRegister(arm64.MOVD, int64(c.locationStack.sp)<<3, arm64ReservedRegisterForTemporary)
+	c.assembler.CompileConstToRegister(arm64.MOVD, int64(c.locationStack.sp), arm64ReservedRegisterForTemporary)
 	c.assembler.CompileRegisterToMemory(arm64.STRD, arm64ReservedRegisterForTemporary, arm64ReservedRegisterForCallEngine,
-		callEngineValueStackContextStackPointerInBytesOffset)
+		callEngineValueStackContextStackPointerOffset)
 
 	if status != 0 {
 		c.assembler.CompileConstToRegister(arm64.MOVW, int64(status), arm64ReservedRegisterForTemporary)

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -230,14 +230,14 @@ func (c *arm64Compiler) compileMaybeGrowValueStack() error {
 	// "tmpX = len(ce.valueStack)"
 	c.assembler.CompileMemoryToRegister(
 		arm64.LDRD,
-		arm64ReservedRegisterForCallEngine, callEngineGlobalContextValueStackLenOffset,
+		arm64ReservedRegisterForCallEngine, callEngineGlobalContextValueStackLenInBytesOffset,
 		tmpX,
 	)
 
 	// "tmpY = ce.stackBasePointer"
 	c.assembler.CompileMemoryToRegister(
 		arm64.LDRD,
-		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset,
+		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset,
 		tmpY,
 	)
 
@@ -256,7 +256,9 @@ func (c *arm64Compiler) compileMaybeGrowValueStack() error {
 	)
 	// At this point of compilation, we don't know the value of stack point ceil,
 	// so we lazily resolve the value later.
-	c.onStackPointerCeilDeterminedCallBack = func(stackPointerCeil uint64) { loadStackPointerCeil.AssignSourceConstant(int64(stackPointerCeil)) }
+	c.onStackPointerCeilDeterminedCallBack = func(stackPointerCeil uint64) {
+		loadStackPointerCeil.AssignSourceConstant(int64(stackPointerCeil) << 3)
+	}
 
 	// Compare tmpX (len(ce.valueStack) - ce.stackBasePointer) and tmpY (ce.stackPointerCeil)
 	c.assembler.CompileTwoRegistersToNone(arm64.CMP, tmpX, tmpY)
@@ -347,11 +349,11 @@ func (c *arm64Compiler) compileReturnFunction() error {
 	// 1) Set ce.valueStackContext.stackBasePointer to the value on "rb.caller".
 	c.assembler.CompileMemoryToRegister(arm64.LDRD,
 		// "rb.caller" is below the top address.
-		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerOffset),
+		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerInBytesOffset),
 		tmpReg)
 	c.assembler.CompileRegisterToMemory(arm64.STRD,
 		tmpReg,
-		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset)
+		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset)
 
 	// 2) Load rc.caller.moduleInstanceAddress into arm64CallingConventionModuleInstanceAddressRegister.
 	c.assembler.CompileMemoryToRegister(arm64.LDRD,
@@ -376,9 +378,9 @@ func (c *arm64Compiler) compileReturnFunction() error {
 // compileExitFromNativeCode adds instructions to give the control back to ce.exec with the given status code.
 func (c *arm64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 	// Write the current stack pointer to the ce.stackPointer.
-	c.assembler.CompileConstToRegister(arm64.MOVD, int64(c.locationStack.sp), arm64ReservedRegisterForTemporary)
+	c.assembler.CompileConstToRegister(arm64.MOVD, int64(c.locationStack.sp)<<3, arm64ReservedRegisterForTemporary)
 	c.assembler.CompileRegisterToMemory(arm64.STRD, arm64ReservedRegisterForTemporary, arm64ReservedRegisterForCallEngine,
-		callEngineValueStackContextStackPointerOffset)
+		callEngineValueStackContextStackPointerInBytesOffset)
 
 	if status != 0 {
 		c.assembler.CompileConstToRegister(arm64.MOVW, int64(status), arm64ReservedRegisterForTemporary)
@@ -982,12 +984,12 @@ func (c *arm64Compiler) compileCallImpl(index wasm.Index, targetFunctionAddressR
 
 	// 1) Set rb.current so that we can return back to this function properly.
 	c.assembler.CompileMemoryToRegister(arm64.LDRD,
-		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset,
+		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset,
 		oldStackBasePointer)
 	c.assembler.CompileRegisterToMemory(arm64.STRD,
 		oldStackBasePointer,
 		// "rb.current" is BELOW the top address. See the above example for detail.
-		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerOffset))
+		callFrameStackTopAddressRegister, -(callFrameDataSize - callFrameReturnStackBasePointerInBytesOffset))
 
 	// 2) Set ce.valueStackContext.stackBasePointer for the next function.
 	//
@@ -995,10 +997,10 @@ func (c *arm64Compiler) compileCallImpl(index wasm.Index, targetFunctionAddressR
 	// stack base pointer by "old stack base pointer + old stack pointer - # of function params"
 	// See the comments in ce.pushCallFrame which does exactly the same calculation in Go.
 	if offset := int64(c.locationStack.sp) - int64(functype.ParamNumInUint64); offset > 0 {
-		c.assembler.CompileConstToRegister(arm64.ADD, offset, oldStackBasePointer)
+		c.assembler.CompileConstToRegister(arm64.ADD, offset<<3, oldStackBasePointer)
 		c.assembler.CompileRegisterToMemory(arm64.STRD,
 			oldStackBasePointer,
-			arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset)
+			arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset)
 	}
 
 	// 3) Set rc.next to specify which function is executed on the current call frame.
@@ -4098,15 +4100,11 @@ func (c *arm64Compiler) compileReservedStackBasePointerRegisterInitialization() 
 
 	// next we move the base pointer (ce.stackBasePointer) to arm64ReservedRegisterForTemporary.
 	c.assembler.CompileMemoryToRegister(arm64.LDRD,
-		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerOffset,
+		arm64ReservedRegisterForCallEngine, callEngineValueStackContextStackBasePointerInBytesOffset,
 		arm64ReservedRegisterForTemporary)
 
-	// Finally, we calculate "arm64ReservedRegisterForStackBasePointerAddress + arm64ReservedRegisterForTemporary << 3"
-	// where we shift tmpReg by 3 because stack pointer is an index in the []uint64
-	// so we must multiply the value by the size of uint64 = 8 bytes.
-	c.assembler.CompileLeftShiftedRegisterToRegister(arm64.ADD,
-		arm64ReservedRegisterForTemporary, 3, arm64ReservedRegisterForStackBasePointerAddress,
-		arm64ReservedRegisterForStackBasePointerAddress)
+	// Finally, we calculate "callEngineValueStackContextStackBasePointerInBytesOffset + arm64ReservedRegisterForTemporary << 3"
+	c.assembler.CompileRegisterToRegister(arm64.ADD, arm64ReservedRegisterForTemporary, arm64ReservedRegisterForStackBasePointerAddress)
 }
 
 func (c *arm64Compiler) compileReservedMemoryRegisterInitialization() {


### PR DESCRIPTION
To reduce the redundant instructions and register usage on the hot path.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>