### PR TITLE
renames writefs to syscallfs and implements utimes in gojs

### DIFF
--- a/experimental/writefs/writefs.go
+++ b/experimental/writefs/writefs.go
@@ -10,19 +10,20 @@ package writefs
 import (
 	"io/fs"
 
-	"github.com/tetratelabs/wazero/internal/writefs"
+	"github.com/tetratelabs/wazero/internal/syscallfs"
 )
 
 // DirFS creates a writeable filesystem at the given path on the host filesystem.
 //
 // This is like os.DirFS, but allows creation and deletion of files and
-// directories, which aren't yet supported in fs.FS.
+// directories, as well as timestamp modifications. None of which are supported
+// in fs.FS.
 //
 // # Isolation
 //
 // Symbolic links can escape the root path as files are opened via os.OpenFile
 // which cannot restrict following them.
 func DirFS(dir string) fs.FS {
-	// writefs.FS is intentionally internal as it is still evolving
-	return writefs.DirFS(dir)
+	// writefs.DirFS is intentionally internal as it is still evolving
+	return syscallfs.DirFS(dir)
 }

--- a/internal/gojs/custom/fs.go
+++ b/internal/gojs/custom/fs.go
@@ -15,6 +15,7 @@ const (
 	NameFsMkdir   = "mkdir"
 	NameFsRmdir   = "rmdir"
 	NameFsUnlink  = "unlink"
+	NameFsUtimes  = "utimes"
 )
 
 // FsNameSection are the functions defined in the object named NameFs. Results
