### PR TITLE
Removes context parameter from instruction-scoped operations

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -117,6 +117,17 @@ Besides security, this practice prevents other bugs and allows centralization of
 
 ## API Design
 
+### Why is `context.Context` inconsistent?
+
+It may seem strange that only certain API have an initial `context.Context`
+parameter. We originally had a `context.Context` for anything that might be
+traced, but it turned out to be only useful for lifecycle and host functions.
+
+For instruction-scoped aspects like memory updates, a context parameter is too
+fine-grained and also invisible in practice. For example, most users will use
+the compiler engine, and its memory, global or table access will never use go's
+context.
+
 ### Why does `api.ValueType` map to uint64?
 
 WebAssembly allows functions to be defined either by the guest or the host,

--- a/examples/allocation/rust/greet.go
+++ b/examples/allocation/rust/greet.go
@@ -67,9 +67,9 @@ func main() {
 	defer deallocate.Call(ctx, namePtr, nameSize)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
+	if !mod.Memory().Write(uint32(namePtr), []byte(name)) {
 		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-			namePtr, nameSize, mod.Memory().Size(ctx))
+			namePtr, nameSize, mod.Memory().Size())
 	}
 
 	// Now, we can call "greet", which reads the string we wrote to memory!
@@ -91,16 +91,16 @@ func main() {
 	defer deallocate.Call(ctx, uint64(greetingPtr), uint64(greetingSize))
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if bytes, ok := mod.Memory().Read(ctx, greetingPtr, greetingSize); !ok {
+	if bytes, ok := mod.Memory().Read(greetingPtr, greetingSize); !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range of memory size %d",
-			greetingPtr, greetingSize, mod.Memory().Size(ctx))
+			greetingPtr, greetingSize, mod.Memory().Size())
 	} else {
 		fmt.Println("go >>", string(bytes))
 	}
 }
 
 func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}

--- a/examples/allocation/tinygo/greet.go
+++ b/examples/allocation/tinygo/greet.go
@@ -73,9 +73,9 @@ func main() {
 	defer free.Call(ctx, namePtr)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
+	if !mod.Memory().Write(uint32(namePtr), []byte(name)) {
 		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-			namePtr, nameSize, mod.Memory().Size(ctx))
+			namePtr, nameSize, mod.Memory().Size())
 	}
 
 	// Now, we can call "greet", which reads the string we wrote to memory!
@@ -94,16 +94,16 @@ func main() {
 	greetingPtr := uint32(ptrSize[0] >> 32)
 	greetingSize := uint32(ptrSize[0])
 	// The pointer is a linear memory offset, which is where we write the name.
-	if bytes, ok := mod.Memory().Read(ctx, greetingPtr, greetingSize); !ok {
+	if bytes, ok := mod.Memory().Read(greetingPtr, greetingSize); !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range of memory size %d",
-			greetingPtr, greetingSize, mod.Memory().Size(ctx))
+			greetingPtr, greetingSize, mod.Memory().Size())
 	} else {
 		fmt.Println("go >>", string(bytes))
 	}
 }
 
-func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+func logString(_ context.Context, m api.Module, offset, byteCount uint32) {
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}

--- a/examples/allocation/zig/greet.go
+++ b/examples/allocation/zig/greet.go
@@ -81,9 +81,9 @@ func run() error {
 	defer free.Call(ctx, namePtr, nameSize)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !mod.Memory().Write(ctx, uint32(namePtr), []byte(name)) {
+	if !mod.Memory().Write(uint32(namePtr), []byte(name)) {
 		return fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d",
-			namePtr, nameSize, mod.Memory().Size(ctx))
+			namePtr, nameSize, mod.Memory().Size())
 	}
 
 	// Now, we can call "greet", which reads the string we wrote to memory!
@@ -102,9 +102,9 @@ func run() error {
 	greetingPtr := uint32(ptrSize[0] >> 32)
 	greetingSize := uint32(ptrSize[0])
 	// The pointer is a linear memory offset, which is where we write the name.
-	if bytes, ok := mod.Memory().Read(ctx, greetingPtr, greetingSize); !ok {
+	if bytes, ok := mod.Memory().Read(greetingPtr, greetingSize); !ok {
 		return fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			greetingPtr, greetingSize, mod.Memory().Size(ctx))
+			greetingPtr, greetingSize, mod.Memory().Size())
 	} else {
 		fmt.Println("go >>", string(bytes))
 	}
@@ -112,8 +112,8 @@ func run() error {
 	return nil
 }
 
-func logString(ctx context.Context, m api.Module, offset, byteCount uint32) {
-	buf, ok := m.Memory().Read(ctx, offset, byteCount)
+func logString(_ context.Context, m api.Module, offset, byteCount uint32) {
+	buf, ok := m.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("Memory.Read(%d, %d) out of range", offset, byteCount)
 	}

--- a/imports/go/gojs.go
+++ b/imports/go/gojs.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, r wazero.Runtime, compiled wazero.CompiledModule, 
 
 	// Extract the args and env from the module config and write it to memory.
 	ctx = WithState(ctx)
-	argc, argv, err := WriteArgsAndEnviron(ctx, mod)
+	argc, argv, err := WriteArgsAndEnviron(mod)
 	if err != nil {
 		return err
 	}

--- a/imports/wasi_snapshot_preview1/args.go
+++ b/imports/wasi_snapshot_preview1/args.go
@@ -49,7 +49,7 @@ var argsGet = newHostFunc(argsGetName, argsGetFn, []api.ValueType{i32, i32}, "ar
 func argsGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	argv, argvBuf := uint32(params[0]), uint32(params[1])
-	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Args(), argv, argvBuf, sysCtx.ArgsSize())
+	return writeOffsetsAndNullTerminatedValues(mod.Memory(), sysCtx.Args(), argv, argvBuf, sysCtx.ArgsSize())
 }
 
 // argsSizesGet is the WASI function named argsSizesGetName that reads

--- a/imports/wasi_snapshot_preview1/args_test.go
+++ b/imports/wasi_snapshot_preview1/args_test.go
@@ -22,7 +22,7 @@ func Test_argsGet(t *testing.T) {
 		'?', // stopped after encoding
 	}
 
-	maskMemory(t, testCtx, mod, len(expectedMemory)+int(argvBuf))
+	maskMemory(t, mod, len(expectedMemory)+int(argvBuf))
 
 	// Invoke argsGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, argsGetName, uint64(argv), uint64(argvBuf))
