### PR TITLE
wasi: ensure someone can tell if root is a real file

### DIFF
--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -48,7 +48,7 @@ var (
 	testCtx context.Context
 	testFS  = fstest.MapFS{
 		"empty.txt":    {},
-		"test.txt":     {Data: []byte("animals")},
+		"test.txt":     {Data: []byte("animals\n")},
 		"sub":          {Mode: fs.ModeDir},
 		"sub/test.txt": {Data: []byte("greet sub dir\n")},
 	}

--- a/internal/gojs/fs_test.go
+++ b/internal/gojs/fs_test.go
@@ -20,6 +20,7 @@ Not a directory
 /test.txt ok
 test.txt ok
 contents: animals
+
 empty: 
 `, stdout)
 }

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -2,8 +2,12 @@ package sys
 
 import (
 	"context"
+	"embed"
 	"errors"
+	"io/fs"
+	"os"
 	"testing"
+	"testing/fstest"
 
 	testfs "github.com/tetratelabs/wazero/internal/testing/fs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -11,6 +15,64 @@ import (
 
 // testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
 var testCtx = context.WithValue(context.Background(), struct{}{}, "arbitrary")
+
+//go:embed testdata
+var testdata embed.FS
+
+var testFS = fstest.MapFS{
+	"empty.txt":    {},
+	"test.txt":     {Data: []byte("animals\n")},
+	"sub":          {Mode: fs.ModeDir},
+	"sub/test.txt": {Data: []byte("greet sub dir\n")},
+}
+
+func TestNewFSContext(t *testing.T) {
+	embedFS, err := fs.Sub(testdata, "testdata")
+	require.NoError(t, err)
+
+	// Test various usual configuration for the file system.
+	tests := []struct {
+		name         string
+		fs           fs.FS
+		expectOsFile bool
+	}{
+		{
+			name: "embed.FS",
+			fs:   embedFS,
+		},
+		{
+			name:         "os.DirFS",
+			fs:           os.DirFS("testdata"),
+			expectOsFile: true,
+		},
+		{
+			name: "fstest.MapFS",
+			fs:   testFS,
+		},
+		{
+			name: "fstest.MapFS",
+			fs:   testFS,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(b *testing.T) {
+			fsc, err := NewFSContext(tc.fs)
+			require.NoError(t, err)
+			defer fsc.Close(testCtx)
+
+			require.Equal(t, tc.fs, fsc.fs)
+			require.Equal(t, "/", fsc.openedFiles[FdRoot].Path)
+			rootFile := fsc.openedFiles[FdRoot].File
+			require.NotNil(t, rootFile)
+
+			_, osFile := rootFile.(*os.File)
+			require.Equal(t, tc.expectOsFile, osFile)
+		})
+	}
+}
 
 func TestEmptyFS(t *testing.T) {
 	testFS := EmptyFS

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -41,8 +41,10 @@ func TestNewFSContext(t *testing.T) {
 			fs:   embedFS,
 		},
 		{
-			name:         "os.DirFS",
-			fs:           os.DirFS("testdata"),
+			name: "os.DirFS",
+			// Don't use "testdata" because it may not be present in
+			// cross-architecture (a.k.a. scratch) build containers.
+			fs:           os.DirFS("."),
 			expectOsFile: true,
 		},
 		{

--- a/internal/sys/testdata/sub/test.txt
+++ b/internal/sys/testdata/sub/test.txt
@@ -1,0 +1,1 @@
+greet sub dir

--- a/internal/sys/testdata/test.txt
+++ b/internal/sys/testdata/test.txt
@@ -1,0 +1,1 @@
+animals


### PR DESCRIPTION
`os.DirFS` ironically doesn't implement `fs.ReadDirFS`, so we cannot open a directory this way. This blindly attempts to open "." regardless of if the `fs.FS` implementation is a `fs.ReadDirFS` or not, and if successful, enforces that the file returned is a directory. If not, a fake directory is returned.

Doing so allows real stat to be returned for root, and also a chance to know if a filesystem configured is real or not. Later, we'll need this to implement open flags.