### PR TITLE
add internal/sys.FileTable

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -595,10 +595,10 @@ satisfy its processor.
 ### File descriptor allocation strategy
 
 File descriptor allocation currently uses a strategy similar the one implemented
-by unix systems: when opening a file, the lowest unused number is used.
+by unix systems: when opening a file, the lowest unused number is picked.
 
 The WASI standard documents that programs cannot expect that file descriptor
-numbers will be allocated with a lowest-first strategy, and they shouldi instead
+numbers will be allocated with a lowest-first strategy, and they should instead
 assume the values will be random. Since _random_ is a very imprecise concept in
 computers, we technically satisfying the implementation with the descriptor
 allocation strategy we use in Wazero. We could imagine adding more _randomness_

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -592,6 +592,20 @@ operation will err if it needs to. This helps reduce the complexity of the code
 in wazero and also accommodates the scenario where the bytes read are enough to
 satisfy its processor.
 
+### File descriptor allocation strategy
+
+File descriptor allocation currently uses a strategy similar the one implemented
+by unix systems: when opening a file, the lowest unused number is used.
+
+The WASI standard documents that programs cannot expect that file descriptor
+numbers will be allocated with a lowest-first strategy, and they shouldi instead
+assume the values will be random. Since _random_ is a very imprecise concept in
+computers, we technically satisfying the implementation with the descriptor
+allocation strategy we use in Wazero. We could imagine adding more _randomness_
+to the descriptor selection process, however this should never be used as a
+security measure to prevent applications from guessing the next file number so
+there are no strong incentives to complicate the logic.
+
 ### fd_pread: io.Seeker fallback when io.ReaderAt is not supported
 
 `ReadAt` is the Go equivalent to `pread`: it does not affect, and is not