@@ -33,7 +33,7 @@ func Test_argsGet(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, argvBuf-1, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(argvBuf-1, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -42,7 +42,7 @@ func Test_argsGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithArgs("a", "bc"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 	validAddress := uint32(0) // arbitrary
 
 	tests := []struct {
@@ -124,7 +124,7 @@ func Test_argsSizesGet(t *testing.T) {
 		'?', // stopped after encoding
 	}
 
-	maskMemory(t, testCtx, mod, int(resultArgc)+len(expectedMemory))
+	maskMemory(t, mod, int(resultArgc)+len(expectedMemory))
 
 	// Invoke argsSizesGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, argsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
@@ -137,7 +137,7 @@ func Test_argsSizesGet(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, resultArgc-1, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(resultArgc-1, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -146,7 +146,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithArgs("a", "bc"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 	validAddress := uint32(0) // arbitrary valid address as arguments to args_sizes_get. We chose 0 here.
 
 	tests := []struct {

--- a/imports/wasi_snapshot_preview1/clock.go
+++ b/imports/wasi_snapshot_preview1/clock.go
@@ -116,7 +116,7 @@ var clockTimeGet = proxyResultParams(&wasm.HostFunc{
 	Code:        &wasm.Code{IsHostFunction: true, GoFunc: i64ResultParam(clockTimeGetFn)},
 }, clockTimeGetName)
 
-func clockTimeGetFn(ctx context.Context, mod api.Module, stack []uint64) (timestamp int64, errno Errno) {
+func clockTimeGetFn(_ context.Context, mod api.Module, stack []uint64) (timestamp int64, errno Errno) {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	id := uint32(stack[0])
 	// TODO: precision is currently ignored.
@@ -124,10 +124,10 @@ func clockTimeGetFn(ctx context.Context, mod api.Module, stack []uint64) (timest
 
 	switch id {
 	case clockIDRealtime:
-		sec, nsec := sysCtx.Walltime(ctx)
+		sec, nsec := sysCtx.Walltime()
 		timestamp = (sec * time.Second.Nanoseconds()) + int64(nsec)
 	case clockIDMonotonic:
-		timestamp = sysCtx.Nanotime(ctx)
+		timestamp = sysCtx.Nanotime()
 	default:
 		return 0, ErrnoInval
 	}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -65,12 +65,12 @@ func Test_clockResGet(t *testing.T) {
 			defer log.Reset()
 
 			resultResolution := 16 // arbitrary offset
-			maskMemory(t, testCtx, mod, resultResolution+len(tc.expectedMemory))
+			maskMemory(t, mod, resultResolution+len(tc.expectedMemory))
 
 			requireErrno(t, ErrnoSuccess, mod, clockResGetName, uint64(tc.clockID), uint64(resultResolution))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, uint32(resultResolution-1), uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(uint32(resultResolution-1), uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 		})
@@ -193,12 +193,12 @@ func Test_clockTimeGet(t *testing.T) {
 			defer log.Reset()
 
 			resultTimestamp := 16 // arbitrary offset
-			maskMemory(t, testCtx, mod, resultTimestamp+len(tc.expectedMemory))
+			maskMemory(t, mod, resultTimestamp+len(tc.expectedMemory))
 
 			requireErrno(t, ErrnoSuccess, mod, clockTimeGetName, uint64(tc.clockID), 0 /* TODO: precision */, uint64(resultTimestamp))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, uint32(resultTimestamp-1), uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(uint32(resultTimestamp-1), uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 		})
@@ -273,7 +273,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig())
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 
 	tests := []struct {
 		name                     string

--- a/imports/wasi_snapshot_preview1/environ.go
+++ b/imports/wasi_snapshot_preview1/environ.go
@@ -46,11 +46,11 @@ const (
 // See https://en.wikipedia.org/wiki/Null-terminated_string
 var environGet = newHostFunc(environGetName, environGetFn, []api.ValueType{i32, i32}, "environ", "environ_buf")
 
-func environGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
+func environGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	environ, environBuf := uint32(params[0]), uint32(params[1])
 
-	return writeOffsetsAndNullTerminatedValues(ctx, mod.Memory(), sysCtx.Environ(), environ, environBuf, sysCtx.EnvironSize())
+	return writeOffsetsAndNullTerminatedValues(mod.Memory(), sysCtx.Environ(), environ, environBuf, sysCtx.EnvironSize())
 }
 
 // environSizesGet is the WASI function named environSizesGetName that

--- a/imports/wasi_snapshot_preview1/environ_test.go
+++ b/imports/wasi_snapshot_preview1/environ_test.go
@@ -24,7 +24,7 @@ func Test_environGet(t *testing.T) {
 		'?', // stopped after encoding
 	}
 
-	maskMemory(t, testCtx, mod, len(expectedMemory)+int(resultEnvironBuf))
+	maskMemory(t, mod, len(expectedMemory)+int(resultEnvironBuf))
 
 	// Invoke environGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, environGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
@@ -35,7 +35,7 @@ func Test_environGet(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, resultEnvironBuf-1, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(resultEnvironBuf-1, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -45,7 +45,7 @@ func Test_environGet_Errors(t *testing.T) {
 		WithEnv("a", "bc").WithEnv("b", "cd"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 	validAddress := uint32(0) // arbitrary valid address as arguments to environ_get. We chose 0 here.
 
 	tests := []struct {
@@ -128,7 +128,7 @@ func Test_environSizesGet(t *testing.T) {
 		'?', // stopped after encoding
 	}
 
-	maskMemory(t, testCtx, mod, len(expectedMemory)+int(resultEnvironc))
+	maskMemory(t, mod, len(expectedMemory)+int(resultEnvironc))
 
 	// Invoke environSizesGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, environSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
@@ -141,7 +141,7 @@ func Test_environSizesGet(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, resultEnvironc-1, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(resultEnvironc-1, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -151,7 +151,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 		WithEnv("a", "b").WithEnv("b", "cd"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 	validAddress := uint32(0) // arbitrary
 
 	tests := []struct {

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -105,7 +105,7 @@ func Test_fdFdstatGet(t *testing.T) {
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	defer r.Close(testCtx)
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 
 	// open both paths without using WASI
 	fsc := mod.(*wasm.CallContext).Sys.FS()
@@ -250,12 +250,12 @@ func Test_fdFdstatGet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			maskMemory(t, testCtx, mod, len(tc.expectedMemory))
+			maskMemory(t, mod, len(tc.expectedMemory))
 
 			requireErrno(t, tc.expectedErrno, mod, fdFdstatGetName, uint64(tc.fd), uint64(tc.resultFdstat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 		})
@@ -294,7 +294,7 @@ func Test_fdFilestatGet(t *testing.T) {
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	defer r.Close(testCtx)
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 
 	// open both paths without using WASI
 	fsc := mod.(*wasm.CallContext).Sys.FS()
@@ -463,12 +463,12 @@ func Test_fdFilestatGet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			maskMemory(t, testCtx, mod, len(tc.expectedMemory))
+			maskMemory(t, mod, len(tc.expectedMemory))
 
 			requireErrno(t, tc.expectedErrno, mod, fdFilestatGetName, uint64(tc.fd), uint64(tc.resultFilestat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 		})
@@ -567,15 +567,15 @@ func Test_fdPread(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			maskMemory(t, testCtx, mod, len(tc.expectedMemory))
+			maskMemory(t, mod, len(tc.expectedMemory))
 
-			ok := mod.Memory().Write(testCtx, 0, initialMemory)
+			ok := mod.Memory().Write(0, initialMemory)
 			require.True(t, ok)
 
 			requireErrno(t, ErrnoSuccess, mod, fdPreadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(tc.offset), uint64(resultNread))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 		})
@@ -719,7 +719,7 @@ func Test_fdPread_Errors(t *testing.T) {
 
 			offset := uint32(wasm.MemoryPagesToBytesNum(testMemoryPageSize) - uint64(len(tc.memory)))
 
-			memoryWriteOK := mod.Memory().Write(testCtx, offset, tc.memory)
+			memoryWriteOK := mod.Memory().Write(offset, tc.memory)
 			require.True(t, memoryWriteOK)
 
 			requireErrno(t, tc.expectedErrno, mod, fdPreadName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount+offset), uint64(tc.offset), uint64(tc.resultNread+offset))
@@ -743,7 +743,7 @@ func Test_fdPrestatGet(t *testing.T) {
 		'?',
 	}
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
+	maskMemory(t, mod, len(expectedMemory))
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatGetName, uint64(fd), uint64(resultPrestat))
 	require.Equal(t, `
@@ -755,7 +755,7 @@ func Test_fdPrestatGet(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -765,7 +765,7 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 	defer r.Close(testCtx)
 	fd := internalsys.FdRoot // only pre-opened directory currently supported.
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 	tests := []struct {
 		name          string
 		fd            uint32
@@ -825,7 +825,7 @@ func Test_fdPrestatDirName(t *testing.T) {
 		'?', '?', '?', '?',
 	}
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
+	maskMemory(t, mod, len(expectedMemory))
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatDirNameName, uint64(fd), uint64(path), uint64(pathLen))
 	require.Equal(t, `
@@ -835,7 +835,7 @@ func Test_fdPrestatDirName(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -845,7 +845,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 	defer r.Close(testCtx)
 	fd := internalsys.FdRoot // only pre-opened directory currently supported.
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 	validAddress := uint32(0) // Arbitrary valid address as arguments to fd_prestat_dir_name. We chose 0 here.
 	pathLen := uint32(len("/"))
 
@@ -960,9 +960,9 @@ func Test_fdRead(t *testing.T) {
 		'?',
 	)
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
+	maskMemory(t, mod, len(expectedMemory))
 
-	ok := mod.Memory().Write(testCtx, 0, initialMemory)
+	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
 	requireErrno(t, ErrnoSuccess, mod, fdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
@@ -975,7 +975,7 @@ func Test_fdRead(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -1103,7 +1103,7 @@ func Test_fdRead_Errors(t *testing.T) {
 
 			offset := uint32(wasm.MemoryPagesToBytesNum(testMemoryPageSize) - uint64(len(tc.memory)))
 
-			memoryWriteOK := mod.Memory().Write(testCtx, offset, tc.memory)
+			memoryWriteOK := mod.Memory().Write(offset, tc.memory)
 			require.True(t, memoryWriteOK)
 
 			requireErrno(t, tc.expectedErrno, mod, fdReadName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount+offset), uint64(tc.resultNread+offset))
@@ -1489,7 +1489,7 @@ func Test_fdReaddir(t *testing.T) {
 			file.File = dir.File
 			file.ReadDir = dir.ReadDir
 
-			maskMemory(t, testCtx, mod, int(tc.bufLen))
+			maskMemory(t, mod, int(tc.bufLen))
 
 			resultBufused := uint32(0) // where to write the amount used out of bufLen
 			buf := uint32(8)           // where to start the dirents
@@ -1497,11 +1497,11 @@ func Test_fdReaddir(t *testing.T) {
 				uint64(fd), uint64(buf), uint64(tc.bufLen), uint64(tc.cookie), uint64(resultBufused))
 
 			// read back the bufused and compare memory against it
-			bufUsed, ok := mod.Memory().ReadUint32Le(testCtx, resultBufused)
+			bufUsed, ok := mod.Memory().ReadUint32Le(resultBufused)
 			require.True(t, ok)
 			require.Equal(t, tc.expectedBufused, bufUsed)
 
-			mem, ok := mod.Memory().Read(testCtx, buf, bufUsed)
+			mem, ok := mod.Memory().Read(buf, bufUsed)
 			require.True(t, ok)
 
 			if tc.expectedMem != nil {
@@ -1519,7 +1519,7 @@ func Test_fdReaddir(t *testing.T) {
 func Test_fdReaddir_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fdReadDirFs))
 	defer r.Close(testCtx)
-	memLen := mod.Memory().Size(testCtx)
+	memLen := mod.Memory().Size()
 
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
@@ -2013,7 +2013,7 @@ func Test_fdSeek(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			maskMemory(t, testCtx, mod, len(tc.expectedMemory))
+			maskMemory(t, mod, len(tc.expectedMemory))
 
 			// Since we initialized this file, we know it is a seeker (because it is a MapFile)
 			fsc := mod.(*wasm.CallContext).Sys.FS()
@@ -2029,7 +2029,7 @@ func Test_fdSeek(t *testing.T) {
 			requireErrno(t, ErrnoSuccess, mod, fdSeekName, uint64(fd), uint64(tc.offset), uint64(tc.whence), uint64(resultNewoffset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 
@@ -2044,7 +2044,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 	mod, fd, log, r := requireOpenFile(t, "/test_path", []byte("wazero"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 
 	tests := []struct {
 		name                    string
@@ -2155,8 +2155,8 @@ func Test_fdWrite(t *testing.T) {
 		'?',
 	)
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
-	ok := mod.Memory().Write(testCtx, 0, initialMemory)
+	maskMemory(t, mod, len(expectedMemory))
+	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
 	requireErrno(t, ErrnoSuccess, mod, fdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
@@ -2169,7 +2169,7 @@ func Test_fdWrite(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 
@@ -2209,8 +2209,8 @@ func Test_fdWrite_discard(t *testing.T) {
 		'?',
 	)
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
-	ok := mod.Memory().Write(testCtx, 0, initialMemory)
+	maskMemory(t, mod, len(expectedMemory))
+	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
 	fd := 1 // stdout
@@ -2224,7 +2224,7 @@ func Test_fdWrite_discard(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -2237,7 +2237,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 
 	// Setup valid test memory
 	iovsCount := uint32(1)
-	memSize := mod.Memory().Size(testCtx)
+	memSize := mod.Memory().Size()
 
 	tests := []struct {
 		name                     string
@@ -2333,7 +2333,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			mod.Memory().Write(testCtx, tc.iovs, append(
+			mod.Memory().Write(tc.iovs, append(
 				leb128.EncodeUint32(tc.iovs+8), // = iovs[0].offset (where the data "hi" begins)
 				// = iovs[0].length (how many bytes are in "hi")
 				2, 0, 0, 0,
@@ -2372,7 +2372,7 @@ func Test_pathFilestatGet(t *testing.T) {
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	defer r.Close(testCtx)
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 
 	// open both paths without using WASI
 	fsc := mod.(*wasm.CallContext).Sys.FS()
@@ -2566,14 +2566,14 @@ func Test_pathFilestatGet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			maskMemory(t, testCtx, mod, len(tc.expectedMemory))
-			mod.Memory().Write(testCtx, 0, tc.memory)
+			maskMemory(t, mod, len(tc.expectedMemory))
+			mod.Memory().Write(0, tc.memory)
 
 			flags := uint32(0)
 			requireErrno(t, tc.expectedErrno, mod, pathFilestatGetName, uint64(tc.fd), uint64(flags), uint64(1), uint64(tc.pathLen), uint64(tc.resultFilestat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(tc.expectedMemory)))
+			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMemory, actual)
 		})
@@ -2629,8 +2629,8 @@ func Test_pathOpen(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	defer r.Close(testCtx)
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
-	ok := mod.Memory().Write(testCtx, 0, initialMemory)
+	maskMemory(t, mod, len(expectedMemory))
+	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
 	requireErrno(t, ErrnoSuccess, mod, pathOpenName, uint64(rootFD), uint64(dirflags), uint64(path),
@@ -2644,7 +2644,7 @@ func Test_pathOpen(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, uint32(len(expectedMemory)))
+	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 
@@ -2691,7 +2691,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 		{
 			name:          "out-of-memory reading path",
 			fd:            validFD,
-			path:          mod.Memory().Size(testCtx),
+			path:          mod.Memory().Size(),
 			pathLen:       validPathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
@@ -2723,7 +2723,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			name:          "out-of-memory reading pathLen",
 			fd:            validFD,
 			path:          validPath,
-			pathLen:       mod.Memory().Size(testCtx) + 1, // path is in the valid memory range, but pathLen is out-of-memory for path
+			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is out-of-memory for path
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 --> proxy.path_open(fd=3,dirflags=0,path=0,path_len=65537,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
@@ -2756,7 +2756,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:       dirName,
 			path:           validPath,
 			pathLen:        validPathLen,
-			resultOpenedFd: mod.Memory().Size(testCtx), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
+			resultOpenedFd: mod.Memory().Size(), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
 --> proxy.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=65536)
@@ -2789,7 +2789,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			mod.Memory().Write(testCtx, validPath, []byte(tc.pathName))
+			mod.Memory().Write(validPath, []byte(tc.pathName))
 
 			requireErrno(t, tc.expectedErrno, mod, pathOpenName, uint64(tc.fd), uint64(0), uint64(tc.path),
 				uint64(tc.pathLen), uint64(tc.oflags), 0, 0, 0, uint64(tc.resultOpenedFd))

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -35,8 +35,8 @@ func Test_pollOneoff(t *testing.T) {
 	nsubscriptions := uint32(1)
 	resultNevents := uint32(512) // past out
 
-	maskMemory(t, testCtx, mod, 1024)
-	mod.Memory().Write(testCtx, in, mem)
+	maskMemory(t, mod, 1024)
+	mod.Memory().Write(in, mem)
 
 	requireErrno(t, ErrnoSuccess, mod, pollOneoffName, uint64(in), uint64(out), uint64(nsubscriptions),
 		uint64(resultNevents))
@@ -49,11 +49,11 @@ func Test_pollOneoff(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	outMem, ok := mod.Memory().Read(testCtx, out, uint32(len(expectedMem)))
+	outMem, ok := mod.Memory().Read(out, uint32(len(expectedMem)))
 	require.True(t, ok)
 	require.Equal(t, expectedMem, outMem)
 
-	nevents, ok := mod.Memory().ReadUint32Le(testCtx, resultNevents)
+	nevents, ok := mod.Memory().ReadUint32Le(resultNevents)
 	require.True(t, ok)
 	require.Equal(t, nsubscriptions, nevents)
 }
@@ -161,23 +161,23 @@ func Test_pollOneoff_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			maskMemory(t, testCtx, mod, 1024)
+			maskMemory(t, mod, 1024)
 
 			if tc.mem != nil {
-				mod.Memory().Write(testCtx, tc.in, tc.mem)
+				mod.Memory().Write(tc.in, tc.mem)
 			}
 
 			requireErrno(t, tc.expectedErrno, mod, pollOneoffName, uint64(tc.in), uint64(tc.out),
 				uint64(tc.nsubscriptions), uint64(tc.resultNevents))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			out, ok := mod.Memory().Read(testCtx, tc.out, uint32(len(tc.expectedMem)))
+			out, ok := mod.Memory().Read(tc.out, uint32(len(tc.expectedMem)))
 			require.True(t, ok)
 			require.Equal(t, tc.expectedMem, out)
 
 			// Events should be written on success regardless of nested failure.
 			if tc.expectedErrno == ErrnoSuccess {
-				nevents, ok := mod.Memory().ReadUint32Le(testCtx, tc.resultNevents)
+				nevents, ok := mod.Memory().ReadUint32Le(tc.resultNevents)
 				require.True(t, ok)
 				require.Equal(t, uint32(1), nevents)
 			}

--- a/imports/wasi_snapshot_preview1/random.go
+++ b/imports/wasi_snapshot_preview1/random.go
@@ -41,7 +41,7 @@ func randomGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
 	randSource := sysCtx.RandSource()
 	buf, bufLen := uint32(params[0]), uint32(params[1])
 
-	randomBytes, ok := mod.Memory().Read(ctx, buf, bufLen)
+	randomBytes, ok := mod.Memory().Read(buf, bufLen)
 	if !ok { // out-of-range
 		return ErrnoFault
 	}

--- a/imports/wasi_snapshot_preview1/random_test.go
+++ b/imports/wasi_snapshot_preview1/random_test.go
@@ -24,7 +24,7 @@ func Test_randomGet(t *testing.T) {
 	length := uint32(5) // arbitrary length,
 	offset := uint32(1) // offset,
 
-	maskMemory(t, testCtx, mod, len(expectedMemory))
+	maskMemory(t, mod, len(expectedMemory))
 
 	// Invoke randomGet and check the memory side effects!
 	requireErrno(t, ErrnoSuccess, mod, randomGetName, uint64(offset), uint64(length))
@@ -35,7 +35,7 @@ func Test_randomGet(t *testing.T) {
 <-- 0
 `, "\n"+log.String())
 
-	actual, ok := mod.Memory().Read(testCtx, 0, offset+length+1)
+	actual, ok := mod.Memory().Read(0, offset+length+1)
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
 }
@@ -44,7 +44,7 @@ func Test_randomGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig())
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size(testCtx)
+	memorySize := mod.Memory().Size()
 
 	tests := []struct {
 		name           string

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -221,16 +221,16 @@ func exportFunctions(builder wazero.HostModuleBuilder) {
 // writeOffsetsAndNullTerminatedValues is used to write NUL-terminated values
 // for args or environ, given a pre-defined bytesLen (which includes NUL
 // terminators).
-func writeOffsetsAndNullTerminatedValues(ctx context.Context, mem api.Memory, values [][]byte, offsets, bytes, bytesLen uint32) Errno {
+func writeOffsetsAndNullTerminatedValues(mem api.Memory, values [][]byte, offsets, bytes, bytesLen uint32) Errno {
 	// The caller may not place bytes directly after offsets, so we have to
 	// read them independently.
 	valuesLen := len(values)
 	offsetsLen := uint32(valuesLen * 4) // uint32Le
-	offsetsBuf, ok := mem.Read(ctx, offsets, offsetsLen)
+	offsetsBuf, ok := mem.Read(offsets, offsetsLen)
 	if !ok {
 		return ErrnoFault
 	}
-	bytesBuf, ok := mem.Read(ctx, bytes, bytesLen)
+	bytesBuf, ok := mem.Read(bytes, bytesLen)
 	if !ok {
 		return ErrnoFault
 	}

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -71,7 +71,7 @@ func Benchmark_fdRead(b *testing.B) {
 	}
 	fn := mod.ExportedFunction(fdReadName)
 
-	mod.Memory().Write(testCtx, 0, []byte{
+	mod.Memory().Write(0, []byte{
 		32, 0, 0, 0, // = iovs[0].offset
 		8, 0, 0, 0, // = iovs[0].length
 		40, 0, 0, 0, // = iovs[1].offset
@@ -297,7 +297,7 @@ func Benchmark_pathFilestat(b *testing.B) {
 				pathLen := len(bc.path)
 				resultFilestat := 1024 // where to write the stat
 
-				if !mod.Memory().WriteString(testCtx, path, bc.path) {
+				if !mod.Memory().WriteString(path, bc.path) {
 					b.Fatal("could not write path")
 				}
 
@@ -341,7 +341,7 @@ func Benchmark_fdWrite(b *testing.B) {
 	fn := mod.ExportedFunction(fdWriteName)
 
 	iovs := uint32(1) // arbitrary offset
-	mod.Memory().Write(testCtx, 0, []byte{
+	mod.Memory().Write(0, []byte{
 		'?',         // `iovs` is after this
 		18, 0, 0, 0, // = iovs[0].offset
 		4, 0, 0, 0, // = iovs[0].length

--- a/imports/wasi_snapshot_preview1/wasi_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_test.go
@@ -75,9 +75,9 @@ func TestNewFunctionExporter(t *testing.T) {
 }
 
 // maskMemory sets the first memory in the store to '?' * size, so tests can see what's written.
-func maskMemory(t *testing.T, ctx context.Context, mod api.Module, size int) {
+func maskMemory(t *testing.T, mod api.Module, size int) {
 	for i := uint32(0); i < uint32(size); i++ {
-		require.True(t, mod.Memory().WriteByte(ctx, i, '?'))
+		require.True(t, mod.Memory().WriteByte(i, '?'))
 	}
 }
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -921,11 +921,11 @@ entry:
 			caller := ce.moduleContext.fn
 			switch ce.exitContext.builtinFunctionCallIndex {
 			case builtinFunctionIndexMemoryGrow:
-				ce.builtinFunctionMemoryGrow(ce.ctx, caller.source.Module.Memory)
+				ce.builtinFunctionMemoryGrow(caller.source.Module.Memory)
 			case builtinFunctionIndexGrowStack:
 				ce.builtinFunctionGrowStack(caller.stackPointerCeil)
 			case builtinFunctionIndexTableGrow:
-				ce.builtinFunctionTableGrow(ce.ctx, caller.source.Module.Tables)
+				ce.builtinFunctionTableGrow(caller.source.Module.Tables)
 			case builtinFunctionIndexFunctionListenerBefore:
 				ce.builtinFunctionFunctionListenerBefore(ce.ctx, caller)
 			case builtinFunctionIndexFunctionListenerAfter:
@@ -970,10 +970,10 @@ func (ce *callEngine) builtinFunctionGrowStack(stackPointerCeil uint64) {
 	ce.stackContext.stackLenInBytes = newLen << 3
 }
 
-func (ce *callEngine) builtinFunctionMemoryGrow(ctx context.Context, mem *wasm.MemoryInstance) {
+func (ce *callEngine) builtinFunctionMemoryGrow(mem *wasm.MemoryInstance) {
 	newPages := ce.popValue()
 
-	if res, ok := mem.Grow(ctx, uint32(newPages)); !ok {
+	if res, ok := mem.Grow(uint32(newPages)); !ok {
 		ce.pushValue(uint64(0xffffffff)) // = -1 in signed 32-bit integer.
 	} else {
 		ce.pushValue(uint64(res))
@@ -985,12 +985,12 @@ func (ce *callEngine) builtinFunctionMemoryGrow(ctx context.Context, mem *wasm.M
 	ce.moduleContext.memoryElement0Address = bufSliceHeader.Data
 }
 
-func (ce *callEngine) builtinFunctionTableGrow(ctx context.Context, tables []*wasm.TableInstance) {
+func (ce *callEngine) builtinFunctionTableGrow(tables []*wasm.TableInstance) {
 	tableIndex := uint32(ce.popValue())
 	table := tables[tableIndex] // verified not to be out of range by the func validation at compilation phase.
 	num := ce.popValue()
 	ref := ce.popValue()
-	res := table.Grow(ctx, uint32(num), uintptr(ref))
+	res := table.Grow(uint32(num), uintptr(ref))
 	ce.pushValue(uint64(res))
 }
 

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -339,7 +339,7 @@ func TestCallEngine_builtinFunctionTableGrow(t *testing.T) {
 	}
 
 	table := &wasm.TableInstance{References: []wasm.Reference{}, Min: 10}
-	ce.builtinFunctionTableGrow(context.Background(), []*wasm.TableInstance{table})
+	ce.builtinFunctionTableGrow([]*wasm.TableInstance{table})
 
 	require.Equal(t, 1, len(table.References))
 	require.Equal(t, uintptr(0xff), table.References[0])

--- a/internal/gojs/argsenv.go
+++ b/internal/gojs/argsenv.go
@@ -1,7 +1,6 @@
 package gojs
 
 import (
-	"context"
 	"errors"
 
 	"github.com/tetratelabs/wazero/api"
@@ -17,7 +16,7 @@ const (
 
 // WriteArgsAndEnviron writes arguments and environment variables to memory, so
 // they can be read by main, Go compiles as the function export "run".
-func WriteArgsAndEnviron(ctx context.Context, mod api.Module) (argc, argv uint32, err error) {
+func WriteArgsAndEnviron(mod api.Module) (argc, argv uint32, err error) {
 	mem := mod.Memory()
 	sysCtx := mod.(*wasm.CallContext).Sys
 	args := sysCtx.Args()
@@ -29,7 +28,7 @@ func WriteArgsAndEnviron(ctx context.Context, mod api.Module) (argc, argv uint32
 	strPtr := func(val []byte, field string, i int) (ptr uint32) {
 		// TODO: return err and format "%s[%d], field, i"
 		ptr = offset
-		mustWrite(ctx, mem, field, offset, append(val, 0))
+		mustWrite(mem, field, offset, append(val, 0))
 		offset += uint32(len(val) + 1)
 		if pad := offset % 8; pad != 0 {
 			offset += 8 - pad
@@ -50,7 +49,7 @@ func WriteArgsAndEnviron(ctx context.Context, mod api.Module) (argc, argv uint32
 	argv = offset
 	for _, ptr := range argvPtrs {
 		// TODO: return err and format "argvPtrs[%d], i"
-		mustWriteUint64Le(ctx, mem, "argvPtrs[i]", offset, uint64(ptr))
+		mustWriteUint64Le(mem, "argvPtrs[i]", offset, uint64(ptr))
 		offset += 8
 	}
 

--- a/internal/gojs/runtime.go
+++ b/internal/gojs/runtime.go
@@ -58,7 +58,7 @@ var WasmWrite = spfunc.MustCallFromSP(false, &wasm.HostFunc{
 	},
 })
 
-func wasmWrite(ctx context.Context, mod api.Module, stack []uint64) {
+func wasmWrite(_ context.Context, mod api.Module, stack []uint64) {
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
 	fd, p, n := uint32(stack[0]), uint32(stack[1]), uint32(stack[2])
@@ -68,7 +68,7 @@ func wasmWrite(ctx context.Context, mod api.Module, stack []uint64) {
 		panic(fmt.Errorf("unexpected fd %d", fd))
 	}
 
-	if _, err := writer.Write(mustRead(ctx, mod.Memory(), "p", p, n)); err != nil {
+	if _, err := writer.Write(mustRead(mod.Memory(), "p", p, n)); err != nil {
 		panic(fmt.Errorf("error writing p: %w", err))
 	}
 }
@@ -99,8 +99,8 @@ var Nanotime1 = spfunc.MustCallFromSP(false, &wasm.HostFunc{
 	},
 })
 
-func nanotime1(ctx context.Context, mod api.Module, stack []uint64) {
-	time := mod.(*wasm.CallContext).Sys.Nanotime(ctx)
+func nanotime1(_ context.Context, mod api.Module, stack []uint64) {
+	time := mod.(*wasm.CallContext).Sys.Nanotime()
 	stack[0] = api.EncodeI64(time)
 }
 
@@ -118,8 +118,8 @@ var Walltime = spfunc.MustCallFromSP(false, &wasm.HostFunc{
 	},
 })
 
-func walltime(ctx context.Context, mod api.Module, stack []uint64) {
-	sec, nsec := mod.(*wasm.CallContext).Sys.Walltime(ctx)
+func walltime(_ context.Context, mod api.Module, stack []uint64) {
+	sec, nsec := mod.(*wasm.CallContext).Sys.Walltime()
 	stack[0] = api.EncodeI64(sec)
 	stack[1] = api.EncodeI32(nsec)
 }
@@ -158,11 +158,11 @@ var GetRandomData = spfunc.MustCallFromSP(false, &wasm.HostFunc{
 	},
 })
 
-func getRandomData(ctx context.Context, mod api.Module, stack []uint64) {
+func getRandomData(_ context.Context, mod api.Module, stack []uint64) {
 	randSource := mod.(*wasm.CallContext).Sys.RandSource()
 	buf, bufLen := uint32(stack[0]), uint32(stack[1])
 
-	r := mustRead(ctx, mod.Memory(), "r", buf, bufLen)
+	r := mustRead(mod.Memory(), "r", buf, bufLen)
 
 	if n, err := randSource.Read(r); err != nil {
 		panic(fmt.Errorf("RandSource.Read(r /* len=%d */) failed: %w", bufLen, err))

--- a/internal/gojs/spfunc/spfunc_test.go
+++ b/internal/gojs/spfunc/spfunc_test.go
@@ -248,7 +248,7 @@ func TestMustCallFromSP(t *testing.T) {
 	mod, err := r.InstantiateModuleFromBinary(testCtx, bin)
 	require.NoError(t, err)
 
-	memView, ok := mod.Memory().Read(testCtx, 0, uint32(len(spMem)))
+	memView, ok := mod.Memory().Read(0, uint32(len(spMem)))
 	require.True(t, ok)
 	copy(memView, spMem)
 

--- a/internal/gojs/state.go
+++ b/internal/gojs/state.go
@@ -107,7 +107,7 @@ func loadValue(ctx context.Context, ref ref) interface{} { // nolint
 func loadArgs(ctx context.Context, mod api.Module, sliceAddr, sliceLen uint32) []interface{} { // nolint
 	result := make([]interface{}, 0, sliceLen)
 	for i := uint32(0); i < sliceLen; i++ { // nolint
-		iRef := mustReadUint64Le(ctx, mod.Memory(), "iRef", sliceAddr+i*8)
+		iRef := mustReadUint64Le(mod.Memory(), "iRef", sliceAddr+i*8)
 		result = append(result, loadValue(ctx, ref(iRef)))
 	}
 	return result

--- a/internal/gojs/syscall.go
+++ b/internal/gojs/syscall.go
@@ -75,7 +75,7 @@ var StringVal = spfunc.MustCallFromSP(false, &wasm.HostFunc{
 func stringVal(ctx context.Context, mod api.Module, stack []uint64) {
 	xAddr, xLen := uint32(stack[0]), uint32(stack[1])
 
-	x := string(mustRead(ctx, mod.Memory(), "x", xAddr, xLen))
+	x := string(mustRead(mod.Memory(), "x", xAddr, xLen))
 
 	stack[0] = storeRef(ctx, x)
 }
@@ -104,7 +104,7 @@ func valueGet(ctx context.Context, mod api.Module, stack []uint64) {
 	pAddr := uint32(stack[1])
 	pLen := uint32(stack[2])
 
-	p := string(mustRead(ctx, mod.Memory(), "p", pAddr, pLen))
+	p := string(mustRead(mod.Memory(), "p", pAddr, pLen))
 	v := loadValue(ctx, ref(vRef))
 
 	var result interface{}
@@ -150,7 +150,7 @@ func valueSet(ctx context.Context, mod api.Module, stack []uint64) {
 	xRef := stack[3]
 
 	v := loadValue(ctx, ref(vRef))
-	p := string(mustRead(ctx, mod.Memory(), "p", pAddr, pLen))
+	p := string(mustRead(mod.Memory(), "p", pAddr, pLen))
 	x := loadValue(ctx, ref(xRef))
 	if v == getState(ctx) {
 		switch p {
@@ -240,7 +240,7 @@ func valueCall(ctx context.Context, mod api.Module, stack []uint64) {
 
 	this := ref(vRef)
 	v := loadValue(ctx, this)
-	m := string(mustRead(ctx, mod.Memory(), "m", mAddr, mLen))
+	m := string(mustRead(mod.Memory(), "m", mAddr, mLen))
 	args := loadArgs(ctx, mod, argsArray, argsLen)
 
 	var xRef uint64
@@ -414,7 +414,7 @@ func valueLoadString(ctx context.Context, mod api.Module, stack []uint64) {
 
 	v := loadValue(ctx, ref(vRef))
 	s := valueString(v)
-	b := mustRead(ctx, mod.Memory(), "b", bAddr, bLen)
+	b := mustRead(mod.Memory(), "b", bAddr, bLen)
 	copy(b, s)
 }
 
@@ -452,7 +452,7 @@ func copyBytesToGo(ctx context.Context, mod api.Module, stack []uint64) {
 	_ /* unknown */ = uint32(stack[2])
 	srcRef := stack[3]
 
-	dst := mustRead(ctx, mod.Memory(), "dst", dstAddr, dstLen) // nolint
+	dst := mustRead(mod.Memory(), "dst", dstAddr, dstLen) // nolint
 	v := loadValue(ctx, ref(srcRef))
 
 	var n, ok uint32
@@ -493,7 +493,7 @@ func copyBytesToJS(ctx context.Context, mod api.Module, stack []uint64) {
 	srcLen := uint32(stack[2])
 	_ /* unknown */ = uint32(stack[3])
 
-	src := mustRead(ctx, mod.Memory(), "src", srcAddr, srcLen) // nolint
+	src := mustRead(mod.Memory(), "src", srcAddr, srcLen) // nolint
 	v := loadValue(ctx, ref(dstRef))
 
 	var n, ok uint32

--- a/internal/gojs/util.go
+++ b/internal/gojs/util.go
@@ -1,7 +1,6 @@
 package gojs
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/tetratelabs/wazero/api"
@@ -26,8 +25,8 @@ func stubFunction(name string) *wasm.HostFunc {
 
 // mustRead is like api.Memory except that it panics if the offset and
 // byteCount are out of range.
-func mustRead(ctx context.Context, mem api.Memory, fieldName string, offset, byteCount uint32) []byte {
-	buf, ok := mem.Read(ctx, offset, byteCount)
+func mustRead(mem api.Memory, fieldName string, offset, byteCount uint32) []byte {
+	buf, ok := mem.Read(offset, byteCount)
 	if !ok {
 		panic(fmt.Errorf("out of memory reading %s", fieldName))
 	}
@@ -36,8 +35,8 @@ func mustRead(ctx context.Context, mem api.Memory, fieldName string, offset, byt
 
 // mustReadUint64Le is like api.Memory except that it panics if the offset
 // is out of range.
-func mustReadUint64Le(ctx context.Context, mem api.Memory, fieldName string, offset uint32) uint64 {
-	result, ok := mem.ReadUint64Le(ctx, offset)
+func mustReadUint64Le(mem api.Memory, fieldName string, offset uint32) uint64 {
+	result, ok := mem.ReadUint64Le(offset)
 	if !ok {
 		panic(fmt.Errorf("out of memory reading %s", fieldName))
 	}
@@ -46,16 +45,16 @@ func mustReadUint64Le(ctx context.Context, mem api.Memory, fieldName string, off
 
 // mustWrite is like api.Memory except that it panics if the offset
 // is out of range.
-func mustWrite(ctx context.Context, mem api.Memory, fieldName string, offset uint32, val []byte) {
-	if ok := mem.Write(ctx, offset, val); !ok {
+func mustWrite(mem api.Memory, fieldName string, offset uint32, val []byte) {
+	if ok := mem.Write(offset, val); !ok {
 		panic(fmt.Errorf("out of memory writing %s", fieldName))
 	}
 }
 
 // mustWriteUint64Le is like api.Memory except that it panics if the offset
 // is out of range.
-func mustWriteUint64Le(ctx context.Context, mem api.Memory, fieldName string, offset uint32, val uint64) {
-	if ok := mem.WriteUint64Le(ctx, offset, val); !ok {
+func mustWriteUint64Le(mem api.Memory, fieldName string, offset uint32, val uint64) {
+	if ok := mem.WriteUint64Le(offset, val); !ok {
 		panic(fmt.Errorf("out of memory writing %s", fieldName))
 	}
 }

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -244,11 +244,11 @@ func createRuntime(b *testing.B, config wazero.RuntimeConfig) wazero.Runtime {
 		}
 
 		offset := uint32(results[0])
-		m.Memory().WriteUint32Le(ctx, retBufPtr, offset)
-		m.Memory().WriteUint32Le(ctx, retBufSize, 10)
+		m.Memory().WriteUint32Le(retBufPtr, offset)
+		m.Memory().WriteUint32Le(retBufSize, 10)
 		b := make([]byte, 10)
 		_, _ = rand.Read(b)
-		m.Memory().Write(ctx, offset, b)
+		m.Memory().Write(offset, b)
 	}
 
 	r := wazero.NewRuntimeWithConfig(testCtx, config)

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -149,8 +149,8 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 		CodeSection: []*wasm.Code{
 			{
 				IsHostFunction: true,
-				GoFunc: api.GoModuleFunc(func(ctx context.Context, mod api.Module, stack []uint64) {
-					ret, ok := mod.Memory().ReadUint32Le(ctx, uint32(stack[0]))
+				GoFunc: api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
+					ret, ok := mod.Memory().ReadUint32Le(uint32(stack[0]))
 					if !ok {
 						panic("couldn't read memory")
 					}
@@ -158,8 +158,8 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 				}),
 			},
 			wasm.MustParseGoReflectFuncCode(
-				func(ctx context.Context, m api.Module, pos uint32) float32 {
-					ret, ok := m.Memory().ReadUint32Le(ctx, pos)
+				func(_ context.Context, m api.Module, pos uint32) float32 {
+					ret, ok := m.Memory().ReadUint32Le(pos)
 					if !ok {
 						panic("couldn't read memory")
 					}

--- a/internal/integration_test/bench/memory_bench_test.go
+++ b/internal/integration_test/bench/memory_bench_test.go
@@ -8,13 +8,13 @@ import (
 
 func BenchmarkMemory(b *testing.B) {
 	mem := &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize), Min: 1}
-	if !mem.WriteByte(testCtx, 10, 16) {
+	if !mem.WriteByte(10, 16) {
 		b.Fail()
 	}
 
 	b.Run("ReadByte", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if v, ok := mem.ReadByte(testCtx, 10); !ok || v != 16 {
+			if v, ok := mem.ReadByte(10); !ok || v != 16 {
 				b.Fail()
 			}
 		}
@@ -22,7 +22,7 @@ func BenchmarkMemory(b *testing.B) {
 
 	b.Run("ReadUint32Le", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if v, ok := mem.ReadUint32Le(testCtx, 10); !ok || v != 16 {
+			if v, ok := mem.ReadUint32Le(10); !ok || v != 16 {
 				b.Fail()
 			}
 		}
@@ -30,7 +30,7 @@ func BenchmarkMemory(b *testing.B) {
 
 	b.Run("WriteByte", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if !mem.WriteByte(testCtx, 10, 16) {
+			if !mem.WriteByte(10, 16) {
 				b.Fail()
 			}
 		}
@@ -38,7 +38,7 @@ func BenchmarkMemory(b *testing.B) {
 
 	b.Run("WriteUint32Le", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if !mem.WriteUint32Le(testCtx, 10, 16) {
+			if !mem.WriteUint32Le(10, 16) {
 				b.Fail()
 			}
 		}

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -211,7 +211,7 @@ func testRecursiveEntry(t *testing.T, r wazero.Runtime) {
 func testHostFuncMemory(t *testing.T, r wazero.Runtime) {
 	var memory *wasm.MemoryInstance
 	storeInt := func(ctx context.Context, m api.Module, offset uint32, val uint64) uint32 {
-		if !m.Memory().WriteUint64Le(ctx, offset, val) {
+		if !m.Memory().WriteUint64Le(offset, val) {
 			return 1
 		}
 		// sneak a reference to the memory, so we can check it later
@@ -571,7 +571,7 @@ func testMemOps(t *testing.T, r wazero.Runtime) {
 	results, err := sizeFn.Call(testCtx)
 	require.NoError(t, err)
 	require.Zero(t, results[0])
-	require.Zero(t, memory.Size(testCtx))
+	require.Zero(t, memory.Size())
 
 	// Any offset should be out of bounds error even when it is less than memory capacity(=memoryCapacityPages).
 	_, err = storeFn.Call(testCtx, wasm.MemoryPagesToBytesNum(memoryCapacityPages)-8)
@@ -589,8 +589,8 @@ func testMemOps(t *testing.T, r wazero.Runtime) {
 	// Check the size command works!
 	results, err = sizeFn.Call(testCtx)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), results[0])               // 1 page
-	require.Equal(t, uint32(65536), memory.Size(testCtx)) // 64KB
+	require.Equal(t, uint64(1), results[0])        // 1 page
+	require.Equal(t, uint32(65536), memory.Size()) // 64KB
 
 	// Grow again so that the memory size matches memory capacity.
 	results, err = growFn.Call(testCtx, 1)
@@ -633,7 +633,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 		defer module.Close(testCtx)
 
 		// Ensure that compilation cache doesn't cause race on memory instance.
-		before, ok := module.Memory().ReadUint64Le(testCtx, 1)
+		before, ok := module.Memory().ReadUint64Le(1)
 		require.True(t, ok)
 		// Value must be zero as the memory must not be affected by the previously instantiated modules.
 		require.Zero(t, before)
@@ -645,7 +645,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 		require.NoError(t, err)
 
 		// After the call, the value must be set properly.
-		after, ok := module.Memory().ReadUint64Le(testCtx, 1)
+		after, ok := module.Memory().ReadUint64Le(1)
 		require.True(t, ok)
 		require.Equal(t, uint64(1000), after)
 	}

--- a/internal/integration_test/fuzzcases/fuzzcases_test.go
+++ b/internal/integration_test/fuzzcases/fuzzcases_test.go
@@ -325,7 +325,7 @@ func Test733(t *testing.T) {
 			mem := mod.Memory()
 			require.NotNil(t, mem)
 
-			v, ok := mem.ReadUint64Le(ctx, 0x80000100)
+			v, ok := mem.ReadUint64Le(0x80000100)
 			require.True(t, ok)
 			require.Equal(t, uint64(0xffffffffffffffff), v)
 		})

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -492,7 +492,7 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, newEngine func(
 								expType = wasm.ValueTypeF64
 							}
 							require.Equal(t, expType, global.Type(), msg)
-							require.Equal(t, exps[0], global.Get(ctx), msg)
+							require.Equal(t, exps[0], global.Get(), msg)
 						default:
 							t.Fatalf("unsupported action type type: %v", c)
 						}

--- a/internal/integration_test/vs/bench_allocation.go
+++ b/internal/integration_test/vs/bench_allocation.go
@@ -46,7 +46,7 @@ func allocationCall(m Module, _ int) error {
 	}
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if err = m.WriteMemory(testCtx, namePtr, []byte(allocationParam)); err != nil {
+	if err = m.WriteMemory(namePtr, []byte(allocationParam)); err != nil {
 		return err
 	}
 

--- a/internal/integration_test/vs/runtime.go
+++ b/internal/integration_test/vs/runtime.go
@@ -40,7 +40,7 @@ type Module interface {
 	CallI32_V(ctx context.Context, funcName string, param uint32) error
 	CallV_V(ctx context.Context, funcName string) error
 	CallI64_I64(ctx context.Context, funcName string, param uint64) (uint64, error)
-	WriteMemory(ctx context.Context, offset uint32, bytes []byte) error
+	WriteMemory(offset uint32, bytes []byte) error
 	Memory() []byte
 	Close(context.Context) error
 }
@@ -79,10 +79,10 @@ func (m *wazeroModule) Memory() []byte {
 	return m.mod.Memory().(*wasm.MemoryInstance).Buffer
 }
 
-func (r *wazeroRuntime) log(ctx context.Context, mod api.Module, stack []uint64) {
+func (r *wazeroRuntime) log(_ context.Context, mod api.Module, stack []uint64) {
 	offset, byteCount := uint32(stack[0]), uint32(stack[1])
 
-	buf, ok := mod.Memory().Read(ctx, offset, byteCount)
+	buf, ok := mod.Memory().Read(offset, byteCount)
 	if !ok {
 		panic("out of memory reading log buffer")
 	}
@@ -197,8 +197,8 @@ func (m *wazeroModule) CallI64_I64(ctx context.Context, funcName string, param u
 	return 0, nil
 }
 
-func (m *wazeroModule) WriteMemory(ctx context.Context, offset uint32, bytes []byte) error {
-	if !m.mod.Memory().Write(ctx, offset, bytes) {
+func (m *wazeroModule) WriteMemory(offset uint32, bytes []byte) error {
+	if !m.mod.Memory().Write(offset, bytes) {
 		return errors.New("out of memory writing name")
 	}
 	return nil

--- a/internal/integration_test/vs/wasmedge/wasmedge.go
+++ b/internal/integration_test/vs/wasmedge/wasmedge.go
@@ -173,7 +173,7 @@ func (m *wasmedgeModule) CallI64_I64(_ context.Context, funcName string, param u
 	}
 }
 
-func (m *wasmedgeModule) WriteMemory(_ context.Context, offset uint32, bytes []byte) error {
+func (m *wasmedgeModule) WriteMemory(offset uint32, bytes []byte) error {
 	mod := m.vm.GetActiveModule()
 	mem := mod.FindMemory("memory")
 	if unsafeSlice, err := mem.GetData(uint(offset), uint(len(bytes))); err != nil {

--- a/internal/integration_test/vs/wasmer/wasmer.go
+++ b/internal/integration_test/vs/wasmer/wasmer.go
@@ -185,7 +185,7 @@ func (m *wasmerModule) CallI64_I64(_ context.Context, funcName string, param uin
 	}
 }
 
-func (m *wasmerModule) WriteMemory(_ context.Context, offset uint32, bytes []byte) error {
+func (m *wasmerModule) WriteMemory(offset uint32, bytes []byte) error {
 	unsafeSlice := m.mem.Data()
 	copy(unsafeSlice[offset:], bytes)
 	return nil

--- a/internal/integration_test/vs/wasmtime/wasmtime.go
+++ b/internal/integration_test/vs/wasmtime/wasmtime.go
@@ -187,7 +187,7 @@ func (m *wasmtimeModule) CallI64_I64(_ context.Context, funcName string, param u
 	}
 }
 
-func (m *wasmtimeModule) WriteMemory(_ context.Context, offset uint32, bytes []byte) error {
+func (m *wasmtimeModule) WriteMemory(offset uint32, bytes []byte) error {
 	unsafeSlice := m.mem.UnsafeData(m.store)
 	copy(unsafeSlice[offset:], bytes)
 	return nil

--- a/internal/platform/time_test.go
+++ b/internal/platform/time_test.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -13,27 +12,27 @@ func Test_NewFakeWalltime(t *testing.T) {
 	wt := NewFakeWalltime()
 
 	// Base should be the same as FakeEpochNanos
-	sec, nsec := (*wt)(context.Background())
+	sec, nsec := (*wt)()
 	ft := time.UnixMicro(FakeEpochNanos / time.Microsecond.Nanoseconds()).UTC()
 	require.Equal(t, ft, time.Unix(sec, int64(nsec)).UTC())
 
 	// next reading should increase by 1ms
-	sec, nsec = (*wt)(context.Background())
+	sec, nsec = (*wt)()
 	require.Equal(t, ft.Add(time.Millisecond), time.Unix(sec, int64(nsec)).UTC())
 }
 
 func Test_NewFakeNanotime(t *testing.T) {
 	nt := NewFakeNanotime()
 
-	require.Equal(t, int64(0), (*nt)(context.Background()))
+	require.Equal(t, int64(0), (*nt)())
 
 	// next reading should increase by 1ms
-	require.Equal(t, int64(time.Millisecond), (*nt)(context.Background()))
+	require.Equal(t, int64(time.Millisecond), (*nt)())
 }
 
 func Test_Walltime(t *testing.T) {
 	now := time.Now().Unix()
-	sec, nsec := Walltime(context.Background())
+	sec, nsec := Walltime()
 
 	// Loose test that the second variant is close to now.
 	// The only thing that could flake this is a time adjustment during the test.
@@ -50,16 +49,14 @@ func Test_Nanotime(t *testing.T) {
 		nanotime sys.Nanotime
 	}{
 		{"Nanotime", Nanotime},
-		{"nanotimePortable", func(ctx context.Context) int64 {
-			return nanotimePortable()
-		}},
+		{"nanotimePortable", nanotimePortable},
 	}
 
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			delta := time.Since(nanoBase).Nanoseconds()
-			nanos := Nanotime(context.Background())
+			nanos := Nanotime()
 
 			// It takes more than a nanosecond to make the two clock readings required
 			// to implement time.Now. Hence, delta will always be less than nanos.
@@ -74,9 +71,9 @@ func Test_Nanosleep(t *testing.T) {
 	ns := int64(50 * time.Millisecond)
 	max := ns * 5
 
-	start := Nanotime(context.Background())
-	Nanosleep(context.Background(), ns)
-	duration := Nanotime(context.Background()) - start
+	start := Nanotime()
+	Nanosleep(ns)
+	duration := Nanotime() - start
 
 	require.True(t, duration > 0 && duration < max, "Nanosleep(%d) slept for %d", ns, duration)
 }

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -1,7 +1,6 @@
 package sys
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -64,8 +63,8 @@ func (c *Context) EnvironSize() uint32 {
 }
 
 // Walltime implements sys.Walltime.
-func (c *Context) Walltime(ctx context.Context) (sec int64, nsec int32) {
-	return (*(c.walltime))(ctx)
+func (c *Context) Walltime() (sec int64, nsec int32) {
+	return (*(c.walltime))()
 }
 
 // WalltimeResolution returns resolution of Walltime.
@@ -74,8 +73,8 @@ func (c *Context) WalltimeResolution() sys.ClockResolution {
 }
 
 // Nanotime implements sys.Nanotime.
-func (c *Context) Nanotime(ctx context.Context) int64 {
-	return (*(c.nanotime))(ctx)
+func (c *Context) Nanotime() int64 {
+	return (*(c.nanotime))()
 }
 
 // NanotimeResolution returns resolution of Nanotime.
@@ -84,8 +83,8 @@ func (c *Context) NanotimeResolution() sys.ClockResolution {
 }
 
 // Nanosleep implements sys.Nanosleep.
-func (c *Context) Nanosleep(ctx context.Context, ns int64) {
-	(*(c.nanosleep))(ctx, ns)
+func (c *Context) Nanosleep(ns int64) {
+	(*(c.nanosleep))(ns)
 }
 
 // FS returns the possibly empty (EmptyFS) file system context.

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -2,7 +2,6 @@ package sys
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"testing"
 	"time"
@@ -44,10 +43,10 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Zero(t, sysCtx.EnvironSize())
 	// To compare functions, we can only compare pointers, but the pointer will
 	// change. Hence, we have to compare the results instead.
-	sec, _ := sysCtx.Walltime(testCtx)
+	sec, _ := sysCtx.Walltime()
 	require.Equal(t, platform.FakeEpochNanos/time.Second.Nanoseconds(), sec)
 	require.Equal(t, sys.ClockResolution(1_000), sysCtx.WalltimeResolution())
-	require.Zero(t, sysCtx.Nanotime(testCtx)) // See above on functions.
+	require.Zero(t, sysCtx.Nanotime()) // See above on functions.
 	require.Equal(t, sys.ClockResolution(1), sysCtx.NanotimeResolution())
 	require.Equal(t, &ns, sysCtx.nanosleep)
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
@@ -311,8 +310,7 @@ func Test_clockResolutionInvalid(t *testing.T) {
 }
 
 func TestNewContext_Nanosleep(t *testing.T) {
-	var aNs sys.Nanosleep = func(context.Context, int64) {
-	}
+	var aNs sys.Nanosleep = func(int64) {}
 	sysCtx, err := NewContext(
 		0,   // max
 		nil, // args

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -483,7 +483,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 	require.NoError(t, err)
 	linkModuleToEngine(module, me)
 
-	buf, ok := memory.Read(testCtx, 0, wasmPhraseSize)
+	buf, ok := memory.Read(0, wasmPhraseSize)
 	require.True(t, ok)
 	require.Equal(t, make([]byte, wasmPhraseSize), buf)
 
@@ -505,7 +505,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 
 	// The underlying memory should be updated. This proves that Memory.Read returns a re-slice, not a copy, and that
 	// programs can rely on this (for example, to update shared state in Wasm and view that in Go and visa versa).
-	buf2, ok := memory.Read(testCtx, 0, wasmPhraseSize)
+	buf2, ok := memory.Read(0, wasmPhraseSize)
 	require.True(t, ok)
 	require.Equal(t, buf, buf2)
 
@@ -514,7 +514,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 	require.Equal(t, hostPhrase, string(buf))
 
 	// To prove the above, we re-read the memory and should not see the appended bytes (rather zeros instead).
-	buf2, ok = memory.Read(testCtx, 0, hostPhraseSize)
+	buf2, ok = memory.Read(0, hostPhraseSize)
 	require.True(t, ok)
 	hostPhraseTruncated := "Goodbye, cruel world. I'm off to join the circ" + string([]byte{0, 0, 0})
 	require.Equal(t, hostPhraseTruncated, string(buf2))
@@ -567,8 +567,8 @@ const (
 	callImportCallReadMemName = "call_import->call->read_mem"
 )
 
-func readMemGo(ctx context.Context, m api.Module) uint64 {
-	ret, ok := m.Memory().ReadUint64Le(ctx, 0)
+func readMemGo(_ context.Context, m api.Module) uint64 {
+	ret, ok := m.Memory().ReadUint64Le(0)
 	if !ok {
 		panic("couldn't read memory")
 	}

--- a/internal/wasm/global.go
+++ b/internal/wasm/global.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/tetratelabs/wazero/api"
@@ -20,12 +19,12 @@ func (g *mutableGlobal) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g *mutableGlobal) Get(context.Context) uint64 {
+func (g *mutableGlobal) Get() uint64 {
 	return g.g.Val
 }
 
 // Set implements the same method as documented on api.MutableGlobal.
-func (g *mutableGlobal) Set(_ context.Context, v uint64) {
+func (g *mutableGlobal) Set(v uint64) {
 	g.g.Val = v
 }
 
@@ -33,11 +32,11 @@ func (g *mutableGlobal) Set(_ context.Context, v uint64) {
 func (g *mutableGlobal) String() string {
 	switch g.Type() {
 	case ValueTypeI32, ValueTypeI64:
-		return fmt.Sprintf("global(%d)", g.Get(context.Background()))
+		return fmt.Sprintf("global(%d)", g.Get())
 	case ValueTypeF32:
-		return fmt.Sprintf("global(%f)", api.DecodeF32(g.Get(context.Background())))
+		return fmt.Sprintf("global(%f)", api.DecodeF32(g.Get()))
 	case ValueTypeF64:
-		return fmt.Sprintf("global(%f)", api.DecodeF64(g.Get(context.Background())))
+		return fmt.Sprintf("global(%f)", api.DecodeF64(g.Get()))
 	default:
 		panic(fmt.Errorf("BUG: unknown value type %X", g.Type()))
 	}
@@ -54,7 +53,7 @@ func (g globalI32) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalI32) Get(context.Context) uint64 {
+func (g globalI32) Get() uint64 {
 	return uint64(g)
 }
 
@@ -74,7 +73,7 @@ func (g globalI64) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalI64) Get(context.Context) uint64 {
+func (g globalI64) Get() uint64 {
 	return uint64(g)
 }
 
@@ -94,13 +93,13 @@ func (g globalF32) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalF32) Get(context.Context) uint64 {
+func (g globalF32) Get() uint64 {
 	return uint64(g)
 }
 
 // String implements fmt.Stringer
 func (g globalF32) String() string {
-	return fmt.Sprintf("global(%f)", api.DecodeF32(g.Get(context.Background())))
+	return fmt.Sprintf("global(%f)", api.DecodeF32(g.Get()))
 }
 
 type globalF64 uint64
@@ -114,11 +113,11 @@ func (g globalF64) Type() api.ValueType {
 }
 
 // Get implements the same method as documented on api.Global.
-func (g globalF64) Get(context.Context) uint64 {
+func (g globalF64) Get() uint64 {
 	return uint64(g)
 }
 
 // String implements fmt.Stringer
 func (g globalF64) String() string {
-	return fmt.Sprintf("global(%f)", api.DecodeF64(g.Get(context.Background())))
+	return fmt.Sprintf("global(%f)", api.DecodeF64(g.Get()))
 }

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -126,20 +126,18 @@ func TestGlobalTypes(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			for _, ctx := range []context.Context{nil, testCtx} { // Ensure it doesn't crash on nil!
-				require.Equal(t, tc.expectedType, tc.global.Type())
-				require.Equal(t, tc.expectedVal, tc.global.Get(ctx))
-				require.Equal(t, tc.expectedString, tc.global.String())
+			require.Equal(t, tc.expectedType, tc.global.Type())
+			require.Equal(t, tc.expectedVal, tc.global.Get())
+			require.Equal(t, tc.expectedString, tc.global.String())
 
-				mutable, ok := tc.global.(api.MutableGlobal)
-				require.Equal(t, tc.expectedMutable, ok)
-				if ok {
-					mutable.Set(ctx, 2)
-					require.Equal(t, uint64(2), tc.global.Get(ctx))
+			mutable, ok := tc.global.(api.MutableGlobal)
+			require.Equal(t, tc.expectedMutable, ok)
+			if ok {
+				mutable.Set(2)
+				require.Equal(t, uint64(2), tc.global.Get())
 
-					mutable.Set(ctx, tc.expectedVal) // Set it back!
-					require.Equal(t, tc.expectedVal, tc.global.Get(ctx))
-				}
+				mutable.Set(tc.expectedVal) // Set it back!
+				require.Equal(t, tc.expectedVal, tc.global.Get())
 			}
 		})
 	}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -59,12 +58,12 @@ func (m *MemoryInstance) Definition() api.MemoryDefinition {
 }
 
 // Size implements the same method as documented on api.Memory.
-func (m *MemoryInstance) Size(context.Context) uint32 {
+func (m *MemoryInstance) Size() uint32 {
 	return m.size()
 }
 
 // ReadByte implements the same method as documented on api.Memory.
-func (m *MemoryInstance) ReadByte(_ context.Context, offset uint32) (byte, bool) {
+func (m *MemoryInstance) ReadByte(offset uint32) (byte, bool) {
 	if offset >= m.size() {
 		return 0, false
 	}
@@ -72,7 +71,7 @@ func (m *MemoryInstance) ReadByte(_ context.Context, offset uint32) (byte, bool)
 }
 
 // ReadUint16Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) ReadUint16Le(_ context.Context, offset uint32) (uint16, bool) {
+func (m *MemoryInstance) ReadUint16Le(offset uint32) (uint16, bool) {
 	if !m.hasSize(offset, 2) {
 		return 0, false
 	}
@@ -80,12 +79,12 @@ func (m *MemoryInstance) ReadUint16Le(_ context.Context, offset uint32) (uint16,
 }
 
 // ReadUint32Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) ReadUint32Le(_ context.Context, offset uint32) (uint32, bool) {
+func (m *MemoryInstance) ReadUint32Le(offset uint32) (uint32, bool) {
 	return m.readUint32Le(offset)
 }
 
 // ReadFloat32Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) ReadFloat32Le(_ context.Context, offset uint32) (float32, bool) {
+func (m *MemoryInstance) ReadFloat32Le(offset uint32) (float32, bool) {
 	v, ok := m.readUint32Le(offset)
 	if !ok {
 		return 0, false
@@ -94,12 +93,12 @@ func (m *MemoryInstance) ReadFloat32Le(_ context.Context, offset uint32) (float3
 }
 
 // ReadUint64Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) ReadUint64Le(_ context.Context, offset uint32) (uint64, bool) {
+func (m *MemoryInstance) ReadUint64Le(offset uint32) (uint64, bool) {
 	return m.readUint64Le(offset)
 }
 
 // ReadFloat64Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) ReadFloat64Le(_ context.Context, offset uint32) (float64, bool) {
+func (m *MemoryInstance) ReadFloat64Le(offset uint32) (float64, bool) {
 	v, ok := m.readUint64Le(offset)
 	if !ok {
 		return 0, false
@@ -108,7 +107,7 @@ func (m *MemoryInstance) ReadFloat64Le(_ context.Context, offset uint32) (float6
 }
 
 // Read implements the same method as documented on api.Memory.
-func (m *MemoryInstance) Read(_ context.Context, offset, byteCount uint32) ([]byte, bool) {
+func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
 	if !m.hasSize(offset, byteCount) {
 		return nil, false
 	}
@@ -116,7 +115,7 @@ func (m *MemoryInstance) Read(_ context.Context, offset, byteCount uint32) ([]by
 }
 
 // WriteByte implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteByte(_ context.Context, offset uint32, v byte) bool {
+func (m *MemoryInstance) WriteByte(offset uint32, v byte) bool {
 	if offset >= m.size() {
 		return false
 	}
@@ -125,7 +124,7 @@ func (m *MemoryInstance) WriteByte(_ context.Context, offset uint32, v byte) boo
 }
 
 // WriteUint16Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteUint16Le(_ context.Context, offset uint32, v uint16) bool {
+func (m *MemoryInstance) WriteUint16Le(offset uint32, v uint16) bool {
 	if !m.hasSize(offset, 2) {
 		return false
 	}
@@ -134,27 +133,27 @@ func (m *MemoryInstance) WriteUint16Le(_ context.Context, offset uint32, v uint1
 }
 
 // WriteUint32Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteUint32Le(_ context.Context, offset, v uint32) bool {
+func (m *MemoryInstance) WriteUint32Le(offset, v uint32) bool {
 	return m.writeUint32Le(offset, v)
 }
 
 // WriteFloat32Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteFloat32Le(_ context.Context, offset uint32, v float32) bool {
+func (m *MemoryInstance) WriteFloat32Le(offset uint32, v float32) bool {
 	return m.writeUint32Le(offset, math.Float32bits(v))
 }
 
 // WriteUint64Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteUint64Le(_ context.Context, offset uint32, v uint64) bool {
+func (m *MemoryInstance) WriteUint64Le(offset uint32, v uint64) bool {
 	return m.writeUint64Le(offset, v)
 }
 
 // WriteFloat64Le implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteFloat64Le(_ context.Context, offset uint32, v float64) bool {
+func (m *MemoryInstance) WriteFloat64Le(offset uint32, v float64) bool {
 	return m.writeUint64Le(offset, math.Float64bits(v))
 }
 
 // Write implements the same method as documented on api.Memory.
-func (m *MemoryInstance) Write(_ context.Context, offset uint32, val []byte) bool {
+func (m *MemoryInstance) Write(offset uint32, val []byte) bool {
 	if !m.hasSize(offset, uint32(len(val))) {
 		return false
 	}
@@ -163,7 +162,7 @@ func (m *MemoryInstance) Write(_ context.Context, offset uint32, val []byte) boo
 }
 
 // WriteString implements the same method as documented on api.Memory.
-func (m *MemoryInstance) WriteString(_ context.Context, offset uint32, val string) bool {
+func (m *MemoryInstance) WriteString(offset uint32, val string) bool {
 	if !m.hasSize(offset, uint32(len(val))) {
 		return false
 	}
@@ -177,7 +176,7 @@ func MemoryPagesToBytesNum(pages uint32) (bytesNum uint64) {
 }
 
 // Grow implements the same method as documented on api.Memory.
-func (m *MemoryInstance) Grow(_ context.Context, delta uint32) (result uint32, ok bool) {
+func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 	// We take write-lock here as the following might result in a new slice
 	m.mux.Lock()
 	defer m.mux.Unlock()
@@ -203,7 +202,7 @@ func (m *MemoryInstance) Grow(_ context.Context, delta uint32) (result uint32, o
 }
 
 // PageSize returns the current memory buffer size in pages.
-func (m *MemoryInstance) PageSize(context.Context) (result uint32) {
+func (m *MemoryInstance) PageSize() (result uint32) {
 	return memoryBytesNumToPages(uint64(len(m.Buffer)))
 }
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -82,7 +82,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 
 			mem := instance.ExportedMemory("memory")
 			if tc.expected {
-				require.Equal(t, tc.expectedLen, mem.Size(testCtx))
+				require.Equal(t, tc.expectedLen, mem.Size())
 			} else {
 				require.Nil(t, mem)
 			}

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"sync"
@@ -340,7 +339,7 @@ func (m *Module) verifyImportGlobalI32(sectionID SectionID, sectionIdx Index, id
 // Returns -1 if the operation is not valid, otherwise the old length of the table.
 //
 // https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-grow-x
-func (t *TableInstance) Grow(_ context.Context, delta uint32, initialRef Reference) (currentLen uint32) {
+func (t *TableInstance) Grow(delta uint32, initialRef Reference) (currentLen uint32) {
 	// We take write-lock here as the following might result in a new slice
 	t.mux.Lock()
 	defer t.mux.Unlock()

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -1080,7 +1080,7 @@ func TestTableInstance_Grow(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			table := &TableInstance{References: make([]uintptr, tc.currentLen), Max: tc.max}
-			actual := table.Grow(testCtx, tc.delta, 0)
+			actual := table.Grow(tc.delta, 0)
 			require.Equal(t, tc.exp, actual)
 		})
 	}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -224,7 +224,7 @@ func TestModule_Memory(t *testing.T) {
 
 			mem := module.ExportedMemory("memory")
 			if tc.expected {
-				require.Equal(t, tc.expectedLen, mem.Size(testCtx))
+				require.Equal(t, tc.expectedLen, mem.Size())
 			} else {
 				require.Nil(t, mem)
 			}
@@ -310,13 +310,13 @@ func TestModule_Global(t *testing.T) {
 				require.Nil(t, global)
 				return
 			}
-			require.Equal(t, uint64(globalVal), global.Get(testCtx))
+			require.Equal(t, uint64(globalVal), global.Get())
 
 			mutable, ok := global.(api.MutableGlobal)
 			require.Equal(t, tc.expectedMutable, ok)
 			if ok {
-				mutable.Set(testCtx, 2)
-				require.Equal(t, uint64(2), global.Get(testCtx))
+				mutable.Set(2)
+				require.Equal(t, uint64(2), global.Get())
 			}
 		})
 	}

--- a/sys/clock.go
+++ b/sys/clock.go
@@ -1,7 +1,5 @@
 package sys
 
-import "context"
-
 // ClockResolution is a positive granularity of clock precision in
 // nanoseconds. For example, if the resolution is 1us, this returns 1000.
 //
@@ -11,14 +9,14 @@ import "context"
 type ClockResolution uint32
 
 // Walltime returns the current time in epoch seconds with a nanosecond fraction.
-type Walltime func(context.Context) (sec int64, nsec int32)
+type Walltime func() (sec int64, nsec int32)
 
 // Nanotime returns nanoseconds since an arbitrary start point, used to measure
 // elapsed time. This is sometimes referred to as a tick or monotonic time.
 //
 // Note: There are no constraints on the value return except that it
 // increments. For example, -1 is a valid if the next value is >= 0.
-type Nanotime func(context.Context) int64
+type Nanotime func() int64
 
 // Nanosleep puts the current goroutine to sleep for at least ns nanoseconds.
-type Nanosleep func(ctx context.Context, ns int64)
+type Nanosleep func(ns int64)


### PR DESCRIPTION
We originally had a `context.Context` for anything that might be traced, but it turned out to be only useful for lifecycle and host functions.

For instruction-scoped aspects like memory updates, a context parameter is too fine-grained and also invisible in practice. For example, most users will use the compiler engine, and its memory, global or table access will never use go's context.