### PR TITLE
compilationcache: uses version-specific subdirectory

### DIFF
--- a/experimental/compilation_cache.go
+++ b/experimental/compilation_cache.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 
 	"github.com/tetratelabs/wazero/internal/compilationcache"
+	"github.com/tetratelabs/wazero/internal/version"
 )
 
 // WithCompilationCacheDirName configures the destination directory of the compilation cache.
@@ -29,25 +32,47 @@ import (
 //
 //	ctx, _ := experimental.WithCompilationCacheDirName(context.Background(), "/home/me/.cache/wazero")
 //	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigCompiler())
-func WithCompilationCacheDirName(ctx context.Context, dirname string) (context.Context, error) {
+func WithCompilationCacheDirName(ctx context.Context, baseDirname string) (context.Context, error) {
+	// Allow overriding for testing
+	var wazeroVersion string
+	if v := ctx.Value(version.WazeroVersionKey{}); v != nil {
+		wazeroVersion = v.(string)
+	} else {
+		wazeroVersion = version.GetWazeroVersion()
+	}
+
 	// Resolve a potentially relative directory into an absolute one.
 	var err error
-	dirname, err = filepath.Abs(dirname)
+	baseDirname, err = filepath.Abs(baseDirname)
 	if err != nil {
 		return nil, err
 	}
 
-	if st, err := os.Stat(dirname); errors.Is(err, os.ErrNotExist) {
-		// If the directory not found, create the cache dir.
-		if err = os.MkdirAll(dirname, 0o700); err != nil {
-			return nil, fmt.Errorf("create diretory %s: %v", dirname, err)
-		}
-	} else if err != nil {
+	// Ensure the user-supplied directory.
+	if err = mkdir(baseDirname); err != nil {
 		return nil, err
-	} else if !st.IsDir() {
-		return nil, fmt.Errorf("%s is not dir", dirname)
+	}
+
+	// Create a version-specific directory to avoid conflicts.
+	dirname := path.Join(baseDirname, "wazero-"+wazeroVersion+"-"+runtime.GOARCH+"-"+runtime.GOOS)
+	if err = mkdir(dirname); err != nil {
+		return nil, err
 	}
 
 	ctx = context.WithValue(ctx, compilationcache.FileCachePathKey{}, dirname)
 	return ctx, nil
+}
+
+func mkdir(dirname string) error {
+	if st, err := os.Stat(dirname); errors.Is(err, os.ErrNotExist) {
+		// If the directory not found, create the cache dir.
+		if err = os.MkdirAll(dirname, 0o700); err != nil {
+			return fmt.Errorf("create directory %s: %v", dirname, err)
+		}
+	} else if err != nil {
+		return err
+	} else if !st.IsDir() {
+		return fmt.Errorf("%s is not dir", dirname)
+	}
+	return nil
 }

--- a/internal/compilationcache/file_cache.go
+++ b/internal/compilationcache/file_cache.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"runtime"
 	"sync"
 )
 
@@ -41,7 +40,7 @@ type fileReadCloser struct {
 }
 
 func (fc *fileCache) path(key Key) string {
-	return path.Join(fc.dirPath, runtime.GOARCH+"-"+runtime.GOOS+"-"+hex.EncodeToString(key[:]))
+	return path.Join(fc.dirPath, hex.EncodeToString(key[:]))
 }
 
 func (fc *fileCache) Get(key Key) (content io.ReadCloser, ok bool, err error) {

--- a/internal/compilationcache/file_cache_test.go
+++ b/internal/compilationcache/file_cache_test.go
@@ -4,11 +4,8 @@ package compilationcache
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -142,7 +139,5 @@ func TestFileCache_Get(t *testing.T) {
 func TestFileCache_path(t *testing.T) {
 	fc := &fileCache{dirPath: "/tmp/.wazero"}
 	actual := fc.path(Key{1, 2, 3, 4, 5})
-	require.Contains(t, actual, fmt.Sprintf("%s-%s-", runtime.GOARCH, runtime.GOOS))
-	require.True(t, strings.HasPrefix(actual, fc.dirPath))
-	require.True(t, strings.HasSuffix(actual, "0102030405000000000000000000000000000000000000000000000000000000"))
+	require.Equal(t, "/tmp/.wazero/0102030405000000000000000000000000000000000000000000000000000000", actual)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,7 +16,6 @@ type WazeroVersionKey struct{}
 //
 // Note: this is tested in ./testdata/main_test.go with a separate go.mod to pretend as the wazero user.
 func GetWazeroVersion() (ret string) {
-	ret = "dev"
 	info, ok := debug.ReadBuildInfo()
 	if ok {
 		for _, dep := range info.Deps {
@@ -27,9 +26,16 @@ func GetWazeroVersion() (ret string) {
 		}
 
 		// In wazero CLI, wazero is a main module, so we have to get the version info from info.Main.
-		if ret == "dev" {
+		if versionMissing(ret) {
 			ret = info.Main.Version
 		}
 	}
-	return
+	if versionMissing(ret) {
+		return "dev" // don't return parens
+	}
+	return ret
+}
+
+func versionMissing(ret string) bool {
+	return ret == "" || ret == "(devel)" // pkg.go defaults to (devel)
 }


### PR DESCRIPTION
This makes the version, arch, os tuple into a subdirectory to help troubleshooting and cache management in general. The version is left inside the binary key regardless.

Note: when installing via `go install ./cmd/wazero/...` the version ends up as `dev`. This helps make that obvious. For example.

```bash
$ wazero version
dev
$ ./build/tinygo test -target wasi -c -o os.wasm os
$ wazero run -cachedir=$HOME/.wazero -mount=.:/ -env=HOME=.  os.wasm -test.v
$ find $HOME/.wazero
/Users/adrian/.wazero
/Users/adrian/.wazero/wazero-dev-amd64-darwin
/Users/adrian/.wazero/wazero-dev-amd64-darwin/1f149f4bf475a33023ce33302780bee29ec08e89bd57cfbdf639c65c6009f1a4
```

See #977