### PR TITLE
wasi: skips fd allocation on path_filestat_get and backfills benchmarks

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2567,7 +2567,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			maskMemory(t, testCtx, mod, len(tc.expectedMemory))
 			mod.Memory().Write(testCtx, 0, tc.memory)
 
-			requireErrno(t, tc.expectedErrno, mod, pathFilestatGetName, uint64(tc.fd), uint64(0), uint64(1), uint64(tc.pathLen), uint64(tc.resultFilestat))
+			flags := uint32(0)
+			requireErrno(t, tc.expectedErrno, mod, pathFilestatGetName, uint64(tc.fd), uint64(flags), uint64(1), uint64(tc.pathLen), uint64(tc.resultFilestat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(tc.expectedMemory)))

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -133,7 +133,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			mem: []byte{
 				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // userdata
 				eventTypeFdRead, 0x0, 0x0, 0x0,
-				internalsys.FdStdin, 0x0, 0x0, 0x0, // valid readable FD
+				byte(internalsys.FdStdin), 0x0, 0x0, 0x0, // valid readable FD
 				'?', // stopped after encoding
 			},
 			expectedErrno: ErrnoSuccess,


### PR DESCRIPTION
```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_pathFilestat
Benchmark_pathFilestat/embed.FS_fd=root
Benchmark_pathFilestat/embed.FS_fd=root-16         	  410125	      2712 ns/op	     144 B/op	       6 allocs/op
Benchmark_pathFilestat/embed.FS_fd=directory
Benchmark_pathFilestat/embed.FS_fd=directory-16    	  461304	      2717 ns/op	     160 B/op	       8 allocs/op
Benchmark_pathFilestat/os.DirFS_fd=root
Benchmark_pathFilestat/os.DirFS_fd=root-16         	   58639	     21299 ns/op	     408 B/op	       8 allocs/op
Benchmark_pathFilestat/os.DirFS_fd=directory
Benchmark_pathFilestat/os.DirFS_fd=directory-16    	   56630	     21274 ns/op	     456 B/op
```