### PR TITLE
compiler: make moduleContext.functions non-pointer slice

### DIFF
--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -679,16 +679,15 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 
 			// Now that we've generated the code for this function,
 			// add it to the module engine and assign its pointer to the table index.
-			f := function{
+			me.functions = append(me.functions, function{
 				parent:                &code{codeSegment: c},
 				codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
 				moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
 				source: &wasm.FunctionInstance{
 					TypeID: targetTypeID,
 				},
-			}
-			me.functions = append(me.functions, f)
-			table[i] = uintptr(unsafe.Pointer(&f))
+			})
+			table[i] = uintptr(unsafe.Pointer(&me.functions[len(me.functions)-1]))
 		}
 
 		// Test to ensure that we can call all the functions stored in the table.

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -651,7 +651,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		// and the typeID matches the table[targetOffset]'s type ID.
 		env.module().TypeIDs = make([]wasm.FunctionTypeID, 100)
 		env.module().TypeIDs[operation.TypeIndex] = targetTypeID
-		env.module().Engine = &moduleEngine{functions: []*function{}}
+		env.module().Engine = &moduleEngine{functions: []function{}}
 
 		me := env.moduleEngine()
 		for i := 0; i < len(table); i++ {
@@ -679,7 +679,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 
 			// Now that we've generated the code for this function,
 			// add it to the module engine and assign its pointer to the table index.
-			f := &function{
+			f := function{
 				parent:                &code{codeSegment: c},
 				codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
 				moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
@@ -688,7 +688,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 				},
 			}
 			me.functions = append(me.functions, f)
-			table[i] = uintptr(unsafe.Pointer(f))
+			table[i] = uintptr(unsafe.Pointer(&f))
 		}
 
 		// Test to ensure that we can call all the functions stored in the table.
@@ -746,7 +746,7 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 	operation := &wazeroir.OperationCallIndirect{TypeIndex: typeIndex}
 	env.module().TypeIDs = make([]wasm.FunctionTypeID, typeIndex+1)
 	env.module().TypeIDs[typeIndex] = typeID
-	env.module().Engine = &moduleEngine{functions: []*function{}}
+	env.module().Engine = &moduleEngine{functions: []function{}}
 
 	types := make([]*wasm.FunctionType, typeIndex+1)
 	types[typeIndex] = &wasm.FunctionType{}
@@ -762,14 +762,14 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 		c, _, err := compiler.compile()
 		require.NoError(t, err)
 
-		f := &function{
+		f := function{
 			parent:                &code{codeSegment: c},
 			codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
 			moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
 			source:                &wasm.FunctionInstance{TypeID: 0},
 		}
 		me.functions = append(me.functions, f)
-		table[0] = uintptr(unsafe.Pointer(f))
+		table[0] = uintptr(unsafe.Pointer(&f))
 	}
 
 	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
