### PR TITLE
wasi: detect if stdio are char devices instead of assuming

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -291,12 +291,6 @@ type wasiFiletype uint8
 const (
 	wasiFiletypeUnknown wasiFiletype = iota
 	wasiFiletypeBlockDevice
-	// wasiFiletypeCharacterDevice is set when the FD is a character device.
-	//
-	// Note: wazero currently returns this for stdio descriptors even if the
-	// actual file is not a TTY, to ensure python can work. This avoids
-	// dependencies needed to be more precise.
-	// See https://github.com/mattn/go-isatty
 	wasiFiletypeCharacterDevice
 	wasiFiletypeDirectory
 	wasiFiletypeRegularFile
@@ -312,29 +306,17 @@ func fdFilestatGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 }
 
 func fdFilestatGetFunc(mod api.Module, fd, resultBuf uint32) Errno {
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+
 	// Ensure we can write the filestat
 	buf, ok := mod.Memory().Read(resultBuf, 64)
 	if !ok {
 		return ErrnoFault
 	}
 
-	// Special-case the stdio character devices
-	switch fd {
-	case internalsys.FdStdin, internalsys.FdStdout, internalsys.FdStderr:
-		copy(buf, charFilestat)
-		return ErrnoSuccess
-	}
-
-	// Otherwise, look up the file corresponding to the file descriptor.
-	fsc := mod.(*wasm.CallContext).Sys.FS()
-	file, ok := fsc.OpenedFile(fd)
-	if !ok {
-		return ErrnoBadf
-	}
-
-	stat, err := file.File.Stat()
+	stat, err := fsc.StatFile(fd)
 	if err != nil {
-		return ErrnoIo
+		return toErrno(err)
 	}
 
 	writeFilestat(buf, stat)
@@ -358,10 +340,10 @@ func getWasiFiletype(fileMode fs.FileMode) wasiFiletype {
 	return wasiFileType
 }
 
-var charFilestat = []byte{
+var blockFilestat = []byte{
 	0, 0, 0, 0, 0, 0, 0, 0, // device
 	0, 0, 0, 0, 0, 0, 0, 0, // inode
-	byte(wasiFiletypeCharacterDevice), 0, 0, 0, 0, 0, 0, 0, // filetype
+	byte(wasiFiletypeBlockDevice), 0, 0, 0, 0, 0, 0, 0, // filetype
 	1, 0, 0, 0, 0, 0, 0, 0, // nlink
 	0, 0, 0, 0, 0, 0, 0, 0, // filesize
 	0, 0, 0, 0, 0, 0, 0, 0, // atim
@@ -375,7 +357,7 @@ func writeFilestat(buf []byte, stat fs.FileInfo) {
 	mtim := stat.ModTime().UnixNano()
 
 	// memory is re-used, so ensure the result is defaulted.
-	copy(buf, charFilestat[:32])
+	copy(buf, blockFilestat[:32])
 	buf[16] = uint8(filetype)
 	le.PutUint64(buf[32:], filesize)     // filesize
 	le.PutUint64(buf[40:], uint64(mtim)) // atim
@@ -1485,13 +1467,11 @@ func openFile(fsc *internalsys.FSContext, name string) (fd uint32, errno Errno) 
 // statFile attempts to stat the file at the given path. Errors coerce to WASI
 // Errno.
 func statFile(fsc *internalsys.FSContext, name string) (stat fs.FileInfo, errno Errno) {
-	s, err := fsc.StatFile(name)
-	if err == nil {
-		stat = s
-		errno = ErrnoSuccess
-		return
+	var err error
+	stat, err = fsc.StatPath(name)
+	if err != nil {
+		errno = toErrno(err)
 	}
-	errno = toErrno(err)
 	return
 }
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -127,7 +127,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			name: "stdin",
 			fd:   internalsys.FdStdin,
 			expectedMemory: []byte{
-				2, 0, // fs_filetype
+				1, 0, // fs_filetype
 				0, 0, 0, 0, 0, 0, // fs_flags
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_base
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
@@ -143,7 +143,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			name: "stdout",
 			fd:   internalsys.FdStdout,
 			expectedMemory: []byte{
-				2, 0, // fs_filetype
+				1, 0, // fs_filetype
 				1, 0, 0, 0, 0, 0, // fs_flags
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_base
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
@@ -159,7 +159,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			name: "stderr",
 			fd:   internalsys.FdStderr,
 			expectedMemory: []byte{
-				2, 0, // fs_filetype
+				1, 0, // fs_filetype
 				1, 0, 0, 0, 0, 0, // fs_flags
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_base
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -318,7 +318,8 @@ func Test_fdFilestatGet(t *testing.T) {
 			expectedMemory: []byte{
 				0, 0, 0, 0, 0, 0, 0, 0, // dev
 				0, 0, 0, 0, 0, 0, 0, 0, // ino
-				2, 0, 0, 0, 0, 0, 0, 0, // filetype + padding
+				// expect block device because stdin isn't a real file
+				1, 0, 0, 0, 0, 0, 0, 0, // filetype + padding
 				1, 0, 0, 0, 0, 0, 0, 0, // nlink
 				0, 0, 0, 0, 0, 0, 0, 0, // size
 				0, 0, 0, 0, 0, 0, 0, 0, // atim
@@ -338,7 +339,8 @@ func Test_fdFilestatGet(t *testing.T) {
 			expectedMemory: []byte{
 				0, 0, 0, 0, 0, 0, 0, 0, // dev
 				0, 0, 0, 0, 0, 0, 0, 0, // ino
-				2, 0, 0, 0, 0, 0, 0, 0, // filetype + padding
+				// expect block device because stdout isn't a real file
+				1, 0, 0, 0, 0, 0, 0, 0, // filetype + padding
 				1, 0, 0, 0, 0, 0, 0, 0, // nlink
 				0, 0, 0, 0, 0, 0, 0, 0, // size
 				0, 0, 0, 0, 0, 0, 0, 0, // atim
@@ -358,7 +360,8 @@ func Test_fdFilestatGet(t *testing.T) {
 			expectedMemory: []byte{
 				0, 0, 0, 0, 0, 0, 0, 0, // dev
 				0, 0, 0, 0, 0, 0, 0, 0, // ino
-				2, 0, 0, 0, 0, 0, 0, 0, // filetype + padding
+				// expect block device because stderr isn't a real file
+				1, 0, 0, 0, 0, 0, 0, 0, // filetype + padding
 				1, 0, 0, 0, 0, 0, 0, 0, // nlink
 				0, 0, 0, 0, 0, 0, 0, 0, // size
 				0, 0, 0, 0, 0, 0, 0, 0, // atim

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -110,10 +110,11 @@ func testFdReaddirStat(t *testing.T, bin []byte) {
 
 	console := compileAndRun(t, moduleConfig.WithFS(fstest.MapFS{}), bin)
 
+	// TODO: switch this to a real stat test
 	require.Equal(t, `
-stdin isatty: true
-stdout isatty: true
-stderr isatty: true
+stdin isatty: false
+stdout isatty: false
+stderr isatty: false
 / isatty: false
 `, "\n"+console)
 }

--- a/internal/platform/bench_test.go
+++ b/internal/platform/bench_test.go
@@ -1,0 +1,12 @@
+package platform
+
+import (
+	"os"
+	"testing"
+)
+
+func Benchmark_IsTerminal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		IsTerminal(os.Stdout.Fd())
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -48,3 +48,8 @@ func MunmapCodeSegment(code []byte) error {
 	}
 	return munmapCodeSegment(code)
 }
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd uintptr) bool {
+	return isTerminal(fd)
+}

--- a/internal/platform/terminal.go
+++ b/internal/platform/terminal.go
@@ -1,0 +1,14 @@
+//go:build darwin || linux || freebsd
+
+package platform
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func isTerminal(fd uintptr) bool {
+	var val syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&val)), 0, 0, 0)
+	return err == 0
+}

--- a/internal/platform/terminal_bsd.go
+++ b/internal/platform/terminal_bsd.go
@@ -1,0 +1,7 @@
+//go:build darwin || freebsd
+
+package platform
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA

--- a/internal/platform/terminal_linux.go
+++ b/internal/platform/terminal_linux.go
@@ -1,0 +1,5 @@
+package platform
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TCGETS

--- a/internal/platform/terminal_test.go
+++ b/internal/platform/terminal_test.go
@@ -17,6 +17,7 @@ func Test_IsTerminal(t *testing.T) {
 	require.NoError(t, os.WriteFile(path.Join(dir, "foo"), nil, 0o400))
 	file, err := os.Open(path.Join(dir, "foo"))
 	require.NoError(t, err)
+	defer file.Close()
 
 	// We aren't guaranteed to have a terminal device for os.Stdout, due to how
 	// `go test` forks processes. Instead, we test if this is consistent. For

--- a/internal/platform/terminal_test.go
+++ b/internal/platform/terminal_test.go
@@ -1,0 +1,43 @@
+package platform
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func Test_IsTerminal(t *testing.T) {
+	if !CompilerSupported() {
+		t.Skip() // because it will always return false
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(path.Join(dir, "foo"), nil, 0o400))
+	file, err := os.Open(path.Join(dir, "foo"))
+	require.NoError(t, err)
+
+	// We aren't guaranteed to have a terminal device for os.Stdout, due to how
+	// `go test` forks processes. Instead, we test if this is consistent. For
+	// example, when run in a debugger, this could end up true.
+	stdioIsTTY := IsTerminal(os.Stdout.Fd())
+
+	tests := []struct {
+		name     string
+		file     *os.File
+		expected bool
+	}{
+		{name: "Stdin", file: os.Stdin, expected: stdioIsTTY},
+		{name: "Stdout", file: os.Stdout, expected: stdioIsTTY},
+		{name: "Stderr", file: os.Stderr, expected: stdioIsTTY},
+		{name: "File", file: file, expected: false},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, IsTerminal(tc.file.Fd()))
+		})
+	}
+}

--- a/internal/platform/terminal_unsupported.go
+++ b/internal/platform/terminal_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !(darwin || linux || freebsd || windows)
+
+package platform
+
+func isTerminal(fd uintptr) bool {
+	return false
+}

--- a/internal/platform/terminal_windows.go
+++ b/internal/platform/terminal_windows.go
@@ -1,0 +1,14 @@
+package platform
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+
+func isTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -89,8 +89,11 @@ func TestEmptyFSContext(t *testing.T) {
 
 	expected := &FSContext{
 		stdin:       eofReader{},
+		stdinStat:   fileModeStat(fs.ModeDevice),
 		stdout:      io.Discard,
+		stdoutStat:  fileModeStat(fs.ModeDevice),
 		stderr:      io.Discard,
+		stderrStat:  fileModeStat(fs.ModeDevice),
 		fs:          EmptyFS,
 		openedFiles: map[uint32]*FileEntry{},
 		lastFD:      2,


### PR DESCRIPTION
This uses ioctl syscalls or appropriate alternative, to detect if stdin/out/err are character devices or not. This caches the result, to ensure performance is ok at runtime as executing stat can approach microsecond overhead.

Fixes #928