### PR TITLE
Optimize wasm.(*ModuleInstance).BuildFunctions

### DIFF
--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -2,9 +2,9 @@ package bench
 
 import (
 	"context"
+	"crypto/rand"
 	_ "embed"
 	"fmt"
-	"math/rand"
 	"runtime"
 	"testing"
 
@@ -89,9 +89,10 @@ func runCompilation(b *testing.B, r wazero.Runtime) wazero.CompiledModule {
 func runInitializationBench(b *testing.B, r wazero.Runtime) {
 	compiled := runCompilation(b, r)
 	defer compiled.Close(testCtx)
+	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		mod, err := r.InstantiateModule(testCtx, compiled, wazero.NewModuleConfig())
+		mod, err := r.InstantiateModule(testCtx, compiled, config)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Before:
```sh
❯ go test -benchmem -memprofile memprofile.out -cpuprofile profile.out -run=^$ -bench ^BenchmarkInitialization/compiler$ github.com/tetratelabs/wazero/internal/integration_test/bench
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
BenchmarkInitialization/compiler-10                69037             18685 ns/op          145951 B/op        128 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   2.850s
```
<img width="1341" alt="Screenshot 2022-11-05 at 13 36 14" src="https://user-images.githubusercontent.com/1851985/200140281-90167063-06eb-41f9-b0e4-c28ebb0e12d7.png">


After:
```sh
❯ go test -benchmem -memprofile memprofile.out -cpuprofile profile.out -run=^$ -bench ^BenchmarkInitialization/compiler$ github.com/tetratelabs/wazero/internal/integration_test/bench
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
BenchmarkInitialization/compiler-10                64510             17417 ns/op          145950 B/op        128 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   1.600s
```
<img width="1335" alt="Screenshot 2022-11-05 at 13 39 00" src="https://user-images.githubusercontent.com/1851985/200140452-57ea1161-945d-4181-9f54-b7e31ef49db9.png">

Not a massive win but simpler code IMO