### PR TITLE
compiler: simplify calling convention

### DIFF
--- a/internal/buildoptions/stackoverflow.go
+++ b/internal/buildoptions/stackoverflow.go
@@ -1,7 +1,0 @@
-package buildoptions
-
-// CallStackCeiling is the maximum WebAssembly call stack height. This allows wazero to raise
-// wasm.ErrCallStackOverflow instead of overflowing the Go runtime.
-//
-// The default value should suffice for most use cases. Those wishing to change this can via `go build -ldflags`.
-var CallStackCeiling = 2000

--- a/internal/engine/compiler/compiler_bench_test.go
+++ b/internal/engine/compiler/compiler_bench_test.go
@@ -110,12 +110,8 @@ func BenchmarkCompiler_compileMemoryFill(b *testing.B) {
 }
 
 func (j *compilerEnv) execBench(b *testing.B, codeSegment []byte) {
-	f := j.newFunction(codeSegment)
-
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		j.ce.callFrameStack[j.ce.globalContext.callFrameStackPointer] = callFrame{function: f}
-		j.ce.globalContext.callFrameStackPointer++
 		nativecall(
 			uintptr(unsafe.Pointer(&codeSegment[0])),
 			uintptr(unsafe.Pointer(j.ce)),

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -26,6 +26,7 @@ func TestCompiler_conditional_value_saving(t *testing.T) {
 	}
 
 	// Pick the f32 floating point local (1.0) twice.
+	// Note that the f32 (function local variable in general) is placed above the call frame.
 	err = compiler.compilePick(&wazeroir.OperationPick{Depth: int(compiler.runtimeValueLocationStack().sp - 1 - callFrameDataSizeInUint64)})
 
 	require.NoError(t, err)

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -26,9 +26,11 @@ func TestCompiler_conditional_value_saving(t *testing.T) {
 	}
 
 	// Pick the f32 floating point local (1.0) twice.
-	err = compiler.compilePick(&wazeroir.OperationPick{Depth: int(compiler.runtimeValueLocationStack().sp - 1)})
+	err = compiler.compilePick(&wazeroir.OperationPick{Depth: int(compiler.runtimeValueLocationStack().sp - 1 - callFrameDataSizeInUint64)})
+
 	require.NoError(t, err)
-	err = compiler.compilePick(&wazeroir.OperationPick{Depth: int(compiler.runtimeValueLocationStack().sp - 1)})
+	err = compiler.compilePick(&wazeroir.OperationPick{Depth: int(compiler.runtimeValueLocationStack().sp - 1 - callFrameDataSizeInUint64)})
+
 	require.NoError(t, err)
 	// Generate conditional flag via floating point comparisons.
 	err = compiler.compileLe(&wazeroir.OperationLe{Type: wazeroir.SignedTypeFloat32})

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -647,7 +647,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		env.addTable(&wasm.TableInstance{References: table})
 
 		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
-		// and the typeID  matches the table[targetOffset]'s type ID.
+		// and the typeID matches the table[targetOffset]'s type ID.
 		env.module().TypeIDs = make([]wasm.FunctionTypeID, 100)
 		env.module().TypeIDs[operation.TypeIndex] = targetTypeID
 		env.module().Engine = &moduleEngine{functions: []*function{}}

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -23,10 +23,11 @@ func TestCompiler_compileHostFunction(t *testing.T) {
 	env.exec(code)
 
 	// On the return, the code must exit with the host call status.
-	require.Equal(t, nativeCallStatusCodeCallHostFunction, env.compilerStatus())
+	require.Equal(t, nativeCallStatusCodeCallGoHostFunction, env.compilerStatus())
 
 	// Re-enter the return address.
-	nativecall(env.callFrameStackPeek().returnAddress,
+	require.NotEqual(t, uintptr(0), uintptr(env.ce.returnAddress))
+	nativecall(env.ce.returnAddress,
 		uintptr(unsafe.Pointer(env.callEngine())),
 		uintptr(unsafe.Pointer(env.module())),
 	)
@@ -233,7 +234,7 @@ func TestCompiler_compileBrIf(t *testing.T) {
 					require.NoError(t, err)
 
 					tc.setupFunc(t, compiler, shouldGoToElse)
-					require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 					err = compiler.compileBrIf(&wazeroir.OperationBrIf{Then: thenBranchTarget, Else: elseBranchTarget})
 					require.NoError(t, err)
@@ -296,7 +297,7 @@ func TestCompiler_compileBrTable(t *testing.T) {
 		env.exec(code)
 
 		// Check the returned value.
-		require.Equal(t, uint64(1), env.stackPointer())
+		require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 		require.Equal(t, expValue, env.stackTopAsUint32())
 	}
 
@@ -634,110 +635,98 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		for _, growCallFrameStack := range []bool{false} {
-			growCallFrameStack := growCallFrameStack
-			t.Run(fmt.Sprintf("grow=%v", growCallFrameStack), func(t *testing.T) {
-				targetType := &wasm.FunctionType{
-					Params:  []wasm.ValueType{},
-					Results: []wasm.ValueType{wasm.ValueTypeI32}}
-				targetTypeID := wasm.FunctionTypeID(10) // Arbitrary number is fine for testing.
-				operation := &wazeroir.OperationCallIndirect{TypeIndex: 0}
+		targetType := &wasm.FunctionType{
+			Results:           []wasm.ValueType{wasm.ValueTypeI32},
+			ResultNumInUint64: 1,
+		}
+		targetTypeID := wasm.FunctionTypeID(10) // Arbitrary number is fine for testing.
+		operation := &wazeroir.OperationCallIndirect{TypeIndex: 0}
 
-				table := make([]wasm.Reference, 10)
-				env := newCompilerEnvironment()
-				env.addTable(&wasm.TableInstance{References: table})
+		table := make([]wasm.Reference, 10)
+		env := newCompilerEnvironment()
+		env.addTable(&wasm.TableInstance{References: table})
 
-				// Ensure that the module instance has the type information for targetOperation.TypeIndex,
-				// and the typeID  matches the table[targetOffset]'s type ID.
-				env.module().TypeIDs = make([]wasm.FunctionTypeID, 100)
-				env.module().TypeIDs[operation.TypeIndex] = targetTypeID
-				env.module().Engine = &moduleEngine{functions: []*function{}}
+		// Ensure that the module instance has the type information for targetOperation.TypeIndex,
+		// and the typeID  matches the table[targetOffset]'s type ID.
+		env.module().TypeIDs = make([]wasm.FunctionTypeID, 100)
+		env.module().TypeIDs[operation.TypeIndex] = targetTypeID
+		env.module().Engine = &moduleEngine{functions: []*function{}}
 
-				me := env.moduleEngine()
-				for i := 0; i < len(table); i++ {
-					// First we create the call target function with function address = i,
-					// and it returns one value.
-					expectedReturnValue := uint32(i * 1000)
+		me := env.moduleEngine()
+		for i := 0; i < len(table); i++ {
+			// First we create the call target function with function address = i,
+			// and it returns one value.
+			expectedReturnValue := uint32(i * 1000)
 
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
-					err := compiler.compilePreamble()
-					require.NoError(t, err)
-					err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: expectedReturnValue})
-					require.NoError(t, err)
-					err = compiler.compileReturnFunction()
-					require.NoError(t, err)
+			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+				Signature: targetType,
+			})
+			err := compiler.compilePreamble()
+			require.NoError(t, err)
+			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: expectedReturnValue})
+			require.NoError(t, err)
 
-					c, _, err := compiler.compile()
-					require.NoError(t, err)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			err = compiler.compileSet(&wazeroir.OperationSet{Depth: 1 + callFrameDataSizeInUint64})
+			require.NoError(t, err)
+			err = compiler.compileReturnFunction()
+			require.NoError(t, err)
 
-					f := &function{
-						parent:                &code{codeSegment: c},
-						codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
-						moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
-						source: &wasm.FunctionInstance{
-							TypeID: targetTypeID,
-						},
-					}
-					me.functions = append(me.functions, f)
-					table[i] = uintptr(unsafe.Pointer(f))
-				}
+			c, _, err := compiler.compile()
+			require.NoError(t, err)
 
-				for i := 1; i < len(table); i++ {
-					expectedReturnValue := uint32(i * 1000)
-					t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-						if growCallFrameStack {
-							env.setCallFrameStackPointerLen(1)
-						}
+			f := &function{
+				parent:                &code{codeSegment: c},
+				codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
+				moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
+				source: &wasm.FunctionInstance{
+					TypeID: targetTypeID,
+				},
+			}
+			me.functions = append(me.functions, f)
+			table[i] = uintptr(unsafe.Pointer(f))
+		}
 
-						compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-							Signature: targetType,
-							Types:     []*wasm.FunctionType{targetType},
-							HasTable:  true,
-						})
-						err := compiler.compilePreamble()
-						require.NoError(t, err)
+		for i := 1; i < len(table); i++ {
+			expectedReturnValue := uint32(i * 1000)
+			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 
-						// Place the offset value. Here we try calling a function of functionaddr == table[i].FunctionIndex.
-						err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: uint32(i)})
-						require.NoError(t, err)
+				compiler := env.requireNewCompiler(t, newCompiler,
+					&wazeroir.CompilationResult{
+						Signature: &wasm.FunctionType{},
+						Types:     []*wasm.FunctionType{targetType},
+						HasTable:  true,
+					},
+				)
+				err := compiler.compilePreamble()
+				require.NoError(t, err)
 
-						// At this point, we should have one item (offset value) on the stack.
-						require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+				// Place the offset value. Here we try calling a function of functionaddr == table[i].FunctionIndex.
+				err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: uint32(i)})
+				require.NoError(t, err)
 
-						require.NoError(t, compiler.compileCallIndirect(operation))
+				// At this point, we should have one item (offset value) on the stack.
+				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, // Call frame + the const ^.
+					compiler.runtimeValueLocationStack().sp)
 
-						// At this point, we consumed the offset value, but the function returns one value,
-						// so the stack pointer results in the same.
-						require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+				require.NoError(t, compiler.compileCallIndirect(operation))
 
-						err = compiler.compileReturnFunction()
-						require.NoError(t, err)
+				// At this point, we consumed the offset value, but the function returns one value,
+				// so the stack pointer results in the same.
+				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, // Call frame + the return value from the called function.
+					compiler.runtimeValueLocationStack().sp)
 
-						// Generate the code under test and run.
-						code, _, err := compiler.compile()
-						require.NoError(t, err)
-						env.exec(code)
+				err = compiler.compileReturnFunction()
+				require.NoError(t, err)
 
-						if growCallFrameStack {
-							// If the call frame stack pointer equals the length of call frame stack length,
-							// we have to call the builtin function to grow the slice.
-							require.Equal(t, nativeCallStatusCodeCallBuiltInFunction, env.compilerStatus())
-							require.Equal(t, builtinFunctionIndexGrowCallFrameStack, env.builtinFunctionCallAddress())
+				// Generate the code under test and run.
+				code, _, err := compiler.compile()
+				require.NoError(t, err)
+				env.exec(code)
 
-							// Grow the callFrame stack, and exec again from the return address.
-							ce := env.callEngine()
-							ce.builtinFunctionGrowCallFrameStack()
-							nativecall(
-								env.callFrameStackPeek().returnAddress, uintptr(unsafe.Pointer(ce)),
-								uintptr(unsafe.Pointer(env.module())),
-							)
-						}
-
-						require.Equal(t, nativeCallStatusCodeReturned.String(), env.compilerStatus().String())
-						require.Equal(t, uint64(1), env.stackPointer())
-						require.Equal(t, expectedReturnValue, uint32(env.ce.popValue()))
-					})
-				}
+				require.Equal(t, nativeCallStatusCodeReturned.String(), env.compilerStatus().String())
+				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+				require.Equal(t, expectedReturnValue, uint32(env.ce.popValue()))
 			})
 		}
 	})
@@ -804,184 +793,86 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 }
 
 func TestCompiler_compileCall(t *testing.T) {
-	for _, growCallFrameStack := range []bool{false, true} {
-		growCallFrameStack := growCallFrameStack
-		t.Run(fmt.Sprintf("grow=%v", growCallFrameStack), func(t *testing.T) {
-			env := newCompilerEnvironment()
-			me := env.moduleEngine()
-			expectedValue := uint32(0)
+	env := newCompilerEnvironment()
+	me := env.moduleEngine()
+	expectedValue := uint32(0)
 
-			if growCallFrameStack {
-				env.setCallFrameStackPointerLen(1)
-			}
-
-			// Emit the call target function.
-			const numCalls = 3
-			targetFunctionType := &wasm.FunctionType{
-				Params:           []wasm.ValueType{wasm.ValueTypeI32},
-				Results:          []wasm.ValueType{wasm.ValueTypeI32},
-				ParamNumInUint64: 1, ResultNumInUint64: 1,
-			}
-			for i := 0; i < numCalls; i++ {
-				// Each function takes one argument, adds the value with 100 + i and returns the result.
-				addTargetValue := uint32(100 + i)
-				expectedValue += addTargetValue
-
-				compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{Signature: targetFunctionType})
-
-				err := compiler.compilePreamble()
-				require.NoError(t, err)
-
-				err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: uint32(addTargetValue)})
-				require.NoError(t, err)
-				err = compiler.compileAdd(&wazeroir.OperationAdd{Type: wazeroir.UnsignedTypeI32})
-				require.NoError(t, err)
-
-				err = compiler.compileReturnFunction()
-				require.NoError(t, err)
-
-				c, _, err := compiler.compile()
-				require.NoError(t, err)
-				index := wasm.Index(i)
-				me.functions = append(me.functions, &function{
-					parent:                &code{codeSegment: c},
-					codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
-					moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
-				})
-				env.module().Functions = append(env.module().Functions,
-					&wasm.FunctionInstance{Type: targetFunctionType, Idx: index})
-			}
-
-			// Now we start building the caller's code.
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				Signature: &wasm.FunctionType{},
-				Functions: make([]uint32, numCalls),
-				Types:     []*wasm.FunctionType{targetFunctionType},
-			})
-
-			err := compiler.compilePreamble()
-			require.NoError(t, err)
-
-			const initialValue = 100
-			expectedValue += initialValue
-			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: 0}) // Dummy value so the base pointer would be non-trivial for callees.
-			require.NoError(t, err)
-			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: initialValue})
-			require.NoError(t, err)
-
-			// Call all the built functions.
-			for i := 0; i < numCalls; i++ {
-				err = compiler.compileCall(&wazeroir.OperationCall{FunctionIndex: uint32(i)})
-				require.NoError(t, err)
-			}
-
-			err = compiler.compileReturnFunction()
-			require.NoError(t, err)
-
-			code, _, err := compiler.compile()
-			require.NoError(t, err)
-			env.exec(code)
-
-			if growCallFrameStack {
-				// If the call frame stack pointer equals the length of call frame stack length,
-				// we have to call the builtin function to grow the slice.
-				require.Equal(t, nativeCallStatusCodeCallBuiltInFunction, env.compilerStatus())
-				require.Equal(t, builtinFunctionIndexGrowCallFrameStack, env.builtinFunctionCallAddress())
-
-				// Grow the callFrame stack, and exec again from the return address.
-				ce := env.callEngine()
-				ce.builtinFunctionGrowCallFrameStack()
-				nativecall(
-					env.callFrameStackPeek().returnAddress, uintptr(unsafe.Pointer(ce)),
-					uintptr(unsafe.Pointer(env.module())),
-				)
-			}
-
-			// Check status and returned values.
-			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-			require.Equal(t, uint64(2), env.stackPointer()) // Must be 2 (dummy value + the calculation results)
-			require.Equal(t, uint64(0), env.stackBasePointer())
-			require.Equal(t, expectedValue, env.stackTopAsUint32())
-		})
+	// Emit the call target function.
+	const numCalls = 3
+	targetFunctionType := &wasm.FunctionType{
+		Params:           []wasm.ValueType{wasm.ValueTypeI32},
+		Results:          []wasm.ValueType{wasm.ValueTypeI32},
+		ParamNumInUint64: 1, ResultNumInUint64: 1,
 	}
-}
+	for i := 0; i < numCalls; i++ {
+		// Each function takes one argument, adds the value with 100 + i and returns the result.
+		addTargetValue := uint32(100 + i)
+		expectedValue += addTargetValue
+		compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+			Signature: targetFunctionType,
+		})
 
-func TestCompiler_returnFunction(t *testing.T) {
-	t.Run("exit", func(t *testing.T) {
-		env := newCompilerEnvironment()
-
-		// Compile code.
-		compiler := env.requireNewCompiler(t, newCompiler, nil)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
+
+		err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: addTargetValue})
+		require.NoError(t, err)
+		err = compiler.compilePick(&wazeroir.OperationPick{Depth: 1 + callFrameDataSizeInUint64})
+		require.NoError(t, err)
+		err = compiler.compileAdd(&wazeroir.OperationAdd{Type: wazeroir.UnsignedTypeI32})
+		require.NoError(t, err)
+		err = compiler.compileSet(&wazeroir.OperationSet{Depth: 1 + callFrameDataSizeInUint64})
+		require.NoError(t, err)
+
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		code, _, err := compiler.compile()
+		c, _, err := compiler.compile()
 		require.NoError(t, err)
+		index := wasm.Index(i)
+		me.functions = append(me.functions, &function{
+			parent:                &code{codeSegment: c},
+			codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
+			moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
+		})
+		env.module().Functions = append(env.module().Functions,
+			&wasm.FunctionInstance{Type: targetFunctionType, Idx: index})
+	}
 
