### PR TITLE
Optimizes GoModuleFunction signature and ensures function result slices are unique

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -20,11 +20,11 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 		return 0
 	}
 
-	gofunc1 := api.GoFunc(func(ctx context.Context, params []uint64) []uint64 {
-		return []uint64{0}
+	gofunc1 := api.GoFunc(func(ctx context.Context, stack []uint64) {
+		stack[0] = 0
 	})
-	gofunc2 := api.GoFunc(func(ctx context.Context, params []uint64) []uint64 {
-		return []uint64{0}
+	gofunc2 := api.GoFunc(func(ctx context.Context, stack []uint64) {
+		stack[0] = 0
 	})
 
 	tests := []struct {

--- a/imports/emscripten/emscripten.go
+++ b/imports/emscripten/emscripten.go
@@ -147,12 +147,12 @@ var invokeI = &wasm.HostFunc{
 	},
 }
 
-func invokeIFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "v_i32", wasm.Index(params[0]), nil)
+func invokeIFn(ctx context.Context, mod api.Module, stack []uint64) {
+	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "v_i32", wasm.Index(stack[0]), nil)
 	if err != nil {
 		panic(err)
 	}
-	return ret
+	stack[0] = ret[0]
 }
 
 var invokeIi = &wasm.HostFunc{
@@ -167,12 +167,12 @@ var invokeIi = &wasm.HostFunc{
 	},
 }
 
-func invokeIiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32_i32", wasm.Index(params[0]), params[1:])
+func invokeIiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32_i32", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
+	stack[0] = ret[0]
 }
 
 var invokeIii = &wasm.HostFunc{
@@ -187,12 +187,12 @@ var invokeIii = &wasm.HostFunc{
 	},
 }
 
-func invokeIiiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32_i32", wasm.Index(params[0]), params[1:])
+func invokeIiiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32_i32", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
+	stack[0] = ret[0]
 }
 
 var invokeIiii = &wasm.HostFunc{
@@ -207,12 +207,12 @@ var invokeIiii = &wasm.HostFunc{
 	},
 }
 
-func invokeIiiiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32_i32", wasm.Index(params[0]), params[1:])
+func invokeIiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32_i32", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
+	stack[0] = ret[0]
 }
 
 var invokeIiiii = &wasm.HostFunc{
@@ -227,12 +227,12 @@ var invokeIiiii = &wasm.HostFunc{
 	},
 }
 
-func invokeIiiiiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32i32_i32", wasm.Index(params[0]), params[1:])
+func invokeIiiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32i32_i32", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
+	stack[0] = ret[0]
 }
 
 var invokeV = &wasm.HostFunc{
@@ -247,12 +247,11 @@ var invokeV = &wasm.HostFunc{
 	},
 }
 
-func invokeVFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "v_v", wasm.Index(params[0]), nil)
+func invokeVFn(ctx context.Context, mod api.Module, stack []uint64) {
+	_, err := callDynamic(ctx, mod.(*wasm.CallContext), "v_v", wasm.Index(stack[0]), nil)
 	if err != nil {
 		panic(err)
 	}
-	return ret
 }
 
 var invokeVi = &wasm.HostFunc{
@@ -267,12 +266,11 @@ var invokeVi = &wasm.HostFunc{
 	},
 }
 
-func invokeViFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32_v", wasm.Index(params[0]), params[1:])
+func invokeViFn(ctx context.Context, mod api.Module, stack []uint64) {
+	_, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32_v", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
 }
 
 var invokeVii = &wasm.HostFunc{
@@ -287,12 +285,11 @@ var invokeVii = &wasm.HostFunc{
 	},
 }
 
-func invokeViiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32_v", wasm.Index(params[0]), params[1:])
+func invokeViiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	_, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32_v", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
 }
 
 var invokeViii = &wasm.HostFunc{
@@ -307,12 +304,11 @@ var invokeViii = &wasm.HostFunc{
 	},
 }
 
-func invokeViiiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32_v", wasm.Index(params[0]), params[1:])
+func invokeViiiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	_, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32_v", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
 }
 
 var invokeViiii = &wasm.HostFunc{
@@ -327,12 +323,11 @@ var invokeViiii = &wasm.HostFunc{
 	},
 }
 
