### PR TITLE
wasi: improves fd_write perf when not discarded

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1118,9 +1118,7 @@ func fdWriteFn(ctx context.Context, mod api.Module, stack []uint64) (uint32, Err
 	if !ok {
 		return 0, ErrnoFault
 	}
-	for i := uint32(0); i < iovsCount; i++ {
-		iovsPos := i * 8
-
+	for iovsPos := uint32(0); iovsPos < (iovsCount << 3); iovsPos += 8 {
 		offset := le.Uint32(iovsBuf[iovsPos:])
 		l := le.Uint32(iovsBuf[iovsPos+4:])
 

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1114,7 +1114,7 @@ func fdWriteFn(ctx context.Context, mod api.Module, stack []uint64) (uint32, Err
 
 	var err error
 	var nwritten uint32
-	iovsBuf, ok := mod.Memory().Read(ctx, iovs, iovsCount*8)
+	iovsBuf, ok := mod.Memory().Read(ctx, iovs, iovsCount<<3)
 	if !ok {
 		return 0, ErrnoFault
 	}

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
 )
 
@@ -36,6 +37,74 @@ func Benchmark_ArgsEnviron(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				results, err := fn.Call(testCtx, uint64(0), uint64(4))
+				if err != nil {
+					b.Fatal(err)
+				}
+				errno := Errno(results[0])
+				if errno != 0 {
+					b.Fatal(ErrnoName(errno))
+				}
+			}
+		})
+	}
+}
+
+type writerFunc func(p []byte) (n int, err error)
+
+func (f writerFunc) Write(p []byte) (n int, err error) {
+	return f(p)
+}
+
+func Benchmark_fdWrite(b *testing.B) {
+	r := wazero.NewRuntime(testCtx)
+	defer r.Close(testCtx)
+
+	mod, err := instantiateProxyModule(r, wazero.NewModuleConfig().
+		WithStdout(writerFunc(func(p []byte) (n int, err error) { return len(p), nil })),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fn := mod.ExportedFunction(fdWriteName)
+
+	iovs := uint32(1) // arbitrary offset
+	mod.Memory().Write(testCtx, 0, []byte{
+		'?',         // `iovs` is after this
+		18, 0, 0, 0, // = iovs[0].offset
+		4, 0, 0, 0, // = iovs[0].length
+		23, 0, 0, 0, // = iovs[1].offset
+		2, 0, 0, 0, // = iovs[1].length
+		'?',                // iovs[0].offset is after this
+		'w', 'a', 'z', 'e', // iovs[0].length bytes
+		'?',      // iovs[1].offset is after this
+		'r', 'o', // iovs[1].length bytes
+		'?',
+	})
+
+	iovsCount := uint32(2)       // The count of iovs
+	resultNwritten := uint32(26) // arbitrary offset
+
+	benches := []struct {
+		name string
+		fd   uint32
+	}{
+		{
+			name: "io.Writer",
+			fd:   sys.FdStdout,
+		},
+		{
+			name: "io.Discard",
+			fd:   sys.FdStderr,
+		},
+	}
+
+	for _, bb := range benches {
+		bc := bb
+
+		b.ReportAllocs()
+		b.Run(bc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				results, err := fn.Call(testCtx, uint64(bc.fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 				if err != nil {
 					b.Fatal(err)
 				}


### PR DESCRIPTION
```bash
$ go test -run='^$' -bench '^Benchmark_fdWrite$' -count=5 > old.txt
$ go test -run='^$' -bench '^Benchmark_fdWrite$' -count=5 > new.txt
$ benchstat old.txt new.txt
name                    old time/op  new time/op  delta
_fdWrite/io.Writer-16    138ns ± 1%   132ns ± 3%  -3.95%  (p=0.008 n=5+5)
_fdWrite/io.Discard-16   137ns ± 6%   139ns ± 4%    ~     (p=0.421 n=5+5)
```