### PR TITLE
Replaces MemorySizer and CompileConfig with RuntimeConfig

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -280,8 +280,6 @@ space. It is accepted that the options pattern is common in Go, which is the mai
 wazero's configuration types cover the three main scopes of WebAssembly use:
 * `RuntimeConfig`: This is the broadest scope, so applies also to compilation
   and instantiation. Ex. This controls the WebAssembly Specification Version.
-* `CompileConfig`: This affects any compilation related concerns not defined in
-  the binary format. Ex. This controls the allocation of linear memory.
 * `ModuleConfig`: This affects modules instantiated after compilation and what
   resources are allowed. Ex. This defines how or if STDOUT is captured.
 

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -486,18 +486,3 @@ func EncodeF64(input float64) uint64 {
 func DecodeF64(input uint64) float64 {
 	return math.Float64frombits(input)
 }
-
-// MemorySizer applies during compilation after a module has been decoded from wasm, but before it is instantiated.
-// This determines the amount of memory pages (65536 bytes per page) to use when a memory is instantiated as a []byte.
-//
-// Ex. Here's how to set the capacity to max instead of min, when set:
-//
-//	capIsMax := func(minPages uint32, maxPages *uint32) (min, capacity, max uint32) {
-//		if maxPages != nil {
-//			return minPages, *maxPages, *maxPages
-//		}
-//		return minPages, minPages, 65536
-//	}
-//
-// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem
-type MemorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32)

