### PR TITLE
Adds more context for ADR offset overrun

### DIFF
--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1838,7 +1838,7 @@ func (a *AssemblerImpl) encodeADR(n *nodeImpl) (err error) {
 		if offset > math.MaxUint8 {
 			// We could support up to 20-bit integer, but byte should be enough for our impl.
 			// If the necessity comes up, we could fix the below to support larger offsets.
-			return fmt.Errorf("BUG: too large offset for ADR")
+			return fmt.Errorf("BUG: too large offset for ADR: %d", offset)
 		}
 
 		// Now ready to write an offset byte.

--- a/internal/asm/arm64/impl_4_test.go
+++ b/internal/asm/arm64/impl_4_test.go
@@ -702,6 +702,6 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 		targetNode.offsetInBinaryField = uint64(math.MaxInt64)
 
 		err := cb(nil)
-		require.EqualError(t, err, "BUG: too large offset for ADR")
+		require.EqualError(t, err, "BUG: too large offset for ADR: 9223372036854775807")
 	})
 }


### PR DESCRIPTION
This is mainly so we can tell if changing this will work. e.g. if 20 bits are enough for #847 