### PR TITLE
site: Adds notes about how GOARCH=js GOOS=wasm tests work

### DIFF
--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -342,7 +342,7 @@ FAIL    os      0.034s
 FAIL
 ```
 
-Hosts like OS/x and Linux pass these tests because they include files like
+Hosts like Darwin and Linux pass these tests because they include files like
 `/etc/passwd` and the test runner (`wasm_exec_node.js`) is configured to pass
 through any file system calls without filtering. Specifically,
 `globalThis.fs = require("fs")` allows code compiled to wasm any file access

--- a/site/content/languages/go.md
+++ b/site/content/languages/go.md
@@ -9,7 +9,7 @@ When `GOARCH=wasm GOOS=js`, Go's compiler targets WebAssembly Binary format
 
 Here's a typical compilation command:
 ```bash
-$ GOOS=js GOARCH=wasm go build -o my.wasm .
+$ GOARCH=wasm GOOS=js go build -o my.wasm .
 ```
 
 The operating system is "js", but more specifically it is [wasm_exec.js][1].
@@ -266,7 +266,7 @@ go that require version matching. Build a go binary from source to avoid these:
 
 ```bash
 $ cd src
-$ GOOS=js GOARCH=wasm ./make.bash
+$ GOARCH=wasm GOOS=js ./make.bash
 Building Go cmd/dist using /usr/local/go. (go1.19 darwin/amd64)
 Building Go toolchain1 using /usr/local/go.
 --snip--
@@ -298,14 +298,43 @@ like wazero. In other words, go can't run the wasm it just built. Instead,
 
 Now, you should be all set and can iterate similar to normal Go development.
 The main thing to keep in mind is where files are, and remember to set
-`GOOS=js GOARCH=wasm` when running go commands.
+`GOARCH=wasm GOOS=js` when running go commands.
 
 For example, if you fixed something in the `syscall/js` package
 (`${GOROOT}/src/syscall/js`), test it like so:
 ```bash
-$ GOOS=js GOARCH=wasm go test syscall/js
+$ GOARCH=wasm GOOS=js go test syscall/js
 ok  	syscall/js	1.093s
 ```
+
+### Notes
+
+Here are some notes about testing `GOARCH=wasm GOOS=js`
+
+#### Skipped tests
+
+You may find tests are skipped (e.g. when run with `-v` arg).
+```
+=== RUN   TestSeekError
+    os_test.go:1598: skipping test on js
+```
+
+The go test tree has functions to check if a platform is supported before
+proceeding. This allows incremental development of platforms, or avoids things
+like launching subprocesses on wasm, which won't likely ever support that.
+
+#### Filesystem access
+
+`TestStat` tries to read `/etc/passwd` due to a [runtime.GOOS default][21].
+As `GOARCH=wasm GOOS=js` is a virtualized operating system, this may not make
+sense, as it has no such files. Moreover, as of Go 1.19, tests don't pass
+through any configuration to hint at the real OS underneath the VM.
+
+The reason tests in packages like `os` proceed is due to configuration of
+node.js in [wasm_exec_node.js][22]. Specifically, functions that implement file
+system calls are not filtered: `globalThis.fs = require("fs")`. This means code
+compiled to wasm can read or write any file the operating system's underlying
+access controls permit.
 
 [1]: https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec.js
 [2]: https://github.com/golang/go/blob/go1.19/src/cmd/link/internal/wasm/asm.go
@@ -327,3 +356,5 @@ ok  	syscall/js	1.093s
 [18]: https://github.com/WebAssembly/spec/blob/wg-2.0.draft1/proposals/sign-extension-ops/Overview.md
 [19]: https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/
 [20]: https://github.com/golang/go/blob/go1.19/CONTRIBUTING.md
+[21]: https://github.com/golang/go/blob/go1.19/src/os/os_test.go#L110-L116
+[22]: https://github.com/golang/go/blob/go1.19/misc/wasm/wasm_exec_node.js


### PR DESCRIPTION
Go's tests are configured to require reading of files like /etc/passwd, which was surprising to me.