### PR TITLE
improve readme to show tinygo wasi binaries need a main function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Here's source in [TinyGo](https://wazero.io/languages/tinygo), which exports an
 ```go
 package main
 
+// main function is required to run a TinyGo wasi binary.
+// If omitted, you will receive a "module[env] not instantiated" error.
+func main() {}
+
 //export add
 func add(x, y uint32) uint32 {
 	return x + y


### PR DESCRIPTION
When just plainly taking the README example I got the following error:

2022/08/31 12:00:39 module[env] not instantiated
panic: module[env] not instantiated


goroutine 1 [running]:
log.Panicln({0xc000105ef8?, 0x11b1410?, 0xc0000a0000?})
	/usr/local/go/src/log/log.go:399 +0x65
main.main()
	.../cmd/main.go:37 +0x265

TinyGo seems to need the main function but will not error out on compilation, so it is easy to overlook.