### PR TITLE
Ensures writes aren't allowed when opening for read

### DIFF
--- a/internal/syscallfs/dirfs.go
+++ b/internal/syscallfs/dirfs.go
@@ -32,7 +32,16 @@ func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, err
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
-	return os.OpenFile(path.Join(string(dir), name), flag, perm)
+
+	f, err := os.OpenFile(path.Join(string(dir), name), flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	if flag == 0 || flag == os.O_RDONLY {
+		return maskForReads(f), nil
+	}
+	return f, nil
 }
 
 // Mkdir implements FS.Mkdir

--- a/internal/syscallfs/readfs.go
+++ b/internal/syscallfs/readfs.go
@@ -1,0 +1,55 @@
+package syscallfs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+func NewReadFS(fs FS) FS {
+	if _, ok := fs.(*readFS); ok {
+		return fs
+	}
+	return &readFS{fs}
+}
+
+type readFS struct{ fs FS }
+
+// Open implements the same method as documented on fs.FS
+func (ro *readFS) Open(name string) (fs.File, error) {
+	panic(fmt.Errorf("unexpected to call fs.FS.Open(%s)", name))
+}
+
+// OpenFile implements FS.OpenFile
+func (ro *readFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+	if flag == 0 || flag == os.O_RDONLY {
+		return ro.fs.OpenFile(name, flag, perm)
+	}
+	return nil, syscall.ENOSYS
+}
+
+// Mkdir implements FS.Mkdir
+func (ro *readFS) Mkdir(name string, perm fs.FileMode) error {
+	return syscall.ENOSYS
+}
+
+// Rename implements FS.Rename
+func (ro *readFS) Rename(from, to string) error {
+	return syscall.ENOSYS
+}
+
+// Rmdir implements FS.Rmdir
+func (ro *readFS) Rmdir(name string) error {
+	return syscall.ENOSYS
+}
+
+// Unlink implements FS.Unlink
+func (ro *readFS) Unlink(name string) error {
+	return syscall.ENOSYS
+}
+
+// Utimes implements FS.Utimes
+func (ro *readFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
+	return ro.fs.Utimes(name, atimeNsec, mtimeNsec)
+}

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -1,0 +1,74 @@
+package syscallfs
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestReadFS_MkDir(t *testing.T) {
+	dir := t.TempDir()
+
+	testFS := NewReadFS(dirFS(dir))
+
+	err := testFS.Mkdir("mkdir", fs.ModeDir)
+	require.Equal(t, syscall.ENOSYS, err)
+}
+
+func TestReadFS_Rename(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(dirFS(tmpDir))
+
+	file1 := "file1"
+	file1Path := path.Join(tmpDir, file1)
+	file1Contents := []byte{1}
+	err := os.WriteFile(file1Path, file1Contents, 0o600)
+	require.NoError(t, err)
+
+	file2 := "file2"
+	file2Path := path.Join(tmpDir, file2)
+	file2Contents := []byte{2}
+	err = os.WriteFile(file2Path, file2Contents, 0o600)
+	require.NoError(t, err)
+
+	err = testFS.Rename(file1, file2)
+	require.Equal(t, syscall.ENOSYS, err)
+}
+
+func TestReadFS_Rmdir(t *testing.T) {
+	dir := t.TempDir()
+
+	testFS := NewReadFS(dirFS(dir))
+
+	name := "rmdir"
+	realPath := path.Join(dir, name)
+	require.NoError(t, os.Mkdir(realPath, 0o700))
+
+	err := testFS.Rmdir(name)
+	require.Equal(t, syscall.ENOSYS, err)
+}
+
+func TestReadFS_Unlink(t *testing.T) {
+	dir := t.TempDir()
+
+	testFS := NewReadFS(dirFS(dir))
+
+	name := "unlink"
+	realPath := path.Join(dir, name)
+	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
+
+	err := testFS.Unlink(name)
+	require.Equal(t, syscall.ENOSYS, err)
+}
+
+func TestReadFS_Utimes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testFS := NewReadFS(dirFS(tmpDir))
+
+	testFS_Utimes(t, tmpDir, testFS)
+}

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -72,3 +72,11 @@ func TestReadFS_Utimes(t *testing.T) {
 
 	testFS_Utimes(t, tmpDir, testFS)
 }
