### PR TITLE
arm64: adds support for large in-block jumps with ADR

### DIFF
--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1833,11 +1833,11 @@ func (a *AssemblerImpl) encodeADR(n *nodeImpl) (err error) {
 		}
 
 		offset := targetNode.OffsetInBinary() - n.OffsetInBinary()
-		if offset > 1<<20 {
+		if i64 := int64(offset); i64 >= 1<<20 || i64 < -1<<20 {
 			// We could support offset over 20-bit range by special casing them here,
 			// but 20-bit range should be enough for our impl. If the necessity comes up,
 			// we could add the special casing here to support arbitrary large offset.
-			return fmt.Errorf("BUG: too large offset for ADR: %d", offset)
+			return fmt.Errorf("BUG: too large offset for ADR: %#x", offset)
 		}
 
 		adrInstructionBytes := code[n.OffsetInBinary() : n.OffsetInBinary()+4]

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"github.com/tetratelabs/wazero/internal/asm"
 )
 


### PR DESCRIPTION
Fixes #847 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>