### PR TITLE
Consolidates internal code to syscallfs

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/sys"
+	"github.com/tetratelabs/wazero/internal/syscallfs"
 	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
@@ -57,8 +58,8 @@ func fdCloseFn(_ context.Context, mod api.Module, params []uint64) Errno {
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 	fd := uint32(params[0])
 
-	if ok := fsc.CloseFile(fd); !ok {
-		return ErrnoBadf
+	if err := fsc.CloseFile(fd); err != nil {
+		return ToErrno(err)
 	}
 	return ErrnoSuccess
 }
@@ -121,20 +122,19 @@ func fdFdstatGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 		return ErrnoFault
 	}
 
-	stat, err := fsc.StatFile(fd)
-	if err != nil {
-		return ToErrno(err)
-	}
-
-	filetype := getWasiFiletype(stat.Mode())
 	var fdflags uint16
-
-	// Determine if it is writeable
-	if w := fsc.FdWriter(fd); w != nil {
+	var stat fs.FileInfo
+	var err error
+	if f, ok := fsc.LookupFile(fd); !ok {
+		return ErrnoBadf
+	} else if stat, err = f.File.Stat(); err != nil {
+		return ToErrno(err)
+	} else if _, ok := f.File.(io.Writer); ok {
 		// TODO: maybe cache flags to open instead
 		fdflags = FD_APPEND
 	}
 
+	filetype := getWasiFiletype(stat.Mode())
 	writeFdstat(buf, filetype, fdflags)
 
 	return ErrnoSuccess
@@ -233,7 +233,7 @@ func fdFilestatGetFunc(mod api.Module, fd, resultBuf uint32) Errno {
 		return ErrnoFault
 	}
 
-	stat, err := fsc.StatFile(fd)
+	stat, err := sys.StatFile(fsc, fd)
 	if err != nil {
 		return ToErrno(err)
 	}
@@ -358,14 +358,16 @@ func fdPrestatGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 		return ErrnoBadf
 	}
 
-	entry, ok := fsc.OpenedFile(fd)
-	if !ok {
-		return ErrnoBadf
+	var name string
+	if f, ok := fsc.LookupFile(fd); !ok {
+		return ErrnoBadf // closed
+	} else {
+		name = f.Name
 	}
 
 	// Upper 32-bits are zero because...
 	// * Zero-value 8-bit tag, and 3-byte zero-value padding
-	prestat := uint64(len(entry.Name) << 32)
+	prestat := uint64(len(name) << 32)
 	if !mod.Memory().WriteUint64Le(resultPrestat, prestat) {
 		return ErrnoFault
 	}
@@ -417,17 +419,19 @@ func fdPrestatDirNameFn(_ context.Context, mod api.Module, params []uint64) Errn
 		return ErrnoBadf
 	}
 