--- a/internal/sys/file_table.go
+++ b/internal/sys/file_table.go
@@ -1,0 +1,132 @@
+package sys
+
+import "math/bits"
+
+// FileTable is a data structure mapping 32 bit file descriptor to file objects.
+//
+// The data structure optimizes for memory density and lookup performance,
+// trading off compute at insertion time. This is a useful compromise for the
+// use cases we employ it with: files are usually read or written a lot more
+// often than they are opened, each operation requires a table lookup so we are
+// better off spending extra compute to insert files in the table in order to
+// get cheaper lookups. Memory efficiency is also crucial to support scaling
+// with programs that open thousands of files: having a high or non-linear
+// memory-to-item ratio could otherwise be used as an attack vector by malicous
+// applications attempting to damage performance of the host.
+type FileTable struct {
+	masks []uint64
+	files []*FileEntry
+}
+
+// Len returns the number of files stored in the table.
+func (t *FileTable) Len() (n int) {
+	// We could make this a O(1) operation if we cached the number of files in
+	// the table. More state usually means more problems, so until we have a
+	// clear need for this, the simple implementation may be a better trade off.
+	for _, mask := range t.masks {
+		n += bits.OnesCount64(mask)
+	}
+	return n
+}
+
+// Grow ensures that t has enough room for n files, potentially reallocating the
+// internal buffers if their capacity was too small to hold this many files.
+func (t *FileTable) Grow(n int) {
+	// Round up to a multiple of 64 since this is the smallest increment due to
+	// using 64 bits masks.
+	n = (n*64 + 63) / 64
+
+	if n > len(t.masks) {
+		masks := make([]uint64, n)
+		copy(masks, t.masks)
+
+		files := make([]*FileEntry, n*64)
+		copy(files, t.files)
+
+		t.masks = masks
+		t.files = files
+	}
+}
+
+// Insert inserts the given file to the table, returning the fd that it is
+// mapped to.
+//
+// The method does not perform deduplication, it is possible for the same file
+// to be inserted multiple times, each insertion will return a different fd.
+func (t *FileTable) Insert(file *FileEntry) (fd uint32) {
+	offset := 0
+insert:
+	// Note: this loop could be made a lot more efficient using vectorized
+	// operations: 256 bits vector registers would yield a theoretical 4x
+	// speed up (e.g. using AVX2).
+	for index, mask := range t.masks[offset:] {
+		if ^mask != 0 { // not full?
+			shift := bits.TrailingZeros64(^mask)
+			index += offset
+			fd = uint32(index)*64 + uint32(shift)
+			t.files[fd] = file
+			t.masks[index] = mask | uint64(1<<shift)
+			return fd
+		}
+	}
+
+	offset = len(t.masks)
+	n := 2 * len(t.masks)
+	if n == 0 {
+		n = 1
+	}
+
+	t.Grow(n)
+	goto insert
+}
+
+// Lookup returns the file associated with the given fd (may be nil).
+func (t *FileTable) Lookup(fd uint32) (file *FileEntry, found bool) {
+	if i := int(fd); i >= 0 && i < len(t.files) {
+		index := uint(fd) / 64
+		shift := uint(fd) % 64
+		if (t.masks[index] & (1 << shift)) != 0 {
+			file, found = t.files[i], true
+		}
+	}
+	return
+}
+
+// Delete deletes the file stored at the given fd from the table.
+func (t *FileTable) Delete(fd uint32) {
+	if index, shift := fd/64, fd%64; int(index) < len(t.masks) {
+		mask := t.masks[index]
+		if (mask & (1 << shift)) != 0 {
+			t.files[fd] = nil
+			t.masks[index] = mask & ^uint64(1<<shift)
+		}
+	}
+}
+
+// Range calls f for each file and its associated fd in the table. The function
+// f might return false to interupt the iteration.
+func (t *FileTable) Range(f func(uint32, *FileEntry) bool) {
+	for i, mask := range t.masks {
+		if mask == 0 {
+			continue
+		}
+		for j := uint32(0); j < 64; j++ {
+			if (mask & (1 << j)) == 0 {
+				continue
+			}
+			if fd := uint32(i)*64 + j; !f(fd, t.files[fd]) {
+				return
+			}
+		}
+	}
+}
+
+// Reset clears the content of the table.
+func (t *FileTable) Reset() {
+	for i := range t.masks {
+		t.masks[i] = 0
+	}
+	for i := range t.files {
+		t.files[i] = nil
+	}
+}