-func invokeViiiiFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32i32_v", wasm.Index(params[0]), params[1:])
+func invokeViiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
+	_, err := callDynamic(ctx, mod.(*wasm.CallContext), "i32i32i32i32_v", wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
-	return ret
 }
 
 // callDynamic special cases dynamic calls needed for emscripten `invoke_`

--- a/imports/wasi_snapshot_preview1/clock.go
+++ b/imports/wasi_snapshot_preview1/clock.go
@@ -59,11 +59,11 @@ var clockResGet = &wasm.HostFunc{
 	ResultTypes: []api.ValueType{i32},
 	Code: &wasm.Code{
 		IsHostFunction: true,
-		GoFunc:         api.GoModuleFunc(clockResGetFn),
+		GoFunc:         wasiFunc(clockResGetFn),
 	},
 }
 
-func clockResGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func clockResGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	id, resultResolution := uint32(params[0]), uint32(params[1])
 
@@ -74,12 +74,13 @@ func clockResGetFn(ctx context.Context, mod api.Module, params []uint64) []uint6
 	case clockIDMonotonic:
 		resolution = uint64(sysCtx.NanotimeResolution())
 	default:
-		return errnoInval
+		return ErrnoInval
 	}
+
 	if !mod.Memory().WriteUint64Le(ctx, resultResolution, resolution) {
-		return errnoFault
+		return ErrnoFault
 	}
-	return errnoSuccess
+	return ErrnoSuccess
 }
 
 // clockTimeGet is the WASI function named functionClockTimeGet that returns
@@ -121,15 +122,15 @@ var clockTimeGet = &wasm.HostFunc{
 	ResultTypes: []api.ValueType{i32},
 	Code: &wasm.Code{
 		IsHostFunction: true,
-		GoFunc:         api.GoModuleFunc(clockTimeGetFn),
+		GoFunc:         wasiFunc(clockTimeGetFn),
 	},
 }
 
-func clockTimeGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func clockTimeGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	id := uint32(params[0])
 	// TODO: precision is currently ignored.
-	_ = params[1]
+	// precision = params[1]
 	resultTimestamp := uint32(params[2])
 
 	var val uint64
@@ -140,11 +141,11 @@ func clockTimeGetFn(ctx context.Context, mod api.Module, params []uint64) []uint
 	case clockIDMonotonic:
 		val = uint64(sysCtx.Nanotime(ctx))
 	default:
-		return errnoInval
+		return ErrnoInval
 	}
 
 	if !mod.Memory().WriteUint64Le(ctx, resultTimestamp, val) {
-		return errnoFault
+		return ErrnoFault
 	}
-	return errnoSuccess
+	return ErrnoSuccess
 }

--- a/imports/wasi_snapshot_preview1/environ.go
+++ b/imports/wasi_snapshot_preview1/environ.go
@@ -52,13 +52,14 @@ var environGet = &wasm.HostFunc{
 	ResultTypes: []api.ValueType{i32},
 	Code: &wasm.Code{
 		IsHostFunction: true,
-		GoFunc:         api.GoModuleFunc(environGetFn),
+		GoFunc:         wasiFunc(environGetFn),
 	},
 }
 
-func environGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func environGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	environ, environBuf := uint32(params[0]), uint32(params[1])
+
 	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Environ(), environ, environBuf)
 }
 
@@ -101,20 +102,20 @@ var environSizesGet = &wasm.HostFunc{
 	ResultTypes: []api.ValueType{i32},
 	Code: &wasm.Code{
 		IsHostFunction: true,
-		GoFunc:         api.GoModuleFunc(environSizesGetFn),
+		GoFunc:         wasiFunc(environSizesGetFn),
 	},
 }
 
-func environSizesGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func environSizesGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	mem := mod.Memory()
 	resultEnvironc, resultEnvironvLen := uint32(params[0]), uint32(params[1])
 
 	if !mem.WriteUint32Le(ctx, resultEnvironc, uint32(len(sysCtx.Environ()))) {
-		return errnoFault
+		return ErrnoFault
 	}
 	if !mem.WriteUint32Le(ctx, resultEnvironvLen, sysCtx.EnvironSize()) {
-		return errnoFault
+		return ErrnoFault
 	}