--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -94,7 +94,7 @@ func doRun(args []string, stdOut io.Writer, stdErr io.Writer, exit func(code int
 		WithSysNanotime().
 		WithSysWalltime().
 		WithArgs(append([]string{wasmExe}, wasmArgs...)...)
-	code, err := rt.CompileModule(ctx, wasm, wazero.NewCompileConfig())
+	code, err := rt.CompileModule(ctx, wasm)
 	if err != nil {
 		fmt.Fprintf(stdErr, "error compiling wasm binary: %v\n", err)
 		exit(1)

--- a/examples/allocation/zig/greet.go
+++ b/examples/allocation/zig/greet.go
@@ -45,7 +45,7 @@ func run() error {
 
 	// Instantiate a WebAssembly module that imports the "log" function defined
 	// in "env" and exports "memory" and functions we'll use in this example.
-	compiled, err := r.CompileModule(ctx, greetWasm, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(ctx, greetWasm)
 	if err != nil {
 		return err
 	}

--- a/examples/namespace/counter.go
+++ b/examples/namespace/counter.go
@@ -29,7 +29,7 @@ func main() {
 	defer r.Close(ctx) // This closes everything this Runtime created.
 
 	// Compile WebAssembly that requires its own "env" module.
-	compiled, err := r.CompileModule(ctx, counterWasm, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(ctx, counterWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/experimental/compilation_cache_example_test.go
+++ b/experimental/compilation_cache_example_test.go
@@ -41,7 +41,7 @@ func newRuntimeCompileClose(ctx context.Context) {
 	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx) // This closes everything this Runtime created except the file system cache.
 
-	_, err := r.CompileModule(ctx, fsWasm, wazero.NewCompileConfig())
+	_, err := r.CompileModule(ctx, fsWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -64,7 +64,7 @@ func Example_customListenerFactory() {
 	wasi_snapshot_preview1.MustInstantiate(ctx, r)
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, listenerWasm, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, listenerWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -53,7 +53,7 @@ func TestFunctionListenerFactory(t *testing.T) {
 		t.Run("fails on compile if compiler", func(t *testing.T) {
 			r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
 			defer r.Close(testCtx) // This closes everything this Runtime created.
-			_, err := r.CompileModule(ctx, bin, wazero.NewCompileConfig())
+			_, err := r.CompileModule(ctx, bin)
 			require.EqualError(t, err,
 				"context includes a FunctionListenerFactoryKey, which is only supported in the interpreter")
 		})
@@ -62,7 +62,7 @@ func TestFunctionListenerFactory(t *testing.T) {
 	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
 	defer r.Close(ctx) // This closes everything this Runtime created.
 
-	_, err := r.CompileModule(ctx, bin, wazero.NewCompileConfig())
+	_, err := r.CompileModule(ctx, bin)
 	require.NoError(t, err)
 
 	// Ensure each function was converted to a listener eagerly

--- a/experimental/logging/log_listener_example_test.go
+++ b/experimental/logging/log_listener_example_test.go
@@ -30,7 +30,7 @@ func Example_newLoggingListenerFactory() {
 	wasi_snapshot_preview1.MustInstantiate(ctx, r)
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, listenerWasm, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, listenerWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/imports/assemblyscript/assemblyscript_test.go
+++ b/imports/assemblyscript/assemblyscript_test.go
@@ -435,7 +435,7 @@ func requireProxyModule(t *testing.T, fns FunctionExporter, config wazero.Module
 
 	proxyBin := proxy.GetProxyModuleBinary("env", envCompiled)
 
-	proxyCompiled, err := r.CompileModule(ctx, proxyBin, wazero.NewCompileConfig())
+	proxyCompiled, err := r.CompileModule(ctx, proxyBin)
 	require.NoError(t, err)
 
 	mod, err := r.InstantiateModule(ctx, proxyCompiled, config)

--- a/imports/assemblyscript/example/assemblyscript.go
+++ b/imports/assemblyscript/example/assemblyscript.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, asWasm, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, asWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/imports/go/example/stars.go
+++ b/imports/go/example/stars.go
@@ -46,7 +46,7 @@ func main() {
 
 	// Compile the WebAssembly module using the default configuration.
 	start := time.Now()
-	compiled, err := r.CompileModule(ctx, bin, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(ctx, bin)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/imports/go/example/stars_test.go
+++ b/imports/go/example/stars_test.go
@@ -71,7 +71,7 @@ func Benchmark_main(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	compiled, err := r.CompileModule(ctx, bin, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(ctx, bin)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/imports/wasi_snapshot_preview1/example/cat.go
+++ b/imports/wasi_snapshot_preview1/example/cat.go
@@ -77,7 +77,7 @@ func main() {
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, catWasm, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, catWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/imports/wasi_snapshot_preview1/example_test.go
+++ b/imports/wasi_snapshot_preview1/example_test.go
@@ -36,7 +36,7 @@ func Example() {
 	defer wm.Close(testCtx)
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := r.CompileModule(ctx, exitOnStartWasm, wazero.NewCompileConfig())
+	code, err := r.CompileModule(ctx, exitOnStartWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/imports/wasi_snapshot_preview1/usage_test.go
+++ b/imports/wasi_snapshot_preview1/usage_test.go
@@ -25,7 +25,7 @@ func TestInstantiateModule(t *testing.T) {
 	require.NoError(t, err)
 	defer wm.Close(testCtx)
 
-	compiled, err := r.CompileModule(testCtx, wasiArg, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(testCtx, wasiArg)
 	require.NoError(t, err)
 	defer compiled.Close(testCtx)
 

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -46,7 +46,7 @@ func Benchmark_EnvironGet(b *testing.B) {
 	compiled, err := r.CompileModule(testCtx, binaryformat.EncodeModule(&wasm.Module{
 		MemorySection: &wasm.Memory{Min: 1, Max: 1},
 		ExportSection: []*wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
-	}), wazero.NewCompileConfig())
+	}))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/imports/wasi_snapshot_preview1/wasi_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_test.go
@@ -42,7 +42,7 @@ func requireProxyModule(t *testing.T, config wazero.ModuleConfig) (api.Module, a
 
 	proxyBin := proxy.GetProxyModuleBinary(ModuleName, wasiModuleCompiled)
 
-	proxyCompiled, err := r.CompileModule(ctx, proxyBin, wazero.NewCompileConfig())
+	proxyCompiled, err := r.CompileModule(ctx, proxyBin)
 	require.NoError(t, err)
 
 	mod, err := r.InstantiateModule(ctx, proxyCompiled, config)
@@ -72,7 +72,7 @@ func requireErrnoNosys(t *testing.T, funcName string, params ...uint64) string {
 
 	proxyBin := proxy.GetProxyModuleBinary(ModuleName, wasiModuleCompiled)
 
-	proxyCompiled, err := r.CompileModule(ctx, proxyBin, wazero.NewCompileConfig())
+	proxyCompiled, err := r.CompileModule(ctx, proxyBin)
 	require.NoError(t, err)
 
 	mod, err := r.InstantiateModule(ctx, proxyCompiled, wazero.NewModuleConfig())

--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -27,7 +27,7 @@ func compileAndRun(ctx context.Context, arg string, config wazero.ModuleConfig) 
 	r := wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfig())
 	defer r.Close(ctx)
 
-	compiled, compileErr := r.CompileModule(ctx, testBin, wazero.NewCompileConfig())
+	compiled, compileErr := r.CompileModule(ctx, testBin)
 	if compileErr != nil {
 		err = compileErr
 		return
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 	// one test from a cache-miss performance penalty.
 	rt := wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfig())
 	defer rt.Close(testCtx)
-	_, err = rt.CompileModule(testCtx, testBin, wazero.NewCompileConfig())
+	_, err = rt.CompileModule(testCtx, testBin)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -79,7 +79,7 @@ func BenchmarkCompilation(b *testing.B) {
 }
 
 func runCompilation(b *testing.B, r wazero.Runtime) wazero.CompiledModule {
-	compiled, err := r.CompileModule(testCtx, caseWasm, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(testCtx, caseWasm)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/integration_test/bench/codec_test.go
+++ b/internal/integration_test/bench/codec_test.go
@@ -89,7 +89,7 @@ func newExample() *wasm.Module {
 
 func TestExampleUpToDate(t *testing.T) {
 	t.Run("binary.DecodeModule", func(t *testing.T) {
-		m, err := binary.DecodeModule(exampleWasm, api.CoreFeaturesV2, wasm.MemorySizer)
+		m, err := binary.DecodeModule(exampleWasm, api.CoreFeaturesV2, wasm.MemoryLimitPages, false)
 		require.NoError(t, err)
 		require.Equal(t, example, m)
 	})
@@ -116,7 +116,7 @@ func BenchmarkCodec(b *testing.B) {
 	b.Run("binary.DecodeModule", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			if _, err := binary.DecodeModule(exampleWasm, api.CoreFeaturesV2, wasm.MemorySizer); err != nil {
+			if _, err := binary.DecodeModule(exampleWasm, api.CoreFeaturesV2, wasm.MemoryLimitPages, false); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -26,14 +26,6 @@ const (
 
 var memoryCapacityPages = uint32(2)
 
-var compileConfig = wazero.NewCompileConfig().
-	WithMemorySizer(func(minPages uint32, maxPages *uint32) (min, capacity, max uint32) {
-		if maxPages != nil {
-			return minPages, memoryCapacityPages, *maxPages
-		}
-		return minPages, memoryCapacityPages, memoryCapacityPages
-	})
-
 var moduleConfig = wazero.NewModuleConfig()
 
 var tests = map[string]func(t *testing.T, r wazero.Runtime){
@@ -529,7 +521,7 @@ func testCloseInFlight(t *testing.T, r wazero.Runtime) {
 
 			// Import that module.
 			binary := callReturnImportWasm(t, imported.Name(), t.Name()+"-importing", i32)
-			importingCode, err = r.CompileModule(testCtx, binary, compileConfig)
+			importingCode, err = r.CompileModule(testCtx, binary)
 			require.NoError(t, err)
 
 			importing, err = r.InstantiateModule(testCtx, importingCode, moduleConfig)
@@ -622,7 +614,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 		}},
 		ExportSection: []*wasm.Export{{Name: "store"}},
 	})
-	compiled, err := r.CompileModule(testCtx, bin, compileConfig)
+	compiled, err := r.CompileModule(testCtx, bin)
 	require.NoError(t, err)
 	defer compiled.Close(testCtx)
 

--- a/internal/integration_test/fs/fs_test.go
+++ b/internal/integration_test/fs/fs_test.go
@@ -158,7 +158,7 @@ func TestReader(t *testing.T) {
 	sys := wazero.NewModuleConfig().WithFS(realFs)
 
 	// Create a module that just delegates to wasi functions.
-	compiled, err := r.CompileModule(testCtx, fsWasm, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(testCtx, fsWasm)
 	require.NoError(t, err)
 
 	mod, err := r.InstantiateModule(testCtx, compiled, sys)

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -327,7 +327,7 @@ var spectestWasm []byte
 // See https://github.com/WebAssembly/spec/blob/wg-1.0/test/core/imports.wast
 // See https://github.com/WebAssembly/spec/blob/wg-1.0/interpreter/script/js.ml#L13-L25
 func addSpectestModule(t *testing.T, ctx context.Context, s *wasm.Store, ns *wasm.Namespace, enabledFeatures api.CoreFeatures) {
-	mod, err := binaryformat.DecodeModule(spectestWasm, api.CoreFeaturesV2, wasm.MemorySizer)
+	mod, err := binaryformat.DecodeModule(spectestWasm, api.CoreFeaturesV2, wasm.MemoryLimitPages, false)
 	require.NoError(t, err)
 
 	// (global (export "global_i32") i32 (i32.const 666))
@@ -422,7 +422,7 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, newEngine func(
 					case "module":
 						buf, err := testDataFS.ReadFile(testdataPath(c.Filename))
 						require.NoError(t, err, msg)
-						mod, err := binaryformat.DecodeModule(buf, enabledFeatures, wasm.MemorySizer)
+						mod, err := binaryformat.DecodeModule(buf, enabledFeatures, wasm.MemoryLimitPages, false)
 						require.NoError(t, err, msg)
 						require.NoError(t, mod.Validate(enabledFeatures))
 						mod.AssignModuleID(buf)
@@ -563,7 +563,7 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, newEngine func(
 							//
 							// In practice, such a module instance can be used for invoking functions without any issue. In addition, we have to
 							// retain functions after the expected "instantiation" failure, so in wazero we choose to not raise error in that case.
-							mod, err := binaryformat.DecodeModule(buf, s.EnabledFeatures, wasm.MemorySizer)
+							mod, err := binaryformat.DecodeModule(buf, s.EnabledFeatures, wasm.MemoryLimitPages, false)
 							require.NoError(t, err, msg)
 
 							err = mod.Validate(s.EnabledFeatures)
@@ -592,7 +592,7 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, newEngine func(
 }
 
 func requireInstantiationError(t *testing.T, ctx context.Context, s *wasm.Store, ns *wasm.Namespace, buf []byte, msg string) {
-	mod, err := binaryformat.DecodeModule(buf, s.EnabledFeatures, wasm.MemorySizer)
+	mod, err := binaryformat.DecodeModule(buf, s.EnabledFeatures, wasm.MemoryLimitPages, false)
 	if err != nil {
 		return
 	}
@@ -860,7 +860,7 @@ func TestBinaryEncoder(t *testing.T, testDataFS embed.FS, enabledFeatures api.Co
 
 						buf = requireStripCustomSections(t, buf)
 
-						mod, err := binaryformat.DecodeModule(buf, enabledFeatures, wasm.MemorySizer)
+						mod, err := binaryformat.DecodeModule(buf, enabledFeatures, wasm.MemoryLimitPages, false)
 						require.NoError(t, err)
 
 						encodedBuf := binaryformat.EncodeModule(mod)

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -108,7 +108,7 @@ func (r *wazeroRuntime) Compile(ctx context.Context, cfg *RuntimeConfig) (err er
 			return err
 		}
 	}
-	r.compiled, err = r.runtime.CompileModule(ctx, cfg.ModuleWasm, wazero.NewCompileConfig())
+	r.compiled, err = r.runtime.CompileModule(ctx, cfg.ModuleWasm)
 	return
 }
 

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -81,7 +81,7 @@ func TestDecodeModule(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			m, e := DecodeModule(EncodeModule(tc.input), api.CoreFeaturesV1, wasm.MemorySizer)
+			m, e := DecodeModule(EncodeModule(tc.input), api.CoreFeaturesV1, wasm.MemoryLimitPages, false)
 			require.NoError(t, e)
 			require.Equal(t, tc.input, m)
 		})
@@ -92,7 +92,7 @@ func TestDecodeModule(t *testing.T) {
 			wasm.SectionIDCustom, 0xf, // 15 bytes in this section
 			0x04, 'm', 'e', 'm', 'e',
 			1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
-		m, e := DecodeModule(input, api.CoreFeaturesV1, wasm.MemorySizer)
+		m, e := DecodeModule(input, api.CoreFeaturesV1, wasm.MemoryLimitPages, false)
 		require.NoError(t, e)
 		require.Equal(t, &wasm.Module{}, m)
 	})
@@ -107,14 +107,14 @@ func TestDecodeModule(t *testing.T) {
 			subsectionIDModuleName, 0x07, // 7 bytes in this subsection
 			0x06, // the Module name simple is 6 bytes long
 			's', 'i', 'm', 'p', 'l', 'e')
-		m, e := DecodeModule(input, api.CoreFeaturesV1, wasm.MemorySizer)
+		m, e := DecodeModule(input, api.CoreFeaturesV1, wasm.MemoryLimitPages, false)
 		require.NoError(t, e)
 		require.Equal(t, &wasm.Module{NameSection: &wasm.NameSection{ModuleName: "simple"}}, m)
 	})
 	t.Run("data count section disabled", func(t *testing.T) {
 		input := append(append(Magic, version...),
 			wasm.SectionIDDataCount, 1, 0)
-		_, e := DecodeModule(input, api.CoreFeaturesV1, wasm.MemorySizer)
+		_, e := DecodeModule(input, api.CoreFeaturesV1, wasm.MemoryLimitPages, false)
 		require.EqualError(t, e, `data count section not supported as feature "bulk-memory-operations" is disabled`)
 	})
 }
@@ -164,7 +164,7 @@ func TestDecodeModule_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, e := DecodeModule(tc.input, api.CoreFeaturesV1, wasm.MemorySizer)
+			_, e := DecodeModule(tc.input, api.CoreFeaturesV1, wasm.MemoryLimitPages, false)
 			require.EqualError(t, e, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -13,6 +13,7 @@ func decodeImport(
 	r *bytes.Reader,
 	idx uint32,
 	memorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32),
+	memoryLimitPages uint32,
 	enabledFeatures api.CoreFeatures,
 ) (i *wasm.Import, err error) {
 	i = &wasm.Import{}
@@ -35,7 +36,7 @@ func decodeImport(
 	case wasm.ExternTypeTable:
 		i.DescTable, err = decodeTable(r, enabledFeatures)
 	case wasm.ExternTypeMemory:
-		i.DescMem, err = decodeMemory(r, memorySizer)
+		i.DescMem, err = decodeMemory(r, memorySizer, memoryLimitPages)
 	case wasm.ExternTypeGlobal:
 		i.DescGlobal, err = decodeGlobalType(r)
 	default:

--- a/internal/wasm/binary/memory.go
+++ b/internal/wasm/binary/memory.go
@@ -12,6 +12,7 @@ import (
 func decodeMemory(
 	r *bytes.Reader,
 	memorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32),
+	memoryLimitPages uint32,
 ) (*wasm.Memory, error) {
 	min, maxP, err := decodeLimitsType(r)
 	if err != nil {
@@ -21,7 +22,7 @@ func decodeMemory(
 	min, capacity, max := memorySizer(min, maxP)
 	mem := &wasm.Memory{Min: min, Cap: capacity, Max: max, IsMaxEncoded: maxP != nil}
 
-	return mem, mem.Validate()
+	return mem, mem.Validate(memoryLimitPages)
 }
 
 // encodeMemory returns the wasm.Memory encoded in WebAssembly 1.0 (20191205) Binary Format.

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -28,6 +28,7 @@ func decodeTypeSection(enabledFeatures api.CoreFeatures, r *bytes.Reader) ([]*wa
 func decodeImportSection(
 	r *bytes.Reader,
 	memorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32),
+	memoryLimitPages uint32,
 	enabledFeatures api.CoreFeatures,
 ) ([]*wasm.Import, error) {
 	vs, _, err := leb128.DecodeUint32(r)
@@ -37,7 +38,7 @@ func decodeImportSection(
 
 	result := make([]*wasm.Import, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeImport(r, i, memorySizer, enabledFeatures); err != nil {
+		if result[i], err = decodeImport(r, i, memorySizer, memoryLimitPages, enabledFeatures); err != nil {
 			return nil, err
 		}
 	}
@@ -84,6 +85,7 @@ func decodeTableSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*w
 func decodeMemorySection(
 	r *bytes.Reader,
 	memorySizer func(minPages uint32, maxPages *uint32) (min, capacity, max uint32),
+	memoryLimitPages uint32,
 ) (*wasm.Memory, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
@@ -93,7 +95,7 @@ func decodeMemorySection(
 		return nil, fmt.Errorf("at most one memory allowed in module, but read %d", vs)
 	}
 
-	return decodeMemory(r, memorySizer)
+	return decodeMemory(r, memorySizer, memoryLimitPages)
 }
 
 func decodeGlobalSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*wasm.Global, error) {

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -81,6 +81,8 @@ func TestTableSection_Errors(t *testing.T) {
 }
 
 func TestMemorySection(t *testing.T) {
+	max := wasm.MemoryLimitPages
+
 	three := uint32(3)
 	tests := []struct {
 		name     string
@@ -101,7 +103,7 @@ func TestMemorySection(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			memories, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemorySizer)
+			memories, err := decodeMemorySection(bytes.NewReader(tc.input), newMemorySizer(max, false), max)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, memories)
 		})
@@ -109,6 +111,8 @@ func TestMemorySection(t *testing.T) {
 }
 
 func TestMemorySection_Errors(t *testing.T) {
+	max := wasm.MemoryLimitPages
+
 	tests := []struct {
 		name        string
 		input       []byte
@@ -129,7 +133,7 @@ func TestMemorySection_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeMemorySection(bytes.NewReader(tc.input), wasm.MemorySizer)
+			_, err := decodeMemorySection(bytes.NewReader(tc.input), newMemorySizer(max, false), max)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -24,15 +24,6 @@ const (
 	MemoryPageSizeInBits = 16
 )
 
-// MemorySizer is the default function that derives min, capacity and max pages from decoded wasm. The capacity
-// returned is set to minPages and max defaults to MemoryLimitPages when maxPages is nil.
-var MemorySizer api.MemorySizer = func(minPages uint32, maxPages *uint32) (min, capacity, max uint32) {
-	if maxPages != nil {
-		return minPages, minPages, *maxPages
-	}
-	return minPages, minPages, MemoryLimitPages
-}
-
 // compile-time check to ensure MemoryInstance implements api.Memory
 var _ api.Memory = &MemoryInstance{}
 

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -14,21 +14,6 @@ func TestMemoryPageConsts(t *testing.T) {
 	require.Equal(t, MemoryLimitPages, uint32(1<<16))
 }
 
-func TestMemoryPages(t *testing.T) {
-	t.Run("cap=min, nil max", func(t *testing.T) {
-		min, capacity, max := MemorySizer(1, nil)
-		require.Equal(t, uint32(1), min)
-		require.Equal(t, uint32(1), capacity)
-		require.Equal(t, MemoryLimitPages, max)
-	})
-	t.Run("cap=min, max", func(t *testing.T) {
-		min, capacity, max := MemorySizer(1, uint32Ptr(2))
-		require.Equal(t, uint32(1), min)
-		require.Equal(t, uint32(1), capacity)
-		require.Equal(t, uint32(2), max)
-	})
-}
-
 func TestMemoryPagesToBytesNum(t *testing.T) {
 	for _, numPage := range []uint32{0, 1, 5, 10} {
 		require.Equal(t, uint64(numPage*MemoryPageSize), MemoryPagesToBytesNum(numPage))

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -751,24 +751,24 @@ type Memory struct {
 }
 
 // Validate ensures values assigned to Min, Cap and Max are within valid thresholds.
-func (m *Memory) Validate() error {
+func (m *Memory) Validate(memoryLimitPages uint32) error {
 	min, capacity, max := m.Min, m.Cap, m.Max
 
-	if max > MemoryLimitPages {
+	if max > memoryLimitPages {
 		return fmt.Errorf("max %d pages (%s) over limit of %d pages (%s)",
-			max, PagesToUnitOfBytes(max), MemoryLimitPages, PagesToUnitOfBytes(MemoryLimitPages))
-	} else if min > MemoryLimitPages {
+			max, PagesToUnitOfBytes(max), memoryLimitPages, PagesToUnitOfBytes(memoryLimitPages))
+	} else if min > memoryLimitPages {
 		return fmt.Errorf("min %d pages (%s) over limit of %d pages (%s)",
-			min, PagesToUnitOfBytes(min), MemoryLimitPages, PagesToUnitOfBytes(MemoryLimitPages))
+			min, PagesToUnitOfBytes(min), memoryLimitPages, PagesToUnitOfBytes(memoryLimitPages))
 	} else if min > max {
 		return fmt.Errorf("min %d pages (%s) > max %d pages (%s)",
 			min, PagesToUnitOfBytes(min), max, PagesToUnitOfBytes(max))
 	} else if capacity < min {
 		return fmt.Errorf("capacity %d pages (%s) less than minimum %d pages (%s)",
 			capacity, PagesToUnitOfBytes(capacity), min, PagesToUnitOfBytes(min))
-	} else if capacity > MemoryLimitPages {
+	} else if capacity > memoryLimitPages {
 		return fmt.Errorf("capacity %d pages (%s) over limit of %d pages (%s)",
-			capacity, PagesToUnitOfBytes(capacity), MemoryLimitPages, PagesToUnitOfBytes(MemoryLimitPages))
+			capacity, PagesToUnitOfBytes(capacity), memoryLimitPages, PagesToUnitOfBytes(memoryLimitPages))
 	}
 	return nil
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -109,7 +109,7 @@ func TestMemory_Validate(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.mem.Validate()
+			err := tc.mem.Validate(MemoryLimitPages)
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
We formerly introduced `MemorySizer` as a way to control capacity independently of size. This was the first and only feature in `CompileConfig`. While possibly used privately, `MemorySizer` has never been used in public GitHub code.

These APIs interfere with how we do caching of compiled modules. Notably, they can change the min or max defined in wasm, which invalidates some constants. This has also had a bad experience, forcing everyone to boilerplate`wazero.NewCompileConfig()` despite that API never being used in open source.

This addresses the use cases in a different way, by moving configuration to `RuntimeConfig` instead. This allows us to remove `MemorySizer` and `CompileConfig`, and the problems with them, yet still retaining functionality in case someone uses it.

* `RuntimeConfig.WithMemoryLimitPages(uint32)`: Prevents memory from growing to 4GB (spec limit) per instance.
  * This works regardless of whether the wasm encodes max or not. If there is no max, it becomes effectively this value.
* `RuntimeConfig.WithMemoryCapacityFromMax(bool)`: Prevents reallocations (when growing).
  * Wasm that never sets max will grow from min to the limit above.

Note: Those who want to change their wasm (ex insert a max where there was none), have to do that externally, ex via compiler settings or post-build transformations such as [wabin](https://github.com/tetratelabs/wabin)

