### PR TITLE
Replace module name check linear scan with map lookup

### DIFF
--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -559,7 +559,8 @@ func (m *Module) validateDataCountSection() (err error) {
 }
 
 func (m *Module) buildGlobals(importedGlobals []*GlobalInstance) (globals []*GlobalInstance) {
-	for _, gs := range m.GlobalSection {
+	globals = make([]*GlobalInstance, len(m.GlobalSection))
+	for i, gs := range m.GlobalSection {
 		g := &GlobalInstance{Type: gs.Type}
 		switch v := executeConstExpression(importedGlobals, gs.Init).(type) {
 		case uint32:
@@ -577,7 +578,7 @@ func (m *Module) buildGlobals(importedGlobals []*GlobalInstance) (globals []*Glo
 		default:
 			panic(fmt.Errorf("BUG: invalid conversion %d", v))
 		}
-		globals = append(globals, g)
+		globals[i] = g
 	}
 	return
 }
@@ -707,9 +708,10 @@ func (f *FunctionType) key() string {
 		ret += ValueTypeName(b)
 	}
 	if len(f.Params) == 0 {
-		ret += "v"
+		ret += "v_"
+	} else {
+		ret += "_"
 	}
-	ret += "_"
 	for _, b := range f.Results {
 		ret += ValueTypeName(b)
 	}

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -594,7 +594,7 @@ func (s *Store) getFunctionTypeIDs(ts []*FunctionType) ([]FunctionTypeID, error)
 }
 
 func (s *Store) getFunctionTypeID(t *FunctionType) (FunctionTypeID, error) {
-	key := t.String()
+	key := t.key()
 	s.mux.RLock()
 	id, ok := s.typeIDs[key]
 	s.mux.RUnlock()
@@ -605,11 +605,11 @@ func (s *Store) getFunctionTypeID(t *FunctionType) (FunctionTypeID, error) {
 		if id, ok = s.typeIDs[key]; ok {
 			return id, nil
 		}
-		l := uint32(len(s.typeIDs))
-		if l >= s.functionMaxTypes {
+		l := len(s.typeIDs)
+		if uint32(l) >= s.functionMaxTypes {
 			return 0, fmt.Errorf("too many function types in a store")
 		}
-		id = FunctionTypeID(len(s.typeIDs))
+		id = FunctionTypeID(l)
 		s.typeIDs[key] = id
 	}
 	return id, nil


### PR DESCRIPTION
The check in module initialization to ensure a uniqueness of a module name in a a namespace does a linear scan of a string slice. Because the namespace needs to be fully locked during this check it means module initializations slows down as you have more active modules. This change replaces the linear scan with a map lookup. I've added a benchmark to track the performance of having multiple simiultainus module instances.

Before:
```
❯ go test -benchmem -memprofile memprofile.out -cpuprofile profile.out -blockprofile blockprofile.out -run=^$ -bench ^BenchmarkInitialization github.com/tetratelabs/wazero/internal/integration_test/bench
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkInitialization/interpreter-12             29836             40640 ns/op          142743 B/op        144 allocs/op
BenchmarkInitialization/interpreter-multiple-12    25544             83117 ns/op          143663 B/op        150 allocs/op
BenchmarkInitialization/compiler-12                31640             38680 ns/op          145935 B/op        128 allocs/op
BenchmarkInitialization/compiler-multiple-12       28410             72372 ns/op          146676 B/op        134 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   8.945s
```

After:
```
❯ go test -benchmem -memprofile memprofile.out -cpuprofile profile.out -blockprofile blockprofile.out -run=^$ -bench ^BenchmarkInitialization github.com/tetratelabs/wazero/internal/integration_test/bench
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkInitialization/interpreter-12             29815             40490 ns/op          142742 B/op        144 allocs/op
BenchmarkInitialization/interpreter-multiple-12    49501             27282 ns/op          143808 B/op        150 allocs/op
BenchmarkInitialization/compiler-12                25664             39947 ns/op          145934 B/op        128 allocs/op
BenchmarkInitialization/compiler-multiple-12       48870             39809 ns/op          146652 B/op        134 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/bench   7.726s
```

I've batched in a few other micro optimizations but I don't expect any of them to make much of a meaningful difference.