### PR TITLE
Adds checks into the Makefile for 32-bit platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ check:
 # Ensure we build on linux arm for Dapr:
 #	gh release view -R dapr/dapr --json assets --jq 'first(.assets[] | select(.name = "daprd_linux_arm.tar.gz") | {url, downloadCount})'
 	@GOARCH=arm GOOS=linux go build ./...
-# Ensure we build on linux arm for Dapr:
+# Ensure we build on linux 386 for Trivy:
 #	gh release view -R aquasecurity/trivy --json assets --jq 'first(.assets[] | select(.name| test("Linux-32bit.*tar.gz")) | {url, downloadCount})'
 	@GOARCH=386 GOOS=linux go build ./...
 	@$(MAKE) lint golangci_lint_goarch=arm64

--- a/Makefile
+++ b/Makefile
@@ -210,10 +210,21 @@ format:
 	@go run $(gofumpt) -l -w .
 	@go run $(gosimports) -local github.com/tetratelabs/ -w $(shell find . -name '*.go' -type f)
 
-.PHONY: check
+.PHONY: check  # Pre-flight check for pull requests
 check:
-	@GOARCH=amd64 GOOS=dragonfly go build ./... # Check if the internal/platform can be built on compiler-unsupported platforms
-	@GOARCH=386 GOOS=linux go build ./... # Check if the internal/platform can be built on compiler-unsupported platforms
+# The following checks help ensure our platform-specific code used for system
+# calls safely falls back on a platform unsupported by the compiler engine.
+# This makes sure the intepreter can be used. Most often the package that can
+# drift here is "platform" or "syscallfs":
+#
+# Ensure we build on an arbitrary operating system
+	@GOARCH=amd64 GOOS=dragonfly go build ./...
+# Ensure we build on linux arm for Dapr:
+#	gh release view -R dapr/dapr --json assets --jq 'first(.assets[] | select(.name = "daprd_linux_arm.tar.gz") | {url, downloadCount})'
+	@GOARCH=arm GOOS=linux go build ./...
+# Ensure we build on linux arm for Dapr:
+#	gh release view -R aquasecurity/trivy --json assets --jq 'first(.assets[] | select(.name| test("Linux-32bit.*tar.gz")) | {url, downloadCount})'
+	@GOARCH=386 GOOS=linux go build ./...
 	@$(MAKE) lint golangci_lint_goarch=arm64
 	@$(MAKE) lint golangci_lint_goarch=amd64
 	@$(MAKE) format


### PR DESCRIPTION
Developers don't commonly think about 32-bit platforms and in one instance we broke a release due to this (quickly fixed in pre.7). This ensures arm and 386, used by dapr and trivy respectively are tested. It also helps prove these are in use to avoid a later developer removing support by thinking they aren't.

Don't read into these results, as they are new releases. This is just an example that shows the output of the commands:
```bash
$ gh release view -R aquasecurity/trivy --json assets --jq 'first(.assets[] | select(.name| test("Linux-32bit.*tar.gz")) | {url, downloadCount})'
{"downloadCount":1,"url":"https://github.com/aquasecurity/trivy/releases/download/v0.36.0/trivy_0.36.0_Linux-32bit.tar.gz"
$ gh release view -R dapr/dapr --json assets --jq 'first(.assets[] | select(.name = "daprd_linux_arm.tar.gz") | {url, downloadCount})'
{"downloadCount":16,"url":"https://github.com/dapr/dapr/releases/download/v1.9.5/dapr-operator.yaml"}
```

apologies to @knqyf263 and @berndverst