### PR TITLE
wasi: stubs sock_accept and removes things removed from WASI

### DIFF
--- a/imports/wasi_snapshot_preview1/clock.go
+++ b/imports/wasi_snapshot_preview1/clock.go
@@ -19,10 +19,8 @@ const (
 	clockIDRealtime = iota
 	// clockIDMonotonic is the name ID named "monotonic" like sys.Nanotime
 	clockIDMonotonic
-	// clockIDProcessCputime is the unsupported "process_cputime_id"
-	clockIDProcessCputime
-	// clockIDThreadCputime is the unsupported "thread_cputime_id"
-	clockIDThreadCputime
+	// Note: clockIDProcessCputime and clockIDThreadCputime were removed by
+	// WASI maintainers: https://github.com/WebAssembly/wasi-libc/pull/294
 )
 
 // clockResGet is the WASI function named functionClockResGet that returns the
@@ -65,11 +63,6 @@ var clockResGet = wasm.NewGoFunc(
 			resolution = uint64(sysCtx.WalltimeResolution())
 		case clockIDMonotonic:
 			resolution = uint64(sysCtx.NanotimeResolution())
-		case clockIDProcessCputime, clockIDThreadCputime:
-			// Similar to many other runtimes, we only support realtime and
-			// monotonic clocks. Other types are slated to be removed from the next
-			// version of WASI.
-			return ErrnoNotsup
 		default:
 			return ErrnoInval
 		}
