### PR TITLE
wasi: adds path_filestat_get

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1157,6 +1157,7 @@ func openFile(ctx context.Context, fsc *internalsys.FSContext, name string) (fd 
 	case errors.Is(err, fs.ErrExist):
 		errnoResult = errnoExist
 	case errors.Is(err, syscall.EBADF):
+		// fsc.OpenFile currently returns this on out of file descriptors
 		errnoResult = errnoBadf
 	default:
 		errnoResult = errnoIo

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -1591,12 +1591,12 @@ func Test_pathFilestatGet(t *testing.T) {
 			memory:         []byte("?../foo"),
 			pathLen:        6,
 			resultFilestat: 7,
-			expectedErrno:  ErrnoInval,
+			expectedErrno:  ErrnoNoent,
 			expectedLog: `
 --> proxy.path_filestat_get(fd=5,flags=0,path=1,path_len=6,result.buf=7)
 	==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=6,result.buf=7)
-	<== EINVAL
-<-- (28)
+	<== ENOENT
+<-- (44)
 `,
 		},
 		{

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -222,6 +222,7 @@ var (
 	errnoInval       = []uint64{uint64(ErrnoInval)}
 	errnoIo          = []uint64{uint64(ErrnoIo)}
 	errnoNoent       = []uint64{uint64(ErrnoNoent)}
+	errnoNotdir      = []uint64{uint64(ErrnoNotdir)}
 	errnoFault       = []uint64{uint64(ErrnoFault)}
 	errnoNametoolong = []uint64{uint64(ErrnoNametoolong)}
 	errnoSuccess     = []uint64{uint64(ErrnoSuccess)}

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -127,7 +127,7 @@ func (c *FSContext) OpenFile(_ context.Context, name string /* TODO: flags int, 
 	}
 
 	newFD := c.nextFD()
-	if newFD == 0 {
+	if newFD == 0 { // TODO: out of file descriptors
 		_ = f.Close()
 		return 0, syscall.EBADF
 	}


### PR DESCRIPTION
This adds path_filestat_get which is needed for PDFium and zig's fstatatWasi.

https://github.com/ziglang/zig/blob/aea617c60be848ed372343e08465bb0ac6cb7b85/lib/std/os.zig#L4171

The original source of this was written by @jerbob92