### PR TITLE
Removes importedFn

### DIFF
--- a/internal/wasm/call_context.go
+++ b/internal/wasm/call_context.go
@@ -162,12 +162,7 @@ func (m *CallContext) function(f *FunctionInstance) api.Function {
 	if err != nil {
 		return nil
 	}
-
-	if f.Module == m.module {
-		return &function{fi: f, ce: ce}
-	} else {
-		return &importedFn{importingModule: m, importedFn: f, ce: ce}
-	}
+	return &function{fi: f, ce: ce}
 }
 
 // function implements api.Function. This couples FunctionInstance with CallEngine so that
@@ -185,27 +180,6 @@ func (f *function) Definition() api.FunctionDefinition {
 // Call implements the same method as documented on api.Function.
 func (f *function) Call(ctx context.Context, params ...uint64) (ret []uint64, err error) {
 	return f.ce.Call(ctx, f.fi.Module.CallCtx, params)
-}
-
-// importedFn implements api.Function and ensures the call context of an imported function is the importing module.
-type importedFn struct {
-	ce              CallEngine
-	importingModule *CallContext
-	importedFn      *FunctionInstance
-}
-
-// Definition implements the same method as documented on api.Function.
-func (f *importedFn) Definition() api.FunctionDefinition {
-	return f.importedFn.Definition
-}
-
-// Call implements the same method as documented on api.Function.
-func (f *importedFn) Call(ctx context.Context, params ...uint64) (ret []uint64, err error) {
-	if f.importedFn.IsHostFunction {
-		return nil, fmt.Errorf("directly calling host function is not supported")
-	}
-	mod := f.importingModule
-	return f.ce.Call(ctx, mod, params)
 }
 
 // GlobalVal is an internal hack to get the lower 64 bits of a global.

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -324,35 +324,6 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 	})
 }
 
-func TestCallContext_ExportedFunction(t *testing.T) {
-	host, err := NewHostModule("host", map[string]interface{}{"host_fn": func() {}}, map[string]*HostFuncNames{"host_fn": {}}, api.CoreFeaturesV1)
-	require.NoError(t, err)
-
-	s, ns := newStore()
-
-	// Add the host module
-	imported, err := s.Instantiate(testCtx, ns, host, host.NameSection.ModuleName, nil)
-	require.NoError(t, err)
-	defer imported.Close(testCtx)
-
-	t.Run("imported function", func(t *testing.T) {
-		importing, err := s.Instantiate(testCtx, ns, &Module{
-			TypeSection:   []*FunctionType{v_v},
-			ImportSection: []*Import{{Type: ExternTypeFunc, Module: "host", Name: "host_fn", DescFunc: 0}},
-			MemorySection: &Memory{Min: 1, Cap: 1},
-			ExportSection: []*Export{{Type: ExternTypeFunc, Name: "host.fn", Index: 0}},
-		}, "test", nil)
-		require.NoError(t, err)
-		defer importing.Close(testCtx)
-
-		fn := importing.ExportedFunction("host.fn")
-		require.NotNil(t, fn)
-
-		require.Equal(t, fn.(*importedFn).importedFn, imported.ExportedFunction("host_fn").(*function).fi)
-		require.Equal(t, fn.(*importedFn).importingModule, importing)
-	})
-}
-
 type mockEngine struct {
 	shouldCompileFail bool
 	callFailIndex     int


### PR DESCRIPTION
I think this is a remnant since a while and no we don't need it 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>