@@ -74,6 +75,11 @@ var FsNameSection = map[string]*Names{
 	NameFsUnlink: {
 		Name:        NameFsUnlink,
 		ParamNames:  []string{"path", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsUtimes: {
+		Name:        NameFsUtimes,
+		ParamNames:  []string{"path", "atime", "mtime", NameCallback},
 		ResultNames: []string{"err", "ok"},
 	},
 }

--- a/internal/gojs/testdata/fs/main.go
+++ b/internal/gojs/testdata/fs/main.go
@@ -53,5 +53,5 @@ func testAdHoc() {
 	if err != nil {
 		log.Panicln(err)
 	}
-	fmt.Println("empty:", string(b))
+	fmt.Println("empty:" + string(b))
 }

--- a/internal/gojs/testdata/writefs/times.go
+++ b/internal/gojs/testdata/writefs/times.go
@@ -1,0 +1,13 @@
+//go:build !js
+
+package writefs
+
+import (
+	"os"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+)
+
+func statTimes(t os.FileInfo) (atimeSec, atimeNsec, mtimeSec, mtimeNsec, ctimeSec, ctimeNsec int64) {
+	return platform.StatTimes(t) // allow the file to compile and run outside JS
+}

--- a/internal/gojs/testdata/writefs/times_js.go
+++ b/internal/gojs/testdata/writefs/times_js.go
@@ -1,0 +1,11 @@
+package writefs
+
+import (
+	"os"
+	"syscall"
+)
+
+func statTimes(t os.FileInfo) (atimeSec, atimeNsec, mtimeSec, mtimeNsec, ctimeSec, ctimeNsec int64) {
+	d := t.Sys().(*syscall.Stat_t)
+	return d.Atime, d.AtimeNsec, d.Mtime, d.MtimeNsec, d.Ctime, d.CtimeNsec
+}

--- a/internal/platform/mmap_windows.go
+++ b/internal/platform/mmap_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package platform
 
 import (

--- a/internal/platform/stat.go
+++ b/internal/platform/stat.go
@@ -1,0 +1,19 @@
+package platform
+
+import "os"
+
+// StatTimes returns platform-specific values if os.FileInfo Sys is available.
+// Otherwise, it returns the mod time for all values.
+func StatTimes(t os.FileInfo) (atimeSec, atimeNsec, mtimeSec, mtimeNsec, ctimeSec, ctimeNsec int64) {
+	if t.Sys() == nil { // possibly fake filesystem
+		return mtimes(t)
+	}
+	return statTimes(t)
+}
+
+func mtimes(t os.FileInfo) (int64, int64, int64, int64, int64, int64) {
+	mtime := t.ModTime().UnixNano()
+	mtimeSec := mtime / 1e9
+	mtimeNsec := mtime % 1e9
+	return mtimeSec, mtimeNsec, mtimeSec, mtimeNsec, mtimeSec, mtimeNsec
+}

--- a/internal/platform/stat_bsd.go
+++ b/internal/platform/stat_bsd.go
@@ -1,0 +1,16 @@
+//go:build darwin || freebsd
+
+package platform
+
+import (
+	"os"
+	"syscall"
+)
+
+func statTimes(t os.FileInfo) (atimeSec, atimeNSec, mtimeSec, mtimeNSec, ctimeSec, ctimeNSec int64) {
+	d := t.Sys().(*syscall.Stat_t)
+	atime := d.Atimespec
+	mtime := d.Mtimespec
+	ctime := d.Ctimespec
+	return atime.Sec, atime.Nsec, mtime.Sec, mtime.Nsec, ctime.Sec, ctime.Nsec
+}

--- a/internal/platform/stat_linux.go
+++ b/internal/platform/stat_linux.go
@@ -1,0 +1,14 @@
+package platform
+
+import (
+	"os"
+	"syscall"
+)
+
+func statTimes(t os.FileInfo) (atimeSec, atimeNSec, mtimeSec, mtimeNSec, ctimeSec, ctimeNSec int64) {
+	d := t.Sys().(*syscall.Stat_t)
+	atime := d.Atim
+	mtime := d.Mtim
+	ctime := d.Ctim
+	return atime.Sec, atime.Nsec, mtime.Sec, mtime.Nsec, ctime.Sec, ctime.Nsec
+}

--- a/internal/platform/stat_test.go
+++ b/internal/platform/stat_test.go
@@ -1,0 +1,56 @@
+package platform
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func Test_StatTimes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	file := path.Join(tmpDir, "file")
+	err := os.WriteFile(file, []byte{}, 0o700)
+	require.NoError(t, err)
+
+	type test struct {
+		name                                     string
+		atimeSec, atimeNsec, mtimeSec, mtimeNsec int64
+	}
+	// Note: This sets microsecond granularity because Windows doesn't support
+	// nanosecond.
+	tests := []test{
+		{name: "positive", atimeSec: 123, atimeNsec: 4 * 1e3, mtimeSec: 567, mtimeNsec: 8 * 1e3},
+		{name: "zero"},
+	}
+
+	// linux and freebsd report inaccurate results when the input ts is negative.
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		tests = append(tests,
+			test{name: "negative", atimeSec: -123, atimeNsec: -4 * 1e3, mtimeSec: -567, mtimeNsec: -8 * 1e3},
+		)
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			err := os.Chtimes(file, time.Unix(tc.atimeSec, tc.atimeNsec), time.Unix(tc.mtimeSec, tc.mtimeNsec))
+			require.NoError(t, err)
+
+			stat, err := os.Stat(file)
+			require.NoError(t, err)
+
+			atimeSec, atimeNsec, mtimeSec, mtimeNsec, _, _ := StatTimes(stat)
+			if CompilerSupported() {
+				require.Equal(t, atimeSec, tc.atimeSec)
+				require.Equal(t, atimeNsec, tc.atimeNsec)
+			} // else only mtimes will return.
+			require.Equal(t, mtimeSec, tc.mtimeSec)
+			require.Equal(t, mtimeNsec, tc.mtimeNsec)
+		})
+	}
+}

--- a/internal/platform/stat_unsupported.go
+++ b/internal/platform/stat_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !(darwin || linux || freebsd || windows)
+
+package platform
+
+import "os"
+
+func statTimes(t os.FileInfo) (atimeSec, atimeNSec, mtimeSec, mtimeNSec, ctimeSec, ctimeNSec int64) {
+	return mtimes(t)
+}

