### PR TITLE
Delete buildoptions pkg

### DIFF
--- a/internal/buildoptions/debug_disabled.go
+++ b/internal/buildoptions/debug_disabled.go
@@ -1,5 +1,0 @@
-//go:build !debug_mode
-
-package buildoptions
-
-const IsDebugMode = false

--- a/internal/buildoptions/debug_enabled.go
+++ b/internal/buildoptions/debug_enabled.go
@@ -1,5 +1,0 @@
-//go:build debug_mode
-
-package buildoptions
-
-const IsDebugMode = true

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -10,7 +10,6 @@ import (
 	"unsafe"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/compilationcache"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/version"
@@ -804,7 +803,7 @@ entry:
 			case builtinFunctionIndexTableGrow:
 				ce.builtinFunctionTableGrow(ctx, caller.source.Module.Tables)
 			}
-			if buildoptions.IsDebugMode {
+			if false {
 				if ce.exitContext.builtinFunctionCallIndex == builtinFunctionIndexBreakPoint {
 					runtime.Breakpoint()
 				}
@@ -907,7 +906,7 @@ func compileWasmFunction(_ api.CoreFeatures, ir *wazeroir.CompilationResult) (*c
 			continue
 		}
 
-		if buildoptions.IsDebugMode {
+		if false {
 			fmt.Printf("compiling op=%s: %s\n", op.Kind(), compiler)
 		}
 		var err error

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/amd64"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/u32"
 	"github.com/tetratelabs/wazero/internal/u64"
@@ -634,7 +633,7 @@ func (c *amd64Compiler) assignJumpTarget(labelKey string, jmpInstruction asm.Nod
 
 // compileLabel implements compiler.compileLabel for the amd64 architecture.
 func (c *amd64Compiler) compileLabel(o *wazeroir.OperationLabel) (skipLabel bool) {
-	if buildoptions.IsDebugMode {
+	if false {
 		fmt.Printf("[label %s ends]\n\n", c.currentLabel)
 	}
 
@@ -667,7 +666,7 @@ func (c *amd64Compiler) compileLabel(o *wazeroir.OperationLabel) (skipLabel bool
 	// Clear for debugging purpose. See the comment in "len(amd64LabelInfo.labelBeginningCallbacks) > 0" block above.
 	labelInfo.labelBeginningCallbacks = nil
 
-	if buildoptions.IsDebugMode {
+	if false {
 		fmt.Printf("[label %s (num callers=%d)]\n%s\n", labelKey, c.ir.LabelCallers[labelKey], c.locationStack)
 	}
 	c.currentLabel = labelKey

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/leb128"
 )
 
@@ -78,7 +77,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 	// control blocks and value types to check the validity of all instructions.
 	for pc := uint64(0); pc < uint64(len(body)); pc++ {
 		op := body[pc]
-		if buildoptions.IsDebugMode {
+		if false {
 			var instName string
 			if op == OpcodeMiscPrefix {
 				instName = MiscInstructionName(body[pc+1])

--- a/internal/wasmdebug/debug.go
+++ b/internal/wasmdebug/debug.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
 	"github.com/tetratelabs/wazero/sys"
 )
@@ -113,7 +112,7 @@ type stackTrace struct {
 }
 
 func (s *stackTrace) FromRecovered(recovered interface{}) error {
-	if buildoptions.IsDebugMode {
+	if false {
 		debug.PrintStack()
 	}
 

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/buildoptions"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
@@ -360,7 +359,7 @@ func compile(enabledFeatures api.CoreFeatures,
 // and emit the results into c.results.
 func (c *compiler) handleInstruction() error {
 	op := c.body[c.pc]
-	if buildoptions.IsDebugMode {
+	if false {
 		var instName string
 		if op == wasm.OpcodeVecPrefix {
 			instName = wasm.VectorInstructionName(c.body[c.pc+1])
@@ -3027,7 +3026,7 @@ func (c *compiler) emit(ops ...Operation) {
 				}
 			}
 			c.result.Operations = append(c.result.Operations, op)
-			if buildoptions.IsDebugMode {
+			if false {
 				fmt.Printf("emitting ")
 				formatOperation(os.Stdout, op)
 			}


### PR DESCRIPTION
This has existed since the beginning, but I have never used recently 
since it's used everywhere and stdout gets pretty messy if enabled.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>