### PR TITLE
Adds HostFunctionBuilder to enable high performance host functions

### DIFF
--- a/examples/allocation/rust/greet.go
+++ b/examples/allocation/rust/greet.go
@@ -31,7 +31,7 @@ func main() {
 	// Instantiate a Go-defined module named "env" that exports a function to
 	// log to the console.
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, r)
 	if err != nil {
 		log.Panicln(err)

--- a/examples/allocation/tinygo/greet.go
+++ b/examples/allocation/tinygo/greet.go
@@ -32,7 +32,7 @@ func main() {
 	// Instantiate a Go-defined module named "env" that exports a function to
 	// log to the console.
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, r)
 	if err != nil {
 		log.Panicln(err)

--- a/examples/allocation/zig/greet.go
+++ b/examples/allocation/zig/greet.go
@@ -37,7 +37,7 @@ func run() error {
 	// Instantiate a Go-defined module named "env" that exports a function to
 	// log to the console.
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("log", logString).
+		NewFunctionBuilder().WithFunc(logString).Export("log").
 		Instantiate(ctx, r)
 	if err != nil {
 		return err

--- a/examples/import-go/age-calculator.go
+++ b/examples/import-go/age-calculator.go
@@ -34,20 +34,24 @@ func main() {
 	// Instantiate a Go-defined module named "env" that exports functions to
 	// get the current year and log to the console.
 	//
-	// Note: As noted on ExportFunction documentation, function signatures are
-	// constrained to a subset of numeric types.
+	// Note: As noted on wazero.HostFunctionBuilder documentation, function
+	// signatures are constrained to a subset of numeric types.
 	// Note: "env" is a module name conventionally used for arbitrary
 	// host-defined functions, but any name would do.
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("log_i32", func(v uint32) {
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, v uint32) {
 			fmt.Println("log_i32 >>", v)
 		}).
-		ExportFunction("current_year", func() uint32 {
+		Export("log_i32").
+		NewFunctionBuilder().
+		WithFunc(func(context.Context) uint32 {
 			if envYear, err := strconv.ParseUint(os.Getenv("CURRENT_YEAR"), 10, 64); err == nil {
 				return uint32(envYear) // Allow env-override to prevent annual test maintenance!
 			}
 			return uint32(time.Now().Year())
 		}).
+		Export("current_year").
 		Instantiate(ctx, r)
 	if err != nil {
 		log.Panicln(err)

--- a/examples/multiple-results/multiple-results.go
+++ b/examples/multiple-results/multiple-results.go
@@ -111,11 +111,14 @@ func multiValueFromImportedHostWasmFunctions(ctx context.Context, r wazero.Runti
 	// Instantiate the host module with the exported `get_age` function which returns multiple results.
 	if _, err := r.NewHostModuleBuilder("multi-value/host").
 		// Define a function that returns two results
-		ExportFunction("get_age", func() (age uint64, errno uint32) {
+		NewFunctionBuilder().
+		WithFunc(func(context.Context) (age uint64, errno uint32) {
 			age = 37
 			errno = 0
 			return
-		}).Instantiate(ctx, r); err != nil {
+		}).
+		Export("get_age").
+		Instantiate(ctx, r); err != nil {
 		return nil, err
 	}
 	// Then, creates the module which imports the `get_age` function from the `multi-value/host` module above.

--- a/examples/namespace/counter.go
+++ b/examples/namespace/counter.go
@@ -58,7 +58,7 @@ type counter struct {
 	counter uint32
 }
 
-func (e *counter) getAndIncrement() (ret uint32) {
+func (e *counter) getAndIncrement(context.Context) (ret uint32) {
 	ret = e.counter
 	e.counter++
 	return
@@ -72,7 +72,7 @@ func instantiateWithEnv(ctx context.Context, r wazero.Runtime, module wazero.Com
 	// Instantiate a new "env" module which exports a stateful function.
 	c := &counter{}
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("next_i32", c.getAndIncrement).
+		NewFunctionBuilder().WithFunc(c.getAndIncrement).Export("next_i32").
 		Instantiate(ctx, ns)
 	if err != nil {
 		log.Panicln(err)

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -36,7 +36,7 @@ func (u uniqGoFuncs) callees() []string {
 
 // NewListener implements FunctionListenerFactory.NewListener
 func (u uniqGoFuncs) NewListener(def api.FunctionDefinition) FunctionListener {
-	if def.GoFunc() == nil {
+	if def.GoFunction() == nil {
 		return nil // only track go funcs
 	}
 	return u

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -64,14 +64,14 @@ func (l *loggingListener) writeIndented(before bool, err error, vals []uint64, i
 		message.WriteByte('\t')
 	}
 	if before {
-		if l.fnd.GoFunc() != nil {
+		if l.fnd.GoFunction() != nil {
 			message.WriteString("==> ")
 		} else {
 			message.WriteString("--> ")
 		}
 		l.writeFuncEnter(&message, vals)
 	} else { // after
-		if l.fnd.GoFunc() != nil {
+		if l.fnd.GoFunction() != nil {
 			message.WriteString("<== ")
 		} else {
 			message.WriteString("<-- ")

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -266,7 +266,7 @@ func Test_loggingListener(t *testing.T) {
 
 	var out bytes.Buffer
 	lf := logging.NewLoggingListenerFactory(&out)
-	fn := func() {}
+	fn := func(context.Context) {}
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
@@ -287,7 +287,7 @@ func Test_loggingListener(t *testing.T) {
 			}
 
 			if tc.isHostFunc {
-				m.CodeSection = []*wasm.Code{wasm.MustParseGoFuncCode(fn)}
+				m.CodeSection = []*wasm.Code{wasm.MustParseGoReflectFuncCode(fn)}
 			} else {
 				m.CodeSection = []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}}
 			}

--- a/imports/assemblyscript/assemblyscript_example_test.go
+++ b/imports/assemblyscript/assemblyscript_example_test.go
@@ -32,7 +32,9 @@ func Example_functionExporter() {
 
 	// First construct your own module builder for "env"
 	envBuilder := r.NewHostModuleBuilder("env").
-		ExportFunction("get_int", func() uint32 { return 1 })
+		NewFunctionBuilder().
+		WithFunc(func(context.Context) uint32 { return 1 }).
+		Export("get_int")
 
 	// Now, add AssemblyScript special function imports into it.
 	assemblyscript.NewFunctionExporter().

--- a/imports/emscripten/emscripten.go
+++ b/imports/emscripten/emscripten.go
@@ -62,7 +62,8 @@ type functionExporter struct{}
 
 // ExportFunctions implements FunctionExporter.ExportFunctions
 func (e *functionExporter) ExportFunctions(builder wazero.HostModuleBuilder) {
-	builder.ExportFunction(notifyMemoryGrowth.Name, notifyMemoryGrowth)
+	exporter := builder.(wasm.HostFuncExporter)
+	exporter.ExportHostFunc(notifyMemoryGrowth)
 }
 
 // emscriptenNotifyMemoryGrowth is called when wasm is compiled with

--- a/imports/emscripten/emscripten_example_test.go
+++ b/imports/emscripten/emscripten_example_test.go
@@ -39,7 +39,9 @@ func Example_functionExporter() {
 	// Next, construct your own module builder for "env" with any functions
 	// you need.
 	envBuilder := r.NewHostModuleBuilder("env").
-		ExportFunction("get_int", func() uint32 { return 1 })
+		NewFunctionBuilder().
+		WithFunc(func(context.Context) uint32 { return 1 }).
+		Export("get_int")
 
 	// Now, add Emscripten special function imports into it.
 	emscripten.NewFunctionExporter().ExportFunctions(envBuilder)

--- a/imports/go/gojs.go
+++ b/imports/go/gojs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	. "github.com/tetratelabs/wazero/internal/gojs"
+	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 // WithRoundTripper sets the http.RoundTripper used to Run Wasm.
@@ -87,31 +88,35 @@ func Run(ctx context.Context, r wazero.Runtime, compiled wazero.CompiledModule, 
 }
 
 // hostModuleBuilder returns a new wazero.HostModuleBuilder
-func hostModuleBuilder(r wazero.Runtime) wazero.HostModuleBuilder {
-	return r.NewHostModuleBuilder("go").
-		ExportFunction(GetRandomData.Name(), GetRandomData).
-		ExportFunction(Nanotime1.Name(), Nanotime1).
-		ExportFunction(WasmExit.Name(), WasmExit).
-		ExportFunction(CopyBytesToJS.Name(), CopyBytesToJS).
-		ExportFunction(ValueCall.Name(), ValueCall).
-		ExportFunction(ValueGet.Name(), ValueGet).
-		ExportFunction(ValueIndex.Name(), ValueIndex).
-		ExportFunction(ValueLength.Name(), ValueLength).
-		ExportFunction(ValueNew.Name(), ValueNew).
-		ExportFunction(ValueSet.Name(), ValueSet).
-		ExportFunction(WasmWrite.Name(), WasmWrite).
-		ExportFunction(ResetMemoryDataView.Name, ResetMemoryDataView).
-		ExportFunction(Walltime.Name(), Walltime).
-		ExportFunction(ScheduleTimeoutEvent.Name, ScheduleTimeoutEvent).
-		ExportFunction(ClearTimeoutEvent.Name, ClearTimeoutEvent).
-		ExportFunction(FinalizeRef.Name(), FinalizeRef).
-		ExportFunction(StringVal.Name(), StringVal).
-		ExportFunction(ValueDelete.Name, ValueDelete).
-		ExportFunction(ValueSetIndex.Name, ValueSetIndex).
-		ExportFunction(ValueInvoke.Name, ValueInvoke).
-		ExportFunction(ValuePrepareString.Name(), ValuePrepareString).
-		ExportFunction(ValueInstanceOf.Name, ValueInstanceOf).
-		ExportFunction(ValueLoadString.Name(), ValueLoadString).
-		ExportFunction(CopyBytesToGo.Name(), CopyBytesToGo).
-		ExportFunction(Debug.Name, Debug)
+func hostModuleBuilder(r wazero.Runtime) (builder wazero.HostModuleBuilder) {
+	builder = r.NewHostModuleBuilder("go")
+	hfExporter := builder.(wasm.HostFuncExporter)
+	pfExporter := builder.(wasm.ProxyFuncExporter)
+
+	pfExporter.ExportProxyFunc(GetRandomData)
+	pfExporter.ExportProxyFunc(Nanotime1)
+	pfExporter.ExportProxyFunc(WasmExit)
+	pfExporter.ExportProxyFunc(CopyBytesToJS)
+	pfExporter.ExportProxyFunc(ValueCall)
+	pfExporter.ExportProxyFunc(ValueGet)
+	pfExporter.ExportProxyFunc(ValueIndex)
+	pfExporter.ExportProxyFunc(ValueLength)
+	pfExporter.ExportProxyFunc(ValueNew)
+	pfExporter.ExportProxyFunc(ValueSet)
+	pfExporter.ExportProxyFunc(WasmWrite)
+	hfExporter.ExportHostFunc(ResetMemoryDataView)
+	pfExporter.ExportProxyFunc(Walltime)
+	hfExporter.ExportHostFunc(ScheduleTimeoutEvent)
+	hfExporter.ExportHostFunc(ClearTimeoutEvent)
+	pfExporter.ExportProxyFunc(FinalizeRef)
+	pfExporter.ExportProxyFunc(StringVal)
+	hfExporter.ExportHostFunc(ValueDelete)
+	hfExporter.ExportHostFunc(ValueSetIndex)
+	hfExporter.ExportHostFunc(ValueInvoke)
+	pfExporter.ExportProxyFunc(ValuePrepareString)
+	hfExporter.ExportHostFunc(ValueInstanceOf)
+	pfExporter.ExportProxyFunc(ValueLoadString)
+	pfExporter.ExportProxyFunc(CopyBytesToGo)
+	hfExporter.ExportHostFunc(Debug)
+	return
 }

--- a/imports/wasi_snapshot_preview1/args.go
+++ b/imports/wasi_snapshot_preview1/args.go
@@ -21,23 +21,21 @@ const (
 //     encoding to api.Memory
 //   - argsSizesGet result argc * 4 bytes are written to this offset
 //   - argvBuf: offset to write the null terminated arguments to api.Memory
-//   - argsSizesGet result argv_buf_size bytes are written to this offset
+//   - argsSizesGet result argv_len bytes are written to this offset
 //
 // Result (Errno)
 //
 // The return value is ErrnoSuccess except the following error conditions:
 //   - ErrnoFault: there is not enough memory to write results
 //
-// For example, if argsSizesGet wrote argc=2 and argvBufSize=5 for arguments:
+// For example, if argsSizesGet wrote argc=2 and argvLen=5 for arguments:
 // "a" and "bc" parameters argv=7 and argvBuf=1, this function writes the below
 // to api.Memory:
 //
-//	   argvBufSize          uint32le    uint32le
-//	+----------------+     +--------+  +--------+
-//	|                |     |        |  |        |
-//
-// []byte{?, 'a', 0, 'b', 'c', 0, ?, 1, 0, 0, 0, 3, 0, 0, 0, ?}
-//
+//	                   argvLen          uint32le    uint32le
+//	            +----------------+     +--------+  +--------+
+//	            |                |     |        |  |        |
+//	 []byte{?, 'a', 0, 'b', 'c', 0, ?, 1, 0, 0, 0, 3, 0, 0, 0, ?}
 //	argvBuf --^                      ^           ^
 //	                          argv --|           |
 //	        offset that begins "a" --+           |
@@ -46,14 +44,23 @@ const (
 // See argsSizesGet
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_get
 // See https://en.wikipedia.org/wiki/Null-terminated_string
-var argsGet = wasm.NewGoFunc(
-	functionArgsGet, functionArgsGet,
-	[]string{"argv", "argv_buf"},
-	func(ctx context.Context, mod api.Module, argv, argvBuf uint32) Errno {
-		sysCtx := mod.(*wasm.CallContext).Sys
-		return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Args(), argv, argvBuf)
+var argsGet = &wasm.HostFunc{
+	ExportNames: []string{functionArgsGet},
+	Name:        functionArgsGet,
+	ParamTypes:  []api.ValueType{i32, i32},
+	ParamNames:  []string{"argv", "argv_buf"},
+	ResultTypes: []api.ValueType{i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(argsGetFn),
 	},
-)
+}
+
+func argsGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	sysCtx := mod.(*wasm.CallContext).Sys
+	argv, argvBuf := uint32(params[0]), uint32(params[1])
+	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Args(), argv, argvBuf)
+}
 
 // argsSizesGet is the WASI function named functionArgsSizesGet that reads
 // command-line argument sizes.
@@ -61,7 +68,7 @@ var argsGet = wasm.NewGoFunc(
 // # Parameters
 //
 //   - resultArgc: offset to write the argument count to api.Memory
-//   - resultArgvBufSize: offset to write the null-terminated argument length to
+//   - resultArgvLen: offset to write the null-terminated argument length to
 //     api.Memory
 //
 // Result (Errno)
@@ -70,7 +77,7 @@ var argsGet = wasm.NewGoFunc(
 //   - ErrnoFault: there is not enough memory to write results
 //
 // For example, if args are "a", "bc" and parameters resultArgc=1 and
-// resultArgvBufSize=6, this function writes the below to api.Memory:
+// resultArgvLen=6, this function writes the below to api.Memory:
 //
 //	                uint32le       uint32le
 //	               +--------+     +--------+
@@ -78,25 +85,34 @@ var argsGet = wasm.NewGoFunc(
 //	     []byte{?, 2, 0, 0, 0, ?, 5, 0, 0, 0, ?}
 //	  resultArgc --^              ^
 //	      2 args --+              |
-//	          resultArgvBufSize --|
+//	              resultArgvLen --|
 //	len([]byte{'a',0,'b',c',0}) --+
 //
 // See argsGet
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_sizes_get
 // See https://en.wikipedia.org/wiki/Null-terminated_string
-var argsSizesGet = wasm.NewGoFunc(
-	functionArgsSizesGet, functionArgsSizesGet,
-	[]string{"result.argc", "result.argv_buf_size"},
-	func(ctx context.Context, mod api.Module, resultArgc, resultArgvBufSize uint32) Errno {
-		sysCtx := mod.(*wasm.CallContext).Sys
-		mem := mod.Memory()
-
-		if !mem.WriteUint32Le(ctx, resultArgc, uint32(len(sysCtx.Args()))) {
-			return ErrnoFault
-		}
-		if !mem.WriteUint32Le(ctx, resultArgvBufSize, sysCtx.ArgsSize()) {
-			return ErrnoFault
-		}
-		return ErrnoSuccess
+var argsSizesGet = &wasm.HostFunc{
+	ExportNames: []string{functionArgsSizesGet},
+	Name:        functionArgsSizesGet,
+	ParamTypes:  []api.ValueType{i32, i32},
+	ParamNames:  []string{"result.argc", "result.argv_len"},
+	ResultTypes: []api.ValueType{i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(argsSizesGetFn),
 	},
-)
+}
+
+func argsSizesGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	sysCtx := mod.(*wasm.CallContext).Sys
+	mem := mod.Memory()
+	resultArgc, resultArgvLen := uint32(params[0]), uint32(params[1])
+
+	if !mem.WriteUint32Le(ctx, resultArgc, uint32(len(sysCtx.Args()))) {
+		return errnoFault
+	}
+	if !mem.WriteUint32Le(ctx, resultArgvLen, sysCtx.ArgsSize()) {
+		return errnoFault
+	}
+	return errnoSuccess
+}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -257,9 +257,9 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 	memorySize := mod.Memory().Size(testCtx)
 
 	tests := []struct {
-		name                         string
-		resultTimestamp, argvBufSize uint32
-		expectedLog                  string
+		name                     string
+		resultTimestamp, argvLen uint32
+		expectedLog              string
 	}{
 		{
 			name:            "resultTimestamp out-of-memory",

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -621,7 +621,7 @@ func Test_fdRead_shouldContinueRead(t *testing.T) {
 		n, l          uint32
 		err           error
 		expectedOk    bool
-		expectedErrno Errno
+		expectedErrno []uint64
 	}{
 		{
 			name: "break when nothing to read",
@@ -668,13 +668,13 @@ func Test_fdRead_shouldContinueRead(t *testing.T) {
 		{
 			name:          "return ErrnoIo on error on nothing to read",
 			err:           io.ErrClosedPipe,
-			expectedErrno: ErrnoIo,
+			expectedErrno: errnoIo,
 		},
 		{
 			name:          "return ErrnoIo on error on nothing read",
 			l:             4,
 			err:           io.ErrClosedPipe,
-			expectedErrno: ErrnoIo,
+			expectedErrno: errnoIo,
 		},
 		{ // Special case, allows processing data before err
 			name: "break on error on partial read",
@@ -1170,7 +1170,7 @@ func Test_pathOpen(t *testing.T) {
 	)
 
 	dirflags := uint32(0)
-	pathPtr := uint32(1)
+	path := uint32(1)
 	pathLen := uint32(len(pathName))
 	oflags := uint32(0)
 	fsRightsBase := uint64(1)       // ignored: rights were removed from WASI.
@@ -1186,7 +1186,7 @@ func Test_pathOpen(t *testing.T) {
 	ok := mod.Memory().Write(testCtx, 0, initialMemory)
 	require.True(t, ok)
 
-	requireErrno(t, ErrnoSuccess, mod, functionPathOpen, uint64(rootFD), uint64(dirflags), uint64(pathPtr),
+	requireErrno(t, ErrnoSuccess, mod, functionPathOpen, uint64(rootFD), uint64(dirflags), uint64(path),
 		uint64(pathLen), uint64(oflags), fsRightsBase, fsRightsInheriting, uint64(fdflags), uint64(resultOpenedFd))
 	require.Equal(t, `
 --> proxy.path_open(fd=3,dirflags=0,path=1,path_len=6,oflags=0,fs_rights_base=1,fs_rights_inheriting=2,fdflags=0,result.opened_fd=8)

--- a/imports/wasi_snapshot_preview1/testdata/wasi_arg.wat
+++ b/imports/wasi_snapshot_preview1/testdata/wasi_arg.wat
@@ -10,7 +10,7 @@
 	;;
 	;; See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-args_sizes_get---errno-size-size
     (import "wasi_snapshot_preview1" "args_sizes_get"
-        (func $wasi.args_sizes_get (param $result.argc i32) (param $result.argv_buf_size i32) (result (;errno;) i32)))
+        (func $wasi.args_sizes_get (param $result.argc i32) (param $result.argv_len i32) (result (;errno;) i32)))
 
     ;; fd_write write bytes to a file descriptor.
     ;;
@@ -45,7 +45,7 @@
         ;; Next, we need to know how many bytes were loaded, as that's how much we'll copy to the file.
         (call $wasi.args_sizes_get
             (global.get $ignored) ;; ignore $result.argc as we only read the argv_buf.
-            (i32.add (global.get $iovs) (i32.const 4)) ;; store $result.argv_buf_size as the length to copy
+            (i32.add (global.get $iovs) (i32.const 4)) ;; store $result.argv_len as the length to copy
         )
         drop ;; ignore the errno returned
 

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -121,77 +121,91 @@ func (b *builder) Instantiate(ctx context.Context, ns wazero.Namespace) (api.Clo
 // exportFunctions adds all go functions that implement wasi.
 // These should be exported in the module named ModuleName.
 func exportFunctions(builder wazero.HostModuleBuilder) {
+	exporter := builder.(wasm.HostFuncExporter)
+
 	// Note: these are ordered per spec for consistency even if the resulting
 	// map can't guarantee that.
 	// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#functions
-	builder.ExportFunction(argsGet.Name, argsGet)
-	builder.ExportFunction(argsSizesGet.Name, argsSizesGet)
-	builder.ExportFunction(environGet.Name, environGet)
-	builder.ExportFunction(environSizesGet.Name, environSizesGet)
-	builder.ExportFunction(clockResGet.Name, clockResGet)
-	builder.ExportFunction(clockTimeGet.Name, clockTimeGet)
-	builder.ExportFunction(fdAdvise.Name, fdAdvise)
-	builder.ExportFunction(fdAllocate.Name, fdAllocate)
-	builder.ExportFunction(fdClose.Name, fdClose)
-	builder.ExportFunction(fdDatasync.Name, fdDatasync)
-	builder.ExportFunction(fdFdstatGet.Name, fdFdstatGet)
-	builder.ExportFunction(fdFdstatSetFlags.Name, fdFdstatSetFlags)
-	builder.ExportFunction(fdFdstatSetRights.Name, fdFdstatSetRights)
-	builder.ExportFunction(fdFilestatGet.Name, fdFilestatGet)
-	builder.ExportFunction(fdFilestatSetSize.Name, fdFilestatSetSize)
-	builder.ExportFunction(fdFilestatSetTimes.Name, fdFilestatSetTimes)
-	builder.ExportFunction(fdPread.Name, fdPread)
-	builder.ExportFunction(fdPrestatGet.Name, fdPrestatGet)
-	builder.ExportFunction(fdPrestatDirName.Name, fdPrestatDirName)
-	builder.ExportFunction(fdPwrite.Name, fdPwrite)
-	builder.ExportFunction(fdRead.Name, fdRead)
-	builder.ExportFunction(fdReaddir.Name, fdReaddir)
-	builder.ExportFunction(fdRenumber.Name, fdRenumber)
-	builder.ExportFunction(fdSeek.Name, fdSeek)
-	builder.ExportFunction(fdSync.Name, fdSync)
-	builder.ExportFunction(fdTell.Name, fdTell)
-	builder.ExportFunction(fdWrite.Name, fdWrite)
-	builder.ExportFunction(pathCreateDirectory.Name, pathCreateDirectory)
-	builder.ExportFunction(pathFilestatGet.Name, pathFilestatGet)
-	builder.ExportFunction(pathFilestatSetTimes.Name, pathFilestatSetTimes)
-	builder.ExportFunction(pathLink.Name, pathLink)
-	builder.ExportFunction(pathOpen.Name, pathOpen)
-	builder.ExportFunction(pathReadlink.Name, pathReadlink)
-	builder.ExportFunction(pathRemoveDirectory.Name, pathRemoveDirectory)
-	builder.ExportFunction(pathRename.Name, pathRename)
-	builder.ExportFunction(pathSymlink.Name, pathSymlink)
-	builder.ExportFunction(pathUnlinkFile.Name, pathUnlinkFile)
-	builder.ExportFunction(pollOneoff.Name, pollOneoff)
-	builder.ExportFunction(procExit.Name, procExit)
-	builder.ExportFunction(procRaise.Name, procRaise)
-	builder.ExportFunction(schedYield.Name, schedYield)
-	builder.ExportFunction(randomGet.Name, randomGet)
-	builder.ExportFunction(sockAccept.Name, sockAccept)
-	builder.ExportFunction(sockRecv.Name, sockRecv)
-	builder.ExportFunction(sockSend.Name, sockSend)
-	builder.ExportFunction(sockShutdown.Name, sockShutdown)
+	exporter.ExportHostFunc(argsGet)
+	exporter.ExportHostFunc(argsSizesGet)
+	exporter.ExportHostFunc(environGet)
+	exporter.ExportHostFunc(environSizesGet)
+	exporter.ExportHostFunc(clockResGet)
+	exporter.ExportHostFunc(clockTimeGet)
+	exporter.ExportHostFunc(fdAdvise)
+	exporter.ExportHostFunc(fdAllocate)
+	exporter.ExportHostFunc(fdClose)
+	exporter.ExportHostFunc(fdDatasync)
+	exporter.ExportHostFunc(fdFdstatGet)
+	exporter.ExportHostFunc(fdFdstatSetFlags)
+	exporter.ExportHostFunc(fdFdstatSetRights)
+	exporter.ExportHostFunc(fdFilestatGet)
+	exporter.ExportHostFunc(fdFilestatSetSize)
+	exporter.ExportHostFunc(fdFilestatSetTimes)
+	exporter.ExportHostFunc(fdPread)
+	exporter.ExportHostFunc(fdPrestatGet)
+	exporter.ExportHostFunc(fdPrestatDirName)
+	exporter.ExportHostFunc(fdPwrite)
+	exporter.ExportHostFunc(fdRead)
+	exporter.ExportHostFunc(fdReaddir)
+	exporter.ExportHostFunc(fdRenumber)
+	exporter.ExportHostFunc(fdSeek)
+	exporter.ExportHostFunc(fdSync)
+	exporter.ExportHostFunc(fdTell)
+	exporter.ExportHostFunc(fdWrite)
+	exporter.ExportHostFunc(pathCreateDirectory)
+	exporter.ExportHostFunc(pathFilestatGet)
+	exporter.ExportHostFunc(pathFilestatSetTimes)
+	exporter.ExportHostFunc(pathLink)
+	exporter.ExportHostFunc(pathOpen)
+	exporter.ExportHostFunc(pathReadlink)
+	exporter.ExportHostFunc(pathRemoveDirectory)
+	exporter.ExportHostFunc(pathRename)
+	exporter.ExportHostFunc(pathSymlink)
+	exporter.ExportHostFunc(pathUnlinkFile)
+	exporter.ExportHostFunc(pollOneoff)
+	exporter.ExportHostFunc(procExit)
+	exporter.ExportHostFunc(procRaise)
+	exporter.ExportHostFunc(schedYield)
+	exporter.ExportHostFunc(randomGet)
+	exporter.ExportHostFunc(sockAccept)
+	exporter.ExportHostFunc(sockRecv)
+	exporter.ExportHostFunc(sockSend)
+	exporter.ExportHostFunc(sockShutdown)
 }
 
-func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, values []string, offsets, bytes uint32) Errno {
+// Declare constants to avoid slice allocation per call.
+var (
+	errnoBadf        = []uint64{uint64(ErrnoBadf)}
+	errnoExist       = []uint64{uint64(ErrnoExist)}
+	errnoInval       = []uint64{uint64(ErrnoInval)}
+	errnoIo          = []uint64{uint64(ErrnoIo)}
+	errnoNoent       = []uint64{uint64(ErrnoNoent)}
+	errnoFault       = []uint64{uint64(ErrnoFault)}
+	errnoNametoolong = []uint64{uint64(ErrnoNametoolong)}
+	errnoSuccess     = []uint64{uint64(ErrnoSuccess)}
+)
+
+func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, values []string, offsets, bytes uint32) []uint64 {
 	for _, value := range values {
 		// Write current offset and advance it.
 		if !mem.WriteUint32Le(ctx, offsets, bytes) {
-			return ErrnoFault
+			return errnoFault
 		}
 		offsets += 4 // size of uint32
 
 		// Write the next value to memory with a NUL terminator
 		if !mem.Write(ctx, bytes, []byte(value)) {
-			return ErrnoFault
+			return errnoFault
 		}
 		bytes += uint32(len(value))
 		if !mem.WriteByte(ctx, bytes, 0) {
-			return ErrnoFault
+			return errnoFault
 		}
 		bytes++
 	}
 
-	return ErrnoSuccess
+	return errnoSuccess
 }
 
 // stubFunction stubs for GrainLang per #271.

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -206,7 +206,6 @@ func (j *compilerEnv) newFunction(codeSegment []byte) *function {
 		codeInitialAddress:    uintptr(unsafe.Pointer(&codeSegment[0])),
 		moduleInstanceAddress: uintptr(unsafe.Pointer(j.moduleInstance)),
 		source: &wasm.FunctionInstance{
-			Kind:   wasm.FunctionKindWasm,
 			Type:   &wasm.FunctionType{},
 			Module: j.moduleInstance,
 		},

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -194,7 +194,7 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 
 	const hostModuleName = "env"
 	const hostFnName = "grow_and_shrink_goroutine_stack"
-	hm, err := wasm.NewHostModule(hostModuleName, map[string]interface{}{hostFnName: func() {
+	hm, err := wasm.NewHostModule(hostModuleName, map[string]interface{}{hostFnName: func(context.Context) {
 		// This function aggressively grow the goroutine stack by recursively
 		// calling the function many times.
 		var callNum = 1000

--- a/internal/gojs/crypto_test.go
+++ b/internal/gojs/crypto_test.go
@@ -12,8 +12,8 @@ func Test_crypto(t *testing.T) {
 
 	stdout, stderr, err := compileAndRun(testCtx, "crypto", wazero.NewModuleConfig())
 
-	require.EqualError(t, err, `module "" closed with exit_code(0)`)
 	require.Zero(t, stderr)
+	require.EqualError(t, err, `module "" closed with exit_code(0)`)
 	require.Equal(t, `7a0c9f9f0d
 `, stdout)
 }

--- a/internal/gojs/runtime.go
+++ b/internal/gojs/runtime.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	i32, i64 = api.ValueTypeI32, api.ValueTypeI64
+
 	functionWasmExit             = "runtime.wasmExit"
 	functionWasmWrite            = "runtime.wasmWrite"
 	functionResetMemoryDataView  = "runtime.resetMemoryDataView"
@@ -24,40 +26,60 @@ const (
 // WasmExit implements runtime.wasmExit which supports runtime.exit.
 //
 // See https://github.com/golang/go/blob/go1.19/src/runtime/sys_wasm.go#L28
-var WasmExit = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionWasmExit, functionWasmExit,
-	[]string{"code"},
-	func(ctx context.Context, mod api.Module, code int32) {
-		getState(ctx).clear()
-		_ = mod.CloseWithExitCode(ctx, uint32(code)) // TODO: should ours be signed bit (like -1 == 255)?
+var WasmExit = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionWasmExit},
+	Name:        functionWasmExit,
+	ParamTypes:  []api.ValueType{i32},
+	ParamNames:  []string{"code"},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(wasmExit),
 	},
-))
+})
+
+func wasmExit(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+	code := uint32(params[0])
+
+	getState(ctx).clear()
+	_ = mod.CloseWithExitCode(ctx, code) // TODO: should ours be signed bit (like -1 == 255)?
+	return
+}
 
 // WasmWrite implements runtime.wasmWrite which supports runtime.write and
 // runtime.writeErr. This implements `println`.
 //
 // See https://github.com/golang/go/blob/go1.19/src/runtime/os_js.go#L29
-var WasmWrite = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionWasmWrite, functionWasmWrite,
-	[]string{"code"},
-	func(ctx context.Context, mod api.Module, fd, p, n uint32) {
-		var writer io.Writer
-
-		switch fd {
-		case 1:
-			writer = mod.(*wasm.CallContext).Sys.Stdout()
-		case 2:
-			writer = mod.(*wasm.CallContext).Sys.Stderr()
-		default:
-			// Keep things simple by expecting nothing past 2
-			panic(fmt.Errorf("unexpected fd %d", fd))
-		}
-
-		if _, err := writer.Write(mustRead(ctx, mod.Memory(), "p", p, n)); err != nil {
-			panic(fmt.Errorf("error writing p: %w", err))
-		}
+var WasmWrite = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionWasmWrite},
+	Name:        functionWasmWrite,
+	ParamTypes:  []api.ValueType{i32, i32, i32},
+	ParamNames:  []string{"fd", "p", "n"},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(wasmWrite),
 	},
-))
+})
+
+func wasmWrite(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+	fd, p, n := uint32(params[0]), uint32(params[1]), uint32(params[2])
+
+	var writer io.Writer
+
+	switch fd {
+	case 1:
+		writer = mod.(*wasm.CallContext).Sys.Stdout()
+	case 2:
+		writer = mod.(*wasm.CallContext).Sys.Stderr()
+	default:
+		// Keep things simple by expecting nothing past 2
+		panic(fmt.Errorf("unexpected fd %d", fd))
+	}
+
+	if _, err := writer.Write(mustRead(ctx, mod.Memory(), "p", p, n)); err != nil {
+		panic(fmt.Errorf("error writing p: %w", err))
+	}
+	return
+}
 
 // ResetMemoryDataView signals wasm.OpcodeMemoryGrow happened, indicating any
 // cached view of memory should be reset.
@@ -75,22 +97,38 @@ var ResetMemoryDataView = &wasm.HostFunc{
 // Nanotime1 implements runtime.nanotime which supports time.Since.
 //
 // See https://github.com/golang/go/blob/go1.19/src/runtime/sys_wasm.s#L184
-var Nanotime1 = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionNanotime1, functionNanotime1,
-	[]string{},
-	func(ctx context.Context, mod api.Module) int64 {
-		return mod.(*wasm.CallContext).Sys.Nanotime(ctx)
-	}))
+var Nanotime1 = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionNanotime1},
+	Name:        functionNanotime1,
+	ResultTypes: []api.ValueType{i64},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(nanotime1),
+	},
+})
+
+func nanotime1(ctx context.Context, mod api.Module, _ []uint64) []uint64 {
+	time := mod.(*wasm.CallContext).Sys.Nanotime(ctx)
+	return []uint64{api.EncodeI64(time)}
+}
 
 // Walltime implements runtime.walltime which supports time.Now.
 //
 // See https://github.com/golang/go/blob/go1.19/src/runtime/sys_wasm.s#L188
-var Walltime = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionWalltime, functionWalltime,
-	[]string{},
-	func(ctx context.Context, mod api.Module) (sec int64, nsec int32) {
-		return mod.(*wasm.CallContext).Sys.Walltime(ctx)
-	}))
+var Walltime = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionWalltime},
+	Name:        functionWalltime,
+	ResultTypes: []api.ValueType{i64, i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(walltime),
+	},
+})
+
+func walltime(ctx context.Context, mod api.Module, _ []uint64) []uint64 {
+	sec, nsec := mod.(*wasm.CallContext).Sys.Walltime(ctx)
+	return []uint64{api.EncodeI64(sec), api.EncodeI32(nsec)}
+}
 
 // ScheduleTimeoutEvent implements runtime.scheduleTimeoutEvent which supports
 // runtime.notetsleepg used by runtime.signal_recv.
@@ -115,18 +153,27 @@ var ClearTimeoutEvent = stubFunction(functionClearTimeoutEvent)
 // for runtime.fastrand.
 //
 // See https://github.com/golang/go/blob/go1.19/src/runtime/sys_wasm.s#L200
-var GetRandomData = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionGetRandomData, functionGetRandomData,
-	[]string{"buf", "bufLen"},
-	func(ctx context.Context, mod api.Module, buf, bufLen uint32) {
-		randSource := mod.(*wasm.CallContext).Sys.RandSource()
-
-		r := mustRead(ctx, mod.Memory(), "r", buf, bufLen)
-
-		if n, err := randSource.Read(r); err != nil {
-			panic(fmt.Errorf("RandSource.Read(r /* len=%d */) failed: %w", bufLen, err))
-		} else if uint32(n) != bufLen {
-			panic(fmt.Errorf("RandSource.Read(r /* len=%d */) read %d bytes", bufLen, n))
-		}
+var GetRandomData = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionGetRandomData},
+	Name:        functionGetRandomData,
+	ParamTypes:  []api.ValueType{i32, i32},
+	ParamNames:  []string{"buf", "bufLen"},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(getRandomData),
 	},
-))
+})
+
+func getRandomData(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+	randSource := mod.(*wasm.CallContext).Sys.RandSource()
+	buf, bufLen := uint32(params[0]), uint32(params[1])
+
+	r := mustRead(ctx, mod.Memory(), "r", buf, bufLen)
+
+	if n, err := randSource.Read(r); err != nil {
+		panic(fmt.Errorf("RandSource.Read(r /* len=%d */) failed: %w", bufLen, err))
+	} else if uint32(n) != bufLen {
+		panic(fmt.Errorf("RandSource.Read(r /* len=%d */) read %d bytes", bufLen, n))
+	}
+	return
+}

--- a/internal/gojs/syscall.go
+++ b/internal/gojs/syscall.go
@@ -38,27 +38,47 @@ const (
 // runtime.SetFinalizer on the given reference.
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L61
-var FinalizeRef = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionFinalizeRef, functionFinalizeRef,
-	[]string{"r"},
-	func(ctx context.Context, mod api.Module, id uint32) { // 32-bits of the ref are the ID
-		getState(ctx).values.decrement(id)
+var FinalizeRef = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionFinalizeRef},
+	Name:        functionFinalizeRef,
+	ParamTypes:  []api.ValueType{i32},
+	ParamNames:  []string{"r"},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoFunc(finalizeRef),
 	},
-))
+})
+
+func finalizeRef(ctx context.Context, params []uint64) (_ []uint64) {
+	id := uint32(params[0]) // 32-bits of the ref are the ID
+
+	getState(ctx).values.decrement(id)
+	return
+}
 
 // StringVal implements js.stringVal, which is used to load the string for
 // `js.ValueOf(x)`. For example, this is used when setting HTTP headers.
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L212
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L305-L308
-var StringVal = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionStringVal, functionStringVal,
-	[]string{"xAddr", "xLen"},
-	func(ctx context.Context, mod api.Module, xAddr, xLen uint32) uint64 {
-		x := string(mustRead(ctx, mod.Memory(), "x", xAddr, xLen))
-		return storeRef(ctx, x)
+var StringVal = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionStringVal},
+	Name:        functionStringVal,
+	ParamTypes:  []api.ValueType{i32, i32},
+	ParamNames:  []string{"xAddr", "xLen"},
+	ResultTypes: []api.ValueType{i64},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(stringVal),
 	},
-))
+})
+
+func stringVal(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	xAddr, xLen := uint32(params[0]), uint32(params[1])
+
+	x := string(mustRead(ctx, mod.Memory(), "x", xAddr, xLen))
+	return []uint64{storeRef(ctx, x)}
+}
 
 // ValueGet implements js.valueGet, which is used to load a js.Value property
 // by name, e.g. `v.Get("address")`. Notably, this is used by js.handleEvent to
@@ -66,33 +86,45 @@ var StringVal = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L295
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L311-L316
-var ValueGet = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionValueGet, functionValueGet,
-	[]string{"v", "pAddr", "pLen"},
-	func(ctx context.Context, mod api.Module, vRef uint64, pAddr, pLen uint32) uint64 {
-		p := string(mustRead(ctx, mod.Memory(), "p", pAddr, pLen))
-		v := loadValue(ctx, ref(vRef))
+var ValueGet = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionValueGet},
+	Name:        functionValueGet,
+	ParamTypes:  []api.ValueType{i64, i32, i32},
+	ParamNames:  []string{"v", "pAddr", "pLen"},
+	ResultTypes: []api.ValueType{i64},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(valueGet),
+	},
+})
 
-		var result interface{}
-		if g, ok := v.(jsGet); ok {
-			result = g.get(ctx, p)
-		} else if e, ok := v.(error); ok {
-			switch p {
-			case "message": // js (GOOS=js) error, can be anything.
-				result = e.Error()
-			case "code": // syscall (GOARCH=wasm) error, must match key in mapJSError in fs_js.go
-				result = mapJSError(e).Error()
-			default:
-				panic(fmt.Errorf("TODO: valueGet(v=%v, p=%s)", v, p))
-			}
-		} else {
+func valueGet(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	vRef := params[0]
+	pAddr := uint32(params[1])
+	pLen := uint32(params[2])
+
+	p := string(mustRead(ctx, mod.Memory(), "p", pAddr, pLen))
+	v := loadValue(ctx, ref(vRef))
+
+	var result interface{}
+	if g, ok := v.(jsGet); ok {
+		result = g.get(ctx, p)
+	} else if e, ok := v.(error); ok {
+		switch p {
+		case "message": // js (GOOS=js) error, can be anything.
+			result = e.Error()
+		case "code": // syscall (GOARCH=wasm) error, must match key in mapJSError in fs_js.go
+			result = mapJSError(e).Error()
+		default:
 			panic(fmt.Errorf("TODO: valueGet(v=%v, p=%s)", v, p))
 		}
+	} else {
+		panic(fmt.Errorf("TODO: valueGet(v=%v, p=%s)", v, p))
+	}
 
-		xRef := storeRef(ctx, result)
-		return xRef
-	},
-))
+	xRef := storeRef(ctx, result)
+	return []uint64{xRef}
+}
 
 // ValueSet implements js.valueSet, which is used to store a js.Value property
 // by name, e.g. `v.Set("address", a)`. Notably, this is used by js.handleEvent
@@ -100,34 +132,46 @@ var ValueGet = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L309
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L318-L322
-var ValueSet = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionValueSet, functionValueSet,
-	[]string{"v", "pAddr", "pLen", "x"},
-	func(ctx context.Context, mod api.Module, vRef uint64, pAddr, pLen uint32, xRef uint64) {
-		v := loadValue(ctx, ref(vRef))
-		p := string(mustRead(ctx, mod.Memory(), "p", pAddr, pLen))
-		x := loadValue(ctx, ref(xRef))
-		if v == getState(ctx) {
-			switch p {
-			case "_pendingEvent":
-				if x == nil { // syscall_js.handleEvent
-					v.(*state)._pendingEvent = nil
-					return
-				}
-			}
-		} else if e, ok := v.(*event); ok { // syscall_js.handleEvent
-			switch p {
-			case "result":
-				e.result = x
+var ValueSet = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionValueSet},
+	Name:        functionValueSet,
+	ParamTypes:  []api.ValueType{i64, i32, i32, i64},
+	ParamNames:  []string{"v", "pAddr", "pLen", "x"},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(valueSet),
+	},
+})
+
+func valueSet(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+	vRef := params[0]
+	pAddr := uint32(params[1])
+	pLen := uint32(params[2])
+	xRef := params[3]
+
+	v := loadValue(ctx, ref(vRef))
+	p := string(mustRead(ctx, mod.Memory(), "p", pAddr, pLen))
+	x := loadValue(ctx, ref(xRef))
+	if v == getState(ctx) {
+		switch p {
+		case "_pendingEvent":
+			if x == nil { // syscall_js.handleEvent
+				v.(*state)._pendingEvent = nil
 				return
 			}
-		} else if m, ok := v.(*object); ok {
-			m.properties[p] = x // e.g. opt.Set("method", req.Method)
+		}
+	} else if e, ok := v.(*event); ok { // syscall_js.handleEvent
+		switch p {
+		case "result":
+			e.result = x
 			return
 		}
-		panic(fmt.Errorf("TODO: valueSet(v=%v, p=%s, x=%v)", v, p, x))
-	},
-))
+	} else if m, ok := v.(*object); ok {
+		m.properties[p] = x // e.g. opt.Set("method", req.Method)
+		return
+	}
+	panic(fmt.Errorf("TODO: valueSet(v=%v, p=%s, x=%v)", v, p, x))
+}
 
 // ValueDelete is stubbed as it isn't used in Go's main source tree.
 //
@@ -140,16 +184,28 @@ var ValueDelete = stubFunction(functionValueDelete)
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L334
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L331-L334
-var ValueIndex = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionValueIndex, functionValueIndex,
-	[]string{"v", "i"},
-	func(ctx context.Context, mod api.Module, vRef uint64, i uint32) (xRef uint64) {
-		v := loadValue(ctx, ref(vRef))
-		result := v.(*objectArray).slice[i]
-		xRef = storeRef(ctx, result)
-		return
+var ValueIndex = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionValueIndex},
+	Name:        functionValueIndex,
+	ParamTypes:  []api.ValueType{i64, i32},
+	ParamNames:  []string{"v", "i"},
+	ResultTypes: []api.ValueType{i64},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoFunc(valueIndex),
 	},
-))
+})
+
+func valueIndex(ctx context.Context, params []uint64) []uint64 {
+	vRef := params[0]
+	i := uint32(params[1])
+
+	v := loadValue(ctx, ref(vRef))
+	result := v.(*objectArray).slice[i]
+	xRef := storeRef(ctx, result)
+
+	return []uint64{xRef}
+}
 
 // ValueSetIndex is stubbed as it is only used for js.ValueOf when the input is
 // []interface{}, which doesn't appear to occur in Go's source tree.
@@ -163,29 +219,45 @@ var ValueSetIndex = stubFunction(functionValueSetIndex)
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L394
 //
 //	https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L343-L358
-var ValueCall = spfunc.MustCallFromSP(true, wasm.NewGoFunc(
-	functionValueCall, functionValueCall,
-	[]string{"v", "mAddr", "mLen", "argsArray", "argsLen"},
-	func(ctx context.Context, mod api.Module, vRef uint64, mAddr, mLen, argsArray, argsLen uint32) (xRef uint64, ok uint32, sp uint32) {
-		this := ref(vRef)
-		v := loadValue(ctx, this)
-		m := string(mustRead(ctx, mod.Memory(), "m", mAddr, mLen))
-		args := loadArgs(ctx, mod, argsArray, argsLen)
-
-		if c, isCall := v.(jsCall); !isCall {
-			panic(fmt.Errorf("TODO: valueCall(v=%v, m=%v, args=%v)", v, m, args))
-		} else if result, err := c.call(ctx, mod, this, m, args...); err != nil {
-			xRef = storeRef(ctx, err)
-			ok = 0
-		} else {
-			xRef = storeRef(ctx, result)
-			ok = 1
-		}
-
-		sp = refreshSP(mod)
-		return
+var ValueCall = spfunc.MustCallFromSP(true, &wasm.HostFunc{
+	ExportNames: []string{functionValueCall},
+	Name:        functionValueCall,
+	ParamTypes:  []api.ValueType{i64, i32, i32, i32, i32},
+	ParamNames:  []string{"v", "mAddr", "mLen", "argsArray", "argsLen"},
+	ResultTypes: []api.ValueType{i64, i32, i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(valueCall),
 	},
-))
+})
+
+func valueCall(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	vRef := params[0]
+	mAddr := uint32(params[1])
+	mLen := uint32(params[2])
+	argsArray := uint32(params[3])
+	argsLen := uint32(params[4])
+
+	this := ref(vRef)
+	v := loadValue(ctx, this)
+	m := string(mustRead(ctx, mod.Memory(), "m", mAddr, mLen))
+	args := loadArgs(ctx, mod, argsArray, argsLen)
+
+	var xRef uint64
+	var ok, sp uint32
+	if c, isCall := v.(jsCall); !isCall {
+		panic(fmt.Errorf("TODO: valueCall(v=%v, m=%v, args=%v)", v, m, args))
+	} else if result, err := c.call(ctx, mod, this, m, args...); err != nil {
+		xRef = storeRef(ctx, err)
+		ok = 0
+	} else {
+		xRef = storeRef(ctx, result)
+		ok = 1
+	}
+
+	sp = refreshSP(mod)
+	return []uint64{xRef, uint64(ok), uint64(sp)}
+}
 
 // ValueInvoke is stubbed as it isn't used in Go's main source tree.
 //
@@ -197,67 +269,93 @@ var ValueInvoke = stubFunction(functionValueInvoke)
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L432
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L380-L391
-var ValueNew = spfunc.MustCallFromSP(true, wasm.NewGoFunc(
-	functionValueNew, functionValueNew,
-	[]string{"v", "argsArray", "argsLen"},
-	func(ctx context.Context, mod api.Module, vRef uint64, argsArray, argsLen uint32) (xRef uint64, ok uint32, sp uint32) {
-		args := loadArgs(ctx, mod, argsArray, argsLen)
-		ref := ref(vRef)
-		v := loadValue(ctx, ref)
+var ValueNew = spfunc.MustCallFromSP(true, &wasm.HostFunc{
+	ExportNames: []string{functionValueNew},
+	Name:        functionValueNew,
+	ParamTypes:  []api.ValueType{i64, i32, i32},
+	ParamNames:  []string{"v", "argsArray", "argsLen"},
+	ResultTypes: []api.ValueType{i64, i32, i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(valueNew),
+	},
+})
 
-		switch ref {
-		case refArrayConstructor:
-			result := &objectArray{}
-			xRef = storeRef(ctx, result)
-			ok = 1
-		case refUint8ArrayConstructor:
-			var result *byteArray
-			if n, ok := args[0].(float64); ok {
-				result = &byteArray{make([]byte, uint32(n))}
-			} else if n, ok := args[0].(uint32); ok {
-				result = &byteArray{make([]byte, n)}
-			} else if b, ok := args[0].(*byteArray); ok {
-				// In case of below, in HTTP, return the same ref
-				//	uint8arrayWrapper := uint8Array.New(args[0])
-				result = b
-			} else {
-				panic(fmt.Errorf("TODO: valueNew(v=%v, args=%v)", v, args))
-			}
-			xRef = storeRef(ctx, result)
-			ok = 1
-		case refObjectConstructor:
-			result := &object{properties: map[string]interface{}{}}
-			xRef = storeRef(ctx, result)
-			ok = 1
-		case refHttpHeadersConstructor:
-			result := &headers{headers: http.Header{}}
-			xRef = storeRef(ctx, result)
-			ok = 1
-		case refJsDateConstructor:
-			xRef = uint64(refJsDate)
-			ok = 1
-		default:
+func valueNew(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	vRef := params[0]
+	argsArray := uint32(params[1])
+	argsLen := uint32(params[2])
+
+	args := loadArgs(ctx, mod, argsArray, argsLen)
+	ref := ref(vRef)
+	v := loadValue(ctx, ref)
+
+	var xRef uint64
+	var ok, sp uint32
+	switch ref {
+	case refArrayConstructor:
+		result := &objectArray{}
+		xRef = storeRef(ctx, result)
+		ok = 1
+	case refUint8ArrayConstructor:
+		var result *byteArray
+		if n, ok := args[0].(float64); ok {
+			result = &byteArray{make([]byte, uint32(n))}
+		} else if n, ok := args[0].(uint32); ok {
+			result = &byteArray{make([]byte, n)}
+		} else if b, ok := args[0].(*byteArray); ok {
+			// In case of below, in HTTP, return the same ref
+			//	uint8arrayWrapper := uint8Array.New(args[0])
+			result = b
+		} else {
 			panic(fmt.Errorf("TODO: valueNew(v=%v, args=%v)", v, args))
 		}
+		xRef = storeRef(ctx, result)
+		ok = 1
+	case refObjectConstructor:
+		result := &object{properties: map[string]interface{}{}}
+		xRef = storeRef(ctx, result)
+		ok = 1
+	case refHttpHeadersConstructor:
+		result := &headers{headers: http.Header{}}
+		xRef = storeRef(ctx, result)
+		ok = 1
+	case refJsDateConstructor:
+		xRef = uint64(refJsDate)
+		ok = 1
+	default:
+		panic(fmt.Errorf("TODO: valueNew(v=%v, args=%v)", v, args))
+	}
 
-		sp = refreshSP(mod)
-		return
-	},
-))
+	sp = refreshSP(mod)
+	return []uint64{xRef, uint64(ok), uint64(sp)}
+}
 
 // ValueLength implements js.valueLength, which is used to load the length
 // property of a value, e.g. `array.length`.
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L372
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L396-L397
-var ValueLength = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionValueLength, functionValueLength,
-	[]string{"v"},
-	func(ctx context.Context, mod api.Module, vRef uint64) uint32 {
-		v := loadValue(ctx, ref(vRef))
-		return uint32(len(v.(*objectArray).slice))
+var ValueLength = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionValueLength},
+	Name:        functionValueLength,
+	ParamTypes:  []api.ValueType{i64},
+	ParamNames:  []string{"v"},
+	ResultTypes: []api.ValueType{i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoFunc(valueLength),
 	},
-))
+})
+
+func valueLength(ctx context.Context, params []uint64) []uint64 {
+	vRef := params[0]
+
+	v := loadValue(ctx, ref(vRef))
+	l := uint32(len(v.(*objectArray).slice))
+
+	return []uint64{uint64(l)}
+}
 
 // ValuePrepareString implements js.valuePrepareString, which is used to load
 // the string for `o.String()` (via js.jsString) for string, boolean and
@@ -266,17 +364,29 @@ var ValueLength = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L531
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L402-L405
-var ValuePrepareString = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionValuePrepareString, functionValuePrepareString,
-	[]string{"v"},
-	func(ctx context.Context, mod api.Module, vRef uint64) (sRef uint64, sLen uint32) {
-		v := loadValue(ctx, ref(vRef))
-		s := valueString(v)
-		sRef = storeRef(ctx, s)
-		sLen = uint32(len(s))
-		return
+var ValuePrepareString = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionValuePrepareString},
+	Name:        functionValuePrepareString,
+	ParamTypes:  []api.ValueType{i64},
+	ParamNames:  []string{"v"},
+	ResultTypes: []api.ValueType{i64, i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoFunc(valuePrepareString),
 	},
-))
+})
+
+func valuePrepareString(ctx context.Context, params []uint64) []uint64 {
+	vRef := params[0]
+
+	v := loadValue(ctx, ref(vRef))
+	s := valueString(v)
+
+	sRef := storeRef(ctx, s)
+	sLen := uint32(len(s))
+
+	return []uint64{sRef, uint64(sLen)}
+}
 
 // ValueLoadString implements js.valueLoadString, which is used copy a string
 // value for `o.String()`.
@@ -284,16 +394,28 @@ var ValuePrepareString = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L533
 //
 //	https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L410-L412
-var ValueLoadString = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionValueLoadString, functionValueLoadString,
-	[]string{"v", "bAddr", "bLen"},
-	func(ctx context.Context, mod api.Module, vRef uint64, bAddr, bLen uint32) {
-		v := loadValue(ctx, ref(vRef))
-		s := valueString(v)
-		b := mustRead(ctx, mod.Memory(), "b", bAddr, bLen)
-		copy(b, s)
+var ValueLoadString = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionValueLoadString},
+	Name:        functionValueLoadString,
+	ParamTypes:  []api.ValueType{i64, i32, i32},
+	ParamNames:  []string{"v", "bAddr", "bLen"},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(valueLoadString),
 	},
-))
+})
+
+func valueLoadString(ctx context.Context, mod api.Module, params []uint64) (_ []uint64) {
+	vRef := params[0]
+	bAddr := uint32(params[1])
+	bLen := uint32(params[2])
+
+	v := loadValue(ctx, ref(vRef))
+	s := valueString(v)
+	b := mustRead(ctx, mod.Memory(), "b", bAddr, bLen)
+	copy(b, s)
+	return
+}
 
 // ValueInstanceOf is stubbed as it isn't used in Go's main source tree.
 //
@@ -310,19 +432,35 @@ var ValueInstanceOf = stubFunction(functionValueInstanceOf)
 //
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L569
 // and https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L424-L433
-var CopyBytesToGo = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionCopyBytesToGo, functionCopyBytesToGo,
-	[]string{"dstAddr", "dstLen", "src"},
-	func(ctx context.Context, mod api.Module, dstAddr, dstLen, _ uint32, srcRef uint64) (n, ok uint32) {
-		dst := mustRead(ctx, mod.Memory(), "dst", dstAddr, dstLen) // nolint
-		v := loadValue(ctx, ref(srcRef))
-		if src, isBuf := v.(*byteArray); isBuf {
-			n = uint32(copy(dst, src.slice))
-			ok = 1
-		}
-		return
+var CopyBytesToGo = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionCopyBytesToGo},
+	Name:        functionCopyBytesToGo,
+	ParamTypes:  []api.ValueType{i32, i32, i32, i64},
+	ParamNames:  []string{"dstAddr", "dstLen", "_", "src"},
+	ResultTypes: []api.ValueType{i32, i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(copyBytesToGo),
 	},
-))
+})
+
+func copyBytesToGo(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	dstAddr := uint32(params[0])
+	dstLen := uint32(params[1])
+	_ /* unknown */ = uint32(params[2])
+	srcRef := params[3]
+
+	dst := mustRead(ctx, mod.Memory(), "dst", dstAddr, dstLen) // nolint
+	v := loadValue(ctx, ref(srcRef))
+
+	var n, ok uint32
+	if src, isBuf := v.(*byteArray); isBuf {
+		n = uint32(copy(dst, src.slice))
+		ok = 1
+	}
+
+	return []uint64{uint64(n), uint64(ok)}
+}
 
 // CopyBytesToJS copies linear memory to a JavaScript managed byte array.
 // For example, this is used to read an HTTP request body.
@@ -335,21 +473,37 @@ var CopyBytesToGo = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
 // See https://github.com/golang/go/blob/go1.19/src/syscall/js/js.go#L583
 //
 //	https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js#L438-L448
-var CopyBytesToJS = spfunc.MustCallFromSP(false, wasm.NewGoFunc(
-	functionCopyBytesToJS, functionCopyBytesToJS,
-	[]string{"dst", "srcAddr", "srcLen"},
-	func(ctx context.Context, mod api.Module, dstRef uint64, srcAddr, srcLen, _ uint32) (n, ok uint32) {
-		src := mustRead(ctx, mod.Memory(), "src", srcAddr, srcLen) // nolint
-		v := loadValue(ctx, ref(dstRef))
-		if dst, isBuf := v.(*byteArray); isBuf {
-			if dst != nil { // empty is possible on EOF
-				n = uint32(copy(dst.slice, src))
-			}
-			ok = 1
-		}
-		return
+var CopyBytesToJS = spfunc.MustCallFromSP(false, &wasm.HostFunc{
+	ExportNames: []string{functionCopyBytesToJS},
+	Name:        functionCopyBytesToJS,
+	ParamTypes:  []api.ValueType{i64, i32, i32, i32},
+	ParamNames:  []string{"dst", "srcAddr", "srcLen", "_"},
+	ResultTypes: []api.ValueType{i32, i32},
+	Code: &wasm.Code{
+		IsHostFunction: true,
+		GoFunc:         api.GoModuleFunc(copyBytesToJS),
 	},
-))
+})
+
+func copyBytesToJS(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+	dstRef := params[0]
+	srcAddr := uint32(params[1])
+	srcLen := uint32(params[2])
+	_ /* unknown */ = uint32(params[3])
+
+	src := mustRead(ctx, mod.Memory(), "src", srcAddr, srcLen) // nolint
+	v := loadValue(ctx, ref(dstRef))
+
+	var n, ok uint32
+	if dst, isBuf := v.(*byteArray); isBuf {
+		if dst != nil { // empty is possible on EOF
+			n = uint32(copy(dst.slice, src))
+		}
+		ok = 1
+	}
+
+	return []uint64{uint64(n), uint64(ok)}
+}
 
 // refreshSP refreshes the stack pointer, which is needed prior to storeValue
 // when in an operation that can trigger a Go event handler.

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -216,7 +216,7 @@ func createRuntime(b *testing.B, config wazero.RuntimeConfig) wazero.Runtime {
 	r := wazero.NewRuntimeWithConfig(testCtx, config)
 
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("get_random_string", getRandomString).
+		NewFunctionBuilder().WithFunc(getRandomString).Export("get_random_string").
 		Instantiate(testCtx, r)
 	if err != nil {
 		b.Fatal(err)

--- a/internal/testing/require/require.go
+++ b/internal/testing/require/require.go
@@ -22,6 +22,10 @@ type TestingT interface {
 	Fatal(args ...interface{})
 }
 
+type EqualTo interface {
+	EqualTo(that interface{}) bool
+}
+
 // TODO: implement, test and document each function without using testify
 
 // Contains fails if `s` does not contain `substr` using strings.Contains.
@@ -69,6 +73,18 @@ func Equal(t TestingT, expected, actual interface{}, formatWithArgs ...interface
 	} else if et.Kind() < reflect.Array {
 		fail(t, fmt.Sprintf("expected %v, but was %v", expected, actual), "", formatWithArgs...)
 		return
+	} else if et.Kind() == reflect.Func {
+		// compare funcs by string pointer
+		expected := fmt.Sprintf("%v", expected)
+		actual := fmt.Sprintf("%v", actual)
+		if expected != actual {
+			fail(t, fmt.Sprintf("expected %s, but was %s", expected, actual), "", formatWithArgs...)
+		}
+		return
+	} else if eq, ok := actual.(EqualTo); ok {
+		if !eq.EqualTo(expected) {
+			fail(t, fmt.Sprintf("expected %v, but was %v", expected, actual), "", formatWithArgs...)
+		}
 	}
 
 	// If we have the same type, and it isn't a string, but the expected and actual values on a different line.

--- a/internal/wasm/binary/code.go
+++ b/internal/wasm/binary/code.go
@@ -84,7 +84,7 @@ func decodeCode(r *bytes.Reader) (*wasm.Code, error) {
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-code
 func encodeCode(c *wasm.Code) []byte {
 	if c.GoFunc != nil {
-		panic("BUG: GoFunc is not encodable")
+		panic("BUG: GoFunction is not encodable")
 	}
 
 	// local blocks compress locals while preserving index order by grouping locals of the same type.

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -1,9 +1,9 @@
 package binary
 
 import (
+	"context"
 	"testing"
 
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -211,13 +211,13 @@ func TestModule_Encode(t *testing.T) {
 
 func TestModule_Encode_HostFunctionSection_Unsupported(t *testing.T) {
 	// We don't currently have an approach to serialize reflect.Value pointers
-	fn := func(api.Module) {}
+	fn := func(context.Context) {}
 
 	captured := require.CapturePanic(func() {
 		EncodeModule(&wasm.Module{
 			TypeSection: []*wasm.FunctionType{{}},
-			CodeSection: []*wasm.Code{wasm.MustParseGoFuncCode(fn)},
+			CodeSection: []*wasm.Code{wasm.MustParseGoReflectFuncCode(fn)},
 		})
 	})
-	require.EqualError(t, captured, "BUG: GoFunc is not encodable")
+	require.EqualError(t, captured, "BUG: GoFunction is not encodable")
 }

--- a/internal/wasm/call_context.go
+++ b/internal/wasm/call_context.go
@@ -168,7 +168,7 @@ func (f *function) Definition() api.FunctionDefinition {
 
 // Call implements the same method as documented on api.Function.
 func (f *function) Call(ctx context.Context, params ...uint64) (ret []uint64, err error) {
-	return f.ce.Call(ctx, f.fi.Module.CallCtx, params...)
+	return f.ce.Call(ctx, f.fi.Module.CallCtx, params)
 }
 
 // importedFn implements api.Function and ensures the call context of an imported function is the importing module.
@@ -189,7 +189,7 @@ func (f *importedFn) Call(ctx context.Context, params ...uint64) (ret []uint64, 
 		return nil, fmt.Errorf("directly calling host function is not supported")
 	}
 	mod := f.importingModule
-	return f.ce.Call(ctx, mod, params...)
+	return f.ce.Call(ctx, mod, params)
 }
 
 // GlobalVal is an internal hack to get the lower 64 bits of a global.

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -59,7 +59,7 @@ type ModuleEngine interface {
 // internally, and shouldn't be used concurrently.
 type CallEngine interface {
 	// Call invokes a function instance f with given parameters.
-	Call(ctx context.Context, m *CallContext, params ...uint64) (results []uint64, err error)
+	Call(ctx context.Context, m *CallContext, params []uint64) (results []uint64, err error)
 }
 
 // TableInitEntry is normalized element segment used for initializing tables by engines.

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -1,8 +1,6 @@
 package wasm
 
 import (
-	"reflect"
-
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
 )
@@ -110,7 +108,7 @@ type FunctionDefinition struct {
 	index       Index
 	name        string
 	debugName   string
-	goFunc      *reflect.Value
+	goFunc      interface{}
 	funcType    *FunctionType
 	importDesc  *[2]string
 	exportNames []string
@@ -151,7 +149,7 @@ func (f *FunctionDefinition) ExportNames() []string {
 }
 
 // GoFunc implements the same method as documented on api.FunctionDefinition.
-func (f *FunctionDefinition) GoFunc() *reflect.Value {
+func (f *FunctionDefinition) GoFunction() interface{} {
 	return f.goFunc
 }
 

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -1,6 +1,7 @@
 package wasm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
@@ -9,7 +10,7 @@ import (
 
 func TestModule_BuildFunctionDefinitions(t *testing.T) {
 	nopCode := &Code{Body: []byte{OpcodeEnd}}
-	fn := func() {}
+	fn := func(context.Context) {}
 	tests := []struct {
 		name            string
 		m               *Module
@@ -35,13 +36,13 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 			m: &Module{
 				TypeSection:     []*FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{MustParseGoFuncCode(fn)},
+				CodeSection:     []*Code{MustParseGoReflectFuncCode(fn)},
 			},
 			expected: []*FunctionDefinition{
 				{
 					index:     0,
 					debugName: ".$0",
-					goFunc:    MustParseGoFuncCode(fn).GoFunc,
+					goFunc:    MustParseGoReflectFuncCode(fn).GoFunc,
 					funcType:  v_v,
 				},
 			},

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -15,78 +15,42 @@ var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
 
 func Test_parseGoFunc(t *testing.T) {
 	var tests = []struct {
-		name         string
-		inputFunc    interface{}
-		expectedKind FunctionKind
-		expectedType *FunctionType
+		name              string
+		input             interface{}
+		expectNeedsModule bool
+		expectedType      *FunctionType
 	}{
 		{
-			name:         "nullary",
-			inputFunc:    func() {},
-			expectedKind: FunctionKindGoNoContext,
+			name:         "(ctx) -> ()",
+			input:        func(context.Context) {},
 			expectedType: &FunctionType{},
 		},
 		{
-			name:         "wasm.Module void return",
-			inputFunc:    func(api.Module) {},
-			expectedKind: FunctionKindGoModule,
-			expectedType: &FunctionType{},
-		},
-		{
-			name:         "context.Context void return",
-			inputFunc:    func(context.Context) {},
-			expectedKind: FunctionKindGoContext,
-			expectedType: &FunctionType{},
-		},
-		{
-			name:         "context.Context and api.Module void return",
-			inputFunc:    func(context.Context, api.Module) {},
-			expectedKind: FunctionKindGoContextModule,
-			expectedType: &FunctionType{},
+			name:              "(ctx, mod) -> ()",
+			input:             func(context.Context, api.Module) {},
+			expectNeedsModule: true,
+			expectedType:      &FunctionType{},
 		},
 		{
 			name:         "all supported params and i32 result",
-			inputFunc:    func(uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
-			expectedKind: FunctionKindGoNoContext,
+			input:        func(context.Context, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
 			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
 		},
 		{
-			name: "all supported params and all supported results",
-			inputFunc: func(uint32, uint64, float32, float64, uintptr) (uint32, uint64, float32, float64, uintptr) {
-				return 0, 0, 0, 0, 0
-			},
-			expectedKind: FunctionKindGoNoContext,
-			expectedType: &FunctionType{
-				Params:  []ValueType{i32, i64, f32, f64, externref},
-				Results: []ValueType{i32, i64, f32, f64, externref},
-			},
-		},
-		{
-			name:         "all supported params and i32 result - wasm.Module",
-			inputFunc:    func(api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
-			expectedKind: FunctionKindGoModule,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
-		},
-		{
-			name:         "all supported params and i32 result - context.Context",
-			inputFunc:    func(context.Context, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
-			expectedKind: FunctionKindGoContext,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
-		},
-		{
-			name:         "all supported params and i32 result - context.Context and api.Module",
-			inputFunc:    func(context.Context, api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
-			expectedKind: FunctionKindGoContextModule,
-			expectedType: &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
+			name:              "all supported params and i32 result - context.Context and api.Module",
+			input:             func(context.Context, api.Module, uint32, uint64, float32, float64, uintptr) uint32 { return 0 },
+			expectNeedsModule: true,
+			expectedType:      &FunctionType{Params: []ValueType{i32, i64, f32, f64, externref}, Results: []ValueType{i32}},
 		},
 	}
 	for _, tt := range tests {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			paramTypes, resultTypes, code, err := parseGoFunc(tc.inputFunc)
+			paramTypes, resultTypes, code, err := parseGoReflectFunc(tc.input)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedKind, code.Kind)
+			_, isModuleFunc := code.GoFunc.(api.GoModuleFunction)
+			require.Equal(t, tc.expectNeedsModule, isModuleFunc)
 			require.Equal(t, tc.expectedType, &FunctionType{Params: paramTypes, Results: resultTypes})
 		})
 	}
@@ -94,11 +58,20 @@ func Test_parseGoFunc(t *testing.T) {
 
 func Test_parseGoFunc_Errors(t *testing.T) {
 	tests := []struct {
-		name             string
-		input            interface{}
-		allowErrorResult bool
-		expectedErr      string
+		name        string
+		input       interface{}
+		expectedErr string
 	}{
+		{
+			name:        "no context",
+			input:       func() {},
+			expectedErr: "invalid signature: context.Context must be param[0]",
+		},
+		{
+			name:        "module no context",
+			input:       func(api.Module) {},
+			expectedErr: "invalid signature: api.Module parameter must be preceded by context.Context",
+		},
 		{
 			name:        "not a func",
 			input:       struct{}{},
@@ -106,23 +79,23 @@ func Test_parseGoFunc_Errors(t *testing.T) {
 		},
 		{
 			name:        "unsupported param",
-			input:       func(uint32, string) {},
-			expectedErr: "param[1] is unsupported: string",
+			input:       func(context.Context, uint32, string) {},
+			expectedErr: "param[2] is unsupported: string",
 		},
 		{
 			name:        "unsupported result",
-			input:       func() string { return "" },
+			input:       func(context.Context) string { return "" },
 			expectedErr: "result[0] is unsupported: string",
 		},
 		{
 			name:        "error result",
-			input:       func() error { return nil },
+			input:       func(context.Context) error { return nil },
 			expectedErr: "result[0] is an error, which is unsupported",
 		},
 		{
-			name:        "multiple context types",
+			name:        "incorrect order",
 			input:       func(api.Module, context.Context) error { return nil },
-			expectedErr: "param[1] is a context.Context, which may be defined only once as param[0]",
+			expectedErr: "invalid signature: api.Module parameter must be preceded by context.Context",
 		},
 		{
 			name:        "multiple context.Context",
@@ -131,8 +104,8 @@ func Test_parseGoFunc_Errors(t *testing.T) {
 		},
 		{
 			name:        "multiple wasm.Module",
-			input:       func(api.Module, uint64, api.Module) error { return nil },
-			expectedErr: "param[2] is a api.Module, which may be defined only once as param[0]",
+			input:       func(context.Context, api.Module, uint64, api.Module) error { return nil },
+			expectedErr: "param[3] is a api.Module, which may be defined only once as param[0]",
 		},
 	}
 
@@ -140,7 +113,7 @@ func Test_parseGoFunc_Errors(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, _, err := parseGoFunc(tc.input)
+			_, _, _, err := parseGoReflectFunc(tc.input)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -195,164 +168,31 @@ func TestPopValues(t *testing.T) {
 	}
 }
 
-func TestPopGoFuncParams(t *testing.T) {
-	stackVals := []uint64{1, 2, 3, 4, 5, 6, 7}
-	var tests = []struct {
-		name      string
-		inputFunc interface{}
-		expected  []uint64
-	}{
-		{
-			name:      "nullary",
-			inputFunc: func() {},
-		},
-		{
-			name:      "wasm.Module",
-			inputFunc: func(api.Module) {},
-		},
-		{
-			name:      "context.Context",
-			inputFunc: func(context.Context) {},
-		},
-		{
-			name:      "context.Context and api.Module",
-			inputFunc: func(context.Context, api.Module) {},
-		},
-		{
-			name:      "all supported params",
-			inputFunc: func(uint32, uint64, float32, float64, uintptr) {},
-			expected:  []uint64{3, 4, 5, 6, 7},
-		},
-		{
-			name:      "all supported params - wasm.Module",
-			inputFunc: func(api.Module, uint32, uint64, float32, float64, uintptr) {},
-			expected:  []uint64{3, 4, 5, 6, 7},
-		},
-		{
-			name:      "all supported params - context.Context",
-			inputFunc: func(context.Context, uint32, uint64, float32, float64, uintptr) {},
-			expected:  []uint64{3, 4, 5, 6, 7},
-		},
-		{
-			name:      "all supported params - context.Context and api.Module",
-			inputFunc: func(context.Context, api.Module, uint32, uint64, float32, float64, uintptr) {},
-			expected:  []uint64{3, 4, 5, 6, 7},
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			_, _, code, err := parseGoFunc(tc.inputFunc)
-			require.NoError(t, err)
-
-			vals := PopGoFuncParams(&FunctionInstance{Kind: code.Kind, GoFunc: code.GoFunc}, (&stack{stackVals}).pop)
-			require.Equal(t, tc.expected, vals)
-		})
-	}
-}
-
-func TestCallGoFunc(t *testing.T) {
+func Test_callGoFunc(t *testing.T) {
 	tPtr := uintptr(unsafe.Pointer(t))
 	callCtx := &CallContext{}
-	callCtxPtr := uintptr(unsafe.Pointer(callCtx))
 
 	var tests = []struct {
 		name                         string
-		inputFunc                    interface{}
+		input                        interface{}
 		inputParams, expectedResults []uint64
 	}{
 		{
-			name:      "nullary",
-			inputFunc: func() {},
-		},
-		{
-			name: "wasm.Module void return",
-			inputFunc: func(m api.Module) {
-				require.Equal(t, callCtx, m)
-			},
-		},
-		{
 			name: "context.Context void return",
-			inputFunc: func(ctx context.Context) {
+			input: func(ctx context.Context) {
 				require.Equal(t, testCtx, ctx)
 			},
 		},
 		{
 			name: "context.Context and api.Module void return",
-			inputFunc: func(ctx context.Context, m api.Module) {
+			input: func(ctx context.Context, m api.Module) {
 				require.Equal(t, testCtx, ctx)
 				require.Equal(t, callCtx, m)
 			},
 		},
 		{
-			name: "all supported params and i32 result",
-			inputFunc: func(v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
-				require.Equal(t, tPtr, v)
-				require.Equal(t, uint32(math.MaxUint32), w)
-				require.Equal(t, uint64(math.MaxUint64), x)
-				require.Equal(t, float32(math.MaxFloat32), y)
-				require.Equal(t, math.MaxFloat64, z)
-				return 100
-			},
-			inputParams: []uint64{
-				api.EncodeExternref(tPtr),
-				math.MaxUint32,
-				math.MaxUint64,
-				api.EncodeF32(math.MaxFloat32),
-				api.EncodeF64(math.MaxFloat64),
-			},
-			expectedResults: []uint64{100},
-		},
-		{
-			name: "all supported params and all supported results",
-			inputFunc: func(v uintptr, w uint32, x uint64, y float32, z float64) (uintptr, uint32, uint64, float32, float64) {
-				require.Equal(t, tPtr, v)
-				require.Equal(t, uint32(math.MaxUint32), w)
-				require.Equal(t, uint64(math.MaxUint64), x)
-				require.Equal(t, float32(math.MaxFloat32), y)
-				require.Equal(t, math.MaxFloat64, z)
-				return uintptr(unsafe.Pointer(callCtx)), 100, 200, 300, 400
-			},
-			inputParams: []uint64{
-				api.EncodeExternref(tPtr),
-				math.MaxUint32,
-				math.MaxUint64,
-				api.EncodeF32(math.MaxFloat32),
-				api.EncodeF64(math.MaxFloat64),
-			},
-			expectedResults: []uint64{
-				api.EncodeExternref(callCtxPtr),
-				api.EncodeI32(100),
-				200,
-				api.EncodeF32(300),
-				api.EncodeF64(400),
-			},
-		},
-		{
-			name: "all supported params and i32 result - wasm.Module",
-			inputFunc: func(m api.Module, v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
-				require.Equal(t, callCtx, m)
-				require.Equal(t, tPtr, v)
-				require.Equal(t, uint32(math.MaxUint32), w)
-				require.Equal(t, uint64(math.MaxUint64), x)
-				require.Equal(t, float32(math.MaxFloat32), y)
-				require.Equal(t, math.MaxFloat64, z)
-				return 100
-			},
-			inputParams: []uint64{
-				api.EncodeExternref(tPtr),
-				math.MaxUint32,
-				math.MaxUint64,
-				api.EncodeF32(math.MaxFloat32),
-				api.EncodeF64(math.MaxFloat64),
-			},
-			expectedResults: []uint64{100},
-		},
-		{
 			name: "all supported params and i32 result - context.Context",
-			inputFunc: func(ctx context.Context, v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
+			input: func(ctx context.Context, v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
 				require.Equal(t, testCtx, ctx)
 				require.Equal(t, tPtr, v)
 				require.Equal(t, uint32(math.MaxUint32), w)
@@ -372,7 +212,7 @@ func TestCallGoFunc(t *testing.T) {
 		},
 		{
 			name: "all supported params and i32 result - context.Context and api.Module",
-			inputFunc: func(ctx context.Context, m api.Module, v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
+			input: func(ctx context.Context, m api.Module, v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
 				require.Equal(t, testCtx, ctx)
 				require.Equal(t, callCtx, m)
 				require.Equal(t, tPtr, v)
@@ -396,20 +236,18 @@ func TestCallGoFunc(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			paramTypes, resultTypes, code, err := parseGoFunc(tc.inputFunc)
+			_, _, code, err := parseGoReflectFunc(tc.input)
 			require.NoError(t, err)
 
-			results := CallGoFunc(
-				testCtx,
-				callCtx,
-				&FunctionInstance{
-					IsHostFunction: code.IsHostFunction,
-					Kind:           code.Kind,
-					Type:           &FunctionType{Params: paramTypes, Results: resultTypes},
-					GoFunc:         code.GoFunc,
-				},
-				tc.inputParams,
-			)
+			var results []uint64
+			switch code.GoFunc.(type) {
+			case api.GoFunction:
+				results = code.GoFunc.(api.GoFunction).Call(testCtx, tc.inputParams)
+			case api.GoModuleFunction:
+				results = code.GoFunc.(api.GoModuleFunction).Call(testCtx, callCtx, tc.inputParams)
+			default:
+				t.Fatal("unexpected type.")
+			}
 			require.Equal(t, tc.expectedResults, results)
 		})
 	}

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -595,7 +594,6 @@ func (m *ModuleInstance) BuildFunctions(mod *Module, listeners []experimental.Fu
 		code := mod.CodeSection[i]
 		fns = append(fns, &FunctionInstance{
 			IsHostFunction: code.IsHostFunction,
-			Kind:           code.Kind,
 			LocalTypes:     code.LocalTypes,
 			Body:           code.Body,
 			GoFunc:         code.GoFunc,
@@ -816,9 +814,6 @@ type Code struct {
 	// See https://www.w3.org/TR/wasm-core-1/#host-functions%E2%91%A0
 	IsHostFunction bool
 
-	// Kind describes how this function should be called.
-	Kind FunctionKind
-
 	// LocalTypes are any function-scoped variables in insertion order.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-local
 	LocalTypes []ValueType
@@ -827,13 +822,13 @@ type Code struct {
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-expr
 	Body []byte
 
-	// GoFunc is a host function defined in Go.
-	//
-	// When present, LocalTypes and Body must be nil.
+	// GoFunc is non-nil when IsHostFunction and defined in go, either
+	// api.GoFunction or api.GoModuleFunction. When present, LocalTypes and Body must
+	// be nil.
 	//
 	// Note: This has no serialization format, so is not encodable.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#host-functions%E2%91%A2
-	GoFunc *reflect.Value
+	GoFunc interface{}
 }
 
 type DataSegment struct {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -91,7 +91,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 
 func TestStore_Instantiate(t *testing.T) {
 	s, ns := newStore()
-	m, err := NewHostModule("", map[string]interface{}{"fn": func(api.Module) {}}, nil, api.CoreFeaturesV1)
+	m, err := NewHostModule("", map[string]interface{}{"fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	sysCtx := sys.DefaultContext(nil)
@@ -169,7 +169,7 @@ func TestStore_CloseWithExitCode(t *testing.T) {
 func TestStore_hammer(t *testing.T) {
 	const importedModuleName = "imported"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func(api.Module) {}}, nil, api.CoreFeaturesV1)
+	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	s, ns := newStore()
@@ -223,7 +223,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 	const importedModuleName = "imported"
 	const importingModuleName = "test"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func(api.Module) {}}, nil, api.CoreFeaturesV1)
+	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	t.Run("Fails if module name already in use", func(t *testing.T) {
@@ -314,7 +314,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 }
 
 func TestCallContext_ExportedFunction(t *testing.T) {
-	host, err := NewHostModule("host", map[string]interface{}{"host_fn": func(api.Module) {}}, nil, api.CoreFeaturesV1)
+	host, err := NewHostModule("host", map[string]interface{}{"host_fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	s, ns := newStore()
@@ -400,7 +400,7 @@ func (e *mockModuleEngine) Close(_ context.Context) {
 }
 
 // Call implements the same method as documented on wasm.ModuleEngine.
-func (ce *mockCallEngine) Call(ctx context.Context, callCtx *CallContext, _ ...uint64) (results []uint64, err error) {
+func (ce *mockCallEngine) Call(ctx context.Context, callCtx *CallContext, _ []uint64) (results []uint64, err error) {
 	if ce.callFailIndex >= 0 && ce.f.Definition.Index() == Index(ce.callFailIndex) {
 		err = errors.New("call failed")
 		return

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -82,25 +82,16 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoFuncCode(func() {})},
+				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(func(context.Context) {})},
 			},
 			expected: &CompilationResult{IsHostFunction: true},
-		},
-		{
-			name: "host go api.Module uses memory",
-			module: &wasm.Module{
-				TypeSection:     []*wasm.FunctionType{v_v},
-				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoFuncCode(func(api.Module) {})},
-			},
-			expected: &CompilationResult{IsHostFunction: true, UsesMemory: true},
 		},
 		{
 			name: "host go context.Context api.Module uses memory",
 			module: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoFuncCode(func(context.Context, api.Module) {})},
+				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(func(context.Context, api.Module) {})},
 			},
 			expected: &CompilationResult{IsHostFunction: true, UsesMemory: true},
 		},

--- a/runtime.go
+++ b/runtime.go
@@ -27,10 +27,12 @@ type Runtime interface {
 	// Below defines and instantiates a module named "env" with one function:
 	//
 	//	ctx := context.Background()
-	//	hello := func() {
+	//	hello := func(context.Context) {
 	//		fmt.Fprintln(stdout, "hello!")
 	//	}
-	//	_, err := r.NewHostModuleBuilder("env").ExportFunction("hello", hello).Instantiate(ctx, r)
+	//	_, err := r.NewHostModuleBuilder("env").
+	//		NewFunctionBuilder().WithFunc(hello).Export("hello").
+	//		Instantiate(ctx, r)
 	NewHostModuleBuilder(moduleName string) HostModuleBuilder
 
 	// CompileModule decodes the WebAssembly binary (%.wasm) or errs if invalid.

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -333,7 +333,7 @@ func TestRuntime_InstantiateModule_UsesContext(t *testing.T) {
 	}
 
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("start", start).
+		NewFunctionBuilder().WithFunc(start).Export("start").
 		Instantiate(testCtx, r)
 	require.NoError(t, err)
 
@@ -410,7 +410,7 @@ func TestRuntime_InstantiateModuleFromBinary_ErrorOnStart(t *testing.T) {
 			}
 
 			host, err := r.NewHostModuleBuilder("").
-				ExportFunction("start", start).
+				NewFunctionBuilder().WithFunc(start).Export("start").
 				Instantiate(testCtx, r)
 			require.NoError(t, err)
 
@@ -461,7 +461,9 @@ func TestRuntime_InstantiateModule_ExitError(t *testing.T) {
 		require.NoError(t, m.CloseWithExitCode(ctx, 2))
 	}
 
-	_, err := r.NewHostModuleBuilder("env").ExportFunction("exit", start).Instantiate(testCtx, r)
+	_, err := r.NewHostModuleBuilder("env").
+		NewFunctionBuilder().WithFunc(start).Export("exit").
+		Instantiate(testCtx, r)
 	require.NoError(t, err)
 
 	one := uint32(1)
@@ -580,8 +582,8 @@ func TestHostFunctionWithCustomContext(t *testing.T) {
 	}
 
 	_, err := r.NewHostModuleBuilder("env").
-		ExportFunction("host", start).
-		ExportFunction("host2", callFunc).
+		NewFunctionBuilder().WithFunc(start).Export("host").
+		NewFunctionBuilder().WithFunc(callFunc).Export("host2").
 		Instantiate(hostCtx, r)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR follows @hafeidejiangyou advice to not only enable end users to
avoid reflection when calling host functions, but also use that approach
ourselves internally. The performance results are staggering and will be
noticable in high performance applications.

Before
```
BenchmarkHostCall/Call
BenchmarkHostCall/Call-16            	 1000000	      1050 ns/op
Benchmark_EnvironGet/environGet
Benchmark_EnvironGet/environGet-16         	  525492	      2224 ns/op
```

Now
```
BenchmarkHostCall/Call
BenchmarkHostCall/Call-16            	14807203	        83.22 ns/op
Benchmark_EnvironGet/environGet
Benchmark_EnvironGet/environGet-16         	  951690	      1054 ns/op
```

To accomplish this, this PR consolidates code around host function
definition and enables a fast path for functions where the user takes
responsibility for defining its WebAssembly mappings. Existing users
will need to change their code a bit, as signatures have changed.

For example, we are now more strict that all host functions require a
context parameter zero. Also, we've replaced
`HostModuleBuilder.ExportFunction` and `ExportFunctions` with a new type
`HostFunctionBuilder` that consolidates the responsibility and the
documentation.

```diff
 ctx := context.Background()
-hello := func() {
+hello := func(context.Context) {
         fmt.Fprintln(stdout, "hello!")
 }
-_, err := r.NewHostModuleBuilder("env").ExportFunction("hello", hello).Instantiate(ctx, r)
+_, err := r.NewHostModuleBuilder("env").
+        NewFunctionBuilder().WithFunc(hello).Export("hello").
+        Instantiate(ctx, r)
```

Power users can now use `HostFunctionBuilder` to define functions that
won't use reflection. There are two choices of interfaces to use
depending on if that function needs access to the calling module or not:
`api.GoFunction` and `api.GoModuleFunction`. Here's an example defining
one.

```go
builder.WithGoFunction(api.GoFunc(func(ctx context.Context, params []uint64) []uint64 {
	x, y := uint32(params[0]), uint32(params[1])
	sum := x + y
	return []uint64{sum}
}, []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32})
```
As you'll notice and as documented, this approach is more verbose and
not for everyone. If you aren't making a low-level library, you are
likely able to afford the 1us penalty for the convenience of reflection.
However, we are happy to enable this option for foundational libraries
and those with high performance requirements (like ourselves)!

Fixes https://github.com/tetratelabs/wazero/pull/825