### PR TITLE
gojs: implements timeout events

### DIFF
--- a/imports/go/gojs.go
+++ b/imports/go/gojs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	. "github.com/tetratelabs/wazero/internal/gojs"
+	. "github.com/tetratelabs/wazero/internal/gojs/run"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -138,20 +139,6 @@ func WithRoundTripper(ctx context.Context, rt http.RoundTripper) context.Context
 //     Use experimental.WithCompilationCacheDirName to improve performance.
 //   - The guest module is closed after being run.
 func Run(ctx context.Context, ns wazero.Namespace, compiled wazero.CompiledModule, config wazero.ModuleConfig) error {
-	// Instantiate the module compiled by go, noting it has no init function.
-	mod, err := ns.InstantiateModule(ctx, compiled, config)
-	if err != nil {
-		return err
-	}
-	defer mod.Close(ctx)
-
-	// Extract the args and env from the module config and write it to memory.
-	ctx = WithState(ctx)
-	argc, argv, err := WriteArgsAndEnviron(mod)
-	if err != nil {
-		return err
-	}
-	// Invoke the run function.
-	_, err = mod.ExportedFunction("run").Call(ctx, uint64(argc), uint64(argv))
+	_, err := RunAndReturnState(ctx, ns, compiled, config)
 	return err
 }

--- a/internal/gojs/custom/names.go
+++ b/internal/gojs/custom/names.go
@@ -31,8 +31,8 @@ const (
 	NameRuntimeResetMemoryDataView  = "runtime.resetMemoryDataView"
 	NameRuntimeNanotime1            = "runtime.nanotime1"
 	NameRuntimeWalltime             = "runtime.walltime"
-	NameRuntimeScheduleTimeoutEvent = "runtime.scheduleTimeoutEvent" // TODO: trigger usage
-	NameRuntimeClearTimeoutEvent    = "runtime.clearTimeoutEvent"    // TODO: trigger usage
+	NameRuntimeScheduleTimeoutEvent = "runtime.scheduleTimeoutEvent"
+	NameRuntimeClearTimeoutEvent    = "runtime.clearTimeoutEvent"
 	NameRuntimeGetRandomData        = "runtime.getRandomData"
 )
 

--- a/internal/gojs/goarch/wasm.go
+++ b/internal/gojs/goarch/wasm.go
@@ -24,16 +24,6 @@ func StubFunction(name string) *wasm.HostFunc {
 	}
 }
 
-func NoopFunction(name string) *wasm.HostFunc {
-	return &wasm.HostFunc{
-		ExportNames: []string{name},
-		Name:        name,
-		ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
-		ParamNames:  []string{"sp"},
-		Code:        &wasm.Code{IsHostFunction: true, Body: []byte{wasm.OpcodeEnd}},
-	}
-}
-
 var le = binary.LittleEndian
 
 type Stack interface {
@@ -103,7 +93,7 @@ func (s *stack) ParamBytes(mem api.Memory, i int) (res []byte) {
 
 // ParamString implements Stack.ParamString
 func (s *stack) ParamString(mem api.Memory, i int) string {
-	return string(s.ParamBytes(mem, i))
+	return string(s.ParamBytes(mem, i)) // safe copy of guest memory
 }
 
 // ParamUint32 implements Stack.ParamUint32

--- a/internal/gojs/run/gojs.go
+++ b/internal/gojs/run/gojs.go
@@ -1,0 +1,33 @@
+// Package run exists to avoid dependency cycles when keeping most of gojs
+// code internal.
+package run
+
+import (
+	"context"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/internal/gojs"
+)
+
+func RunAndReturnState(ctx context.Context, ns wazero.Namespace, compiled wazero.CompiledModule, config wazero.ModuleConfig) (*gojs.State, error) {
+	// Instantiate the module compiled by go, noting it has no init function.
+	mod, err := ns.InstantiateModule(ctx, compiled, config)
+	if err != nil {
+		return nil, err
+	}
+	defer mod.Close(ctx)
+
+	// Extract the args and env from the module config and write it to memory.
+	argc, argv, err := gojs.WriteArgsAndEnviron(mod)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create host-side state for JavaScript values and events.
+	s := gojs.NewState(ctx)
+	ctx = context.WithValue(ctx, gojs.StateKey{}, s)
+
+	// Invoke the run function.
+	_, err = mod.ExportedFunction("run").Call(ctx, uint64(argc), uint64(argv))
+	return s, err
+}

--- a/internal/gojs/syscall.go
+++ b/internal/gojs/syscall.go
@@ -94,7 +94,7 @@ func valueSet(ctx context.Context, mod api.Module, stack goos.Stack) {
 		switch p {
 		case "_pendingEvent":
 			if x == nil { // syscall_js.handleEvent
-				s := v.(*state)
+				s := v.(*State)
 				s._lastEvent = s._pendingEvent
 				s._pendingEvent = nil
 				return

--- a/internal/gojs/testdata/stdio/main.go
+++ b/internal/gojs/testdata/stdio/main.go
@@ -1,17 +1,30 @@
 package stdio
 
 import (
-	"bufio"
+	"fmt"
+	"io"
 	"os"
 )
 
 func Main() {
-	reader := bufio.NewReader(os.Stdin)
-	input, _, err := reader.ReadLine()
+	b, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		panic(err)
 	}
-	println("println", string(input))
-	os.Stdout.Write([]byte("Stdout.Write"))
-	os.Stderr.Write([]byte("Stderr.Write"))
+
+	printToFile("stdout", os.Stdout, len(b))
+	printToFile("stderr", os.Stderr, len(b))
+}
+
+func printToFile(name string, file *os.File, size int) {
+	message := fmt.Sprint(name, " ", size)
+	n, err := fmt.Fprintln(file, message)
+	if err != nil {
+		println(err.Error())
+		panic(name)
+	}
+	if n != len(message)+1 /* \n */ {
+		println(n, "!=", len(message))
+		panic(name)
+	}
 }


### PR DESCRIPTION
This implements functionality needed for #980. When run with interpreter, `Test_stdio_large` triggers timeout events.

However, interpreter is currently too slow to run large wasm in CI. If the interpreter ever becomes fast, we could consider running it. However, performance of the interpreter is currently not a priority.