### PR TITLE
gojs: stubs all remaining filesystem calls to ENOSYS

### DIFF
--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -252,7 +252,7 @@ func TestRun(t *testing.T) {
 			wazeroOpts: []string{"--hostlogging=filesystem", fmt.Sprintf("--mount=%s:/", filepath.Dir(bearPath))},
 			wasmArgs:   []string{"/bear.txt"},
 			stdOut:     "pooh\n",
-			stdErr: fmt.Sprintf(`==> go.syscall/js.valueCall(fs.open(name=/bear.txt,flags=,perm=----------))
+			stdErr: fmt.Sprintf(`==> go.syscall/js.valueCall(fs.open(path=/bear.txt,flags=,perm=----------))
 <== (err=<nil>,fd=4)
 ==> go.syscall/js.valueCall(fs.fstat(fd=4))
 <== (err=<nil>,stat={isDir=false,mode=%[1]s,size=5,mtimeMs=%[2]d})

--- a/internal/gojs/builtin.go
+++ b/internal/gojs/builtin.go
@@ -25,7 +25,7 @@ func newJsGlobal(rt http.RoundTripper) *jsVal {
 			"fs":              jsfs,
 			"Date":            jsDateConstructor,
 		}).
-		addFunction("fetch", &fetch{})
+		addFunction("fetch", httpFetch{})
 }
 
 var (
@@ -48,13 +48,13 @@ var (
 			"pid":  float64(1),        // Get("pid").Int() in syscall_js.go for syscall.Getpid
 			"ppid": goos.RefValueZero, // Get("ppid").Int() in syscall_js.go for syscall.Getppid
 		}).
-		addFunction("cwd", &cwd{}).                     // syscall.Cwd in fs_js.go
-		addFunction("chdir", &chdir{}).                 // syscall.Chdir in fs_js.go
-		addFunction("getuid", &returnZero{}).           // syscall.Getuid in syscall_js.go
-		addFunction("getgid", &returnZero{}).           // syscall.Getgid in syscall_js.go
-		addFunction("geteuid", &returnZero{}).          // syscall.Geteuid in syscall_js.go
-		addFunction("getgroups", &returnSliceOfZero{}). // syscall.Getgroups in syscall_js.go
-		addFunction("umask", &returnArg0{})             // syscall.Umask in syscall_js.go
+		addFunction("cwd", processCwd{}).              // syscall.Cwd in fs_js.go
+		addFunction("chdir", processChdir{}).          // syscall.Chdir in fs_js.go
+		addFunction("getuid", returnZero{}).           // syscall.Getuid in syscall_js.go
+		addFunction("getgid", returnZero{}).           // syscall.Getgid in syscall_js.go
+		addFunction("geteuid", returnZero{}).          // syscall.Geteuid in syscall_js.go
+		addFunction("getgroups", returnSliceOfZero{}). // syscall.Getgroups in syscall_js.go
+		addFunction("umask", returnArg0{})             // syscall.Umask in syscall_js.go
 
 	// uint8ArrayConstructor = js.Global().Get("Uint8Array")
 	//	// fs_js.go, rand_js.go, roundtrip_js.go init

