### PR TITLE
site: adds instructions on how to hack go

### DIFF
--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -241,6 +241,52 @@ signature unrelated to the source, more care is needed implementing the host
 side, to ensure the proper count of parameters are read and results written to
 the Go stack.
 
+## Hacking
+
+If you run into an issue where you need to change Go's sourcecode, the first
+thing you should do is read the [contributing guide][20], which details how to
+confirm an issue exists and a fix would be accepted. Assuming they say get a
+yes, the next step is to ensure you can build and test go.
+
+### Setting up your GOROOT
+
+First, clone upstream or your fork of golang/go and make a branch off `master`
+for your work, as GitHub pull requests are against that branch.
+
+```bash
+$ git clone https://github.com/golang/go.git
+$ cd go
+$ export GOROOT=$PWD
+$ git checkout -b my-fix
+```
+
+### Build a branch-specific `go` binary
+
+While your change may not affect the go binary itself, there are checks inside
+go that require version matching. Build a go binary from source to avoid these:
+```bash
+$ cd src
+$ GOOS=js GOARCH=wasm ./make.bash
+Building Go cmd/dist using /usr/local/go. (go1.19 darwin/amd64)
+Building Go toolchain1 using /usr/local/go.
+--snip--
+$ cd ..
+$ bin/go version
+go version devel go1.19-c5da4fb7ac Fri Jul 22 20:12:19 2022 +0000 darwin/amd64
+```
+
+### Iterate until ready to submit
+
+Now that you have your `GOROOT` and a valid binary at `${GOROOT}/bin/go`,
+iterate on changes until they work.
+
+Ex. If you fixed something in the `syscall/js` package
+(`${GOROOT}/src/syscall/js`), test it like so:
+```bash
+$ GOOS=js GOARCH=wasm ${GOROOT}/bin/go test syscall/js
+ok  	syscall/js	1.093s
+```
+
 [1]: https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js
 [2]: https://github.com/golang/go/blob/go1.19/src/cmd/link/internal/wasm/asm.go
 [3]: https://github.com/WebAssembly/wabt
@@ -260,3 +306,4 @@ the Go stack.
 [17]: https://github.com/WebAssembly/spec/blob/wg-2.0.draft1/proposals/nontrapping-float-to-int-conversion/Overview.md
 [18]: https://github.com/WebAssembly/spec/blob/wg-2.0.draft1/proposals/sign-extension-ops/Overview.md
 [19]: https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/
+[20]: https://github.com/golang/go/blob/go1.19/CONTRIBUTING.md

--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -245,8 +245,8 @@ the Go stack.
 
 If you run into an issue where you need to change Go's sourcecode, the first
 thing you should do is read the [contributing guide][20], which details how to
-confirm an issue exists and a fix would be accepted. Assuming they say get a
-yes, the next step is to ensure you can build and test go.
+confirm an issue exists and a fix would be accepted. Assuming they say yes, the
+next step is to ensure you can build and test go.
 
 ### Setting up your GOROOT
 

--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -254,7 +254,7 @@ First, clone upstream or your fork of golang/go and make a branch off `master`
 for your work, as GitHub pull requests are against that branch.
 
 ```bash
-$ git clone https://github.com/golang/go.git
+$ git clone --depth=1 https://github.com/golang/go.git
 $ cd go
 $ git checkout -b my-fix
 ```

--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -248,7 +248,7 @@ thing you should do is read the [contributing guide][20], which details how to
 confirm an issue exists and a fix would be accepted. Assuming they say yes, the
 next step is to ensure you can build and test go.
 
-### Setting up your GOROOT
+### Make a branch for your changes
 
 First, clone upstream or your fork of golang/go and make a branch off `master`
 for your work, as GitHub pull requests are against that branch.
@@ -256,7 +256,6 @@ for your work, as GitHub pull requests are against that branch.
 ```bash
 $ git clone https://github.com/golang/go.git
 $ cd go
-$ export GOROOT=$PWD
 $ git checkout -b my-fix
 ```
 
@@ -264,6 +263,7 @@ $ git checkout -b my-fix
 
 While your change may not affect the go binary itself, there are checks inside
 go that require version matching. Build a go binary from source to avoid these:
