### PR TITLE
Optimize compiler.(*engine).NewModuleEngine

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -479,16 +479,16 @@ func (e *engine) CompileModule(ctx context.Context, module *wasm.Module) error {
 
 // NewModuleEngine implements the same method as documented on wasm.Engine.
 func (e *engine) NewModuleEngine(name string, module *wasm.Module, importedFunctions, moduleFunctions []*wasm.FunctionInstance, tables []*wasm.TableInstance, tableInits []wasm.TableInitEntry) (wasm.ModuleEngine, error) {
-	imported := uint32(len(importedFunctions))
+	imported := len(importedFunctions)
 	me := &moduleEngine{
 		name:                  name,
-		functions:             make([]*function, 0, imported+uint32(len(moduleFunctions))),
-		importedFunctionCount: imported,
+		functions:             make([]*function, imported+len(moduleFunctions)),
+		importedFunctionCount: uint32(imported),
 	}
 
-	for _, f := range importedFunctions {
+	for i, f := range importedFunctions {
 		cf := f.Module.Engine.(*moduleEngine).functions[f.Idx]
-		me.functions = append(me.functions, cf)
+		me.functions[i] = cf
 	}
 
 	codes, ok, err := e.getCodes(module)
@@ -501,7 +501,7 @@ func (e *engine) NewModuleEngine(name string, module *wasm.Module, importedFunct
 	for i, c := range codes {
 		f := moduleFunctions[i]
 		function := c.createFunction(f)
-		me.functions = append(me.functions, function)
+		me.functions[imported+i] = function
 	}
 
 	for _, init := range tableInits {

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -89,6 +89,8 @@ func runCompilation(b *testing.B, r wazero.Runtime) wazero.CompiledModule {
 func runInitializationBench(b *testing.B, r wazero.Runtime) {
 	compiled := runCompilation(b, r)
 	defer compiled.Close(testCtx)
+	// Configure with real sources to avoid performance hit initializing fake ones. These sources are not used
+	// in the benchmark.
 	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -2,9 +2,9 @@ package bench
 
 import (
 	"context"
+	"crypto/rand"
 	_ "embed"
 	"fmt"
-	"math/rand"
 	"runtime"
 	"testing"
 
@@ -89,9 +89,10 @@ func runCompilation(b *testing.B, r wazero.Runtime) wazero.CompiledModule {
 func runInitializationBench(b *testing.B, r wazero.Runtime) {
 	compiled := runCompilation(b, r)
 	defer compiled.Close(testCtx)
+	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		mod, err := r.InstantiateModule(testCtx, compiled, wazero.NewModuleConfig())
+		mod, err := r.InstantiateModule(testCtx, compiled, config)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Before:
```sh
❯ go test -benchmem -memprofile memprofile.out -cpuprofile profile.out -run=^$ -bench ^BenchmarkInitialization/compiler$ github.com/tetratelabs/wazero/internal/integration_test/bench
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
BenchmarkInitialization/compiler-10                64510             17417 ns/op          145950 B/op        128 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   1.600s
```
<img width="1340" alt="Screenshot 2022-11-05 at 14 06 24" src="https://user-images.githubusercontent.com/1851985/200141469-a57e30a8-6732-4f70-acf6-f4f72e41bdd1.png">

After:
```sh
❯ go test -benchmem -memprofile memprofile.out -cpuprofile profile.out -run=^$ -bench ^BenchmarkInitialization/compiler$ github.com/tetratelabs/wazero/internal/integration_test/bench
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
BenchmarkInitialization/compiler-10                59250             17296 ns/op          145950 B/op        128 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   1.493s
```
<img width="1354" alt="Screenshot 2022-11-05 at 14 15 46" src="https://user-images.githubusercontent.com/1851985/200141634-185e28d7-5345-4742-bb12-3f578854e855.png">

Another pretty minor win. Includes commits from #841, if that one can get merged first this will be a clean diff.