-	return errnoSuccess
+	return ErrnoSuccess
 }

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -925,7 +925,7 @@ func Test_fdRead_shouldContinueRead(t *testing.T) {
 		n, l          uint32
 		err           error
 		expectedOk    bool
-		expectedErrno []uint64
+		expectedErrno Errno
 	}{
 		{
 			name: "break when nothing to read",
@@ -972,13 +972,13 @@ func Test_fdRead_shouldContinueRead(t *testing.T) {
 		{
 			name:          "return ErrnoIo on error on nothing to read",
 			err:           io.ErrClosedPipe,
-			expectedErrno: errnoIo,
+			expectedErrno: ErrnoIo,
 		},
 		{
 			name:          "return ErrnoIo on error on nothing read",
 			l:             4,
 			err:           io.ErrClosedPipe,
-			expectedErrno: errnoIo,
+			expectedErrno: ErrnoIo,
 		},
 		{ // Special case, allows processing data before err
 			name: "break on error on partial read",

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -29,11 +29,11 @@ var procExit = &wasm.HostFunc{
 	ParamNames:  []string{"rval"},
 	Code: &wasm.Code{
 		IsHostFunction: true,
-		GoFunc:         api.GoModuleFunc(procExitFn),
+		GoFunc:         wasiFunc(procExitFn),
 	},
 }
 
-func procExitFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func procExitFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	exitCode := uint32(params[0])
 
 	// Ensure other callers see the exit code.

--- a/imports/wasi_snapshot_preview1/random.go
+++ b/imports/wasi_snapshot_preview1/random.go
@@ -42,24 +42,24 @@ var randomGet = &wasm.HostFunc{
 	ResultTypes: []api.ValueType{i32},
 	Code: &wasm.Code{
 		IsHostFunction: true,
-		GoFunc:         api.GoModuleFunc(randomGetFn),
+		GoFunc:         wasiFunc(randomGetFn),
 	},
 }
 
-func randomGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func randomGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	randSource := sysCtx.RandSource()
 	buf, bufLen := uint32(params[0]), uint32(params[1])
 
 	randomBytes, ok := mod.Memory().Read(ctx, buf, bufLen)
 	if !ok { // out-of-range
-		return errnoFault
+		return ErrnoFault
 	}
 
 	// We can ignore the returned n as it only != byteCount on error
 	if _, err := io.ReadAtLeast(randSource, randomBytes, int(bufLen)); err != nil {
-		return errnoIo
+		return ErrnoIo
 	}
 
-	return errnoSuccess
+	return ErrnoSuccess
 }

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -241,7 +241,7 @@ func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, va
 // result. The returned value will be written back to the stack at index zero.
 type wasiFunc func(ctx context.Context, mod api.Module, params []uint64) Errno
 
-// Call implements the same method as documented on api.GoModuleFunc.
+// Call implements the same method as documented on api.GoModuleFunction.
 func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
 	// Write the result back onto the stack
 	stack[0] = uint64(f(ctx, mod, stack))

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -215,39 +215,36 @@ func exportFunctions(builder wazero.HostModuleBuilder) {
 	exporter.ExportHostFunc(sockShutdown)
 }
 
-// Declare constants to avoid slice allocation per call.
-var (
-	errnoBadf        = []uint64{uint64(ErrnoBadf)}
-	errnoExist       = []uint64{uint64(ErrnoExist)}
-	errnoInval       = []uint64{uint64(ErrnoInval)}
-	errnoIo          = []uint64{uint64(ErrnoIo)}
-	errnoNoent       = []uint64{uint64(ErrnoNoent)}
-	errnoNotdir      = []uint64{uint64(ErrnoNotdir)}
-	errnoFault       = []uint64{uint64(ErrnoFault)}
-	errnoNametoolong = []uint64{uint64(ErrnoNametoolong)}
-	errnoSuccess     = []uint64{uint64(ErrnoSuccess)}
-)
-
-func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, values []string, offsets, bytes uint32) []uint64 {
+func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, values []string, offsets, bytes uint32) Errno {
 	for _, value := range values {
 		// Write current offset and advance it.
 		if !mem.WriteUint32Le(ctx, offsets, bytes) {
-			return errnoFault
+			return ErrnoFault
 		}
 		offsets += 4 // size of uint32
 
 		// Write the next value to memory with a NUL terminator
 		if !mem.Write(ctx, bytes, []byte(value)) {
-			return errnoFault
+			return ErrnoFault
 		}
 		bytes += uint32(len(value))
 		if !mem.WriteByte(ctx, bytes, 0) {
-			return errnoFault
+			return ErrnoFault
 		}
 		bytes++
 	}
 
-	return errnoSuccess
+	return ErrnoSuccess
+}
+
+// wasiFunc special cases that all WASI functions return a single Errno
+// result. The returned value will be written back to the stack at index zero.
+type wasiFunc func(ctx context.Context, mod api.Module, params []uint64) Errno
+
+// Call implements the same method as documented on wasiFunction.
+func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	// Write the result back onto the stack
+	stack[0] = uint64(f(ctx, mod, stack))
 }
 
 // stubFunction stubs for GrainLang per #271.

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -241,7 +241,7 @@ func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, va
 // result. The returned value will be written back to the stack at index zero.
 type wasiFunc func(ctx context.Context, mod api.Module, params []uint64) Errno
 
-// Call implements the same method as documented on wasiFunction.
+// Call implements the same method as documented on api.GoModuleFunc.
 func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
 	// Write the result back onto the stack
 	stack[0] = uint64(f(ctx, mod, stack))

--- a/internal/gojs/spfunc/spfunc_test.go
+++ b/internal/gojs/spfunc/spfunc_test.go
@@ -175,12 +175,12 @@ var spMem = []byte{
 	10, 0, 0, 0, 0, 0, 0, 0,
 }
 
-func i64i32i32i32i32_i64i32_withSP(_ context.Context, params []uint64) []uint64 {
-	vRef := params[0]
-	mAddr := uint32(params[1])
-	mLen := uint32(params[2])
-	argsArray := uint32(params[3])
-	argsLen := uint32(params[4])
+func i64i32i32i32i32_i64i32_withSP(_ context.Context, stack []uint64) {
+	vRef := stack[0]
+	mAddr := uint32(stack[1])
+	mLen := uint32(stack[2])
+	argsArray := uint32(stack[3])
+	argsLen := uint32(stack[4])
 
 	if vRef != 1 {
 		panic("vRef")
@@ -198,7 +198,10 @@ func i64i32i32i32i32_i64i32_withSP(_ context.Context, params []uint64) []uint64 
 		panic("argsLen")
 	}
 
-	return []uint64{10, 20, 8}
+	// set results
+	stack[0] = 10
+	stack[1] = 20
+	stack[2] = 8
 }
 
 func TestMustCallFromSP(t *testing.T) {

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -148,12 +148,12 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 		CodeSection: []*wasm.Code{
 			{
 				IsHostFunction: true,
-				GoFunc: api.GoModuleFunc(func(ctx context.Context, mod api.Module, params []uint64) []uint64 {
-					ret, ok := mod.Memory().ReadUint32Le(ctx, uint32(params[0]))
+				GoFunc: api.GoModuleFunc(func(ctx context.Context, mod api.Module, stack []uint64) {
+					ret, ok := mod.Memory().ReadUint32Le(ctx, uint32(stack[0]))
 					if !ok {
 						panic("couldn't read memory")
 					}
-					return []uint64{uint64(ret)}
+					stack[0] = uint64(ret)
 				}),
 			},
 			wasm.MustParseGoReflectFuncCode(

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -519,6 +519,14 @@ func runTestModuleEngine_Call_HostFn(t *testing.T, et EngineTester, hostDivBy *w
 			results, err := ce.Call(testCtx, m, []uint64{1})
 			require.NoError(t, err)
 			require.Equal(t, uint64(1), results[0])
+
+			results2, err := ce.Call(testCtx, m, []uint64{1})
+			require.NoError(t, err)
+			require.Equal(t, results, results2)
+
+			// Ensure the result slices are unique
+			results[0] = 255
+			require.Equal(t, uint64(1), results2[0])
 		})
 	}
 }

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -286,7 +286,7 @@ func Test_callGoFunc(t *testing.T) {
 
 			var results []uint64
 			if resultLen > 0 {
-				results = stack[0:resultLen]
+				results = stack[:resultLen]
 			}
 			require.Equal(t, tc.expectedResults, results)
 		})

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -267,14 +267,26 @@ func Test_callGoFunc(t *testing.T) {
 			_, _, code, err := parseGoReflectFunc(tc.input)
 			require.NoError(t, err)
 
-			var results []uint64
+			resultLen := len(tc.expectedResults)
+			stackLen := len(tc.inputParams)
+			if resultLen > stackLen {
+				stackLen = resultLen
+			}
+			stack := make([]uint64, stackLen)
+			copy(stack, tc.inputParams)
+
 			switch code.GoFunc.(type) {
 			case api.GoFunction:
-				results = code.GoFunc.(api.GoFunction).Call(testCtx, tc.inputParams)
+				code.GoFunc.(api.GoFunction).Call(testCtx, stack)
 			case api.GoModuleFunction:
-				results = code.GoFunc.(api.GoModuleFunction).Call(testCtx, callCtx, tc.inputParams)
+				code.GoFunc.(api.GoModuleFunction).Call(testCtx, callCtx, stack)
 			default:
 				t.Fatal("unexpected type.")
+			}
+
+			var results []uint64
+			if resultLen > 0 {
+				results = stack[0:resultLen]
 			}
 			require.Equal(t, tc.expectedResults, results)
 		})


### PR DESCRIPTION
This fixes a bug where function call results used the same slice (in the compiler engine). This was due to it being a write-through of a shared stack. What happens is a user of a first result can corrupt the next, or possibly worse:

```go
results, err := fn.Call(ctx, 1)
results2, err := fn.Call(ctx, 2)
results[0] = 255 // affects results2[0]
```

The safe approach is to always copy-out (internally). However, stack re-use was an optimization to avoid copying. To pay for the copy-out, this optimizes the signatures of `api.GoFunction` and `api.GoModuleFunction` as described below. As these are low-level interfaces, most users will have no impact to this change. I'll help port things on github that use them, though.

### Design

The general idea is that if we want to make Function.Call safe (ex copy-out results), we should pay for that by reducing the amount of slices we allocate.

Currently, we require host functions to allocate a temporary slice to hold results when we will have to copy them out anyway. This changes the design so that low-level functions accept a slice representing the stack instead. The size is the max of the parameter or result count.

```diff
 type GoModuleFunction interface {
-       Call(ctx context.Context, mod Module, params []uint64) []uint64
+       Call(ctx context.Context, mod Module, stack []uint64)
 }
```

This approach reduces allocation and also copies as currently both impls needed to copy results back to the stack anyway.

### Porting 

Common functions who return a single value, like WASI, can be adapted using a custom type instead of `api.GoModuleFunction`.

Here's an example:
```go
// wasiFunc special cases that all WASI functions return a single Errno
// result. The returned value will be written back to the stack at index 0.
type wasiFunc func(ctx context.Context, mod api.Module, params []uint64) Errno

// Call implements the same method as documented on wasiFunction.
func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
	// Write the result back onto the stack
	stack[0] = uint64(f(ctx, mod, stack))
}
```

The diff then is mostly mechanical:
```diff
--- a/imports/wasi_snapshot_preview1/args.go
+++ b/imports/wasi_snapshot_preview1/args.go
@@ -52,11 +52,11 @@ var argsGet = &wasm.HostFunc{
        ResultTypes: []api.ValueType{i32},
        Code: &wasm.Code{
                IsHostFunction: true,
-               GoFunc:         api.GoModuleFunc(argsGetFn),
+               GoFunc:         wasiFunc(argsGetFn),
        },
 }
 
-func argsGetFn(ctx context.Context, mod api.Module, params []uint64) []uint64 {
+func argsGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
        sysCtx := mod.(*wasm.CallContext).Sys
        argv, argvBuf := uint32(params[0]), uint32(params[1])
        return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Args(), argv, argvBuf)
@@ -99,20 +99,21 @@ var argsSizesGet = &wasm.HostFunc{
        ResultTypes: []api.ValueType{i32},
        Code: &wasm.Code{
                IsHostFunction: true,
-               GoFunc:         api.GoModuleFunc(argsSizesGetFn),
+               GoFunc:         wasiFunc(argsSizesGetFn),
        },
 }
```