### PR TITLE
writefs: require ENOTEMPTY

### DIFF
--- a/internal/writefs/syscall_windows.go
+++ b/internal/writefs/syscall_windows.go
@@ -17,6 +17,10 @@ const (
 	// ERROR_DIRECTORY is a Windows error returned by syscall.Rmdir
 	// instead of syscall.ENOTDIR
 	ERROR_DIRECTORY = syscall.Errno(267)
+
+	// ERROR_DIR_NOT_EMPTY is a Windows error returned by syscall.Rmdir
+	// instead of syscall.ENOTEMPTY
+	ERROR_DIR_NOT_EMPTY = syscall.Errno(145)
 )
 
 func adjustMkdirError(err error) error {
@@ -28,8 +32,11 @@ func adjustMkdirError(err error) error {
 }
 
 func adjustRmdirError(err error) error {
-	if err == ERROR_DIRECTORY {
+	switch err {
+	case ERROR_DIRECTORY:
 		return syscall.ENOTDIR
+	case ERROR_DIR_NOT_EMPTY:
+		return syscall.ENOTEMPTY
 	}
 	return err
 }

--- a/internal/writefs/writefs.go
+++ b/internal/writefs/writefs.go
@@ -32,6 +32,7 @@ type FS interface {
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.ENOENT: `path` doesn't exist.
 	//   - syscall.ENOTDIR: `path` exists, but isn't a directory.
+	//   - syscall.ENOTEMPTY: `path` exists, but isn't empty.
 	Rmdir(path string) error
 
 	// Unlink is similar to syscall.Unlink, except the path is relative to this

--- a/internal/writefs/writefs_test.go
+++ b/internal/writefs/writefs_test.go
@@ -83,9 +83,18 @@ func TestDirFS_Rmdir(t *testing.T) {
 		require.Equal(t, syscall.ENOENT, err)
 	})
 
-	t.Run("dir exists", func(t *testing.T) {
+	t.Run("dir not empty", func(t *testing.T) {
 		require.NoError(t, os.Mkdir(realPath, 0o700))
+		fileInDir := path.Join(realPath, "file")
+		require.NoError(t, os.WriteFile(fileInDir, []byte{}, 0o600))
 
+		err := testFS.Rmdir(name)
+		require.Equal(t, syscall.ENOTEMPTY, err)
+
+		require.NoError(t, os.Remove(fileInDir))
+	})
+
+	t.Run("dir empty", func(t *testing.T) {
 		require.NoError(t, testFS.Rmdir(name))
 		_, err := os.Stat(realPath)
 		require.Error(t, err)


### PR DESCRIPTION
adding a test case so that we can depend on it.