### PR TITLE
Restores ability to define host functions w/o context via reflection

### DIFF
--- a/config.go
+++ b/config.go
@@ -216,7 +216,7 @@ func (c *compiledModule) Name() (moduleName string) {
 }
 
 // Close implements CompiledModule.Close
-func (c *compiledModule) Close(_ context.Context) error {
+func (c *compiledModule) Close(context.Context) error {
 	c.compiledEngine.DeleteCompiledModule(c.module)
 	// It is possible the underlying may need to return an error later, but in any case this matches api.Module.Close.
 	return nil

--- a/examples/import-go/age-calculator.go
+++ b/examples/import-go/age-calculator.go
@@ -40,12 +40,12 @@ func main() {
 	// host-defined functions, but any name would do.
 	_, err := r.NewHostModuleBuilder("env").
 		NewFunctionBuilder().
-		WithFunc(func(ctx context.Context, v uint32) {
+		WithFunc(func(v uint32) {
 			fmt.Println("log_i32 >>", v)
 		}).
 		Export("log_i32").
 		NewFunctionBuilder().
-		WithFunc(func(context.Context) uint32 {
+		WithFunc(func() uint32 {
 			if envYear, err := strconv.ParseUint(os.Getenv("CURRENT_YEAR"), 10, 64); err == nil {
 				return uint32(envYear) // Allow env-override to prevent annual test maintenance!
 			}

--- a/examples/namespace/counter.go
+++ b/examples/namespace/counter.go
@@ -58,7 +58,7 @@ type counter struct {
 	counter uint32
 }
 
-func (e *counter) getAndIncrement(context.Context) (ret uint32) {
+func (e *counter) getAndIncrement() (ret uint32) {
 	ret = e.counter
 	e.counter++
 	return

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -266,7 +266,7 @@ func Test_loggingListener(t *testing.T) {
 
 	var out bytes.Buffer
 	lf := logging.NewLoggingListenerFactory(&out)
-	fn := func(context.Context) {}
+	fn := func() {}
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {

--- a/imports/assemblyscript/assemblyscript_example_test.go
+++ b/imports/assemblyscript/assemblyscript_example_test.go
@@ -33,7 +33,7 @@ func Example_functionExporter() {
 	// First construct your own module builder for "env"
 	envBuilder := r.NewHostModuleBuilder("env").
 		NewFunctionBuilder().
-		WithFunc(func(context.Context) uint32 { return 1 }).
+		WithFunc(func() uint32 { return 1 }).
 		Export("get_int")
 
 	// Now, add AssemblyScript special function imports into it.

--- a/imports/emscripten/emscripten_example_test.go
+++ b/imports/emscripten/emscripten_example_test.go
@@ -40,7 +40,7 @@ func Example_functionExporter() {
 	// you need.
 	envBuilder := r.NewHostModuleBuilder("env").
 		NewFunctionBuilder().
-		WithFunc(func(context.Context) uint32 { return 1 }).
+		WithFunc(func() uint32 { return 1 }).
 		Export("get_int")
 
 	// Now, add Emscripten special function imports into it.

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -194,7 +194,7 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 
 	const hostModuleName = "env"
 	const hostFnName = "grow_and_shrink_goroutine_stack"
-	hm, err := wasm.NewHostModule(hostModuleName, map[string]interface{}{hostFnName: func(context.Context) {
+	hm, err := wasm.NewHostModule(hostModuleName, map[string]interface{}{hostFnName: func() {
 		// This function aggressively grow the goroutine stack by recursively
 		// calling the function many times.
 		var callNum = 1000

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -165,7 +165,7 @@ func testGlobalExtend(t *testing.T, r wazero.Runtime) {
 }
 
 func testUnreachable(t *testing.T, r wazero.Runtime) {
-	callUnreachable := func(context.Context) {
+	callUnreachable := func() {
 		panic("panic in host function")
 	}
 

--- a/internal/integration_test/vs/wasmedge/wasmedge.go
+++ b/internal/integration_test/vs/wasmedge/wasmedge.go
@@ -124,7 +124,7 @@ func (r *wasmedgeRuntime) Instantiate(_ context.Context, cfg *vs.RuntimeConfig) 
 	return
 }
 
-func (r *wasmedgeRuntime) Close(_ context.Context) error {
+func (r *wasmedgeRuntime) Close(context.Context) error {
 	if conf := r.conf; conf != nil {
 		conf.Release()
 	}
@@ -183,7 +183,7 @@ func (m *wasmedgeModule) WriteMemory(_ context.Context, offset uint32, bytes []b
 	return nil
 }
 
-func (m *wasmedgeModule) Close(_ context.Context) error {
+func (m *wasmedgeModule) Close(context.Context) error {
 	if env := m.env; env != nil {
 		env.Release()
 	}

--- a/internal/integration_test/vs/wasmer/wasmer.go
+++ b/internal/integration_test/vs/wasmer/wasmer.go
@@ -144,7 +144,7 @@ func (r *wasmerRuntime) Instantiate(_ context.Context, cfg *vs.RuntimeConfig) (m
 	return
 }
 
-func (r *wasmerRuntime) Close(_ context.Context) error {
+func (r *wasmerRuntime) Close(context.Context) error {
 	r.engine = nil
 	return nil
 }
@@ -195,7 +195,7 @@ func (m *wasmerModule) Memory() []byte {
 	return m.mem.Data()
 }
 
-func (m *wasmerModule) Close(_ context.Context) error {
+func (m *wasmerModule) Close(context.Context) error {
 	if instance := m.instance; instance != nil {
 		instance.Close()
 	}

--- a/internal/integration_test/vs/wasmtime/wasmtime.go
+++ b/internal/integration_test/vs/wasmtime/wasmtime.go
@@ -142,7 +142,7 @@ func (r *wasmtimeRuntime) Instantiate(_ context.Context, cfg *vs.RuntimeConfig) 
 	return
 }
 
-func (r *wasmtimeRuntime) Close(_ context.Context) error {
+func (r *wasmtimeRuntime) Close(context.Context) error {
 	r.engine = nil
 	return nil // wasmtime only closes via finalizer
 }
@@ -193,7 +193,7 @@ func (m *wasmtimeModule) WriteMemory(_ context.Context, offset uint32, bytes []b
 	return nil
 }
 
-func (m *wasmtimeModule) Close(_ context.Context) error {
+func (m *wasmtimeModule) Close(context.Context) error {
 	m.store = nil
 	m.instance = nil
 	m.funcs = nil

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -153,7 +153,7 @@ func (c *FSContext) CloseFile(_ context.Context, fd uint32) bool {
 }
 
 // Close implements io.Closer
-func (c *FSContext) Close(_ context.Context) (err error) {
+func (c *FSContext) Close(context.Context) (err error) {
 	// Close any files opened in this context
 	for fd, entry := range c.openedFiles {
 		delete(c.openedFiles, fd)

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -672,7 +672,7 @@ const (
 	callImportCallDivByGoName = "call_import->" + callDivByGoName
 )
 
-func divByGo(_ context.Context, d uint32) uint32 {
+func divByGo(d uint32) uint32 {
 	if d == math.MaxUint32 {
 		panic(errors.New("host-function panic"))
 	}

--- a/internal/wasm/binary/encoder_test.go
+++ b/internal/wasm/binary/encoder_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/leb128"
@@ -211,7 +210,7 @@ func TestModule_Encode(t *testing.T) {
 
 func TestModule_Encode_HostFunctionSection_Unsupported(t *testing.T) {
 	// We don't currently have an approach to serialize reflect.Value pointers
-	fn := func(context.Context) {}
+	fn := func() {}
 
 	captured := require.CapturePanic(func() {
 		EncodeModule(&wasm.Module{

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"context"
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
@@ -10,7 +9,7 @@ import (
 
 func TestModule_BuildFunctionDefinitions(t *testing.T) {
 	nopCode := &Code{Body: []byte{OpcodeEnd}}
-	fn := func(context.Context) {}
+	fn := func() {}
 	tests := []struct {
 		name            string
 		m               *Module

--- a/internal/wasm/global.go
+++ b/internal/wasm/global.go
@@ -20,7 +20,7 @@ func (g *mutableGlobal) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g *mutableGlobal) Get(_ context.Context) uint64 {
+func (g *mutableGlobal) Get(context.Context) uint64 {
 	return g.g.Val
 }
 
@@ -54,7 +54,7 @@ func (g globalI32) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalI32) Get(_ context.Context) uint64 {
+func (g globalI32) Get(context.Context) uint64 {
 	return uint64(g)
 }
 
@@ -74,7 +74,7 @@ func (g globalI64) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalI64) Get(_ context.Context) uint64 {
+func (g globalI64) Get(context.Context) uint64 {
 	return uint64(g)
 }
 
@@ -94,7 +94,7 @@ func (g globalF32) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalF32) Get(_ context.Context) uint64 {
+func (g globalF32) Get(context.Context) uint64 {
 	return uint64(g)
 }
 
@@ -114,7 +114,7 @@ func (g globalF64) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalF64) Get(_ context.Context) uint64 {
+func (g globalF64) Get(context.Context) uint64 {
 	return uint64(g)
 }
 

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -135,7 +135,7 @@ func TestNewHostModule_Errors(t *testing.T) {
 		},
 		{
 			name:         "function has multiple results",
-			nameToGoFunc: map[string]interface{}{"fn": func(context.Context) (uint32, uint32) { return 0, 0 }},
+			nameToGoFunc: map[string]interface{}{"fn": func() (uint32, uint32) { return 0, 0 }},
 			expectedErr:  "func[.fn] multiple result types invalid as feature \"multi-value\" is disabled",
 		},
 	}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -59,7 +59,7 @@ func (m *MemoryInstance) Definition() api.MemoryDefinition {
 }
 
 // Size implements the same method as documented on api.Memory.
-func (m *MemoryInstance) Size(_ context.Context) uint32 {
+func (m *MemoryInstance) Size(context.Context) uint32 {
 	return m.size()
 }
 
@@ -203,7 +203,7 @@ func (m *MemoryInstance) Grow(_ context.Context, delta uint32) (result uint32, o
 }
 
 // PageSize returns the current memory buffer size in pages.
-func (m *MemoryInstance) PageSize(_ context.Context) (result uint32) {
+func (m *MemoryInstance) PageSize(context.Context) (result uint32) {
 	return memoryBytesNumToPages(uint64(len(m.Buffer)))
 }
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -278,7 +278,7 @@ func NewStore(enabledFeatures api.CoreFeatures, engine Engine) (*Store, *Namespa
 }
 
 // NewNamespace implements the same method as documented on wazero.Runtime.
-func (s *Store) NewNamespace(_ context.Context) *Namespace {
+func (s *Store) NewNamespace(context.Context) *Namespace {
 	ns := newNamespace()
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -91,7 +91,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 
 func TestStore_Instantiate(t *testing.T) {
 	s, ns := newStore()
-	m, err := NewHostModule("", map[string]interface{}{"fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
+	m, err := NewHostModule("", map[string]interface{}{"fn": func() {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	sysCtx := sys.DefaultContext(nil)
@@ -169,7 +169,7 @@ func TestStore_CloseWithExitCode(t *testing.T) {
 func TestStore_hammer(t *testing.T) {
 	const importedModuleName = "imported"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
+	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func() {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	s, ns := newStore()
@@ -223,7 +223,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 	const importedModuleName = "imported"
 	const importingModuleName = "test"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
+	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func() {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	t.Run("Fails if module name already in use", func(t *testing.T) {
@@ -314,7 +314,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 }
 
 func TestCallContext_ExportedFunction(t *testing.T) {
-	host, err := NewHostModule("host", map[string]interface{}{"host_fn": func(context.Context) {}}, nil, api.CoreFeaturesV1)
+	host, err := NewHostModule("host", map[string]interface{}{"host_fn": func() {}}, nil, api.CoreFeaturesV1)
 	require.NoError(t, err)
 
 	s, ns := newStore()
@@ -396,7 +396,7 @@ func (e *mockModuleEngine) Name() string {
 }
 
 // Close implements the same method as documented on wasm.ModuleEngine.
-func (e *mockModuleEngine) Close(_ context.Context) {
+func (e *mockModuleEngine) Close(context.Context) {
 }
 
 // Call implements the same method as documented on wasm.ModuleEngine.

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -82,7 +82,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []*wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(func(context.Context) {})},
+				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(func() {})},
 			},
 			expected: &CompilationResult{IsHostFunction: true},
 		},

--- a/runtime.go
+++ b/runtime.go
@@ -27,7 +27,7 @@ type Runtime interface {
 	// Below defines and instantiates a module named "env" with one function:
 	//
 	//	ctx := context.Background()
-	//	hello := func(context.Context) {
+	//	hello := func() {
 	//		fmt.Fprintln(stdout, "hello!")
 	//	}
 	//	_, err := r.NewHostModuleBuilder("env").

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -405,7 +405,7 @@ func TestRuntime_InstantiateModuleFromBinary_ErrorOnStart(t *testing.T) {
 			r := NewRuntime(testCtx)
 			defer r.Close(testCtx)
 
-			start := func(context.Context) {
+			start := func() {
 				panic(errors.New("ice cream"))
 			}
 


### PR DESCRIPTION
This restores the ability to leave out the initial context parameter when defining functions with reflection. This is important because some projects are porting from a different library to wazero, and all the alternatives are not contextualized.

For example, this project is porting envoy host functions, and the original definitions (in mosn) don't have a context parameter. By being lenient, they can migrate easier.

See https://github.com/cisco-open/nasp/blob/6b813482b6177385311fdfc42d92a9d3e096b8f2/pkg/proxywasm/wazero/imports_v1.go