### PR TITLE
logging: extracts utilities to read parameters and results from memory

### DIFF
--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -17,6 +17,9 @@ type FunctionListenerFactory interface {
 	// NewListener returns a FunctionListener for a defined function. If nil is
 	// returned, no listener will be notified.
 	NewListener(api.FunctionDefinition) FunctionListener
+	// ^^ A single instance can be returned to avoid instantiating a listener
+	// per function, especially as they may be thousands of functions. Shared
+	// listeners use their FunctionDefinition parameter to clarify.
 }
 
 // FunctionListener can be registered for any function via
@@ -29,19 +32,25 @@ type FunctionListener interface {
 	//
 	//   - ctx: the context of the caller function which must be the same
 	//	   instance or parent of the result.
+	//   - mod: the calling module.
 	//   - def: the function definition.
 	//   - paramValues:  api.ValueType encoded parameters.
-	Before(ctx context.Context, def api.FunctionDefinition, paramValues []uint64) context.Context
+	//
+	// Note: api.Memory is meant for inspection, not modification.
+	Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64) context.Context
 
 	// After is invoked after a function is called.
 	//
 	// # Params
 	//
 	//   - ctx: the context returned by Before.
+	//   - mod: the calling module.
 	//   - def: the function definition.
 	//   - err: nil if the function didn't err
 	//   - resultValues: api.ValueType encoded results.
-	After(ctx context.Context, def api.FunctionDefinition, err error, resultValues []uint64)
+	//
+	// Note: api.Memory is meant for inspection, not modification.
+	After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
 }
 
 // TODO: We need to add tests to enginetest to ensure contexts nest. A good test can use a combination of call and call

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -43,13 +43,13 @@ func (u uniqGoFuncs) NewListener(def api.FunctionDefinition) FunctionListener {
 }
 
 // Before implements FunctionListener.Before
-func (u uniqGoFuncs) Before(ctx context.Context, def api.FunctionDefinition, _ []uint64) context.Context {
+func (u uniqGoFuncs) Before(ctx context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64) context.Context {
 	u[def.DebugName()] = struct{}{}
 	return ctx
 }
 
 // After implements FunctionListener.After
-func (u uniqGoFuncs) After(context.Context, api.FunctionDefinition, error, []uint64) {}
+func (u uniqGoFuncs) After(context.Context, api.Module, api.FunctionDefinition, error, []uint64) {}
 
 // This shows how to make a listener that counts go function calls.
 func Example_customListenerFactory() {

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -21,12 +21,12 @@ type recorder struct {
 	beforeNames, afterNames []string
 }
 
-func (r *recorder) Before(ctx context.Context, def api.FunctionDefinition, _ []uint64) context.Context {
+func (r *recorder) Before(ctx context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64) context.Context {
 	r.beforeNames = append(r.beforeNames, def.DebugName())
 	return ctx
 }
 
-func (r *recorder) After(_ context.Context, def api.FunctionDefinition, _ error, _ []uint64) {
+func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefinition, _ error, _ []uint64) {
 	r.afterNames = append(r.afterNames, def.DebugName())
 }
 

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -298,11 +298,11 @@ func Test_loggingListener(t *testing.T) {
 			}
 			m.BuildFunctionDefinitions()
 			def := m.FunctionDefinitionSection[0]
-			l := lf.NewListener(m.FunctionDefinitionSection[0])
+			l := lf.NewListener(def)
 
 			out.Reset()
-			ctx := l.Before(testCtx, def, tc.params)
-			l.After(ctx, def, tc.err, tc.results)
+			ctx := l.Before(testCtx, nil, def, tc.params)
+			l.After(ctx, nil, def, tc.err, tc.results)
 			require.Equal(t, tc.expected, out.String())
 		})
 	}