@@ -835,7 +835,7 @@ func TestCompiler_compileCall(t *testing.T) {
 		c, _, err := compiler.compile()
 		require.NoError(t, err)
 		index := wasm.Index(i)
-		me.functions = append(me.functions, &function{
+		me.functions = append(me.functions, function{
 			parent:                &code{codeSegment: c},
 			codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
 			moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -120,7 +120,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 				ir.Globals = append(ir.Globals, g.Type)
 			}
 			compiler := env.requireNewCompiler(t, newCompiler, ir)
-			me := &moduleEngine{functions: make([]*function, 10)}
+			me := &moduleEngine{functions: make([]function, 10)}
 			tc.moduleInstance.Engine = me
 
 			err := compiler.compileModuleContextInitialization()

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -949,7 +949,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 	me := env.moduleEngine()
 	const numFuncs = 20
 	for i := 0; i < numFuncs; i++ {
-		me.functions = append(me.functions, &function{source: &wasm.FunctionInstance{}})
+		me.functions = append(me.functions, function{source: &wasm.FunctionInstance{}})
 	}
 
 	for i := 0; i < numFuncs; i++ {
@@ -974,7 +974,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 			require.Equal(t, uint64(1), env.stackPointer())
-			require.Equal(t, uintptr(unsafe.Pointer(me.functions[i])), uintptr(env.stackTopAsUint64()))
+			require.Equal(t, uintptr(unsafe.Pointer(&me.functions[i])), uintptr(env.stackTopAsUint64()))
 		})
 	}
 }

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -68,6 +68,7 @@ func init() {
 	requireEqual(int(unsafe.Offsetof(compiledFunc.codeInitialAddress)), functionCodeInitialAddressOffset, "functionCodeInitialAddressOffset")
 	requireEqual(int(unsafe.Offsetof(compiledFunc.source)), functionSourceOffset, "functionSourceOffset")
 	requireEqual(int(unsafe.Offsetof(compiledFunc.moduleInstanceAddress)), functionModuleInstanceAddressOffset, "functionModuleInstanceAddressOffset")
+	requireEqual(int(unsafe.Sizeof(compiledFunc)), functionSize, "functionModuleInstanceAddressOffset")
 
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -49,7 +49,7 @@ func (e *engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
 // CompiledFunctionPointerValue implements the same method as documented on enginetest.EngineTester.
 func (e engineTester) CompiledFunctionPointerValue(me wasm.ModuleEngine, funcIndex wasm.Index) uint64 {
 	internal := me.(*moduleEngine)
-	return uint64(uintptr(unsafe.Pointer(internal.functions[funcIndex])))
+	return uint64(uintptr(unsafe.Pointer(&internal.functions[funcIndex])))
 }
 
 func TestCompiler_Engine_NewModuleEngine(t *testing.T) {

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -22,7 +22,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	// and the typeID  matches the table[targetOffset]'s type ID.
 	operation := &wazeroir.OperationCallIndirect{TypeIndex: 0}
 	env.module().TypeIDs = []wasm.FunctionTypeID{0}
-	env.module().Engine = &moduleEngine{functions: []*function{}}
+	env.module().Engine = &moduleEngine{functions: []function{}}
 
 	me := env.moduleEngine()
 	{ // Compiling call target.
@@ -35,14 +35,14 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		c, _, err := compiler.compile()
 		require.NoError(t, err)
 
-		f := &function{
+		f := function{
 			parent:                &code{codeSegment: c},
 			codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
 			moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
 			source:                &wasm.FunctionInstance{TypeID: 0},
 		}
 		me.functions = append(me.functions, f)
-		table[0] = uintptr(unsafe.Pointer(f))
+		table[0] = uintptr(unsafe.Pointer(&f))
 	}
 
 	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -898,9 +898,9 @@ func (c *arm64Compiler) compileCall(o *wazeroir.OperationCall) error {
 		arm64ReservedRegisterForCallEngine, callEngineModuleContextFunctionsElement0AddressOffset,
 		targetFunctionAddressReg)
 
-	c.assembler.CompileMemoryToRegister(
-		arm64.LDRD,
-		targetFunctionAddressReg, int64(o.FunctionIndex)*8, // * 8 because the size of *function equals 8 bytes.
+	c.assembler.CompileConstToRegister(
+		arm64.ADD,
+		int64(o.FunctionIndex)*functionSize, // * 8 because the size of *function equals 8 bytes.
 		targetFunctionAddressReg)
 
 	return c.compileCallImpl(targetFunctionAddressReg, tp)
@@ -3577,13 +3577,12 @@ func (c *arm64Compiler) compileRefFunc(o *wazeroir.OperationRefFunc) error {
 	//                                   = &moduleEngine.functions[0]
 	c.assembler.CompileMemoryToRegister(arm64.LDRD,
 		arm64ReservedRegisterForCallEngine, callEngineModuleContextFunctionsElement0AddressOffset,
-		arm64ReservedRegisterForTemporary)
+		ref)
 
-	// ref = [arm64ReservedRegisterForTemporary +  int64(o.FunctionIndex)*8]
-	//     = [&moduleEngine.functions[0] + sizeOf(*function) * index]
-	//     = moduleEngine.functions[index]
-	c.assembler.CompileMemoryToRegister(arm64.LDRD,
-		arm64ReservedRegisterForTemporary, int64(o.FunctionIndex)*8, // * 8 because the size of *code equals 8 bytes.
+	// ref = ref + int64(o.FunctionIndex)*sizeOf(function)
+	//     = &moduleEngine.functions[index]
+	c.assembler.CompileConstToRegister(arm64.ADD,
+		int64(o.FunctionIndex)*functionSize,
 		ref,
 	)
 

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -21,7 +21,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	// and the typeID  matches the table[targetOffset]'s type ID.
 	operation := &wazeroir.OperationCallIndirect{TypeIndex: 0}
 	env.module().TypeIDs = []wasm.FunctionTypeID{0}
-	env.module().Engine = &moduleEngine{functions: []*function{}}
+	env.module().Engine = &moduleEngine{functions: []function{}}
 
 	me := env.moduleEngine()
 	{ // Compiling call target.
@@ -34,14 +34,14 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		c, _, err := compiler.compile()
 		require.NoError(t, err)
 
-		f := &function{
+		f := function{
 			parent:                &code{codeSegment: c},
 			codeInitialAddress:    uintptr(unsafe.Pointer(&c[0])),
 			moduleInstanceAddress: uintptr(unsafe.Pointer(env.moduleInstance)),
 			source:                &wasm.FunctionInstance{TypeID: 0},
 		}
 		me.functions = append(me.functions, f)
-		table[0] = uintptr(unsafe.Pointer(f))
+		table[0] = uintptr(unsafe.Pointer(&f))
 	}
 
 	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{


### PR DESCRIPTION
Ref #889 

This further reduces the allocations during instantiation

```
$ benchstat old_re2.txt new_re2.txt
name                                    old time/op    new time/op    delta
Initialization/interpreter-10              136µs ± 2%     137µs ± 2%    ~     (p=0.222 n=5+5)
Initialization/interpreter-multiple-10    62.5µs ±17%    67.4µs ±13%    ~     (p=0.421 n=5+5)
Initialization/compiler-10                 167µs ± 5%     156µs ± 4%  -6.66%  (p=0.008 n=5+5)
Initialization/compiler-multiple-10       44.1µs ± 8%    43.0µs ± 9%    ~     (p=0.548 n=5+5)

name                                    old alloc/op   new alloc/op   delta
Initialization/interpreter-10              550kB ± 0%     550kB ± 0%    ~     (p=0.881 n=5+5)
Initialization/interpreter-multiple-10     551kB ± 0%     551kB ± 0%    ~     (p=0.548 n=5+5)
Initialization/compiler-10                 506kB ± 0%     498kB ± 0%  -1.62%  (p=0.008 n=5+5)
Initialization/compiler-multiple-10        507kB ± 0%     498kB ± 0%  -1.60%  (p=0.008 n=5+5)

name                                    old allocs/op  new allocs/op  delta
Initialization/interpreter-10              1.88k ± 0%     1.88k ± 0%    ~     (all equal)
Initialization/interpreter-multiple-10     1.88k ± 0%     1.88k ± 0%    ~     (all equal)
Initialization/compiler-10                  37.0 ± 0%      36.0 ± 0%  -2.70%  (p=0.008 n=5+5)
Initialization/compiler-multiple-10         44.0 ± 0%      43.0 ± 0%  -2.27%  (p=0.008 n=5+5)
```