### PR TITLE
Implements rename in GOOS=js and WASI

### DIFF
--- a/internal/gojs/custom/fs.go
+++ b/internal/gojs/custom/fs.go
@@ -9,11 +9,12 @@ const (
 	NameFsFstat   = "fstat"
 	NameFsLstat   = "lstat"
 	NameFsClose   = "close"
-	NameFsRead    = "read"
 	NameFsWrite   = "write"
+	NameFsRead    = "read"
 	NameFsReaddir = "readdir"
 	NameFsMkdir   = "mkdir"
 	NameFsRmdir   = "rmdir"
+	NameFsRename  = "rename"
 	NameFsUnlink  = "unlink"
 	NameFsUtimes  = "utimes"
 )
@@ -70,6 +71,11 @@ var FsNameSection = map[string]*Names{
 	NameFsRmdir: {
 		Name:        NameFsRmdir,
 		ParamNames:  []string{"path", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsRename: {
+		Name:        NameFsRename,
+		ParamNames:  []string{"from", "to", NameCallback},
 		ResultNames: []string{"err", "ok"},
 	},
 	NameFsUnlink: {

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -13,6 +13,7 @@ import (
 func Main() {
 	// Create a test directory
 	dir := path.Join(os.TempDir(), "dir")
+	dir1 := path.Join(os.TempDir(), "dir1")
 	err := os.Mkdir(dir, 0o700)
 	if err != nil {
 		log.Panicln(err)
@@ -22,6 +23,7 @@ func Main() {
 
 	// Create a test file in that directory
 	file := path.Join(dir, "file")
+	file1 := path.Join(os.TempDir(), "file1")
 	err = os.WriteFile(file, []byte{}, 0o600)
 	if err != nil {
 		log.Panicln(err)
@@ -65,24 +67,40 @@ func Main() {
 		fmt.Println("times:", atimeSec, atimeNsec, mtimeSec, mtimeNsec)
 	}
 
-	// Test unlinking a file
-	if err = syscall.Rmdir(file); err != syscall.ENOTDIR {
+	// Test renaming a file
+	if err = syscall.Rename(file, dir); err != syscall.EISDIR {
 		log.Panicln("unexpected error", err)
 	}
-	if err = syscall.Unlink(file); err != nil {
+	if err = syscall.Rename(file, file1); err != nil {
+		log.Panicln("unexpected error", err)
+	}
+
+	// Test renaming a directory
+	if err = syscall.Rename(dir, file1); err != syscall.ENOTDIR {
+		log.Panicln("unexpected error", err)
+	}
+	if err = syscall.Rename(dir, dir1); err != nil {
+		log.Panicln("unexpected error", err)
+	}
+
+	// Test unlinking a file
+	if err = syscall.Rmdir(file1); err != syscall.ENOTDIR {
+		log.Panicln("unexpected error", err)
+	}
+	if err = syscall.Unlink(file1); err != nil {
 		log.Panicln("unexpected error", err)
 	}
 
 	// Test removing an empty directory
-	if err = syscall.Unlink(dir); err != syscall.EISDIR {
+	if err = syscall.Unlink(dir1); err != syscall.EISDIR {
 		log.Panicln("unexpected error", err)
 	}
-	if err = syscall.Rmdir(dir); err != nil {
+	if err = syscall.Rmdir(dir1); err != nil {
 		log.Panicln("unexpected error", err)
 	}
 
 	// shouldn't fail
-	if err = os.RemoveAll(dir); err != nil {
+	if err = os.RemoveAll(dir1); err != nil {
 		log.Panicln(err)
 		return
 	}

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -67,17 +67,18 @@ func Main() {
 		fmt.Println("times:", atimeSec, atimeNsec, mtimeSec, mtimeNsec)
 	}
 
-	// Test renaming a file
-	if err = syscall.Rename(file, dir); err != syscall.EISDIR {
-		log.Panicln("unexpected error", err)
+	// Test renaming a file, noting we can't verify error numbers as they
+	// vary per operating system.
+	if err = syscall.Rename(file, dir); err == nil {
+		log.Panicln("expected error")
 	}
 	if err = syscall.Rename(file, file1); err != nil {
 		log.Panicln("unexpected error", err)
 	}
 
 	// Test renaming a directory
-	if err = syscall.Rename(dir, file1); err != syscall.ENOTDIR {
-		log.Panicln("unexpected error", err)
+	if err = syscall.Rename(dir, file1); err == nil {
+		log.Panicln("expected error")
 	}
 	if err = syscall.Rename(dir, dir1); err != nil {
 		log.Panicln("unexpected error", err)

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -346,6 +346,17 @@ func (c *FSContext) StatPath(name string) (fs.FileInfo, error) {
 	return c.StatFile(fd)
 }
 
+// Rename is like syscall.Rename.
+func (c *FSContext) Rename(from, to string) (err error) {
+	if wfs, ok := c.fs.(syscallfs.FS); ok {
+		from = c.cleanPath(from)
+		to = c.cleanPath(to)
+		return wfs.Rename(from, to)
+	}
+	err = syscall.ENOSYS
+	return
+}
+
 // Unlink is like syscall.Unlink.
 func (c *FSContext) Unlink(name string) (err error) {
 	if wfs, ok := c.fs.(syscallfs.FS); ok {

--- a/internal/syscallfs/syscall.go
+++ b/internal/syscallfs/syscall.go
@@ -18,3 +18,7 @@ func adjustUnlinkError(err error) error {
 	}
 	return err
 }
+
+func rename(old, new string) error {
+	return syscall.Rename(old, new)
+}

--- a/internal/syscallfs/syscallfs.go
+++ b/internal/syscallfs/syscallfs.go
@@ -19,30 +19,30 @@ type FS interface {
 	// OpenFile is similar to os.OpenFile, except the path is relative to this
 	// file system.
 	OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error)
-	// ^^ TODO: Switch to syscall.Open, though this implies defining and
+	// ^^ TODO: Consider syscall.Open, though this implies defining and
 	// coercing flags and perms similar to what is done in os.OpenFile.
 
 	// Mkdir is similar to os.Mkdir, except the path is relative to this file
 	// system.
 	Mkdir(name string, perm fs.FileMode) error
-	// ^^ TODO: Switch to syscall.Mkdir, though this implies defining and
+	// ^^ TODO: Consider syscall.Mkdir, though this implies defining and
 	// coercing flags and perms similar to what is done in os.Mkdir.
 
-	// Utimes is similar to syscall.UtimesNano, except the path is relative to
-	// this file system.
+	// Rename is similar to syscall.Rename, except the path is relative to this
+	// file system.
 	//
 	// # Errors
 	//
 	// The following errors are expected:
-	//   - syscall.EINVAL: `path` is invalid.
-	//   - syscall.ENOENT: `path` doesn't exist
+	//   - syscall.EINVAL: `from` or `to` is invalid.
+	//   - syscall.ENOENT: `from` or `to` don't exist.
+	//   - syscall.ENOTDIR: `from` is a directory and `to` exists, but is a file.
+	//   - syscall.EISDIR: `from` is a file and `to` exists, but is a directory.
 	//
 	// # Notes
 	//
-	//   - To set wall clock time, retrieve it first from sys.Walltime.
-	//   - syscall.UtimesNano cannot change the ctime. Also, neither WASI nor
-	//     runtime.GOOS=js support changing it. Hence, ctime it is absent here.
-	Utimes(path string, atimeSec, atimeNsec, mtimeSec, mtimeNsec int64) error
+	//   -  Windows doesn't let you overwrite an existing directory.
+	Rename(from, to string) error
 
 	// Rmdir is similar to syscall.Rmdir, except the path is relative to this
 	// file system.
@@ -68,4 +68,20 @@ type FS interface {
 	//   - syscall.ENOENT: `path` doesn't exist.
 	//   - syscall.EISDIR: `path` exists, but is a directory.
 	Unlink(path string) error
+
+	// Utimes is similar to syscall.UtimesNano, except the path is relative to
+	// this file system.
+	//
+	// # Errors
+	//
+	// The following errors are expected:
+	//   - syscall.EINVAL: `path` is invalid.
+	//   - syscall.ENOENT: `path` doesn't exist
+	//
+	// # Notes
+	//
+	//   - To set wall clock time, retrieve it first from sys.Walltime.
+	//   - syscall.UtimesNano cannot change the ctime. Also, neither WASI nor
+	//     runtime.GOOS=js support changing it. Hence, ctime it is absent here.
+	Utimes(path string, atimeSec, atimeNsec, mtimeSec, mtimeNsec int64) error
 }


### PR DESCRIPTION
This implements rename, which is the last function needed to pass TinyGo os package tests:

```bash
$ wazero run  -mount=.:/ os.wasm -test.v
=== RUN   TestExpand
--- PASS: TestExpand (0.00s)
=== RUN   TestConsistentEnviron
--- PASS: TestConsistentEnviron (0.00s)
=== RUN   TestUnsetenv
--- PASS: TestUnsetenv (0.00s)
=== RUN   TestClearenv
--- PASS: TestClearenv (0.00s)
=== RUN   TestLookupEnv
--- PASS: TestLookupEnv (0.00s)
=== RUN   TestEnvironConsistency
--- PASS: TestEnvironConsistency (0.00s)
=== RUN   TestSetenvUnixEinval
--- PASS: TestSetenvUnixEinval (0.00s)
=== RUN   TestExpandEnvShellSpecialVar
--- PASS: TestExpandEnvShellSpecialVar (0.00s)
=== RUN   TestTempDir
--- PASS: TestTempDir (0.00s)
=== RUN   TestChdir
--- PASS: TestChdir (0.00s)
=== RUN   TestStandardFd
--- PASS: TestStandardFd (0.00s)
=== RUN   TestFd
--- PASS: TestFd (0.00s)
=== RUN   TestGetpagesize
--- PASS: TestGetpagesize (0.00s)
=== RUN   TestMkdir
--- PASS: TestMkdir (0.00s)
=== RUN   TestStatBadDir
--- PASS: TestStatBadDir (0.00s)
=== RUN   TestFstat
--- PASS: TestFstat (0.00s)
=== RUN   TestRemove
--- PASS: TestRemove (0.00s)
=== RUN   TestRename
--- PASS: TestRename (0.00s)
=== RUN   TestRenameOverwriteDest
--- PASS: TestRenameOverwriteDest (0.00s)
=== RUN   TestRenameFailed
--- PASS: TestRenameFailed (0.00s)
=== RUN   TestUserHomeDir
--- PASS: TestUserHomeDir (0.00s)
    UserHomeDir failed: $HOME is not defined
=== RUN   TestDirFS
--- PASS: TestDirFS (0.00s)
    TODO: allow foo/bar/. as synonym for path foo/bar on wasi?
=== RUN   TestDirFSPathsValid
--- PASS: TestDirFSPathsValid (0.00s)
    skipping on wasi because it fails on wasi on windows
=== RUN   TestRead0
--- PASS: TestRead0 (0.00s)
=== RUN   TestReadAt0
--- PASS: TestReadAt0 (0.00s)
=== RUN   TestSeek
--- PASS: TestSeek (0.00s)
=== RUN   TestReadAt
--- PASS: TestReadAt (0.00s)
=== RUN   TestReadAtOffset
--- PASS: TestReadAtOffset (0.00s)
=== RUN   TestReadAtNegativeOffset
--- PASS: TestReadAtNegativeOffset (0.00s)
=== RUN   TestReadAtEOF
--- PASS: TestReadAtEOF (0.00s)
=== RUN   TestMkdirAll
--- PASS: TestMkdirAll (0.00s)
=== RUN   TestDirAndSymlinkStats
--- PASS: TestDirAndSymlinkStats (0.00s)
=== RUN   TestFileAndSymlinkStats
--- PASS: TestFileAndSymlinkStats (0.00s)
PASS
```