### PR TITLE
Reduce lock contention during module close

### DIFF
--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -125,10 +125,11 @@ func runInitializationConcurrentBench(b *testing.B, r wazero.Runtime) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		go func(name string) {
-			_, err := r.InstantiateModule(testCtx, compiled, config.WithName(name))
+			m, err := r.InstantiateModule(testCtx, compiled, config.WithName(name))
 			if err != nil {
 				b.Error(err)
 			}
+			m.Close(testCtx)
 			wg.Done()
 		}(strconv.Itoa(i))
 	}


### PR DESCRIPTION
During module close the module name needs to be removed from the module list in the namespace. Previously the time complexity of deleting a name was O(n). This change replaces the name slice with a doubly linked list for O(1) deletion while preserving the reverse insert order.

This change further reduces the lock contention when lots of modules are created and closed.

Blocking profile before:
<img width="1519" alt="Screenshot 2022-12-07 at 16 45 47" src="https://user-images.githubusercontent.com/1851985/206328737-4b8a9d1d-874a-4fab-a8b6-b65b0db290a4.png">

Blocking profile after:
<img width="1504" alt="Screenshot 2022-12-07 at 16 46 34" src="https://user-images.githubusercontent.com/1851985/206328800-99743601-1ad6-4d4b-8d95-c9bfb8241741.png">


Signed-off-by: Clifton Kaznocha <ckaznocha@users.noreply.github.com>