### PR TITLE
interpreter: removes unneeded fields from func instances

### DIFF
--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -92,7 +92,7 @@ func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
 // CompiledFunctionPointerValue implements enginetest.EngineTester CompiledFunctionPointerValue.
 func (e engineTester) CompiledFunctionPointerValue(me wasm.ModuleEngine, funcIndex wasm.Index) uint64 {
 	internal := me.(*moduleEngine)
-	return uint64(uintptr(unsafe.Pointer(internal.functions[funcIndex])))
+	return uint64(uintptr(unsafe.Pointer(&internal.functions[funcIndex])))
 }
 
 func TestInterpreter_MemoryGrowInRecursiveCall(t *testing.T) {

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -365,7 +365,7 @@ func TestInterpreter_NonTrappingFloatToIntConversion(t *testing.T) {
 					ce := &callEngine{}
 					f := &function{
 						source: &wasm.FunctionInstance{Module: &wasm.ModuleInstance{Engine: &moduleEngine{}}},
-						body:   body,
+						parent: &code{body: body},
 					}
 					ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
 
@@ -428,11 +428,11 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 				ce := &callEngine{}
 				f := &function{
 					source: &wasm.FunctionInstance{Module: &wasm.ModuleInstance{Engine: &moduleEngine{}}},
-					body: []*interpreterOp{
+					parent: &code{body: []*interpreterOp{
 						{kind: wazeroir.OperationKindConstI32, us: []uint64{uint64(uint32(tc.in))}},
 						{kind: translateToIROperationKind(tc.opcode)},
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
-					},
+					}},
 				}
 				ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
 				require.Equal(t, tc.expected, int32(uint32(ce.popValue())))
@@ -482,11 +482,11 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 				ce := &callEngine{}
 				f := &function{
 					source: &wasm.FunctionInstance{Module: &wasm.ModuleInstance{Engine: &moduleEngine{}}},
-					body: []*interpreterOp{
+					parent: &code{body: []*interpreterOp{
 						{kind: wazeroir.OperationKindConstI64, us: []uint64{uint64(tc.in)}},
 						{kind: translateToIROperationKind(tc.opcode)},
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
-					},
+					}},
 				}
 				ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
 				require.Equal(t, tc.expected, int64(ce.popValue()))


### PR DESCRIPTION
improves instantiation perf:

```
$ benchstat old.txt new.txt
name                                    old time/op    new time/op    delta
Initialization/interpreter-10             34.2µs ± 5%    29.6µs ± 1%  -13.65%  (p=0.000 n=10+8)
Initialization/interpreter-multiple-10    13.7µs ± 3%    12.9µs ± 4%   -6.00%  (p=0.000 n=9+9)

name                                    old alloc/op   new alloc/op   delta
Initialization/interpreter-10              140kB ± 0%     138kB ± 0%   -1.62%  (p=0.000 n=10+10)
Initialization/interpreter-multiple-10     141kB ± 0%     138kB ± 0%   -1.61%  (p=0.000 n=9+9)

name                                    old allocs/op  new allocs/op  delta
Initialization/interpreter-10               93.0 ± 0%      52.0 ± 0%  -44.09%  (p=0.000 n=10+10)
Initialization/interpreter-multiple-10      99.0 ± 0%      58.0 ± 0%  -41.41%  (p=0.000 n=9+9)
```
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>