### PR TITLE
compiler: zero-initializes moduleInstanceAddress of call engine

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -101,6 +101,9 @@ type (
 	moduleContext struct {
 		// moduleInstanceAddress is the address of module instance from which we initialize
 		// the following fields. This is set whenever we enter a function or return from function calls.
+		//
+		// On the entry to the native code, this must be initialized to zero to let native code preamble know
+		// that this is the initial function call (which leads to moduleContext initialization pass).
 		moduleInstanceAddress uintptr //lint:ignore U1000 This is only used by Compiler code.
 
 		// globalElement0Address is the address of the first element in the global slice,
@@ -560,9 +563,7 @@ func (ce *callEngine) Call(ctx context.Context, callCtx *wasm.CallContext, param
 		}
 		// TODO: ^^ Will not fail if the function was imported from a closed module.
 
-		if v := recover(); v != nil {
-			err = ce.recoverOnCall(v)
-		}
+		err = ce.deferredOnCall(recover())
 	}()
 
 	for _, v := range params {
@@ -573,19 +574,23 @@ func (ce *callEngine) Call(ctx context.Context, callCtx *wasm.CallContext, param
 	return
 }
 
-// recoverOnCall takes the recovered value `recoverOnCall`, and wraps it
-// with the call frame stack traces. Also, reset the state of callEngine
-// so that it can be used for the subsequent calls.
-func (ce *callEngine) recoverOnCall(v interface{}) (err error) {
-	builder := wasmdebug.NewErrorBuilder()
-	for i := uint64(0); i < ce.callFrameStackPointer; i++ {
-		def := ce.callFrameStack[ce.callFrameStackPointer-1-i].function.source.FunctionDefinition
-		builder.AddFrame(def.DebugName(), def.ParamTypes(), def.ResultTypes())
+// deferredOnCall takes the recovered value `recovered`, and wraps it
+// with the call frame stack traces if v != nil. Also, reset
+// the state of callEngine so that it can be used for the subsequent calls.
+//
+// This is defined for testability.
+func (ce *callEngine) deferredOnCall(recovered interface{}) (err error) {
+	if recovered != nil {
+		builder := wasmdebug.NewErrorBuilder()
+		for i := uint64(0); i < ce.callFrameStackPointer; i++ {
+			def := ce.callFrameStack[ce.callFrameStackPointer-1-i].function.source.FunctionDefinition
+			builder.AddFrame(def.DebugName(), def.ParamTypes(), def.ResultTypes())
+		}
+		err = builder.FromRecovered(recovered)
 	}
-	err = builder.FromRecovered(v)
 
 	// Allows the reuse of CallEngine.
-	ce.stackPointer, ce.callFrameStackPointer = 0, 0
+	ce.stackBasePointerInBytes, ce.stackPointer, ce.callFrameStackPointer, ce.moduleInstanceAddress = 0, 0, 0, 0
 	return
 }
 

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -331,9 +331,10 @@ wasm stack trace:
 	2()
 	1()`)
 
-	// After recover, the stack pointers must be reset, but the underlying slices must be intact
-	// for the subsequent calls.
+	// After recover, the state of callEngine must be reset except that the underlying slices must be intact
+	// for the subsequent calls to avoid additional allocations on each call.
 	require.Equal(t, uint64(0), ce.stackBasePointerInBytes)
+	require.Equal(t, uint64(0), ce.stackPointer)
 	require.Equal(t, uint64(0), ce.callFrameStackPointer)
 	require.Equal(t, uintptr(0), ce.moduleInstanceAddress)
 	require.Equal(t, beforeRecoverValueStack, ce.valueStack)


### PR DESCRIPTION
This fixes a bug introduced in #761 where the reuse of the api.Function
causes some trouble around module context initialization.



Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>