### PR TITLE
wasi: allows closing stdio file descriptors

### DIFF
--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -2,7 +2,6 @@ package sys
 
 import (
 	"bytes"
-	"io"
 	"testing"
 	"time"
 
@@ -52,9 +51,12 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
 
 	expectedFS, _ := NewFSContext(nil, nil, nil, testfs.FS{})
-	require.Equal(t, eofReader{}, expectedFS.stdin)
-	require.Equal(t, io.Discard, expectedFS.stdout)
-	require.Equal(t, io.Discard, expectedFS.stderr)
+	require.Equal(t, map[uint32]*FileEntry{
+		FdStdin:  noopStdin,
+		FdStdout: noopStdout,
+		FdStderr: noopStderr,
+		FdRoot:   {Name: "/", File: emptyRootDir{}},
+	}, expectedFS.openedFiles)
 	require.Equal(t, expectedFS, sysCtx.FS())
 }
 


### PR DESCRIPTION
This allows wasm to close stdio file descriptors such as STDOUT(1). This will not close the underlying host resource as that would break a lot of folks doing logging to the console.

Thanks a lot to @vyskocilm for making this easy to identify and fix!

```bash
$ cat > fclose.c <<EOF
#include <stdlib.h>
#include <stdio.h>

int main() {
    int ret = fclose(stdin);
    if (ret != 0) {
        perror("fclose <stdin>");
    }
    exit(ret);
}
EOF

$ zig cc --target=wasm32-wasi fclose.c -o fclose.wasm
$ go build -o wazero ./cmd/wazero/...
$ ./wazero run fclose.wasm
```

Fixes #953