+
+func TestReadFS_Open_Read(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testFS := NewReadFS(dirFS(tmpDir))
+
+	testFS_Open_Read(t, tmpDir, testFS)
+}

--- a/internal/syscallfs/syscallfs.go
+++ b/internal/syscallfs/syscallfs.go
@@ -87,7 +87,7 @@ type FS interface {
 	Utimes(path string, atimeNsec, mtimeNsec int64) error
 }
 
-// maskForReads masks the inst with read-only interfaces used by wazero.
+// maskForReads masks the file with read-only interfaces used by wazero.
 //
 // Note: This technique was adapted from similar code in zipkin-go.
 func maskForReads(f fs.File) fs.File {

--- a/internal/syscallfs/syscallfs.go
+++ b/internal/syscallfs/syscallfs.go
@@ -1,6 +1,7 @@
 package syscallfs
 
 import (
+	"io"
 	"io/fs"
 )
 
@@ -84,4 +85,59 @@ type FS interface {
 	//   - syscall.UtimesNano cannot change the ctime. Also, neither WASI nor
 	//     runtime.GOOS=js support changing it. Hence, ctime it is absent here.
 	Utimes(path string, atimeNsec, mtimeNsec int64) error
+}
+
+// maskForReads masks the inst with read-only interfaces used by wazero.
+//
+// Note: This technique was adapted from similar code in zipkin-go.
+func maskForReads(f fs.File) fs.File {
+	// The below are the types wazero casts into.
+	// Note: os.File implements this even for normal files.
+	d, i0 := f.(fs.ReadDirFile)
+	ra, i1 := f.(io.ReaderAt)
+	s, i2 := f.(io.Seeker)
+
+	// Wrap any combination of the types above.
+	switch {
+	case !i0 && !i1 && !i2: // 0, 0, 0
+		return struct{ fs.File }{f}
+	case !i0 && !i1 && i2: // 0, 0, 1
+		return struct {
+			fs.File
+			io.Seeker
+		}{f, s}
+	case !i0 && i1 && !i2: // 0, 1, 0
+		return struct {
+			fs.File
+			io.ReaderAt
+		}{f, ra}
+	case !i0 && i1 && i2: // 0, 1, 1
+		return struct {
+			fs.File
+			io.ReaderAt
+			io.Seeker
+		}{f, ra, s}
+	case i0 && !i1 && !i2: // 1, 0, 0
+		return struct {
+			fs.ReadDirFile
+		}{d}
+	case i0 && !i1 && i2: // 1, 0, 1
+		return struct {
+			fs.ReadDirFile
+			io.Seeker
+		}{d, s}
+	case i0 && i1 && !i2: // 1, 1, 0
+		return struct {
+			fs.ReadDirFile
+			io.ReaderAt
+		}{d, ra}
+	case i0 && i1 && i2: // 1, 1, 1
+		return struct {
+			fs.ReadDirFile
+			io.ReaderAt
+			io.Seeker
+		}{d, ra, s}
+	default:
+		panic("BUG: unhandled pattern")
+	}
 }

--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -1,0 +1,165 @@
+package syscallfs
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
+	file := "file"
+	fileContents := []byte{1, 2, 3, 4}
+	err := os.WriteFile(path.Join(tmpDir, file), fileContents, 0o700)
+	require.NoError(t, err)
+
+	dir := "dir"
+	dirRealPath := path.Join(tmpDir, dir)
+	err = os.Mkdir(dirRealPath, 0o700)
+	require.NoError(t, err)
+
+	file1 := "file1"
+	fileInDir := path.Join(dirRealPath, file1)
+	require.NoError(t, os.WriteFile(fileInDir, []byte{2}, 0o600))
+
+	t.Run("doesn't exist", func(t *testing.T) {
+		_, err := testFS.OpenFile("nope", os.O_RDONLY, 0)
+
+		// We currently follow os.Open not syscall.Open, so the error is wrapped.
+		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
+	})
+
+	t.Run("dir exists", func(t *testing.T) {
+		f, err := testFS.OpenFile(dir, os.O_RDONLY, 0)
+		require.NoError(t, err)
+		defer f.Close()
+
+		// Ensure it implements fs.ReadDirFile
+		d, ok := f.(fs.ReadDirFile)
+		require.True(t, ok)
+		e, err := d.ReadDir(-1)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(e))
+		require.False(t, e[0].IsDir())
+		require.Equal(t, file1, e[0].Name())
+
+		// Ensure it doesn't implement io.Writer
+		_, ok = f.(io.Writer)
+		require.False(t, ok)
+	})
+
+	t.Run("file exists", func(t *testing.T) {
+		f, err := testFS.OpenFile(file, os.O_RDONLY, 0)
+		require.NoError(t, err)
+		defer f.Close()
+
+		// Ensure it implements io.ReaderAt
+		r, ok := f.(io.ReaderAt)
+		require.True(t, ok)
+		lenToRead := len(fileContents) - 1
+		buf := make([]byte, lenToRead)
+		n, err := r.ReadAt(buf, 1)
+		require.NoError(t, err)
+		require.Equal(t, lenToRead, n)
+		require.Equal(t, fileContents[1:], buf)
+
+		// Ensure it implements io.Seeker
+		s, ok := f.(io.Seeker)
+		require.True(t, ok)
+		offset, err := s.Seek(1, io.SeekStart)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), offset)
+		b, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.Equal(t, fileContents[1:], b)
+
+		// Ensure it doesn't implement io.Writer
+		_, ok = f.(io.Writer)
+		require.False(t, ok)
+	})
+}
+
+func testFS_Utimes(t *testing.T, tmpDir string, testFS FS) {
+	file := "file"
+	err := os.WriteFile(path.Join(tmpDir, file), []byte{}, 0o700)
+	require.NoError(t, err)
+
+	dir := "dir"
+	err = os.Mkdir(path.Join(tmpDir, dir), 0o700)
+	require.NoError(t, err)
+
+	t.Run("doesn't exist", func(t *testing.T) {
+		err := testFS.Utimes("nope",
+			time.Unix(123, 4*1e3).UnixNano(),
+			time.Unix(567, 8*1e3).UnixNano())
+		require.Equal(t, syscall.ENOENT, err)
+	})
+
+	type test struct {
+		name                 string
+		path                 string
+		atimeNsec, mtimeNsec int64
+	}
+
+	// Note: This sets microsecond granularity because Windows doesn't support
+	// nanosecond.
+	tests := []test{
+		{
+			name:      "file positive",
+			path:      file,
+			atimeNsec: time.Unix(123, 4*1e3).UnixNano(),
+			mtimeNsec: time.Unix(567, 8*1e3).UnixNano(),
+		},
+		{
+			name:      "dir positive",
+			path:      dir,
+			atimeNsec: time.Unix(123, 4*1e3).UnixNano(),
+			mtimeNsec: time.Unix(567, 8*1e3).UnixNano(),
+		},
+		{name: "file zero", path: file},
+		{name: "dir zero", path: dir},
+	}
+
+	// linux and freebsd report inaccurate results when the input ts is negative.
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		tests = append(tests,
+			test{
+				name:      "file negative",
+				path:      file,
+				atimeNsec: time.Unix(-123, -4*1e3).UnixNano(),
+				mtimeNsec: time.Unix(-567, -8*1e3).UnixNano(),
+			},
+			test{
+				name:      "dir negative",
+				path:      dir,
+				atimeNsec: time.Unix(-123, -4*1e3).UnixNano(),
+				mtimeNsec: time.Unix(-567, -8*1e3).UnixNano(),
+			},
+		)
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			err := testFS.Utimes(tc.path, tc.atimeNsec, tc.mtimeNsec)
+			require.NoError(t, err)
+
+			stat, err := os.Stat(path.Join(tmpDir, tc.path))
+			require.NoError(t, err)
+
+			atimeNsec, mtimeNsec, _ := platform.StatTimes(stat)
+			if platform.CompilerSupported() {
+				require.Equal(t, atimeNsec, tc.atimeNsec)
+			} // else only mtimes will return.
+			require.Equal(t, mtimeNsec, tc.mtimeNsec)
+		})
+	}
+}


### PR DESCRIPTION
This masks interfaces returned by `fs.File` so that we don't accidentally allow writes when opened for reading. This also adds `syscall.NewReadFS` which can enforce read-only access in general, such as would be ideal for tests that try to read files from the host root filesystem (e.g. /etc/passwd).

Note: this is intentionally not exposed as `experimental` yet. We should wait until user request, or the end of the month before deciding which surviving apis to expose.