### PR TITLE
wasi: allows stat on root file descriptor (3)

### DIFF
--- a/experimental/fs.go
+++ b/experimental/fs.go
@@ -9,13 +9,16 @@ import (
 )
 
 // WithFS overrides fs.FS in the context-based manner. Caller needs to take
-// responsibility for closing the filesystem.
+// responsibility for closing the returned api.Closer.
 //
 // Note: This has the same effect as the same function on wazero.ModuleConfig.
-func WithFS(ctx context.Context, fs fs.FS) (context.Context, api.Closer) {
+func WithFS(ctx context.Context, fs fs.FS) (context.Context, api.Closer, error) {
 	if fs == nil {
 		fs = internalfs.EmptyFS
 	}
-	fsCtx := internalfs.NewFSContext(fs)
-	return context.WithValue(ctx, internalfs.FSKey{}, fsCtx), fsCtx
+	if fsCtx, err := internalfs.NewFSContext(fs); err != nil {
+		return nil, nil, err
+	} else {
+		return context.WithValue(ctx, internalfs.FSKey{}, fsCtx), fsCtx, err
+	}
 }

--- a/experimental/fs_example_test.go
+++ b/experimental/fs_example_test.go
@@ -35,9 +35,12 @@ func Example_withFS() {
 		log.Panicln(err)
 	}
 
-	// Setup the filesystem overlay, noting that it can fail if the directory is
-	// invalid and must be closed.
-	ctx, closer := experimental.WithFS(ctx, os.DirFS("."))
+	// Configure the filesystem overlay, noting that it can fail if the
+	// directory is invalid. The closer must be closed.
+	ctx, closer, err := experimental.WithFS(ctx, os.DirFS("."))
+	if err != nil {
+		log.Panicln(err)
+	}
 	defer closer.Close(ctx)
 
 	fdPrestatDirName := mod.ExportedFunction("fd_prestat_dir_name")

--- a/experimental/fs_test.go
+++ b/experimental/fs_test.go
@@ -17,7 +17,8 @@ func TestWithFS(t *testing.T) {
 	mapfs := fstest.MapFS{fileName: &fstest.MapFile{Data: []byte(`animals`)}}
 
 	// Set context to one that has experimental fs config
-	ctx, closer := experimental.WithFS(context.Background(), mapfs)
+	ctx, closer, err := experimental.WithFS(context.Background(), mapfs)
+	require.NoError(t, err)
 	defer closer.Close(ctx)
 
 	v := ctx.Value(sys.FSKey{})
@@ -30,7 +31,8 @@ func TestWithFS(t *testing.T) {
 	require.Equal(t, "/", entry.Path)
 
 	// Override to nil context, ex to block file access
-	ctx, closer = experimental.WithFS(ctx, nil)
+	ctx, closer, err = experimental.WithFS(ctx, nil)
+	require.NoError(t, err)
 	defer closer.Close(ctx)
 
 	v = ctx.Value(sys.FSKey{})

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -173,7 +173,7 @@ func Test_fdFdstatGet(t *testing.T) {
 		},
 		{
 			name: "root",
-			fd:   internalsys.FdStderr + 1,
+			fd:   internalsys.FdRoot,
 			expectedMemory: []byte{
 				3, 0, // fs_filetype
 				0, 0, 0, 0, 0, 0, // fs_flags
@@ -286,7 +286,11 @@ func Test_fdFdstatSetRights(t *testing.T) {
 
 func Test_fdFilestatGet(t *testing.T) {
 	file, dir := "a", "b"
-	testFS := fstest.MapFS{file: {Data: make([]byte, 10), ModTime: time.Unix(1667482413, 0)}, dir: {Mode: fs.ModeDir, ModTime: time.Unix(1667482413, 0)}}
+	testFS := fstest.MapFS{
+		".":  {Mode: 0o755 | fs.ModeDir, ModTime: time.Unix(0, 0)},
+		file: {Data: make([]byte, 10), ModTime: time.Unix(1667482413, 0)},
+		dir:  {Mode: fs.ModeDir, ModTime: time.Unix(1667482413, 0)},
+	}
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	defer r.Close(testCtx)
@@ -370,7 +374,7 @@ func Test_fdFilestatGet(t *testing.T) {
 		},
 		{
 			name: "root",
-			fd:   internalsys.FdStderr + 1,
+			fd:   internalsys.FdRoot,
 			expectedMemory: []byte{
 				0, 0, 0, 0, 0, 0, 0, 0, // dev
 				0, 0, 0, 0, 0, 0, 0, 0, // ino

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -224,9 +224,9 @@ func NewContext(
 	}
 
 	if fs != nil {
-		sysCtx.fsc = NewFSContext(fs)
+		sysCtx.fsc, err = NewFSContext(fs)
 	} else {
-		sysCtx.fsc = NewFSContext(EmptyFS)
+		sysCtx.fsc, err = NewFSContext(EmptyFS)
 	}
 
 	return

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -16,11 +16,16 @@ import (
 func TestContext_FS(t *testing.T) {
 	sysCtx := DefaultContext(testfs.FS{})
 
-	require.Equal(t, NewFSContext(testfs.FS{}), sysCtx.FS(testCtx))
+	fsc1, err := NewFSContext(testfs.FS{})
+	require.NoError(t, err)
+
+	require.Equal(t, fsc1, sysCtx.FS(testCtx))
+
+	fsc2, err := NewFSContext(testfs.FS{"foo": &testfs.File{}})
+	require.NoError(t, err)
 
 	// can override to something else
-	fsc := NewFSContext(testfs.FS{"foo": &testfs.File{}})
-	require.Equal(t, fsc, sysCtx.FS(context.WithValue(testCtx, FSKey{}, fsc)))
+	require.Equal(t, fsc2, sysCtx.FS(context.WithValue(testCtx, FSKey{}, fsc2)))
 }
 
 func TestDefaultSysContext(t *testing.T) {
@@ -55,7 +60,8 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, sys.ClockResolution(1), sysCtx.NanotimeResolution())
 	require.Equal(t, &ns, sysCtx.nanosleep)
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
-	require.Equal(t, NewFSContext(testfs.FS{}), sysCtx.FS(testCtx))
+	expectedFS, _ := NewFSContext(testfs.FS{})
+	require.Equal(t, expectedFS, sysCtx.FS(testCtx))
 }
 
 func TestNewContext_Args(t *testing.T) {


### PR DESCRIPTION
Before, we didn't allow a real stat on the root file descriptor. Now, those that pass fs.ReadDirFS will return the stat of the root file (which is implemented by a open against ".").

This also simplifies logic as we always have a file representing root, even if faked.
