### PR TITLE
arm64: fixes runtimeValueType for i32.wrap_i64

### DIFF
--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -280,3 +280,15 @@ func newCompilerEnvironment() *compilerEnv {
 func requireRuntimeLocationStackPointerEqual(t *testing.T, expSP uint64, c compiler) {
 	require.Equal(t, expSP, c.runtimeValueLocationStack().sp-callFrameDataSizeInUint64)
 }
+
+// TestCompileI32WrapFromI64 is the regression test for https://github.com/tetratelabs/wazero/issues/1008
+func TestCompileI32WrapFromI64(t *testing.T) {
+	c := newCompiler()
+	// Push the original i64 value.
+	loc := c.runtimeValueLocationStack().pushRuntimeValueLocationOnStack()
+	loc.valueType = runtimeValueTypeI64
+	// Wrap it as the i32, and this should result in having runtimeValueTypeI32 on top of the stack.
+	err := c.compileI32WrapFromI64()
+	require.NoError(t, err)
+	require.Equal(t, runtimeValueTypeI32, loc.valueType)
+}

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -2084,7 +2084,7 @@ func (c *arm64Compiler) compileCopysign(o *wazeroir.OperationCopysign) error {
 
 // compileI32WrapFromI64 implements compiler.compileI32WrapFromI64 for the arm64 architecture.
 func (c *arm64Compiler) compileI32WrapFromI64() error {
-	return c.compileSimpleUnop(arm64.MOVW, runtimeValueTypeI64)
+	return c.compileSimpleUnop(arm64.MOVW, runtimeValueTypeI32)
 }
 
 // compileITruncFromF implements compiler.compileITruncFromF for the arm64 architecture.


### PR DESCRIPTION
Fixes #1008 


```
$ uname -m
arm64
$ go install ./cmd/wazero
$ echo "\q" | wazero run ./internal/integration_test/engine/testdata/qjs.wasm
QuickJS - Type "\h" for help
qjs > \q
```

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>