+
 ```bash
 $ cd src
 $ GOOS=js GOARCH=wasm ./make.bash
@@ -275,15 +275,34 @@ $ bin/go version
 go version devel go1.19-c5da4fb7ac Fri Jul 22 20:12:19 2022 +0000 darwin/amd64
 ```
 
+Note: The above `bin/go` was built with whatever go version you had in your
+path!
+
+### Setup ENV variables for your branch.
+
+To test the Go you just built, you need to have `GOROOT` set to your workspace,
+and your PATH configured to find both `bin/go` and `bin/misc/go_js_wasm_exec`.
+
+Ex.
+```bash
+$ export GOROOT=$PWD
+$ export PATH=${GOROOT}/bin/misc:${GOROOT}/bin:$PATH
+```
+
+Tip: `go_js_wasm_exec` is used because Go doesn't embed a WebAssembly runtime
+like wazero. In other words, go can't run the wasm it just built. Instead,
+`go test` uses Node.js which it assumes is installed on your host!
+
 ### Iterate until ready to submit
 
-Now that you have your `GOROOT` and a valid binary at `${GOROOT}/bin/go`,
-iterate on changes until they work.
+Now, you should be all set and can iterate similar to normal Go development.
+The main thing to keep in mind is where files are, and remember to set
+`GOOS=js GOARCH=wasm` when running go commands. 
 
 Ex. If you fixed something in the `syscall/js` package
 (`${GOROOT}/src/syscall/js`), test it like so:
 ```bash
-$ GOOS=js GOARCH=wasm ${GOROOT}/bin/go test syscall/js
+$ GOOS=js GOARCH=wasm /go test syscall/js
 ok  	syscall/js	1.093s
 ```
 

--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -275,8 +275,10 @@ $ bin/go version
 go version devel go1.19-c5da4fb7ac Fri Jul 22 20:12:19 2022 +0000 darwin/amd64
 ```
 
-Note: The above `bin/go` was built with whatever go version you had in your
-path!
+Tips:
+* The above `bin/go` was built with whatever go version you had in your path!
+* `GOARCH` here is what the resulting `go` binary can target. It isn't the
+  architecture of the current host (`GOHOSTARCH`).
 
 ### Setup ENV variables for your branch.
 
@@ -297,7 +299,7 @@ like wazero. In other words, go can't run the wasm it just built. Instead,
 
 Now, you should be all set and can iterate similar to normal Go development.
 The main thing to keep in mind is where files are, and remember to set
-`GOOS=js GOARCH=wasm` when running go commands. 
+`GOOS=js GOARCH=wasm` when running go commands.
 
 Ex. If you fixed something in the `syscall/js` package
 (`${GOROOT}/src/syscall/js`), test it like so:

--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -283,12 +283,12 @@ Tips:
 ### Setup ENV variables for your branch.
 
 To test the Go you just built, you need to have `GOROOT` set to your workspace,
-and your PATH configured to find both `bin/go` and `bin/misc/go_js_wasm_exec`.
+and your PATH configured to find both `bin/go` and `misc/wasm/go_js_wasm_exec`.
 
 Ex.
 ```bash
 $ export GOROOT=$PWD
-$ export PATH=${GOROOT}/bin/misc:${GOROOT}/bin:$PATH
+$ export PATH=${GOROOT}/misc/wasm:${GOROOT}/bin:$PATH
 ```
 
 Tip: `go_js_wasm_exec` is used because Go doesn't embed a WebAssembly runtime
@@ -304,7 +304,7 @@ The main thing to keep in mind is where files are, and remember to set
 Ex. If you fixed something in the `syscall/js` package
 (`${GOROOT}/src/syscall/js`), test it like so:
 ```bash
-$ GOOS=js GOARCH=wasm /go test syscall/js
+$ GOOS=js GOARCH=wasm go test syscall/js
 ok  	syscall/js	1.093s
 ```
 


### PR DESCRIPTION
One reality of wasm compilers is that they are incomplete and often have bugs. While I don't want our site to become overwhelmed with instructions, it is helpful I think to have tips on how to do routine changes to the compiler, at least how to test them.

This is for Go, and I'll also add one on TinyGo as in both cases, it might not be obvious that you need may need to rebuild the binary in order to test changes, and if you do it may be difficult to figure out how.