### PR TITLE
wasi: benchmarks fd_readdir for both real and fake file systems

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -716,8 +716,13 @@ func fdReaddirFn(ctx context.Context, mod api.Module, stack []uint64) (uint32, E
 	}
 
 	// expect a cookie only if we are continuing a read.
-	if cookie == 0 && dir.CountRead > 0 {
-		return 0, ErrnoInval // invalid as a cookie is minimally one.
+	if cookie == 0 {
+		// TODO: When bufLen < 8 we can't ever pass a cookie > 0 later, as the
+		// first d_next can't be read. It may be assumed in wasi that bufLen is
+		// always >=8 or 24. We may want to fail if below that.
+		if dir.CountRead > 0 {
+			return 0, ErrnoInval // invalid as a cookie is minimally one.
+		}
 	}
 
 	// First, determine the maximum directory entries that can be encoded as

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -159,7 +159,6 @@ func Benchmark_fdReaddir(b *testing.B) {
 	for _, bb := range benches {
 		bc := bb
 
-		b.ReportAllocs()
 		b.Run(bc.name, func(b *testing.B) {
 			r := wazero.NewRuntime(testCtx)
 			defer r.Close(testCtx)
@@ -184,6 +183,7 @@ func Benchmark_fdReaddir(b *testing.B) {
 			defer fsc.CloseFile(testCtx, fd)
 
 			b.ResetTimer()
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -2,7 +2,6 @@ package wasi_snapshot_preview1
 
 import (
 	"embed"
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"io/fs"
 	"os"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
+	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 // configArgsEnviron ensures the result data are the same between args and ENV.


### PR DESCRIPTION
It is likely we'll have to special-case real files in wasi, as wasi-libc makes behavioral choices based on presence of non-zero inode data. This adds a defensive benchmark, so that we know what our performance base case is. This adds both real and fake file systems as both patterns are in use today.

```bash
$ go test -run='^$' -bench '^Benchmark_fdReaddir$'
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_fdReaddir/embed.FS-16         	  457398	      2416 ns/op
Benchmark_fdReaddir/os.DirFS-16         	   45662	     26271 ns/op
PASS
ok  	github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1	35.632s
```

See https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-17 and https://github.com/WebAssembly/wasi-filesystem/issues/65

cc @jerbob92