-		env.exec(code)
-
-		// Compiler status must be returned.
-		require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-		// Plus, the call frame stack pointer must be zero after return.
-		require.Equal(t, uint64(0), env.callFrameStackPointer())
+	// Now we start building the caller's code.
+	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+		Signature: &wasm.FunctionType{},
+		Functions: make([]uint32, numCalls),
+		Types:     []*wasm.FunctionType{targetFunctionType},
 	})
-	t.Run("deep call stack", func(t *testing.T) {
-		env := newCompilerEnvironment()
-		moduleEngine := env.moduleEngine()
-		ce := env.callEngine()
 
-		// Push the call frames.
-		const callFrameNums = 10
-		stackPointerToExpectedValue := map[uint64]uint32{}
-		for funcIndex := wasm.Index(0); funcIndex < callFrameNums; funcIndex++ {
-			// Each function pushes its funcaddr and soon returns.
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
-			err := compiler.compilePreamble()
-			require.NoError(t, err)
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
 
-			// Push its functionIndex.
-			expValue := uint32(funcIndex)
-			err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: expValue})
-			require.NoError(t, err)
+	const initialValue = 100
+	expectedValue += initialValue
+	err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: 1234}) // Dummy value so the base pointer would be non-trivial for callees.
+	require.NoError(t, err)
+	err = compiler.compileConstI32(&wazeroir.OperationConstI32{Value: initialValue})
+	require.NoError(t, err)
 
-			err = compiler.compileReturnFunction()
-			require.NoError(t, err)
+	// Call all the built functions.
+	for i := 0; i < numCalls; i++ {
+		err = compiler.compileCall(&wazeroir.OperationCall{FunctionIndex: uint32(i)})
+		require.NoError(t, err)
+	}
 
-			c, _, err := compiler.compile()
-			require.NoError(t, err)
+	// Set the result slot
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
 
-			// Compiles and adds to the engine.
-			f := &function{
-				parent:                &code{codeSegment: c},
-				codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
-				moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
-			}
-			moduleEngine.functions = append(moduleEngine.functions, f)
+	code, _, err := compiler.compile()
+	require.NoError(t, err)
+	env.exec(code)
 
-			// Pushes the frame whose return address equals the beginning of the function just compiled.
-			frame := callFrame{
-				// Set the return address to the beginning of the function so that we can execute the constI32 above.
-				returnAddress: f.codeInitialAddress,
-				// Note: return stack base pointer is set to funcaddr*5 and this is where the const should be pushed.
-				returnStackBasePointerInBytes: (uint64(funcIndex) * 5) << 3,
-				function:                      f,
-			}
-			ce.callFrameStack[ce.globalContext.callFrameStackPointer] = frame
-			ce.globalContext.callFrameStackPointer++
-			stackPointerToExpectedValue[frame.returnStackBasePointerInBytes>>3] = expValue
-		}
-
-		require.Equal(t, uint64(callFrameNums), env.callFrameStackPointer())
-
-		// Run code from the top frame.
-		env.exec(ce.callFrameTop().function.parent.codeSegment)
-
-		// Check the exit status and the values on stack.
-		require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-		for pos, exp := range stackPointerToExpectedValue {
-			require.Equal(t, exp, uint32(env.stack()[pos]))
-		}
-	})
+	// Check status and returned values.
+	require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
+	require.Equal(t, uint64(0), env.stackBasePointer())
+	require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer()) // Must be 2 (dummy value + the calculation results)
+	require.Equal(t, expectedValue, env.stackTopAsUint32())
 }

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -125,7 +125,7 @@ func TestCompiler_compileExtend(t *testing.T) {
 					require.NoError(t, err)
 					env.exec(code)
 
-					require.Equal(t, uint64(1), env.stackPointer())
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 					if signed {
 						expected := int64(int32(v))
 						require.Equal(t, expected, env.stackTopAsInt64())
@@ -419,7 +419,7 @@ func TestCompiler_compileFConvertFromI(t *testing.T) {
 					env.exec(code)
 
 					// Check the result.
-					require.Equal(t, uint64(1), env.stackPointer())
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 					actualBits := env.stackTopAsUint64()
 					if tc.outputType == wazeroir.Float32 && tc.inputType == wazeroir.SignedInt32 {
 						exp := float32(int32(v))
@@ -490,7 +490,7 @@ func TestCompiler_compileF64PromoteFromF32(t *testing.T) {
 			env.exec(code)
 
 			// Check the result.
-			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 			if math.IsNaN(float64(v)) {
 				require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 			} else {
@@ -536,7 +536,7 @@ func TestCompiler_compileF32DemoteFromF64(t *testing.T) {
 			env.exec(code)
 
 			// Check the result.
-			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 			if math.IsNaN(v) {
 				require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 			} else {

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -125,7 +125,7 @@ func TestCompiler_compileExtend(t *testing.T) {
 					require.NoError(t, err)
 					env.exec(code)
 
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+					require.Equal(t, uint64(1), env.stackPointer())
 					if signed {
 						expected := int64(int32(v))
 						require.Equal(t, expected, env.stackTopAsInt64())
@@ -419,7 +419,7 @@ func TestCompiler_compileFConvertFromI(t *testing.T) {
 					env.exec(code)
 
 					// Check the result.
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+					require.Equal(t, uint64(1), env.stackPointer())
 					actualBits := env.stackTopAsUint64()
 					if tc.outputType == wazeroir.Float32 && tc.inputType == wazeroir.SignedInt32 {
 						exp := float32(int32(v))
@@ -490,7 +490,7 @@ func TestCompiler_compileF64PromoteFromF32(t *testing.T) {
 			env.exec(code)
 
 			// Check the result.
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 			if math.IsNaN(float64(v)) {
 				require.True(t, math.IsNaN(env.stackTopAsFloat64()))
 			} else {
@@ -536,7 +536,7 @@ func TestCompiler_compileF32DemoteFromF64(t *testing.T) {
 			env.exec(code)
 
 			// Check the result.
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 			if math.IsNaN(v) {
 				require.True(t, math.IsNaN(float64(env.stackTopAsFloat32())))
 			} else {

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -55,7 +55,7 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			// Since we call global.get, the top of the stack must be the global value.
 			require.Equal(t, globalValue, env.stackTopAsUint64())
 			// Plus as we push the value, the stack pointer must be incremented.
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 		})
 	}
 }
@@ -94,12 +94,12 @@ func TestCompiler_compileGlobalGet_v128(t *testing.T) {
 	// Run the code assembled above.
 	env.exec(code)
 
-	require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer())
+	require.Equal(t, uint64(2), env.stackPointer())
 	require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
 	// Since we call global.get, the top of the stack must be the global value.
 	actual := globals[1]
-	sp := env.stackPointer()
+	sp := env.ce.stackContext.stackPointer
 	stack := env.stack()
 	require.Equal(t, actual.Val, stack[sp-2])
 	require.Equal(t, actual.ValHi, stack[sp-1])
@@ -142,7 +142,8 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 
 			op := &wazeroir.OperationGlobalSet{Index: 1}
 			err = compiler.compileGlobalSet(op)
-			require.Equal(t, uint64(callFrameDataSizeInUint64), compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, 0, compiler)
+
 			require.NoError(t, err)
 
 			err = compiler.compileReturnFunction()
@@ -157,7 +158,7 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			actual := env.globals()[op.Index]
 			require.Equal(t, valueToSet, actual.Val)
 			// Plus we consumed the top of the stack, the stack pointer must be decremented.
-			require.Equal(t, uint64(callFrameDataSizeInUint64), env.stackPointer())
+			require.Equal(t, uint64(0), env.stackPointer())
 		})
 	}
 }
@@ -199,7 +200,7 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 	require.NoError(t, err)
 	env.exec(code)
 
-	require.Equal(t, uint64(callFrameDataSizeInUint64), env.stackPointer())
+	require.Equal(t, uint64(0), env.stackPointer())
 	require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
 	// The global value should be set to valueToSet.

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -189,7 +189,7 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 
 	op := &wazeroir.OperationGlobalSet{Index: 1}
 	err = compiler.compileGlobalSet(op)
-	require.Equal(t, uint64(callFrameDataSizeInUint64), compiler.runtimeValueLocationStack().sp)
+	requireRuntimeLocationStackPointerEqual(t, 0, compiler)
 	require.NoError(t, err)
 
 	err = compiler.compileReturnFunction()

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -61,7 +61,7 @@ func TestCompiler_compileMemorySize(t *testing.T) {
 	err = compiler.compileMemorySize()
 	require.NoError(t, err)
 	// At this point, the size of memory should be pushed onto the stack.
-	require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+	requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
@@ -250,7 +250,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 			tc.operationSetupFn(t, compiler)
 
 			// At this point, the loaded value must be on top of the stack, and placed on a register.
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 			loadedLocation := compiler.runtimeValueLocationStack().peek()
 			require.True(t, loadedLocation.onRegister())
@@ -268,7 +268,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 			env.exec(code)
 
 			// Verify the loaded value.
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 			tc.loadedValueVerifyFn(t, env.stackTopAsUint64())
 		})
 	}
@@ -392,7 +392,7 @@ func TestCompiler_compileStore(t *testing.T) {
 
 			// At this point, no registers must be in use, and no values on the stack since we consumed two values.
 			require.Zero(t, len(compiler.runtimeValueLocationStack().usedRegisters))
-			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(0), compiler)
 
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -77,9 +77,9 @@ func TestCompiler_compileConsts(t *testing.T) {
 					// Compiler status must be returned.
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 					if op == wazeroir.OperationKindV128Const {
-						require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer()) // a vector value consists of two uint64.
+						require.Equal(t, uint64(2), env.stackPointer()) // a vector value consists of two uint64.
 					} else {
-						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+						require.Equal(t, uint64(1), env.stackPointer())
 					}
 
 					switch op {
@@ -155,7 +155,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							}
 
 							// At this point, two values exist.
-							require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+							requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 
 							// Emit the operation.
 							switch kind {
@@ -169,7 +169,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							require.NoError(t, err)
 
 							// We consumed two values, but push the result back.
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+							requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 							resultLocation := compiler.runtimeValueLocationStack().peek()
 							// Plus the result must be located on a register.
 							require.True(t, resultLocation.onRegister())
@@ -189,7 +189,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							env.exec(code)
 
 							// Check the stack.
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+							require.Equal(t, uint64(1), env.stackPointer())
 
 							switch kind {
 							case wazeroir.OperationKindAdd:
@@ -325,7 +325,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								}
 
 								// At this point, two values exist.
-								require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+								requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 
 								// Emit the operation.
 								switch kind {
@@ -345,7 +345,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								require.NoError(t, err)
 
 								// We consumed two values, but push the result back.
-								require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+								requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 								resultLocation := compiler.runtimeValueLocationStack().peek()
 								// Also, the result must have an appropriate register type.
 								require.Equal(t, registerTypeGeneralPurpose, resultLocation.getRegisterType())
@@ -359,7 +359,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								env.exec(code)
 
 								// Check the stack.
-								require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+								require.Equal(t, uint64(1), env.stackPointer())
 
 								switch kind {
 								case wazeroir.OperationKindAnd:
@@ -453,14 +453,14 @@ func TestCompiler_compileShr(t *testing.T) {
 						}
 
 						// At this point, two values exist.
-						require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+						requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 
 						// Emit the operation.
 						err = compiler.compileShr(&wazeroir.OperationShr{Type: signedInt})
 						require.NoError(t, err)
 
 						// We consumed two values, but push the result back.
-						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+						requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 						resultLocation := compiler.runtimeValueLocationStack().peek()
 						// Plus the result must be located on a register.
 						require.True(t, resultLocation.onRegister())
@@ -476,7 +476,7 @@ func TestCompiler_compileShr(t *testing.T) {
 						env.exec(code)
 
 						// Check the stack.
-						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+						require.Equal(t, uint64(1), env.stackPointer())
 
 						switch signedInt {
 						case wazeroir.SignedInt32:
@@ -575,10 +575,10 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							if isEqz {
 								// Eqz only needs one value, so pop the top one (x2).
 								compiler.runtimeValueLocationStack().pop()
-								require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+								requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 							} else {
 								// At this point, two values exist for comparison.
-								require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+								requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 							}
 
 							// Emit the operation.
@@ -627,7 +627,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							require.NoError(t, err)
 
 							// We consumed two values, but push the result back.
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+							requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
@@ -638,7 +638,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							env.exec(code)
 
 							// There should only be one value on the stack
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+							require.Equal(t, uint64(1), env.stackPointer())
 
 							actual := env.stackTopAsUint32() == 1
 
@@ -793,7 +793,7 @@ func TestCompiler_compile_Clz_Ctz_Popcnt(t *testing.T) {
 							env.exec(code)
 
 							// One value must be pushed as a result.
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+							require.Equal(t, uint64(1), env.stackPointer())
 
 							switch kind {
 							case wazeroir.OperationKindClz:
@@ -978,13 +978,13 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					}
 
 					// At this point two values are pushed.
-					require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+					requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 					require.Equal(t, 2, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					tc.setupFunc(t, compiler)
 
 					// We consumed two values, but push one value after operation.
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+					requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 					require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					err = compiler.compileReturnFunction()
@@ -996,7 +996,7 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					env.exec(code)
 
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer()) // Result must be pushed!
+					require.Equal(t, uint64(1), env.stackPointer()) // Result must be pushed!
 
 					tc.verifyFunc(t, x1, x2, env.stackTopAsUint64())
 				})
@@ -1281,13 +1281,13 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					}
 
 					// At this point two values are pushed.
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+					requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 					require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					tc.setupFunc(t, compiler)
 
 					// We consumed one value, but push the result after operation.
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+					requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 					require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					err = compiler.compileReturnFunction()
@@ -1299,7 +1299,7 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					env.exec(code)
 
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer()) // Result must be pushed!
+					require.Equal(t, uint64(1), env.stackPointer()) // Result must be pushed!
 
 					tc.verifyFunc(t, v, env.stackTopAsUint64())
 				})
@@ -1394,7 +1394,7 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 							}
 
 							// At this point, two values exist for comparison.
-							require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+							requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 
 							switch kind {
 							case wazeroir.OperationKindDiv:

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -77,9 +77,9 @@ func TestCompiler_compileConsts(t *testing.T) {
 					// Compiler status must be returned.
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 					if op == wazeroir.OperationKindV128Const {
-						require.Equal(t, uint64(2), env.stackPointer()) // a vector value consists of two uint64.
+						require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer()) // a vector value consists of two uint64.
 					} else {
-						require.Equal(t, uint64(1), env.stackPointer())
+						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 					}
 
 					switch op {
@@ -155,7 +155,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							}
 
 							// At this point, two values exist.
-							require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+							require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 							// Emit the operation.
 							switch kind {
@@ -169,7 +169,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							require.NoError(t, err)
 
 							// We consumed two values, but push the result back.
-							require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 							resultLocation := compiler.runtimeValueLocationStack().peek()
 							// Plus the result must be located on a register.
 							require.True(t, resultLocation.onRegister())
@@ -189,7 +189,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							env.exec(code)
 
 							// Check the stack.
-							require.Equal(t, uint64(1), env.stackPointer())
+							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 
 							switch kind {
 							case wazeroir.OperationKindAdd:
@@ -325,7 +325,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								}
 
 								// At this point, two values exist.
-								require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+								require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 								// Emit the operation.
 								switch kind {
@@ -345,7 +345,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								require.NoError(t, err)
 
 								// We consumed two values, but push the result back.
-								require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+								require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 								resultLocation := compiler.runtimeValueLocationStack().peek()
 								// Also, the result must have an appropriate register type.
 								require.Equal(t, registerTypeGeneralPurpose, resultLocation.getRegisterType())
@@ -359,7 +359,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								env.exec(code)
 
 								// Check the stack.
-								require.Equal(t, uint64(1), env.stackPointer())
+								require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 
 								switch kind {
 								case wazeroir.OperationKindAnd:
@@ -453,14 +453,14 @@ func TestCompiler_compileShr(t *testing.T) {
 						}
 
 						// At this point, two values exist.
-						require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+						require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 						// Emit the operation.
 						err = compiler.compileShr(&wazeroir.OperationShr{Type: signedInt})
 						require.NoError(t, err)
 
 						// We consumed two values, but push the result back.
-						require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 						resultLocation := compiler.runtimeValueLocationStack().peek()
 						// Plus the result must be located on a register.
 						require.True(t, resultLocation.onRegister())
@@ -476,7 +476,7 @@ func TestCompiler_compileShr(t *testing.T) {
 						env.exec(code)
 
 						// Check the stack.
-						require.Equal(t, uint64(1), env.stackPointer())
+						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 
 						switch signedInt {
 						case wazeroir.SignedInt32:
@@ -547,7 +547,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 						isEqz := kind == wazeroir.OperationKindEqz
 						if isEqz && (signedType == wazeroir.SignedTypeFloat32 || signedType == wazeroir.SignedTypeFloat64) {
 							// Eqz isn't defined for float.
-							t.Skip()
+							return
 						}
 						t.Run(fmt.Sprintf("x1=0x%x,x2=0x%x", x1, x2), func(t *testing.T) {
 							env := newCompilerEnvironment()
@@ -575,10 +575,10 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							if isEqz {
 								// Eqz only needs one value, so pop the top one (x2).
 								compiler.runtimeValueLocationStack().pop()
-								require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+								require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 							} else {
 								// At this point, two values exist for comparison.
-								require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+								require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 							}
 
 							// Emit the operation.
@@ -627,7 +627,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							require.NoError(t, err)
 
 							// We consumed two values, but push the result back.
-							require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
@@ -638,7 +638,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							env.exec(code)
 
 							// There should only be one value on the stack
-							require.Equal(t, uint64(1), env.stackPointer())
+							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 
 							actual := env.stackTopAsUint32() == 1
 
@@ -793,7 +793,7 @@ func TestCompiler_compile_Clz_Ctz_Popcnt(t *testing.T) {
 							env.exec(code)
 
 							// One value must be pushed as a result.
-							require.Equal(t, uint64(1), env.stackPointer())
+							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 
 							switch kind {
 							case wazeroir.OperationKindClz:
@@ -978,13 +978,13 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					}
 
 					// At this point two values are pushed.
-					require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+					require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 					require.Equal(t, 2, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					tc.setupFunc(t, compiler)
 
 					// We consumed two values, but push one value after operation.
-					require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 					require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					err = compiler.compileReturnFunction()
@@ -996,7 +996,7 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					env.exec(code)
 
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-					require.Equal(t, uint64(1), env.stackPointer()) // Result must be pushed!
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer()) // Result must be pushed!
 
 					tc.verifyFunc(t, x1, x2, env.stackTopAsUint64())
 				})
@@ -1281,13 +1281,13 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					}
 
 					// At this point two values are pushed.
-					require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 					require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					tc.setupFunc(t, compiler)
 
 					// We consumed one value, but push the result after operation.
-					require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 					require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 					err = compiler.compileReturnFunction()
@@ -1299,7 +1299,7 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					env.exec(code)
 
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-					require.Equal(t, uint64(1), env.stackPointer()) // Result must be pushed!
+					require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer()) // Result must be pushed!
 
 					tc.verifyFunc(t, v, env.stackTopAsUint64())
 				})
@@ -1394,7 +1394,7 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 							}
 
 							// At this point, two values exist for comparison.
-							require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+							require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 							switch kind {
 							case wazeroir.OperationKindDiv:
@@ -1411,10 +1411,10 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 									err = compiler.compileRem(&wazeroir.OperationRem{Type: wazeroir.SignedUint64})
 								case wazeroir.SignedTypeFloat32:
 									// Rem undefined for float32.
-									t.Skip()
+									return
 								case wazeroir.SignedTypeFloat64:
 									// Rem undefined for float64.
-									t.Skip()
+									return
 								}
 							}
 							require.NoError(t, err)

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -69,7 +69,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				require.NoError(t, err)
 				env.exec(code)
 
-				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+				require.Equal(t, uint64(1), env.stackPointer())
 				require.Equal(t, tc.expected, env.stackTopAsInt32())
 			})
 		}
@@ -142,7 +142,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				require.NoError(t, err)
 				env.exec(code)
 
-				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+				require.Equal(t, uint64(1), env.stackPointer())
 				require.Equal(t, tc.expected, env.stackTopAsInt64())
 			})
 		}
