### PR TITLE
docs: correct link to tinygo page

### DIFF
--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -31,7 +31,7 @@ portability from release to release, or that the code will work well in
 production.
 
 Due to lack of adoption, support and relatively high implementation overhead,
-most choose [TinyGo](tinygo) to compile source code, even if it supports less
+most choose [TinyGo]({{< relref "/tinygo.md" >}}) to compile source code, even if it supports less
 features.
 
 ## WebAssembly Features


### PR DESCRIPTION
The [link syntax](https://gohugo.io/content-management/cross-references/) in
hugo is different from GitHub markdown.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>