@@ -337,10 +337,10 @@ func Test_loggingListener_indentation(t *testing.T) {
 	def2 := m.FunctionDefinitionSection[1]
 	l2 := lf.NewListener(def2)
 
-	ctx := l1.Before(testCtx, def1, []uint64{})
-	ctx1 := l2.Before(ctx, def2, []uint64{})
-	l2.After(ctx1, def2, nil, []uint64{})
-	l1.After(ctx, def1, nil, []uint64{})
+	ctx := l1.Before(testCtx, nil, def1, []uint64{})
+	ctx1 := l2.Before(ctx, nil, def2, []uint64{})
+	l2.After(ctx1, nil, def2, nil, []uint64{})
+	l1.After(ctx, nil, def1, nil, []uint64{})
 	require.Equal(t, `--> test.fn1()
 	--> test.fn2()
 	<--

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -461,7 +461,7 @@ func fdPrestatGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 var fdPrestatDirName = newHostFunc(
 	fdPrestatDirNameName, fdPrestatDirNameFn,
 	[]api.ValueType{i32, i32, i32},
-	"fd", "path", "path_len",
+	"fd", "result.path", "result.path_len",
 )
 
 func fdPrestatDirNameFn(_ context.Context, mod api.Module, params []uint64) Errno {

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -742,7 +742,7 @@ func Test_fdPrestatDirName(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatDirNameName, uint64(fd), uint64(path), uint64(pathLen))
 	require.Equal(t, `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=1,path_len=0)
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=1,result.path_len=0)
 <== ESUCCESS
 `, "\n"+log.String())
 
@@ -775,7 +775,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=65536,result.path_len=1)
 <== EFAULT
 `,
 		},
@@ -786,7 +786,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=65536,result.path_len=1)
 <== EFAULT
 `,
 		},
@@ -797,7 +797,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen + 1,
 			expectedErrno: ErrnoNametoolong,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=0,path_len=2)
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=0,result.path_len=2)
 <== ENAMETOOLONG
 `,
 		},
