### PR TITLE
Makes log listener default to signed interpretation

### DIFF
--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -183,14 +183,18 @@ func (l *loggingListener) writeParam(message *strings.Builder, i int, vals []uin
 	return l.writeVal(message, l.fnd.ParamTypes()[i], i, vals)
 }
 
+// writeVal formats integers as signed even though the call site determines
+// if it is signed or not. This presents a better experience for values that
+// are often signed, such as seek offset. This concedes the rare intentional
+// unsigned value at the end of its range will show up as negative.
 func (l *loggingListener) writeVal(message *strings.Builder, t api.ValueType, i int, vals []uint64) int {
 	v := vals[i]
 	i++
 	switch t {
 	case api.ValueTypeI32:
-		message.WriteString(strconv.FormatUint(uint64(uint32(v)), 10))
+		message.WriteString(strconv.FormatInt(int64(int32(v)), 10))
 	case api.ValueTypeI64:
-		message.WriteString(strconv.FormatUint(v, 10))
+		message.WriteString(strconv.FormatInt(int64(v), 10))
 	case api.ValueTypeF32:
 		message.WriteString(strconv.FormatFloat(float64(api.DecodeF32(v)), 'g', -1, 32))
 	case api.ValueTypeF64:

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -106,7 +106,7 @@ func Test_loggingListener(t *testing.T) {
 			name:     "i32",
 			functype: &wasm.FunctionType{Params: []api.ValueType{api.ValueTypeI32}},
 			params:   []uint64{math.MaxUint32},
-			expected: `--> test.fn(4294967295)
+			expected: `--> test.fn(-1)
 <--
 `,
 		},
@@ -115,7 +115,7 @@ func Test_loggingListener(t *testing.T) {
 			functype:   &wasm.FunctionType{Params: []api.ValueType{api.ValueTypeI32}},
 			params:     []uint64{math.MaxUint32},
 			paramNames: []string{"x"},
-			expected: `--> test.fn(x=4294967295)
+			expected: `--> test.fn(x=-1)
 <--
 `,
 		},
@@ -123,7 +123,7 @@ func Test_loggingListener(t *testing.T) {
 			name:     "i64",
 			functype: &wasm.FunctionType{Params: []api.ValueType{api.ValueTypeI64}},
 			params:   []uint64{math.MaxUint64},
-			expected: `--> test.fn(18446744073709551615)
+			expected: `--> test.fn(-1)
 <--
 `,
 		},
@@ -132,7 +132,7 @@ func Test_loggingListener(t *testing.T) {
 			functype:   &wasm.FunctionType{Params: []api.ValueType{api.ValueTypeI64}},
 			params:     []uint64{math.MaxUint64},
 			paramNames: []string{"x"},
-			expected: `--> test.fn(x=18446744073709551615)
+			expected: `--> test.fn(x=-1)
 <--
 `,
 		},
@@ -226,7 +226,7 @@ func Test_loggingListener(t *testing.T) {
 			functype: &wasm.FunctionType{Results: []api.ValueType{api.ValueTypeI32}},
 			results:  []uint64{math.MaxUint32},
 			expected: `--> test.fn()
-<-- 4294967295
+<-- -1
 `,
 		},
 		{
@@ -237,7 +237,7 @@ func Test_loggingListener(t *testing.T) {
 			},
 			params:  []uint64{math.MaxUint32},
 			results: []uint64{api.EncodeF32(math.MaxFloat32)},
-			expected: `--> test.fn(4294967295)
+			expected: `--> test.fn(-1)
 <-- 3.4028235e+38
 `,
 		},
@@ -249,7 +249,7 @@ func Test_loggingListener(t *testing.T) {
 			},
 			params:  []uint64{math.MaxUint32, math.MaxUint64},
 			results: []uint64{api.EncodeF32(math.MaxFloat32), api.EncodeF64(math.MaxFloat64)},
-			expected: `--> test.fn(4294967295,18446744073709551615)
+			expected: `--> test.fn(-1,-1)
 <-- (3.4028235e+38,1.7976931348623157e+308)
 `,
 		},
@@ -262,7 +262,7 @@ func Test_loggingListener(t *testing.T) {
 			params:     []uint64{math.MaxUint32, math.MaxUint64},
 			paramNames: []string{"x", "y"},
 			results:    []uint64{api.EncodeF32(math.MaxFloat32), api.EncodeF64(math.MaxFloat64)},
-			expected: `--> test.fn(x=4294967295,y=18446744073709551615)
+			expected: `--> test.fn(x=-1,y=-1)
 <-- (3.4028235e+38,1.7976931348623157e+308)
 `,
 		},

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -85,7 +85,7 @@ func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
 	// TODO: Currently, the listener doesn't get notified on errors as they are
 	// implemented with panic. This means the end hooks aren't make resulting
 	// in dangling logs like this:
-	//	==> host.host_div_by(4294967295)
+	//	==> host.host_div_by(-1)
 	// instead of seeing a return like
 	//	<== DivByZero
 	require.Equal(t, `
@@ -96,8 +96,8 @@ func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
 --> imported.div_by.wasm(0)
 --> imported.div_by.wasm(1)
 <-- 1
---> imported.call->div_by.go(4294967295)
-	==> host.div_by.go(4294967295)
+--> imported.call->div_by.go(-1)
+	==> host.div_by.go(-1)
 --> imported.call->div_by.go(1)
 	==> host.div_by.go(1)
 	<== 1
@@ -111,9 +111,9 @@ func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
 		<== 1
 	<-- 1
 <-- 1
---> importing.call_import->call->div_by.go(4294967295)
-	--> imported.call->div_by.go(4294967295)
-		==> host.div_by.go(4294967295)
+--> importing.call_import->call->div_by.go(-1)
+	--> imported.call->div_by.go(-1)
+		==> host.div_by.go(-1)
 --> importing.call_import->call->div_by.go(1)
 	--> imported.call->div_by.go(1)
 		==> host.div_by.go(1)

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -124,7 +124,7 @@ func TestInterpreter_ModuleEngine_Call_Errors(t *testing.T) {
 	// TODO: Currently, the listener doesn't get notified on errors as they are
 	// implemented with panic. This means the end hooks aren't make resulting
 	// in dangling logs like this:
-	//	==> host.host_div_by(4294967295)
+	//	==> host.host_div_by(-1)
 	// instead of seeing a return like
 	//	<== DivByZero
 	require.Equal(t, `
@@ -135,8 +135,8 @@ func TestInterpreter_ModuleEngine_Call_Errors(t *testing.T) {
 --> imported.div_by.wasm(0)
 --> imported.div_by.wasm(1)
 <-- 1
---> imported.call->div_by.go(4294967295)
-	==> host.div_by.go(4294967295)
+--> imported.call->div_by.go(-1)
+	==> host.div_by.go(-1)
 --> imported.call->div_by.go(1)
 	==> host.div_by.go(1)
 	<== 1
@@ -150,9 +150,9 @@ func TestInterpreter_ModuleEngine_Call_Errors(t *testing.T) {
 		<== 1
 	<-- 1
 <-- 1
---> importing.call_import->call->div_by.go(4294967295)
-	--> imported.call->div_by.go(4294967295)
-		==> host.div_by.go(4294967295)
+--> importing.call_import->call->div_by.go(-1)
+	--> imported.call->div_by.go(-1)
+		==> host.div_by.go(-1)
 --> importing.call_import->call->div_by.go(1)
 	--> imported.call->div_by.go(1)
 		==> host.div_by.go(1)


### PR DESCRIPTION
This changes the log listener to assume a value is signed instead of unsigned, as it leads to logs looking more correct than the other way around. Notably, values that are often negative, such as seek offset, look better without a lot of downside.

discussed with @anuraaga 