@@ -798,7 +798,7 @@ func TestCompiler_compileTableSet(t *testing.T) {
 				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			} else {
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-				require.Equal(t, uint64(0)+callFrameDataSizeInUint64, env.stackPointer())
+				require.Equal(t, uint64(0), env.stackPointer())
 
 				if tc.expExtern {
 					actual := dogFromPtr(externTable.References[tc.offset])
@@ -927,7 +927,7 @@ func TestCompiler_compileTableGet(t *testing.T) {
 				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			} else {
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+				require.Equal(t, uint64(1), env.stackPointer())
 				require.Equal(t, uint64(tc.exp), env.stackTopAsUint64())
 			}
 		})
@@ -968,7 +968,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 			require.Equal(t, uintptr(unsafe.Pointer(me.functions[i])), uintptr(env.stackTopAsUint64()))
 		})
 	}

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -69,7 +69,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				require.NoError(t, err)
 				env.exec(code)
 
-				require.Equal(t, uint64(1), env.stackPointer())
+				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 				require.Equal(t, tc.expected, env.stackTopAsInt32())
 			})
 		}
@@ -142,7 +142,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				require.NoError(t, err)
 				env.exec(code)
 
-				require.Equal(t, uint64(1), env.stackPointer())
+				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 				require.Equal(t, tc.expected, env.stackTopAsInt64())
 			})
 		}
@@ -798,7 +798,7 @@ func TestCompiler_compileTableSet(t *testing.T) {
 				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			} else {
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-				require.Equal(t, uint64(0), env.stackPointer())
+				require.Equal(t, uint64(0)+callFrameDataSizeInUint64, env.stackPointer())
 
 				if tc.expExtern {
 					actual := dogFromPtr(externTable.References[tc.offset])
@@ -927,7 +927,7 @@ func TestCompiler_compileTableGet(t *testing.T) {
 				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
 			} else {
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-				require.Equal(t, uint64(1), env.stackPointer())
+				require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 				require.Equal(t, uint64(tc.exp), env.stackTopAsUint64())
 			}
 		})
@@ -968,7 +968,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 			require.Equal(t, uintptr(unsafe.Pointer(me.functions[i])), uintptr(env.stackTopAsUint64()))
 		})
 	}

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -724,7 +724,7 @@ func TestCompiler_compileSet(t *testing.T) {
 				x1Value = 1
 			}
 
-			// Swap x1 and x2.
+			// Set x2 into the x1.
 			err = compiler.compileSet(&wazeroir.OperationSet{Depth: 2})
 			require.NoError(t, err)
 
@@ -738,7 +738,7 @@ func TestCompiler_compileSet(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, uint64(2), env.stackPointer())
-			// Check the value was set.
+			// Check the value was set. Note that it is placed above the call frame.
 			require.Equal(t, uint64(x1Value), env.stack()[callFrameDataSizeInUint64])
 		})
 	}

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -116,31 +116,31 @@ type compilerEnv struct {
 }
 
 func (j *compilerEnv) stackTopAsUint32() uint32 {
-	return uint32(j.stack()[j.stackPointer()-1])
+	return uint32(j.stack()[j.ce.stackContext.stackPointer-1])
 }
 
 func (j *compilerEnv) stackTopAsInt32() int32 {
-	return int32(j.stack()[j.stackPointer()-1])
+	return int32(j.stack()[j.ce.stackContext.stackPointer-1])
 }
 func (j *compilerEnv) stackTopAsUint64() uint64 {
-	return j.stack()[j.stackPointer()-1]
+	return j.stack()[j.ce.stackContext.stackPointer-1]
 }
 
 func (j *compilerEnv) stackTopAsInt64() int64 {
-	return int64(j.stack()[j.stackPointer()-1])
+	return int64(j.stack()[j.ce.stackContext.stackPointer-1])
 }
 
 func (j *compilerEnv) stackTopAsFloat32() float32 {
-	return math.Float32frombits(uint32(j.stack()[j.stackPointer()-1]))
+	return math.Float32frombits(uint32(j.stack()[j.ce.stackContext.stackPointer-1]))
 }
 
 func (j *compilerEnv) stackTopAsFloat64() float64 {
-	return math.Float64frombits(j.stack()[j.stackPointer()-1])
+	return math.Float64frombits(j.stack()[j.ce.stackContext.stackPointer-1])
 }
 
 func (j *compilerEnv) stackTopAsV128() (lo uint64, hi uint64) {
 	st := j.stack()
-	return st[j.stackPointer()-2], st[j.stackPointer()-1]
+	return st[j.ce.stackContext.stackPointer-2], st[j.ce.stackContext.stackPointer-1]
 }
 
 func (j *compilerEnv) memory() []byte {
@@ -159,8 +159,9 @@ func (j *compilerEnv) builtinFunctionCallAddress() wasm.Index {
 	return j.ce.exitContext.builtinFunctionCallIndex
 }
 
+// stackPointer returns the stack pointer minus the call frame.
 func (j *compilerEnv) stackPointer() uint64 {
-	return j.ce.stackContext.stackPointer
+	return j.ce.stackContext.stackPointer - callFrameDataSizeInUint64
 }
 
 func (j *compilerEnv) stackBasePointer() uint64 {

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -276,3 +276,9 @@ func newCompilerEnvironment() *compilerEnv {
 		ce: me.newCallEngine(initialStackSize, nil),
 	}
 }
+
+// requireRuntimeLocationStackPointerEqual ensures that the compiler's runtimeValueLocationStack has
+// the expected stack pointer value relative to the call frame.
+func requireRuntimeLocationStackPointerEqual(t *testing.T, expSP uint64, c compiler) {
+	require.Equal(t, expSP, c.runtimeValueLocationStack().sp-callFrameDataSizeInUint64)
+}

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -35,46 +35,37 @@ func init() {
 	requireEqual(int(unsafe.Offsetof(me.functions)), moduleEngineFunctionsOffset, "moduleEngineFunctionsOffset")
 
 	var ce callEngine
-	// Offsets for callEngine.globalContext.
-	requireEqual(int(unsafe.Offsetof(ce.valueStackElement0Address)), callEngineGlobalContextValueStackElement0AddressOffset, "callEngineGlobalContextValueStackElement0AddressOffset")
-	requireEqual(int(unsafe.Offsetof(ce.valueStackLenInBytes)), callEngineGlobalContextValueStackLenInBytesOffset, "callEngineGlobalContextValueStackLenInBytesOffset")
-	requireEqual(int(unsafe.Offsetof(ce.callFrameStackElementZeroAddress)), callEngineGlobalContextCallFrameStackElement0AddressOffset, "callEngineGlobalContextCallFrameStackElement0AddressOffset")
-	requireEqual(int(unsafe.Offsetof(ce.callFrameStackLen)), callEngineGlobalContextCallFrameStackLenOffset, "callEngineGlobalContextCallFrameStackLenOffset")
-	requireEqual(int(unsafe.Offsetof(ce.callFrameStackPointer)), callEngineGlobalContextCallFrameStackPointerOffset, "callEngineGlobalContextCallFrameStackPointerOffset")
-
 	// Offsets for callEngine.moduleContext.
+	requireEqual(int(unsafe.Offsetof(ce.fn)), callEngineModuleContextFnOffset, "callEngineModuleContextFnOffset")
 	requireEqual(int(unsafe.Offsetof(ce.moduleInstanceAddress)), callEngineModuleContextModuleInstanceAddressOffset, "callEngineModuleContextModuleInstanceAddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.globalElement0Address)), callEngineModuleContextGlobalElement0AddressOffset, "callEngineModuleContextGlobalElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.memoryElement0Address)), callEngineModuleContextMemoryElement0AddressOffset, "callEngineModuleContextMemoryElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.memorySliceLen)), callEngineModuleContextMemorySliceLenOffset, "callEngineModuleContextMemorySliceLenOffset")
+	requireEqual(int(unsafe.Offsetof(ce.memoryInstance)), callEngineModuleContextMemoryInstanceOffset, "callEngineModuleContextMemoryInstanceOffset")
 	requireEqual(int(unsafe.Offsetof(ce.tablesElement0Address)), callEngineModuleContextTablesElement0AddressOffset, "callEngineModuleContextTablesElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.functionsElement0Address)), callEngineModuleContextFunctionsElement0AddressOffset, "callEngineModuleContextFunctionsElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.typeIDsElement0Address)), callEngineModuleContextTypeIDsElement0AddressOffset, "callEngineModuleContextTypeIDsElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.dataInstancesElement0Address)), callEngineModuleContextDataInstancesElement0AddressOffset, "callEngineModuleContextDataInstancesElement0AddressOffset")
 	requireEqual(int(unsafe.Offsetof(ce.elementInstancesElement0Address)), callEngineModuleContextElementInstancesElement0AddressOffset, "callEngineModuleContextElementInstancesElement0AddressOffset")
 
-	// Offsets for callEngine.valueStackContext
-	requireEqual(int(unsafe.Offsetof(ce.stackPointer)), callEngineValueStackContextStackPointerOffset, "callEngineValueStackContextStackPointerOffset")
-	requireEqual(int(unsafe.Offsetof(ce.stackBasePointerInBytes)), callEngineValueStackContextStackBasePointerInBytesOffset, "callEngineValueStackContextStackBasePointerInBytesOffset")
+	// Offsets for callEngine.stackContext
+	requireEqual(int(unsafe.Offsetof(ce.stackPointer)), callEngineStackContextStackPointerOffset, "callEngineStackContextStackPointerOffset")
+	requireEqual(int(unsafe.Offsetof(ce.stackBasePointerInBytes)), callEngineStackContextStackBasePointerInBytesOffset, "callEngineStackContextStackBasePointerInBytesOffset")
+	requireEqual(int(unsafe.Offsetof(ce.stackElement0Address)), callEngineStackContextStackElement0AddressOffset, "callEngineStackContextStackElement0AddressOffset")
+	requireEqual(int(unsafe.Offsetof(ce.stackLenInBytes)), callEngineStackContextStackLenInBytesOffset, "callEngineStackContextStackLenInBytesOffset")
 
 	// Offsets for callEngine.exitContext.
 	requireEqual(int(unsafe.Offsetof(ce.statusCode)), callEngineExitContextNativeCallStatusCodeOffset, "callEngineExitContextNativeCallStatusCodeOffset")
-	requireEqual(int(unsafe.Offsetof(ce.builtinFunctionCallIndex)), callEngineExitContextBuiltinFunctionCallAddressOffset, "callEngineExitContextBuiltinFunctionCallAddressOffset")
+	requireEqual(int(unsafe.Offsetof(ce.builtinFunctionCallIndex)), callEngineExitContextBuiltinFunctionCallIndexOffset, "callEngineExitContextBuiltinFunctionCallIndexOffset")
+	requireEqual(int(unsafe.Offsetof(ce.returnAddress)), callEngineExitContextReturnAddressOffset, "callEngineExitContextReturnAddressOffset")
 
 	// Size and offsets for callFrame.
 	var frame callFrame
-	requireEqual(int(unsafe.Sizeof(frame)), callFrameDataSize, "callFrameDataSize")
-	// Sizeof call-frame must be a power of 2 as we do SHL on the index by "callFrameDataSizeMostSignificantSetBit" to obtain the offset address.
-	requireEqual(0, callFrameDataSize&(callFrameDataSize-1), "callFrameDataSize&(callFrameDataSize-1)")
-	requireEqual(math.Ilogb(float64(callFrameDataSize)), callFrameDataSizeMostSignificantSetBit, "callFrameDataSizeMostSignificantSetBit")
-	requireEqual(int(unsafe.Offsetof(frame.returnAddress)), callFrameReturnAddressOffset, "callFrameReturnAddressOffset")
-	requireEqual(int(unsafe.Offsetof(frame.returnStackBasePointerInBytes)), callFrameReturnStackBasePointerInBytesOffset, "callFrameReturnStackBasePointerInBytesOffset")
-	requireEqual(int(unsafe.Offsetof(frame.function)), callFrameFunctionOffset, "callFrameFunctionOffset")
+	requireEqual(int(unsafe.Sizeof(frame))/8, callFrameDataSizeInUint64, "callFrameDataSize")
 
 	// Offsets for code.
 	var compiledFunc function
 	requireEqual(int(unsafe.Offsetof(compiledFunc.codeInitialAddress)), functionCodeInitialAddressOffset, "functionCodeInitialAddressOffset")
-	requireEqual(int(unsafe.Offsetof(compiledFunc.stackPointerCeil)), functionStackPointerCeilOffset, "functionStackPointerCeilOffset")
 	requireEqual(int(unsafe.Offsetof(compiledFunc.source)), functionSourceOffset, "functionSourceOffset")
 	requireEqual(int(unsafe.Offsetof(compiledFunc.moduleInstanceAddress)), functionModuleInstanceAddressOffset, "functionModuleInstanceAddressOffset")
 
