### PR TITLE
cli: allows use of GOOS=js

### DIFF
--- a/cmd/wazero/testdata/cat/.gitignore
+++ b/cmd/wazero/testdata/cat/.gitignore
@@ -1,0 +1,2 @@
+# GOARCH=wasm GOOS=js binaries are too huge to check-in
+cat.wasm

--- a/cmd/wazero/testdata/cat/cat.go
+++ b/cmd/wazero/testdata/cat/cat.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+)
+
+// main runs cat: concatenate and print files.
+func main() {
+	// Start at arg[1] because args[0] is the program name.
+	for i := 1; i < len(os.Args); i++ {
+		bytes, err := os.ReadFile(os.Args[i])
+		if err != nil {
+			os.Exit(1)
+		}
+
+		// Use write to avoid needing to worry about Windows newlines.
+		os.Stdout.Write(bytes)
+	}
+}

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -470,8 +470,8 @@ func runMain(t *testing.T, args []string) (int, string, string) {
 	return exitCode, stdOut.String(), stdErr.String()
 }
 
-// compileGoJS compiles "stars/main.go" on demand as the binary generated is
-// too big (>7MB) to check into the source tree.
+// compileGoJS compiles "testdata/cat/cat.go" on demand as the binary generated
+// is too big (1.6MB) to check into the source tree.
 func compileGoJS() (err error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -481,6 +481,7 @@ func compileGoJS() (err error) {
 	srcDir := path.Join(dir, "testdata", "cat")
 	outPath := path.Join(srcDir, "cat.wasm")
 
+	// This doesn't add "-ldflags=-s -w", as the binary size only changes 28KB.
 	cmd := exec.Command("go", "build", "-o", outPath, ".")
 	cmd.Dir = srcDir
 	cmd.Env = append(os.Environ(), "GOARCH=wasm", "GOOS=js", "GOWASM=satconv,signext")


### PR DESCRIPTION
This changes the CLI to detect if GOOS=js is likely in use and switches accordingly. This makes it easier to find bugs and may eventually lead to go being able to swap out node.js for wazero. This adds 1.5-2MB to the binary depending on ldflags.

Note: GOOS=js a.k.a. gojs isn't complete, yet, so this helps identify that as well. For example, similar to WASI there's no support for mkdir yet.
```bash
$ GOOS=js GOARCH=wasm go test -o os.wasm -c os
$ wazero run os.wasm -test.v
=== RUN   TestExpand
--- PASS: TestExpand (0.00s)
=== RUN   TestConsistentEnviron
--- PASS: TestConsistentEnviron (0.00s)
=== RUN   TestUnsetenv
--- PASS: TestUnsetenv (0.00s)
=== RUN   TestClearenv
--- PASS: TestClearenv (0.00s)
=== RUN   TestLookupEnv
--- PASS: TestLookupEnv (0.00s)
=== RUN   TestEnvironConsistency
--- PASS: TestEnvironConsistency (0.00s)
=== RUN   TestErrIsExist
    error_test.go:19: open ErrIsExist tempfile: open /tmp/_Go_ErrIsExist1152228349: No such file or directory
--- FAIL: TestErrIsExist (0.00s)
=== RUN   TestErrIsNotExist
error instantiating wasm binary: TODO: call fs.mkdir (recovered by wazero)
wasm stack trace:
	go.syscall/js.valueCall(i32)
	.syscall_js.valueCall(i32) i32
	.syscall_js.Value.Call(i32) i32
	.syscall.fsCall(i32) i32
	.syscall.Mkdir(i32) i32
	.os.Mkdir.func1(i32) i32
	.os.Mkdir(i32) i32
	.os.MkdirTemp(i32) i32
	.wasm_pc_f_loop()
	.wasm_export_run(i32,i32)
```
