### PR TITLE
wasi: optimize and benchmark fd_read

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -638,12 +638,13 @@ func fdReadOrPread(ctx context.Context, mod api.Module, stack []uint64, isPread 
 	}
 
 	var nread uint32
-	iovsBuf, ok := mod.Memory().Read(ctx, iovs, iovsCount<<3)
+	iovsStop := iovsCount << 3 // iovsCount * 8
+	iovsBuf, ok := mod.Memory().Read(ctx, iovs, iovsStop)
 	if !ok {
 		return 0, ErrnoFault
 	}
 
-	for iovsPos := uint32(0); iovsPos < (iovsCount << 3); iovsPos += 8 {
+	for iovsPos := uint32(0); iovsPos < iovsStop; iovsPos += 8 {
 		offset := le.Uint32(iovsBuf[iovsPos:])
 		l := le.Uint32(iovsBuf[iovsPos+4:])
 
@@ -1113,11 +1114,13 @@ func fdWriteFn(ctx context.Context, mod api.Module, stack []uint64) (uint32, Err
 
 	var err error
 	var nwritten uint32
-	iovsBuf, ok := mod.Memory().Read(ctx, iovs, iovsCount<<3)
+	iovsStop := iovsCount << 3 // iovsCount * 8
+	iovsBuf, ok := mod.Memory().Read(ctx, iovs, iovsStop)
 	if !ok {
 		return 0, ErrnoFault
 	}
-	for iovsPos := uint32(0); iovsPos < (iovsCount << 3); iovsPos += 8 {
+
+	for iovsPos := uint32(0); iovsPos < iovsStop; iovsPos += 8 {
 		offset := le.Uint32(iovsBuf[iovsPos:])
 		l := le.Uint32(iovsBuf[iovsPos+4:])
 


### PR DESCRIPTION
```bash
# before change
$ go test -run='^$' -bench '^Benchmark_fdRead$' -count=5 > old.txt
# after change
$ go test -run='^$' -bench '^Benchmark_fdRead$' -count=5 > new.txt
$ benchstat old.txt new.txt
name             old time/op  new time/op  delta
_fdRead/1x8-16    157ns ± 5%   133ns ± 1%  -15.34%  (p=0.008 n=5+5)
_fdRead/2x16-16   193ns ± 6%   155ns ± 1%  -19.77%  (p=0.008 n=5+5)
```
