### PR TITLE
Hides internal logging

### DIFF
--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -41,6 +41,10 @@ type loggingListenerFactory struct {
 // NewListener implements the same method as documented on
 // experimental.FunctionListener.
 func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+	if fnd.ModuleName() == "internal/testing/proxy/proxy.go" {
+		return nil // special internal name we use to re-export host modules
+	}
+
 	exported := len(fnd.ExportNames()) > 0
 	if f.hostOnly && // choose functions defined or callable by the host
 		fnd.GoFunction() == nil && // not defined by the host

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -41,10 +41,6 @@ type loggingListenerFactory struct {
 // NewListener implements the same method as documented on
 // experimental.FunctionListener.
 func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
-	if fnd.ModuleName() == "internal/testing/proxy/proxy.go" {
-		return nil // special internal name we use to re-export host modules
-	}
-
 	exported := len(fnd.ExportNames()) > 0
 	if f.hostOnly && // choose functions defined or callable by the host
 		fnd.GoFunction() == nil && // not defined by the host

--- a/imports/assemblyscript/assemblyscript_test.go
+++ b/imports/assemblyscript/assemblyscript_test.go
@@ -61,8 +61,7 @@ func TestAbort(t *testing.T) {
 			require.True(t, ok, err)
 			require.Equal(t, uint32(255), sysErr.ExitCode())
 			require.Equal(t, `
---> proxy.abort(message=4,fileName=22,lineNumber=1,columnNumber=2)
-	==> env.~lib/builtins/abort(message=4,fileName=22,lineNumber=1,columnNumber=2)
+==> env.~lib/builtins/abort(message=4,fileName=22,lineNumber=1,columnNumber=2)
 `, "\n"+log.String())
 
 			require.Equal(t, tc.expected, stderr.String())
@@ -86,8 +85,7 @@ func TestAbort_Error(t *testing.T) {
 			messageUTF16:  encodeUTF16("message")[:5],
 			fileNameUTF16: encodeUTF16("filename"),
 			expectedLog: `
---> proxy.abort(message=4,fileName=13,lineNumber=1,columnNumber=2)
-	==> env.~lib/builtins/abort(message=4,fileName=13,lineNumber=1,columnNumber=2)
+==> env.~lib/builtins/abort(message=4,fileName=13,lineNumber=1,columnNumber=2)
 `,
 		},
 		{
@@ -95,8 +93,7 @@ func TestAbort_Error(t *testing.T) {
 			messageUTF16:  encodeUTF16("message"),
 			fileNameUTF16: encodeUTF16("filename")[:5],
 			expectedLog: `
---> proxy.abort(message=4,fileName=22,lineNumber=1,columnNumber=2)
-	==> env.~lib/builtins/abort(message=4,fileName=22,lineNumber=1,columnNumber=2)
+==> env.~lib/builtins/abort(message=4,fileName=22,lineNumber=1,columnNumber=2)
 `,
 		},
 	}
@@ -130,10 +127,8 @@ func TestSeed(t *testing.T) {
 	ret, err := mod.ExportedFunction(functionSeed).Call(testCtx)
 	require.NoError(t, err)
 	require.Equal(t, `
---> proxy.seed()
-	==> env.~lib/builtins/seed()
-	<== rand=4.958153677776298e-175
-<-- 4.958153677776298e-175
+==> env.~lib/builtins/seed()
+<== rand=4.958153677776298e-175
 `, "\n"+log.String())
 
 	require.Equal(t, "538c7f96b164bf1b", hex.EncodeToString(u64.LeBytes(ret[0])))
@@ -151,7 +146,7 @@ func TestSeed_error(t *testing.T) {
 			expectedErr: `error reading random seed: unexpected EOF (recovered by wazero)
 wasm stack trace:
 	env.~lib/builtins/seed() f64
-	proxy.seed() f64`,
+	internal/testing/proxy/proxy.go.seed() f64`,
 		},
 		{
 			name:   "error reading",
@@ -159,7 +154,7 @@ wasm stack trace:
 			expectedErr: `error reading random seed: ice cream (recovered by wazero)
 wasm stack trace:
 	env.~lib/builtins/seed() f64
-	proxy.seed() f64`,
+	internal/testing/proxy/proxy.go.seed() f64`,
 		},
 	}
 
@@ -173,8 +168,7 @@ wasm stack trace:
 			_, err := mod.ExportedFunction(functionSeed).Call(testCtx)
 			require.EqualError(t, err, tc.expectedErr)
 			require.Equal(t, `
---> proxy.seed()
-	==> env.~lib/builtins/seed()
+==> env.~lib/builtins/seed()
 `, "\n"+log.String())
 		})
 	}