-	f, ok := fsc.OpenedFile(fd)
-	if !ok {
-		return ErrnoBadf
+	var name string
+	if f, ok := fsc.LookupFile(fd); !ok {
+		return ErrnoBadf // closed
+	} else {
+		name = f.Name
 	}
 
 	// Some runtimes may have another semantics. See /RATIONALE.md
-	if uint32(len(f.Name)) < pathLen {
+	if uint32(len(name)) < pathLen {
 		return ErrnoNametoolong
 	}
 
-	if !mod.Memory().Write(path, []byte(f.Name)[:pathLen]) {
+	if !mod.Memory().Write(path, []byte(name)[:pathLen]) {
 		return ErrnoFault
 	}
 	return ErrnoSuccess
@@ -519,21 +523,21 @@ func fdReadOrPread(mod api.Module, params []uint64, isPread bool) Errno {
 		resultNread = uint32(params[3])
 	}
 
-	r := fsc.FdReader(fd)
-	if r == nil {
+	r, ok := fsc.LookupFile(fd)
+	if !ok {
 		return ErrnoBadf
 	}
 
-	read := r.Read
+	read := r.File.Read
 	if isPread {
-		if ra, ok := r.(io.ReaderAt); ok {
+		if ra, ok := r.File.(io.ReaderAt); ok {
 			// ReadAt is the Go equivalent to pread.
 			read = func(p []byte) (int, error) {
 				n, err := ra.ReadAt(p, offset)
 				offset += int64(n)
 				return n, err
 			}
-		} else if s, ok := r.(io.Seeker); ok {
+		} else if s, ok := r.File.(io.Seeker); ok {
 			// Unfortunately, it is often not supported.
 			// See /RATIONALE.md "fd_pread: io.Seeker fallback when io.ReaderAt is not supported"
 			initialOffset, err := s.Seek(0, io.SeekCurrent)
@@ -853,7 +857,7 @@ func writeDirent(buf []byte, dNext uint64, dNamlen uint32, dType bool) {
 
 // openedDir returns the directory and ErrnoSuccess if the fd points to a readable directory.
 func openedDir(fsc *sys.FSContext, fd uint32) (fs.ReadDirFile, *sys.ReadDir, Errno) {
-	if f, ok := fsc.OpenedFile(fd); !ok {
+	if f, ok := fsc.LookupFile(fd); !ok {
 		return nil, nil, ErrnoBadf
 	} else if d, ok := f.File.(fs.ReadDirFile); !ok {
 		// fd_readdir docs don't indicate whether to return ErrnoNotdir or
@@ -933,7 +937,7 @@ func fdSeekFn(_ context.Context, mod api.Module, params []uint64) Errno {
 
 	var seeker io.Seeker
 	// Check to see if the file descriptor is available
-	if f, ok := fsc.OpenedFile(fd); !ok {
+	if f, ok := fsc.LookupFile(fd); !ok {
 		return ErrnoBadf
 		// fs.FS doesn't declare io.Seeker, but implementations such as os.File implement it.
 	} else if seeker, ok = f.File.(io.Seeker); !ok {
@@ -1040,7 +1044,7 @@ func fdWriteFn(_ context.Context, mod api.Module, params []uint64) Errno {
 	iovsCount := uint32(params[2])
 	resultNwritten := uint32(params[3])
 
-	writer := fsc.FdWriter(fd)
+	writer := sys.WriterForFile(fsc, fd)
 	if writer == nil {
 		return ErrnoBadf
 	}
@@ -1118,10 +1122,8 @@ func pathCreateDirectoryFn(_ context.Context, mod api.Module, params []uint64) E
 		return errno
 	}
 
-	if fd, err := fsc.Mkdir(pathName, 0o700); err != nil {
+	if err := fsc.FS().Mkdir(pathName, 0o700); err != nil {
 		return ToErrno(err)
-	} else {
-		_ = fsc.CloseFile(fd)
 	}
 
 	return ErrnoSuccess
@@ -1183,20 +1185,23 @@ func pathFilestatGetFn(_ context.Context, mod api.Module, params []uint64) Errno
 	}
 	pathName := string(b)
 
-	// Prepend the path if necessary.
-	if dir, ok := fsc.OpenedFile(dirfd); !ok {
-		return ErrnoBadf
-	} else if _, ok := dir.File.(fs.ReadDirFile); !ok {
-		return ErrnoNotdir // TODO: cache filetype instead of poking.
-	} else {
+	// os.File implements ReadDirFile, so we have to check with stat.
+	stat, err := sys.StatFile(fsc, dirfd)
+	if err != nil {
+		return ToErrno(err)
+	}
+
+	if !stat.IsDir() {
+		return ErrnoNotdir
+	} else { // prepend the name
 		// TODO: consolidate "at" logic with path_open as same issues occur.
-		pathName = path.Join(dir.Name, pathName)
+		pathName = path.Join(stat.Name(), pathName)
 	}
 
 	// Stat the file without allocating a file descriptor
-	stat, errnoResult := statFile(fsc, pathName)
-	if errnoResult != ErrnoSuccess {
-		return errnoResult
+	stat, err = syscallfs.StatPath(fsc.FS(), pathName)
+	if err != nil {
+		return ToErrno(err)
 	}
 
 	// Write the stat result to memory
@@ -1315,22 +1320,20 @@ func pathOpenFn(_ context.Context, mod api.Module, params []uint64) Errno {
 
 	fileOpenFlags, isDir := openFlags(oflags, fdflags)
 
-	var newFD uint32
-	var err error
 	if isDir && oflags&O_CREAT != 0 {
 		return ErrnoInval // use pathCreateDirectory!
-	} else {
-		newFD, err = fsc.OpenFile(pathName, fileOpenFlags, 0o600)
 	}
 
+	newFD, err := fsc.OpenFile(pathName, fileOpenFlags, 0o600)
 	if err != nil {
 		return ToErrno(err)
 	}
 
 	// Check any flags that require the file to evaluate.
 	if isDir {
-		if errno := failIfNotDirectory(fsc, newFD); errno != ErrnoSuccess {
-			return errno
+		if stat, err := sys.StatFile(fsc, newFD); err != nil || !stat.IsDir() {
+			_ = fsc.CloseFile(newFD)
+			return ErrnoNotdir
 		}
 	}
 
@@ -1358,8 +1361,8 @@ func atPath(fsc *sys.FSContext, mem api.Memory, dirFd, path, pathLen uint32) (st
 		// "/tmp/foo/bar" not "/bar".
 	}
 
-	if _, ok := fsc.OpenedFile(dirFd); !ok {
-		return "", ErrnoBadf
+	if _, ok := fsc.LookupFile(dirFd); !ok {
+		return "", ErrnoBadf // closed
 	}
 
 	b, ok := mem.Read(path, pathLen)
@@ -1390,17 +1393,6 @@ func openFlags(oflags, fdflags uint16) (openFlags int, isDir bool) {
 		openFlags |= os.O_EXCL
 	}
 	return
-}
-
-func failIfNotDirectory(fsc *sys.FSContext, fd uint32) Errno {
-	// Lookup the previous file
-	if f, ok := fsc.OpenedFile(fd); !ok {
-		return ErrnoBadf
-	} else if _, ok := f.File.(fs.ReadDirFile); !ok {
-		_ = fsc.CloseFile(fd)
-		return ErrnoNotdir
-	}
-	return ErrnoSuccess
 }
 
 // pathReadlink is the WASI function named PathReadlinkName that reads the
@@ -1453,7 +1445,7 @@ func pathRemoveDirectoryFn(_ context.Context, mod api.Module, params []uint64) E
 		return errno
 	}
 
-	if err := fsc.Rmdir(pathName); err != nil {
+	if err := fsc.FS().Rmdir(pathName); err != nil {
 		return ToErrno(err)
 	}
 
@@ -1512,7 +1504,7 @@ func pathRenameFn(_ context.Context, mod api.Module, params []uint64) Errno {
 		return errno
 	}
 
-	if err := fsc.Rename(oldPathName, newPathName); err != nil {
+	if err := fsc.FS().Rename(oldPathName, newPathName); err != nil {
 		return ToErrno(err)
 	}
 
@@ -1568,20 +1560,9 @@ func pathUnlinkFileFn(_ context.Context, mod api.Module, params []uint64) Errno 
 		return errno
 	}
 
-	if err := fsc.Unlink(pathName); err != nil {
+	if err := fsc.FS().Unlink(pathName); err != nil {
 		return ToErrno(err)
 	}
 
 	return ErrnoSuccess
-}
-
-// statFile attempts to stat the file at the given path. Errors coerce to WASI
-// Errno.
-func statFile(fsc *sys.FSContext, name string) (stat fs.FileInfo, errno Errno) {
-	var err error
-	stat, err = fsc.StatPath(name)
-	if err != nil {
-		errno = ToErrno(err)
-	}
-	return
 }

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/tetratelabs/wazero/api"
+	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
@@ -132,9 +133,11 @@ func processFDEvent(mod api.Module, eventType byte, inBuf []byte) Errno {
 	// Choose the best error, which falls back to unsupported, until we support
 	// files.
 	errno := ErrnoNotsup
-	if eventType == EventTypeFdRead && fsc.FdReader(fd) == nil {
-		errno = ErrnoBadf
-	} else if eventType == EventTypeFdWrite && fsc.FdWriter(fd) == nil {
+	if eventType == EventTypeFdRead {
+		if _, ok := fsc.LookupFile(fd); !ok {
+			errno = ErrnoBadf
+		}
+	} else if eventType == EventTypeFdWrite && internalsys.WriterForFile(fsc, fd) == nil {
 		errno = ErrnoBadf
 	}
 

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -178,11 +178,11 @@ func Benchmark_fdReaddir(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			f, ok := fsc.OpenedFile(fd)
+			f, ok := fsc.LookupFile(fd)
 			if !ok {
 				b.Fatal("couldn't open fd ", fd)
 			}
-			defer fsc.CloseFile(fd)
+			defer fsc.CloseFile(fd) //nolint
 
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -284,7 +284,7 @@ func Benchmark_pathFilestat(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				defer fsc.CloseFile(fd)
+				defer fsc.CloseFile(fd) //nolint
 			}
 
 			fn := mod.ExportedFunction(PathFilestatGetName)

--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -22,6 +22,7 @@ import (
 	gojs "github.com/tetratelabs/wazero/imports/go"
 	internalgojs "github.com/tetratelabs/wazero/internal/gojs"
 	"github.com/tetratelabs/wazero/internal/gojs/run"
+	"github.com/tetratelabs/wazero/internal/syscallfs"
 )
 
 func compileAndRun(ctx context.Context, arg string, config wazero.ModuleConfig) (stdout, stderr string, err error) {
@@ -65,12 +66,12 @@ var testBin []byte
 // testCtx is configured in TestMain to re-use wazero's compilation cache.
 var (
 	testCtx context.Context
-	testFS  = fstest.MapFS{
+	testFS  = syscallfs.Adapt(fstest.MapFS{
 		"empty.txt":    {},
 		"test.txt":     {Data: []byte("animals\n"), Mode: 0o644},
 		"sub":          {Mode: fs.ModeDir | 0o755},
 		"sub/test.txt": {Data: []byte("greet sub dir\n"), Mode: 0o444},
-	}
+	})
 	rt wazero.Runtime
 )
 

--- a/internal/gojs/runtime.go
+++ b/internal/gojs/runtime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/gojs/custom"
 	"github.com/tetratelabs/wazero/internal/gojs/goarch"
+	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -39,12 +40,9 @@ func wasmWrite(_ context.Context, mod api.Module, stack goarch.Stack) {
 	p := stack.ParamBytes(mod.Memory(), 1 /*, 2 */)
 
 	fsc := mod.(*wasm.CallContext).Sys.FS()
-	writer := fsc.FdWriter(fd)
-	if writer == nil {
-		panic(fmt.Errorf("unexpected fd %d", fd))
-	}
-
-	if _, err := writer.Write(p); err != nil {
+	if writer := internalsys.WriterForFile(fsc, fd); writer == nil {
+		panic(fmt.Errorf("fd %d invalid", fd))
+	} else if _, err := writer.Write(p); err != nil {
 		panic(fmt.Errorf("error writing p: %w", err))
 	}
 }

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/syscallfs"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -181,9 +182,9 @@ func NewContext(
 	}
 
 	if fs != nil {
-		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, fs)
+		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, syscallfs.Adapt(fs))
 	} else {
-		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, EmptyFS)
+		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, syscallfs.EmptyFS)
 	}
 
 	return

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/syscallfs"
 	testfs "github.com/tetratelabs/wazero/internal/testing/fs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
 )
 
 func TestContext_FS(t *testing.T) {
-	sysCtx := DefaultContext(testfs.FS{})
+	sysCtx := DefaultContext(syscallfs.EmptyFS)
 
-	fsc, err := NewFSContext(nil, nil, nil, testfs.FS{})
+	fsc, err := NewFSContext(nil, nil, nil, syscallfs.EmptyFS)
 	require.NoError(t, err)
 
 	require.Equal(t, fsc, sysCtx.FS())
@@ -50,7 +51,8 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, &ns, sysCtx.nanosleep)
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
 
-	expectedFS, _ := NewFSContext(nil, nil, nil, testfs.FS{})
+	testFS := syscallfs.Adapt(testfs.FS{})
+	expectedFS, _ := NewFSContext(nil, nil, nil, testFS)
 
 	expectedOpenedFiles := FileTable{}
 	expectedOpenedFiles.Insert(noopStdin)

--- a/internal/syscallfs/adapter.go
+++ b/internal/syscallfs/adapter.go
@@ -1,0 +1,77 @@
+package syscallfs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	pathutil "path"
+	"syscall"
+)
+
+// Adapt returns a read-only FS unless the input is already one.
+func Adapt(fs fs.FS) FS {
+	if sys, ok := fs.(FS); ok {
+		return sys
+	}
+	return &adapter{fs}
+}
+
+type adapter struct{ fs fs.FS }
+
+// Open implements the same method as documented on fs.FS
+func (ro *adapter) Open(name string) (fs.File, error) {
+	panic(fmt.Errorf("unexpected to call fs.FS.Open(%s)", name))
+}
+
+// OpenFile implements FS.OpenFile
+func (ro *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
+	if flag != 0 && flag != os.O_RDONLY {
+		return nil, syscall.ENOSYS
+	}
+
+	path = cleanPath(path)
+	f, err := ro.fs.Open(path)
+	if err != nil {
+		// wrapped is fine while FS.OpenFile emulates os.OpenFile vs syscall.OpenFile.
+		return nil, err
+	}
+	return maskForReads(f), nil
+}
+
+func cleanPath(name string) string {
+	if len(name) == 0 {
+		return name
+	}
+	// fs.ValidFile cannot be rooted (start with '/')
+	cleaned := name
+	if name[0] == '/' {
+		cleaned = name[1:]
+	}
+	cleaned = pathutil.Clean(cleaned) // e.g. "sub/." -> "sub"
+	return cleaned
+}
+
+// Mkdir implements FS.Mkdir
+func (ro *adapter) Mkdir(path string, perm fs.FileMode) error {
+	return syscall.ENOSYS
+}
+
+// Rename implements FS.Rename
+func (ro *adapter) Rename(from, to string) error {
+	return syscall.ENOSYS
+}
+
+// Rmdir implements FS.Rmdir
+func (ro *adapter) Rmdir(path string) error {
+	return syscall.ENOSYS
+}
+
+// Unlink implements FS.Unlink
+func (ro *adapter) Unlink(path string) error {
+	return syscall.ENOSYS
+}
+
+// Utimes implements FS.Utimes
+func (ro *adapter) Utimes(path string, atimeNsec, mtimeNsec int64) error {
+	return syscall.ENOSYS
+}

--- a/internal/syscallfs/dirfs.go
+++ b/internal/syscallfs/dirfs.go
@@ -29,10 +29,6 @@ func (dir dirFS) Open(name string) (fs.File, error) {
 
 // OpenFile implements FS.OpenFile
 func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
-	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
-	}
-
 	f, err := os.OpenFile(path.Join(string(dir), name), flag, perm)
 	if err != nil {
 		return nil, err
@@ -46,23 +42,12 @@ func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, err
 
 // Mkdir implements FS.Mkdir
 func (dir dirFS) Mkdir(name string, perm fs.FileMode) error {
-	if !fs.ValidPath(name) {
-		return &fs.PathError{Op: "mkdir", Path: name, Err: fs.ErrInvalid}
-	}
-
 	err := os.Mkdir(path.Join(string(dir), name), perm)
-
 	return adjustMkdirError(err)
 }
 
 // Rename implements FS.Rename
 func (dir dirFS) Rename(from, to string) error {
-	if !fs.ValidPath(from) {
-		return syscall.EINVAL
-	}
-	if !fs.ValidPath(to) {
-		return syscall.EINVAL
-	}
 	if from == to {
 		return nil
 	}
@@ -71,31 +56,18 @@ func (dir dirFS) Rename(from, to string) error {
 
 // Rmdir implements FS.Rmdir
 func (dir dirFS) Rmdir(name string) error {
-	if !fs.ValidPath(name) {
-		return syscall.EINVAL
-	}
-
 	err := syscall.Rmdir(path.Join(string(dir), name))
-
 	return adjustRmdirError(err)
 }
 
 // Unlink implements FS.Unlink
 func (dir dirFS) Unlink(name string) error {
-	if !fs.ValidPath(name) {
-		return syscall.EINVAL
-	}
-
 	err := syscall.Unlink(path.Join(string(dir), name))
-
 	return adjustUnlinkError(err)
 }
 
 // Utimes implements FS.Utimes
 func (dir dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
-	if !fs.ValidPath(name) {
-		return syscall.EINVAL
-	}
 	return syscall.UtimesNano(path.Join(string(dir), name), []syscall.Timespec{
 		syscall.NsecToTimespec(atimeNsec),
 		syscall.NsecToTimespec(mtimeNsec),

--- a/internal/syscallfs/dirfs_test.go
+++ b/internal/syscallfs/dirfs_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
-	"path"
+	pathutil "path"
 	"runtime"
 	"syscall"
 	"testing"
@@ -18,7 +18,7 @@ func TestDirFS_MkDir(t *testing.T) {
 	testFS := dirFS(dir)
 
 	name := "mkdir"
-	realPath := path.Join(dir, name)
+	realPath := pathutil.Join(dir, name)
 
 	t.Run("doesn't exist", func(t *testing.T) {
 		require.NoError(t, testFS.Mkdir(name, fs.ModeDir))
@@ -48,7 +48,7 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		file1 := "file1"
-		file1Path := path.Join(tmpDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		err := os.WriteFile(file1Path, []byte{1}, 0o600)
 		require.NoError(t, err)
 
@@ -60,13 +60,13 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		file1 := "file1"
-		file1Path := path.Join(tmpDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		file2 := "file2"
-		file2Path := path.Join(tmpDir, file2)
+		file2Path := pathutil.Join(tmpDir, file2)
 		err = testFS.Rename(file1, file2)
 		require.NoError(t, err)
 
@@ -83,11 +83,11 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		dir1 := "dir1"
-		dir1Path := path.Join(tmpDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		dir2 := "dir2"
-		dir2Path := path.Join(tmpDir, dir2)
+		dir2Path := pathutil.Join(tmpDir, dir2)
 		err := testFS.Rename(dir1, dir2)
 		require.NoError(t, err)
 
@@ -104,11 +104,11 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		dir1 := "dir1"
-		dir1Path := path.Join(tmpDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		dir2 := "dir2"
-		dir2Path := path.Join(tmpDir, dir2)
+		dir2Path := pathutil.Join(tmpDir, dir2)
 
 		// write a file to that path
 		err := os.WriteFile(dir2Path, []byte{2}, 0o600)
@@ -131,13 +131,13 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		file1 := "file1"
-		file1Path := path.Join(tmpDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
-		dir1Path := path.Join(tmpDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		err = testFS.Rename(file1, dir1)
@@ -148,18 +148,18 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		dir1 := "dir1"
-		dir1Path := path.Join(tmpDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		// add a file to that directory
 		file1 := "file1"
-		file1Path := path.Join(dir1Path, file1)
+		file1Path := pathutil.Join(dir1Path, file1)
 		file1Contents := []byte{1}
 		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		dir2 := "dir2"
-		dir2Path := path.Join(tmpDir, dir2)
+		dir2Path := pathutil.Join(tmpDir, dir2)
 		require.NoError(t, os.Mkdir(dir2Path, 0o700))
 
 		err = testFS.Rename(dir1, dir2)
@@ -175,7 +175,7 @@ func TestDirFS_Rename(t *testing.T) {
 		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
 
 		// Show the file inside that directory moved
-		s, err := os.Stat(path.Join(dir2Path, file1))
+		s, err := os.Stat(pathutil.Join(dir2Path, file1))
 		require.NoError(t, err)
 		require.False(t, s.IsDir())
 	})
@@ -184,13 +184,13 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		file1 := "file1"
-		file1Path := path.Join(tmpDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		file2 := "file2"
-		file2Path := path.Join(tmpDir, file2)
+		file2Path := pathutil.Join(tmpDir, file2)
 		file2Contents := []byte{2}
 		err = os.WriteFile(file2Path, file2Contents, 0o600)
 		require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		dir1 := "dir1"
-		dir1Path := path.Join(tmpDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		err := testFS.Rename(dir1, dir1)
@@ -227,7 +227,7 @@ func TestDirFS_Rename(t *testing.T) {
 		testFS := dirFS(tmpDir)
 
 		file1 := "file1"
-		file1Path := path.Join(tmpDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestDirFS_Rmdir(t *testing.T) {
 	testFS := dirFS(dir)
 
 	name := "rmdir"
-	realPath := path.Join(dir, name)
+	realPath := pathutil.Join(dir, name)
 
 	t.Run("doesn't exist", func(t *testing.T) {
 		err := testFS.Rmdir(name)
@@ -256,7 +256,7 @@ func TestDirFS_Rmdir(t *testing.T) {
 
 	t.Run("dir not empty", func(t *testing.T) {
 		require.NoError(t, os.Mkdir(realPath, 0o700))
-		fileInDir := path.Join(realPath, "file")
+		fileInDir := pathutil.Join(realPath, "file")
 		require.NoError(t, os.WriteFile(fileInDir, []byte{}, 0o600))
 
 		err := testFS.Rmdir(name)
@@ -287,7 +287,7 @@ func TestDirFS_Unlink(t *testing.T) {
 	testFS := dirFS(dir)
 
 	name := "unlink"
-	realPath := path.Join(dir, name)
+	realPath := pathutil.Join(dir, name)
 
 	t.Run("doesn't exist", func(t *testing.T) {
 		err := testFS.Unlink(name)
@@ -323,7 +323,18 @@ func TestDirFS_Utimes(t *testing.T) {
 func TestDirFS_Open_Read(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	testFS := dirFS(tmpDir)
+	// Create a subdirectory, so we can test reads outside the FS root.
+	tmpDir = pathutil.Join(tmpDir, t.Name())
+	require.NoError(t, os.Mkdir(tmpDir, 0o700))
+
+	testFS := Adapt(dirFS(tmpDir))
 
 	testFS_Open_Read(t, tmpDir, testFS)
+
+	t.Run("path outside root valid", func(t *testing.T) {
+		_, err := testFS.OpenFile("../foo", os.O_RDONLY, 0)
+
+		// syscall.FS allows relative path lookups
+		require.True(t, errors.Is(err, fs.ErrNotExist))
+	})
 }

--- a/internal/syscallfs/empty.go
+++ b/internal/syscallfs/empty.go
@@ -1,0 +1,48 @@
+package syscallfs
+
+import (
+	"fmt"
+	"io/fs"
+	"syscall"
+)
+
+// EmptyFS is an FS that returns syscall.ENOENT for all read functions, and
+// syscall.ENOSYS otherwise.
+var EmptyFS FS = unsupported{}
+
+type unsupported struct{}
+
+// Open implements the same method as documented on fs.FS
+func (unsupported) Open(name string) (fs.File, error) {
+	panic(fmt.Errorf("unexpected to call fs.FS.Open(%s)", name))
+}
+
+// OpenFile implements FS.OpenFile
+func (unsupported) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
+	return nil, &fs.PathError{Op: "open", Path: path, Err: syscall.ENOENT}
+}
+
+// Mkdir implements FS.Mkdir
+func (unsupported) Mkdir(path string, perm fs.FileMode) error {
+	return syscall.ENOSYS
+}
+
+// Rename implements FS.Rename
+func (unsupported) Rename(from, to string) error {
+	return syscall.ENOSYS
+}
+
+// Rmdir implements FS.Rmdir
+func (unsupported) Rmdir(path string) error {
+	return syscall.ENOSYS
+}
+
+// Unlink implements FS.Unlink
+func (unsupported) Unlink(path string) error {
+	return syscall.ENOSYS
+}
+
+// Utimes implements FS.Utimes
+func (unsupported) Utimes(path string, atimeNsec, mtimeNsec int64) error {
+	return syscall.ENOSYS
+}

--- a/internal/syscallfs/readfs.go
+++ b/internal/syscallfs/readfs.go
@@ -22,15 +22,15 @@ func (ro *readFS) Open(name string) (fs.File, error) {
 }
 
 // OpenFile implements FS.OpenFile
-func (ro *readFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
+func (ro *readFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
 	if flag == 0 || flag == os.O_RDONLY {
-		return ro.fs.OpenFile(name, flag, perm)
+		return ro.fs.OpenFile(path, flag, perm)
 	}
 	return nil, syscall.ENOSYS
 }
 
 // Mkdir implements FS.Mkdir
-func (ro *readFS) Mkdir(name string, perm fs.FileMode) error {
+func (ro *readFS) Mkdir(path string, perm fs.FileMode) error {
 	return syscall.ENOSYS
 }
 
@@ -40,16 +40,16 @@ func (ro *readFS) Rename(from, to string) error {
 }
 
 // Rmdir implements FS.Rmdir
-func (ro *readFS) Rmdir(name string) error {
+func (ro *readFS) Rmdir(path string) error {
 	return syscall.ENOSYS
 }
 
 // Unlink implements FS.Unlink
-func (ro *readFS) Unlink(name string) error {
+func (ro *readFS) Unlink(path string) error {
 	return syscall.ENOSYS
 }
 
 // Utimes implements FS.Utimes
-func (ro *readFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
-	return ro.fs.Utimes(name, atimeNsec, mtimeNsec)
+func (ro *readFS) Utimes(path string, atimeNsec, mtimeNsec int64) error {
+	return syscall.ENOSYS
 }

--- a/internal/wasm/call_context_test.go
+++ b/internal/wasm/call_context_test.go
@@ -155,14 +155,14 @@ func TestCallContext_Close(t *testing.T) {
 
 		// We use side effects to determine if Close in fact called Context.Close (without repeating sys_test.go).
 		// One side effect of Context.Close is that it clears the openedFiles map. Verify our base case.
-		_, ok := fsCtx.OpenedFile(3)
+		_, ok := fsCtx.LookupFile(3)
 		require.True(t, ok, "sysCtx.openedFiles was empty")
 
 		// Closing should not err.
 		require.NoError(t, m.Close(testCtx))
 
 		// Verify our intended side-effect
-		_, ok = fsCtx.OpenedFile(3)
+		_, ok = fsCtx.LookupFile(3)
 		require.False(t, ok, "expected no opened files")
 
 		// Verify no error closing again.
@@ -184,7 +184,7 @@ func TestCallContext_Close(t *testing.T) {
 		require.EqualError(t, m.Close(testCtx), "error closing")
 
 		// Verify our intended side-effect
-		_, ok := fsCtx.OpenedFile(3)
+		_, ok := fsCtx.LookupFile(3)
 		require.False(t, ok, "expected no opened files")
 	})
 }
@@ -251,14 +251,14 @@ func TestCallContext_CallDynamic(t *testing.T) {
 
 		// We use side effects to determine if Close in fact called Context.Close (without repeating sys_test.go).
 		// One side effect of Context.Close is that it clears the openedFiles map. Verify our base case.
-		_, ok := fsCtx.OpenedFile(3)
+		_, ok := fsCtx.LookupFile(3)
 		require.True(t, ok, "sysCtx.openedFiles was empty")
 
 		// Closing should not err.
 		require.NoError(t, m.Close(testCtx))
 
 		// Verify our intended side-effect
-		_, ok = fsCtx.OpenedFile(3)
+		_, ok = fsCtx.LookupFile(3)
 		require.False(t, ok, "expected no opened files")
 
 		// Verify no error closing again.
@@ -271,7 +271,8 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		sysCtx := sys.DefaultContext(testFS)
 		fsCtx := sysCtx.FS()
 
-		_, err := fsCtx.OpenFile("/foo", os.O_RDONLY, 0)
+		path := "/foo"
+		_, err := fsCtx.OpenFile(path, os.O_RDONLY, 0)
 		require.NoError(t, err)
 
 		m, err := s.Instantiate(context.Background(), ns, &Module{}, t.Name(), sysCtx)
@@ -280,7 +281,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		require.EqualError(t, m.Close(testCtx), "error closing")
 
 		// Verify our intended side-effect
-		_, ok := fsCtx.OpenedFile(3)
+		_, ok := fsCtx.LookupFile(3)
 		require.False(t, ok, "expected no opened files")
 	})
 }


### PR DESCRIPTION
This consolidates internal code to syscallfs, which removes the fs.FS specific path rules, except when adapting one to syscallfs. For example, this allows the underlying filesystem to decide if relative paths are supported or not, as well any EINVAL related concerns.