@@ -808,7 +808,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42,path=0,path_len=1)
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42,result.path=0,result.path_len=1)
 <== EBADF
 `,
 		},

--- a/imports/wasi_snapshot_preview1/random.go
+++ b/imports/wasi_snapshot_preview1/random.go
@@ -36,7 +36,7 @@ const randomGetName = "random_get"
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-random_getbuf-pointeru8-bufLen-size---errno
 var randomGet = newHostFunc(randomGetName, randomGetFn, []api.ValueType{i32, i32}, "buf", "buf_len")
 
-func randomGetFn(ctx context.Context, mod api.Module, params []uint64) Errno {
+func randomGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
 	randSource := sysCtx.RandSource()
 	buf, bufLen := uint32(params[0]), uint32(params[1])

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -29,7 +30,7 @@ import (
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
 const (
-	ModuleName = "wasi_snapshot_preview1"
+	ModuleName = wasi_snapshot_preview1.ModuleName
 	i32, i64   = wasm.ValueTypeI32, wasm.ValueTypeI64
 )
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -928,9 +928,9 @@ entry:
 			case builtinFunctionIndexTableGrow:
 				ce.builtinFunctionTableGrow(caller.source.Module.Tables)
 			case builtinFunctionIndexFunctionListenerBefore:
-				ce.builtinFunctionFunctionListenerBefore(ce.ctx, caller)
+				ce.builtinFunctionFunctionListenerBefore(ce.ctx, callCtx.WithMemory(ce.memoryInstance), caller)
 			case builtinFunctionIndexFunctionListenerAfter:
-				ce.builtinFunctionFunctionListenerAfter(ce.ctx, caller)
+				ce.builtinFunctionFunctionListenerAfter(ce.ctx, callCtx.WithMemory(ce.memoryInstance), caller)
 			}
 			if false {
 				if ce.exitContext.builtinFunctionCallIndex == builtinFunctionIndexBreakPoint {
@@ -995,17 +995,17 @@ func (ce *callEngine) builtinFunctionTableGrow(tables []*wasm.TableInstance) {
 	ce.pushValue(uint64(res))
 }
 
-func (ce *callEngine) builtinFunctionFunctionListenerBefore(ctx context.Context, fn *function) {
+func (ce *callEngine) builtinFunctionFunctionListenerBefore(ctx context.Context, mod api.Module, fn *function) {
 	base := int(ce.stackBasePointerInBytes >> 3)
-	listerCtx := fn.parent.listener.Before(ctx, fn.source.Definition, ce.stack[base:base+fn.source.Type.ParamNumInUint64])
+	listerCtx := fn.parent.listener.Before(ctx, mod, fn.source.Definition, ce.stack[base:base+fn.source.Type.ParamNumInUint64])
 	prevStackTop := ce.contextStack
 	ce.contextStack = &contextStack{self: ctx, prev: prevStackTop}
 	ce.ctx = listerCtx
 }
 
-func (ce *callEngine) builtinFunctionFunctionListenerAfter(ctx context.Context, fn *function) {
+func (ce *callEngine) builtinFunctionFunctionListenerAfter(ctx context.Context, mod api.Module, fn *function) {
 	base := int(ce.stackBasePointerInBytes >> 3)
-	fn.parent.listener.After(ctx, fn.source.Definition, nil, ce.stack[base:base+fn.source.Type.ResultNumInUint64])
+	fn.parent.listener.After(ctx, mod, fn.source.Definition, nil, ce.stack[base:base+fn.source.Type.ResultNumInUint64])
 	ce.ctx = ce.contextStack.self
 	ce.contextStack = ce.contextStack.prev
 }

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -577,7 +577,7 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 		},
 		parent: &code{
 			listener: mockListener{
-				before: func(ctx context.Context, def api.FunctionDefinition, paramValues []uint64) context.Context {
+				before: func(ctx context.Context, _ api.Module, def api.FunctionDefinition, paramValues []uint64) context.Context {
 					require.Equal(t, currentContext, ctx)
 					require.Equal(t, []uint64{2, 3, 4}, paramValues)
 					return nextContext
@@ -590,7 +590,7 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 		stackContext: stackContext{stackBasePointerInBytes: 16},
 		contextStack: &contextStack{self: prevContext},
 	}
-	ce.builtinFunctionFunctionListenerBefore(ce.ctx, f)
+	ce.builtinFunctionFunctionListenerBefore(ce.ctx, &wasm.CallContext{}, f)
 
 	// Contexts must be stacked.
 	require.Equal(t, currentContext, ce.contextStack.self)
@@ -606,7 +606,7 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 		},
 		parent: &code{
 			listener: mockListener{
-				after: func(ctx context.Context, def api.FunctionDefinition, err error, resultValues []uint64) {
+				after: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64) {
 					require.Equal(t, currentContext, ctx)
 					require.Equal(t, []uint64{5}, resultValues)
 				},
@@ -619,7 +619,7 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 		stackContext: stackContext{stackBasePointerInBytes: 40},
 		contextStack: &contextStack{self: prevContext},
 	}
-	ce.builtinFunctionFunctionListenerAfter(ce.ctx, f)
+	ce.builtinFunctionFunctionListenerAfter(ce.ctx, &wasm.CallContext{}, f)
 
 	// Contexts must be popped.
 	require.Nil(t, ce.contextStack)
@@ -627,16 +627,16 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 }
 
 type mockListener struct {
-	before func(ctx context.Context, def api.FunctionDefinition, paramValues []uint64) context.Context
-	after  func(ctx context.Context, def api.FunctionDefinition, err error, resultValues []uint64)
+	before func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64) context.Context
+	after  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
 }
 
-func (m mockListener) Before(ctx context.Context, def api.FunctionDefinition, paramValues []uint64) context.Context {
-	return m.before(ctx, def, paramValues)
+func (m mockListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64) context.Context {
+	return m.before(ctx, mod, def, paramValues)
 }
 
-func (m mockListener) After(ctx context.Context, def api.FunctionDefinition, err error, resultValues []uint64) {
-	m.after(ctx, def, err, resultValues)
+func (m mockListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64) {
+	m.after(ctx, mod, def, err, resultValues)
 }
 
 func TestFunction_getSourceOffsetInWasmBinary(t *testing.T) {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,228 @@
+// Package logging includes utilities used to log function calls. This is in
+// an independent package to avoid dependency cycles.
+package logging
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/tetratelabs/wazero/api"
+)
+
+// ValueType is an extended form of api.ValueType, used to control logging in
+// cases such as bitmasks or strings.
+type ValueType = api.ValueType
+
+const (
+	ValueTypeI32                 = api.ValueTypeI32
+	ValueTypeI64                 = api.ValueTypeI64
+	ValueTypeF32                 = api.ValueTypeF32
+	ValueTypeF64                 = api.ValueTypeF64
+	ValueTypeV128      ValueType = 0x7b // same as wasm.ValueTypeV128
+	ValueTypeFuncref   ValueType = 0x70 // same as wasm.ValueTypeFuncref
+	ValueTypeExternref           = api.ValueTypeExternref
+
+	// ValueTypeMemI32 is a non-standard type which writes ValueTypeI32 from the memory offset.
+	ValueTypeMemI32 = 0xfd
+	// ValueTypeMemH64 is a non-standard type which writes 64-bits fixed-width hex from the memory offset.
+	ValueTypeMemH64 = 0xfe
+	// ValueTypeString is a non-standard type describing an offset/len pair of a string.
+	ValueTypeString = 0xff
+)
+
+// LoggerKey is a context.Context Value key with a FunctionLogger value.
+type LoggerKey struct{}
+
+type ParamLogger func(ctx context.Context, mod api.Module, w Writer, params []uint64)
+
+type ResultLogger func(ctx context.Context, mod api.Module, w Writer, params, results []uint64)
+
+type Writer interface {
+	io.Writer
+	io.StringWriter
+	io.ByteWriter
+}
+
+// ValWriter formats an indexed value. For example, if `vals[i]` is a
+// ValueTypeI32, this would format it by default as signed. If a
+// ValueTypeString, it would read `vals[i+1]` and write the string from memory.
+type ValWriter func(ctx context.Context, mod api.Module, w Writer, i uint32, vals []uint64)
+
+func ValueLoggers(fnd api.FunctionDefinition) (paramLoggers []ParamLogger, resultLoggers []ResultLogger) {
+	if paramLen := uint32(len(fnd.ParamTypes())); paramLen > 0 {
+		paramLoggers = make([]ParamLogger, paramLen)
+		hasParamNames := len(fnd.ParamNames()) > 0
+		for i, t := range fnd.ParamTypes() {
+			if hasParamNames {
+				paramLoggers[i] = NewParamLogger(uint32(i), fnd.ParamNames()[i], t)
+			} else {
+				paramLoggers[i] = paramLogger{idx: uint32(i), valWriter: ValWriterForType(t)}.Log
+			}
+		}
+	}
+	if resultLen := uint32(len(fnd.ResultTypes())); resultLen > 0 {
+		resultLoggers = make([]ResultLogger, resultLen)
+		hasResultNames := len(fnd.ResultNames()) > 0
+		for i, t := range fnd.ResultTypes() {
+			if hasResultNames {
+				resultLoggers[i] = NewResultLogger(uint32(i), fnd.ResultNames()[i], t)
+			} else {
+				resultLoggers[i] = resultLogger{idx: uint32(i), valWriter: ValWriterForType(t)}.Log
+			}
+		}
+	}
+	return
+}
+
+type paramLogger struct {
+	idx       uint32
+	valWriter ValWriter
+}
+
+func (n paramLogger) Log(ctx context.Context, mod api.Module, w Writer, params []uint64) {
+	n.valWriter(ctx, mod, w, n.idx, params)
+}
+
+func NewParamLogger(idx uint32, name string, t ValueType) ParamLogger {
+	return namedParamLogger{idx, name, ValWriterForType(t)}.Log
+}
+
+type namedParamLogger struct {
+	idx       uint32
+	name      string
+	valWriter ValWriter
+}
+
+func (n namedParamLogger) Log(ctx context.Context, mod api.Module, w Writer, params []uint64) {
+	w.WriteString(n.name) // nolint
+	w.WriteByte('=')      // nolint
+	n.valWriter(ctx, mod, w, n.idx, params)
+}
+
+type resultLogger struct {
+	idx       uint32
+	valWriter ValWriter
+}
+
+func (n resultLogger) Log(ctx context.Context, mod api.Module, w Writer, _, results []uint64) {
+	n.valWriter(ctx, mod, w, n.idx, results)
+}
+
+func NewResultLogger(idx uint32, name string, t ValueType) ResultLogger {
+	return namedResultLogger{idx, name, ValWriterForType(t)}.Log
+}
+
+type namedResultLogger struct {
+	idx       uint32
+	name      string
+	valWriter ValWriter
+}
+
+func (n namedResultLogger) Log(ctx context.Context, mod api.Module, w Writer, _, results []uint64) {
+	w.WriteString(n.name) // nolint
+	w.WriteByte('=')      // nolint
+	n.valWriter(ctx, mod, w, n.idx, results)
+}
+
+func ValWriterForType(vt ValueType) ValWriter {
+	switch vt {
+	case ValueTypeI32:
+		return writeI32
+	case ValueTypeI64:
+		return writeI64
+	case ValueTypeF32:
+		return writeF32
+	case ValueTypeF64:
+		return writeF64
+	case ValueTypeV128:
+		return writeV128
+	case ValueTypeExternref, ValueTypeFuncref:
+		return writeRef
+	case ValueTypeMemI32:
+		return writeMemI32
+	case ValueTypeMemH64:
+		return writeMemH64
+	case ValueTypeString:
+		return writeString
+	default:
+		panic(fmt.Errorf("BUG: unsupported type %d", vt))
+	}
+}
+
+func writeI32(_ context.Context, _ api.Module, w Writer, i uint32, vals []uint64) {
+	v := vals[i]
+	w.WriteString(strconv.FormatInt(int64(int32(v)), 10)) //nolint
+}
+
+func writeI64(_ context.Context, _ api.Module, w Writer, i uint32, vals []uint64) {
+	v := vals[i]
+	w.WriteString(strconv.FormatInt(int64(v), 10)) //nolint
+}
+
+func writeF32(_ context.Context, _ api.Module, w Writer, i uint32, vals []uint64) {
+	v := vals[i]
+	s := strconv.FormatFloat(float64(api.DecodeF32(v)), 'g', -1, 32)
+	w.WriteString(s) //nolint
+}
+
+func writeF64(_ context.Context, _ api.Module, w Writer, i uint32, vals []uint64) {
+	v := vals[i]
+	s := strconv.FormatFloat(api.DecodeF64(v), 'g', -1, 64)
+	w.WriteString(s) //nolint
+}
+
+// logV128 logs in fixed-width hex
+func writeV128(_ context.Context, _ api.Module, w Writer, i uint32, vals []uint64) {
+	v1, v2 := vals[i], vals[i+1]
+	w.WriteString(fmt.Sprintf("%016x%016x", v1, v2)) //nolint
+}
+
+// logRef logs in fixed-width hex
+func writeRef(_ context.Context, _ api.Module, w Writer, i uint32, vals []uint64) {
+	v := vals[i]
+	w.WriteString(fmt.Sprintf("%016x", v)) //nolint
+}
+
+func writeMemI32(_ context.Context, mod api.Module, w Writer, i uint32, vals []uint64) {
+	offset := uint32(vals[i])
+	byteCount := uint32(4)
+	if v, ok := mod.Memory().ReadUint32Le(offset); ok {
+		w.WriteString(strconv.FormatInt(int64(int32(v)), 10)) //nolint
+	} else { // log the positions that were out of memory
+		WriteOOM(w, offset, byteCount)
+	}
+}
+
+func writeMemH64(_ context.Context, mod api.Module, w Writer, i uint32, vals []uint64) {
+	offset := uint32(vals[i])
+	byteCount := uint32(8)
+	if s, ok := mod.Memory().Read(offset, byteCount); ok {
+		hex.NewEncoder(w).Write(s) //nolint
+	} else { // log the positions that were out of memory
+		WriteOOM(w, offset, byteCount)
+	}
+}
+
+func writeString(_ context.Context, mod api.Module, w Writer, i uint32, vals []uint64) {
+	offset, byteCount := uint32(vals[i]), uint32(vals[i+1])
+	WriteStringOrOOM(mod.Memory(), w, offset, byteCount)
+}
+
+func WriteStringOrOOM(mem api.Memory, w Writer, offset, byteCount uint32) {
+	if s, ok := mem.Read(offset, byteCount); ok {
+		w.Write(s) //nolint
+	} else { // log the positions that were out of memory
+		WriteOOM(w, offset, byteCount)
+	}
+}
+
+func WriteOOM(w Writer, offset uint32, byteCount uint32) {
+	w.WriteString("OOM(")                       //nolint
+	w.WriteString(strconv.Itoa(int(offset)))    //nolint
+	w.WriteByte(',')                            //nolint
+	w.WriteString(strconv.Itoa(int(byteCount))) //nolint
+	w.WriteByte(')')                            //nolint
+}

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -1,8 +1,6 @@
 package proxy
 
 import (
-	"io"
-
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
@@ -16,7 +14,7 @@ const proxyModuleName = "internal/testing/proxy/proxy.go"
 
 // NewLoggingListenerFactory is like logging.NewHostLoggingListenerFactory,
 // except it skips logging proxying functions from NewModuleBinary.
-func NewLoggingListenerFactory(writer io.Writer) experimental.FunctionListenerFactory {
+func NewLoggingListenerFactory(writer logging.Writer) experimental.FunctionListenerFactory {
 	return &loggingListenerFactory{logging.NewHostLoggingListenerFactory(writer)}
 }
 

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
 )
 
 func argsSizesGet(ctx context.Context, mod api.Module, resultArgc, resultArgvBufSize uint32) uint32 {
@@ -42,7 +43,7 @@ func TestNewHostModule(t *testing.T) {
 		},
 		{
 			name:       "funcs",
-			moduleName: "wasi_snapshot_preview1",
+			moduleName: wasi_snapshot_preview1.ModuleName,
 			nameToGoFunc: map[string]interface{}{
 				argsSizesGetName: argsSizesGet,
 				fdWriteName:      fdWrite,
@@ -71,7 +72,7 @@ func TestNewHostModule(t *testing.T) {
 					{Name: "fd_write", Type: ExternTypeFunc, Index: 1},
 				},
 				NameSection: &NameSection{
-					ModuleName: "wasi_snapshot_preview1",
+					ModuleName: wasi_snapshot_preview1.ModuleName,
 					FunctionNames: NameMap{
 						{Index: 0, Name: "args_sizes_get"},
 						{Index: 1, Name: "fd_write"},


### PR DESCRIPTION
This changes the listener signature to accept context and calling
module, so that all possible parameters and results can be logged. This
also changes the logging listener to make parameters visible when
logging results.

This infrastructure supports some helpful use cases, such as logging
WASI result parameters, such as the prestat path, which is only knowable
after the function has been called. The context parameter supposed
reading results of gojs functions, which are stored host-side in a go
context object.

Future pull requests will complete this as well backfill unit tests.
This is raised independently mainly to keep the PR size down of the
upcoming filesystem logger.