--- a/internal/sys/file_table_test.go
+++ b/internal/sys/file_table_test.go
@@ -1,0 +1,124 @@
+package sys_test
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/sys"
+)
+
+func TestFileTable(t *testing.T) {
+	table := new(sys.FileTable)
+
+	if n := table.Len(); n != 0 {
+		t.Errorf("new table is not empty: length=%d", n)
+	}
+
+	// The id field is used as a sentinel value.
+	v0 := &sys.FileEntry{Name: "1"}
+	v1 := &sys.FileEntry{Name: "2"}
+	v2 := &sys.FileEntry{Name: "3"}
+
+	k0 := table.Insert(v0)
+	k1 := table.Insert(v1)
+	k2 := table.Insert(v2)
+
+	for _, lookup := range []struct {
+		key uint32
+		val *sys.FileEntry
+	}{
+		{key: k0, val: v0},
+		{key: k1, val: v1},
+		{key: k2, val: v2},
+	} {
+		if v, ok := table.Lookup(lookup.key); !ok {
+			t.Errorf("value not found for key '%v'", lookup.key)
+		} else if v.Name != lookup.val.Name {
+			t.Errorf("wrong value returned for key '%v': want=%v got=%v", lookup.key, lookup.val.Name, v.Name)
+		}
+	}
+
+	if n := table.Len(); n != 3 {
+		t.Errorf("wrong table length: want=3 got=%d", n)
+	}
+
+	k0Found := false
+	k1Found := false
+	k2Found := false
+	table.Range(func(k uint32, v *sys.FileEntry) bool {
+		var want *sys.FileEntry
+		switch k {
+		case k0:
+			k0Found, want = true, v0
+		case k1:
+			k1Found, want = true, v1
+		case k2:
+			k2Found, want = true, v2
+		}
+		if v.Name != want.Name {
+			t.Errorf("wrong value found ranging over '%v': want=%v got=%v", k, want.Name, v.Name)
+		}
+		return true
+	})
+
+	for _, found := range []struct {
+		key uint32
+		ok  bool
+	}{
+		{key: k0, ok: k0Found},
+		{key: k1, ok: k1Found},
+		{key: k2, ok: k2Found},
+	} {
+		if !found.ok {
+			t.Errorf("key not found while ranging over table: %v", found.key)
+		}
+	}
+
+	for i, deletion := range []struct {
+		key uint32
+	}{
+		{key: k1},
+		{key: k0},
+		{key: k2},
+	} {
+		table.Delete(deletion.key)
+		if _, ok := table.Lookup(deletion.key); ok {
+			t.Errorf("item found after deletion of '%v'", deletion.key)
+		}
+		if n, want := table.Len(), 3-(i+1); n != want {
+			t.Errorf("wrong table length after deletion: want=%d got=%d", want, n)
+		}
+	}
+}
+
+func BenchmarkFileTableInsert(b *testing.B) {
+	table := new(sys.FileTable)
+	entry := new(sys.FileEntry)
+
+	for i := 0; i < b.N; i++ {
+		table.Insert(entry)
+
+		if (i % 65536) == 0 {
+			table.Reset() // to avoid running out of memory
+		}
+	}
+}
+
+func BenchmarkFileTableLookup(b *testing.B) {
+	const sentinel = "42"
+	const numFiles = 65536
+	table := new(sys.FileTable)
+	files := make([]uint32, numFiles)
+	entry := &sys.FileEntry{Name: sentinel}
+
+	for i := range files {
+		files[i] = table.Insert(entry)
+	}
+
+	var f *sys.FileEntry
+	for i := 0; i < b.N; i++ {
+		f, _ = table.Lookup(files[i%numFiles])
+	}
+	if f.Name != sentinel {
+		b.Error("wrong file returned by lookup")
+	}
+}

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -51,12 +51,14 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
 
 	expectedFS, _ := NewFSContext(nil, nil, nil, testfs.FS{})
-	require.Equal(t, map[uint32]*FileEntry{
-		FdStdin:  noopStdin,
-		FdStdout: noopStdout,
-		FdStderr: noopStderr,
-		FdRoot:   {Name: "/", File: emptyRootDir{}},
-	}, expectedFS.openedFiles)
+
+	expectedOpenedFiles := FileTable{}
+	expectedOpenedFiles.Insert(noopStdin)
+	expectedOpenedFiles.Insert(noopStdout)
+	expectedOpenedFiles.Insert(noopStderr)
+	expectedOpenedFiles.Insert(&FileEntry{Name: "/", File: emptyRootDir{}})
+
+	require.Equal(t, expectedOpenedFiles, expectedFS.openedFiles)
 	require.Equal(t, expectedFS, sysCtx.FS())
 }
 


### PR DESCRIPTION
As discussed on Slack, this PR brings the file table from https://github.com/achille-roussel/wazero/tree/experimental/sys into upstream Wazero.

I added the data structure as `internal/sys.FileTable`, and I made it a generic type despite the single use in `FSContext` in anticipation that:
- I'm going to bring these changes in https://github.com/achille-roussel/wazero/tree/experimental/sys
- we may have to change the key or value type as we work towards full support of writefs
- we may have multiple instances of it for wasi and gojs (and maybe more with wasi2)

If these assumption turn out not to be true we can revisit and 1) unexport the type and 2) drop the generic type parameters.

Please take a look and let me know if anything needs to be changed!