### PR TITLE
HostFunc: remove reflect for host function call

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"reflect"
 )
 
 // ExternType classifies imports and exports with their respective types.
@@ -102,6 +101,13 @@ const (
 	// Note: The usage of this type is toggled with api.CoreFeatureBulkMemoryOperations.
 	ValueTypeExternref ValueType = 0x6f
 )
+
+// HostFuncSignature is the signature of host function
+type HostFuncSignature struct {
+	Fn     func(context.Context, Module, ...uint64) ([]uint64, error)
+	NumIn  []ValueType
+	NumOut []ValueType
+}
 
 // ValueTypeName returns the type name of the given ValueType as a string.
 // These type names match the names used in the WebAssembly text format.
@@ -260,7 +266,7 @@ type FunctionDefinition interface {
 	// different from its defining module.
 	//
 	// See https://www.w3.org/TR/wasm-core-1/#host-functions%E2%91%A0
-	GoFunc() *reflect.Value
+	GoFunc() *HostFuncSignature
 
 	// ParamTypes are the possibly empty sequence of value types accepted by a
 	// function with this signature.

--- a/examples/import-go/age-calculator_test.go
+++ b/examples/import-go/age-calculator_test.go
@@ -1,11 +1,29 @@
 package main
 
 import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/engine/compiler"
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/wasm"
+	"math"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/maintester"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
+
+const (
+	// callGoHostName is the name of exported function which calls the Go-implemented host function.
+	callGoHostName = "call_go_host"
+	// callWasmHostName is the name of exported function which calls the Wasm-implemented host function.
+	callWasmHostName = "call_wasm_host"
+)
+
+// testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
+var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
 // Test_main ensures the following will work:
 //
@@ -18,4 +36,171 @@ func Test_main(t *testing.T) {
 	require.Equal(t, `println >> 21
 log_i32 >> 21
 `, stdout)
+}
+
+// BenchmarkHostFunctionCall measures the cost of host function calls whose target functions are either
+// Go-implemented or Wasm-implemented, and compare the results between them.
+func BenchmarkHostFunctionCall(b *testing.B) {
+	if !platform.CompilerSupported() {
+		b.Skip()
+	}
+
+	m := setupHostCallBench(func(err error) {
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	const offset = 100
+	const val = float32(1.1234)
+
+	binary.LittleEndian.PutUint32(m.Memory.Buffer[offset:], math.Float32bits(val))
+
+	b.Run(callGoHostName, func(b *testing.B) {
+		ce, err := getCallEngine(m, callGoHostName)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			res, err := ce.Call(testCtx, m.CallCtx, offset)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if uint32(res[0]) != math.Float32bits(val) {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run(callWasmHostName, func(b *testing.B) {
+		ce, err := getCallEngine(m, callWasmHostName)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			res, err := ce.Call(testCtx, m.CallCtx, offset)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if uint32(res[0]) != math.Float32bits(val) {
+				b.Fail()
+			}
+		}
+	})
+}
+
+func getCallEngine(m *wasm.ModuleInstance, name string) (ce wasm.CallEngine, err error) {
+	f := m.Exports[name].Function
+	if f == nil {
+		err = fmt.Errorf("%s not found", name)
+		return
+	}
+
+	ce, err = m.Engine.NewCallEngine(m.CallCtx, f)
+	return
+}
+
+func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
+	eng := compiler.NewEngine(context.Background(), api.CoreFeaturesV2)
+
+	ft := &wasm.FunctionType{
+		Params:           []wasm.ValueType{wasm.ValueTypeI32},
+		Results:          []wasm.ValueType{wasm.ValueTypeF32},
+		ParamNumInUint64: 1, ResultNumInUint64: 1,
+	}
+
+	// Build the host module.
+	hostModule := &wasm.Module{
+		TypeSection:     []*wasm.FunctionType{ft},
+		FunctionSection: []wasm.Index{0, 0},
+		CodeSection: []*wasm.Code{
+			wasm.MustParseGoFuncCode(
+				&api.HostFuncSignature{
+					Fn: func(ctx context.Context, m api.Module, params ...uint64) ([]uint64, error) {
+						ret, ok := m.Memory().ReadUint32Le(ctx, uint32(params[0]))
+						if !ok {
+							panic("couldn't read memory")
+						}
+						return []uint64{uint64(ret)}, nil
+					},
+					NumIn:  []api.ValueType{api.ValueTypeI32},
+					NumOut: []api.ValueType{api.ValueTypeF32},
+				},
+			),
+			{
+				IsHostFunction: true,
+				Body: []byte{
+					wasm.OpcodeLocalGet, 0,
+					wasm.OpcodeI32Load, 0x2, 0x0, // offset = 0
+					wasm.OpcodeF32ReinterpretI32,
+					wasm.OpcodeEnd,
+				},
+			},
+		},
+		ExportSection: []*wasm.Export{
+			{Name: "go", Type: wasm.ExternTypeFunc, Index: 0},
+			{Name: "wasm", Type: wasm.ExternTypeFunc, Index: 1},
+		},
+		ID: wasm.ModuleID{1, 2, 3, 4, 5},
+	}
+	hostModule.BuildFunctionDefinitions()
+
+	host := &wasm.ModuleInstance{Name: "host", TypeIDs: []wasm.FunctionTypeID{0}}
+	host.Functions = host.BuildFunctions(hostModule, nil)
+	host.BuildExports(hostModule.ExportSection)
+	goFn, wasnFn := host.Exports["go"].Function, host.Exports["wasm"].Function
+
+	err := eng.CompileModule(testCtx, hostModule)
+	requireNoError(err)
+
+	hostME, err := eng.NewModuleEngine(host.Name, hostModule, nil, host.Functions, nil, nil)
+	requireNoError(err)
+	linkModuleToEngine(host, hostME)
+
+	// Build the importing module.
+	importingModule := &wasm.Module{
+		TypeSection: []*wasm.FunctionType{ft},
+		ImportSection: []*wasm.Import{
+			// Placeholders for imports from hostModule.
+			{Type: wasm.ExternTypeFunc},
+			{Type: wasm.ExternTypeFunc},
+		},
+		FunctionSection: []wasm.Index{0, 0},
+		ExportSection: []*wasm.Export{
+			{Name: callGoHostName, Type: wasm.ExternTypeFunc, Index: 2},
+			{Name: callWasmHostName, Type: wasm.ExternTypeFunc, Index: 3},
+		},
+		CodeSection: []*wasm.Code{
+			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Calling the index 0 = host.go.
+			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 1, wasm.OpcodeEnd}}, // Calling the index 1 = host.wasm.
+		},
+		// Indicates that this module has a memory so that compilers are able to assemble memory-related initialization.
+		MemorySection: &wasm.Memory{Min: 1},
+		ID:            wasm.ModuleID{1},
+	}
+
+	importingModule.BuildFunctionDefinitions()
+	err = eng.CompileModule(testCtx, importingModule)
+	requireNoError(err)
+
+	importing := &wasm.ModuleInstance{TypeIDs: []wasm.FunctionTypeID{0}}
+	importingFunctions := importing.BuildFunctions(importingModule, nil)
+	importing.Functions = append([]*wasm.FunctionInstance{goFn, wasnFn}, importingFunctions...)
+	importing.BuildExports(importingModule.ExportSection)
+
+	importingMe, err := eng.NewModuleEngine(importing.Name, importingModule, []*wasm.FunctionInstance{goFn, wasnFn}, importingFunctions, nil, nil)
+	requireNoError(err)
+	linkModuleToEngine(importing, importingMe)
+
+	importing.Memory = &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize), Min: 1, Cap: 1, Max: 1}
+	return importing
+}
+
+func linkModuleToEngine(module *wasm.ModuleInstance, me wasm.ModuleEngine) {
+	module.Engine = me
+	module.CallCtx = wasm.NewCallContext(nil, module, nil)
 }

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
-	"reflect"
 	"strings"
 	"sync"
 	"unsafe"
