### PR TITLE
Extends build compatability to one version behind Go's support policy

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,7 +14,7 @@ on:
       - 'netlify.toml'
 
 env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.18"  # 1.xx == latest patch of 1.xx
+  GO_VERSION: "1.19"  # 1.xx == latest patch of 1.xx
 
 defaults:
   run:  # use bash for all operating systems unless overridden
@@ -24,12 +24,6 @@ jobs:
   check:
     name: Pre-commit check, Go-${{ matrix.go-version }}
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:  # use latest available versions and be consistent on all workflows!
-        go-version:
-        - "1.18" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.19"
-
     steps:
       - name: Install latest wast2json
         run: |  # Needed for build.spectest. wabt includes wast2json.
@@ -41,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:  # not cache: true as we also need to cache golint
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/cache@v3
         with:
@@ -61,11 +55,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
-      matrix:  # use latest available versions and be consistent on all workflows!
+      matrix:  # Use versions consistent with wazero's Go support policy.
         os: [ubuntu-20.04, macos-12, windows-2022]
         go-version:
-        - "1.18" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
+
 
     steps:
 
@@ -93,10 +88,10 @@ jobs:
     runs-on: macos-12
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
-      matrix:
+      matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.18" # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-          - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
 
     steps:
 
@@ -126,14 +121,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
-      matrix:
+      matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-        - "1.18"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-        - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
         arch:
-        - "amd64"
-        - "arm64"
-        - "riscv64"
+          - "amd64"
+          - "arm64"
+          - "riscv64"
 
     steps:
 

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -26,10 +26,10 @@ jobs:
     name: Build examples
     runs-on: ubuntu-20.04
     strategy:
-      matrix:  # use latest available versions and be consistent on all workflows!
+      matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.18"  # == ${{ env.GO_VERSION }} because matrix cannot expand env variables
-          - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
 
     steps:
       - name: Checkout

--- a/.github/workflows/spectest.yaml
+++ b/.github/workflows/spectest.yaml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
-      matrix:
+      matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-        - "1.18"
-        - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
         spec-version:
-        - "v1"
-        - "v2"
+          - "v1"
+          - "v2"
 
     steps:
       - uses: actions/checkout@v3
@@ -46,10 +46,10 @@ jobs:
     runs-on: macos-12
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
-      matrix:
+      matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.18"
-          - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
         spec-version:
           - "v1"
           - "v2"
@@ -81,16 +81,16 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
-      matrix:
+      matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-        - "1.18"
-        - "1.19"
+          - "1.19"  # Current Go version
+          - "1.17"  # Floor Go version of wazero (current - 2)
         arch:
-        - "arm64"
-        - "riscv64"
+          - "arm64"
+          - "riscv64"
         spec-version:
-        - "v1"
-        - "v2"
+          - "v1"
+          - "v2"
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ go get github.com/tetratelabs/wazero@latest
 ```
 
 wazero will tag a new pre-release at least once a month until 1.0. 1.0 is
-scheduled for Feb 2023, following the release of Go 1.20.
+scheduled for Feb 2023, following the release of Go 1.20. wazero 1.0 will build
+with Go 1.18 and above per the below policy.
 
 Meanwhile, please practice the current APIs to ensure they work for you, and
 give us a [star][15] if you are enjoying it so far!
@@ -134,12 +135,15 @@ give us a [star][15] if you are enjoying it so far!
 wazero has no dependencies except Go, so the only source of conflict in your
 project's use of wazero is the Go version.
 
-To simplify our support policy, we adopt Go's [Release Policy][10] (two versions).
+wazero follows the same version policy as Go's [Release Policy][10]: two
+versions. wazero will ensure these versions work and bugs are valid if there's
+an issue with a current Go version.
 
-This means wazero will remain compilable and tested on the version prior to the
-latest release of Go.
-
-For example, once Go 1.29 is released, wazero may use a Go 1.28 feature.
+Additionally, wazero intentionally delays usage of language or standard library
+features one additional version. For example, when Go 1.29 is released, wazero
+can use language features or standard libraries added in 1.27. This is a
+convenience for embedders who have a slower version policy than Go. However,
+only supported Go versions may be used to raise support issues.
 
 ### Platform
 

--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -93,12 +93,12 @@ func doRun(args []string, stdOut io.Writer, stdErr io.Writer, exit func(code int
 	// Don't use map to preserve order
 	var env []string
 	for _, e := range envs {
-		key, value, ok := strings.Cut(e, "=")
-		if !ok {
+		fields := strings.SplitN(e, "=", 2)
+		if len(fields) != 2 {
 			fmt.Fprintf(stdErr, "invalid environment variable: %s\n", e)
 			exit(1)
 		}
-		env = append(env, key, value)
+		env = append(env, fields[0], fields[1])
 	}
 
 	var mountFS fs.FS

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/tetratelabs/wazero
 
-// This should be the minimum supported Go version per
-// https://go.dev/doc/devel/release (1 version behind latest)
-go 1.18
+// Floor Go version of wazero (current - 2)
+go 1.17
 
 // All the beta tags are retracted and replaced with "pre" to prevent users
 // from accidentally upgrading into the broken beta 1.

--- a/imports/go/example/stars/go.mod
+++ b/imports/go/example/stars/go.mod
@@ -1,3 +1,3 @@
 module github.com/tetratelabs/wazero/examples/gojs/stars
 
-go 1.18
+go 1.17

--- a/internal/compilationcache/file_cache_test.go
+++ b/internal/compilationcache/file_cache_test.go
@@ -1,3 +1,5 @@
+//go:build go1.18
+
 package compilationcache
 
 import (

--- a/internal/integration_test/vs/time/go.mod
+++ b/internal/integration_test/vs/time/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/clock
 
-go 1.18
+go 1.17
 
 require github.com/tetratelabs/wazero v0.0.0
 

--- a/internal/integration_test/vs/wasmedge/go.mod
+++ b/internal/integration_test/vs/wasmedge/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmedge
 
-go 1.18
+go 1.17
 
 require (
 	github.com/second-state/WasmEdge-go v0.11.0

--- a/internal/integration_test/vs/wasmer/go.mod
+++ b/internal/integration_test/vs/wasmer/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmer
 
-go 1.18
+go 1.17
 
 require (
 	github.com/tetratelabs/wazero v0.0.0

--- a/internal/integration_test/vs/wasmtime/go.mod
+++ b/internal/integration_test/vs/wasmtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmtime
 
-go 1.18
+go 1.17
 
 require (
 	github.com/bytecodealliance/wasmtime-go v0.40.0

--- a/internal/version/testdata/go.mod
+++ b/internal/version/testdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/version/testdata
 
-go 1.18
+go 1.17
 
 require github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1 // indirect
 


### PR DESCRIPTION
This enforces that wazero will build and operate one version behind Go's support policy, making wazero's Go policy effectively three versions.

This is to allow libraries with wider Go policies to be able to use wazero. Specifically, mosn is the first to need this.