--- a/internal/gojs/crypto.go
+++ b/internal/gojs/crypto.go
@@ -16,12 +16,12 @@ import (
 //
 // This is defined as `Get("crypto")` in rand_js.go init
 var jsCrypto = newJsVal(goos.RefJsCrypto, "crypto").
-	addFunction("getRandomValues", &getRandomValues{})
+	addFunction("getRandomValues", cryptoGetRandomValues{})
 
-type getRandomValues struct{}
+// cryptoGetRandomValues implements jsFn
+type cryptoGetRandomValues struct{}
 
-// invoke implements jsFn.invoke
-func (*getRandomValues) invoke(_ context.Context, mod api.Module, args ...interface{}) (interface{}, error) {
+func (cryptoGetRandomValues) invoke(_ context.Context, mod api.Module, args ...interface{}) (interface{}, error) {
 	randSource := mod.(*wasm.CallContext).Sys.RandSource()
 
 	r := args[0].(*byteArray)

--- a/internal/gojs/custom/fs.go
+++ b/internal/gojs/custom/fs.go
@@ -3,20 +3,31 @@ package custom
 const (
 	NameCallback = "callback"
 
-	NameFs        = "fs"
-	NameFsOpen    = "open"
-	NameFsStat    = "stat"
-	NameFsFstat   = "fstat"
-	NameFsLstat   = "lstat"
-	NameFsClose   = "close"
-	NameFsWrite   = "write"
-	NameFsRead    = "read"
-	NameFsReaddir = "readdir"
-	NameFsMkdir   = "mkdir"
-	NameFsRmdir   = "rmdir"
-	NameFsRename  = "rename"
-	NameFsUnlink  = "unlink"
-	NameFsUtimes  = "utimes"
+	NameFs          = "fs"
+	NameFsOpen      = "open"
+	NameFsStat      = "stat"
+	NameFsFstat     = "fstat"
+	NameFsLstat     = "lstat"
+	NameFsClose     = "close"
+	NameFsWrite     = "write"
+	NameFsRead      = "read"
+	NameFsReaddir   = "readdir"
+	NameFsMkdir     = "mkdir"
+	NameFsRmdir     = "rmdir"
+	NameFsRename    = "rename"
+	NameFsUnlink    = "unlink"
+	NameFsUtimes    = "utimes"
+	NameFsChmod     = "chmod"
+	NameFsFchmod    = "fchmod"
+	NameFsChown     = "chown"
+	NameFsFchown    = "fchown"
+	NameFsLchown    = "lchown"
+	NameFsTruncate  = "truncate"
+	NameFsFtruncate = "ftruncate"
+	NameFsReadlink  = "readlink"
+	NameFsLink      = "link"
+	NameFsSymlink   = "symlink"
+	NameFsFsync     = "fsync"
 )
 
 // FsNameSection are the functions defined in the object named NameFs. Results
@@ -25,12 +36,12 @@ const (
 var FsNameSection = map[string]*Names{
 	NameFsOpen: {
 		Name:        NameFsOpen,
-		ParamNames:  []string{"name", "flags", "perm", NameCallback},
+		ParamNames:  []string{"path", "flags", "perm", NameCallback},
 		ResultNames: []string{"err", "fd"},
 	},
 	NameFsStat: {
 		Name:        NameFsStat,
-		ParamNames:  []string{"name", NameCallback},
+		ParamNames:  []string{"path", NameCallback},
 		ResultNames: []string{"err", "stat"},
 	},
 	NameFsFstat: {
@@ -40,7 +51,7 @@ var FsNameSection = map[string]*Names{
 	},
 	NameFsLstat: {
 		Name:        NameFsLstat,
-		ParamNames:  []string{"name", NameCallback},
+		ParamNames:  []string{"path", NameCallback},
 		ResultNames: []string{"err", "stat"},
 	},
 	NameFsClose: {
@@ -60,7 +71,7 @@ var FsNameSection = map[string]*Names{
 	},
 	NameFsReaddir: {
 		Name:        NameFsReaddir,
-		ParamNames:  []string{"name", NameCallback},
+		ParamNames:  []string{"path", NameCallback},
 		ResultNames: []string{"err", "dirents"},
 	},
 	NameFsMkdir: {
@@ -86,6 +97,61 @@ var FsNameSection = map[string]*Names{
 	NameFsUtimes: {
 		Name:        NameFsUtimes,
 		ParamNames:  []string{"path", "atime", "mtime", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsChmod: {
+		Name:        NameFsChmod,
+		ParamNames:  []string{"path", "mode", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsFchmod: {
+		Name:        NameFsFchmod,
+		ParamNames:  []string{"fd", "mode", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsChown: {
+		Name:        NameFsChown,
+		ParamNames:  []string{"path", "uid", "gid", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsFchown: {
+		Name:        NameFsFchown,
+		ParamNames:  []string{"fd", "uid", "gid", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsLchown: {
+		Name:        NameFsLchown,
+		ParamNames:  []string{"path", "uid", "gid", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsTruncate: {
+		Name:        NameFsTruncate,
+		ParamNames:  []string{"path", "length", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsFtruncate: {
+		Name:        NameFsFtruncate,
+		ParamNames:  []string{"fd", "length", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsReadlink: {
+		Name:        NameFsReadlink,
+		ParamNames:  []string{"path", NameCallback},
+		ResultNames: []string{"err", "dst"},
+	},
+	NameFsLink: {
+		Name:        NameFsLink,
+		ParamNames:  []string{"path", "link", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsSymlink: {
+		Name:        NameFsSymlink,
+		ParamNames:  []string{"path", "link", NameCallback},
+		ResultNames: []string{"err", "ok"},
+	},
+	NameFsFsync: {
+		Name:        NameFsFsync,
+		ParamNames:  []string{"fd", NameCallback},
 		ResultNames: []string{"err", "ok"},
 	},
 }

--- a/internal/gojs/http.go
+++ b/internal/gojs/http.go
@@ -24,7 +24,7 @@ func getRoundTripper(ctx context.Context) http.RoundTripper {
 	return nil
 }
 
-// fetch is used to implement http.RoundTripper
+// httpFetch implements jsFn for http.RoundTripper
 //
 // Reference in roundtrip_js.go init
 //
@@ -33,10 +33,9 @@ func getRoundTripper(ctx context.Context) http.RoundTripper {
 // In http.Transport RoundTrip, this returns a promise
 //
 //	fetchPromise := js.Global().Call("fetch", req.URL.String(), opt)
-type fetch struct{}
+type httpFetch struct{}
 
-// invoke implements jsFn.invoke
-func (*fetch) invoke(ctx context.Context, _ api.Module, args ...interface{}) (interface{}, error) {
+func (httpFetch) invoke(ctx context.Context, _ api.Module, args ...interface{}) (interface{}, error) {
 	rt := getRoundTripper(ctx)
 	if rt == nil {
 		panic("unexpected to reach here without roundtripper as property is nil checked")

--- a/internal/gojs/js.go
+++ b/internal/gojs/js.go
@@ -9,6 +9,8 @@ import (
 )
 
 // jsFn is a jsCall.call function, configured via jsVal.addFunction.
+//
+// Note: This is not a `func` because we need it to be a hashable type.
 type jsFn interface {
 	invoke(ctx context.Context, mod api.Module, args ...interface{}) (interface{}, error)
 }

--- a/internal/gojs/logging/logging.go
+++ b/internal/gojs/logging/logging.go
@@ -53,7 +53,7 @@ func syscallValueCallParamLogger(ctx context.Context, mod api.Module, w logging.
 
 	if m == custom.NameFsOpen {
 		w.WriteString("fs.open(")       //nolint
-		w.WriteString("name=")          //nolint
+		w.WriteString("path=")          //nolint
 		w.WriteString(args[0].(string)) //nolint
 		w.WriteString(",flags=")        //nolint
 		writeOFlags(w, int(args[1].(float64)))

--- a/internal/gojs/syscall.go
+++ b/internal/gojs/syscall.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/gojs/custom"
 	"github.com/tetratelabs/wazero/internal/gojs/goarch"
 	"github.com/tetratelabs/wazero/internal/gojs/goos"
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -405,18 +404,12 @@ func mapJSError(err error) *syscallErr {
 	}
 }
 
-// syscallOpen is like syscall.Open
-func syscallOpen(mod api.Module, name string, flags uint64, perm uint32) (uint32, error) {
-	fsc := mod.(*wasm.CallContext).Sys.FS()
-	return fsc.OpenFile(name, int(flags), fs.FileMode(perm))
-}
-
 // funcWrapper is the result of go's js.FuncOf ("_makeFuncWrapper" here).
 //
 // This ID is managed on the Go side an increments (possibly rolling over).
 type funcWrapper uint32
 
-// jsFn implements jsFn.invoke
+// invoke implements jsFn
 func (f funcWrapper) invoke(ctx context.Context, mod api.Module, args ...interface{}) (interface{}, error) {
 	e := &event{id: uint32(f), this: args[0].(goos.Ref)}
 

--- a/internal/gojs/time.go
+++ b/internal/gojs/time.go
@@ -16,12 +16,12 @@ var (
 	// jsDate is used inline in zoneinfo_js.go for time.initLocal.
 	// `.Call("getTimezoneOffset").Int()` returns a timezone offset.
 	jsDate = newJsVal(goos.RefJsDate, "jsDate").
-		addFunction("getTimezoneOffset", &getTimezoneOffset{})
+		addFunction("getTimezoneOffset", jsDateGetTimezoneOffset{})
 )
 
-type getTimezoneOffset struct{}
+// jsDateGetTimezoneOffset implements jsFn
+type jsDateGetTimezoneOffset struct{}
 
-// invoke implements jsFn.invoke
-func (*getTimezoneOffset) invoke(context.Context, api.Module, ...interface{}) (interface{}, error) {
+func (jsDateGetTimezoneOffset) invoke(context.Context, api.Module, ...interface{}) (interface{}, error) {
 	return uint32(0), nil // UTC
 }


### PR DESCRIPTION
This stubs all remaining syscalls for `GOARCH=wasm GOOS=js` to return ENOSYS, instead of panic'ing. This allows us to see the parameters it receives.

For example:
```
==> go.syscall/js.valueCall(fs.truncate(path=/tmp/_Go_TestTruncate135754730,length=0))
<== (err=function not implemented,ok=false)
```