### PR TITLE
Adds rationale for api.ValueType encoding

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -46,6 +46,7 @@ x/sys as a platform plugin without forcing all users to maintain that
 dependency.
 
 ## Project structure
+
 wazero uses internal packages extensively to balance API compatability desires for end users with the need to safely
 share internals between compilers.
 
@@ -57,6 +58,7 @@ notably the name of the folder becomes the binary name. We chose to use `cmd/waz
 and less surprising than `wazero/wazero`.
 
 ### Internal packages
+
 Most code in wazero is internal, and it is acknowledged that this prevents external implementation of facets such as
 compilers or decoding. It also prevents splitting this code into separate repositories, resulting in a larger monorepo.
 This also adds work as more code needs to be centrally reviewed.
@@ -78,6 +80,7 @@ realities are friendly OSS licensing, high rigor and a collaborative spirit whic
 codebase productive.
 
 ### Avoiding cyclic dependencies
+
 wazero shares constants and interfaces with internal code by a sharing pattern described below:
 * shared interfaces and constants go in one package under root: `api`.
 * user APIs and structs depend on `api` and go into the root package `wazero`.
@@ -111,6 +114,65 @@ Here are some examples:
 * There is no exported symbol for the `[]byte` representing the `CodeSection`
 
 Besides security, this practice prevents other bugs and allows centralization of validation logic such as decoding Wasm.
+
+## API Design
+
+### Why are Go function signature parameters and results uint64?
+
+Go-defined function signatures include parameters and results expressed as a
+slice of uint64 values. The most notable rationale for this is that a uint64 is
+holds the largest value type in WebAssembly 1.0 (i64). A slice allows you to
+express empty (e.g. a nullary signature), for example a start function.
+
+Here's an example of calling a function, noting this syntax works for both a
+signature `(param i32 i32) (result i32)` and `(param i64 i64) (result i64)`
+```go
+x, y := uint64(1), uint64(2)
+results, err := mod.ExportedFunction("add").Call(ctx, x, y)
+if err != nil {
+	log.Panicln(err)
+}
+fmt.Printf("%d + %d = %d\n", x, y, results[0])
+```
+
+WebAssembly does not define an encoding strategy for host defined parameters or
+results. This means the encoding rules above are defined by wazero instead. To
+address this, we clarified mapping both in `api.ValueType` and added helper
+functions like `api.EncodeF64`. This allows users conversions typical in Go
+programming, and utilities to avoid ambiguity and edge cases around casting.
+
+Alternatively, we could have defined a byte buffer based approach and a binary
+encoding of value types in and out. For example, an empty byte slice would mean
+no values, while a non-empty could use a binary encoding for supported values.
+This could work, but it is more difficult for the normal case of i32 and i64.
+It also shares a struggle with the current approach, which is that value types
+were added after WebAssembly 1.0 and not all of them have an encoding. More on
+this below.
+
+In summary, wazero chose an approach for signature mapping because there was
+none, and the one we chose biases towards simplicity with integers and handles
+the rest with documentation and utilities.
+
+#### Post 1.0 value types
+
+Value types added after WebAssembly 1.0 stressed the current model, as some
+have no encoding or are larger than 64 bits. While problematic, these value
+types are not commonly used in exported (extern) functions. However, some
+decisions were made and detailed below.
+
+For example `externref` has no guest representation. wazero chose to map
+references to uint64 as that's the largest value needed to encode a pointer on
+supported platforms. While there are two reference types, `externref` and
+`functype`, the latter is an internal detail of function tables, and the former
+is rarely if ever used in function signatures as of the end of 2022.
+
+The only value larger than 64 bits is used for SIMD (`v128`). Vectorizing via
+host functions is not used as of the end of 2022. Even if it were, it would be
+inefficient vs guest vectorization due to host function overhead. In other
+words, the `v128` value type is unlikely to be in an exported function
+signature. That it requires two uint64 values to encode is an internal detail
+and not worth changing the exported function interface `api.Function`, as doing
+so would break all users.
 
 ### Interfaces, not structs
 
@@ -403,6 +465,7 @@ one spec to another with minimal impact. This has other helpful benefits, as cen
 coherently (ex via `Module.Close`).
 
 ### Background on `ModuleConfig` design
+
 WebAssembly 1.0 (20191205) specifies some aspects to control isolation between modules ([sandboxing](https://en.wikipedia.org/wiki/Sandbox_(computer_security))).
 For example, `wasm.Memory` has size constraints and each instance of it is isolated from each other. While `wasm.Memory`
 can be shared, by exporting it, it is not exported by default. In fact a WebAssembly Module (Wasm) has no memory by
@@ -621,6 +684,7 @@ easy and efficient closure over a common program function. We also documented
 `sys.Nanotime` to warn users that some compilers don't optimize sleep.
 
 ## Signed encoding of integer global constant initializers
+
 wazero treats integer global constant initializers signed as their interpretation is not known at declaration time. For
 example, there is no signed integer [value type](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#value-types%E2%91%A0).
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -117,12 +117,26 @@ Besides security, this practice prevents other bugs and allows centralization of
 
 ## API Design
 
-### Why are Go function signature parameters and results uint64?
+### Why does `api.ValueType` map to uint64?
 
-Go-defined function signatures include parameters and results expressed as a
-slice of uint64 values. The most notable rationale for this is that a uint64 is
-holds the largest value type in WebAssembly 1.0 (i64). A slice allows you to
-express empty (e.g. a nullary signature), for example a start function.
+WebAssembly allows functions to be defined either by the guest or the host,
+with signatures expressed as WebAssembly types. For example, `i32` is a 32-bit
+type which might be interpreted as signed. Function signatures can have zero or
+more parameters or results even if WebAssembly 1.0 allows up to one result.
+
+The guest can export functions, so that the host can call it. In the case of
+wazero, the host is Go and an exported function can be called via
+`api.Function`. `api.Function` allows users to supply parameters and read
+results as a slice of uint64. For example, if there are no results, an empty
+slice is returned. The user can learn the signature via `FunctionDescription`,
+which returns the `api.ValueType` corresponding to each parameter or result.
+`api.ValueType` defines the mapping of WebAssembly types to `uint64` values for
+reason described in this section. The special case of `v128` is also mentioned
+below.
+
+wazero maps each value type to a uint64 values because it holds the largest
+type in WebAssembly 1.0 (i64). A slice allows you to express empty (e.g. a
+nullary signature), for example a start function.
 
 Here's an example of calling a function, noting this syntax works for both a
 signature `(param i32 i32) (result i32)` and `(param i64 i64) (result i64)`

--- a/sys/error.go
+++ b/sys/error.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 )
 
-// ExitError is returned to a caller of api.Function still running when api.Module CloseWithExitCode was invoked.
-// ExitCode zero value means success, while any other value is an error.
+// ExitError is returned to a caller of api.Function still running when
+// api.Module CloseWithExitCode was invoked. ExitCode zero value means success,
+// while any other value is an error.
 //
 // Here's an example of how to get the exit code:
 //


### PR DESCRIPTION
We made some decisions around encoding last year, but we didn't detail why. This leads to questions.

e.g. https://gophers.slack.com/archives/C040AKTNTE0/p1668883638982119