### PR TITLE
Adds experimental write support and implements on gojs

### DIFF
--- a/experimental/writefs/writefs.go
+++ b/experimental/writefs/writefs.go
@@ -1,0 +1,62 @@
+package writefs
+
+import (
+	"io/fs"
+	"os"
+)
+
+// FS is a fs.FS which can also create new files or directories.
+//
+// Any unsupported method should return syscall.ENOSYS.
+//
+// See https://github.com/golang/go/issues/45757
+type FS interface {
+	fs.FS
+
+	// OpenFile is similar to os.OpenFile, except the path is relative to this
+	// file system.
+	OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error)
+
+	// Mkdir is similar to os.Mkdir, except the path is relative to this file
+	// system.
+	Mkdir(name string, perm fs.FileMode) error
+
+	// Remove is similar to os.Remove, except the path is relative to this file
+	// system.
+	Remove(path string) error
+}
+
+func New(absoluteDir string) FS {
+	return writeFS(absoluteDir)
+}
+
+type writeFS string
+
+// Open implements fs.FS
+func (dir writeFS) Open(name string) (fs.File, error) {
+	return dir.OpenFile(name, os.O_RDONLY, 0) // same as os.Open(string)
+}
+
+// OpenFile implements FS.OpenFile
+func (dir writeFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	return os.OpenFile(string(dir)+"/"+name, flag, perm)
+}
+
+// Mkdir implements FS.Mkdir
+func (dir writeFS) Mkdir(name string, perm fs.FileMode) error {
+	if !fs.ValidPath(name) {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: fs.ErrInvalid}
+	}
+	return os.Mkdir(string(dir)+"/"+name, perm)
+}
+
+// Remove implements FS.Remove
+func (dir writeFS) Remove(path string) error {
+	if !fs.ValidPath(path) {
+		return &fs.PathError{Op: "remove", Path: path, Err: fs.ErrInvalid}
+	}
+	return os.Remove(string(dir) + "/" + path)
+}

