### PR TITLE
wasi: optimizes args/environ parsing

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -639,8 +639,8 @@ func requireSysContext(
 ) *internalsys.Context {
 	sysCtx, err := internalsys.NewContext(
 		max,
-		args,
-		environ,
+		toByteSlices(args),
+		toByteSlices(environ),
 		stdin,
 		stdout,
 		stderr,

--- a/imports/wasi_snapshot_preview1/args.go
+++ b/imports/wasi_snapshot_preview1/args.go
@@ -59,7 +59,7 @@ var argsGet = &wasm.HostFunc{
 func argsGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	argv, argvBuf := uint32(params[0]), uint32(params[1])
-	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Args(), argv, argvBuf)
+	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Args(), argv, argvBuf, sysCtx.ArgsSize())
 }
 
 // argsSizesGet is the WASI function named functionArgsSizesGet that reads
@@ -108,7 +108,8 @@ func argsSizesGetFn(ctx context.Context, mod api.Module, params []uint64) Errno 
 	mem := mod.Memory()
 	resultArgc, resultArgvLen := uint32(params[0]), uint32(params[1])
 
-	// Write the Errno back to the stack
+	// argc and argv_len offsets are not necessarily sequential, so we have to
+	// write them independently.
 	if !mem.WriteUint32Le(ctx, resultArgc, uint32(len(sysCtx.Args()))) {
 		return ErrnoFault
 	}

--- a/imports/wasi_snapshot_preview1/environ.go
+++ b/imports/wasi_snapshot_preview1/environ.go
@@ -60,7 +60,7 @@ func environGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	environ, environBuf := uint32(params[0]), uint32(params[1])
 
-	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Environ(), environ, environBuf)
+	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Environ(), environ, environBuf, sysCtx.EnvironSize())
 }
 
 // environSizesGet is the WASI function named functionEnvironSizesGet that
@@ -111,6 +111,8 @@ func environSizesGetFn(ctx context.Context, mod api.Module, params []uint64) Err
 	mem := mod.Memory()
 	resultEnvironc, resultEnvironvLen := uint32(params[0]), uint32(params[1])
 
+	// environc and environv_len offsets are not necessarily sequential, so we
+	// have to write them independently.
 	if !mem.WriteUint32Le(ctx, resultEnvironc, uint32(len(sysCtx.Environ()))) {
 		return ErrnoFault
 	}

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -6,60 +6,46 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
-	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-var testMem = []byte{
-	0,                // environBuf is after this
-	'a', '=', 'b', 0, // null terminated "a=b",
-	'b', '=', 'c', 'd', 0, // null terminated "b=cd"
-	0,          // environ is after this
-	1, 0, 0, 0, // little endian-encoded offset of "a=b"
-	5, 0, 0, 0, // little endian-encoded offset of "b=cd"
-	0,
-}
+// configArgsEnviron ensures the result data are the same between args and ENV.
+var configArgsEnviron = wazero.NewModuleConfig().
+	WithArgs("aa=bbbb", "cccccc=dddddddd", "eeeeeeeeee=ffffffffffff").
+	WithEnv("aa", "bbbb").
+	WithEnv("cccccc", "dddddddd").
+	WithEnv("eeeeeeeeee", "ffffffffffff")
 