@@ -157,7 +148,7 @@ func (j *compilerEnv) memory() []byte {
 }
 
 func (j *compilerEnv) stack() []uint64 {
-	return j.ce.valueStack
+	return j.ce.stack
 }
 
 func (j *compilerEnv) compilerStatus() nativeCallStatusCode {
@@ -169,15 +160,15 @@ func (j *compilerEnv) builtinFunctionCallAddress() wasm.Index {
 }
 
 func (j *compilerEnv) stackPointer() uint64 {
-	return j.ce.valueStackContext.stackPointer
+	return j.ce.stackContext.stackPointer
 }
 
 func (j *compilerEnv) stackBasePointer() uint64 {
-	return j.ce.valueStackContext.stackBasePointerInBytes >> 3
+	return j.ce.stackContext.stackBasePointerInBytes >> 3
 }
 
 func (j *compilerEnv) setStackPointer(sp uint64) {
-	j.ce.valueStackContext.stackPointer = sp
+	j.ce.stackContext.stackPointer = sp
 }
 
 func (j *compilerEnv) addGlobals(g ...*wasm.GlobalInstance) {
@@ -192,20 +183,8 @@ func (j *compilerEnv) addTable(table *wasm.TableInstance) {
 	j.moduleInstance.Tables = append(j.moduleInstance.Tables, table)
 }
 
-func (j *compilerEnv) callFrameStackPeek() *callFrame {
-	return &j.ce.callFrameStack[j.ce.globalContext.callFrameStackPointer-1]
-}
-
-func (j *compilerEnv) callFrameStackPointer() uint64 {
-	return j.ce.globalContext.callFrameStackPointer
-}
-
-func (j *compilerEnv) setValueStackBasePointer(sp uint64) {
-	j.ce.valueStackContext.stackBasePointerInBytes = sp << 3
-}
-
-func (j *compilerEnv) setCallFrameStackPointerLen(l uint64) {
-	j.ce.callFrameStackLen = l
+func (j *compilerEnv) setStackBasePointer(sp uint64) {
+	j.ce.stackContext.stackBasePointerInBytes = sp << 3
 }
 
 func (j *compilerEnv) module() *wasm.ModuleInstance {
@@ -235,9 +214,8 @@ func (j *compilerEnv) newFunction(codeSegment []byte) *function {
 
 func (j *compilerEnv) exec(codeSegment []byte) {
 	f := j.newFunction(codeSegment)
-	j.ce.callFrameStack[j.ce.globalContext.callFrameStackPointer] = callFrame{function: f}
-	j.ce.globalContext.callFrameStackPointer++
-	j.ce.compiled = f
+	j.ce.initialFn = f
+	j.ce.fn = f
 
 	nativecall(
 		uintptr(unsafe.Pointer(&codeSegment[0])),
@@ -272,7 +250,7 @@ func (j *compilerEnv) requireNewCompiler(t *testing.T, fn newTestCompiler, ir *w
 type compilerImpl interface {
 	compiler
 	compileExitFromNativeCode(nativeCallStatusCode)
-	compileMaybeGrowValueStack() error
+	compileMaybeGrowStack() error
 	compileReturnFunction() error
 	getOnStackPointerCeilDeterminedCallBack() func(uint64)
 	setStackPointerCeil(uint64)
@@ -294,6 +272,6 @@ func newCompilerEnvironment() *compilerEnv {
 			Globals: []*wasm.GlobalInstance{},
 			Engine:  me,
 		},
-		ce: me.newCallEngine(nil, nil),
+		ce: me.newCallEngine(initialStackSize, nil),
 	}
 }

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -388,8 +388,8 @@ func (v *runtimeValueLocationStack) getCallFrameLocations(sig *wasm.FunctionType
 	return v.stack[offset], v.stack[offset+1], v.stack[offset+2]
 }
 
-// pushCallFrame pushes a call frame's runtime locations onto the stack when the function call parameters
-// are already pushed there.
+// pushCallFrame pushes a call frame's runtime locations onto the stack assuming that
+// the function call parameters are already pushed there.
 //
 // See the diagram in callEngine.stack.
 func (v *runtimeValueLocationStack) pushCallFrame(callTargetFunctionType *wasm.FunctionType) (

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 var (
@@ -14,10 +15,6 @@ var (
 	// unreservedVectorRegisters contains unreserved vector registers.
 	unreservedVectorRegisters []asm.Register
 )
-
-func isNilRegister(r asm.Register) bool {
-	return r == asm.NilRegister
-}
 
 func isGeneralPurposeRegister(r asm.Register) bool {
 	return unreservedGeneralPurposeRegisters[0] <= r && r <= unreservedGeneralPurposeRegisters[len(unreservedGeneralPurposeRegisters)-1]
@@ -212,7 +209,7 @@ func (v *runtimeValueLocationStack) push(loc *runtimeValueLocation) {
 	}
 	v.sp++
 	// stackPointerCeil must be set after sp is incremented since
-	// we skip the stack grow if len(valueStack) >= basePointer+stackPointerCeil.
+	// we skip the stack grow if len(stack) >= basePointer+stackPointerCeil.
 	if v.sp > v.stackPointerCeil {
 		v.stackPointerCeil = v.sp
 	}
@@ -342,4 +339,76 @@ func (v *runtimeValueLocationStack) takeStealTargetFromUsedRegister(tp registerT
 		}
 	}
 	return nil, false
+}
+
+// setupInitialStack set up the runtimeValueLocationStack which reflects the state of
+// the stack at the beginning of the function.
+//
+// See the diagram in callEngine.stack.
+func (v *runtimeValueLocationStack) setupInitialStack(sig *wasm.FunctionType) {
+	for _, t := range sig.Params {
+		loc := v.pushRuntimeValueLocationOnStack()
+		switch t {
+		case wasm.ValueTypeI32:
+			loc.valueType = runtimeValueTypeI32
+		case wasm.ValueTypeI64, wasm.ValueTypeFuncref, wasm.ValueTypeExternref:
+			loc.valueType = runtimeValueTypeI64
+		case wasm.ValueTypeF32:
+			loc.valueType = runtimeValueTypeF32
+		case wasm.ValueTypeF64:
+			loc.valueType = runtimeValueTypeF64
+		case wasm.ValueTypeV128:
+			loc.valueType = runtimeValueTypeV128Lo
+			hi := v.pushRuntimeValueLocationOnStack()
+			hi.valueType = runtimeValueTypeV128Hi
+		default:
+			panic("BUG")
+		}
+	}
+
+	// If the len(results) > len(args), the slots for all results are reserved after
+	// arguments, so we reflect that into the location stack.
+	for i := 0; i < sig.ResultNumInUint64-sig.ParamNumInUint64; i++ {
+		_ = v.pushRuntimeValueLocationOnStack()
+	}
+
+	// Then push the control frame fields.
+	for i := 0; i < callFrameDataSizeInUint64; i++ {
+		loc := v.pushRuntimeValueLocationOnStack()
+		loc.valueType = runtimeValueTypeI64
+	}
+}
+
+// getCallFrameLocations returns each field of callFrame's runtime location.
+//
+// See the diagram in callEngine.stack.
+func (v *runtimeValueLocationStack) getCallFrameLocations(sig *wasm.FunctionType) (
+	returnAddress, callerStackBasePointerInBytes, callerFunction *runtimeValueLocation) {
+	offset := callFrameOffset(sig)
+	return v.stack[offset], v.stack[offset+1], v.stack[offset+2]
+}
+
+// pushCallFrame pushes a call frame's runtime locations onto the stack when the function call parameters
+// are already pushed there.
+//
+// See the diagram in callEngine.stack.
+func (v *runtimeValueLocationStack) pushCallFrame(callTargetFunctionType *wasm.FunctionType) (
+	returnAddress, callerStackBasePointerInBytes, callerFunction *runtimeValueLocation,
+) {
+	// If len(results) > len(args), we reserve the slots for the results below the call frame.
+	reservedSlotsBeforeCallFrame := callTargetFunctionType.ResultNumInUint64 - callTargetFunctionType.ParamNumInUint64
+	for i := 0; i < reservedSlotsBeforeCallFrame; i++ {
+		v.pushRuntimeValueLocationOnStack()
+	}
+
+	// callFrame.returnAddress
+	returnAddress = v.pushRuntimeValueLocationOnStack()
+	returnAddress.valueType = runtimeValueTypeI64
+	// callFrame.returnStackBasePointerInBytes
+	callerStackBasePointerInBytes = v.pushRuntimeValueLocationOnStack()
+	callerStackBasePointerInBytes.valueType = runtimeValueTypeI64
+	// callFrame.function
+	callerFunction = v.pushRuntimeValueLocationOnStack()
+	callerFunction.valueType = runtimeValueTypeI64
+	return
 }

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -341,11 +341,11 @@ func (v *runtimeValueLocationStack) takeStealTargetFromUsedRegister(tp registerT
 	return nil, false
 }
 
-// setupInitialStack set up the runtimeValueLocationStack which reflects the state of
+// init sets up the runtimeValueLocationStack which reflects the state of
 // the stack at the beginning of the function.
 //
 // See the diagram in callEngine.stack.
-func (v *runtimeValueLocationStack) setupInitialStack(sig *wasm.FunctionType) {
+func (v *runtimeValueLocationStack) init(sig *wasm.FunctionType) {
 	for _, t := range sig.Params {
 		loc := v.pushRuntimeValueLocationOnStack()
 		switch t {

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -401,6 +401,9 @@ func (v *runtimeValueLocationStack) pushCallFrame(callTargetFunctionType *wasm.F
 		v.pushRuntimeValueLocationOnStack()
 	}
 
+	// Push the runtime location for each field of callFrame struct. Note that each of them has
+	// uint64 type, and therefore must be treated as runtimeValueTypeI64.
+
 	// callFrame.returnAddress
 	returnAddress = v.pushRuntimeValueLocationOnStack()
 	returnAddress.valueType = runtimeValueTypeI64

--- a/internal/engine/compiler/compiler_value_location_test.go
+++ b/internal/engine/compiler/compiler_value_location_test.go
@@ -185,7 +185,7 @@ func TestRuntimeValueLocationStack_setupInitialStack(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			s := newRuntimeValueLocationStack()
-			s.setupInitialStack(tc.sig)
+			s.init(tc.sig)
 			require.Equal(t, tc.expectedSP, s.sp)
 
 			callFrameLocations := s.stack[s.sp-callFrameDataSizeInUint64 : s.sp]

--- a/internal/engine/compiler/compiler_value_location_test.go
+++ b/internal/engine/compiler/compiler_value_location_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 func Test_isIntRegister(t *testing.T) {
@@ -118,4 +119,104 @@ func TestRuntimeValueLocationStack_takeStealTargetFromUsedRegister(t *testing.T)
 	target, ok = s.takeStealTargetFromUsedRegister(registerTypeGeneralPurpose)
 	require.False(t, ok)
 	require.Nil(t, target)
+}
+
+func TestRuntimeValueLocationStack_setupInitialStack(t *testing.T) {
+	const f32 = wasm.ValueTypeF32
+	tests := []struct {
+		name       string
+		sig        *wasm.FunctionType
+		expectedSP uint64
+	}{
+		{
+			name:       "no params / no results",
+			sig:        &wasm.FunctionType{},
+			expectedSP: callFrameDataSizeInUint64,
+		},
+		{
+			name: "no results",
+			sig: &wasm.FunctionType{
+				Params:           []wasm.ValueType{f32, f32},
+				ParamNumInUint64: 2,
+			},
+			expectedSP: callFrameDataSizeInUint64 + 2,
+		},
+		{
+			name: "no params",
+			sig: &wasm.FunctionType{
+				Results:           []wasm.ValueType{f32, f32},
+				ResultNumInUint64: 2,
+			},
+			expectedSP: callFrameDataSizeInUint64 + 2,
+		},
+		{
+			name: "params == results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{f32, f32},
+				ParamNumInUint64:  2,
+				Results:           []wasm.ValueType{f32, f32},
+				ResultNumInUint64: 2,
+			},
+			expectedSP: callFrameDataSizeInUint64 + 2,
+		},
+		{
+			name: "params > results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{f32, f32, f32},
+				ParamNumInUint64:  3,
+				Results:           []wasm.ValueType{f32, f32},
+				ResultNumInUint64: 2,
+			},
+			expectedSP: callFrameDataSizeInUint64 + 3,
+		},
+		{
+			name: "params <  results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{f32},
+				ParamNumInUint64:  1,
+				Results:           []wasm.ValueType{f32, f32, f32},
+				ResultNumInUint64: 3,
+			},
+			expectedSP: callFrameDataSizeInUint64 + 3,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := newRuntimeValueLocationStack()
+			s.setupInitialStack(tc.sig)
+			require.Equal(t, tc.expectedSP, s.sp)
+
+			callFrameLocations := s.stack[s.sp-callFrameDataSizeInUint64 : s.sp]
+			for _, loc := range callFrameLocations {
+				require.Equal(t, runtimeValueTypeI64, loc.valueType)
+			}
+		})
+	}
+}
+
+func TestRuntimeValueLocation_pushCallFrame(t *testing.T) {
+	for _, sig := range []*wasm.FunctionType{
+		{ParamNumInUint64: 0, ResultNumInUint64: 1},
+		{ParamNumInUint64: 1, ResultNumInUint64: 0},
+		{ParamNumInUint64: 1, ResultNumInUint64: 1},
+		{ParamNumInUint64: 0, ResultNumInUint64: 2},
+		{ParamNumInUint64: 2, ResultNumInUint64: 0},
+		{ParamNumInUint64: 2, ResultNumInUint64: 3},
+	} {
+		sig := sig
+		t.Run(sig.String(), func(t *testing.T) {
+			s := newRuntimeValueLocationStack()
+			// pushCallFrame assumes that the parameters are already pushed.
+			s.sp += uint64(sig.ParamNumInUint64)
+
+			retAddr, stackBasePointer, fn := s.pushCallFrame(sig)
+
+			expOffset := uint64(callFrameOffset(sig))
+			require.Equal(t, expOffset, retAddr.stackPointer)
+			require.Equal(t, expOffset+1, stackBasePointer.stackPointer)
+			require.Equal(t, expOffset+2, fn.stackPointer)
+		})
+	}
 }

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -86,7 +86,7 @@ func TestCompiler_compileV128Add(t *testing.T) {
 			err = compiler.compileV128Add(&wazeroir.OperationV128Add{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -184,7 +184,7 @@ func TestCompiler_compileV128Sub(t *testing.T) {
 			err = compiler.compileV128Sub(&wazeroir.OperationV128Sub{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -557,7 +557,7 @@ func TestCompiler_compileV128Load(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 			loadedLocation := compiler.runtimeValueLocationStack().peek()
 			require.True(t, loadedLocation.onRegister())
@@ -572,7 +572,7 @@ func TestCompiler_compileV128Load(t *testing.T) {
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
-			require.Equal(t, uint64(2), env.stackPointer())
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer())
 			lo, hi := env.stackTopAsV128()
 
 			var actual [16]byte
@@ -765,7 +765,7 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 			loadedLocation := compiler.runtimeValueLocationStack().peek()
 			require.True(t, loadedLocation.onRegister())
@@ -778,7 +778,7 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			require.NoError(t, err)
 			env.exec(code)
 
-			require.Equal(t, uint64(2), env.stackPointer())
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer())
 			lo, hi := env.stackTopAsV128()
 
 			var actual [16]byte
@@ -819,7 +819,7 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			err = compiler.compileV128Store(&wazeroir.OperationV128Store{Arg: &wazeroir.MemoryArg{}})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(0), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -830,7 +830,7 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			require.NoError(t, err)
 			env.exec(code)
 
-			require.Equal(t, uint64(0), env.stackPointer())
+			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, env.stackPointer())
 
 			mem := env.memory()
 			require.Equal(t, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -961,7 +961,7 @@ func TestCompiler_compileV128StoreLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(0), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1132,7 +1132,7 @@ func TestCompiler_compileV128ExtractLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			vt := compiler.runtimeValueLocationStack().peek().valueType
@@ -1381,7 +1381,7 @@ func TestCompiler_compileV128ReplaceLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1479,7 +1479,7 @@ func TestCompiler_compileV128Splat(t *testing.T) {
 			err = compiler.compileV128Splat(&wazeroir.OperationV128Splat{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1527,7 +1527,7 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			err = compiler.compileV128AnyTrue(&wazeroir.OperationV128AnyTrue{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
@@ -1538,7 +1538,7 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
-			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 			require.Equal(t, tc.exp, env.stackTopAsUint32())
 		})
 	}
@@ -1700,7 +1700,7 @@ func TestCompiler_compileV128AllTrue(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
-			require.Equal(t, uint64(1), env.stackPointer())
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
 			require.Equal(t, tc.exp, env.stackTopAsUint32())
 		})
 	}
@@ -1790,7 +1790,7 @@ func TestCompiler_compileV128Swizzle(t *testing.T) {
 			err = compiler.compileV128Swizzle(&wazeroir.OperationV128Swizzle{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1900,7 +1900,7 @@ func TestCompiler_compileV128Shuffle(t *testing.T) {
 			err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: tc.lanes})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2036,7 +2036,7 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 			err = compiler.compileV128BitMask(&wazeroir.OperationV128BitMask{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(1), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2073,7 +2073,7 @@ func TestCompiler_compileV128_Not(t *testing.T) {
 	err = compiler.compileV128Not(&wazeroir.OperationV128Not{})
 	require.NoError(t, err)
 
-	require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+	require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 	require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 	err = compiler.compileReturnFunction()
@@ -2301,7 +2301,7 @@ func TestCompiler_compileV128_And_Or_Xor_AndNot(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2395,7 +2395,7 @@ func TestCompiler_compileV128Bitselect(t *testing.T) {
 			err = compiler.compileV128Bitselect(nil)
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2680,7 +2680,7 @@ func TestCompiler_compileV128Shl(t *testing.T) {
 			err = compiler.compileV128Shl(&wazeroir.OperationV128Shl{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2956,7 +2956,7 @@ func TestCompiler_compileV128Shr(t *testing.T) {
 			err = compiler.compileV128Shr(&wazeroir.OperationV128Shr{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3387,7 +3387,7 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 			err = compiler.compileV128Cmp(&wazeroir.OperationV128Cmp{Type: tc.cmpType})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3468,7 +3468,7 @@ func TestCompiler_compileV128AvgrU(t *testing.T) {
 			err = compiler.compileV128AvgrU(&wazeroir.OperationV128AvgrU{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3535,7 +3535,7 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 			err = compiler.compileV128Sqrt(&wazeroir.OperationV128Sqrt{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3625,7 +3625,7 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 			err = compiler.compileV128Mul(&wazeroir.OperationV128Mul{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3722,7 +3722,7 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 			err = compiler.compileV128Neg(&wazeroir.OperationV128Neg{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3819,7 +3819,7 @@ func TestCompiler_compileV128Abs(t *testing.T) {
 			err = compiler.compileV128Abs(&wazeroir.OperationV128Abs{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3895,7 +3895,7 @@ func TestCompiler_compileV128Div(t *testing.T) {
 			err = compiler.compileV128Div(&wazeroir.OperationV128Div{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4088,7 +4088,7 @@ func TestCompiler_compileV128Min(t *testing.T) {
 			err = compiler.compileV128Min(&wazeroir.OperationV128Min{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4315,7 +4315,7 @@ func TestCompiler_compileV128Max(t *testing.T) {
 			err = compiler.compileV128Max(&wazeroir.OperationV128Max{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4456,7 +4456,7 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 			err = compiler.compileV128AddSat(&wazeroir.OperationV128AddSat{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4568,7 +4568,7 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 			err = compiler.compileV128SubSat(&wazeroir.OperationV128SubSat{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4638,7 +4638,7 @@ func TestCompiler_compileV128Popcnt(t *testing.T) {
 			err = compiler.compileV128Popcnt(&wazeroir.OperationV128Popcnt{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4818,7 +4818,7 @@ func TestCompiler_compileV128Round(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -5111,7 +5111,7 @@ func TestCompiler_compileV128_Pmax_Pmin(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -5805,7 +5805,7 @@ func TestCompiler_compileV128ExtMul(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6278,7 +6278,7 @@ func TestCompiler_compileV128Extend(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6363,7 +6363,7 @@ func TestCompiler_compileV128Q15mulrSatS(t *testing.T) {
 			err = compiler.compileV128Q15mulrSatS(&wazeroir.OperationV128Q15mulrSatS{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6436,7 +6436,7 @@ func TestCompiler_compileFloatPromote(t *testing.T) {
 			err = compiler.compileV128FloatPromote(&wazeroir.OperationV128FloatPromote{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6520,7 +6520,7 @@ func TestCompiler_compileV128FloatDemote(t *testing.T) {
 			err = compiler.compileV128FloatDemote(&wazeroir.OperationV128FloatDemote{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6730,7 +6730,7 @@ func TestCompiler_compileV128ExtAddPairwise(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6978,7 +6978,7 @@ func TestCompiler_compileV128Narrow(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7115,7 +7115,7 @@ func TestCompiler_compileV128FConvertFromI(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7187,7 +7187,7 @@ func TestCompiler_compileV128Dot(t *testing.T) {
 			err = compiler.compileV128Dot(&wazeroir.OperationV128Dot{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7339,7 +7339,7 @@ func TestCompiler_compileV128ITruncSatFromF(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7392,7 +7392,7 @@ func TestCompiler_compileSelect_v128(t *testing.T) {
 		err = compiler.compileSelect(&wazeroir.OperationSelect{IsTargetVector: true})
 		require.NoError(t, err)
 
-		require.Equal(t, uint64(2), compiler.runtimeValueLocationStack().sp)
+		require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 		require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 		err = compiler.compileReturnFunction()

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -86,7 +86,7 @@ func TestCompiler_compileV128Add(t *testing.T) {
 			err = compiler.compileV128Add(&wazeroir.OperationV128Add{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -184,7 +184,7 @@ func TestCompiler_compileV128Sub(t *testing.T) {
 			err = compiler.compileV128Sub(&wazeroir.OperationV128Sub{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -557,7 +557,7 @@ func TestCompiler_compileV128Load(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 			loadedLocation := compiler.runtimeValueLocationStack().peek()
 			require.True(t, loadedLocation.onRegister())
@@ -572,7 +572,7 @@ func TestCompiler_compileV128Load(t *testing.T) {
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(2), env.stackPointer())
 			lo, hi := env.stackTopAsV128()
 
 			var actual [16]byte
@@ -765,7 +765,7 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 			loadedLocation := compiler.runtimeValueLocationStack().peek()
 			require.True(t, loadedLocation.onRegister())
@@ -778,7 +778,7 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			require.NoError(t, err)
 			env.exec(code)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(2), env.stackPointer())
 			lo, hi := env.stackTopAsV128()
 
 			var actual [16]byte
@@ -819,7 +819,7 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			err = compiler.compileV128Store(&wazeroir.OperationV128Store{Arg: &wazeroir.MemoryArg{}})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(0), compiler)
 			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -830,7 +830,7 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			require.NoError(t, err)
 			env.exec(code)
 
-			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(0), env.stackPointer())
 
 			mem := env.memory()
 			require.Equal(t, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -961,7 +961,7 @@ func TestCompiler_compileV128StoreLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(0)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(0), compiler)
 			require.Equal(t, 0, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1132,7 +1132,7 @@ func TestCompiler_compileV128ExtractLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			vt := compiler.runtimeValueLocationStack().peek().valueType
@@ -1381,7 +1381,7 @@ func TestCompiler_compileV128ReplaceLane(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1479,7 +1479,7 @@ func TestCompiler_compileV128Splat(t *testing.T) {
 			err = compiler.compileV128Splat(&wazeroir.OperationV128Splat{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1527,7 +1527,7 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			err = compiler.compileV128AnyTrue(&wazeroir.OperationV128AnyTrue{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
@@ -1538,7 +1538,7 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 			require.Equal(t, tc.exp, env.stackTopAsUint32())
 		})
 	}
@@ -1700,7 +1700,7 @@ func TestCompiler_compileV128AllTrue(t *testing.T) {
 			env.exec(code)
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+			require.Equal(t, uint64(1), env.stackPointer())
 			require.Equal(t, tc.exp, env.stackTopAsUint32())
 		})
 	}
@@ -1790,7 +1790,7 @@ func TestCompiler_compileV128Swizzle(t *testing.T) {
 			err = compiler.compileV128Swizzle(&wazeroir.OperationV128Swizzle{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -1900,7 +1900,7 @@ func TestCompiler_compileV128Shuffle(t *testing.T) {
 			err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: tc.lanes})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2036,7 +2036,7 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 			err = compiler.compileV128BitMask(&wazeroir.OperationV128BitMask{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(1)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(1), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2073,7 +2073,7 @@ func TestCompiler_compileV128_Not(t *testing.T) {
 	err = compiler.compileV128Not(&wazeroir.OperationV128Not{})
 	require.NoError(t, err)
 
-	require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+	requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 	require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 	err = compiler.compileReturnFunction()
@@ -2301,7 +2301,7 @@ func TestCompiler_compileV128_And_Or_Xor_AndNot(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2395,7 +2395,7 @@ func TestCompiler_compileV128Bitselect(t *testing.T) {
 			err = compiler.compileV128Bitselect(nil)
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2680,7 +2680,7 @@ func TestCompiler_compileV128Shl(t *testing.T) {
 			err = compiler.compileV128Shl(&wazeroir.OperationV128Shl{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -2956,7 +2956,7 @@ func TestCompiler_compileV128Shr(t *testing.T) {
 			err = compiler.compileV128Shr(&wazeroir.OperationV128Shr{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3387,7 +3387,7 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 			err = compiler.compileV128Cmp(&wazeroir.OperationV128Cmp{Type: tc.cmpType})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3468,7 +3468,7 @@ func TestCompiler_compileV128AvgrU(t *testing.T) {
 			err = compiler.compileV128AvgrU(&wazeroir.OperationV128AvgrU{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3535,7 +3535,7 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 			err = compiler.compileV128Sqrt(&wazeroir.OperationV128Sqrt{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3625,7 +3625,7 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 			err = compiler.compileV128Mul(&wazeroir.OperationV128Mul{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3722,7 +3722,7 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 			err = compiler.compileV128Neg(&wazeroir.OperationV128Neg{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3819,7 +3819,7 @@ func TestCompiler_compileV128Abs(t *testing.T) {
 			err = compiler.compileV128Abs(&wazeroir.OperationV128Abs{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -3895,7 +3895,7 @@ func TestCompiler_compileV128Div(t *testing.T) {
 			err = compiler.compileV128Div(&wazeroir.OperationV128Div{Shape: tc.shape})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4088,7 +4088,7 @@ func TestCompiler_compileV128Min(t *testing.T) {
 			err = compiler.compileV128Min(&wazeroir.OperationV128Min{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4315,7 +4315,7 @@ func TestCompiler_compileV128Max(t *testing.T) {
 			err = compiler.compileV128Max(&wazeroir.OperationV128Max{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4456,7 +4456,7 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 			err = compiler.compileV128AddSat(&wazeroir.OperationV128AddSat{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4568,7 +4568,7 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 			err = compiler.compileV128SubSat(&wazeroir.OperationV128SubSat{Shape: tc.shape, Signed: tc.signed})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4638,7 +4638,7 @@ func TestCompiler_compileV128Popcnt(t *testing.T) {
 			err = compiler.compileV128Popcnt(&wazeroir.OperationV128Popcnt{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -4818,7 +4818,7 @@ func TestCompiler_compileV128Round(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -5111,7 +5111,7 @@ func TestCompiler_compileV128_Pmax_Pmin(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -5805,7 +5805,7 @@ func TestCompiler_compileV128ExtMul(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6278,7 +6278,7 @@ func TestCompiler_compileV128Extend(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6363,7 +6363,7 @@ func TestCompiler_compileV128Q15mulrSatS(t *testing.T) {
 			err = compiler.compileV128Q15mulrSatS(&wazeroir.OperationV128Q15mulrSatS{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6436,7 +6436,7 @@ func TestCompiler_compileFloatPromote(t *testing.T) {
 			err = compiler.compileV128FloatPromote(&wazeroir.OperationV128FloatPromote{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6520,7 +6520,7 @@ func TestCompiler_compileV128FloatDemote(t *testing.T) {
 			err = compiler.compileV128FloatDemote(&wazeroir.OperationV128FloatDemote{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6730,7 +6730,7 @@ func TestCompiler_compileV128ExtAddPairwise(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -6978,7 +6978,7 @@ func TestCompiler_compileV128Narrow(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7115,7 +7115,7 @@ func TestCompiler_compileV128FConvertFromI(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7187,7 +7187,7 @@ func TestCompiler_compileV128Dot(t *testing.T) {
 			err = compiler.compileV128Dot(&wazeroir.OperationV128Dot{})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7339,7 +7339,7 @@ func TestCompiler_compileV128ITruncSatFromF(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -7392,7 +7392,7 @@ func TestCompiler_compileSelect_v128(t *testing.T) {
 		err = compiler.compileSelect(&wazeroir.OperationSelect{IsTargetVector: true})
 		require.NoError(t, err)
 
-		require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+		requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 		require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 		err = compiler.compileReturnFunction()

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -823,7 +823,7 @@ entry:
 // The default value should suffice for most use cases. Those wishing to change this can via `go build -ldflags`.
 //
 // TODO: allows to configure this via context?
-var callStackCeiling = uint64(10000000) // in uint64 (8 bytes) == 80000000 bytes in total == 80mb.
+var callStackCeiling = uint64(5000000) // in uint64 (8 bytes) == 40000000 bytes in total == 40mb.
 
 func (ce *callEngine) builtinFunctionGrowStack(stackPointerCeil uint64) {
 	oldLen := uint64(len(ce.stack))

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -834,7 +834,6 @@ func (ce *callEngine) builtinFunctionGrowStack(stackPointerCeil uint64) {
 	// Extends the stack's length to oldLen*2+stackPointerCeil.
 	newLen := oldLen<<1 + (stackPointerCeil)
 	newStack := make([]uint64, newLen)
-	ce.stackTopIndex()
 	top := ce.stackTopIndex()
 	copy(newStack[:top], ce.stack[:top])
 	ce.stack = newStack

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -290,9 +290,6 @@ const (
 	callEngineExitContextBuiltinFunctionCallIndexOffset = 124
 	callEngineExitContextReturnAddressOffset            = 128
 
-	// Offsets for callFrame.
-	callFrameDataSizeInUint64 = 24 / 8
-
 	// Offsets for function.
 	functionCodeInitialAddressOffset    = 0
 	functionSourceOffset                = 16
@@ -334,6 +331,9 @@ const (
 
 	// pointerSizeLog2 satisfies: 1 << pointerSizeLog2 = sizeOf(uintptr)
 	pointerSizeLog2 = 3
+
+	// callFrameDataSizeInUint64 is the size of callFrame struct per 8 bytes (= size of uint64).
+	callFrameDataSizeInUint64 = 24 / 8
 )
 
 // nativeCallStatusCode represents the result of `nativecall`.

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -51,54 +51,81 @@ type (
 		// These contexts are read and written by compiled code.
 		// Note: structs are embedded to reduce the costs to access fields inside them. Also, this eases field offset
 		// calculation.
-		globalContext
 		moduleContext
-		valueStackContext
+		stackContext
 		exitContext
 		archContext
 
 		// The following fields are not accessed by compiled code directly.
 
-		// valueStack is the go-allocated stack for holding Wasm values.
+		// stack is the go-allocated stack for holding values and call frames.
 		// Note: We never edit len or cap in compiled code, so we won't get screwed when GC comes in.
-		valueStack []uint64
+		//
+		// At any point of execution, say currently executing function F2 which was called by F1, then
+		// the stack should look like like:
+		//
+		// 	[..., arg0, arg1, ..., argN, _, _, _, v1, v2, v3, ....
+		//	      ^                     {       }
+		//	      |                F1's callFrame
+		//	      |
+		//  stackBasePointer
+		//
+		// where
+		//  - callFrame is the F1's callFrame which called F2. It contains F1's return address, F1's base pointer, and F1's *function.
+		//  - stackBasePointer is the stack base pointer stored at (callEngine stackContext.stackBasePointerInBytes)
+		//  - arg0, ..., argN are the function parameters, and v1, v2, v3,... are the local variables
+		//    including the non-function param locals as well as the temporary variable produced by instructions (e.g i32.const).
+		//
+		// If the F2 makes a function call to F3 which takes two arguments, then the stack will become:
+		//
+		// 	[..., arg0, arg1, ..., argN, _, _, _, v1, v2, v3, _, _, _
+		//	                            {       }     ^      {       }
+		//	                       F1's callFrame     | F2's callFrame
+		//	                                          |
+		//                                     stackBasePointer
+		// where
+		// 	- F2's callFrame is pushed above the v2 and v3 (arguments for F3).
+		//  - The previous stackBasePointer (pointed at arg0) was saved inside the F2's callFrame.
+		//
+		// Then, if F3 returns one result, say w1, then the result will look like:
+		//
+		// 	[..., arg0, arg1, ..., argN, _, _, _, v1, w1, ...
+		//	      ^                     {       }
+		//	      |                F1's callFrame
+		//	      |
+		//  stackBasePointer
+		//
+		// where
+		// 	- stackBasePointer was reverted to the position at arg0
+		//  - The result from F3 was pushed above v1
+		//
+		// If the number of parameters is smaller than that of return values, then the empty slots are reserved
+		// below the callFrame to store the results on teh return.
+		// For example, if F3 takes no parameter but returns N(>0) results, then the stack
+		// after making a call against F3 will look like:
+		//
+		// 	[..., arg0, arg1, ..., argN, _, _, _, v1, v2, v3, res_1, _, res_N, _, _, _
+		//	                            {       }            ^                {       }
+		//	                       F1's callFrame            |           F2's callFrame
+		//	                                                 |
+		//                                            stackBasePointer
+		// where res_1, ..., res_N are the reserved slots below the call frame. In general,
+		// the number of reserved slots equals max(0, len(results)-len(params).
+		//
+		// This reserved slots are necessary to save the result values onto the stack while not destroying
+		// the callFrame value on function returns.
+		stack []uint64
 
-		// callFrameStack is initially callFrameStack[callFrameStackPointer].
-		// The currently executed function call frame lives at callFrameStack[callFrameStackPointer-1]
-		// and that is equivalent to  engine.callFrameTop().
-		callFrameStack []callFrame
-
-		// compiled is the initial function for this call engine.
-		compiled *function
-		// source is the FunctionInstance from which compiled is created from.
-		source *wasm.FunctionInstance
-	}
-
-	// globalContext holds the data which is constant across multiple function calls.
-	globalContext struct {
-		// valueStackElement0Address is &engine.valueStack[0] as uintptr.
-		// Note: this is updated when growing the stack in builtinFunctionGrowValueStack.
-		valueStackElement0Address uintptr
-		// valueStackLenInBytes is len(engine.valueStack[0]) * 8 (bytes).
-		// Note: this is updated when growing the stack in builtinFunctionGrowValueStack.
-		valueStackLenInBytes uint64
-
-		// callFrameStackElementZeroAddress is &engine.callFrameStack[0] as uintptr.
-		// Note: this is updated when growing the stack in builtinFunctionGrowCallFrameStack.
-		callFrameStackElementZeroAddress uintptr
-		// callFrameStackLen is len(engine.callFrameStack).
-		// Note: this is updated when growing the stack in builtinFunctionGrowCallFrameStack.
-		callFrameStackLen uint64
-		// callFrameStackPointer points at the next empty slot on the call frame stack.
-		// For example, for the next function call, we push the new callFrame onto
-		// callFrameStack[callFrameStackPointer]. This value is incremented/decremented in assembly
-		// when making function calls or returning from them.
-		callFrameStackPointer uint64
+		// initialFn is the initial function for this call engine.
+		initialFn *function
 	}
 
 	// moduleContext holds the per-function call specific module information.
 	// This is subject to be manipulated from compiled native code whenever we make function calls.
 	moduleContext struct {
+		// fn holds the currently executed *function.
+		fn *function
+
 		// moduleInstanceAddress is the address of module instance from which we initialize
 		// the following fields. This is set whenever we enter a function or return from function calls.
 		//
@@ -114,6 +141,8 @@ type (
 		memoryElement0Address uintptr
 		// memorySliceLen is the length of the memory buffer, i.e. len(ModuleInstance.Memory.Buffer).
 		memorySliceLen uint64
+		// memoryInstance holds the memory instance for this module instance.
+		memoryInstance *wasm.MemoryInstance
 		// tableElement0Address is the address of the first item in the tables slice,
 		// i.e. &ModuleInstance.Tables[0] as uintptr.
 		tablesElement0Address uintptr
@@ -131,9 +160,9 @@ type (
 		elementInstancesElement0Address uintptr
 	}
 
-	// valueStackContext stores the data to access engine.valueStack.
-	valueStackContext struct {
-		// stackPointer on .valueStack field which is accessed by valueStack[stackBasePointer+stackBasePointerInBytes*8].
+	// stackContext stores the data to access engine.stack.
+	stackContext struct {
+		// stackPointer on .stack field which is accessed by stack[stackBasePointer+stackBasePointerInBytes*8].
 		//
 		// Note: stackPointer is not used in assembly since the native code knows exact position of
 		// each variable in the value stack from the info from compilation.
@@ -147,11 +176,15 @@ type (
 		// functions are compiled, so they access the stack via [stackBasePointer](fixed for entire function) + [stackPointer].
 		// More precisely, stackBasePointer is set to [callee's stack pointer] + [callee's stack base pointer] - [caller's params].
 		// This way, compiled functions can be independent of the timing of functions calls made against them.
-		//
-		// Note: This is saved on callFrameTop().returnStackBasePointer whenever making function call.
-		// Also, this is changed whenever we make function call or return from functions where we execute jump instruction.
-		// In either case, the caller of "jmp" instruction must set this field properly.
 		stackBasePointerInBytes uint64
+
+		// stackElement0Address is &engine.stack[0] as uintptr.
+		// Note: this is updated when growing the stack in builtinFunctionGrowStack.
+		stackElement0Address uintptr
+
+		// stackLenInBytes is len(engine.stack[0]) * 8 (bytes).
+		// Note: this is updated when growing the stack in builtinFunctionGrowStack.
+		stackLenInBytes uint64
 	}
 
 	// exitContext will be manipulated whenever compiled native code returns into the Go function.
@@ -162,23 +195,25 @@ type (
 		// Set when statusCode == compilerStatusCallBuiltInFunction
 		// Indicating the function call index.
 		builtinFunctionCallIndex wasm.Index
+
+		// returnAddress is the return address which the engine jumps into
+		// after executing a builtin function or host function.
+		returnAddress uintptr
 	}
 
 	// callFrame holds the information to which the caller function can return.
-	// callFrame is created for currently executed function frame as well,
-	// so some fields are not yet set when native code is currently executing it.
-	// That is, callFrameTop().returnAddress or returnStackBasePointerInBytes are not set
-	// until it makes a function call.
+	// This is mixed in callEngine.stack with other Wasm values just like any other
+	// native program (where the stack is the system stack though), and we retrieve the struct
+	// with unsafe pointer casts.
 	callFrame struct {
-		// Set when making function call from this function frame, or for the initial function frame to call from
-		// callEngine.execWasmFunction.
+		// returnAddress is the return address to which the engine jumps when the callee function returns.
 		returnAddress uintptr
-		// Set when making function call from this function frame.
+		// returnStackBasePointerInBytes is the stack base pointer to set on stackContext.stackBasePointerInBytes
+		// when the callee function returns.
 		returnStackBasePointerInBytes uint64
-		// Set when making function call to this function frame.
+		// function is the caller *function, and is used to retrieve the stack trace.
+		// Note: should be possible to revive *function from returnAddress, but might be costly.
 		function *function
-		// _ is a necessary padding to make the size of callFrame struct a power of 2.
-		_ [8]byte
 	}
 
 	// Function corresponds to function instance in Wasm, and is created from `code`.
@@ -188,7 +223,7 @@ type (
 		// and we cache the value (uintptr(unsafe.Pointer(&.codeSegment[0]))) to this field,
 		// so we don't need to repeat the calculation on each function call.
 		codeInitialAddress uintptr
-		// stackPointerCeil is the max of the stack pointer this function can reach. Lazily applied via maybeGrowValueStack.
+		// stackPointerCeil is the max of the stack pointer this function can reach. Lazily applied via maybeGrowStack.
 		stackPointerCeil uint64
 		// source is the source function instance from which this is compiled.
 		source *wasm.FunctionInstance
@@ -204,7 +239,7 @@ type (
 		// codeSegment is holding the compiled native code as a byte slice.
 		codeSegment []byte
 		// See the doc for codeStaticData type.
-		// stackPointerCeil is the max of the stack pointer this function can reach. Lazily applied via maybeGrowValueStack.
+		// stackPointerCeil is the max of the stack pointer this function can reach. Lazily applied via maybeGrowStack.
 		stackPointerCeil uint64
 
 		// indexInModule is the index of this function in the module. For logging purpose.
@@ -231,42 +266,35 @@ const (
 	// Offsets for moduleEngine.functions
 	moduleEngineFunctionsOffset = 16
 
-	// Offsets for callEngine globalContext.
-	callEngineGlobalContextValueStackElement0AddressOffset     = 0
-	callEngineGlobalContextValueStackLenInBytesOffset          = 8
-	callEngineGlobalContextCallFrameStackElement0AddressOffset = 16
-	callEngineGlobalContextCallFrameStackLenOffset             = 24
-	callEngineGlobalContextCallFrameStackPointerOffset         = 32
-
 	// Offsets for callEngine moduleContext.
-	callEngineModuleContextModuleInstanceAddressOffset           = 40
-	callEngineModuleContextGlobalElement0AddressOffset           = 48
-	callEngineModuleContextMemoryElement0AddressOffset           = 56
-	callEngineModuleContextMemorySliceLenOffset                  = 64
-	callEngineModuleContextTablesElement0AddressOffset           = 72
-	callEngineModuleContextFunctionsElement0AddressOffset        = 80
-	callEngineModuleContextTypeIDsElement0AddressOffset          = 88
-	callEngineModuleContextDataInstancesElement0AddressOffset    = 96
-	callEngineModuleContextElementInstancesElement0AddressOffset = 104
+	callEngineModuleContextFnOffset                              = 0
+	callEngineModuleContextModuleInstanceAddressOffset           = 8
+	callEngineModuleContextGlobalElement0AddressOffset           = 16
+	callEngineModuleContextMemoryElement0AddressOffset           = 24
+	callEngineModuleContextMemorySliceLenOffset                  = 32
+	callEngineModuleContextMemoryInstanceOffset                  = 40
+	callEngineModuleContextTablesElement0AddressOffset           = 48
+	callEngineModuleContextFunctionsElement0AddressOffset        = 56
+	callEngineModuleContextTypeIDsElement0AddressOffset          = 64
+	callEngineModuleContextDataInstancesElement0AddressOffset    = 72
+	callEngineModuleContextElementInstancesElement0AddressOffset = 80
 
-	// Offsets for callEngine valueStackContext.
-	callEngineValueStackContextStackPointerOffset            = 112
-	callEngineValueStackContextStackBasePointerInBytesOffset = 120
+	// Offsets for callEngine stackContext.
+	callEngineStackContextStackPointerOffset            = 88
+	callEngineStackContextStackBasePointerInBytesOffset = 96
+	callEngineStackContextStackElement0AddressOffset    = 104
+	callEngineStackContextStackLenInBytesOffset         = 112
 
 	// Offsets for callEngine exitContext.
-	callEngineExitContextNativeCallStatusCodeOffset       = 128
-	callEngineExitContextBuiltinFunctionCallAddressOffset = 132
+	callEngineExitContextNativeCallStatusCodeOffset     = 120
+	callEngineExitContextBuiltinFunctionCallIndexOffset = 124
+	callEngineExitContextReturnAddressOffset            = 128
 
 	// Offsets for callFrame.
-	callFrameDataSize                            = 32
-	callFrameDataSizeMostSignificantSetBit       = 5
-	callFrameReturnAddressOffset                 = 0
-	callFrameReturnStackBasePointerInBytesOffset = 8
-	callFrameFunctionOffset                      = 16
+	callFrameDataSizeInUint64 = 24 / 8
 
 	// Offsets for function.
 	functionCodeInitialAddressOffset    = 0
-	functionStackPointerCeilOffset      = 8
 	functionSourceOffset                = 16
 	functionModuleInstanceAddressOffset = 24
 
@@ -315,8 +343,8 @@ type nativeCallStatusCode uint32
 const (
 	// nativeCallStatusCodeReturned means the nativecall reaches the end of function, and returns successfully.
 	nativeCallStatusCodeReturned nativeCallStatusCode = iota
-	// nativeCallStatusCodeCallHostFunction means the nativecall returns to make a host function call.
-	nativeCallStatusCodeCallHostFunction
+	// nativeCallStatusCodeCallGoHostFunction means the nativecall returns to make a host function call.
+	nativeCallStatusCodeCallGoHostFunction
 	// nativeCallStatusCodeCallBuiltInFunction means the nativecall returns to make a builtin function call.
 	nativeCallStatusCodeCallBuiltInFunction
 	// nativeCallStatusCodeUnreachable means the function invocation reaches "unreachable" instruction.
@@ -360,7 +388,7 @@ func (s nativeCallStatusCode) String() (ret string) {
 	switch s {
 	case nativeCallStatusCodeReturned:
 		ret = "returned"
-	case nativeCallStatusCodeCallHostFunction:
+	case nativeCallStatusCodeCallGoHostFunction:
 		ret = "call_host_function"
 	case nativeCallStatusCodeCallBuiltInFunction:
 		ret = "call_builtin_function"
@@ -382,14 +410,6 @@ func (s nativeCallStatusCode) String() (ret string) {
 		panic("BUG")
 	}
 	return
-}
-
-// String implements fmt.Stringer
-func (c *callFrame) String() string {
-	return fmt.Sprintf(
-		"[%s: return address=0x%x, return stack base pointer=%d]",
-		c.function.source.FunctionDefinition.DebugName(), c.returnAddress, c.returnStackBasePointerInBytes>>3,
-	)
 }
 
 // releaseCode is a runtime.SetFinalizer function that munmaps the code.codeSegment.
@@ -430,7 +450,7 @@ func (e *engine) CompileModule(ctx context.Context, module *wasm.Module) error {
 
 	funcs := make([]*code, 0, len(module.FunctionSection))
 
-	irs, err := wazeroir.CompileFunctions(ctx, e.enabledFeatures, module)
+	irs, err := wazeroir.CompileFunctions(ctx, e.enabledFeatures, callFrameDataSizeInUint64, module)
 	if err != nil {
 		return err
 	}
@@ -542,14 +562,21 @@ func (e *moduleEngine) NewCallEngine(callCtx *wasm.CallContext, f *wasm.Function
 		}
 		return
 	}
-	return e.newCallEngine(f, compiled), nil
+
+	initStackSize := initialStackSize
+	if initialStackSize < compiled.stackPointerCeil {
+		initStackSize = compiled.stackPointerCeil * 2
+	}
+	return e.newCallEngine(initStackSize, compiled), nil
 }
 
 // Call implements the same method as documented on wasm.ModuleEngine.
 func (ce *callEngine) Call(ctx context.Context, callCtx *wasm.CallContext, params ...uint64) (results []uint64, err error) {
+	tp := ce.initialFn.source.Type
+
 	paramCount := len(params)
-	if ce.source.Type.ParamNumInUint64 != paramCount {
-		return nil, fmt.Errorf("expected %d params, but passed %d", ce.source.Type.ParamNumInUint64, paramCount)
+	if tp.ParamNumInUint64 != paramCount {
+		return nil, fmt.Errorf("expected %d params, but passed %d", ce.initialFn.source.Type.ParamNumInUint64, paramCount)
 	}
 
 	// We ensure that this Call method never panics as
@@ -565,11 +592,58 @@ func (ce *callEngine) Call(ctx context.Context, callCtx *wasm.CallContext, param
 		}
 	}()
 
-	for _, v := range params {
+	ce.initializeStack(tp, params)
+	ce.execWasmFunction(ctx, callCtx)
+
+	results = ce.stack[:tp.ResultNumInUint64]
+	return
+}
+
+// initializeStack initializes callEngine.stack before entering native code.
+//
+// The stack must look like, if len(params) < len(results):
+//
+//	[arg0, arg1, ..., argN, 0, 0, 0, ...
+//	                       {       } ^
+//	                       callFrame |
+//	                                 |
+//	                            stackPointer
+//
+// else:
+//
+//	[arg0, arg1, ..., argN, _, _, _,  0, 0, 0, ...
+//	                      |        | {       }  ^
+//	                      |reserved| callFrame  |
+//	                      |        |            |
+//	                      |-------->       stackPointer
+//	                 len(results)-len(params)
+//
+//		 where we reserve the slots below the callframe with the length len(results)-len(params).
+//
+// Note: callFrame {  } is zeroed to indicate that the initial "caller" is this callEngine, not the Wasm function.
+//
+// See callEngine.stack as well.
+func (ce *callEngine) initializeStack(tp *wasm.FunctionType, args []uint64) {
+	for _, v := range args {
 		ce.pushValue(v)
 	}
-	ce.execWasmFunction(ctx, callCtx)
-	results = wasm.PopValues(ce.source.Type.ResultNumInUint64, ce.popValue)
+
+	ce.stackPointer = uint64(callFrameOffset(tp))
+
+	for i := 0; i < callFrameDataSizeInUint64; i++ {
+		ce.stack[ce.stackPointer] = 0
+		ce.stackPointer++
+	}
+}
+
+// callFrameOffset returns the offset of the call frame from the stack base pointer.
+//
+// See the diagram in callEngine.stack.
+func callFrameOffset(funcType *wasm.FunctionType) (ret int) {
+	ret = funcType.ResultNumInUint64
+	if ret < funcType.ParamNumInUint64 {
+		ret = funcType.ParamNumInUint64
+	}
 	return
 }
 
@@ -581,15 +655,30 @@ func (ce *callEngine) Call(ctx context.Context, callCtx *wasm.CallContext, param
 func (ce *callEngine) deferredOnCall(recovered interface{}) (err error) {
 	if recovered != nil {
 		builder := wasmdebug.NewErrorBuilder()
-		for i := uint64(0); i < ce.callFrameStackPointer; i++ {
-			def := ce.callFrameStack[ce.callFrameStackPointer-1-i].function.source.FunctionDefinition
+
+		// Unwinds call frames from the values stack, starting from the
+		// current function `ce.fn`, and the current stack base pointer `ce.stackBasePointerInBytes`.
+		fn := ce.fn
+		stackBasePointer := int(ce.stackBasePointerInBytes >> 3)
+		for {
+			def := fn.source.FunctionDefinition
 			builder.AddFrame(def.DebugName(), def.ParamTypes(), def.ResultTypes())
+
+			callFrameOffset := callFrameOffset(fn.source.Type)
+			if stackBasePointer != 0 {
+				frame := *(*callFrame)(unsafe.Pointer(&ce.stack[stackBasePointer+callFrameOffset]))
+				fn = frame.function
+				stackBasePointer = int(frame.returnStackBasePointerInBytes >> 3)
+			} else { // base == 0 means that this was the last call frame stacked.
+				break
+			}
 		}
 		err = builder.FromRecovered(recovered)
 	}
 
 	// Allows the reuse of CallEngine.
-	ce.stackBasePointerInBytes, ce.stackPointer, ce.callFrameStackPointer, ce.moduleInstanceAddress = 0, 0, 0, 0
+	ce.stackBasePointerInBytes, ce.stackPointer, ce.moduleInstanceAddress = 0, 0, 0
+	ce.moduleContext.fn = ce.initialFn
 	return
 }
 
@@ -611,7 +700,7 @@ func newEngine(ctx context.Context, enabledFeatures wasm.Features) *engine {
 	}
 }
 
-// Do not make these variables as constants, otherwise there would be
+// Do not make this variable as constant, otherwise there would be
 // dangerous memory access from native code.
 //
 // Background: Go has a mechanism called "goroutine stack-shrink" where Go
@@ -638,114 +727,80 @@ func newEngine(ctx context.Context, enabledFeatures wasm.Features) *engine {
 //	[2] https://github.com/golang/go/blob/68ecdc2c70544c303aa923139a5f16caf107d955/src/runtime/mgc.go#L9
 //	[3] https://mayurwadekar2.medium.com/escape-analysis-in-golang-ee40a1c064c1
 //	[4] https://medium.com/@yulang.chu/go-stack-or-heap-2-slices-which-keep-in-stack-have-limitation-of-size-b3f3adfd6190
-var (
-	initialValueStackSize     = 64
-	initialCallFrameStackSize = 16
-)
+var initialStackSize uint64 = 512
 
-func (e *moduleEngine) newCallEngine(source *wasm.FunctionInstance, compiled *function) *callEngine {
+func (e *moduleEngine) newCallEngine(stackSize uint64, fn *function) *callEngine {
 	ce := &callEngine{
-		valueStack:     make([]uint64, initialValueStackSize),
-		callFrameStack: make([]callFrame, initialCallFrameStackSize),
-		archContext:    newArchContext(),
-		source:         source,
-		compiled:       compiled,
+		stack:         make([]uint64, stackSize),
+		archContext:   newArchContext(),
+		initialFn:     fn,
+		moduleContext: moduleContext{fn: fn},
 	}
 
-	valueStackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.valueStack))
-	callFrameStackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.callFrameStack))
-	ce.globalContext = globalContext{
-		valueStackElement0Address:        valueStackHeader.Data,
-		valueStackLenInBytes:             uint64(valueStackHeader.Len) << 3,
-		callFrameStackElementZeroAddress: callFrameStackHeader.Data,
-		callFrameStackLen:                uint64(callFrameStackHeader.Len),
-		callFrameStackPointer:            0,
+	stackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.stack))
+	ce.stackContext = stackContext{
+		stackElement0Address: stackHeader.Data,
+		stackLenInBytes:      uint64(stackHeader.Len) << 3,
 	}
 	return ce
 }
 
 func (ce *callEngine) popValue() (ret uint64) {
-	ce.valueStackContext.stackPointer--
-	ret = ce.valueStack[ce.valueStackTopIndex()]
+	ce.stackContext.stackPointer--
+	ret = ce.stack[ce.stackTopIndex()]
 	return
 }
 
 func (ce *callEngine) pushValue(v uint64) {
-	ce.valueStack[ce.valueStackTopIndex()] = v
-	ce.valueStackContext.stackPointer++
+	ce.stack[ce.stackTopIndex()] = v
+	ce.stackContext.stackPointer++
 }
 
-func (ce *callEngine) callFrameTop() *callFrame {
-	return &ce.callFrameStack[ce.globalContext.callFrameStackPointer-1]
-}
-
-func (ce *callEngine) callFrameAt(depth uint64) *callFrame {
-	idx := ce.globalContext.callFrameStackPointer - 1 - depth
-	return &ce.callFrameStack[idx]
-}
-
-func (ce *callEngine) valueStackTopIndex() uint64 {
-	return ce.valueStackContext.stackPointer + (ce.valueStackContext.stackBasePointerInBytes >> 3)
+func (ce *callEngine) stackTopIndex() uint64 {
+	return ce.stackContext.stackPointer + (ce.stackContext.stackBasePointerInBytes >> 3)
 }
 
 const (
 	builtinFunctionIndexMemoryGrow wasm.Index = iota
-	builtinFunctionIndexGrowValueStack
-	builtinFunctionIndexGrowCallFrameStack
+	builtinFunctionIndexGrowStack
 	builtinFunctionIndexTableGrow
 	// builtinFunctionIndexBreakPoint is internal (only for wazero developers). Disabled by default.
 	builtinFunctionIndexBreakPoint
 )
 
 func (ce *callEngine) execWasmFunction(ctx context.Context, callCtx *wasm.CallContext) {
-	// Push the initial callframe.
-	ce.callFrameStack[0] = callFrame{returnAddress: ce.compiled.codeInitialAddress, function: ce.compiled}
-	ce.globalContext.callFrameStackPointer++
+	codeAddr := ce.initialFn.codeInitialAddress
+	modAddr := ce.initialFn.moduleInstanceAddress
 
 entry:
 	{
-		frame := ce.callFrameTop()
-		if buildoptions.IsDebugMode {
-			fmt.Printf("callframe=%s, stackBasePointer: %d, stackPointer: %d\n",
-				frame.String(), ce.valueStackContext.stackBasePointerInBytes>>3, ce.valueStackContext.stackPointer)
-		}
-
 		// Call into the native code.
-		nativecall(frame.returnAddress, uintptr(unsafe.Pointer(ce)), frame.function.moduleInstanceAddress)
+		nativecall(codeAddr, uintptr(unsafe.Pointer(ce)), modAddr)
 
 		// Check the status code from Compiler code.
 		switch status := ce.exitContext.statusCode; status {
 		case nativeCallStatusCodeReturned:
-			// Meaning that all the function frames above the previous call frame stack pointer are executed.
-		case nativeCallStatusCodeCallHostFunction:
-			calleeHostFunction := ce.callFrameTop().function
-			// Not "callFrameTop" but take the below of peek with "callFrameAt(1)" as the top frame is for host function,
-			// but when making host function calls, we need to pass the memory instance of host function caller.
-			callerFunction := ce.callFrameAt(1).function
-			params := wasm.PopGoFuncParams(calleeHostFunction.source, ce.popValue)
+		case nativeCallStatusCodeCallGoHostFunction:
+			calleeHostFunction := ce.moduleContext.fn
+			base := int(ce.stackBasePointerInBytes >> 3)
+			params := ce.stack[base : base+len(calleeHostFunction.source.Type.Params)]
 			results := wasm.CallGoFunc(
 				ctx,
-				// Use the caller's memory, which might be different from the defining module on an imported function.
-				callCtx.WithMemory(callerFunction.source.Module.Memory),
+				callCtx.WithMemory(ce.memoryInstance),
 				calleeHostFunction.source,
 				params,
 			)
-			for _, v := range results {
-				ce.pushValue(v)
-			}
+			copy(ce.stack[base:], results)
+			codeAddr, modAddr = ce.returnAddress, ce.moduleInstanceAddress
 			goto entry
 		case nativeCallStatusCodeCallBuiltInFunction:
+			caller := ce.moduleContext.fn
 			switch ce.exitContext.builtinFunctionCallIndex {
 			case builtinFunctionIndexMemoryGrow:
-				callerFunction := ce.callFrameTop().function
-				ce.builtinFunctionMemoryGrow(ctx, callerFunction.source.Module.Memory)
-			case builtinFunctionIndexGrowValueStack:
-				callerFunction := ce.callFrameTop().function
-				ce.builtinFunctionGrowValueStack(callerFunction.stackPointerCeil)
-			case builtinFunctionIndexGrowCallFrameStack:
-				ce.builtinFunctionGrowCallFrameStack()
+				ce.builtinFunctionMemoryGrow(ctx, caller.source.Module.Memory)
+			case builtinFunctionIndexGrowStack:
+				ce.builtinFunctionGrowStack(caller.stackPointerCeil)
 			case builtinFunctionIndexTableGrow:
-				caller := ce.callFrameTop().function
 				ce.builtinFunctionTableGrow(ctx, caller.source.Module.Tables)
 			}
 			if buildoptions.IsDebugMode {
@@ -753,6 +808,8 @@ entry:
 					runtime.Breakpoint()
 				}
 			}
+
+			codeAddr, modAddr = ce.returnAddress, ce.moduleInstanceAddress
 			goto entry
 		default:
 			status.causePanic()
@@ -760,36 +817,30 @@ entry:
 	}
 }
 
-func (ce *callEngine) builtinFunctionGrowValueStack(stackPointerCeil uint64) {
-	// Extends the valueStack's length to currentLen*2+stackPointerCeil.
-	newLen := uint64(len(ce.valueStack))<<1 + (stackPointerCeil)
-	newStack := make([]uint64, newLen)
-	ce.valueStackTopIndex()
-	top := ce.valueStackTopIndex()
-	copy(newStack[:top], ce.valueStack[:top])
-	ce.valueStack = newStack
-	valueStackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.valueStack))
-	ce.globalContext.valueStackElement0Address = valueStackHeader.Data
-	ce.globalContext.valueStackLenInBytes = newLen << 3
-}
+// callStackCeiling is the maximum WebAssembly call frame stack height. This allows wazero to raise
+// wasm.ErrCallStackOverflow instead of overflowing the Go runtime.
+//
+// The default value should suffice for most use cases. Those wishing to change this can via `go build -ldflags`.
+//
+// TODO: allows to configure this via context?
+var callStackCeiling = uint64(10000000) // in uint64 (8 bytes) == 80000000 bytes in total == 80mb.
 
-var callStackCeiling = uint64(buildoptions.CallStackCeiling)
-
-func (ce *callEngine) builtinFunctionGrowCallFrameStack() {
-	if callStackCeiling < uint64(len(ce.callFrameStack)+1) {
-		panic(wasmruntime.ErrRuntimeCallStackOverflow)
+func (ce *callEngine) builtinFunctionGrowStack(stackPointerCeil uint64) {
+	oldLen := uint64(len(ce.stack))
+	if callStackCeiling < oldLen {
+		panic(wasmruntime.ErrRuntimeStackOverflow)
 	}
 
-	// Double the callstack slice length.
-	newLen := uint64(ce.globalContext.callFrameStackLen) * 2
-	newStack := make([]callFrame, newLen)
-	copy(newStack, ce.callFrameStack)
-	ce.callFrameStack = newStack
-
-	// Update the globalContext's fields as they become stale after the update ^^.
-	stackSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&newStack))
-	ce.globalContext.callFrameStackLen = uint64(stackSliceHeader.Len)
-	ce.globalContext.callFrameStackElementZeroAddress = stackSliceHeader.Data
+	// Extends the stack's length to oldLen*2+stackPointerCeil.
+	newLen := oldLen<<1 + (stackPointerCeil)
+	newStack := make([]uint64, newLen)
+	ce.stackTopIndex()
+	top := ce.stackTopIndex()
+	copy(newStack[:top], ce.stack[:top])
+	ce.stack = newStack
+	stackHeader := (*reflect.SliceHeader)(unsafe.Pointer(&ce.stack))
+	ce.stackContext.stackElement0Address = stackHeader.Data
+	ce.stackContext.stackLenInBytes = newLen << 3
 }
 
 func (ce *callEngine) builtinFunctionMemoryGrow(ctx context.Context, mem *wasm.MemoryInstance) {

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -161,7 +161,7 @@ func (c *amd64Compiler) label(labelKey string) *amd64LabelInfo {
 // and return to the caller.
 func (c *amd64Compiler) compileGoDefinedHostFunction() error {
 	// First we must update the location stack to reflect the number of host function inputs.
-	c.locationStack.setupInitialStack(c.ir.Signature)
+	c.locationStack.init(c.ir.Signature)
 
 	if err := c.compileCallGoHostFunction(); err != nil {
 		return err
@@ -4557,6 +4557,8 @@ func (c *amd64Compiler) compileCallFunctionImpl(functionAddressRegister asm.Regi
 			loc.valueType = runtimeValueTypeV128Lo
 			hi := c.locationStack.pushRuntimeValueLocationOnStack()
 			hi.valueType = runtimeValueTypeV128Hi
+		default:
+			panic("BUG: invalid type: " + wasm.ValueTypeName(t))
 		}
 	}
 	return nil
@@ -4725,7 +4727,7 @@ func (c *amd64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 func (c *amd64Compiler) compilePreamble() (err error) {
 	// We assume all function parameters are already pushed onto the stack by
 	// the caller.
-	c.locationStack.setupInitialStack(c.ir.Signature)
+	c.locationStack.init(c.ir.Signature)
 
 	if err := c.compileModuleContextInitialization(); err != nil {
 		return err

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4588,7 +4588,7 @@ func (c *amd64Compiler) compileReturnFunction() error {
 
 	returnAddress, callerStackBasePointerInBytes, callerFunction := c.locationStack.getCallFrameLocations(c.ir.Signature)
 
-	// If the return address is zero, meaning that we return from the execution.
+	// A zero return address means return from the execution.
 	c.assembler.CompileMemoryToRegister(amd64.MOVQ,
 		amd64ReservedRegisterForStackBasePointerAddress, int64(returnAddress.stackPointer)*8,
 		returnAddressRegister,

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -170,7 +170,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						require.NoError(t, err)
 
 						require.Equal(t, registerTypeGeneralPurpose, compiler.runtimeValueLocationStack().peek().getRegisterType())
-						require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+						requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 						require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 						// At this point, the previous value on the DX register is saved to the stack.
 						require.True(t, prevOnDX.onStack())
@@ -190,7 +190,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						env.exec(code)
 
 						// Verify the stack is in the form of ["any value previously used by DX" + the result of operation]
-						require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+						require.Equal(t, uint64(1), env.stackPointer())
 						switch kind {
 						case wazeroir.OperationKindDiv:
 							require.Equal(t, x1Value/x2Value+uint32(dxValue), env.stackTopAsUint32())
@@ -296,7 +296,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						require.NoError(t, err)
 
 						require.Equal(t, registerTypeGeneralPurpose, compiler.runtimeValueLocationStack().peek().getRegisterType())
-						require.Equal(t, uint64(2)+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+						requireRuntimeLocationStackPointerEqual(t, uint64(2), compiler)
 						require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 						// At this point, the previous value on the DX register is saved to the stack.
 						require.True(t, prevOnDX.onStack())
@@ -319,13 +319,13 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// Verify the stack is in the form of ["any value previously used by DX" + the result of operation]
 						switch kind {
 						case wazeroir.OperationKindDiv:
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+							require.Equal(t, uint64(1), env.stackPointer())
 							require.Equal(t, uint64(x1Value/x2Value)+dxValue, env.stackTopAsUint64())
 						case wazeroir.OperationKindMul:
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+							require.Equal(t, uint64(1), env.stackPointer())
 							require.Equal(t, uint64(x1Value*x2Value)+dxValue, env.stackTopAsUint64())
 						case wazeroir.OperationKindRem:
-							require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+							require.Equal(t, uint64(1), env.stackPointer())
 							require.Equal(t, x1Value%x2Value+dxValue, env.stackTopAsUint64())
 						}
 					})
@@ -388,7 +388,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		env.exec(code)
 
 		require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
-		require.Equal(t, uint64(1)+callFrameDataSizeInUint64, env.stackPointer())
+		require.Equal(t, uint64(1), env.stackPointer())
 		require.Equal(t, expectedReturnValue, env.stackTopAsUint32())
 	})
 }

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -179,7 +179,7 @@ func (c *arm64Compiler) compilePreamble() error {
 	c.markRegisterUsed(arm64CallingConventionModuleInstanceAddressRegister)
 	defer c.markRegisterUnused(arm64CallingConventionModuleInstanceAddressRegister)
 
-	c.locationStack.setupInitialStack(c.ir.Signature)
+	c.locationStack.init(c.ir.Signature)
 
 	// Check if it's necessary to grow the value stack before entering function body.
 	if err := c.compileMaybeGrowStack(); err != nil {
@@ -339,7 +339,7 @@ func (c *arm64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 // compileGoHostFunction implements compiler.compileHostFunction for the arm64 architecture.
 func (c *arm64Compiler) compileGoDefinedHostFunction() error {
 	// First we must update the location stack to reflect the number of host function inputs.
-	c.locationStack.setupInitialStack(c.ir.Signature)
+	c.locationStack.init(c.ir.Signature)
 
 	if err := c.compileCallGoFunction(nativeCallStatusCodeCallGoHostFunction, 0); err != nil {
 		return err

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -142,7 +142,7 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 			},
 			verifyFn: func(t *testing.T, env *compilerEnv) {
 				// at the bottom of stack, the previous value on the CX register must be saved.
-				actual := env.stack()[0]
+				actual := env.stack()[callFrameDataSizeInUint64]
 				require.Equal(t, uint64(100), actual)
 			},
 		},
@@ -175,7 +175,7 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 			},
 			verifyFn: func(t *testing.T, env *compilerEnv) {
 				// at the bottom of stack, the previous value on the CX register must be saved.
-				actual := env.stack()[0]
+				actual := env.stack()[callFrameDataSizeInUint64]
 				require.Equal(t, uint64(100), actual)
 			},
 		},

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -122,7 +122,7 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			},
 			verifyFnc: func(t *testing.T, env *compilerEnv) {
 				// Previous value on the V3 register must be saved onto the stack.
-				lo, hi := env.stack()[0], env.stack()[1]
+				lo, hi := env.stack()[callFrameDataSizeInUint64], env.stack()[callFrameDataSizeInUint64+1]
 				require.Equal(t, uint64(1234), lo)
 				require.Equal(t, uint64(5678), hi)
 			},
@@ -143,7 +143,7 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			},
 			verifyFnc: func(t *testing.T, env *compilerEnv) {
 				// Previous value on the V3 register must be saved onto the stack.
-				lo, hi := env.stack()[0], env.stack()[1]
+				lo, hi := env.stack()[callFrameDataSizeInUint64], env.stack()[callFrameDataSizeInUint64+1]
 				require.Equal(t, uint64(1234), lo)
 				require.Equal(t, uint64(5678), hi)
 			},
@@ -195,7 +195,7 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: lanes})
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expStackPointerAfterShuffle, compiler.runtimeValueLocationStack().sp)
+			require.Equal(t, tc.expStackPointerAfterShuffle+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -217,9 +217,3 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 		})
 	}
 }
-
-// requireRuntimeLocationStackPointerEqual ensures that the compiler's runtimeValueLocationStack has
-// the expected stack pointer value relative to the call frame.
-func requireRuntimeLocationStackPointerEqual(t *testing.T, expSP uint64, c compiler) {
-	require.Equal(t, expSP, c.runtimeValueLocationStack().sp-callFrameDataSizeInUint64)
-}

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -195,7 +195,7 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			err = compiler.compileV128Shuffle(&wazeroir.OperationV128Shuffle{Lanes: lanes})
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expStackPointerAfterShuffle+callFrameDataSizeInUint64, compiler.runtimeValueLocationStack().sp)
+			requireRuntimeLocationStackPointerEqual(t, tc.expStackPointerAfterShuffle, compiler)
 			require.Equal(t, 1, len(compiler.runtimeValueLocationStack().usedRegisters))
 
 			err = compiler.compileReturnFunction()
@@ -216,4 +216,10 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			tc.verifyFnc(t, env)
 		})
 	}
+}
+
+// requireRuntimeLocationStackPointerEqual ensures that the compiler's runtimeValueLocationStack has
+// the expected stack pointer value relative to the call frame.
+func requireRuntimeLocationStackPointerEqual(t *testing.T, expSP uint64, c compiler) {
+	require.Equal(t, expSP, c.runtimeValueLocationStack().sp-callFrameDataSizeInUint64)
 }

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/experimental/logging"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -45,7 +44,8 @@ func TestInterpreter_CallEngine_PushFrame(t *testing.T) {
 }
 
 func TestInterpreter_CallEngine_PushFrame_StackOverflow(t *testing.T) {
-	defer func() { callStackCeiling = buildoptions.CallStackCeiling }()
+	saved := callStackCeiling
+	defer func() { callStackCeiling = saved }()
 
 	callStackCeiling = 3
 
@@ -60,7 +60,7 @@ func TestInterpreter_CallEngine_PushFrame_StackOverflow(t *testing.T) {
 	vm.pushFrame(f3)
 
 	captured := require.CapturePanic(func() { vm.pushFrame(f4) })
-	require.EqualError(t, captured, "callstack overflow")
+	require.EqualError(t, captured, "stack overflow")
 }
 
 // et is used for tests defined in the enginetest package.

--- a/internal/integration_test/filecache/filecache_test.go
+++ b/internal/integration_test/filecache/filecache_test.go
@@ -41,7 +41,7 @@ func TestSpecTestCompilerCache(t *testing.T) {
 		// the subsequent execution of this test will enter the following "else" block.
 		var exp []string
 		buf := bytes.NewBuffer(nil)
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 2; i++ {
 			cmd := exec.Command(testExecutable)
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", cachePathKey, cacheDir))
 			cmd.Stdout = buf
@@ -51,7 +51,7 @@ func TestSpecTestCompilerCache(t *testing.T) {
 			exp = append(exp, "PASS\n")
 		}
 
-		// Ensures that the tests actually run 5 times.
+		// Ensures that the tests actually run 2 times.
 		require.Equal(t, strings.Join(exp, ""), buf.String())
 
 		// Check the number of cache files is greater than zero.

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -587,7 +587,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 		},
 	}
 	m.BuildFunctionDefinitions()
-	// Compile the Wasm into wazeroir
+
 	err := e.CompileModule(testCtx, m)
 	require.NoError(t, err)
 

--- a/internal/wasmdebug/debug_test.go
+++ b/internal/wasmdebug/debug_test.go
@@ -118,13 +118,13 @@ wasm stack trace:
 			build: func(builder ErrorBuilder) error {
 				builder.AddFrame("wasi_snapshot_preview1.fd_write", i32i32i32i32, []api.ValueType{i32})
 				builder.AddFrame("x.y", nil, nil)
-				return builder.FromRecovered(wasmruntime.ErrRuntimeCallStackOverflow)
+				return builder.FromRecovered(wasmruntime.ErrRuntimeStackOverflow)
 			},
-			expectedErr: `wasm error: callstack overflow
+			expectedErr: `wasm error: stack overflow
 wasm stack trace:
 	wasi_snapshot_preview1.fd_write(i32,i32,i32,i32) i32
 	x.y()`,
-			expectUnwrap: wasmruntime.ErrRuntimeCallStackOverflow,
+			expectUnwrap: wasmruntime.ErrRuntimeStackOverflow,
 		},
 	}
 

--- a/internal/wasmruntime/errors.go
+++ b/internal/wasmruntime/errors.go
@@ -4,9 +4,9 @@
 package wasmruntime
 
 var (
-	// ErrRuntimeCallStackOverflow indicates that there are too many function calls,
+	// ErrRuntimeStackOverflow indicates that there are too many function calls,
 	// and the Engine terminated the execution.
-	ErrRuntimeCallStackOverflow = New("callstack overflow")
+	ErrRuntimeStackOverflow = New("stack overflow")
 	// ErrRuntimeInvalidConversionToInteger indicates the Wasm function tries to
 	// convert NaN floating point value to integers during trunc variant instructions.
 	ErrRuntimeInvalidConversionToInteger = New("invalid conversion to integer")

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -232,7 +232,7 @@ func TestCompile(t *testing.T) {
 			for _, tp := range tc.module.TypeSection {
 				tp.CacheNumInUint64()
 			}
-			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
+			res, err := CompileFunctions(ctx, enabledFeatures, 0, tc.module)
 			require.NoError(t, err)
 
 			fn := res[0]
@@ -372,7 +372,7 @@ func TestCompile_BulkMemoryOperations(t *testing.T) {
 		TableTypes:       []wasm.RefType{},
 	}
 
-	res, err := CompileFunctions(ctx, wasm.FeatureBulkMemoryOperations, module)
+	res, err := CompileFunctions(ctx, wasm.FeatureBulkMemoryOperations, 0, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
 }
@@ -668,7 +668,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			for _, tp := range tc.module.TypeSection {
 				tp.CacheNumInUint64()
 			}
-			res, err := CompileFunctions(ctx, enabledFeatures, tc.module)
+			res, err := CompileFunctions(ctx, enabledFeatures, 0, tc.module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0])
 		})
@@ -706,7 +706,7 @@ func TestCompile_NonTrappingFloatToIntConversion(t *testing.T) {
 	for _, tp := range module.TypeSection {
 		tp.CacheNumInUint64()
 	}
-	res, err := CompileFunctions(ctx, wasm.FeatureNonTrappingFloatToIntConversion, module)
+	res, err := CompileFunctions(ctx, wasm.FeatureNonTrappingFloatToIntConversion, 0, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
 }
@@ -737,7 +737,7 @@ func TestCompile_SignExtensionOps(t *testing.T) {
 	for _, tp := range module.TypeSection {
 		tp.CacheNumInUint64()
 	}
-	res, err := CompileFunctions(ctx, wasm.FeatureSignExtensionOps, module)
+	res, err := CompileFunctions(ctx, wasm.FeatureSignExtensionOps, 0, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
 }
@@ -746,7 +746,7 @@ func requireCompilationResult(t *testing.T, enabledFeatures wasm.Features, expec
 	if enabledFeatures == 0 {
 		enabledFeatures = wasm.Features20220419
 	}
-	res, err := CompileFunctions(ctx, enabledFeatures, module)
+	res, err := CompileFunctions(ctx, enabledFeatures, 0, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
 }
@@ -785,7 +785,7 @@ func TestCompile_CallIndirectNonZeroTableIndex(t *testing.T) {
 		Types: []*wasm.FunctionType{v_v, v_v, v_v},
 	}
 
-	res, err := CompileFunctions(ctx, wasm.FeatureBulkMemoryOperations, module)
+	res, err := CompileFunctions(ctx, wasm.FeatureBulkMemoryOperations, 0, module)
 	require.NoError(t, err)
 	require.Equal(t, expected, res[0])
 }
@@ -875,7 +875,7 @@ func TestCompile_Refs(t *testing.T) {
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: tc.body}},
 			}
-			res, err := CompileFunctions(ctx, wasm.Features20220419, module)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0].Operations)
 		})
@@ -944,7 +944,7 @@ func TestCompile_TableGetOrSet(t *testing.T) {
 				CodeSection:     []*wasm.Code{{Body: tc.body}},
 				TableSection:    []*wasm.Table{{}},
 			}
-			res, err := CompileFunctions(ctx, wasm.Features20220419, module)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0].Operations)
 		})
@@ -1013,7 +1013,7 @@ func TestCompile_TableGrowFillSize(t *testing.T) {
 				CodeSection:     []*wasm.Code{{Body: tc.body}},
 				TableSection:    []*wasm.Table{{}},
 			}
-			res, err := CompileFunctions(ctx, wasm.Features20220419, module)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, module)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0].Operations)
 			require.True(t, res[0].HasTable)
@@ -1221,7 +1221,7 @@ func TestCompile_Locals(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := CompileFunctions(ctx, wasm.Features20220419, tc.mod)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, tc.mod)
 			require.NoError(t, err)
 			msg := fmt.Sprintf("\nhave:\n\t%s\nwant:\n\t%s", Format(res[0].Operations), Format(tc.expected))
 			require.Equal(t, tc.expected, res[0].Operations, msg)
@@ -2567,7 +2567,7 @@ func TestCompile_Vec(t *testing.T) {
 				MemorySection:   &wasm.Memory{},
 				CodeSection:     []*wasm.Code{{Body: tc.body}},
 			}
-			res, err := CompileFunctions(ctx, wasm.Features20220419, module)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, module)
 			require.NoError(t, err)
 
 			var actual Operation
@@ -2644,7 +2644,7 @@ func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := CompileFunctions(ctx, wasm.Features20220419, tc.mod)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, tc.mod)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0].Operations)
 		})
@@ -2684,7 +2684,7 @@ func TestCompile_drop_vectors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := CompileFunctions(ctx, wasm.Features20220419, tc.mod)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, tc.mod)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0].Operations)
 		})
@@ -2754,9 +2754,167 @@ func TestCompile_select_vectors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := CompileFunctions(ctx, wasm.Features20220419, tc.mod)
+			res, err := CompileFunctions(ctx, wasm.Features20220419, 0, tc.mod)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, res[0].Operations)
 		})
+	}
+}
+
+func TestCompiler_initializeStack(t *testing.T) {
+	const v128 = wasm.ValueTypeV128
+	tests := []struct {
+		name                               string
+		sig                                *wasm.FunctionType
+		functionLocalTypes                 []wasm.ValueType
+		callFrameStackSizeInUint64         int
+		expLocalIndexToStackHeightInUint64 map[uint32]int
+	}{
+		{
+			name: "no function local, args>results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32, f32},
+				Results:           []wasm.ValueType{i32},
+				ParamNumInUint64:  2,
+				ResultNumInUint64: 1,
+			},
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+				1: 1,
+			},
+		},
+		{
+			name: "no function local, args>results, with vector",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32, v128, f32},
+				Results:           []wasm.ValueType{i32},
+				ParamNumInUint64:  4,
+				ResultNumInUint64: 1,
+			},
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+				1: 1,
+				2: 3,
+			},
+		},
+		{
+			name: "no function local, args<results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{},
+				Results:           []wasm.ValueType{i32},
+				ParamNumInUint64:  0,
+				ResultNumInUint64: 1,
+			},
+			callFrameStackSizeInUint64:         4,
+			expLocalIndexToStackHeightInUint64: map[uint32]int{},
+		},
+		{
+			name: "no function local, args<results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32},
+				Results:           []wasm.ValueType{i32, f32},
+				ParamNumInUint64:  1,
+				ResultNumInUint64: 2,
+			},
+			callFrameStackSizeInUint64:         4,
+			expLocalIndexToStackHeightInUint64: map[uint32]int{0: 0},
+		},
+		{
+			name: "no function local, args<results, with vector",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32},
+				Results:           []wasm.ValueType{i32, v128, f32},
+				ParamNumInUint64:  1,
+				ResultNumInUint64: 4,
+			},
+			callFrameStackSizeInUint64:         4,
+			expLocalIndexToStackHeightInUint64: map[uint32]int{0: 0},
+		},
+
+		// With function locals
+		{
+			name: "function locals, args>results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32, f32},
+				Results:           []wasm.ValueType{i32},
+				ParamNumInUint64:  2,
+				ResultNumInUint64: 1,
+			},
+			functionLocalTypes:         []wasm.ValueType{f64},
+			callFrameStackSizeInUint64: 4,
+			// [i32, f32, callframe.0, callframe.1, callframe.2, callframe.3, f64]
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+				1: 1,
+				// Function local comes after call frame.
+				2: 6,
+			},
+		},
+		{
+			name: "function locals, args>results, with vector",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32, v128, f32},
+				Results:           []wasm.ValueType{i32},
+				ParamNumInUint64:  4,
+				ResultNumInUint64: 1,
+			},
+			functionLocalTypes:         []wasm.ValueType{v128, v128},
+			callFrameStackSizeInUint64: 4,
+			// [i32, v128.lo, v128.hi, f32, callframe.0, callframe.1, callframe.2, callframe.3, v128.lo, v128.hi, v128.lo, v128.hi]
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+				1: 1,
+				2: 3,
+				// Function local comes after call frame.
+				3: 8,
+				4: 10,
+			},
+		},
+		{
+			name: "function locals, args<results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32},
+				Results:           []wasm.ValueType{i32, i32, i32, i32},
+				ParamNumInUint64:  1,
+				ResultNumInUint64: 4,
+			},
+			functionLocalTypes:         []wasm.ValueType{f64},
+			callFrameStackSizeInUint64: 4,
+			// [i32, _, _, _, callframe.0, callframe.1, callframe.2, callframe.3, f64]
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+				1: 8,
+			},
+		},
+		{
+			name: "function locals, args<results with vector",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{v128, f64},
+				Results:           []wasm.ValueType{v128, i32, i32, v128},
+				ParamNumInUint64:  3,
+				ResultNumInUint64: 6,
+			},
+			functionLocalTypes:         []wasm.ValueType{f64},
+			callFrameStackSizeInUint64: 4,
+			// [v128.lo, v128.hi, f64, _, _, _, callframe.0, callframe.1, callframe.2, callframe.3, f64]
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+				1: 2,
+				2: 10,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := &compiler{sig: tc.sig, localTypes: tc.functionLocalTypes,
+				callFrameStackSizeInUint64: tc.callFrameStackSizeInUint64,
+			}
+
+			c.initializeStack()
+			require.Equal(t, tc.expLocalIndexToStackHeightInUint64, c.localIndexToStackHeightInUint64)
+		})
+
 	}
 }

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -2784,6 +2784,18 @@ func TestCompiler_initializeStack(t *testing.T) {
 			},
 		},
 		{
+			name: "no function local, args=results",
+			sig: &wasm.FunctionType{
+				Params:            []wasm.ValueType{i32},
+				Results:           []wasm.ValueType{i32},
+				ParamNumInUint64:  1,
+				ResultNumInUint64: 1,
+			},
+			expLocalIndexToStackHeightInUint64: map[uint32]int{
+				0: 0,
+			},
+		},
+		{
 			name: "no function local, args>results, with vector",
 			sig: &wasm.FunctionType{
 				Params:            []wasm.ValueType{i32, v128, f32},


### PR DESCRIPTION
This simplifies the calling convention, and consolidates the call frame stack
and value stack into a single stack.

As a result, the cost of function calls decreases because we now don't need
to check the boundary twice (value and call frame stacks) at each function call.


The following is the result of the bench mark for recursive fibonnaci
function in integration_test/bench/testdata/case.go, and it shows that
this actually improves the performance of function calls.


### amd64
```
$ benchstat fib_old.txt fib_new.txt
name                               old time/op  new time/op  delta
Invocation/compiler/fib_for_5-32    109ns ± 3%    81ns ± 1%  -25.86%  (p=0.008 n=5+5)
Invocation/compiler/fib_for_10-32   556ns ± 3%   473ns ± 3%  -14.99%  (p=0.008 n=5+5)
Invocation/compiler/fib_for_20-32  61.4µs ± 2%  55.9µs ± 5%   -8.98%  (p=0.008 n=5+5)
Invocation/compiler/fib_for_30-32  7.41ms ± 3%  6.83ms ± 3%   -7.90%  (p=0.008 n=5+5)
```


### arm64
```
$ benchstat old.txt new.txt                    
name                               old time/op    new time/op    delta
Invocation/compiler/fib_for_5-10     67.7ns ± 1%    60.2ns ± 1%  -11.12%  (p=0.000 n=9+9)
Invocation/compiler/fib_for_10-10     487ns ± 1%     460ns ± 0%   -5.56%  (p=0.000 n=10+9)
Invocation/compiler/fib_for_20-10    58.0µs ± 1%    54.3µs ± 1%   -6.38%  (p=0.000 n=10+10)
Invocation/compiler/fib_for_30-10    7.12ms ± 1%    6.67ms ± 1%   -6.31%  (p=0.000 n=10+9)
```