### PR TITLE
gojs: gc fix refcount issue

### DIFF
--- a/internal/gojs/misc_test.go
+++ b/internal/gojs/misc_test.go
@@ -40,3 +40,13 @@ func Test_stdio(t *testing.T) {
 	require.Equal(t, "println stdin\nStderr.Write", stderr)
 	require.Equal(t, "Stdout.Write", stdout)
 }
+
+func Test_gc(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, err := compileAndRun(testCtx, "gc", wazero.NewModuleConfig())
+
+	require.EqualError(t, err, `module "" closed with exit_code(0)`)
+	require.Equal(t, "", stderr)
+	require.Equal(t, "before gc\nafter gc\n", stdout)
+}

--- a/internal/gojs/state.go
+++ b/internal/gojs/state.go
@@ -195,6 +195,7 @@ func (j *values) increment(v interface{}) uint32 {
 }
 
 func (j *values) decrement(id uint32) {
+	// Special IDs are not refcounted.
 	if id < nextID {
 		return
 	}

--- a/internal/gojs/state.go
+++ b/internal/gojs/state.go
@@ -195,6 +195,9 @@ func (j *values) increment(v interface{}) uint32 {
 }
 
 func (j *values) decrement(id uint32) {
+	if id < nextID {
+		return
+	}
 	id -= nextID
 	j.goRefCounts[id]--
 	if j.goRefCounts[id] == 0 {

--- a/internal/gojs/testdata/gc/main.go
+++ b/internal/gojs/testdata/gc/main.go
@@ -1,0 +1,12 @@
+package gc
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func Main() {
+	fmt.Println("before gc")
+	runtime.GC()
+	fmt.Println("after gc")
+}

--- a/internal/gojs/testdata/main.go
+++ b/internal/gojs/testdata/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/argsenv"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/crypto"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/fs"
+	"github.com/tetratelabs/wazero/internal/gojs/testdata/gc"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/goroutine"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/http"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/mem"
@@ -24,6 +25,8 @@ func main() {
 		crypto.Main()
 	case "fs":
 		fs.Main()
+	case "gc":
+		gc.Main()
 	case "goroutine":
 		goroutine.Main()
 	case "http":


### PR DESCRIPTION
I was attempting to use gojs with a binary that read from stdin, did some
transformations, then printed to stdout. This worked or small inputs, but for 
larger values would panic like:

	runtime: g 5: unexpected return pc for syscall/js.Value.Call called from 0x18ca120
	<memory addresses & stack>
	syscall/js.Value.Call({{}, 0x1720028, 0x141c0001}, {0x0, 0x0}, {0x0, 0x0, 0x0})
	        /usr/local/go/src/syscall/js/js.go:384 +0x35 fp=0x8327d0 sp=0x832710 pc=0x16e50035
	created by runtime.createfing
	        /usr/local/go/src/runtime/mfinal.go:157 +0x5

After some debugging, I traced it to gojs.FinalizeRef being called for idJsFs
when a GC is triggered after stdout/stderr is used. I've included a small test
that triggers the same issue (and and is fixed by the same patch). The 
testcase fails with:

	runtime error: index out of range [4294967288] with length 5 (recovered by wazero)
        wasm stack trace:
                go.syscall/js.finalizeRef(i32)
                go.syscall/js.finalizeRef.proxy(i32)

The 4294967288 index results from uint32 underflow after subracting `nextID`
(18) from 10 (the value for `idJsfs`). Looking at the code paths that reach
refcount increment, it seems like decrement for values below nextID should be a
nop or decrement should not be called at all.