--- a/internal/platform/stat_windows.go
+++ b/internal/platform/stat_windows.go
@@ -1,0 +1,14 @@
+package platform
+
+import (
+	"os"
+	"syscall"
+)
+
+func statTimes(t os.FileInfo) (atimeSec, atimeNsec, mtimeSec, mtimeNsec, ctimeSec, ctimeNsec int64) {
+	d := t.Sys().(*syscall.Win32FileAttributeData)
+	atime := d.LastAccessTime.Nanoseconds()
+	mtime := d.LastWriteTime.Nanoseconds()
+	ctime := d.CreationTime.Nanoseconds()
+	return atime / 1e9, atime % 1e9, mtime / 1e9, mtime % 1e9, ctime / 1e9, ctime % 1e9
+}

--- a/internal/syscallfs/syscall.go
+++ b/internal/syscallfs/syscall.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package writefs
+package syscallfs
 
 import "syscall"
 

--- a/internal/syscallfs/syscall_windows.go
+++ b/internal/syscallfs/syscall_windows.go
@@ -1,4 +1,4 @@
-package writefs
+package syscallfs
 
 import (
 	"io/fs"

--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -1,4 +1,4 @@
-package writefs
+package syscallfs
 
 import (
 	"errors"
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
@@ -139,4 +140,65 @@ func TestDirFS_Unlink(t *testing.T) {
 		_, err := os.Stat(realPath)
 		require.Error(t, err)
 	})
+}
+
+func TestDirFS_Utimes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testFS := DirFS(tmpDir)
+
+	file := "file"
+	err := os.WriteFile(path.Join(tmpDir, file), []byte{}, 0o700)
+	require.NoError(t, err)
+
+	dir := "dir"
+	err = os.Mkdir(path.Join(tmpDir, dir), 0o700)
+	require.NoError(t, err)
+
+	t.Run("doesn't exist", func(t *testing.T) {
+		err := testFS.Utimes("nope", 123, 4, 567, 8)
+		require.Equal(t, syscall.ENOENT, err)
+	})
+
+	type test struct {
+		name                                     string
+		path                                     string
+		atimeSec, atimeNsec, mtimeSec, mtimeNsec int64
+	}
+
+	// Note: This sets microsecond granularity because Windows doesn't support
+	// nanosecond.
+	tests := []test{
+		{name: "file positive", path: file, atimeSec: 123, atimeNsec: 4 * 1e3, mtimeSec: 567, mtimeNsec: 8 * 1e3},
+		{name: "dir positive", path: dir, atimeSec: 123, atimeNsec: 4 * 1e3, mtimeSec: 567, mtimeNsec: 8 * 1e3},
+		{name: "file zero", path: file},
+		{name: "dir zero", path: dir},
+	}
+
+	// linux and freebsd report inaccurate results when the input ts is negative.
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		tests = append(tests,
+			test{name: "file negative", path: file, atimeSec: -123, atimeNsec: -4 * 1e3, mtimeSec: -567, mtimeNsec: -8 * 1e3},
+			test{name: "dir negative", path: dir, atimeSec: -123, atimeNsec: -4 * 1e3, mtimeSec: -567, mtimeNsec: -8 * 1e3},
+		)
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			err := testFS.Utimes(tc.path, tc.atimeSec, tc.atimeNsec, tc.mtimeSec, tc.mtimeNsec)
+			require.NoError(t, err)
+
+			stat, err := os.Stat(path.Join(tmpDir, tc.path))
+			require.NoError(t, err)
+
+			atimeSec, atimeNsec, mtimeSec, mtimeNsec, _, _ := platform.StatTimes(stat)
+			if platform.CompilerSupported() {
+				require.Equal(t, atimeSec, tc.atimeSec)
+				require.Equal(t, atimeNsec, tc.atimeNsec)
+			} // else only mtimes will return.
+			require.Equal(t, mtimeSec, tc.mtimeSec)
+			require.Equal(t, mtimeNsec, tc.mtimeNsec)
+		})
+	}
 }


### PR DESCRIPTION
This renames the internal writefs package to syscallfs as it is largely dependent on syscall signatures. This also implements utimes in gojs. WASI will be a follow-up change as it requires more infrastructure. Notably, we also need non-TinyGo tests because TinyGo doesn't yet support os.Chtimes or corresponding syscalls.
