### PR TITLE
Use shifted iota for wasiFdflags values

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -190,7 +190,7 @@ func fdFdstatGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 
 type wasiFdflags = byte // actually 16-bit, but there aren't that many.
 const (
-	wasiFdflagsNone wasiFdflags = iota
+	wasiFdflagsNone wasiFdflags = 1<<iota - 1
 	wasiFdflagsAppend
 	wasiFdflagsDsync
 	wasiFdflagsNonblock


### PR DESCRIPTION
I did not find an authoratative reference in the wasi snapshot 1 docs, but based on the wasi-libc implementation [1] these should not be individual values but a bitmask.

 [1] https://github.com/WebAssembly/wasi-libc/blob/3a261b03809018ceae294e9062cde0758b55b61a/libc-bottom-half/headers/public/wasi/api.h#L891-L921