### PR TITLE
logging: reformats wasi filesystem logs to display paths

### DIFF
--- a/experimental/logging/log_listener_example_test.go
+++ b/experimental/logging/log_listener_example_test.go
@@ -51,9 +51,9 @@ func Example_newHostLoggingListenerFactory() {
 	// Output:
 	//--> listener.rand(len=4)
 	//	==> wasi_snapshot_preview1.random_get(buf=4,buf_len=4)
-	//	<== ESUCCESS
+	//	<== errno=ESUCCESS
 	//	==> wasi_snapshot_preview1.random_get(buf=8,buf_len=4)
-	//	<== ESUCCESS
+	//	<== errno=ESUCCESS
 	//<--
 }
 
@@ -90,9 +90,9 @@ func Example_newLoggingListenerFactory() {
 	//--> listener.rand(len=4)
 	//	--> listener.wasi_rand(len=4)
 	//		==> wasi_snapshot_preview1.random_get(buf=4,buf_len=4)
-	//		<== ESUCCESS
+	//		<== errno=ESUCCESS
 	//		==> wasi_snapshot_preview1.random_get(buf=8,buf_len=4)
-	//		<== ESUCCESS
+	//		<== errno=ESUCCESS
 	//	<--
 	//<--
 }

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -71,7 +71,7 @@ func Test_loggingListener(t *testing.T) {
 			params:      wasiParams,
 			results:     []uint64{uint64(wasi_snapshot_preview1.ErrnoSuccess)},
 			expected: `==> wasi_snapshot_preview1.random_get(buf=0,buf_len=8)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -85,7 +85,7 @@ func Test_loggingListener(t *testing.T) {
 			params:      wasiParams,
 			results:     []uint64{uint64(wasi_snapshot_preview1.ErrnoFault)},
 			expected: `==> wasi_snapshot_preview1.random_get(buf=0,buf_len=8)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{

--- a/imports/wasi_snapshot_preview1/args_test.go
+++ b/imports/wasi_snapshot_preview1/args_test.go
@@ -28,7 +28,7 @@ func Test_argsGet(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, argsGetName, uint64(argv), uint64(argvBuf))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.args_get(argv=22,argv_buf=16)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(argvBuf-1, uint32(len(expectedMemory)))
@@ -54,7 +54,7 @@ func Test_argsGet_Errors(t *testing.T) {
 			argvBuf: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_get(argv=65536,argv_buf=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -63,7 +63,7 @@ func Test_argsGet_Errors(t *testing.T) {
 			argvBuf: memorySize,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_get(argv=0,argv_buf=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -73,7 +73,7 @@ func Test_argsGet_Errors(t *testing.T) {
 			argvBuf: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_get(argv=65529,argv_buf=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -83,7 +83,7 @@ func Test_argsGet_Errors(t *testing.T) {
 			argvBuf: memorySize - 5 + 1,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_get(argv=0,argv_buf=65532)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -120,7 +120,7 @@ func Test_argsSizesGet(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, argsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=16,result.argv_len=21)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(resultArgc-1, uint32(len(expectedMemory)))
@@ -146,7 +146,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argvLen: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=65536,result.argv_len=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -155,7 +155,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argvLen: memorySize,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=0,result.argv_len=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -164,7 +164,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argvLen: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=65533,result.argv_len=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -173,7 +173,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 			argvLen: memorySize - 4 + 1, // 4 is count of bytes to encode uint32le
 			expectedLog: `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=0,result.argv_len=65533)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -36,7 +36,7 @@ func Test_clockResGet(t *testing.T) {
 			expectedMemory: expectedMemoryMicro,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_res_get(id=0,result.resolution=16)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -45,7 +45,7 @@ func Test_clockResGet(t *testing.T) {
 			expectedMemory: expectedMemoryNano,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_res_get(id=1,result.resolution=16)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 	}
@@ -85,7 +85,7 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_res_get(id=2,result.resolution=16)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -94,7 +94,7 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_res_get(id=3,result.resolution=16)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -103,7 +103,7 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_res_get(id=100,result.resolution=16)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 	}
@@ -141,7 +141,7 @@ func Test_clockTimeGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=16)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -154,7 +154,7 @@ func Test_clockTimeGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=1,precision=0,result.timestamp=16)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 	}
@@ -193,7 +193,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=2,precision=0,result.timestamp=16)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -202,7 +202,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=3,precision=0,result.timestamp=16)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -211,7 +211,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=100,precision=0,result.timestamp=16)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 	}
@@ -245,7 +245,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 			resultTimestamp: memorySize,
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -253,7 +253,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 			resultTimestamp: memorySize - 4 + 1, // 4 is the size of uint32, the type of the count of args
 			expectedLog: `
 ==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65533)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/environ_test.go
+++ b/imports/wasi_snapshot_preview1/environ_test.go
@@ -30,7 +30,7 @@ func Test_environGet(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, environGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.environ_get(environ=26,environ_buf=16)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(resultEnvironBuf-1, uint32(len(expectedMemory)))
@@ -57,7 +57,7 @@ func Test_environGet_Errors(t *testing.T) {
 			environBuf: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_get(environ=65536,environ_buf=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -66,7 +66,7 @@ func Test_environGet_Errors(t *testing.T) {
 			environBuf: memorySize,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_get(environ=0,environ_buf=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -76,7 +76,7 @@ func Test_environGet_Errors(t *testing.T) {
 			environBuf: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_get(environ=65529,environ_buf=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -86,7 +86,7 @@ func Test_environGet_Errors(t *testing.T) {
 			environBuf: memorySize - 10 + 1,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_get(environ=0,environ_buf=65527)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -124,7 +124,7 @@ func Test_environSizesGet(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, environSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=16,result.environv_len=21)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(resultEnvironc-1, uint32(len(expectedMemory)))
@@ -151,7 +151,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environLen: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=65536,result.environv_len=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -160,7 +160,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environLen: memorySize,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=0,result.environv_len=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -169,7 +169,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environLen: validAddress,
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=65533,result.environv_len=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -178,7 +178,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 			environLen: memorySize - 4 + 1, // 4 is count of bytes to encode uint32le
 			expectedLog: `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=0,result.environv_len=65533)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -25,7 +25,7 @@ func Test_fdAdvise(t *testing.T) {
 	log := requireErrnoNosys(t, fdAdviseName, 0, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_advise(fd=0,offset=0,len=0,advice=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -34,7 +34,7 @@ func Test_fdAllocate(t *testing.T) {
 	log := requireErrnoNosys(t, fdAllocateName, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_allocate(fd=0,offset=0,len=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -59,7 +59,7 @@ func Test_fdClose(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, fdCloseName, uint64(fdToClose))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_close(fd=4)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	// Verify fdToClose is closed and removed from the opened FDs.
@@ -75,7 +75,7 @@ func Test_fdClose(t *testing.T) {
 		requireErrno(t, ErrnoBadf, mod, fdCloseName, uint64(42)) // 42 is an arbitrary invalid FD
 		require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_close(fd=42)
-<== EBADF
+<== errno=EBADF
 `, "\n"+log.String())
 	})
 }
@@ -85,7 +85,7 @@ func Test_fdDatasync(t *testing.T) {
 	log := requireErrnoNosys(t, fdDatasyncName, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_datasync(fd=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -124,7 +124,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=0,result.stat=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -138,7 +138,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=1,result.stat=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -152,7 +152,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=2,result.stat=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -166,7 +166,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=3,result.stat=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -180,7 +180,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=4,result.stat=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -194,7 +194,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=5,result.stat=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -203,7 +203,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=-1,result.stat=0)
-<== EBADF
+<== errno=EBADF
 `,
 		},
 		{
@@ -213,7 +213,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=5,result.stat=65513)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -241,7 +241,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 	log := requireErrnoNosys(t, fdFdstatSetFlagsName, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=0,flags=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -250,7 +250,7 @@ func Test_fdFdstatSetRights(t *testing.T) {
 	log := requireErrnoNosys(t, fdFdstatSetRightsName, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_fdstat_set_rights(fd=0,fs_rights_base=0,fs_rights_inheriting=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -298,7 +298,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=0,result.buf=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -317,7 +317,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=1,result.buf=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -336,7 +336,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=2,result.buf=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -354,7 +354,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=3,result.buf=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -372,7 +372,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=4,result.buf=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -390,7 +390,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=5,result.buf=0)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -399,7 +399,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=-1,result.buf=0)
-<== EBADF
+<== errno=EBADF
 `,
 		},
 		{
@@ -409,7 +409,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=5,result.buf=65473)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -437,7 +437,7 @@ func Test_fdFilestatSetSize(t *testing.T) {
 	log := requireErrnoNosys(t, fdFilestatSetSizeName, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_filestat_set_size(fd=0,size=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -446,7 +446,7 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 	log := requireErrnoNosys(t, fdFilestatSetTimesName, 0, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_filestat_set_times(fd=0,atim=0,mtim=0,fst_flags=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -486,8 +486,8 @@ func Test_fdPread(t *testing.T) {
 				'?',
 			),
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=0,result.nread=26)
-<== ESUCCESS
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=0)
+<== (nread=6,errno=ESUCCESS)
 `,
 		},
 		{
@@ -501,8 +501,8 @@ func Test_fdPread(t *testing.T) {
 				'?',
 			),
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=2,result.nread=26)
-<== ESUCCESS
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=1,iovs_len=2,offset=2)
+<== (nread=4,errno=ESUCCESS)
 `,
 		},
 	}
@@ -546,8 +546,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nread validation
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=42,iovs=65532,iovs_len=65532,offset=0,result.nread=65532)
-<== EBADF
+==> wasi_snapshot_preview1.fd_pread(fd=42,iovs=65532,iovs_len=65532,offset=0)
+<== (nread=,errno=EBADF)
 `,
 		},
 		{
@@ -556,8 +556,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			offset:        int64(len(contents) + 1),
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65536,offset=7,result.nread=65536)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65536,offset=7)
+<== (nread=OOM(65536,4),errno=EFAULT)
 `,
 		},
 		{
@@ -567,8 +567,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			memory:        []byte{'?'},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65535,offset=0,result.nread=65535)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=65535,offset=0)
+<== (nread=OOM(65535,4),errno=EFAULT)
 `,
 		},
 		{
@@ -581,8 +581,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65532,iovs_len=65532,offset=0,result.nread=65531)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65532,iovs_len=65532,offset=0)
+<== (nread=2367,errno=EFAULT)
 `,
 		},
 		{
@@ -596,8 +596,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65528,iovs_len=65528,offset=0,result.nread=65527)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65528,iovs_len=65528,offset=0)
+<== (nread=16777279,errno=EFAULT)
 `,
 		},
 		{
@@ -612,8 +612,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65526)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0)
+<== (nread=2367,errno=EFAULT)
 `,
 		},
 		{
@@ -629,8 +629,8 @@ func Test_fdPread_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0,result.nread=65536)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=65527,offset=0)
+<== (nread=OOM(65536,4),errno=EFAULT)
 `,
 		},
 	}
@@ -670,8 +670,8 @@ func Test_fdPrestatGet(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatGetName, uint64(fd), uint64(resultPrestat))
 	require.Equal(t, `
-==> wasi_snapshot_preview1.fd_prestat_get(fd=3,result.prestat=1)
-<== ESUCCESS
+==> wasi_snapshot_preview1.fd_prestat_get(fd=3)
+<== (prestat=0000000001000000,errno=ESUCCESS)
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -698,8 +698,8 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			resultPrestat: 0,  // valid offset
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_get(fd=42,result.prestat=0)
-<== EBADF
+==> wasi_snapshot_preview1.fd_prestat_get(fd=42)
+<== (prestat=,errno=EBADF)
 `,
 		},
 		{
@@ -708,8 +708,8 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			resultPrestat: memorySize,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_get(fd=3,result.prestat=65536)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_prestat_get(fd=3)
+<== (prestat=OOM(65536,8),errno=EFAULT)
 `,
 		},
 		// TODO: non pre-opened file == api.ErrnoBadf
@@ -742,8 +742,8 @@ func Test_fdPrestatDirName(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdPrestatDirNameName, uint64(fd), uint64(path), uint64(pathLen))
 	require.Equal(t, `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=1,result.path_len=0)
-<== ESUCCESS
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
+<== (path=,errno=ESUCCESS)
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -757,6 +757,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 	fd := internalsys.FdRoot // only pre-opened directory currently supported.
 
 	memorySize := mod.Memory().Size()
+	maskMemory(t, mod, 10)
+
 	validAddress := uint32(0) // Arbitrary valid address as arguments to fd_prestat_dir_name. We chose 0 here.
 	pathLen := uint32(len("/"))
 
@@ -775,8 +777,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=65536,result.path_len=1)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
+<== (path=OOM(65536,1),errno=EFAULT)
 `,
 		},
 		{
@@ -786,8 +788,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=65536,result.path_len=1)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
+<== (path=OOM(65536,1),errno=EFAULT)
 `,
 		},
 		{
@@ -797,8 +799,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen + 1,
 			expectedErrno: ErrnoNametoolong,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3,result.path=0,result.path_len=2)
-<== ENAMETOOLONG
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
+<== (path=,errno=ENAMETOOLONG)
 `,
 		},
 		{
@@ -808,8 +810,8 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			pathLen:       pathLen,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42,result.path=0,result.path_len=1)
-<== EBADF
+==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42)
+<== (path=,errno=EBADF)
 `,
 		},
 		// TODO: non pre-opened file == ErrnoBadf
@@ -832,7 +834,7 @@ func Test_fdPwrite(t *testing.T) {
 	log := requireErrnoNosys(t, fdPwriteName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_pwrite(fd=0,iovs=0,iovs_len=0,offset=0,result.nwritten=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -868,8 +870,8 @@ func Test_fdRead(t *testing.T) {
 
 	requireErrno(t, ErrnoSuccess, mod, fdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
 	require.Equal(t, `
-==> wasi_snapshot_preview1.fd_read(fd=4,iovs=1,iovs_len=2,result.nread=26)
-<== ESUCCESS
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=1,iovs_len=2)
+<== (nread=6,errno=ESUCCESS)
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -894,8 +896,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nread validation
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_read(fd=42,iovs=65532,iovs_len=65532,result.nread=65532)
-<== EBADF
+==> wasi_snapshot_preview1.fd_read(fd=42,iovs=65532,iovs_len=65532)
+<== (nread=,errno=EBADF)
 `,
 		},
 		{
@@ -905,8 +907,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			memory:        []byte{'?'},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65536,iovs_len=65535,result.nread=65535)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65536,iovs_len=65535)
+<== (nread=OOM(65535,4),errno=EFAULT)
 `,
 		},
 		{
@@ -919,8 +921,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65532,iovs_len=65532,result.nread=65531)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65532,iovs_len=65532)
+<== (nread=2367,errno=EFAULT)
 `,
 		},
 		{
@@ -934,8 +936,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65528,iovs_len=65528,result.nread=65527)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65528,iovs_len=65528)
+<== (nread=16777279,errno=EFAULT)
 `,
 		},
 		{
@@ -950,8 +952,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65526)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527)
+<== (nread=2367,errno=EFAULT)
 `,
 		},
 		{
@@ -967,8 +969,8 @@ func Test_fdRead_Errors(t *testing.T) {
 			},
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527,result.nread=65536)
-<== EFAULT
+==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527)
+<== (nread=OOM(65536,4),errno=EFAULT)
 `,
 		},
 	}