@@ -125,11 +118,6 @@ var clockTimeGet = wasm.NewGoFunc(
 			val = (uint64(sec) * uint64(time.Second.Nanoseconds())) + uint64(nsec)
 		case clockIDMonotonic:
 			val = uint64(sysCtx.Nanotime(ctx))
-		case clockIDProcessCputime, clockIDThreadCputime:
-			// Similar to many other runtimes, we only support realtime and
-			// monotonic clocks. Other types are slated to be removed from the next
-			// version of WASI.
-			return ErrnoNotsup
 		default:
 			return ErrnoInval
 		}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -86,23 +86,23 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 		{
 			name:          "process cputime",
 			clockID:       2,
-			expectedErrno: ErrnoNotsup,
+			expectedErrno: ErrnoInval,
 			expectedLog: `
 --> proxy.clock_res_get(id=2,result.resolution=1)
 	==> wasi_snapshot_preview1.clock_res_get(id=2,result.resolution=1)
-	<== ENOTSUP
-<-- (58)
+	<== EINVAL
+<-- (28)
 `,
 		},
 		{
 			name:          "thread cputime",
 			clockID:       3,
-			expectedErrno: ErrnoNotsup,
+			expectedErrno: ErrnoInval,
 			expectedLog: `
 --> proxy.clock_res_get(id=3,result.resolution=1)
 	==> wasi_snapshot_preview1.clock_res_get(id=3,result.resolution=1)
-	<== ENOTSUP
-<-- (58)
+	<== EINVAL
+<-- (28)
 `,
 		},
 		{
@@ -204,23 +204,23 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 		{
 			name:          "process cputime",
 			clockID:       2,
-			expectedErrno: ErrnoNotsup,
+			expectedErrno: ErrnoInval,
 			expectedLog: `
 --> proxy.clock_time_get(id=2,precision=0,result.timestamp=1)
 	==> wasi_snapshot_preview1.clock_time_get(id=2,precision=0,result.timestamp=1)
-	<== ENOTSUP
-<-- (58)
+	<== EINVAL
+<-- (28)
 `,
 		},
 		{
 			name:          "thread cputime",
 			clockID:       3,
-			expectedErrno: ErrnoNotsup,
+			expectedErrno: ErrnoInval,
 			expectedLog: `
 --> proxy.clock_time_get(id=3,precision=0,result.timestamp=1)
 	==> wasi_snapshot_preview1.clock_time_get(id=3,precision=0,result.timestamp=1)
-	<== ENOTSUP
-<-- (58)
+	<== EINVAL
+<-- (28)
 `,
 		},
 		{

--- a/imports/wasi_snapshot_preview1/errno.go
+++ b/imports/wasi_snapshot_preview1/errno.go
@@ -9,7 +9,8 @@ import (
 // # Notes
 //
 //   - This is not always an error, as ErrnoSuccess is a valid code.
-//   - Codes are defined even when not relevant to WASI for use in higher-level libraries or alignment with POSIX.
+//   - Codes are defined even when not relevant to WASI for use in higher-level
+//     libraries or alignment with POSIX.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-errno-enumu16 and
 // https://linux.die.net/man/3/errno
@@ -176,6 +177,7 @@ const (
 	ErrnoTxtbsy
 	// ErrnoXdev Cross-device link.
 	ErrnoXdev
-	// ErrnoNotcapable Extension: Capabilities insufficient.
-	ErrnoNotcapable
+
+	// Note: ErrnoNotcapable was removed by WASI maintainers.
+	// See https://github.com/WebAssembly/wasi-libc/pull/294
 )

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -1126,9 +1126,8 @@ func Test_pathOpen(t *testing.T) {
 	pathPtr := uint32(1)
 	pathLen := uint32(len(pathName))
 	oflags := uint32(0)
-	// rights are ignored per https://github.com/WebAssembly/WASI/issues/469#issuecomment-1045251844
-	fsRightsBase := uint64(1)
-	fsRightsInheriting := uint64(2)
+	fsRightsBase := uint64(1)       // ignored: rights were removed from WASI.
+	fsRightsInheriting := uint64(2) // ignored: rights were removed from WASI.
 	fdflags := uint32(0)
 	resultOpenedFd := uint32(len(initialMemory) + 1)
 

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -36,8 +36,7 @@ var procExit = wasm.NewGoFunc(
 	},
 )
 
-// procRaise is the WASI function named functionProcRaise which sends a signal
-// to the process of the calling thread.
+// procRaise is stubbed and will never be supported, as it was removed.
 //
-// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-proc_raisesig-signal---errno
+// See https://github.com/WebAssembly/WASI/pull/136
 var procRaise = stubFunction(functionProcRaise, []wasm.ValueType{i32}, []string{"sig"})

--- a/imports/wasi_snapshot_preview1/sock.go
+++ b/imports/wasi_snapshot_preview1/sock.go
@@ -3,9 +3,21 @@ package wasi_snapshot_preview1
 import "github.com/tetratelabs/wazero/internal/wasm"
 
 const (
+	functionSockAccept   = "sock_accept"
 	functionSockRecv     = "sock_recv"
 	functionSockSend     = "sock_send"
 	functionSockShutdown = "sock_shutdown"
+)
+
+// sockAccept is the WASI function named functionSockAccept which accepts a new
+// incoming connection.
+//
+// See: https://github.com/WebAssembly/WASI/blob/0ba0c5e2e37625ca5a6d3e4255a998dfaa3efc52/phases/snapshot/docs.md#sock_accept
+// and https://github.com/WebAssembly/WASI/pull/458
+var sockAccept = stubFunction(
+	functionSockAccept,
+	[]wasm.ValueType{i32, i32, i32},
+	[]string{"fd", "flags", "result.fd"},
 )
 
 // sockRecv is the WASI function named functionSockRecv which receives a

--- a/imports/wasi_snapshot_preview1/sock_test.go
+++ b/imports/wasi_snapshot_preview1/sock_test.go
@@ -6,6 +6,17 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+// Test_sockAccept only tests it is stubbed for GrainLang per #271
+func Test_sockAccept(t *testing.T) {
+	log := requireErrnoNosys(t, functionSockAccept, 0, 0, 0)
+	require.Equal(t, `
+--> proxy.sock_accept(fd=0,flags=0,result.fd=0)
+	--> wasi_snapshot_preview1.sock_accept(fd=0,flags=0,result.fd=0)
+	<-- ENOSYS
+<-- (52)
+`, log)
+}
+
 // Test_sockRecv only tests it is stubbed for GrainLang per #271
 func Test_sockRecv(t *testing.T) {
 	log := requireErrnoNosys(t, functionSockRecv, 0, 0, 0, 0, 0, 0)

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -110,7 +110,8 @@ func (b *builder) Instantiate(ctx context.Context, ns wazero.Namespace) (api.Clo
 // exportFunctions adds all go functions that implement wasi.
 // These should be exported in the module named ModuleName.
 func exportFunctions(builder wazero.ModuleBuilder) {
-	// Note:se are ordered per spec for consistency even if the resulting map can't guarantee that.
+	// Note: these are ordered per spec for consistency even if the resulting
+	// map can't guarantee that.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#functions
 	builder.ExportFunction(argsGet.Name, argsGet)
 	builder.ExportFunction(argsSizesGet.Name, argsSizesGet)
@@ -154,6 +155,7 @@ func exportFunctions(builder wazero.ModuleBuilder) {
 	builder.ExportFunction(procRaise.Name, procRaise)
 	builder.ExportFunction(schedYield.Name, schedYield)
 	builder.ExportFunction(randomGet.Name, randomGet)
+	builder.ExportFunction(sockAccept.Name, sockAccept)
 	builder.ExportFunction(sockRecv.Name, sockRecv)
 	builder.ExportFunction(sockSend.Name, sockSend)
 	builder.ExportFunction(sockShutdown.Name, sockShutdown)

--- a/site/content/languages/tinygo.md
+++ b/site/content/languages/tinygo.md
@@ -115,7 +115,7 @@ in more, see [System Calls](#system-calls).
 ## Memory
 
 When TinyGo compiles go into wasm, it configures the WebAssembly linear memory
-to an initial size of 2 pages (16KB), and marks a position in that memory as
+to an initial size of 2 pages (128KB), and marks a position in that memory as
 the heap base. All memory beyond that is used for the Go heap.
 
 Allocations within Go (compiled to `%.wasm`) are managed as one would expect.

--- a/site/content/specs.md
+++ b/site/content/specs.md
@@ -66,8 +66,9 @@ any working drafts as a result of their work. WASI's last stable point was
 
 Some functions in this tag are used in practice while some others are not known
 to be used at all. Further confusion exists because some compilers, like
-GrainLang, import functions not used. Finally, [wasi_snapshot_preview1][4]
-includes features such as "rights" that [will be removed][13].
+GrainLang, import functions not used. Finally, some functions were added and
+removed after the git tag. For example, [`proc_raise`][13] was removed and
+[`sock_accept`][15] added.
 
 For all of these reasons, wazero will not implement all WASI features, just to
 complete the below chart. If you desire something not yet implemented, please
@@ -91,7 +92,7 @@ your use case (ex which language you are using to compile, a.k.a. target Wasm).
 | fd_datasync             |   ❌    |                 |
 | fd_fdstat_get           |   ✅    |          TinyGo |
 | fd_fdstat_set_flags     |   ❌    |                 |
-| fd_fdstat_set_rights    |   ❌    |                 |
+| fd_fdstat_set_rights    |   💀   |                 |
 | fd_filestat_get         |   ❌    |                 |
 | fd_filestat_set_size    |   ❌    |                 |
 | fd_filestat_set_times   |   ❌    |                 |
@@ -118,12 +119,15 @@ your use case (ex which language you are using to compile, a.k.a. target Wasm).
 | path_unlink_file        |   ❌    |                 |
 | poll_oneoff             |   ✅    | Rust,TinyGo,Zig |
 | proc_exit               |   ✅    |  AssemblyScript |
-| proc_raise              |   ❌    |                 |
+| proc_raise              |   💀   |                 |
 | sched_yield             |   ❌    |                 |
 | random_get              |   ✅    |                 |
+| sock_accept             |   ❌    |                 |
 | sock_recv               |   ❌    |                 |
 | sock_send               |   ❌    |                 |
 | sock_shutdown           |   ❌    |                 |
+
+Note: 💀 means the function was later removed from WASI.
 
 </p>
 </details>
@@ -139,5 +143,6 @@ your use case (ex which language you are using to compile, a.k.a. target Wasm).
 [10]: https://github.com/WebAssembly/proposals
 [11]: https://github.com/WebAssembly/proposals/blob/main/finished-proposals.md
 [12]: https://www.w3.org/community/webassembly/
-[13]: https://github.com/WebAssembly/WASI/issues/469#issuecomment-1045251844
+[13]: https://github.com/WebAssembly/WASI/pull/136
 [14]: https://github.com/WebAssembly/spec/tree/d39195773112a22b245ffbe864bab6d1182ccb06/test/core
+[15]: https://github.com/WebAssembly/WASI/pull/458


### PR DESCRIPTION
This catches up with latest WASI drift.
