### PR TITLE
gojs: fix memory out of bounds

### DIFF
--- a/internal/gojs/misc_test.go
+++ b/internal/gojs/misc_test.go
@@ -3,6 +3,7 @@ package gojs_test
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -37,6 +38,7 @@ func Test_stdio(t *testing.T) {
 
 	input := "stdin\n"
 	stdout, stderr, err := compileAndRun(testCtx, "stdio", wazero.NewModuleConfig().
+		WithEnv("BUF_LEN", strconv.Itoa(len(input))).
 		WithStdin(strings.NewReader(input)))
 
 	require.Equal(t, "stderr 6\n", stderr)
@@ -50,6 +52,7 @@ func Test_stdio_large(t *testing.T) {
 	size := 2 * 1024 * 1024 // 2MB
 	input := make([]byte, size)
 	stdout, stderr, err := compileAndRun(testCtx, "stdio", wazero.NewModuleConfig().
+		WithEnv("BUF_LEN", strconv.Itoa(size)).
 		WithStdin(bytes.NewReader(input)))
 
 	require.EqualError(t, err, `module "" closed with exit_code(0)`)

--- a/internal/gojs/misc_test.go
+++ b/internal/gojs/misc_test.go
@@ -45,7 +45,6 @@ func Test_stdio(t *testing.T) {
 }
 
 func Test_stdio_large(t *testing.T) {
-	t.Skip("TODO: #980 memory out of bounds when run with compiler")
 	t.Parallel()
 
 	size := 2 * 1024 * 1024 // 2MB

--- a/internal/gojs/testdata/stdio/main.go
+++ b/internal/gojs/testdata/stdio/main.go
@@ -6,14 +6,16 @@ import (
 	"os"
 )
 
+var buf = make([]byte, 2*1024*1024)
+
 func Main() {
-	b, err := io.ReadAll(os.Stdin)
+	n, err := io.ReadFull(os.Stdin, buf)
 	if err != nil {
 		panic(err)
 	}
 
-	printToFile("stdout", os.Stdout, len(b))
-	printToFile("stderr", os.Stderr, len(b))
+	printToFile("stdout", os.Stdout, n)
+	printToFile("stderr", os.Stderr, n)
 }
 
 func printToFile(name string, file *os.File, size int) {

--- a/internal/gojs/testdata/stdio/main.go
+++ b/internal/gojs/testdata/stdio/main.go
@@ -4,11 +4,16 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 )
 
-var buf = make([]byte, 2*1024*1024)
-
 func Main() {
+	bufLen, err := strconv.Atoi(os.Getenv("BUF_LEN"))
+	if err != nil {
+		panic(err)
+	}
+	buf := make([]byte, bufLen)
+
 	n, err := io.ReadFull(os.Stdin, buf)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
When in a loop reading a lot of data, the interpreter passes, but the compiler fails after this change. I'd love a hand from @mathetake to figure out the latter!