@@ -1423,7 +1425,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -1434,7 +1436,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=42,buf=0,buf_len=24,cookie=0,result.bufused=1000)
-<== EBADF
+<== errno=EBADF
 `,
 		},
 		{
@@ -1445,7 +1447,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=0,buf_len=24,cookie=0,result.bufused=1000)
-<== EBADF
+<== errno=EBADF
 `,
 		},
 		{
@@ -1456,7 +1458,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65536,buf_len=1000,cookie=0,result.bufused=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -1467,7 +1469,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=65535,buf_len=1000,cookie=0,result.bufused=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -1478,7 +1480,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1,cookie=0,result.bufused=1000)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -1490,7 +1492,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -1502,7 +1504,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=1,result.bufused=2000)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -1515,7 +1517,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=1000,cookie=-1,result.bufused=2000)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 	}
@@ -1770,7 +1772,7 @@ func Test_fdRenumber(t *testing.T) {
 	log := requireErrnoNosys(t, fdRenumberName, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_renumber(fd=0,to=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -1800,7 +1802,7 @@ func Test_fdSeek(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=4,whence=0,result.newoffset=1)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -1815,7 +1817,7 @@ func Test_fdSeek(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=1,whence=1,result.newoffset=1)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -1830,7 +1832,7 @@ func Test_fdSeek(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=-1,whence=2,result.newoffset=1)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 	}
@@ -1887,7 +1889,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=42,offset=0,whence=0,result.newoffset=0)
-<== EBADF
+<== errno=EBADF
 `,
 		},
 		{
@@ -1897,7 +1899,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=3,result.newoffset=0)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -1907,7 +1909,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 			expectedErrno:   ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=0,result.newoffset=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -1928,7 +1930,7 @@ func Test_fdSync(t *testing.T) {
 	log := requireErrnoNosys(t, fdSyncName, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_sync(fd=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -1937,7 +1939,7 @@ func Test_fdTell(t *testing.T) {
 	log := requireErrnoNosys(t, fdTellName, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.fd_tell(fd=0,result.offset=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -1975,7 +1977,7 @@ func Test_fdWrite(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, fdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=1,iovs_len=2,result.nwritten=26)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2026,7 +2028,7 @@ func Test_fdWrite_discard(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, fdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_write(fd=1,iovs=1,iovs_len=2,result.nwritten=26)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2056,7 +2058,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=42,iovs=0,iovs_len=1,result.nwritten=0)
-<== EBADF
+<== errno=EBADF
 `,
 		},
 		{
@@ -2066,7 +2068,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65534,iovs_len=1,result.nwritten=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2076,7 +2078,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65532,iovs_len=1,result.nwritten=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2086,7 +2088,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65531,iovs_len=1,result.nwritten=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2096,7 +2098,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			expectedErrno: ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65527,iovs_len=1,result.nwritten=0)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2106,7 +2108,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=0,iovs_len=1,result.nwritten=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -2134,8 +2136,8 @@ func Test_fdWrite_Errors(t *testing.T) {
 func Test_pathCreateDirectory(t *testing.T) {
 	log := requireErrnoNosys(t, pathCreateDirectoryName, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_create_directory(fd=0,path=0,path_len=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_create_directory(fd=0,path=)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2191,8 +2193,8 @@ func Test_pathFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			),
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-<== ESUCCESS
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=a,result.buf=2)
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -2213,8 +2215,8 @@ func Test_pathFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			),
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
-<== ESUCCESS
+==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=a,result.buf=2)
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -2235,8 +2237,8 @@ func Test_pathFilestatGet(t *testing.T) {
 				0x0, 0x82, 0x13, 0x80, 0x6b, 0x16, 0x24, 0x17, // ctim
 			),
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-<== ESUCCESS
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=b,result.buf=2)
+<== errno=ESUCCESS
 `,
 		},
 		{
@@ -2244,8 +2246,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			fd:            math.MaxUint32,
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=-1,flags=0,path=1,path_len=0,result.buf=0)
-<== EBADF
+==> wasi_snapshot_preview1.path_filestat_get(fd=-1,flags=0,path=,result.buf=0)
+<== errno=EBADF
 `,
 		},
 		{
@@ -2256,8 +2258,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 2,
 			expectedErrno:  ErrnoNotdir,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=4,flags=0,path=1,path_len=1,result.buf=2)
