### PR TITLE
leb128: no allocations in decoding

### DIFF
--- a/internal/leb128/leb128_alloc_test.go
+++ b/internal/leb128/leb128_alloc_test.go
@@ -1,0 +1,113 @@
+package leb128
+
+import (
+	"bytes"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"testing"
+)
+
+func TestLeb128NoAlloc(t *testing.T) {
+	t.Run("LoadUint32", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkLoadUint32)
+		require.Zero(t, result.AllocsPerOp())
+	})
+	t.Run("LoadUint64", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkLoadUint64)
+		require.Zero(t, result.AllocsPerOp())
+	})
+	t.Run("LoadInt32", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkLoadInt32)
+		require.Zero(t, result.AllocsPerOp())
+	})
+	t.Run("LoadInt64", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkLoadInt64)
+		require.Zero(t, result.AllocsPerOp())
+	})
+	t.Run("DecodeUint32", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkDecodeUint32)
+		require.Zero(t, result.AllocsPerOp())
+	})
+	t.Run("DecodeInt32", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkDecodeInt32)
+		require.Zero(t, result.AllocsPerOp())
+	})
+}
+
+func BenchmarkLoadUint32(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, err := LoadUint32([]byte{0x80, 0x80, 0x80, 0x4f})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoadUint64(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, err := LoadUint64([]byte{0x80, 0x80, 0x80, 0x4f})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoadInt32(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, err := LoadInt32([]byte{0x80, 0x80, 0x80, 0x4f})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkLoadInt64(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _, err := LoadInt64([]byte{0x80, 0x80, 0x80, 0x4f})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeUint32(b *testing.B) {
+	b.ReportAllocs()
+	data := []byte{0x80, 0x80, 0x80, 0x4f}
+	r := bytes.NewReader(data)
+	for i := 0; i < b.N; i++ {
+		_, _, err := DecodeUint32(r)
+		if err != nil {
+			b.Fatal(err)
+		}
+		r.Reset(data)
+	}
+}
+
+func BenchmarkDecodeInt32(b *testing.B) {
+	b.ReportAllocs()
+	data := []byte{0x80, 0x80, 0x80, 0x4f}
+	r := bytes.NewReader(data)
+	for i := 0; i < b.N; i++ {
+		_, _, err := DecodeInt32(r)
+		if err != nil {
+			b.Fatal(err)
+		}
+		r.Reset(data)
+	}
+}
+
+func BenchmarkDecodeInt64(b *testing.B) {
+	b.ReportAllocs()
+	data := []byte{0x80, 0x80, 0x80, 0x4f}
+	r := bytes.NewReader(data)
+	for i := 0; i < b.N; i++ {
+		_, _, err := DecodeInt64(r)
+		if err != nil {
+			b.Fatal(err)
+		}
+		r.Reset(data)
+	}
+}

--- a/internal/leb128/leb128_alloc_test.go
+++ b/internal/leb128/leb128_alloc_test.go
@@ -33,6 +33,10 @@ func TestLeb128NoAlloc(t *testing.T) {
 		result := testing.Benchmark(BenchmarkDecodeInt32)
 		require.Zero(t, result.AllocsPerOp())
 	})
+	t.Run("DecodeInt64", func(t *testing.T) {
+		result := testing.Benchmark(BenchmarkDecodeInt64)
+		require.Zero(t, result.AllocsPerOp())
+	})
 }
 
 func BenchmarkLoadUint32(b *testing.B) {

--- a/internal/leb128/leb128_alloc_test.go
+++ b/internal/leb128/leb128_alloc_test.go
@@ -2,10 +2,12 @@ package leb128
 
 import (
 	"bytes"
-	"github.com/tetratelabs/wazero/internal/testing/require"
 	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+// TestLeb128NoAlloc ensures no allocation required in the leb128 package.
 func TestLeb128NoAlloc(t *testing.T) {
 	t.Run("LoadUint32", func(t *testing.T) {
 		result := testing.Benchmark(BenchmarkLoadUint32)


### PR DESCRIPTION
This is a hot pass during compilation. Found while doing #936, and raised this as a separate PR.
```
benchstat leb128_old.txt leb128_new.txt
name             old time/op    new time/op    delta
LoadUint32-10      41.8ns ± 1%    12.0ns ± 0%   -71.35%  (p=0.000 n=10+10)
LoadUint64-10      4.96ns ± 0%    4.95ns ± 0%      ~     (p=0.813 n=9+9)
LoadInt32-10       42.1ns ± 2%    12.4ns ± 0%   -70.56%  (p=0.000 n=10+10)
LoadInt64-10       41.7ns ± 1%    12.4ns ± 0%   -70.27%  (p=0.000 n=10+10)
DecodeUint32-10    38.4ns ± 1%    17.3ns ± 1%   -55.03%  (p=0.000 n=10+10)
DecodeInt32-10     39.3ns ± 1%    17.8ns ± 0%   -54.59%  (p=0.000 n=10+9)
DecodeInt64-10     39.3ns ± 0%    17.6ns ± 0%   -55.28%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
LoadUint32-10       28.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
LoadUint64-10       0.00B          0.00B           ~     (all equal)
LoadInt32-10        28.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
LoadInt64-10        28.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
DecodeUint32-10     16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
DecodeInt32-10      16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
DecodeInt64-10      16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
LoadUint32-10        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
LoadUint64-10        0.00           0.00           ~     (all equal)
LoadInt32-10         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
LoadInt64-10         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
DecodeUint32-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
DecodeInt32-10       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
DecodeInt64-10       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)

```


Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