--- a/experimental/writefs/writefs_test.go
+++ b/experimental/writefs/writefs_test.go
@@ -1,0 +1,85 @@
+package writefs
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+	"testing/fstest"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+var testFiles = map[string]string{
+	"empty.txt":        "",
+	"test.txt":         "animals\n",
+	"sub/test.txt":     "greet sub dir\n",
+	"sub/sub/test.txt": "greet sub sub dir\n",
+}
+
+func TestFS(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(path.Join(dir, "sub", "sub"), 0o700))
+
+	expected := make([]string, 0, len(testFiles))
+	for name, data := range testFiles {
+		expected = append(expected, name)
+		require.NoError(t, os.WriteFile(path.Join(dir, name), []byte(data), 0o600))
+	}
+
+	if err := fstest.TestFS(New(dir), expected...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMkDir(t *testing.T) {
+	dir := t.TempDir()
+
+	testFS := New(dir)
+
+	name := "mkdir"
+
+	t.Run("doesn't exist", func(t *testing.T) {
+		require.NoError(t, testFS.Mkdir(name, fs.ModeDir))
+		stat, err := os.Stat(path.Join(dir, name))
+		require.NoError(t, err)
+		require.Equal(t, name, stat.Name())
+		require.True(t, stat.IsDir())
+	})
+
+	t.Run("exists", func(t *testing.T) {
+		require.Error(t, testFS.Mkdir(name, fs.ModeDir))
+	})
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+
+	testFS := New(dir)
+
+	name := "remove"
+
+	t.Run("doesn't exist", func(t *testing.T) {
+		require.Error(t, testFS.Remove(name))
+	})
+
+	t.Run("dir exists", func(t *testing.T) {
+		realPath := path.Join(dir, name)
+		err := os.Mkdir(realPath, 0o700)
+		require.NoError(t, err)
+
+		require.NoError(t, testFS.Remove(name))
+		_, err = os.Stat(realPath)
+		require.Error(t, err)
+	})
+
+	t.Run("file exists", func(t *testing.T) {
+		realPath := path.Join(dir, name)
+		err := os.WriteFile(realPath, []byte{}, 0o600)
+		require.NoError(t, err)
+
+		require.NoError(t, testFS.Remove(name))
+		_, err = os.Stat(realPath)
+		require.Error(t, err)
+	})
+}

--- a/experimental/writefs/writefs_test.go
+++ b/experimental/writefs/writefs_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"testing/fstest"
 
@@ -18,6 +19,11 @@ var testFiles = map[string]string{
 }
 
 func TestFS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// This abstraction is a toe-hold, but we'll have to sort windows with
+		// our ideal filesystem tester.
+		t.Skip("TODO: windows")
+	}
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(path.Join(dir, "sub", "sub"), 0o700))
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -50,10 +50,10 @@ func Test_fdClose(t *testing.T) {
 	// open both paths without using WASI
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
-	fdToClose, err := fsc.OpenFile(path1)
+	fdToClose, err := fsc.OpenFile(path1, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
-	fdToKeep, err := fsc.OpenFile(path2)
+	fdToKeep, err := fsc.OpenFile(path2, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	// Close
@@ -101,10 +101,10 @@ func Test_fdFdstatGet(t *testing.T) {
 	// open both paths without using WASI
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
-	fileFd, err := fsc.OpenFile(file)
+	fileFd, err := fsc.OpenFile(file, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
-	dirFd, err := fsc.OpenFile(dir)
+	dirFd, err := fsc.OpenFile(dir, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -270,10 +270,10 @@ func Test_fdFilestatGet(t *testing.T) {
 	// open both paths without using WASI
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
-	fileFd, err := fsc.OpenFile(file)
+	fileFd, err := fsc.OpenFile(file, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
-	dirFd, err := fsc.OpenFile(dir)
+	dirFd, err := fsc.OpenFile(dir, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1124,7 +1124,7 @@ func Test_fdReaddir(t *testing.T) {
 
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
-	fd, err := fsc.OpenFile("dir")
+	fd, err := fsc.OpenFile("dir", os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1403,10 +1403,10 @@ func Test_fdReaddir_Errors(t *testing.T) {
 
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 
-	dirFD, err := fsc.OpenFile("dir")
+	dirFD, err := fsc.OpenFile("dir", os.O_RDONLY, 0)
 	require.NoError(t, err)
 
-	fileFD, err := fsc.OpenFile("notdir")
+	fileFD, err := fsc.OpenFile("notdir", os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -2163,10 +2163,10 @@ func Test_pathFilestatGet(t *testing.T) {
 
 	rootFd := uint32(3) // after stderr
 
-	fileFd, err := fsc.OpenFile(file)
+	fileFd, err := fsc.OpenFile(file, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
-	dirFd, err := fsc.OpenFile(dir)
+	dirFd, err := fsc.OpenFile(dir, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -2581,7 +2581,7 @@ func requireOpenFile(t *testing.T, pathName string, data []byte) (api.Module, ui
 	testFS := fstest.MapFS{pathName[1:]: mapFile} // strip the leading slash
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	fsc := mod.(*wasm.CallContext).Sys.FS()
-	fd, err := fsc.OpenFile(pathName)
+	fd, err := fsc.OpenFile(pathName, os.O_RDONLY, 0)
 	require.NoError(t, err)
 	return mod, fd, log, r
 }
@@ -2591,7 +2591,7 @@ func requireOpenWritableFile(t *testing.T, tmpDir string, pathName string) (api.
 	writeable, testFS := createWriteableFile(t, tmpDir, pathName, []byte{})
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testFS))
 	fsc := mod.(*wasm.CallContext).Sys.FS()
-	fd, err := fsc.OpenFile(pathName)
+	fd, err := fsc.OpenFile(pathName, os.O_RDWR, 0)
 	require.NoError(t, err)
 
 	// Swap the read-only file with a writeable one until #390

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -172,7 +172,7 @@ func Benchmark_fdReaddir(b *testing.B) {
 
 			// Open the root directory as a file-descriptor.
 			fsc := mod.(*wasm.CallContext).Sys.FS()
-			fd, err := fsc.OpenFile(".")
+			fd, err := fsc.OpenFile(".", os.O_RDONLY, 0)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -278,7 +278,7 @@ func Benchmark_pathFilestat(b *testing.B) {
 			fd := sys.FdRoot
 			if bc.fd != sys.FdRoot {
 				fsc := mod.(*wasm.CallContext).Sys.FS()
-				fd, err = fsc.OpenFile("zig")
+				fd, err = fsc.OpenFile("zig", os.O_RDONLY, 0)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -51,9 +51,9 @@ var (
 	testCtx context.Context
 	testFS  = fstest.MapFS{
 		"empty.txt":    {},
-		"test.txt":     {Data: []byte("animals\n")},
-		"sub":          {Mode: fs.ModeDir},
-		"sub/test.txt": {Data: []byte("greet sub dir\n")},
+		"test.txt":     {Data: []byte("animals\n"), Mode: 0o644},
+		"sub":          {Mode: fs.ModeDir | 0o755},
+		"sub/test.txt": {Data: []byte("greet sub dir\n"), Mode: 0o444},
 	}
 	rt wazero.Runtime
 )

--- a/internal/gojs/custom/fs.go
+++ b/internal/gojs/custom/fs.go
@@ -12,6 +12,9 @@ const (
 	NameFsRead    = "read"
 	NameFsWrite   = "write"
 	NameFsReaddir = "readdir"
+	NameFsMkdir   = "mkdir"
+	NameFsRmdir   = "rmdir"
+	NameFsUnlink  = "unlink"
 )
 
 // FsNameSection are the functions defined in the object named NameFs. Results
@@ -57,5 +60,20 @@ var FsNameSection = map[string]*Names{
 		Name:        NameFsReaddir,
 		ParamNames:  []string{"name", NameCallback},
 		ResultNames: []string{"err", "dirents"},
+	},
+	NameFsMkdir: {
+		Name:        NameFsMkdir,
+		ParamNames:  []string{"path", "perm", NameCallback},
+		ResultNames: []string{"err", "fd"},
+	},
+	NameFsRmdir: {
+		Name:        NameFsRmdir,
+		ParamNames:  []string{"path", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsUnlink: {
+		Name:        NameFsUnlink,
+		ParamNames:  []string{"path", NameCallback},
+		ResultNames: []string{"err", "ok"},
 	},
 }

--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -170,7 +170,8 @@ func syscallFstat(fsc *internalsys.FSContext, fd uint32) (*jsSt, error) {
 	}
 }
 
-// getJsMode is required to ensure
+// getJsMode is required because the mode property read in `GOOS=js` is
+// incompatible with normal go. Particularly the directory flag isn't the same.
 func getJsMode(mode fs.FileMode) (jsMode uint32) {
 	jsMode = uint32(mode & fs.ModePerm)
 	switch mode & fs.ModeType {

--- a/internal/gojs/fs_test.go
+++ b/internal/gojs/fs_test.go
@@ -1,9 +1,12 @@
 package gojs_test
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/experimental/writefs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
@@ -12,15 +15,33 @@ func Test_fs(t *testing.T) {
 
 	stdout, stderr, err := compileAndRun(testCtx, "fs", wazero.NewModuleConfig().WithFS(testFS))
 
-	require.EqualError(t, err, `module "" closed with exit_code(0)`)
 	require.Zero(t, stderr)
+	require.EqualError(t, err, `module "" closed with exit_code(0)`)
 	require.Equal(t, `TestFS ok
 wd ok
 Not a directory
-/test.txt ok
-test.txt ok
+sub mode drwxr-xr-x
+/test.txt mode -rw-r--r--
+test.txt mode -rw-r--r--
 contents: animals
 
 empty: 
+`, stdout)
+}
+
+func Test_writefs(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	fs := writefs.New(tmpDir)
+	// test expects to write under /tmp
+	require.NoError(t, os.Mkdir(path.Join(tmpDir, "tmp"), 0o700))
+
+	stdout, stderr, err := compileAndRun(testCtx, "writefs", wazero.NewModuleConfig().WithFS(fs))
+
+	require.Zero(t, stderr)
+	require.EqualError(t, err, `module "" closed with exit_code(0)`)
+	require.Equal(t, `/tmp/dir mode drwx------
+/tmp/dir/file mode -rw-------
 `, stdout)
 }

--- a/internal/gojs/state.go
+++ b/internal/gojs/state.go
@@ -144,8 +144,12 @@ func storeRef(ctx context.Context, v interface{}) goos.Ref { //nolint
 	} else if _, ok := v.(string); ok {
 		id := getState(ctx).values.increment(v)
 		return goos.ValueRef(id, goos.TypeFlagString)
+	} else if i32, ok := v.(int32); ok {
+		return toFloatRef(float64(i32))
 	} else if u32, ok := v.(uint32); ok {
 		return toFloatRef(float64(u32))
+	} else if i64, ok := v.(int64); ok {
+		return toFloatRef(float64(i64))
 	} else if u64, ok := v.(uint64); ok {
 		return toFloatRef(float64(u64))
 	} else if f64, ok := v.(float64); ok {
@@ -259,6 +263,15 @@ func toInt64(arg interface{}) int64 {
 		return u
 	}
 	return int64(arg.(float64))
+}
+
+func toUint64(arg interface{}) uint64 {
+	if arg == goos.RefValueZero || arg == undefined {
+		return 0
+	} else if u, ok := arg.(uint64); ok {
+		return u
+	}
+	return uint64(arg.(float64))
 }
 
 func toUint32(arg interface{}) uint32 {

--- a/internal/gojs/testdata/fs/main.go
+++ b/internal/gojs/testdata/fs/main.go
@@ -34,15 +34,13 @@ func testAdHoc() {
 		fmt.Println(err) // should be the textual message of the errno.
 	}
 
-	for _, path := range []string{"/test.txt", "test.txt"} {
-		s, err := os.Stat(path)
-		if err != nil {
+	// Ensure stat works, particularly mode.
+	for _, path := range []string{"sub", "/test.txt", "test.txt"} {
+		if stat, err := os.Stat(path); err != nil {
 			log.Panicln(err)
+		} else {
+			fmt.Println(path, "mode", stat.Mode())
 		}
-		if s.IsDir() {
-			log.Panicln(path, "is dir")
-		}
-		fmt.Println(path, "ok")
 	}
 
 	b, err := os.ReadFile("/test.txt")

--- a/internal/gojs/testdata/main.go
+++ b/internal/gojs/testdata/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/stdio"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/syscall"
 	"github.com/tetratelabs/wazero/internal/gojs/testdata/time"
+	"github.com/tetratelabs/wazero/internal/gojs/testdata/writefs"
 )
 
 // main includes a registry of all tests to reduce compilation time.
@@ -25,6 +26,8 @@ func main() {
 		crypto.Main()
 	case "fs":
 		fs.Main()
+	case "writefs":
+		writefs.Main()
 	case "gc":
 		gc.Main()
 	case "goroutine":

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -1,0 +1,46 @@
+package writefs
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+)
+
+func Main() {
+	dir := path.Join(os.TempDir(), "dir")
+	err := os.Mkdir(dir, 0o700)
+	if err != nil {
+		log.Panicln(err)
+		return
+	}
+	defer os.Remove(dir)
+
+	file := path.Join(dir, "file")
+	err = os.WriteFile(file, []byte{}, 0o600)
+	if err != nil {
+		log.Panicln(err)
+		return
+	}
+	defer os.Remove(file)
+
+	// Ensure stat works, particularly mode.
+	for _, path := range []string{dir, file} {
+		if stat, err := os.Stat(path); err != nil {
+			log.Panicln(err)
+		} else {
+			fmt.Println(path, "mode", stat.Mode())
+		}
+	}
+
+	// should fail due to non-empty dir
+	if err = os.Remove(dir); err == nil {
+		log.Panicln("shouldn't be able to remove", dir)
+	}
+
+	// shouldn't fail
+	if err = os.RemoveAll(dir); err != nil {
+		log.Panicln(err)
+		return
+	}
+}

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -104,7 +104,7 @@ func TestEmptyFSContext(t *testing.T) {
 	}
 
 	t.Run("OpenFile doesn't affect state", func(t *testing.T) {
-		fd, err := testFS.OpenFile("foo.txt")
+		fd, err := testFS.OpenFile("foo.txt", os.O_RDONLY, 0)
 		require.Zero(t, fd)
 		require.EqualError(t, err, "open foo.txt: file does not exist")
 
@@ -158,7 +158,7 @@ func TestContext_File(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(b *testing.T) {
-			fd, err := fsc.OpenFile(tc.name)
+			fd, err := fsc.OpenFile(tc.name, os.O_RDONLY, 0)
 			require.NoError(t, err)
 			defer fsc.CloseFile(fd)
 
@@ -190,7 +190,7 @@ func TestContext_Close(t *testing.T) {
 	// Verify base case
 	require.Equal(t, 1+FdRoot, uint32(len(fsc.openedFiles)))
 
-	_, err = fsc.OpenFile("foo")
+	_, err = fsc.OpenFile("foo", os.O_RDONLY, 0)
 	require.NoError(t, err)
 	require.Equal(t, 2+FdRoot, uint32(len(fsc.openedFiles)))
 
@@ -210,7 +210,7 @@ func TestContext_Close_Error(t *testing.T) {
 	require.NoError(t, err)
 
 	// open another file
-	_, err = fsc.OpenFile("foo")
+	_, err = fsc.OpenFile("foo", os.O_RDONLY, 0)
 	require.NoError(t, err)
 
 	require.EqualError(t, fsc.Close(testCtx), "error closing")

--- a/internal/wasm/call_context_test.go
+++ b/internal/wasm/call_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/sys"
@@ -146,7 +147,7 @@ func TestCallContext_Close(t *testing.T) {
 		sysCtx := sys.DefaultContext(testfs.FS{"foo": &testfs.File{}})
 		fsCtx := sysCtx.FS()
 
-		_, err := fsCtx.OpenFile("/foo")
+		_, err := fsCtx.OpenFile("/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
 		m, err := s.Instantiate(context.Background(), ns, &Module{}, t.Name(), sysCtx)
@@ -174,7 +175,7 @@ func TestCallContext_Close(t *testing.T) {
 		sysCtx := sys.DefaultContext(testFS)
 		fsCtx := sysCtx.FS()
 
-		_, err := fsCtx.OpenFile("/foo")
+		_, err := fsCtx.OpenFile("/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
 		m, err := s.Instantiate(context.Background(), ns, &Module{}, t.Name(), sysCtx)
@@ -242,7 +243,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		sysCtx := sys.DefaultContext(testfs.FS{"foo": &testfs.File{}})
 		fsCtx := sysCtx.FS()
 
-		_, err := fsCtx.OpenFile("/foo")
+		_, err := fsCtx.OpenFile("/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
 		m, err := s.Instantiate(context.Background(), ns, &Module{}, t.Name(), sysCtx)
@@ -270,7 +271,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		sysCtx := sys.DefaultContext(testFS)
 		fsCtx := sysCtx.FS()
 
-		_, err := fsCtx.OpenFile("/foo")
+		_, err := fsCtx.OpenFile("/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
 		m, err := s.Instantiate(context.Background(), ns, &Module{}, t.Name(), sysCtx)

--- a/internal/wasm/namespace_test.go
+++ b/internal/wasm/namespace_test.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/sys"
@@ -237,7 +238,7 @@ func TestNamespace_CloseWithExitCode(t *testing.T) {
 		sysCtx := sys.DefaultContext(testFS)
 		fsCtx := sysCtx.FS()
 
-		_, err := fsCtx.OpenFile("/foo")
+		_, err := fsCtx.OpenFile("/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
 		ns, m1, m2 := newTestNamespace()


### PR DESCRIPTION
This adds writefs.FS, allowing functions to create and delete files. This begins by implementing them on `GOARCH=js GOOS=wasm`. The current status is a lot farther than before, even if completing write on WASI is left for a later PR (possibly by another volunteer).

For example, Go os package tests pass all the way up to symlinks now, something that can also be done in a follow-up.

```bash
$ mkdir tmp
$ wazero run  -mount=.:/ os.wasm -test.v
=== RUN   TestExpand
--- PASS: TestExpand (0.00s)
=== RUN   TestConsistentEnviron
--- PASS: TestConsistentEnviron (0.00s)
=== RUN   TestUnsetenv
--- PASS: TestUnsetenv (0.00s)
=== RUN   TestClearenv
--- PASS: TestClearenv (0.00s)
=== RUN   TestLookupEnv
--- PASS: TestLookupEnv (0.00s)
=== RUN   TestEnvironConsistency
--- PASS: TestEnvironConsistency (0.00s)
=== RUN   TestErrIsExist
--- PASS: TestErrIsExist (0.00s)
=== RUN   TestErrIsNotExist
--- PASS: TestErrIsNotExist (0.00s)
=== RUN   TestIsExist
--- PASS: TestIsExist (0.00s)
=== RUN   TestIsPermission
--- PASS: TestIsPermission (0.00s)
=== RUN   TestErrPathNUL
--- PASS: TestErrPathNUL (0.00s)
=== RUN   TestPathErrorUnwrap
--- PASS: TestPathErrorUnwrap (0.00s)
=== RUN   TestErrorIsMethods
--- PASS: TestErrorIsMethods (0.00s)
=== RUN   TestExecutable
    exec.go:34: skipping test: cannot exec subprocess on js/wasm
--- SKIP: TestExecutable (0.00s)
=== RUN   TestExecutableDeleted
    exec.go:34: skipping test: cannot exec subprocess on js/wasm
--- SKIP: TestExecutableDeleted (0.00s)
=== RUN   TestStat
    os_test.go:178: stat failed: stat /etc/group: No such file or directory
--- FAIL: TestStat (0.00s)
=== RUN   TestStatError
error instantiating wasm binary: TODO: call fs.symlink (recovered by wazero)
wasm stack trace:
	go.syscall/js.valueCall(i32)
	.syscall_js.valueCall(i32) i32
	.syscall_js.Value.Call(i32) i32
	.syscall.fsCall(i32) i32
	.syscall.Symlink(i32) i32
	.os.Symlink(i32) i32
	.os_test.TestStatError(i32) i32
	.wasm_pc_f_loop()
	.wasm_export_run(i32,i32)
```