@@ -184,10 +178,8 @@ wasm stack trace:
 func TestFunctionExporter_Trace(t *testing.T) {
 	noArgs := []uint64{4, 0, 0, 0, 0, 0, 0}
 	noArgsLog := `
---> proxy.trace(message=4,nArgs=0,arg0=0,arg1=0,arg2=0,arg3=0,arg4=0)
-	==> env.~lib/builtins/trace(message=4,nArgs=0,arg0=0,arg1=0,arg2=0,arg3=0,arg4=0)
-	<==
-<--
+==> env.~lib/builtins/trace(message=4,nArgs=0,arg0=0,arg1=0,arg2=0,arg3=0,arg4=0)
+<==
 `
 
 	tests := []struct {
@@ -226,10 +218,8 @@ func TestFunctionExporter_Trace(t *testing.T) {
 			params:   []uint64{4, 1, api.EncodeF64(1), 0, 0, 0, 0},
 			expected: "trace: hello 1\n",
 			expectedLog: `
---> proxy.trace(message=4,nArgs=1,arg0=1,arg1=0,arg2=0,arg3=0,arg4=0)
-	==> env.~lib/builtins/trace(message=4,nArgs=1,arg0=1,arg1=0,arg2=0,arg3=0,arg4=0)
-	<==
-<--
+==> env.~lib/builtins/trace(message=4,nArgs=1,arg0=1,arg1=0,arg2=0,arg3=0,arg4=0)
+<==
 `,
 		},
 		{
@@ -238,10 +228,8 @@ func TestFunctionExporter_Trace(t *testing.T) {
 			params:   []uint64{4, 2, api.EncodeF64(1), api.EncodeF64(2), 0, 0, 0},
 			expected: "trace: hello 1,2\n",
 			expectedLog: `
---> proxy.trace(message=4,nArgs=2,arg0=1,arg1=2,arg2=0,arg3=0,arg4=0)
-	==> env.~lib/builtins/trace(message=4,nArgs=2,arg0=1,arg1=2,arg2=0,arg3=0,arg4=0)
-	<==
-<--
+==> env.~lib/builtins/trace(message=4,nArgs=2,arg0=1,arg1=2,arg2=0,arg3=0,arg4=0)
+<==
 `,
 		},
 		{
@@ -258,10 +246,8 @@ func TestFunctionExporter_Trace(t *testing.T) {
 			},
 			expected: "trace: hello 1,2,3.3,4.4,5\n",
 			expectedLog: `
---> proxy.trace(message=4,nArgs=5,arg0=1,arg1=2,arg2=3.3,arg3=4.4,arg4=5)
-	==> env.~lib/builtins/trace(message=4,nArgs=5,arg0=1,arg1=2,arg2=3.3,arg3=4.4,arg4=5)
-	<==
-<--
+==> env.~lib/builtins/trace(message=4,nArgs=5,arg0=1,arg1=2,arg2=3.3,arg3=4.4,arg4=5)
+<==
 `,
 		},
 		{

--- a/imports/assemblyscript/assemblyscript_test.go
+++ b/imports/assemblyscript/assemblyscript_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	. "github.com/tetratelabs/wazero/experimental"
-	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
@@ -406,7 +405,7 @@ func requireProxyModule(t *testing.T, fns FunctionExporter, config wazero.Module
 	var log bytes.Buffer
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, logging.NewLoggingListenerFactory(&log))
+	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, proxy.NewLoggingListenerFactory(&log))
 
 	r := wazero.NewRuntime(ctx)
 
@@ -419,7 +418,7 @@ func requireProxyModule(t *testing.T, fns FunctionExporter, config wazero.Module
 	_, err = r.InstantiateModule(ctx, envCompiled, config)
 	require.NoError(t, err)
 
-	proxyBin := proxy.GetProxyModuleBinary("env", envCompiled)
+	proxyBin := proxy.NewModuleBinary("env", envCompiled)
 
 	proxyCompiled, err := r.CompileModule(ctx, proxyBin)
 	require.NoError(t, err)

--- a/imports/wasi_snapshot_preview1/args_test.go
+++ b/imports/wasi_snapshot_preview1/args_test.go
@@ -27,10 +27,8 @@ func Test_argsGet(t *testing.T) {
 	// Invoke argsGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, argsGetName, uint64(argv), uint64(argvBuf))
 	require.Equal(t, `
---> proxy.args_get(argv=22,argv_buf=16)
-	==> wasi_snapshot_preview1.args_get(argv=22,argv_buf=16)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.args_get(argv=22,argv_buf=16)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(argvBuf-1, uint32(len(expectedMemory)))
@@ -55,10 +53,8 @@ func Test_argsGet_Errors(t *testing.T) {
 			argv:    memorySize,
 			argvBuf: validAddress,
 			expectedLog: `
---> proxy.args_get(argv=65536,argv_buf=0)
-	==> wasi_snapshot_preview1.args_get(argv=65536,argv_buf=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_get(argv=65536,argv_buf=0)
+<== EFAULT
 `,
 		},
 		{
@@ -66,10 +62,8 @@ func Test_argsGet_Errors(t *testing.T) {
 			argv:    validAddress,
 			argvBuf: memorySize,
 			expectedLog: `
---> proxy.args_get(argv=0,argv_buf=65536)
-	==> wasi_snapshot_preview1.args_get(argv=0,argv_buf=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_get(argv=0,argv_buf=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -78,10 +72,8 @@ func Test_argsGet_Errors(t *testing.T) {
 			argv:    memorySize - 4*2 + 1,
 			argvBuf: validAddress,
 			expectedLog: `
---> proxy.args_get(argv=65529,argv_buf=0)
-	==> wasi_snapshot_preview1.args_get(argv=65529,argv_buf=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_get(argv=65529,argv_buf=0)
+<== EFAULT
 `,
 		},
 		{
@@ -90,10 +82,8 @@ func Test_argsGet_Errors(t *testing.T) {
 			// "a", "bc" size = size of "a0bc0" = 5
 			argvBuf: memorySize - 5 + 1,
 			expectedLog: `
---> proxy.args_get(argv=0,argv_buf=65532)
-	==> wasi_snapshot_preview1.args_get(argv=0,argv_buf=65532)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_get(argv=0,argv_buf=65532)
+<== EFAULT
 `,
 		},
 	}
@@ -129,10 +119,8 @@ func Test_argsSizesGet(t *testing.T) {
 	// Invoke argsSizesGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, argsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
 	require.Equal(t, `
---> proxy.args_sizes_get(result.argc=16,result.argv_len=21)
-	==> wasi_snapshot_preview1.args_sizes_get(result.argc=16,result.argv_len=21)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.args_sizes_get(result.argc=16,result.argv_len=21)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(resultArgc-1, uint32(len(expectedMemory)))
@@ -157,10 +145,8 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argc:    memorySize,
 			argvLen: validAddress,
 			expectedLog: `
---> proxy.args_sizes_get(result.argc=65536,result.argv_len=0)
-	==> wasi_snapshot_preview1.args_sizes_get(result.argc=65536,result.argv_len=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_sizes_get(result.argc=65536,result.argv_len=0)
+<== EFAULT
 `,
 		},
 		{
@@ -168,10 +154,8 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argc:    validAddress,
 			argvLen: memorySize,
 			expectedLog: `
---> proxy.args_sizes_get(result.argc=0,result.argv_len=65536)
-	==> wasi_snapshot_preview1.args_sizes_get(result.argc=0,result.argv_len=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_sizes_get(result.argc=0,result.argv_len=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -179,10 +163,8 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argc:    memorySize - 4 + 1, // 4 is the size of uint32, the type of the count of args
 			argvLen: validAddress,
 			expectedLog: `
---> proxy.args_sizes_get(result.argc=65533,result.argv_len=0)
-	==> wasi_snapshot_preview1.args_sizes_get(result.argc=65533,result.argv_len=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_sizes_get(result.argc=65533,result.argv_len=0)
+<== EFAULT
 `,
 		},
 		{
@@ -190,10 +172,8 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argc:    validAddress,
 			argvLen: memorySize - 4 + 1, // 4 is count of bytes to encode uint32le
 			expectedLog: `
---> proxy.args_sizes_get(result.argc=0,result.argv_len=65533)
-	==> wasi_snapshot_preview1.args_sizes_get(result.argc=0,result.argv_len=65533)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.args_sizes_get(result.argc=0,result.argv_len=65533)
+<== EFAULT
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -35,10 +35,8 @@ func Test_clockResGet(t *testing.T) {
 			clockID:        clockIDRealtime,
 			expectedMemory: expectedMemoryMicro,
 			expectedLog: `
---> proxy.clock_res_get(id=0,result.resolution=16)
-	==> wasi_snapshot_preview1.clock_res_get(id=0,result.resolution=16)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.clock_res_get(id=0,result.resolution=16)
+<== ESUCCESS
 `,
 		},
 		{
@@ -46,10 +44,8 @@ func Test_clockResGet(t *testing.T) {
 			clockID:        clockIDMonotonic,
 			expectedMemory: expectedMemoryNano,
 			expectedLog: `
---> proxy.clock_res_get(id=1,result.resolution=16)
-	==> wasi_snapshot_preview1.clock_res_get(id=1,result.resolution=16)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.clock_res_get(id=1,result.resolution=16)
+<== ESUCCESS
 `,
 		},
 	}
@@ -88,10 +84,8 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			clockID:       2,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.clock_res_get(id=2,result.resolution=16)
-	==> wasi_snapshot_preview1.clock_res_get(id=2,result.resolution=16)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.clock_res_get(id=2,result.resolution=16)
+<== EINVAL
 `,
 		},
 		{
@@ -99,10 +93,8 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			clockID:       3,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.clock_res_get(id=3,result.resolution=16)
-	==> wasi_snapshot_preview1.clock_res_get(id=3,result.resolution=16)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.clock_res_get(id=3,result.resolution=16)
+<== EINVAL
 `,
 		},
 		{
@@ -110,10 +102,8 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			clockID:       100,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.clock_res_get(id=100,result.resolution=16)
-	==> wasi_snapshot_preview1.clock_res_get(id=100,result.resolution=16)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.clock_res_get(id=100,result.resolution=16)
+<== EINVAL
 `,
 		},
 	}
@@ -150,10 +140,8 @@ func Test_clockTimeGet(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
---> proxy.clock_time_get(id=0,precision=0,result.timestamp=16)
-	==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=16)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=16)
+<== ESUCCESS
 `,
 		},
 		{
@@ -165,10 +153,8 @@ func Test_clockTimeGet(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
---> proxy.clock_time_get(id=1,precision=0,result.timestamp=16)
-	==> wasi_snapshot_preview1.clock_time_get(id=1,precision=0,result.timestamp=16)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.clock_time_get(id=1,precision=0,result.timestamp=16)
+<== ESUCCESS
 `,
 		},
 	}
@@ -206,10 +192,8 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       2,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.clock_time_get(id=2,precision=0,result.timestamp=16)
-	==> wasi_snapshot_preview1.clock_time_get(id=2,precision=0,result.timestamp=16)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.clock_time_get(id=2,precision=0,result.timestamp=16)
+<== EINVAL
 `,
 		},
 		{
@@ -217,10 +201,8 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       3,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.clock_time_get(id=3,precision=0,result.timestamp=16)
-	==> wasi_snapshot_preview1.clock_time_get(id=3,precision=0,result.timestamp=16)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.clock_time_get(id=3,precision=0,result.timestamp=16)
+<== EINVAL
 `,
 		},
 		{
@@ -228,10 +210,8 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       100,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.clock_time_get(id=100,precision=0,result.timestamp=16)
-	==> wasi_snapshot_preview1.clock_time_get(id=100,precision=0,result.timestamp=16)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.clock_time_get(id=100,precision=0,result.timestamp=16)
+<== EINVAL
 `,
 		},
 	}
@@ -264,20 +244,16 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 			name:            "resultTimestamp out-of-memory",
 			resultTimestamp: memorySize,
 			expectedLog: `
---> proxy.clock_time_get(id=0,precision=0,result.timestamp=65536)
-	==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65536)
+<== EFAULT
 `,
 		},
 		{
 			name:            "resultTimestamp exceeds the maximum valid address by 1",
 			resultTimestamp: memorySize - 4 + 1, // 4 is the size of uint32, the type of the count of args
 			expectedLog: `
---> proxy.clock_time_get(id=0,precision=0,result.timestamp=65533)
-	==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65533)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65533)
+<== EFAULT
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/environ_test.go
+++ b/imports/wasi_snapshot_preview1/environ_test.go
@@ -29,10 +29,8 @@ func Test_environGet(t *testing.T) {
 	// Invoke environGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, environGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
 	require.Equal(t, `
---> proxy.environ_get(environ=26,environ_buf=16)
-	==> wasi_snapshot_preview1.environ_get(environ=26,environ_buf=16)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.environ_get(environ=26,environ_buf=16)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(resultEnvironBuf-1, uint32(len(expectedMemory)))
@@ -58,10 +56,8 @@ func Test_environGet_Errors(t *testing.T) {
 			environ:    memorySize,
 			environBuf: validAddress,
 			expectedLog: `
---> proxy.environ_get(environ=65536,environ_buf=0)
-	==> wasi_snapshot_preview1.environ_get(environ=65536,environ_buf=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_get(environ=65536,environ_buf=0)
+<== EFAULT
 `,
 		},
 		{
@@ -69,10 +65,8 @@ func Test_environGet_Errors(t *testing.T) {
 			environ:    validAddress,
 			environBuf: memorySize,
 			expectedLog: `
---> proxy.environ_get(environ=0,environ_buf=65536)
-	==> wasi_snapshot_preview1.environ_get(environ=0,environ_buf=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_get(environ=0,environ_buf=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -81,10 +75,8 @@ func Test_environGet_Errors(t *testing.T) {
 			environ:    memorySize - 4*2 + 1,
 			environBuf: validAddress,
 			expectedLog: `
---> proxy.environ_get(environ=65529,environ_buf=0)
-	==> wasi_snapshot_preview1.environ_get(environ=65529,environ_buf=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_get(environ=65529,environ_buf=0)
+<== EFAULT
 `,
 		},
 		{
@@ -93,10 +85,8 @@ func Test_environGet_Errors(t *testing.T) {
 			// "a=bc", "b=cd" size = size of "a=bc0b=cd0" = 10
 			environBuf: memorySize - 10 + 1,
 			expectedLog: `
---> proxy.environ_get(environ=0,environ_buf=65527)
-	==> wasi_snapshot_preview1.environ_get(environ=0,environ_buf=65527)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_get(environ=0,environ_buf=65527)
+<== EFAULT
 `,
 		},
 	}
@@ -133,10 +123,8 @@ func Test_environSizesGet(t *testing.T) {
 	// Invoke environSizesGet and check the memory side effects.
 	requireErrno(t, ErrnoSuccess, mod, environSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
 	require.Equal(t, `
---> proxy.environ_sizes_get(result.environc=16,result.environv_len=21)
-	==> wasi_snapshot_preview1.environ_sizes_get(result.environc=16,result.environv_len=21)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.environ_sizes_get(result.environc=16,result.environv_len=21)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(resultEnvironc-1, uint32(len(expectedMemory)))
@@ -162,10 +150,8 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environc:   memorySize,
 			environLen: validAddress,
 			expectedLog: `
---> proxy.environ_sizes_get(result.environc=65536,result.environv_len=0)
-	==> wasi_snapshot_preview1.environ_sizes_get(result.environc=65536,result.environv_len=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_sizes_get(result.environc=65536,result.environv_len=0)
+<== EFAULT
 `,
 		},
 		{
@@ -173,10 +159,8 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environc:   validAddress,
 			environLen: memorySize,
 			expectedLog: `
---> proxy.environ_sizes_get(result.environc=0,result.environv_len=65536)
-	==> wasi_snapshot_preview1.environ_sizes_get(result.environc=0,result.environv_len=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_sizes_get(result.environc=0,result.environv_len=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -184,10 +168,8 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environc:   memorySize - 4 + 1, // 4 is the size of uint32, the type of the count of environ
 			environLen: validAddress,
 			expectedLog: `
---> proxy.environ_sizes_get(result.environc=65533,result.environv_len=0)
-	==> wasi_snapshot_preview1.environ_sizes_get(result.environc=65533,result.environv_len=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_sizes_get(result.environc=65533,result.environv_len=0)
+<== EFAULT
 `,
 		},
 		{
@@ -195,10 +177,8 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environc:   validAddress,
 			environLen: memorySize - 4 + 1, // 4 is count of bytes to encode uint32le
 			expectedLog: `
---> proxy.environ_sizes_get(result.environc=0,result.environv_len=65533)
-	==> wasi_snapshot_preview1.environ_sizes_get(result.environc=0,result.environv_len=65533)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.environ_sizes_get(result.environc=0,result.environv_len=65533)
+<== EFAULT
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -24,10 +24,8 @@ import (
 func Test_fdAdvise(t *testing.T) {
 	log := requireErrnoNosys(t, fdAdviseName, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.fd_advise(fd=0,offset=0,len=0,advice=0)
-	--> wasi_snapshot_preview1.fd_advise(fd=0,offset=0,len=0,advice=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_advise(fd=0,offset=0,len=0,advice=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -35,10 +33,8 @@ func Test_fdAdvise(t *testing.T) {
 func Test_fdAllocate(t *testing.T) {
 	log := requireErrnoNosys(t, fdAllocateName, 0, 0, 0)
 	require.Equal(t, `
---> proxy.fd_allocate(fd=0,offset=0,len=0)
-	--> wasi_snapshot_preview1.fd_allocate(fd=0,offset=0,len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_allocate(fd=0,offset=0,len=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -62,10 +58,8 @@ func Test_fdClose(t *testing.T) {
 	// Close
 	requireErrno(t, ErrnoSuccess, mod, fdCloseName, uint64(fdToClose))
 	require.Equal(t, `
---> proxy.fd_close(fd=4)
-	==> wasi_snapshot_preview1.fd_close(fd=4)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_close(fd=4)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	// Verify fdToClose is closed and removed from the opened FDs.
@@ -80,10 +74,8 @@ func Test_fdClose(t *testing.T) {
 	t.Run("ErrnoBadF for an invalid FD", func(t *testing.T) {
 		requireErrno(t, ErrnoBadf, mod, fdCloseName, uint64(42)) // 42 is an arbitrary invalid FD
 		require.Equal(t, `
---> proxy.fd_close(fd=42)
-	==> wasi_snapshot_preview1.fd_close(fd=42)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_close(fd=42)
+<== EBADF
 `, "\n"+log.String())
 	})
 }
@@ -92,10 +84,8 @@ func Test_fdClose(t *testing.T) {
 func Test_fdDatasync(t *testing.T) {
 	log := requireErrnoNosys(t, fdDatasyncName, 0)
 	require.Equal(t, `
---> proxy.fd_datasync(fd=0)
-	--> wasi_snapshot_preview1.fd_datasync(fd=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_datasync(fd=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -133,10 +123,8 @@ func Test_fdFdstatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=0,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=0,result.stat=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=0,result.stat=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -149,10 +137,8 @@ func Test_fdFdstatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=1,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=1,result.stat=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=1,result.stat=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -165,10 +151,8 @@ func Test_fdFdstatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=2,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=2,result.stat=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=2,result.stat=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -181,10 +165,8 @@ func Test_fdFdstatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=3,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=3,result.stat=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=3,result.stat=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -197,10 +179,8 @@ func Test_fdFdstatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=4,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=4,result.stat=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=4,result.stat=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -213,10 +193,8 @@ func Test_fdFdstatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=5,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=5,result.stat=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=5,result.stat=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -224,10 +202,8 @@ func Test_fdFdstatGet(t *testing.T) {
 			fd:            math.MaxUint32,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=-1,result.stat=0)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=-1,result.stat=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=-1,result.stat=0)
+<== EBADF
 `,
 		},
 		{
@@ -236,10 +212,8 @@ func Test_fdFdstatGet(t *testing.T) {
 			resultFdstat:  memorySize - 24 + 1,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_fdstat_get(fd=5,result.stat=65513)
-	==> wasi_snapshot_preview1.fd_fdstat_get(fd=5,result.stat=65513)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_fdstat_get(fd=5,result.stat=65513)
+<== EFAULT
 `,
 		},
 	}
@@ -266,10 +240,8 @@ func Test_fdFdstatGet(t *testing.T) {
 func Test_fdFdstatSetFlags(t *testing.T) {
 	log := requireErrnoNosys(t, fdFdstatSetFlagsName, 0, 0)
 	require.Equal(t, `
---> proxy.fd_fdstat_set_flags(fd=0,flags=0)
-	--> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=0,flags=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=0,flags=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -277,10 +249,8 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 func Test_fdFdstatSetRights(t *testing.T) {
 	log := requireErrnoNosys(t, fdFdstatSetRightsName, 0, 0, 0)
 	require.Equal(t, `
---> proxy.fd_fdstat_set_rights(fd=0,fs_rights_base=0,fs_rights_inheriting=0)
-	--> wasi_snapshot_preview1.fd_fdstat_set_rights(fd=0,fs_rights_base=0,fs_rights_inheriting=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_fdstat_set_rights(fd=0,fs_rights_base=0,fs_rights_inheriting=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -327,10 +297,8 @@ func Test_fdFilestatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // ctim
 			},
 			expectedLog: `
---> proxy.fd_filestat_get(fd=0,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=0,result.buf=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_filestat_get(fd=0,result.buf=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -348,10 +316,8 @@ func Test_fdFilestatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // ctim
 			},
 			expectedLog: `
---> proxy.fd_filestat_get(fd=1,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=1,result.buf=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_filestat_get(fd=1,result.buf=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -369,10 +335,8 @@ func Test_fdFilestatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // ctim
 			},
 			expectedLog: `
---> proxy.fd_filestat_get(fd=2,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=2,result.buf=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_filestat_get(fd=2,result.buf=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -389,10 +353,8 @@ func Test_fdFilestatGet(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, // TODO: ctim
 			},
 			expectedLog: `
---> proxy.fd_filestat_get(fd=3,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=3,result.buf=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_filestat_get(fd=3,result.buf=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -409,10 +371,8 @@ func Test_fdFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			},
 			expectedLog: `
---> proxy.fd_filestat_get(fd=4,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=4,result.buf=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_filestat_get(fd=4,result.buf=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -429,10 +389,8 @@ func Test_fdFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			},
 			expectedLog: `
---> proxy.fd_filestat_get(fd=5,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=5,result.buf=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_filestat_get(fd=5,result.buf=0)
+<== ESUCCESS
 `,
 		},
 		{
@@ -440,10 +398,8 @@ func Test_fdFilestatGet(t *testing.T) {
 			fd:            math.MaxUint32,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_filestat_get(fd=-1,result.buf=0)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=-1,result.buf=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_filestat_get(fd=-1,result.buf=0)
+<== EBADF
 `,
 		},
 		{
@@ -452,10 +408,8 @@ func Test_fdFilestatGet(t *testing.T) {
 			resultFilestat: memorySize - 64 + 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.fd_filestat_get(fd=5,result.buf=65473)
-	==> wasi_snapshot_preview1.fd_filestat_get(fd=5,result.buf=65473)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_filestat_get(fd=5,result.buf=65473)
+<== EFAULT
 `,
 		},
 	}
@@ -482,10 +436,8 @@ func Test_fdFilestatGet(t *testing.T) {
 func Test_fdFilestatSetSize(t *testing.T) {
 	log := requireErrnoNosys(t, fdFilestatSetSizeName, 0, 0)
 	require.Equal(t, `
---> proxy.fd_filestat_set_size(fd=0,size=0)
-	--> wasi_snapshot_preview1.fd_filestat_set_size(fd=0,size=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_filestat_set_size(fd=0,size=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -493,10 +445,8 @@ func Test_fdFilestatSetSize(t *testing.T) {
 func Test_fdFilestatSetTimes(t *testing.T) {
 	log := requireErrnoNosys(t, fdFilestatSetTimesName, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.fd_filestat_set_times(fd=0,atim=0,mtim=0,fst_flags=0)
-	--> wasi_snapshot_preview1.fd_filestat_set_times(fd=0,atim=0,mtim=0,fst_flags=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_filestat_set_times(fd=0,atim=0,mtim=0,fst_flags=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -536,10 +486,8 @@ func Test_fdPread(t *testing.T) {
 				'?',
 			),
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=1,iovs_len=2,offset=0,result.nread=26)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=0,result.nread=26)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=0,result.nread=26)
+<== ESUCCESS
 `,
 		},
 		{
@@ -553,10 +501,8 @@ func Test_fdPread(t *testing.T) {
 				'?',
 			),
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=1,iovs_len=2,offset=2,result.nread=26)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=2,result.nread=26)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=2,result.nread=26)
+<== ESUCCESS
 `,
 		},
 	}
@@ -600,10 +546,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nread validation
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_pread(fd=42,iovs=65532,iovs_len=65532,offset=0,result.nread=65532)
-	==> wasi_snapshot_preview1.fd_pread(fd=42,iovs=65532,iovs_len=65532,offset=0,result.nread=65532)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_pread(fd=42,iovs=65532,iovs_len=65532,offset=0,result.nread=65532)
+<== EBADF
 `,
 		},
 		{
@@ -612,10 +556,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			offset:        int64(len(contents) + 1),
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=65536,iovs_len=65536,offset=7,result.nread=65536)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65536,offset=7,result.nread=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65536,offset=7,result.nread=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -625,10 +567,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			memory:        []byte{'?'},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=65536,iovs_len=65535,offset=0,result.nread=65535)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65535,offset=0,result.nread=65535)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65535,offset=0,result.nread=65535)
+<== EFAULT
 `,
 		},
 		{
@@ -641,10 +581,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=65532,iovs_len=65532,offset=0,result.nread=65531)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65532,iovs_len=65532,offset=0,result.nread=65531)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65532,iovs_len=65532,offset=0,result.nread=65531)
+<== EFAULT
 `,
 		},
 		{
@@ -658,10 +596,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=65528,iovs_len=65528,offset=0,result.nread=65527)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65528,iovs_len=65528,offset=0,result.nread=65527)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65528,iovs_len=65528,offset=0,result.nread=65527)
+<== EFAULT
 `,
 		},
 		{
@@ -676,10 +612,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65526)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65526)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65526)
+<== EFAULT
 `,
 		},
 		{
@@ -695,10 +629,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65536)
-	==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65536)
+<== EFAULT
 `,
 		},
 	}
@@ -738,10 +670,8 @@ func Test_fdPrestatGet(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatGetName, uint64(fd), uint64(resultPrestat))
 	require.Equal(t, `
---> proxy.fd_prestat_get(fd=3,result.prestat=1)
-	==> wasi_snapshot_preview1.fd_prestat_get(fd=3,result.prestat=1)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_prestat_get(fd=3,result.prestat=1)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -768,10 +698,8 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			resultPrestat: 0,  // valid offset
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_prestat_get(fd=42,result.prestat=0)
-	==> wasi_snapshot_preview1.fd_prestat_get(fd=42,result.prestat=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_prestat_get(fd=42,result.prestat=0)
+<== EBADF
 `,
 		},
 		{
@@ -780,10 +708,8 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			resultPrestat: memorySize,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_prestat_get(fd=3,result.prestat=65536)
-	==> wasi_snapshot_preview1.fd_prestat_get(fd=3,result.prestat=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_prestat_get(fd=3,result.prestat=65536)
+<== EFAULT
 `,
 		},
 		// TODO: non pre-opened file == api.ErrnoBadf
@@ -816,10 +742,8 @@ func Test_fdPrestatDirName(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatDirNameName, uint64(fd), uint64(path), uint64(pathLen))
 	require.Equal(t, `
---> proxy.fd_prestat_dir_name(fd=3,path=1,path_len=0)
-	==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=1,path_len=0)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=1,path_len=0)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -851,10 +775,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
-	==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
+<== EFAULT
 `,
 		},
 		{
@@ -864,10 +786,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
-	==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=65536,path_len=1)
+<== EFAULT
 `,
 		},
 		{
@@ -877,10 +797,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen + 1,
 			expectedErrno: ErrnoNametoolong,
 			expectedLog: `
---> proxy.fd_prestat_dir_name(fd=3,path=0,path_len=2)
-	==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=0,path_len=2)
-	<== ENAMETOOLONG
-<-- 37
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,path=0,path_len=2)
+<== ENAMETOOLONG
 `,
 		},
 		{
@@ -890,10 +808,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_prestat_dir_name(fd=42,path=0,path_len=1)
-	==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42,path=0,path_len=1)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42,path=0,path_len=1)
+<== EBADF
 `,
 		},
 		// TODO: non pre-opened file == ErrnoBadf
@@ -915,10 +831,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 func Test_fdPwrite(t *testing.T) {
 	log := requireErrnoNosys(t, fdPwriteName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.fd_pwrite(fd=0,iovs=0,iovs_len=0,offset=0,result.nwritten=0)
-	--> wasi_snapshot_preview1.fd_pwrite(fd=0,iovs=0,iovs_len=0,offset=0,result.nwritten=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_pwrite(fd=0,iovs=0,iovs_len=0,offset=0,result.nwritten=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -954,10 +868,8 @@ func Test_fdRead(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
 	require.Equal(t, `
---> proxy.fd_read(fd=4,iovs=1,iovs_len=2,result.nread=26)
-	==> wasi_snapshot_preview1.fd_read(fd=4,iovs=1,iovs_len=2,result.nread=26)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=1,iovs_len=2,result.nread=26)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -982,10 +894,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nread validation
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_read(fd=42,iovs=65532,iovs_len=65532,result.nread=65532)
-	==> wasi_snapshot_preview1.fd_read(fd=42,iovs=65532,iovs_len=65532,result.nread=65532)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_read(fd=42,iovs=65532,iovs_len=65532,result.nread=65532)
+<== EBADF
 `,
 		},
 		{
@@ -995,10 +905,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			memory:        []byte{'?'},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_read(fd=4,iovs=65536,iovs_len=65535,result.nread=65535)
-	==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65536,iovs_len=65535,result.nread=65535)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65536,iovs_len=65535,result.nread=65535)
+<== EFAULT
 `,
 		},
 		{
@@ -1011,10 +919,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_read(fd=4,iovs=65532,iovs_len=65532,result.nread=65531)
-	==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65532,iovs_len=65532,result.nread=65531)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65532,iovs_len=65532,result.nread=65531)
+<== EFAULT
 `,
 		},
 		{
@@ -1028,10 +934,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_read(fd=4,iovs=65528,iovs_len=65528,result.nread=65527)
-	==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65528,iovs_len=65528,result.nread=65527)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65528,iovs_len=65528,result.nread=65527)
+<== EFAULT
 `,
 		},
 		{
@@ -1046,10 +950,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65526)
-	==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65526)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65526)
+<== EFAULT
 `,
 		},
 		{
@@ -1065,10 +967,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65536)
-	==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65536)
+<== EFAULT
 `,
 		},
 	}
@@ -1522,10 +1422,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			bufLen:        1000,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
+<== EFAULT
 `,
 		},
 		{
@@ -1535,10 +1433,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			resultBufused: 1000, // arbitrary
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_readdir(fd=42,buf=0,buf_len=24,cookie=0,result.bufused=1000)
-	==> wasi_snapshot_preview1.fd_readdir(fd=42,buf=0,buf_len=24,cookie=0,result.bufused=1000)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_readdir(fd=42,buf=0,buf_len=24,cookie=0,result.bufused=1000)
+<== EBADF
 `,
 		},
 		{
@@ -1548,10 +1444,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			resultBufused: 1000, // arbitrary
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_readdir(fd=5,buf=0,buf_len=24,cookie=0,result.bufused=1000)
-	==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=0,buf_len=24,cookie=0,result.bufused=1000)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=0,buf_len=24,cookie=0,result.bufused=1000)
+<== EBADF
 `,
 		},
 		{
@@ -1561,10 +1455,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			bufLen:        1000,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
+<== EFAULT
 `,
 		},
 		{
@@ -1574,10 +1466,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			bufLen:        1000,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=65535,buf_len=1000,cookie=0,result.bufused=0)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65535,buf_len=1000,cookie=0,result.bufused=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65535,buf_len=1000,cookie=0,result.bufused=0)
+<== EFAULT
 `,
 		},
 		{
@@ -1587,10 +1477,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			resultBufused: 1000,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=0,buf_len=1,cookie=0,result.bufused=1000)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1,cookie=0,result.bufused=1000)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1,cookie=0,result.bufused=1000)
+<== EINVAL
 `,
 		},
 		{
@@ -1601,10 +1489,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			resultBufused: 2000,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
+<== EINVAL
 `,
 		},
 		{
@@ -1615,10 +1501,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			resultBufused: 2000,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
+<== EINVAL
 `,
 		},
 		{
@@ -1630,10 +1514,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			resultBufused: 2000,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=-1,result.bufused=2000)
-	==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=-1,result.bufused=2000)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=-1,result.bufused=2000)
+<== EINVAL
 `,
 		},
 	}
@@ -1887,10 +1769,8 @@ func Test_writeDirents(t *testing.T) {
 func Test_fdRenumber(t *testing.T) {
 	log := requireErrnoNosys(t, fdRenumberName, 0, 0)
 	require.Equal(t, `
---> proxy.fd_renumber(fd=0,to=0)
-	--> wasi_snapshot_preview1.fd_renumber(fd=0,to=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_renumber(fd=0,to=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -1919,10 +1799,8 @@ func Test_fdSeek(t *testing.T) {
 				'?',
 			},
 			expectedLog: `
---> proxy.fd_seek(fd=4,offset=4,whence=0,result.newoffset=1)
-	==> wasi_snapshot_preview1.fd_seek(fd=4,offset=4,whence=0,result.newoffset=1)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_seek(fd=4,offset=4,whence=0,result.newoffset=1)
+<== ESUCCESS
 `,
 		},
 		{
@@ -1936,10 +1814,8 @@ func Test_fdSeek(t *testing.T) {
 				'?',
 			},
 			expectedLog: `
---> proxy.fd_seek(fd=4,offset=1,whence=1,result.newoffset=1)
-	==> wasi_snapshot_preview1.fd_seek(fd=4,offset=1,whence=1,result.newoffset=1)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_seek(fd=4,offset=1,whence=1,result.newoffset=1)
+<== ESUCCESS
 `,
 		},
 		{
@@ -1953,10 +1829,8 @@ func Test_fdSeek(t *testing.T) {
 				'?',
 			},
 			expectedLog: `
---> proxy.fd_seek(fd=4,offset=-1,whence=2,result.newoffset=1)
-	==> wasi_snapshot_preview1.fd_seek(fd=4,offset=-1,whence=2,result.newoffset=1)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_seek(fd=4,offset=-1,whence=2,result.newoffset=1)
+<== ESUCCESS
 `,
 		},
 	}
@@ -2012,10 +1886,8 @@ func Test_fdSeek_Errors(t *testing.T) {
 			fd:            42, // arbitrary invalid fd
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_seek(fd=42,offset=0,whence=0,result.newoffset=0)
-	==> wasi_snapshot_preview1.fd_seek(fd=42,offset=0,whence=0,result.newoffset=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_seek(fd=42,offset=0,whence=0,result.newoffset=0)
+<== EBADF
 `,
 		},
 		{
@@ -2024,10 +1896,8 @@ func Test_fdSeek_Errors(t *testing.T) {
 			whence:        3, // invalid whence, the largest whence io.SeekEnd(2) + 1
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.fd_seek(fd=4,offset=0,whence=3,result.newoffset=0)
-	==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=3,result.newoffset=0)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=3,result.newoffset=0)
+<== EINVAL
 `,
 		},
 		{
@@ -2036,10 +1906,8 @@ func Test_fdSeek_Errors(t *testing.T) {
 			resultNewoffset: memorySize,
 			expectedErrno:   ErrnoFault,
 			expectedLog: `
---> proxy.fd_seek(fd=4,offset=0,whence=0,result.newoffset=65536)
-	==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=0,result.newoffset=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=0,result.newoffset=65536)
+<== EFAULT
 `,
 		},
 	}
@@ -2059,10 +1927,8 @@ func Test_fdSeek_Errors(t *testing.T) {
 func Test_fdSync(t *testing.T) {
 	log := requireErrnoNosys(t, fdSyncName, 0)
 	require.Equal(t, `
---> proxy.fd_sync(fd=0)
-	--> wasi_snapshot_preview1.fd_sync(fd=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_sync(fd=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2070,10 +1936,8 @@ func Test_fdSync(t *testing.T) {
 func Test_fdTell(t *testing.T) {
 	log := requireErrnoNosys(t, fdTellName, 0, 0)
 	require.Equal(t, `
---> proxy.fd_tell(fd=0,result.offset=0)
-	--> wasi_snapshot_preview1.fd_tell(fd=0,result.offset=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.fd_tell(fd=0,result.offset=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2110,10 +1974,8 @@ func Test_fdWrite(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	require.Equal(t, `
---> proxy.fd_write(fd=4,iovs=1,iovs_len=2,result.nwritten=26)
-	==> wasi_snapshot_preview1.fd_write(fd=4,iovs=1,iovs_len=2,result.nwritten=26)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=1,iovs_len=2,result.nwritten=26)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2163,10 +2025,8 @@ func Test_fdWrite_discard(t *testing.T) {
 	fd := 1 // stdout
 	requireErrno(t, ErrnoSuccess, mod, fdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	require.Equal(t, `
---> proxy.fd_write(fd=1,iovs=1,iovs_len=2,result.nwritten=26)
-	==> wasi_snapshot_preview1.fd_write(fd=1,iovs=1,iovs_len=2,result.nwritten=26)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.fd_write(fd=1,iovs=1,iovs_len=2,result.nwritten=26)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2195,10 +2055,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 			fd:            42, // arbitrary invalid fd
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.fd_write(fd=42,iovs=0,iovs_len=1,result.nwritten=0)
-	==> wasi_snapshot_preview1.fd_write(fd=42,iovs=0,iovs_len=1,result.nwritten=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.fd_write(fd=42,iovs=0,iovs_len=1,result.nwritten=0)
+<== EBADF
 `,
 		},
 		{
@@ -2207,10 +2065,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 			iovs:          memSize - 2,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_write(fd=4,iovs=65534,iovs_len=1,result.nwritten=0)
-	==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65534,iovs_len=1,result.nwritten=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65534,iovs_len=1,result.nwritten=0)
+<== EFAULT
 `,
 		},
 		{
@@ -2219,10 +2075,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 			iovs:          memSize - 4, // iovs[0].offset was 4 bytes and iovs[0].length next, but not enough mod.Memory()!
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_write(fd=4,iovs=65532,iovs_len=1,result.nwritten=0)
-	==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65532,iovs_len=1,result.nwritten=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65532,iovs_len=1,result.nwritten=0)
+<== EFAULT
 `,
 		},
 		{
@@ -2231,10 +2085,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 			iovs:          memSize - 5, // iovs[0].offset (where to read "hi") is outside memory.
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_write(fd=4,iovs=65531,iovs_len=1,result.nwritten=0)
-	==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65531,iovs_len=1,result.nwritten=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65531,iovs_len=1,result.nwritten=0)
+<== EFAULT
 `,
 		},
 		{
@@ -2243,10 +2095,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 			iovs:          memSize - 9, // iovs[0].offset (where to read "hi") is in memory, but truncated.
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.fd_write(fd=4,iovs=65527,iovs_len=1,result.nwritten=0)
-	==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65527,iovs_len=1,result.nwritten=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65527,iovs_len=1,result.nwritten=0)
+<== EFAULT
 `,
 		},
 		{
@@ -2255,10 +2105,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 			resultNwritten: memSize, // read was ok, but there wasn't enough memory to write the result.
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.fd_write(fd=4,iovs=0,iovs_len=1,result.nwritten=65536)
-	==> wasi_snapshot_preview1.fd_write(fd=4,iovs=0,iovs_len=1,result.nwritten=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=0,iovs_len=1,result.nwritten=65536)
+<== EFAULT
 `,
 		},
 	}
@@ -2286,10 +2134,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 func Test_pathCreateDirectory(t *testing.T) {
 	log := requireErrnoNosys(t, pathCreateDirectoryName, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_create_directory(fd=0,path=0,path_len=0)
-	--> wasi_snapshot_preview1.path_create_directory(fd=0,path=0,path_len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_create_directory(fd=0,path=0,path_len=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2345,10 +2191,8 @@ func Test_pathFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			),
 			expectedLog: `
---> proxy.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
+<== ESUCCESS
 `,
 		},
 		{
@@ -2369,10 +2213,8 @@ func Test_pathFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			),
 			expectedLog: `
---> proxy.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
+<== ESUCCESS
 `,
 		},
 		{
@@ -2393,10 +2235,8 @@ func Test_pathFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			),
 			expectedLog: `
---> proxy.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
+<== ESUCCESS
 `,
 		},
 		{
@@ -2404,10 +2244,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			fd:            math.MaxUint32,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.path_filestat_get(fd=-1,flags=0,path=1,path_len=0,result.buf=0)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=-1,flags=0,path=1,path_len=0,result.buf=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.path_filestat_get(fd=-1,flags=0,path=1,path_len=0,result.buf=0)
+<== EBADF
 `,
 		},
 		{
@@ -2418,10 +2256,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 2,
 			expectedErrno:  ErrnoNotdir,
 			expectedLog: `
---> proxy.path_filestat_get(fd=4,flags=0,path=1,path_len=1,result.buf=2)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=4,flags=0,path=1,path_len=1,result.buf=2)
-	<== ENOTDIR
-<-- 54
+==> wasi_snapshot_preview1.path_filestat_get(fd=4,flags=0,path=1,path_len=1,result.buf=2)
+<== ENOTDIR
 `,
 		},
 		{
@@ -2432,10 +2268,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 2,
 			expectedErrno:  ErrnoNoent,
 			expectedLog: `
---> proxy.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-	<== ENOENT
-<-- 44
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
+<== ENOENT
 `,
 		},
 		{
@@ -2446,10 +2280,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 2,
 			expectedErrno:  ErrnoNoent,
 			expectedLog: `
---> proxy.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
-	<== ENOENT
-<-- 44
+==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
+<== ENOENT
 `,
 		},
 		{
@@ -2460,10 +2292,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 7,
 			expectedErrno:  ErrnoNoent,
 			expectedLog: `
---> proxy.path_filestat_get(fd=5,flags=0,path=1,path_len=6,result.buf=7)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=6,result.buf=7)
-	<== ENOENT
-<-- 44
+==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=6,result.buf=7)
+<== ENOENT
 `,
 		},
 		{
@@ -2473,10 +2303,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			pathLen:       memorySize,
 			expectedErrno: ErrnoNametoolong,
 			expectedLog: `
---> proxy.path_filestat_get(fd=3,flags=0,path=1,path_len=65536,result.buf=0)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=65536,result.buf=0)
-	<== ENAMETOOLONG
-<-- 37
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=65536,result.buf=0)
+<== ENAMETOOLONG
 `,
 		},
 		{
@@ -2487,10 +2315,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: memorySize - 64 + 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=65473)
-	==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=65473)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=65473)
+<== EFAULT
 `,
 		},
 	}
@@ -2519,10 +2345,8 @@ func Test_pathFilestatGet(t *testing.T) {
 func Test_pathFilestatSetTimes(t *testing.T) {
 	log := requireErrnoNosys(t, pathFilestatSetTimesName, 0, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_filestat_set_times(fd=0,flags=0,path=0,path_len=0,atim=0,mtim=0,fst_flags=0)
-	--> wasi_snapshot_preview1.path_filestat_set_times(fd=0,flags=0,path=0,path_len=0,atim=0,mtim=0,fst_flags=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_filestat_set_times(fd=0,flags=0,path=0,path_len=0,atim=0,mtim=0,fst_flags=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2530,10 +2354,8 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 func Test_pathLink(t *testing.T) {
 	log := requireErrnoNosys(t, pathLinkName, 0, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_link(old_fd=0,old_flags=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
-	--> wasi_snapshot_preview1.path_link(old_fd=0,old_flags=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_link(old_fd=0,old_flags=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2571,10 +2393,8 @@ func Test_pathOpen(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, pathOpenName, uint64(rootFD), uint64(dirflags), uint64(path),
 		uint64(pathLen), uint64(oflags), fsRightsBase, fsRightsInheriting, uint64(fdflags), uint64(resultOpenedFd))
 	require.Equal(t, `
---> proxy.path_open(fd=3,dirflags=0,path=1,path_len=6,oflags=0,fs_rights_base=1,fs_rights_inheriting=2,fdflags=0,result.opened_fd=8)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=1,path_len=6,oflags=0,fs_rights_base=1,fs_rights_inheriting=2,fdflags=0,result.opened_fd=8)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=1,path_len=6,oflags=0,fs_rights_base=1,fs_rights_inheriting=2,fdflags=0,result.opened_fd=8)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2613,10 +2433,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			fd:            42, // arbitrary invalid fd
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
---> proxy.path_open(fd=42,dirflags=0,path=0,path_len=0,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	==> wasi_snapshot_preview1.path_open(fd=42,dirflags=0,path=0,path_len=0,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	<== EBADF
-<-- 8
+==> wasi_snapshot_preview1.path_open(fd=42,dirflags=0,path=0,path_len=0,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== EBADF
 `,
 		},
 		{
@@ -2626,10 +2444,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       validPathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.path_open(fd=3,dirflags=0,path=65536,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=65536,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=65536,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== EFAULT
 `,
 		},
 		{
@@ -2640,10 +2456,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			// fstest.MapFS returns file not found instead of invalid on invalid path
 			expectedErrno: ErrnoNoent,
 			expectedLog: `
---> proxy.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	<== ENOENT
-<-- 44
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== ENOENT
 `,
 		},
 		{
@@ -2653,10 +2467,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is out-of-memory for path
 			expectedErrno: ErrnoFault,
 			expectedLog: `
---> proxy.path_open(fd=3,dirflags=0,path=0,path_len=65537,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=65537,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=65537,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== EFAULT
 `,
 		},
 		{
@@ -2667,10 +2479,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       validPathLen - 1, // this make the path "wazer", which doesn't exit
 			expectedErrno: ErrnoNoent,
 			expectedLog: `
---> proxy.path_open(fd=3,dirflags=0,path=0,path_len=5,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=5,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	<== ENOENT
-<-- 44
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=5,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== ENOENT
 `,
 		},
 		{
@@ -2682,10 +2492,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			resultOpenedFd: mod.Memory().Size(), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=65536)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -2697,10 +2505,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       validPathLen,
 			expectedErrno: ErrnoNotdir,
 			expectedLog: `
---> proxy.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=3,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=3,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-	<== ENOTDIR
-<-- 54
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=3,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== ENOTDIR
 `,
 		},
 	}
@@ -2723,10 +2529,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 func Test_pathReadlink(t *testing.T) {
 	log := requireErrnoNosys(t, pathReadlinkName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_readlink(fd=0,path=0,path_len=0,buf=0,buf_len=0,result.bufused=0)
-	--> wasi_snapshot_preview1.path_readlink(fd=0,path=0,path_len=0,buf=0,buf_len=0,result.bufused=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_readlink(fd=0,path=0,path_len=0,buf=0,buf_len=0,result.bufused=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2734,10 +2538,8 @@ func Test_pathReadlink(t *testing.T) {
 func Test_pathRemoveDirectory(t *testing.T) {
 	log := requireErrnoNosys(t, pathRemoveDirectoryName, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_remove_directory(fd=0,path=0,path_len=0)
-	--> wasi_snapshot_preview1.path_remove_directory(fd=0,path=0,path_len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_remove_directory(fd=0,path=0,path_len=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2745,10 +2547,8 @@ func Test_pathRemoveDirectory(t *testing.T) {
 func Test_pathRename(t *testing.T) {
 	log := requireErrnoNosys(t, pathRenameName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_rename(fd=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
-	--> wasi_snapshot_preview1.path_rename(fd=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_rename(fd=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2756,10 +2556,8 @@ func Test_pathRename(t *testing.T) {
 func Test_pathSymlink(t *testing.T) {
 	log := requireErrnoNosys(t, pathSymlinkName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_symlink(old_path=0,old_path_len=0,fd=0,new_path=0,new_path_len=0)
-	--> wasi_snapshot_preview1.path_symlink(old_path=0,old_path_len=0,fd=0,new_path=0,new_path_len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_symlink(old_path=0,old_path_len=0,fd=0,new_path=0,new_path_len=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -2767,10 +2565,8 @@ func Test_pathSymlink(t *testing.T) {
 func Test_pathUnlinkFile(t *testing.T) {
 	log := requireErrnoNosys(t, pathUnlinkFileName, 0, 0, 0)
 	require.Equal(t, `
---> proxy.path_unlink_file(fd=0,path=0,path_len=0)
-	--> wasi_snapshot_preview1.path_unlink_file(fd=0,path=0,path_len=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.path_unlink_file(fd=0,path=0,path_len=0)
+<-- ENOSYS
 `, log)
 }
 

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -41,10 +41,8 @@ func Test_pollOneoff(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, pollOneoffName, uint64(in), uint64(out), uint64(nsubscriptions),
 		uint64(resultNevents))
 	require.Equal(t, `
---> proxy.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-	==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	outMem, ok := mod.Memory().Read(out, uint32(len(expectedMem)))
@@ -76,10 +74,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			resultNevents:  512, // past out
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.poll_oneoff(in=65536,out=128,nsubscriptions=1,result.nevents=512)
-	==> wasi_snapshot_preview1.poll_oneoff(in=65536,out=128,nsubscriptions=1,result.nevents=512)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.poll_oneoff(in=65536,out=128,nsubscriptions=1,result.nevents=512)
+<== EFAULT
 `,
 		},
 		{
@@ -89,10 +85,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			nsubscriptions: 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.poll_oneoff(in=0,out=65536,nsubscriptions=1,result.nevents=512)
-	==> wasi_snapshot_preview1.poll_oneoff(in=0,out=65536,nsubscriptions=1,result.nevents=512)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=65536,nsubscriptions=1,result.nevents=512)
+<== EFAULT
 `,
 		},
 		{
@@ -101,10 +95,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			nsubscriptions: 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
---> proxy.poll_oneoff(in=0,out=0,nsubscriptions=1,result.nevents=65536)
-	==> wasi_snapshot_preview1.poll_oneoff(in=0,out=0,nsubscriptions=1,result.nevents=65536)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=0,nsubscriptions=1,result.nevents=65536)
+<== EFAULT
 `,
 		},
 		{
@@ -113,10 +105,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			resultNevents: 512, // past out
 			expectedErrno: ErrnoInval,
 			expectedLog: `
---> proxy.poll_oneoff(in=0,out=128,nsubscriptions=0,result.nevents=512)
-	==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=0,result.nevents=512)
-	<== EINVAL
-<-- 28
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=0,result.nevents=512)
+<== EINVAL
 `,
 		},
 		{
@@ -138,10 +128,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
---> proxy.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-	==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
+<== ESUCCESS
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/proc_test.go
+++ b/imports/wasi_snapshot_preview1/proc_test.go
@@ -21,16 +21,14 @@ func Test_procExit(t *testing.T) {
 			name:     "success (exitcode 0)",
 			exitCode: 0,
 			expectedLog: `
---> proxy.proc_exit(rval=0)
-	==> wasi_snapshot_preview1.proc_exit(rval=0)
+==> wasi_snapshot_preview1.proc_exit(rval=0)
 `,
 		},
 		{
 			name:     "arbitrary non-zero exitcode",
 			exitCode: 42,
 			expectedLog: `
---> proxy.proc_exit(rval=42)
-	==> wasi_snapshot_preview1.proc_exit(rval=42)
+==> wasi_snapshot_preview1.proc_exit(rval=42)
 `,
 		},
 	}
@@ -56,9 +54,7 @@ func Test_procExit(t *testing.T) {
 func Test_procRaise(t *testing.T) {
 	log := requireErrnoNosys(t, procRaiseName, 0)
 	require.Equal(t, `
---> proxy.proc_raise(sig=0)
-	--> wasi_snapshot_preview1.proc_raise(sig=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.proc_raise(sig=0)
+<-- ENOSYS
 `, log)
 }

--- a/imports/wasi_snapshot_preview1/random_test.go
+++ b/imports/wasi_snapshot_preview1/random_test.go
@@ -29,10 +29,8 @@ func Test_randomGet(t *testing.T) {
 	// Invoke randomGet and check the memory side effects!
 	requireErrno(t, ErrnoSuccess, mod, randomGetName, uint64(offset), uint64(length))
 	require.Equal(t, `
---> proxy.random_get(buf=1,buf_len=5)
-	==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
-	<== ESUCCESS
-<-- 0
+==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
+<== ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, offset+length+1)
@@ -56,10 +54,8 @@ func Test_randomGet_Errors(t *testing.T) {
 			offset: memorySize,
 			length: 1,
 			expectedLog: `
---> proxy.random_get(buf=65536,buf_len=1)
-	==> wasi_snapshot_preview1.random_get(buf=65536,buf_len=1)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.random_get(buf=65536,buf_len=1)
+<== EFAULT
 `,
 		},
 		{
@@ -67,10 +63,8 @@ func Test_randomGet_Errors(t *testing.T) {
 			offset: 0, // arbitrary valid offset
 			length: memorySize + 1,
 			expectedLog: `
---> proxy.random_get(buf=0,buf_len=65537)
-	==> wasi_snapshot_preview1.random_get(buf=0,buf_len=65537)
-	<== EFAULT
-<-- 21
+==> wasi_snapshot_preview1.random_get(buf=0,buf_len=65537)
+<== EFAULT
 `,
 		},
 	}
@@ -97,20 +91,16 @@ func Test_randomGet_SourceError(t *testing.T) {
 			name:       "error",
 			randSource: iotest.ErrReader(errors.New("RandSource error")),
 			expectedLog: `
---> proxy.random_get(buf=1,buf_len=5)
-	==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
-	<== EIO
-<-- 29
+==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
+<== EIO
 `,
 		},
 		{
 			name:       "incomplete",
 			randSource: bytes.NewReader([]byte{1, 2}),
 			expectedLog: `
---> proxy.random_get(buf=1,buf_len=5)
-	==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
-	<== EIO
-<-- 29
+==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
+<== EIO
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/sched_test.go
+++ b/imports/wasi_snapshot_preview1/sched_test.go
@@ -10,9 +10,7 @@ import (
 func Test_schedYield(t *testing.T) {
 	log := requireErrnoNosys(t, schedYieldName)
 	require.Equal(t, `
---> proxy.sched_yield()
-	--> wasi_snapshot_preview1.sched_yield()
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.sched_yield()
+<-- ENOSYS
 `, log)
 }

--- a/imports/wasi_snapshot_preview1/sock_test.go
+++ b/imports/wasi_snapshot_preview1/sock_test.go
@@ -10,10 +10,8 @@ import (
 func Test_sockAccept(t *testing.T) {
 	log := requireErrnoNosys(t, sockAcceptName, 0, 0, 0)
 	require.Equal(t, `
---> proxy.sock_accept(fd=0,flags=0,result.fd=0)
-	--> wasi_snapshot_preview1.sock_accept(fd=0,flags=0,result.fd=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.sock_accept(fd=0,flags=0,result.fd=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -21,10 +19,8 @@ func Test_sockAccept(t *testing.T) {
 func Test_sockRecv(t *testing.T) {
 	log := requireErrnoNosys(t, sockRecvName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.sock_recv(fd=0,ri_data=0,ri_data_count=0,ri_flags=0,result.ro_datalen=0,result.ro_flags=0)
-	--> wasi_snapshot_preview1.sock_recv(fd=0,ri_data=0,ri_data_count=0,ri_flags=0,result.ro_datalen=0,result.ro_flags=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.sock_recv(fd=0,ri_data=0,ri_data_count=0,ri_flags=0,result.ro_datalen=0,result.ro_flags=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -32,10 +28,8 @@ func Test_sockRecv(t *testing.T) {
 func Test_sockSend(t *testing.T) {
 	log := requireErrnoNosys(t, sockSendName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> proxy.sock_send(fd=0,si_data=0,si_data_count=0,si_flags=0,result.so_datalen=0)
-	--> wasi_snapshot_preview1.sock_send(fd=0,si_data=0,si_data_count=0,si_flags=0,result.so_datalen=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.sock_send(fd=0,si_data=0,si_data_count=0,si_flags=0,result.so_datalen=0)
+<-- ENOSYS
 `, log)
 }
 
@@ -43,9 +37,7 @@ func Test_sockSend(t *testing.T) {
 func Test_sockShutdown(t *testing.T) {
 	log := requireErrnoNosys(t, sockShutdownName, 0, 0)
 	require.Equal(t, `
---> proxy.sock_shutdown(fd=0,how=0)
-	--> wasi_snapshot_preview1.sock_shutdown(fd=0,how=0)
-	<-- ENOSYS
-<-- 52
+--> wasi_snapshot_preview1.sock_shutdown(fd=0,how=0)
+<-- ENOSYS
 `, log)
 }

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -398,7 +398,7 @@ func instantiateProxyModule(r wazero.Runtime, config wazero.ModuleConfig) (api.M
 		return nil, err
 	}
 
-	proxyBin := proxy.GetProxyModuleBinary(ModuleName, wasiModuleCompiled)
+	proxyBin := proxy.NewModuleBinary(ModuleName, wasiModuleCompiled)
 
 	proxyCompiled, err := r.CompileModule(testCtx, proxyBin)
 	if err != nil {

--- a/imports/wasi_snapshot_preview1/wasi_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	. "github.com/tetratelabs/wazero/experimental"
-	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
@@ -85,7 +84,7 @@ func requireProxyModule(t *testing.T, config wazero.ModuleConfig) (api.Module, a
 	var log bytes.Buffer
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, logging.NewLoggingListenerFactory(&log))
+	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, proxy.NewLoggingListenerFactory(&log))
 
 	r := wazero.NewRuntime(ctx)
 
@@ -95,7 +94,7 @@ func requireProxyModule(t *testing.T, config wazero.ModuleConfig) (api.Module, a
 	_, err = r.InstantiateModule(ctx, wasiModuleCompiled, config)
 	require.NoError(t, err)
 
-	proxyBin := proxy.GetProxyModuleBinary(ModuleName, wasiModuleCompiled)
+	proxyBin := proxy.NewModuleBinary(ModuleName, wasiModuleCompiled)
 
 	proxyCompiled, err := r.CompileModule(ctx, proxyBin)
 	require.NoError(t, err)
@@ -113,7 +112,7 @@ func requireErrnoNosys(t *testing.T, funcName string, params ...uint64) string {
 	var log bytes.Buffer
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, logging.NewHostLoggingListenerFactory(&log))
+	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, proxy.NewLoggingListenerFactory(&log))
 
 	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx)
@@ -125,7 +124,7 @@ func requireErrnoNosys(t *testing.T, funcName string, params ...uint64) string {
 	_, err = r.InstantiateModule(ctx, wasiModuleCompiled, wazero.NewModuleConfig())
 	require.NoError(t, err)
 
-	proxyBin := proxy.GetProxyModuleBinary(ModuleName, wasiModuleCompiled)
+	proxyBin := proxy.NewModuleBinary(ModuleName, wasiModuleCompiled)
 
 	proxyCompiled, err := r.CompileModule(ctx, proxyBin)
 	require.NoError(t, err)

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -20,7 +20,7 @@ func GetProxyModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) 
 	proxyModule := &wasm.Module{
 		MemorySection: &wasm.Memory{Min: 1},
 		ExportSection: []*wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
-		NameSection:   &wasm.NameSection{ModuleName: "proxy"},
+		NameSection:   &wasm.NameSection{ModuleName: "internal/testing/proxy/proxy.go"},
 	}
 	var cnt wasm.Index
 	for _, def := range funcDefs {

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -1,26 +1,52 @@
 package proxy
 
 import (
+	"io"
+
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	binaryformat "github.com/tetratelabs/wazero/internal/wasm/binary"
 )
 
-// GetProxyModuleBinary creates the proxy module to proxy a function call against
+const proxyModuleName = "internal/testing/proxy/proxy.go"
+
+// NewLoggingListenerFactory is like logging.NewHostLoggingListenerFactory,
+// except it skips logging proxying functions from NewModuleBinary.
+func NewLoggingListenerFactory(writer io.Writer) experimental.FunctionListenerFactory {
+	return &loggingListenerFactory{logging.NewHostLoggingListenerFactory(writer)}
+}
+
+type loggingListenerFactory struct {
+	delegate experimental.FunctionListenerFactory
+}
+
+// NewListener implements the same method as documented on
+// experimental.FunctionListener.
+func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+	if fnd.ModuleName() == proxyModuleName {
+		return nil // don't log proxy stuff
+	}
+	return f.delegate.NewListener(fnd)
+}
+
+// NewModuleBinary creates the proxy module to proxy a function call against
 // all the exported functions in `proxyTarget`, and returns its encoded binary.
 // The resulting module exports the proxy functions whose names are exactly the same
 // as the proxy destination.
 //
-// This is used to test host call implementations.
-func GetProxyModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) []byte {
+// This is used to test host call implementations. If logging, use
+// NewLoggingListenerFactory to avoid messages from the proxying module.
+func NewModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) []byte {
 	funcDefs := proxyTarget.ExportedFunctions()
 	funcNum := uint32(len(funcDefs))
 	proxyModule := &wasm.Module{
 		MemorySection: &wasm.Memory{Min: 1},
 		ExportSection: []*wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
-		NameSection:   &wasm.NameSection{ModuleName: "internal/testing/proxy/proxy.go"},
+		NameSection:   &wasm.NameSection{ModuleName: proxyModuleName},
 	}
 	var cnt wasm.Index
 	for _, def := range funcDefs {

--- a/internal/testing/require/require.go
+++ b/internal/testing/require/require.go
@@ -102,7 +102,8 @@ func equal(expected, actual interface{}) bool {
 	return false
 }
 
-// EqualError fails if the err is nil or its `Error()` value is not equal to the expected.
+// EqualError fails if the error is nil or its `Error()` value is not equal to
+// the expected string.
 //
 //   - formatWithArgs are optional. When the first is a string that contains '%', it is treated like fmt.Sprintf.
 func EqualError(t TestingT, err error, expected string, formatWithArgs ...interface{}) {


### PR DESCRIPTION
This makes it easier to do maintenance by hiding the implementation details of using a proxy module to test host modules. What happens is we skip logging of these proxy modules, which makes it easier to see what log affects a change has.