### PR TITLE
Switches from "beta" to "pre"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ If interested, check out the [RATIONALE.md][8] and help us optimize further!
 Both runtimes pass WebAssembly Core [1.0][7] and [2.0][14] specification tests
 on supported platforms:
 
-| Runtime | Usage| amd64 | arm64 | others |
-|:---:|:---:|:---:|:---:|:---:|
-| Interpreter|`wazero.NewRuntimeConfigInterpreter()`|✅ |✅|✅|
-| Compiler |`wazero.NewRuntimeConfigCompiler()`|✅|✅ |❌|
+|   Runtime   |                 Usage                  | amd64 | arm64 | others |
+|:-----------:|:--------------------------------------:|:-----:|:-----:|:------:|
+| Interpreter | `wazero.NewRuntimeConfigInterpreter()` |   ✅   |   ✅   |   ✅    |
+|  Compiler   |  `wazero.NewRuntimeConfigCompiler()`   |   ✅   |   ✅   |   ❌    |
 
 ## Support Policy
 
@@ -117,12 +117,17 @@ wazero into their Go applications.
 ### wazero
 
 wazero is an early project, so APIs are subject to change until version 1.0.
+To use wazero meanwhile, you need to use the latest pre-release like this:
 
-Wazero 1.0 will have a floor Go version of 1.19. The first beta will be the
-end of August 2022, and the final release will be after Go 1.20 is released,
-in February 2023.
+```bash
+go get github.com/tetratelabs/wazero@latest
+```
 
-Meanwhile, please practice the current APIs to ensure they work for you!
+wazero will tag a new pre-release at least once a month until 1.0. 1.0 is
+scheduled for Feb 2023, following the release of Go 1.20.
+
+Meanwhile, please practice the current APIs to ensure they work for you, and
+give us a [star][15] if you are enjoying it so far!
 
 ### Go
 
@@ -175,3 +180,4 @@ wazero is a registered trademark of Tetrate.io, Inc. in the United States and/or
 [12]: https://docs.docker.com/develop/develop-images/baseimages/#create-a-simple-parent-image-using-scratch
 [13]: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
 [14]: https://github.com/WebAssembly/spec/tree/d39195773112a22b245ffbe864bab6d1182ccb06/test/core
+[15]: https://github.com/tetratelabs/wazero/stargazers

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ module github.com/tetratelabs/wazero
 // https://go.dev/doc/devel/release (1 version behind latest)
 go 1.18
 
-// Wrong naming convention
-retract v1.0.0-beta1
-
-// Has memory bug and quickly fixed in v1.0.0-beta.2.
-retract v1.0.0-beta.1
+// All the beta tags are retracted and replaced with "pre" to prevent users
+// from accidentally upgrading into the broken beta 1
+retract (
+	v1.0.0-beta1
+	v1.0.0-beta.1
+	v1.0.0-beta.2
+	v1.0.0-beta.3
+)

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ module github.com/tetratelabs/wazero
 go 1.18
 
 // All the beta tags are retracted and replaced with "pre" to prevent users
-// from accidentally upgrading into the broken beta 1
+// from accidentally upgrading into the broken beta 1.
 retract (
 	v1.0.0-beta1
-	v1.0.0-beta.1
-	v1.0.0-beta.2
 	v1.0.0-beta.3
+	v1.0.0-beta.2
+	v1.0.0-beta.1
 )

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -25,17 +25,17 @@ features you expect in Go, such as safe concurrency and context propagation.
 ### When can I use this?
 
 wazero is an early project, so APIs are subject to change until version 1.0.
-To use wazero meanwhile, you need to add its main branch to your project like
-this:
+To use wazero meanwhile, you need to use the latest pre-release like this:
 
 ```bash
-go get github.com/tetratelabs/wazero@main
+go get github.com/tetratelabs/wazero@latest
 ```
 
-wazero will release its first beta at the end of August 2022, and finalize
-1.0 once Go 1.20 is released in Feb 2023. Meanwhile, please practice the
-current APIs to ensure they work for you, and give us a [star][3] if you are
-enjoying it so far!
+wazero will tag a new pre-release at least once a month until 1.0. 1.0 is
+scheduled for Feb 2023, following the release of Go 1.20.
+
+Meanwhile, please practice the current APIs to ensure they work for you, and
+give us a [star][3] if you are enjoying it so far!
 
 [1]: https://github.com/tetratelabs/wazero/blob/main/examples
 [2]: https://github.com/tetratelabs/wazero/blob/main/examples/basic


### PR DESCRIPTION
This switches our pre-release nomenclature from "beta" to pre-release
("pre") as we are otherwise unable to rank higher than a broken tag and
still be compatible with go mod's naming conventions (semver).

See https://go.dev/blog/module-mirror-launch

Fixes https://github.com/tetratelabs/wazero/issues/789
