### PR TITLE
Removes unused FunctionInstance.LocalTypes

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -352,7 +352,7 @@ const (
 	tableInstanceTableLenOffset = 8
 
 	// Offsets for wasm.FunctionInstance.
-	functionInstanceTypeIDOffset = 88
+	functionInstanceTypeIDOffset = 64
 
 	// Offsets for wasm.MemoryInstance.
 	memoryInstanceBufferOffset    = 0

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -352,7 +352,7 @@ const (
 	tableInstanceTableLenOffset = 8
 
 	// Offsets for wasm.FunctionInstance.
-	functionInstanceTypeIDOffset = 64
+	functionInstanceTypeIDOffset = 40
 
 	// Offsets for wasm.MemoryInstance.
 	memoryInstanceBufferOffset    = 0

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -621,7 +621,6 @@ func (m *ModuleInstance) BuildFunctions(mod *Module, importedFunctions []*Functi
 		// reduces the number of heap objects which improves GC performance.
 		fns[offset] = FunctionInstance{
 			IsHostFunction: code.IsHostFunction,
-			LocalTypes:     code.LocalTypes,
 			Body:           code.Body,
 			GoFunc:         code.GoFunc,
 			TypeID:         m.TypeIDs[section],

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -621,7 +621,6 @@ func (m *ModuleInstance) BuildFunctions(mod *Module, importedFunctions []*Functi
 		// reduces the number of heap objects which improves GC performance.
 		fns[offset] = FunctionInstance{
 			IsHostFunction: code.IsHostFunction,
-			Body:           code.Body,
 			GoFunc:         code.GoFunc,
 			TypeID:         m.TypeIDs[section],
 			Module:         m,

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -830,7 +830,6 @@ func TestModule_buildFunctions(t *testing.T) {
 	instance.BuildFunctions(m, nil)
 	for i, f := range instance.Functions[1:] {
 		require.Equal(t, uint32(i+1), f.Definition.Index())
-		require.Equal(t, nopCode.Body, f.Body)
 	}
 }
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -107,9 +107,6 @@ type (
 		// Type is the signature of this function.
 		Type *FunctionType
 
-		// LocalTypes holds types of locals, set when Kind == FunctionKindWasm
-		LocalTypes []ValueType
-
 		// Body is the function body in WebAssembly Binary Format, set when Kind == FunctionKindWasm
 		Body []byte
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -107,9 +107,6 @@ type (
 		// Type is the signature of this function.
 		Type *FunctionType
 
-		// Body is the function body in WebAssembly Binary Format, set when Kind == FunctionKindWasm
-		Body []byte
-
 		// GoFunc is non-nil when IsHostFunction and defined in go, either
 		// api.GoFunction or api.GoModuleFunction.
 		//


### PR DESCRIPTION
This reduces the memory pressure at instantiation slightly 
#889 

```
$ benchstat old.txt new.txt

name                                    old time/op    new time/op    delta
Initialization/interpreter-10             35.5µs ± 1%    34.5µs ± 1%  -2.73%  (p=0.000 n=10+8)
Initialization/interpreter-multiple-10    13.7µs ± 4%    13.7µs ± 8%    ~     (p=0.684 n=10+10)
Initialization/compiler-10                27.1µs ±49%    24.9µs ±49%    ~     (p=0.165 n=10+10)
Initialization/compiler-multiple-10       12.3µs ± 5%    12.1µs ± 4%    ~     (p=0.247 n=10+10)

name                                    old alloc/op   new alloc/op   delta
Initialization/interpreter-10              141kB ± 0%     139kB ± 0%  -1.27%  (p=0.000 n=10+10)
Initialization/interpreter-multiple-10     142kB ± 0%     140kB ± 0%  -1.26%  (p=0.000 n=8+8)
Initialization/compiler-10                 144kB ± 0%     142kB ± 0%  -1.25%  (p=0.000 n=9+9)
Initialization/compiler-multiple-10        144kB ± 0%     143kB ± 0%  -1.24%  (p=0.000 n=8+10)

name                                    old allocs/op  new allocs/op  delta
Initialization/interpreter-10               86.0 ± 0%      86.0 ± 0%    ~     (all equal)
Initialization/interpreter-multiple-10      92.0 ± 0%      92.0 ± 0%    ~     (all equal)
Initialization/compiler-10                  35.0 ± 0%      35.0 ± 0%    ~     (all equal)
Initialization/compiler-multiple-10         41.0 ± 0%      41.0 ± 0%    ~     (all equal)



```