-func Test_Benchmark_EnvironGet(t *testing.T) {
-	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().
-		WithEnv("a", "b").WithEnv("b", "cd"))
-	defer r.Close(testCtx)
-
-	// Invoke environGet and check the memory side effects.
-	requireErrno(t, ErrnoSuccess, mod, functionEnvironGet, uint64(11), uint64(1))
-	require.Equal(t, `
---> proxy.environ_get(environ=11,environ_buf=1)
-	==> wasi_snapshot_preview1.environ_get(environ=11,environ_buf=1)
-	<== ESUCCESS
-<-- (0)
-`, "\n"+log.String())
-
-	mem, ok := mod.Memory().Read(testCtx, 0, uint32(len(testMem)))
-	require.True(t, ok)
-	require.Equal(t, testMem, mem)
-}
-
-func Benchmark_EnvironGet(b *testing.B) {
+func Benchmark_ArgsEnviron(b *testing.B) {
 	r := wazero.NewRuntime(testCtx)
 	defer r.Close(testCtx)
 
-	mod, err := instantiateProxyModule(r, wazero.NewModuleConfig().
-		WithEnv("a", "b").WithEnv("b", "cd"))
+	mod, err := instantiateProxyModule(r, configArgsEnviron)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	b.Run("environGet", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			results, err := mod.ExportedFunction(functionEnvironGet).Call(testCtx, uint64(0), uint64(4))
-			if err != nil {
-				b.Fatal(err)
+	for _, n := range []string{
+		functionArgsGet,
+		functionArgsSizesGet,
+		functionEnvironGet,
+		functionEnvironSizesGet,
+	} {
+		n := n
+		fn := mod.ExportedFunction(n)
+		b.Run(n, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				results, err := fn.Call(testCtx, uint64(0), uint64(4))
+				if err != nil {
+					b.Fatal(err)
+				}
+				errno := Errno(results[0])
+				if errno != 0 {
+					b.Fatal(ErrnoName(errno))
+				}
 			}
-			errno := Errno(results[0])
-			if errno != ErrnoSuccess {
-				b.Fatal(ErrnoName(errno))
-			}
-		}
-	})
+		})
+	}
 }
 
 // instantiateProxyModule instantiates a guest that re-exports WASI functions.