@@ -172,13 +171,13 @@ type callFrame struct {
 
 type code struct {
 	body   []*interpreterOp
-	hostFn *reflect.Value
+	hostFn *api.HostFuncSignature
 }
 
 type function struct {
 	source *wasm.FunctionInstance
 	body   []*interpreterOp
-	hostFn *reflect.Value
+	hostFn *api.HostFuncSignature
 }
 
 // functionFromUintptr resurrects the original *function from the given uintptr

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -1,8 +1,6 @@
 package wasm
 
 import (
-	"reflect"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
 )
@@ -110,7 +108,7 @@ type FunctionDefinition struct {
 	index       Index
 	name        string
 	debugName   string
-	goFunc      *reflect.Value
+	goFunc      *api.HostFuncSignature
 	funcType    *FunctionType
 	importDesc  *[2]string
 	exportNames []string
@@ -151,7 +149,7 @@ func (f *FunctionDefinition) ExportNames() []string {
 }
 
 // GoFunc implements the same method as documented on api.FunctionDefinition.
-func (f *FunctionDefinition) GoFunc() *reflect.Value {
+func (f *FunctionDefinition) GoFunc() *api.HostFuncSignature {
 	return f.goFunc
 }
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -833,7 +832,7 @@ type Code struct {
 	//
 	// Note: This has no serialization format, so is not encodable.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#host-functions%E2%91%A2
-	GoFunc *reflect.Value
+	GoFunc *api.HostFuncSignature
 }
 
 type DataSegment struct {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"reflect"
 	"sync"
 
 	"github.com/tetratelabs/wazero/api"
@@ -127,7 +126,7 @@ type (
 		// GoFunc holds the runtime representation of host functions.
 		// This is nil when Kind == FunctionKindWasm. Otherwise, all the above fields are ignored as they are
 		// specific to Wasm functions.
-		GoFunc *reflect.Value
+		GoFunc *api.HostFuncSignature
 
 		// Fields above here are settable prior to instantiation. Below are set by the Store during instantiation.
 

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/tetratelabs/wazero/api"
@@ -209,7 +208,7 @@ type CompilationResult struct {
 
 	// GoFunc is the data returned by the same field documented on wasm.Code.
 	// In this case, IsHostFunction is true and other fields can be ignored.
-	GoFunc *reflect.Value
+	GoFunc *api.HostFuncSignature
 
 	// Operations holds wazeroir operations compiled from Wasm instructions in a Wasm function.
 	Operations []Operation


### PR DESCRIPTION
This PR remove reflect for wasm host function call, the benchmark is:

**Before：**
``` 
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
BenchmarkHostFunctionCall
BenchmarkHostFunctionCall/call_go_host
BenchmarkHostFunctionCall/call_go_host-8                  939739              1262 ns/op
BenchmarkHostFunctionCall/call_wasm_host
BenchmarkHostFunctionCall/call_wasm_host-8              22812769                48.90 ns/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   2.658s
```

**After:**

```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/examples/import-go
BenchmarkHostFunctionCall
BenchmarkHostFunctionCall/call_go_host
BenchmarkHostFunctionCall/call_go_host-8                 9719632               125.6 ns/op
BenchmarkHostFunctionCall/call_wasm_host
BenchmarkHostFunctionCall/call_wasm_host-8              24260326                48.20 ns/op
PASS
ok      github.com/tetratelabs/wazero/examples/import-go        2.988s
```