-<== ENOTDIR
+==> wasi_snapshot_preview1.path_filestat_get(fd=4,flags=0,path=a,result.buf=2)
+<== errno=ENOTDIR
 `,
 		},
 		{
@@ -2268,8 +2270,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 2,
 			expectedErrno:  ErrnoNoent,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=2)
-<== ENOENT
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=?,result.buf=2)
+<== errno=ENOENT
 `,
 		},
 		{
@@ -2280,8 +2282,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 2,
 			expectedErrno:  ErrnoNoent,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=1,result.buf=2)
-<== ENOENT
+==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=?,result.buf=2)
+<== errno=ENOENT
 `,
 		},
 		{
@@ -2292,8 +2294,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: 7,
 			expectedErrno:  ErrnoNoent,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=1,path_len=6,result.buf=7)
-<== ENOENT
+==> wasi_snapshot_preview1.path_filestat_get(fd=5,flags=0,path=../foo,result.buf=7)
+<== errno=ENOENT
 `,
 		},
 		{
@@ -2303,8 +2305,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			pathLen:       memorySize,
 			expectedErrno: ErrnoNametoolong,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=65536,result.buf=0)
-<== ENAMETOOLONG
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=OOM(1,65536),result.buf=0)
+<== errno=ENAMETOOLONG
 `,
 		},
 		{
@@ -2315,8 +2317,8 @@ func Test_pathFilestatGet(t *testing.T) {
 			resultFilestat: memorySize - 64 + 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=1,path_len=1,result.buf=65473)
-<== EFAULT
+==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=0,path=a,result.buf=65473)
+<== errno=EFAULT
 `,
 		},
 	}