--- a/internal/gojs/argsenv.go
+++ b/internal/gojs/argsenv.go
@@ -26,10 +26,10 @@ func WriteArgsAndEnviron(ctx context.Context, mod api.Module) (argc, argv uint32
 	argc = uint32(len(args))
 	offset := endOfPageZero
 
-	strPtr := func(val, field string, i int) (ptr uint32) {
+	strPtr := func(val []byte, field string, i int) (ptr uint32) {
 		// TODO: return err and format "%s[%d], field, i"
 		ptr = offset
-		mustWrite(ctx, mem, field, offset, append([]byte(val), 0))
+		mustWrite(ctx, mem, field, offset, append(val, 0))
 		offset += uint32(len(val) + 1)
 		if pad := offset % 8; pad != 0 {
 			offset += 8 - pad

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -15,7 +15,7 @@ import (
 // Context holds module-scoped system resources currently only supported by
 // built-in host functions.
 type Context struct {
-	args, environ         []string
+	args, environ         [][]byte
 	argsSize, environSize uint32
 	stdin                 io.Reader
 	stdout, stderr        io.Writer
@@ -35,7 +35,7 @@ type Context struct {
 //
 // Note: The count will never be more than math.MaxUint32.
 // See wazero.ModuleConfig WithArgs
-func (c *Context) Args() []string {
+func (c *Context) Args() [][]byte {
 	return c.args
 }
 
@@ -52,7 +52,7 @@ func (c *Context) ArgsSize() uint32 {
 //
 // Note: The count will never be more than math.MaxUint32.
 // See wazero.ModuleConfig WithEnv
-func (c *Context) Environ() []string {
+func (c *Context) Environ() [][]byte {
 	return c.environ
 }
 
@@ -150,7 +150,7 @@ var (
 // Note: max is exposed for testing. max is only used for env/args validation.
 func NewContext(
 	max uint32,
-	args, environ []string,
+	args, environ [][]byte,
 	stdin io.Reader,
 	stdout, stderr io.Writer,
 	randSource io.Reader,
@@ -239,7 +239,7 @@ func clockResolutionInvalid(resolution sys.ClockResolution) bool {
 
 // nullTerminatedByteCount ensures the count or Nul-terminated length of the elements doesn't exceed max, and that no
 // element includes the nul character.
-func nullTerminatedByteCount(max uint32, elements []string) (uint32, error) {
+func nullTerminatedByteCount(max uint32, elements [][]byte) (uint32, error) {
 	count := uint32(len(elements))
 	if count > max {
 		return 0, errors.New("exceeds maximum count")

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -61,7 +61,7 @@ func TestDefaultSysContext(t *testing.T) {
 func TestNewContext_Args(t *testing.T) {
 	tests := []struct {
 		name         string
-		args         []string
+		args         [][]byte
 		maxSize      uint32
 		expectedSize uint32
 		expectedErr  string
@@ -69,25 +69,25 @@ func TestNewContext_Args(t *testing.T) {
 		{
 			name:         "ok",
 			maxSize:      10,
-			args:         []string{"a", "bc"},
+			args:         [][]byte{[]byte("a"), []byte("bc")},
 			expectedSize: 5,
 		},
 		{
 			name:        "exceeds max count",
 			maxSize:     1,
-			args:        []string{"a", "bc"},
+			args:        [][]byte{[]byte("a"), []byte("bc")},
 			expectedErr: "args invalid: exceeds maximum count",
 		},
 		{
 			name:        "exceeds max size",
 			maxSize:     4,
-			args:        []string{"a", "bc"},
+			args:        [][]byte{[]byte("a"), []byte("bc")},
 			expectedErr: "args invalid: exceeds maximum size",
 		},
 		{
 			name:        "null character",
 			maxSize:     10,
-			args:        []string{"a", string([]byte{'b', 0})},
+			args:        [][]byte{[]byte("a"), {'b', 0}},
 			expectedErr: "args invalid: contains NUL character",
 		},
 	}
@@ -123,7 +123,7 @@ func TestNewContext_Args(t *testing.T) {
 func TestNewContext_Environ(t *testing.T) {
 	tests := []struct {
 		name         string
-		environ      []string
+		environ      [][]byte
 		maxSize      uint32
 		expectedSize uint32
 		expectedErr  string
@@ -131,25 +131,25 @@ func TestNewContext_Environ(t *testing.T) {
 		{
 			name:         "ok",
 			maxSize:      10,
-			environ:      []string{"a=b", "c=de"},
+			environ:      [][]byte{[]byte("a=b"), []byte("c=de")},
 			expectedSize: 9,
 		},
 		{
 			name:        "exceeds max count",
 			maxSize:     1,
-			environ:     []string{"a=b", "c=de"},
+			environ:     [][]byte{[]byte("a=b"), []byte("c=de")},
 			expectedErr: "environ invalid: exceeds maximum count",
 		},
 		{
 			name:        "exceeds max size",
 			maxSize:     4,
-			environ:     []string{"a=b", "c=de"},
+			environ:     [][]byte{[]byte("a=b"), []byte("c=de")},
 			expectedErr: "environ invalid: exceeds maximum size",
 		},
 		{
 			name:        "null character",
 			maxSize:     10,
-			environ:     []string{"a=b", string(append([]byte("c=d"), 0))},
+			environ:     [][]byte{[]byte("a=b"), append([]byte("c=d"), 0)},
 			expectedErr: "environ invalid: contains NUL character",
 		},
 	}


### PR DESCRIPTION
While most compilers will only read args/environ once, tools like WAGI make heavy use of environment, possibly dozens of long variables. This optimizes both args and environ for this reason and also to setup for optimizing other functions.

Here are the notable changes:
* eagerly coerce to byte slices instead of strings
* re-use null terminated length for writing values
* avoid loops that call mem.WriteXXX internally

Before:
```
Benchmark_ArgsEnviron
Benchmark_ArgsEnviron/args_get
Benchmark_ArgsEnviron/args_get-16         	 6147727	       187.9 ns/op	      72 B/op	       5 allocs/op
Benchmark_ArgsEnviron/args_sizes_get
Benchmark_ArgsEnviron/args_sizes_get-16   	11869351	       100.7 ns/op	      24 B/op	       2 allocs/op
Benchmark_ArgsEnviron/environ_get
Benchmark_ArgsEnviron/environ_get-16      	 6202508	       191.0 ns/op	      72 B/op	       5 allocs/op
Benchmark_ArgsEnviron/environ_sizes_get
Benchmark_ArgsEnviron/environ_sizes_get-16         	11792656	        99.71 ns/op	      24 B/op	       2 allocs/op
```

After:
```
Benchmark_ArgsEnviron
Benchmark_ArgsEnviron/args_get
Benchmark_ArgsEnviron/args_get-16         	 9542246	       119.2 ns/op	      24 B/op	       2 allocs/op
Benchmark_ArgsEnviron/args_sizes_get
Benchmark_ArgsEnviron/args_sizes_get-16   	11963056	       105.7 ns/op	      24 B/op	       2 allocs/op
Benchmark_ArgsEnviron/environ_get
Benchmark_ArgsEnviron/environ_get-16      	 9742885	       123.0 ns/op	      24 B/op	       2 allocs/op
Benchmark_ArgsEnviron/environ_sizes_get
Benchmark_ArgsEnviron/environ_sizes_get-16         	12100869	        97.06 ns/op	      24 B/op	       2 allocs/op
```