### PR TITLE
example: remove deprecated replace-import example link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,8 +13,6 @@ The following example projects can help you practice WebAssembly with wazero:
   from WebAssembly or Go-defined functions.
 * [namespace](namespace) - how WebAssembly modules can import their own host
   module, such as "env".
-* [replace-import](replace-import) - how to override a module name hard-coded
-  in a WebAssembly module.
 * [wasi](../imports/wasi_snapshot_preview1/example) - how to use I/O in your
   WebAssembly modules using WASI (WebAssembly System Interface).
 


### PR DESCRIPTION
I don't remember when it's gone, but yeah it doesn't exist anymore 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>