### PR TITLE
Use repo-scoped image for internal build image

### DIFF
--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Pull and push
         run: |  # This will only push a single architecture, which is fine as we currently only support amd64
           docker pull ${{ matrix.source }}
-          docker tag ${{ matrix.source }} ghcr.io/tetratelabs/wazero/internal-${{ matrix.target_tag }}
-          docker push ghcr.io/tetratelabs/wazero/internal-${{ matrix.target_tag }}
+          docker tag ${{ matrix.source }} ghcr.io/${{ github.repository }}/internal-${{ matrix.target_tag }}
+          docker push ghcr.io/${{ github.repository }}/internal-${{ matrix.target_tag }}

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -8,11 +8,11 @@ on:
     - cron: "23 3 * * *"
   workflow_dispatch:  # Allows manual refresh
 
-# This builds images and pushes them to ghcr.io/tetratelabs/wazero-internal:$tag
+# This builds images and pushes them to ghcr.io/tetratelabs/wazero/internal-$tag
 # Using these avoid docker.io rate-limits particularly on pull requests.
 jobs:
   copy-images:
-    runs-on: ubuntu-20.04  # Hard-coding an LTS means maintenance, but only once each 2 years!
+    runs-on: ubuntu-22.04  # Hard-coding an LTS means maintenance, but only once each 2 years!
     strategy:
       matrix:
         # Be precise in tag versions to improve reproducibility
@@ -23,19 +23,18 @@ jobs:
     steps:
       # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
       - name: "Login into GitHub Container Registry"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          # GHCR_TOKEN=<hex token value>
+          # GITHUB_TOKEN=<hex token value>
           #   - pushes Docker images to ghcr.io
           #   - create via https://github.com/settings/tokens
-          #   - assign via https://github.com/organizations/tetratelabs/settings/secrets/actions
           #   - needs repo:status, public_repo, write:packages, delete:packages
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull and push
         run: |  # This will only push a single architecture, which is fine as we currently only support amd64
           docker pull ${{ matrix.source }}
-          docker tag ${{ matrix.source }} ghcr.io/tetratelabs/wazero-internal:${{ matrix.target_tag }}
-          docker push ghcr.io/tetratelabs/wazero-internal:${{ matrix.target_tag }}
+          docker tag ${{ matrix.source }} ghcr.io/tetratelabs/wazero/internal-${{ matrix.target_tag }}
+          docker push ghcr.io/tetratelabs/wazero/internal-${{ matrix.target_tag }}


### PR DESCRIPTION
I randomly noticed this action start failing on my fork after I pushed main to it recently to verify some other workflows. Having repository-scoped ghcr images is relatively recent so maybe this can be migrated to it - it would allow forks to behave the same as this repo. Or if intentionally using global don't have to make this change and I could send another PR with an `if repo == tetratelabe/wazero` condition to the job instead

Signed-off-by: Anuraag Agrawal <anuraaga@gmail.com>