### PR TITLE
Exposes experimental writefs.DirFS, but hides implementation

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -169,7 +169,7 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 		host := mount[0]
 		guest := mount[1]
 		if guest == "" { // guest is root
-			rootFS = writefs.New(host)
+			rootFS = writefs.DirFS(host)
 		} else { // TODO: subfs
 			rootFS = &compositeFS{
 				paths: map[string]fs.FS{guest: os.DirFS(host)},

--- a/experimental/writefs/writefs_example_test.go
+++ b/experimental/writefs/writefs_example_test.go
@@ -1,0 +1,16 @@
+package writefs_test
+
+import (
+	_ "embed"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/experimental/writefs"
+)
+
+var config wazero.ModuleConfig //nolint
+
+// This shows how to use writefs.DirFS to map paths relative to "/work/appA",
+// as "/". Unlike os.DirFS, these paths will be writable.
+func Example_dirFS() {
+	config = wazero.NewModuleConfig().WithFS(writefs.DirFS("/work/appA"))
+}

--- a/internal/gojs/fs_test.go
+++ b/internal/gojs/fs_test.go
@@ -33,7 +33,7 @@ func Test_writefs(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
-	fs := writefs.New(tmpDir)
+	fs := writefs.DirFS(tmpDir)
 	// test expects to write under /tmp
 	require.NoError(t, os.Mkdir(path.Join(tmpDir, "tmp"), 0o700))
 

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tetratelabs/wazero/experimental/writefs"
 	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/writefs"
 )
 
 const (

--- a/internal/writefs/writefs.go
+++ b/internal/writefs/writefs.go
@@ -1,0 +1,62 @@
+package writefs
+
+import (
+	"io/fs"
+	"os"
+)
+
+// FS is a fs.FS which can also create new files or directories.
+//
+// Any unsupported method should return syscall.ENOSYS.
+//
+// See https://github.com/golang/go/issues/45757
+type FS interface {
+	fs.FS
+
+	// OpenFile is similar to os.OpenFile, except the path is relative to this
+	// file system.
+	OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error)
+
+	// Mkdir is similar to os.Mkdir, except the path is relative to this file
+	// system.
+	Mkdir(name string, perm fs.FileMode) error
+
+	// Remove is similar to os.Remove, except the path is relative to this file
+	// system.
+	Remove(path string) error
+}
+
+func DirFS(dir string) FS {
+	return dirFS(dir)
+}
+
+type dirFS string
+
+// Open implements the same method as documented on fs.FS
+func (dir dirFS) Open(name string) (fs.File, error) {
+	return dir.OpenFile(name, os.O_RDONLY, 0) // same as os.Open(string)
+}
+
+// OpenFile implements FS.OpenFile
+func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	return os.OpenFile(string(dir)+"/"+name, flag, perm)
+}
+
+// Mkdir implements FS.Mkdir
+func (dir dirFS) Mkdir(name string, perm fs.FileMode) error {
+	if !fs.ValidPath(name) {
+		return &fs.PathError{Op: "mkdir", Path: name, Err: fs.ErrInvalid}
+	}
+	return os.Mkdir(string(dir)+"/"+name, perm)
+}
+
+// Remove implements FS.Remove
+func (dir dirFS) Remove(path string) error {
+	if !fs.ValidPath(path) {
+		return &fs.PathError{Op: "remove", Path: path, Err: fs.ErrInvalid}
+	}
+	return os.Remove(string(dir) + "/" + path)
+}

--- a/internal/writefs/writefs_test.go
+++ b/internal/writefs/writefs_test.go
@@ -33,7 +33,7 @@ func TestFS(t *testing.T) {
 		require.NoError(t, os.WriteFile(path.Join(dir, name), []byte(data), 0o600))
 	}
 
-	if err := fstest.TestFS(New(dir), expected...); err != nil {
+	if err := fstest.TestFS(DirFS(dir), expected...); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -41,7 +41,7 @@ func TestFS(t *testing.T) {
 func TestMkDir(t *testing.T) {
 	dir := t.TempDir()
 
-	testFS := New(dir)
+	testFS := DirFS(dir)
 
 	name := "mkdir"
 
@@ -61,7 +61,7 @@ func TestMkDir(t *testing.T) {
 func TestRemove(t *testing.T) {
 	dir := t.TempDir()
 
-	testFS := New(dir)
+	testFS := DirFS(dir)
 
 	name := "remove"
 

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-// TestRuntime_Namespace ensures namespaces are independent.
-func TestRuntime_Namespace(t *testing.T) {
+func TestRuntime_Namespace_Independent(t *testing.T) {
 	r := NewRuntime(testCtx)
 	defer r.Close(testCtx)
 


### PR DESCRIPTION
The type we use to expose write operations is still evolving. It might be a single writefs.FS interface, or similar to go where we have an interface per feature (e.g. writefs.MkdirFS). These choices are all implementation details for DirFS and won't be settled before the end of the month version cutoff. Instead, this only exposes the ability to create a DirFS, not an arbitrary implementation of writefs.FS. This does so by making `writefs.FS` an internal type.