@@ -2345,8 +2347,8 @@ func Test_pathFilestatGet(t *testing.T) {
 func Test_pathFilestatSetTimes(t *testing.T) {
 	log := requireErrnoNosys(t, pathFilestatSetTimesName, 0, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_filestat_set_times(fd=0,flags=0,path=0,path_len=0,atim=0,mtim=0,fst_flags=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_filestat_set_times(fd=0,flags=0,path=,atim=0,mtim=0,fst_flags=0)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2354,8 +2356,8 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 func Test_pathLink(t *testing.T) {
 	log := requireErrnoNosys(t, pathLinkName, 0, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_link(old_fd=0,old_flags=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_link(old_fd=0,old_flags=0,old_path=,new_fd=0,new_path=)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2393,8 +2395,8 @@ func Test_pathOpen(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, pathOpenName, uint64(rootFD), uint64(dirflags), uint64(path),
 		uint64(pathLen), uint64(oflags), fsRightsBase, fsRightsInheriting, uint64(fdflags), uint64(resultOpenedFd))
 	require.Equal(t, `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=1,path_len=6,oflags=0,fs_rights_base=1,fs_rights_inheriting=2,fdflags=0,result.opened_fd=8)
-<== ESUCCESS
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=wazero,oflags=0,fs_rights_base=1,fs_rights_inheriting=2,fdflags=0,result.opened_fd=8)
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2433,8 +2435,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			fd:            42, // arbitrary invalid fd
 			expectedErrno: ErrnoBadf,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=42,dirflags=0,path=0,path_len=0,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-<== EBADF
+==> wasi_snapshot_preview1.path_open(fd=42,dirflags=0,path=,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== errno=EBADF
 `,
 		},
 		{
@@ -2444,8 +2446,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       validPathLen,
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=65536,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-<== EFAULT
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=OOM(65536,6),oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2456,8 +2458,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			// fstest.MapFS returns file not found instead of invalid on invalid path
 			expectedErrno: ErrnoNoent,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-<== ENOENT
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=../foo,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== errno=ENOENT
 `,
 		},
 		{
@@ -2467,8 +2469,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is out-of-memory for path
 			expectedErrno: ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=65537,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-<== EFAULT
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=OOM(0,65537),oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2479,8 +2481,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       validPathLen - 1, // this make the path "wazer", which doesn't exit
 			expectedErrno: ErrnoNoent,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=5,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-<== ENOENT
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=wazer,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== errno=ENOENT
 `,
 		},
 		{
@@ -2492,8 +2494,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			resultOpenedFd: mod.Memory().Size(), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=65536)
-<== EFAULT
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=wazero,oflags=0,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=65536)
+<== errno=EFAULT
 `,
 		},
 		{
@@ -2505,8 +2507,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathLen:       validPathLen,
 			expectedErrno: ErrnoNotdir,
 			expectedLog: `
-==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=0,path_len=6,oflags=3,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
-<== ENOTDIR
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=0,path=notdir,oflags=3,fs_rights_base=0,fs_rights_inheriting=0,fdflags=0,result.opened_fd=0)
+<== errno=ENOTDIR
 `,
 		},
 	}
@@ -2529,8 +2531,8 @@ func Test_pathOpen_Errors(t *testing.T) {
 func Test_pathReadlink(t *testing.T) {
 	log := requireErrnoNosys(t, pathReadlinkName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_readlink(fd=0,path=0,path_len=0,buf=0,buf_len=0,result.bufused=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_readlink(fd=0,path=,buf=0,buf_len=0,result.bufused=0)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2538,8 +2540,8 @@ func Test_pathReadlink(t *testing.T) {
 func Test_pathRemoveDirectory(t *testing.T) {
 	log := requireErrnoNosys(t, pathRemoveDirectoryName, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_remove_directory(fd=0,path=0,path_len=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_remove_directory(fd=0,path=)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2547,8 +2549,8 @@ func Test_pathRemoveDirectory(t *testing.T) {
 func Test_pathRename(t *testing.T) {
 	log := requireErrnoNosys(t, pathRenameName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_rename(fd=0,old_path=0,old_path_len=0,new_fd=0,new_path=0,new_path_len=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_rename(fd=0,old_path=,new_fd=0,new_path=)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2556,8 +2558,8 @@ func Test_pathRename(t *testing.T) {
 func Test_pathSymlink(t *testing.T) {
 	log := requireErrnoNosys(t, pathSymlinkName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_symlink(old_path=0,old_path_len=0,fd=0,new_path=0,new_path_len=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_symlink(old_path=,fd=0,new_path=)
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -2565,8 +2567,8 @@ func Test_pathSymlink(t *testing.T) {
 func Test_pathUnlinkFile(t *testing.T) {
 	log := requireErrnoNosys(t, pathUnlinkFileName, 0, 0, 0)
 	require.Equal(t, `
---> wasi_snapshot_preview1.path_unlink_file(fd=0,path=0,path_len=0)
-<-- ENOSYS
+--> wasi_snapshot_preview1.path_unlink_file(fd=0,path=)
+<-- errno=ENOSYS
 `, log)
 }
 

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -42,7 +42,7 @@ func Test_pollOneoff(t *testing.T) {
 		uint64(resultNevents))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	outMem, ok := mod.Memory().Read(out, uint32(len(expectedMem)))
@@ -75,7 +75,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.poll_oneoff(in=65536,out=128,nsubscriptions=1,result.nevents=512)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -86,7 +86,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.poll_oneoff(in=0,out=65536,nsubscriptions=1,result.nevents=512)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -96,7 +96,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.poll_oneoff(in=0,out=0,nsubscriptions=1,result.nevents=65536)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -106,7 +106,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			expectedErrno: ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=0,result.nevents=512)
-<== EINVAL
+<== errno=EINVAL
 `,
 		},
 		{
@@ -129,7 +129,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-<== ESUCCESS
+<== errno=ESUCCESS
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/proc_test.go
+++ b/imports/wasi_snapshot_preview1/proc_test.go
@@ -55,6 +55,6 @@ func Test_procRaise(t *testing.T) {
 	log := requireErrnoNosys(t, procRaiseName, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.proc_raise(sig=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }

--- a/imports/wasi_snapshot_preview1/random_test.go
+++ b/imports/wasi_snapshot_preview1/random_test.go
@@ -30,7 +30,7 @@ func Test_randomGet(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, randomGetName, uint64(offset), uint64(length))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
-<== ESUCCESS
+<== errno=ESUCCESS
 `, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, offset+length+1)
@@ -55,7 +55,7 @@ func Test_randomGet_Errors(t *testing.T) {
 			length: 1,
 			expectedLog: `
 ==> wasi_snapshot_preview1.random_get(buf=65536,buf_len=1)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 		{
@@ -64,7 +64,7 @@ func Test_randomGet_Errors(t *testing.T) {
 			length: memorySize + 1,
 			expectedLog: `
 ==> wasi_snapshot_preview1.random_get(buf=0,buf_len=65537)
-<== EFAULT
+<== errno=EFAULT
 `,
 		},
 	}
@@ -92,7 +92,7 @@ func Test_randomGet_SourceError(t *testing.T) {
 			randSource: iotest.ErrReader(errors.New("RandSource error")),
 			expectedLog: `
 ==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
-<== EIO
+<== errno=EIO
 `,
 		},
 		{
@@ -100,7 +100,7 @@ func Test_randomGet_SourceError(t *testing.T) {
 			randSource: bytes.NewReader([]byte{1, 2}),
 			expectedLog: `
 ==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
-<== EIO
+<== errno=EIO
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/sched_test.go
+++ b/imports/wasi_snapshot_preview1/sched_test.go
@@ -11,6 +11,6 @@ func Test_schedYield(t *testing.T) {
 	log := requireErrnoNosys(t, schedYieldName)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.sched_yield()
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }

--- a/imports/wasi_snapshot_preview1/sock_test.go
+++ b/imports/wasi_snapshot_preview1/sock_test.go
@@ -11,7 +11,7 @@ func Test_sockAccept(t *testing.T) {
 	log := requireErrnoNosys(t, sockAcceptName, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.sock_accept(fd=0,flags=0,result.fd=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -20,7 +20,7 @@ func Test_sockRecv(t *testing.T) {
 	log := requireErrnoNosys(t, sockRecvName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.sock_recv(fd=0,ri_data=0,ri_data_count=0,ri_flags=0,result.ro_datalen=0,result.ro_flags=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -29,7 +29,7 @@ func Test_sockSend(t *testing.T) {
 	log := requireErrnoNosys(t, sockSendName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.sock_send(fd=0,si_data=0,si_data_count=0,si_flags=0,result.so_datalen=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }
 
@@ -38,6 +38,6 @@ func Test_sockShutdown(t *testing.T) {
 	log := requireErrnoNosys(t, sockShutdownName, 0, 0)
 	require.Equal(t, `
 --> wasi_snapshot_preview1.sock_shutdown(fd=0,how=0)
-<-- ENOSYS
+<-- errno=ENOSYS
 `, log)
 }


### PR DESCRIPTION
This uses logging infrastructure introduced in #938 to show paths and certain result parameters. While further tuning is expected, the main thing this does is show which paths are affected by syscalls.
