### PR TITLE
fs: splits unlink and rmdir from remove

### DIFF
--- a/internal/gojs/syscall.go
+++ b/internal/gojs/syscall.go
@@ -367,6 +367,7 @@ func (e *syscallErr) Error() string {
 var (
 	ebadf     = &syscallErr{"EBADF"}
 	einval    = &syscallErr{"EBADF"}
+	eisdir    = &syscallErr{"EISDIR"}
 	eexist    = &syscallErr{"EEXIST"}
 	enoent    = &syscallErr{"ENOENT"}
 	enosys    = &syscallErr{"ENOSYS"}
@@ -385,6 +386,8 @@ func mapJSError(err error) *syscallErr {
 		return ebadf
 	case errors.Is(err, syscall.EINVAL), errors.Is(err, fs.ErrInvalid):
 		return einval
+	case errors.Is(err, syscall.EISDIR):
+		return eisdir
 	case errors.Is(err, syscall.ENOTEMPTY):
 		return enotempty
 	case errors.Is(err, syscall.EEXIST), errors.Is(err, fs.ErrExist):

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -315,16 +315,6 @@ func (c *FSContext) Mkdir(name string, perm fs.FileMode) (newFD uint32, err erro
 	return
 }
 
-// Unlink is like syscall.Unlink.
-func (c *FSContext) Unlink(name string) (err error) {
-	if wfs, ok := c.fs.(writefs.FS); ok {
-		name = c.cleanPath(name)
-		return wfs.Remove(name)
-	}
-	err = syscall.ENOSYS
-	return
-}
-
 // OpenFile is like syscall.Open and returns the file descriptor of the new file or an error.
 func (c *FSContext) OpenFile(name string, flags int, perm fs.FileMode) (newFD uint32, err error) {
 	create := flags&os.O_CREATE != 0
@@ -351,6 +341,16 @@ func (c *FSContext) OpenFile(name string, flags int, perm fs.FileMode) (newFD ui
 	return newFD, nil
 }
 
+// Rmdir is like syscall.Rmdir.
+func (c *FSContext) Rmdir(name string) (err error) {
+	if wfs, ok := c.fs.(writefs.FS); ok {
+		name = c.cleanPath(name)
+		return wfs.Rmdir(name)
+	}
+	err = syscall.ENOSYS
+	return
+}
+
 func (c *FSContext) StatPath(name string) (fs.FileInfo, error) {
 	f, err := c.openFile(name)
 	if err != nil {
@@ -358,6 +358,16 @@ func (c *FSContext) StatPath(name string) (fs.FileInfo, error) {
 	}
 	defer f.Close()
 	return f.Stat()
+}
+
+// Unlink is like syscall.Unlink.
+func (c *FSContext) Unlink(name string) (err error) {
+	if wfs, ok := c.fs.(writefs.FS); ok {
+		name = c.cleanPath(name)
+		return wfs.Unlink(name)
+	}
+	err = syscall.ENOSYS
+	return
 }
 
 func (c *FSContext) openFile(name string) (fs.File, error) {

--- a/internal/writefs/syscall.go
+++ b/internal/writefs/syscall.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package writefs
+
+import "syscall"
+
+func adjustMkdirError(err error) error {
+	return err
+}
+
+func adjustRmdirError(err error) error {
+	return err
+}
+
+func adjustUnlinkError(err error) error {
+	if err == syscall.EPERM {
+		return syscall.EISDIR
+	}
+	return err
+}

--- a/internal/writefs/syscall_windows.go
+++ b/internal/writefs/syscall_windows.go
@@ -1,0 +1,42 @@
+package writefs
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+const (
+	// ERROR_ACCESS_DENIED is a Windows error returned by syscall.Unlink
+	// instead of syscall.EPERM
+	ERROR_ACCESS_DENIED = syscall.Errno(5)
+
+	// ERROR_ALREADY_EXISTS is a Windows error returned by os.Mkdir
+	// instead of syscall.EEXIST
+	ERROR_ALREADY_EXISTS = syscall.Errno(183)
+
+	// ERROR_DIRECTORY is a Windows error returned by syscall.Rmdir
+	// instead of syscall.ENOTDIR
+	ERROR_DIRECTORY = syscall.Errno(267)
+)
+
+func adjustMkdirError(err error) error {
+	// os.Mkdir wraps the syscall error in a path error
+	if pe, ok := err.(*fs.PathError); ok && pe.Err == ERROR_ALREADY_EXISTS {
+		pe.Err = syscall.EEXIST // adjust it
+	}
+	return err
+}
+
+func adjustRmdirError(err error) error {
+	if err == ERROR_DIRECTORY {
+		return syscall.ENOTDIR
+	}
+	return err
+}
+
+func adjustUnlinkError(err error) error {
+	if err == ERROR_ACCESS_DENIED {
+		return syscall.EISDIR
+	}
+	return err
+}

--- a/internal/writefs/writefs_test.go
+++ b/internal/writefs/writefs_test.go
@@ -20,7 +20,7 @@ var testFiles = map[string]string{
 	"sub/sub/test.txt": "greet sub sub dir\n",
 }
 
-func TestFS(t *testing.T) {
+func TestDirFS_TestFS(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		// This abstraction is a toe-hold, but we'll have to sort windows with
 		// our ideal filesystem tester.
@@ -40,7 +40,7 @@ func TestFS(t *testing.T) {
 	}
 }
 
-func TestMkDir(t *testing.T) {
+func TestDirFS_MkDir(t *testing.T) {
 	dir := t.TempDir()
 
 	testFS := DirFS(dir)
@@ -70,7 +70,7 @@ func TestMkDir(t *testing.T) {
 	})
 }
 
-func TestRmdir(t *testing.T) {
+func TestDirFS_Rmdir(t *testing.T) {
 	dir := t.TempDir()
 
 	testFS := DirFS(dir)
@@ -101,7 +101,7 @@ func TestRmdir(t *testing.T) {
 	})
 }
 
-func TestUnlink(t *testing.T) {
+func TestDirFS_Unlink(t *testing.T) {
 	dir := t.TempDir()
 
 	testFS := DirFS(dir)

--- a/internal/writefs/writefs_test.go
+++ b/internal/writefs/writefs_test.go
@@ -1,10 +1,12 @@
 package writefs
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path"
 	"runtime"
+	"syscall"
 	"testing"
 	"testing/fstest"
 
@@ -53,20 +55,27 @@ func TestMkDir(t *testing.T) {
 		require.True(t, stat.IsDir())
 	})
 
-	t.Run("exists", func(t *testing.T) {
-		require.Error(t, testFS.Mkdir(name, fs.ModeDir))
+	t.Run("dir exists", func(t *testing.T) {
+		err := testFS.Mkdir(name, fs.ModeDir)
+		require.Equal(t, syscall.EEXIST, errors.Unwrap(err))
+	})
+
+	t.Run("file exists", func(t *testing.T) {
+		err := testFS.Mkdir(name, fs.ModeDir)
+		require.Equal(t, syscall.EEXIST, errors.Unwrap(err))
 	})
 }
 
-func TestRemove(t *testing.T) {
+func TestRmdir(t *testing.T) {
 	dir := t.TempDir()
 
 	testFS := DirFS(dir)
 
-	name := "remove"
+	name := "rmdir"
 
 	t.Run("doesn't exist", func(t *testing.T) {
-		require.Error(t, testFS.Remove(name))
+		err := testFS.Rmdir(name)
+		require.Equal(t, syscall.ENOENT, err)
 	})
 
 	t.Run("dir exists", func(t *testing.T) {
@@ -74,7 +83,7 @@ func TestRemove(t *testing.T) {
 		err := os.Mkdir(realPath, 0o700)
 		require.NoError(t, err)
 
-		require.NoError(t, testFS.Remove(name))
+		require.NoError(t, testFS.Rmdir(name))
 		_, err = os.Stat(realPath)
 		require.Error(t, err)
 	})
@@ -84,7 +93,42 @@ func TestRemove(t *testing.T) {
 		err := os.WriteFile(realPath, []byte{}, 0o600)
 		require.NoError(t, err)
 
-		require.NoError(t, testFS.Remove(name))
+		err = testFS.Rmdir(name)
+		require.Equal(t, syscall.ENOTDIR, err)
+
+		require.NoError(t, os.Remove(realPath))
+	})
+}
+
+func TestUnlink(t *testing.T) {
+	dir := t.TempDir()
+
+	testFS := DirFS(dir)
+
+	name := "unlink"
+
+	t.Run("doesn't exist", func(t *testing.T) {
+		err := testFS.Unlink(name)
+		require.Equal(t, syscall.ENOENT, err)
+	})
+
+	t.Run("dir exists", func(t *testing.T) {
+		realPath := path.Join(dir, name)
+		err := os.Mkdir(realPath, 0o700)
+		require.NoError(t, err)
+
+		err = testFS.Unlink(name)
+		require.Equal(t, syscall.EISDIR, err)
+
+		require.NoError(t, os.Remove(realPath))
+	})
+
+	t.Run("file exists", func(t *testing.T) {
+		realPath := path.Join(dir, name)
+		err := os.WriteFile(realPath, []byte{}, 0o600)
+		require.NoError(t, err)
+
+		require.NoError(t, testFS.Unlink(name))
 		_, err = os.Stat(realPath)
 		require.Error(t, err)
 	})


### PR DESCRIPTION
This splits unlink and rmdir from remove, as it is not only more precise in GOOS=js, but it is also needed to implement wasi. I verified this works by running go unit tests with logging.

```
==> go.syscall/js.valueCall(fs.open(name=/tmp/TestErrIsNotExist1062486353,flags=,perm=----------))
<== (err=<nil>,fd=10)
==> go.syscall/js.valueCall(fs.fstat(fd=10))
<== (err=<nil>,stat={isDir=true,mode=-rwx------,size=96,mtimeMs=1672285985206})
==> go.syscall/js.valueCall(fs.readdir(name=/tmp/TestErrIsNotExist1062486353))
<== (err=<nil>,dirents=&{[001]})
==> go.syscall/js.valueCall(fs.unlink(path=/tmp/TestErrIsNotExist1062486353/001))
<== (err=is a directory,ok=true)
==> go.syscall/js.valueCall(fs.rmdir(path=/tmp/TestErrIsNotExist1062486353/001))
<== (err=<nil>,ok=false)
```
