### PR TITLE
fs: Adds tests to prove we allow fs.FS to create new files

### DIFF
--- a/internal/syscallfs/adapter_test.go
+++ b/internal/syscallfs/adapter_test.go
@@ -19,17 +19,17 @@ func TestAdapt_MkDir(t *testing.T) {
 }
 
 func TestAdapt_Rename(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := Adapt(os.DirFS(rootDir))
+	tmpDir := t.TempDir()
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	file1 := "file1"
-	file1Path := pathutil.Join(rootDir, file1)
+	file1Path := pathutil.Join(tmpDir, file1)
 	file1Contents := []byte{1}
 	err := os.WriteFile(file1Path, file1Contents, 0o600)
 	require.NoError(t, err)
 
 	file2 := "file2"
-	file2Path := pathutil.Join(rootDir, file2)
+	file2Path := pathutil.Join(tmpDir, file2)
 	file2Contents := []byte{2}
 	err = os.WriteFile(file2Path, file2Contents, 0o600)
 	require.NoError(t, err)
@@ -39,11 +39,11 @@ func TestAdapt_Rename(t *testing.T) {
 }
 
 func TestAdapt_Rmdir(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := Adapt(os.DirFS(rootDir))
+	tmpDir := t.TempDir()
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	path := "rmdir"
-	realPath := pathutil.Join(rootDir, path)
+	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.Mkdir(realPath, 0o700))
 
 	err := testFS.Rmdir(path)
@@ -51,11 +51,11 @@ func TestAdapt_Rmdir(t *testing.T) {
 }
 
 func TestAdapt_Unlink(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := Adapt(os.DirFS(rootDir))
+	tmpDir := t.TempDir()
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	path := "unlink"
-	realPath := pathutil.Join(rootDir, path)
+	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Unlink(path)
@@ -63,11 +63,11 @@ func TestAdapt_Unlink(t *testing.T) {
 }
 
 func TestAdapt_Utimes(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := Adapt(os.DirFS(rootDir))
+	tmpDir := t.TempDir()
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	path := "utimes"
-	realPath := pathutil.Join(rootDir, path)
+	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Utimes(path, 1, 1)
@@ -76,12 +76,12 @@ func TestAdapt_Utimes(t *testing.T) {
 
 func TestAdapt_Open_Read(t *testing.T) {
 	// Create a subdirectory, so we can test reads outside the FS root.
-	rootDir := t.TempDir()
-	rootDir = pathutil.Join(rootDir, t.Name())
-	require.NoError(t, os.Mkdir(rootDir, 0o700))
-	testFS := Adapt(os.DirFS(rootDir))
+	tmpDir := t.TempDir()
+	tmpDir = pathutil.Join(tmpDir, t.Name())
+	require.NoError(t, os.Mkdir(tmpDir, 0o700))
+	testFS := Adapt(os.DirFS(tmpDir))
 
-	testOpen_Read(t, rootDir, testFS)
+	testOpen_Read(t, tmpDir, testFS)
 
 	t.Run("path outside root invalid", func(t *testing.T) {
 		_, err := testFS.OpenFile("../foo", os.O_RDONLY, 0)
@@ -112,8 +112,8 @@ func (dir hackFS) Open(name string) (fs.File, error) {
 // TestAdapt_HackedWrites ensures we allow writes even if they violate the
 // fs.FS contract.
 func TestAdapt_HackedWrites(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := Adapt(hackFS(rootDir))
+	tmpDir := t.TempDir()
+	testFS := Adapt(hackFS(tmpDir))
 
-	testOpen_O_RDWR(t, rootDir, testFS)
+	testOpen_O_RDWR(t, tmpDir, testFS)
 }

--- a/internal/syscallfs/dirfs.go
+++ b/internal/syscallfs/dirfs.go
@@ -4,17 +4,28 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"syscall"
 )
 
 func NewDirFS(dir string) (FS, error) {
+	if dir == "" {
+		panic("empty dir")
+	}
+	// For easier OS-specific concatenation later, append the path separator.
+	dir = ensureTrailingPathSeparator(dir)
 	if stat, err := os.Stat(dir); err != nil {
 		return nil, syscall.ENOENT
 	} else if !stat.IsDir() {
 		return nil, syscall.ENOTDIR
 	}
 	return dirFS(dir), nil
+}
+
+func ensureTrailingPathSeparator(dir string) string {
+	if dir[len(dir)-1] != os.PathSeparator {
+		return dir + string(os.PathSeparator)
+	}
+	return dir
 }
 
 // dirFS currently validates each path, which means that input paths cannot
@@ -34,20 +45,16 @@ func (dir dirFS) Path() string {
 
 // OpenFile implements FS.OpenFile
 func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
-	f, err := os.OpenFile(path.Join(string(dir), name), flag, perm)
+	f, err := os.OpenFile(dir.join(name), flag, perm)
 	if err != nil {
 		return nil, err
 	}
-
-	if flag == 0 || flag == os.O_RDONLY {
-		return maskForReads(f), nil
-	}
-	return f, nil
+	return maybeWrapFile(f), nil
 }
 
 // Mkdir implements FS.Mkdir
 func (dir dirFS) Mkdir(name string, perm fs.FileMode) error {
-	err := os.Mkdir(path.Join(string(dir), name), perm)
+	err := os.Mkdir(dir.join(name), perm)
 	return adjustMkdirError(err)
 }
 
@@ -56,25 +63,31 @@ func (dir dirFS) Rename(from, to string) error {
 	if from == to {
 		return nil
 	}
-	return rename(path.Join(string(dir), from), path.Join(string(dir), to))
+	return rename(dir.join(from), dir.join(to))
 }
 
 // Rmdir implements FS.Rmdir
 func (dir dirFS) Rmdir(name string) error {
-	err := syscall.Rmdir(path.Join(string(dir), name))
+	err := syscall.Rmdir(dir.join(name))
 	return adjustRmdirError(err)
 }
 
 // Unlink implements FS.Unlink
 func (dir dirFS) Unlink(name string) error {
-	err := syscall.Unlink(path.Join(string(dir), name))
+	err := syscall.Unlink(dir.join(name))
 	return adjustUnlinkError(err)
 }
 
 // Utimes implements FS.Utimes
 func (dir dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
-	return syscall.UtimesNano(path.Join(string(dir), name), []syscall.Timespec{
+	return syscall.UtimesNano(dir.join(name), []syscall.Timespec{
 		syscall.NsecToTimespec(atimeNsec),
 		syscall.NsecToTimespec(mtimeNsec),
 	})
+}
+
+func (dir dirFS) join(name string) string {
+	// TODO: Enforce similar to safefilepath.FromFS(name), but be careful as
+	// relative path inputs are allowed. e.g. dir or name == ../
+	return string(dir) + name
 }

--- a/internal/syscallfs/dirfs_test.go
+++ b/internal/syscallfs/dirfs_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestDirFS_MkDir(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS, err := NewDirFS(rootDir)
+	tmpDir := t.TempDir()
+	testFS, err := NewDirFS(tmpDir)
 	require.NoError(t, err)
 
 	name := "mkdir"
-	realPath := pathutil.Join(rootDir, name)
+	realPath := pathutil.Join(tmpDir, name)
 
 	t.Run("doesn't exist", func(t *testing.T) {
 		require.NoError(t, testFS.Mkdir(name, fs.ModeDir))
@@ -44,12 +44,12 @@ func TestDirFS_MkDir(t *testing.T) {
 
 func TestDirFS_Rename(t *testing.T) {
 	t.Run("from doesn't exist", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		file1 := "file1"
-		file1Path := pathutil.Join(rootDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		err = os.WriteFile(file1Path, []byte{1}, 0o600)
 		require.NoError(t, err)
 
@@ -57,18 +57,18 @@ func TestDirFS_Rename(t *testing.T) {
 		require.Equal(t, syscall.ENOENT, err)
 	})
 	t.Run("file to non-exist", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		file1 := "file1"
-		file1Path := pathutil.Join(rootDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err = os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		file2 := "file2"
-		file2Path := pathutil.Join(rootDir, file2)
+		file2Path := pathutil.Join(tmpDir, file2)
 		err = testFS.Rename(file1, file2)
 		require.NoError(t, err)
 
@@ -81,16 +81,16 @@ func TestDirFS_Rename(t *testing.T) {
 		require.False(t, s.IsDir())
 	})
 	t.Run("dir to non-exist", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
-		dir1Path := pathutil.Join(rootDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		dir2 := "dir2"
-		dir2Path := pathutil.Join(rootDir, dir2)
+		dir2Path := pathutil.Join(tmpDir, dir2)
 		err = testFS.Rename(dir1, dir2)
 		require.NoError(t, err)
 
@@ -103,16 +103,16 @@ func TestDirFS_Rename(t *testing.T) {
 		require.True(t, s.IsDir())
 	})
 	t.Run("dir to file", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
-		dir1Path := pathutil.Join(rootDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		dir2 := "dir2"
-		dir2Path := pathutil.Join(rootDir, dir2)
+		dir2Path := pathutil.Join(tmpDir, dir2)
 
 		// write a file to that path
 		err = os.WriteFile(dir2Path, []byte{2}, 0o600)
@@ -131,30 +131,30 @@ func TestDirFS_Rename(t *testing.T) {
 		}
 	})
 	t.Run("file to dir", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		file1 := "file1"
-		file1Path := pathutil.Join(rootDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err = os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
-		dir1Path := pathutil.Join(rootDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		err = testFS.Rename(file1, dir1)
 		require.Equal(t, syscall.EISDIR, err)
 	})
 	t.Run("dir to dir", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
-		dir1Path := pathutil.Join(rootDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		// add a file to that directory
@@ -165,7 +165,7 @@ func TestDirFS_Rename(t *testing.T) {
 		require.NoError(t, err)
 
 		dir2 := "dir2"
-		dir2Path := pathutil.Join(rootDir, dir2)
+		dir2Path := pathutil.Join(tmpDir, dir2)
 		require.NoError(t, os.Mkdir(dir2Path, 0o700))
 
 		err = testFS.Rename(dir1, dir2)
@@ -186,18 +186,18 @@ func TestDirFS_Rename(t *testing.T) {
 		require.False(t, s.IsDir())
 	})
 	t.Run("file to file", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		file1 := "file1"
-		file1Path := pathutil.Join(rootDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err = os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		file2 := "file2"
-		file2Path := pathutil.Join(rootDir, file2)
+		file2Path := pathutil.Join(tmpDir, file2)
 		file2Contents := []byte{2}
 		err = os.WriteFile(file2Path, file2Contents, 0o600)
 		require.NoError(t, err)
@@ -215,12 +215,12 @@ func TestDirFS_Rename(t *testing.T) {
 		require.Equal(t, file1Contents, b)
 	})
 	t.Run("dir to itself", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
-		dir1Path := pathutil.Join(rootDir, dir1)
+		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		err = testFS.Rename(dir1, dir1)
@@ -231,12 +231,12 @@ func TestDirFS_Rename(t *testing.T) {
 		require.True(t, s.IsDir())
 	})
 	t.Run("file to itself", func(t *testing.T) {
-		rootDir := t.TempDir()
-		testFS, err := NewDirFS(rootDir)
+		tmpDir := t.TempDir()
+		testFS, err := NewDirFS(tmpDir)
 		require.NoError(t, err)
 
 		file1 := "file1"
-		file1Path := pathutil.Join(rootDir, file1)
+		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
 		err = os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
@@ -251,13 +251,13 @@ func TestDirFS_Rename(t *testing.T) {
 }
 
 func TestDirFS_Rmdir(t *testing.T) {
-	rootDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-	testFS, err := NewDirFS(rootDir)
+	testFS, err := NewDirFS(tmpDir)
 	require.NoError(t, err)
 
 	name := "rmdir"
-	realPath := pathutil.Join(rootDir, name)
+	realPath := pathutil.Join(tmpDir, name)
 
 	t.Run("doesn't exist", func(t *testing.T) {
 		err := testFS.Rmdir(name)
@@ -292,13 +292,13 @@ func TestDirFS_Rmdir(t *testing.T) {
 }
 
 func TestDirFS_Unlink(t *testing.T) {
-	rootDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-	testFS, err := NewDirFS(rootDir)
+	testFS, err := NewDirFS(tmpDir)
 	require.NoError(t, err)
 
 	name := "unlink"
-	realPath := pathutil.Join(rootDir, name)
+	realPath := pathutil.Join(tmpDir, name)
 
 	t.Run("doesn't exist", func(t *testing.T) {
 		err := testFS.Unlink(name)
@@ -324,27 +324,27 @@ func TestDirFS_Unlink(t *testing.T) {
 }
 
 func TestDirFS_Utimes(t *testing.T) {
-	rootDir := t.TempDir()
+	tmpDir := t.TempDir()
 
-	testFS, err := NewDirFS(rootDir)
+	testFS, err := NewDirFS(tmpDir)
 	require.NoError(t, err)
 
-	testUtimes(t, rootDir, testFS)
+	testUtimes(t, tmpDir, testFS)
 }
 
 func TestDirFS_Open(t *testing.T) {
-	rootDir := t.TempDir()
+	tmpDir := t.TempDir()
 
 	// Create a subdirectory, so we can test reads outside the FS root.
-	rootDir = pathutil.Join(rootDir, t.Name())
-	require.NoError(t, os.Mkdir(rootDir, 0o700))
+	tmpDir = pathutil.Join(tmpDir, t.Name())
+	require.NoError(t, os.Mkdir(tmpDir, 0o700))
 
-	testFS, err := NewDirFS(rootDir)
+	testFS, err := NewDirFS(tmpDir)
 	require.NoError(t, err)
 
-	testOpen_Read(t, rootDir, testFS)
+	testOpen_Read(t, tmpDir, testFS)
 
-	testOpen_O_RDWR(t, rootDir, testFS)
+	testOpen_O_RDWR(t, tmpDir, testFS)
 
 	t.Run("path outside root valid", func(t *testing.T) {
 		_, err := testFS.OpenFile("../foo", os.O_RDONLY, 0)

--- a/internal/syscallfs/readfs.go
+++ b/internal/syscallfs/readfs.go
@@ -2,11 +2,16 @@ package syscallfs
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"syscall"
 )
 
+// NewReadFS is used to mask an existing FS for reads. Notably, this allows
+// the CLI to do read-only mounts of directories the host user can write, but
+// doesn't want the guest wasm to. For example, Python libraries shouldn't be
+// written to at runtime by the python wasm file.
 func NewReadFS(fs FS) FS {
 	if _, ok := fs.(*readFS); ok {
 		return fs
@@ -28,10 +33,70 @@ func (r *readFS) Path() string {
 
 // OpenFile implements FS.OpenFile
 func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
-	if flag == 0 || flag == os.O_RDONLY {
-		return r.fs.OpenFile(path, flag, perm)
+	if flag != 0 && flag != os.O_RDONLY {
+		return nil, syscall.ENOSYS
 	}
-	return nil, syscall.ENOSYS
+
+	f, err := r.fs.OpenFile(path, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return maskForReads(f), nil
+}
+
+// maskForReads masks the file with read-only interfaces used by wazero.
+//
+// This technique was adapted from similar code in zipkin-go.
+func maskForReads(f fs.File) fs.File {
+	// The below are the types wazero casts into.
+	// Note: os.File implements this even for normal files.
+	d, i0 := f.(fs.ReadDirFile)
+	ra, i1 := f.(io.ReaderAt)
+	s, i2 := f.(io.Seeker)
+
+	// Wrap any combination of the types above.
+	switch {
+	case !i0 && !i1 && !i2: // 0, 0, 0
+		return struct{ fs.File }{f}
+	case !i0 && !i1 && i2: // 0, 0, 1
+		return struct {
+			fs.File
+			io.Seeker
+		}{f, s}
+	case !i0 && i1 && !i2: // 0, 1, 0
+		return struct {
+			fs.File
+			io.ReaderAt
+		}{f, ra}
+	case !i0 && i1 && i2: // 0, 1, 1
+		return struct {
+			fs.File
+			io.ReaderAt
+			io.Seeker
+		}{f, ra, s}
+	case i0 && !i1 && !i2: // 1, 0, 0
+		return struct {
+			fs.ReadDirFile
+		}{d}
+	case i0 && !i1 && i2: // 1, 0, 1
+		return struct {
+			fs.ReadDirFile
+			io.Seeker
+		}{d, s}
+	case i0 && i1 && !i2: // 1, 1, 0
+		return struct {
+			fs.ReadDirFile
+			io.ReaderAt
+		}{d, ra}
+	case i0 && i1 && i2: // 1, 1, 1
+		return struct {
+			fs.ReadDirFile
+			io.ReaderAt
+			io.Seeker
+		}{d, ra, s}
+	default:
+		panic("BUG: unhandled pattern")
+	}
 }
 
 // Mkdir implements FS.Mkdir

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -11,25 +11,25 @@ import (
 )
 
 func TestReadFS_MkDir(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := NewReadFS(Adapt(hackFS(rootDir)))
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(tmpDir)))
 
 	err := testFS.Mkdir("mkdir", fs.ModeDir)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Rename(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := NewReadFS(Adapt(hackFS(rootDir)))
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(tmpDir)))
 
 	file1 := "file1"
-	file1Path := pathutil.Join(rootDir, file1)
+	file1Path := pathutil.Join(tmpDir, file1)
 	file1Contents := []byte{1}
 	err := os.WriteFile(file1Path, file1Contents, 0o600)
 	require.NoError(t, err)
 
 	file2 := "file2"
-	file2Path := pathutil.Join(rootDir, file2)
+	file2Path := pathutil.Join(tmpDir, file2)
 	file2Contents := []byte{2}
 	err = os.WriteFile(file2Path, file2Contents, 0o600)
 	require.NoError(t, err)
@@ -39,11 +39,11 @@ func TestReadFS_Rename(t *testing.T) {
 }
 
 func TestReadFS_Rmdir(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := NewReadFS(Adapt(hackFS(rootDir)))
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(tmpDir)))
 
 	path := "rmdir"
-	realPath := pathutil.Join(rootDir, path)
+	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.Mkdir(realPath, 0o700))
 
 	err := testFS.Rmdir(path)
@@ -51,11 +51,11 @@ func TestReadFS_Rmdir(t *testing.T) {
 }
 
 func TestReadFS_Unlink(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := NewReadFS(Adapt(hackFS(rootDir)))
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(tmpDir)))
 
 	path := "unlink"
-	realPath := pathutil.Join(rootDir, path)
+	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Unlink(path)
@@ -63,11 +63,11 @@ func TestReadFS_Unlink(t *testing.T) {
 }
 
 func TestReadFS_Utimes(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := NewReadFS(Adapt(hackFS(rootDir)))
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(tmpDir)))
 
 	path := "utimes"
-	realPath := pathutil.Join(rootDir, path)
+	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Utimes(path, 1, 1)
@@ -75,8 +75,8 @@ func TestReadFS_Utimes(t *testing.T) {
 }
 
 func TestReadFS_Open_Read(t *testing.T) {
-	rootDir := t.TempDir()
-	testFS := NewReadFS(Adapt(hackFS(rootDir)))
+	tmpDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(tmpDir)))
 
-	testOpen_Read(t, rootDir, testFS)
+	testOpen_Read(t, tmpDir, testFS)
 }

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -11,26 +11,25 @@ import (
 )
 
 func TestReadFS_MkDir(t *testing.T) {
-	dir := t.TempDir()
-
-	testFS := NewReadFS(dirFS(dir))
+	rootDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(rootDir)))
 
 	err := testFS.Mkdir("mkdir", fs.ModeDir)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Rename(t *testing.T) {
-	tmpDir := t.TempDir()
-	testFS := NewReadFS(dirFS(tmpDir))
+	rootDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(rootDir)))
 
 	file1 := "file1"
-	file1Path := pathutil.Join(tmpDir, file1)
+	file1Path := pathutil.Join(rootDir, file1)
 	file1Contents := []byte{1}
 	err := os.WriteFile(file1Path, file1Contents, 0o600)
 	require.NoError(t, err)
 
 	file2 := "file2"
-	file2Path := pathutil.Join(tmpDir, file2)
+	file2Path := pathutil.Join(rootDir, file2)
 	file2Contents := []byte{2}
 	err = os.WriteFile(file2Path, file2Contents, 0o600)
 	require.NoError(t, err)
@@ -40,12 +39,11 @@ func TestReadFS_Rename(t *testing.T) {
 }
 
 func TestReadFS_Rmdir(t *testing.T) {
-	dir := t.TempDir()
-
-	testFS := NewReadFS(dirFS(dir))
+	rootDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(rootDir)))
 
 	path := "rmdir"
-	realPath := pathutil.Join(dir, path)
+	realPath := pathutil.Join(rootDir, path)
 	require.NoError(t, os.Mkdir(realPath, 0o700))
 
 	err := testFS.Rmdir(path)
@@ -53,12 +51,11 @@ func TestReadFS_Rmdir(t *testing.T) {
 }
 
 func TestReadFS_Unlink(t *testing.T) {
-	dir := t.TempDir()
-
-	testFS := NewReadFS(dirFS(dir))
+	rootDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(rootDir)))
 
 	path := "unlink"
-	realPath := pathutil.Join(dir, path)
+	realPath := pathutil.Join(rootDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Unlink(path)
@@ -66,12 +63,11 @@ func TestReadFS_Unlink(t *testing.T) {
 }
 
 func TestReadFS_Utimes(t *testing.T) {
-	dir := t.TempDir()
-
-	testFS := NewReadFS(dirFS(dir))
+	rootDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(rootDir)))
 
 	path := "utimes"
-	realPath := pathutil.Join(dir, path)
+	realPath := pathutil.Join(rootDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Utimes(path, 1, 1)
@@ -79,9 +75,8 @@ func TestReadFS_Utimes(t *testing.T) {
 }
 
 func TestReadFS_Open_Read(t *testing.T) {
-	tmpDir := t.TempDir()
+	rootDir := t.TempDir()
+	testFS := NewReadFS(Adapt(hackFS(rootDir)))
 
-	testFS := NewReadFS(dirFS(tmpDir))
-
-	testFS_Open_Read(t, tmpDir, testFS)
+	testOpen_Read(t, rootDir, testFS)
 }

--- a/internal/syscallfs/syscall.go
+++ b/internal/syscallfs/syscall.go
@@ -22,3 +22,7 @@ func adjustUnlinkError(err error) error {
 func rename(old, new string) error {
 	return syscall.Rename(old, new)
 }
+
+func maybeWrapFile(f file) file {
+	return f
+}

--- a/internal/syscallfs/syscall_windows.go
+++ b/internal/syscallfs/syscall_windows.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 )
 
+// See https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
 const (
 	// ERROR_ACCESS_DENIED is a Windows error returned by syscall.Unlink
 	// instead of syscall.EPERM

--- a/internal/syscallfs/syscall_windows.go
+++ b/internal/syscallfs/syscall_windows.go
@@ -2,6 +2,7 @@ package syscallfs
 
 import (
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"syscall"
@@ -11,6 +12,10 @@ const (
 	// ERROR_ACCESS_DENIED is a Windows error returned by syscall.Unlink
 	// instead of syscall.EPERM
 	ERROR_ACCESS_DENIED = syscall.Errno(5)
+
+	// ERROR_INVALID_HANDLE is a Windows error returned by syscall.Write
+	// instead of syscall.EBADF
+	ERROR_INVALID_HANDLE = syscall.Errno(6)
 
 	// ERROR_ALREADY_EXISTS is a Windows error returned by os.Mkdir
 	// instead of syscall.EEXIST
@@ -68,12 +73,51 @@ func rename(old, new string) (err error) {
 		}
 
 		if oldIsDir && newIsDir {
-			// Windows doesn't let you overwrite a directory
+			// Windows doesn't let you overwrite a directory. If we aim to
+			// allow this, we'll have to delete here and retry.
 			return syscall.EINVAL
 		} else if newIsDir {
 			err = syscall.EISDIR
 		} else { // use a mappable code
 			err = syscall.EPERM
+		}
+	}
+	return
+}
+
+// maybeWrapFile deals with errno portability issues in Windows. This code is
+// likely to change as we complete syscall support needed for WASI and GOOS=js.
+//
+// If we don't map to syscall.Errno, wasm will crash in odd way attempting the
+// same. This approach is an alternative to making our own fs.File public type.
+// We aren't doing that yet, as mapping problems are generally contained to
+// Windows. Hence, file is intentionally not exported.
+func maybeWrapFile(f file) file {
+	return struct {
+		readFile
+		io.Writer
+	}{f, &windowsWriter{f}}
+}
+
+// windowsWriter translates error codes not mapped properly by Go.
+type windowsWriter struct {
+	w io.Writer
+}
+
+// Write implements io.Writer
+func (w windowsWriter) Write(p []byte) (n int, err error) {
+	n, err = w.w.Write(p)
+	if err == nil {
+		return
+	}
+
+	// os.File.Wrap wraps the syscall error in a path error
+	if pe, ok := err.(*fs.PathError); ok {
+		switch pe.Err {
+		case ERROR_INVALID_HANDLE:
+			pe.Err = syscall.EBADF
+		case ERROR_ACCESS_DENIED:
+			pe.Err = syscall.EPERM
 		}
 	}
 	return

--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func testOpen_O_RDWR(t *testing.T, rootDir string, testFS FS) {
+func testOpen_O_RDWR(t *testing.T, tmpDir string, testFS FS) {
 	file := "file"
-	realPath := path.Join(rootDir, file)
+	realPath := path.Join(tmpDir, file)
 	err := os.WriteFile(realPath, []byte{}, 0o600)
 	require.NoError(t, err)
 
@@ -40,14 +40,14 @@ func testOpen_O_RDWR(t *testing.T, rootDir string, testFS FS) {
 	require.Equal(t, fileContents, b)
 }
 
-func testOpen_Read(t *testing.T, rootDir string, testFS FS) {
+func testOpen_Read(t *testing.T, tmpDir string, testFS FS) {
 	file := "file"
 	fileContents := []byte{1, 2, 3, 4}
-	err := os.WriteFile(path.Join(rootDir, file), fileContents, 0o700)
+	err := os.WriteFile(path.Join(tmpDir, file), fileContents, 0o700)
 	require.NoError(t, err)
 
 	dir := "dir"
-	dirRealPath := path.Join(rootDir, dir)
+	dirRealPath := path.Join(tmpDir, dir)
 	err = os.Mkdir(dirRealPath, 0o700)
 	require.NoError(t, err)
 
@@ -118,13 +118,13 @@ func testOpen_Read(t *testing.T, rootDir string, testFS FS) {
 	})
 }
 
-func testUtimes(t *testing.T, rootDir string, testFS FS) {
+func testUtimes(t *testing.T, tmpDir string, testFS FS) {
 	file := "file"
-	err := os.WriteFile(path.Join(rootDir, file), []byte{}, 0o700)
+	err := os.WriteFile(path.Join(tmpDir, file), []byte{}, 0o700)
 	require.NoError(t, err)
 
 	dir := "dir"
-	err = os.Mkdir(path.Join(rootDir, dir), 0o700)
+	err = os.Mkdir(path.Join(tmpDir, dir), 0o700)
 	require.NoError(t, err)
 
 	t.Run("doesn't exist", func(t *testing.T) {
@@ -183,7 +183,7 @@ func testUtimes(t *testing.T, rootDir string, testFS FS) {
 			err := testFS.Utimes(tc.path, tc.atimeNsec, tc.mtimeNsec)
 			require.NoError(t, err)
 
-			stat, err := os.Stat(path.Join(rootDir, tc.path))
+			stat, err := os.Stat(path.Join(tmpDir, tc.path))
 			require.NoError(t, err)
 
 			atimeNsec, mtimeNsec, _ := platform.StatTimes(stat)

--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -15,14 +15,39 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
+func testOpen_O_RDWR(t *testing.T, rootDir string, testFS FS) {
+	file := "file"
+	realPath := path.Join(rootDir, file)
+	err := os.WriteFile(realPath, []byte{}, 0o600)
+	require.NoError(t, err)
+
+	f, err := testFS.OpenFile(file, os.O_RDWR, 0)
+	require.NoError(t, err)
+	defer f.Close()
+
+	w, ok := f.(io.Writer)
+	require.True(t, ok)
+
+	// If the write flag was honored, we should be able to write!
+	fileContents := []byte{1, 2, 3, 4}
+	n, err := w.Write(fileContents)
+	require.NoError(t, err)
+	require.Equal(t, len(fileContents), n)
+
+	// Verify the contents actually wrote.
+	b, err := os.ReadFile(realPath)
+	require.NoError(t, err)
+	require.Equal(t, fileContents, b)
+}
+
+func testOpen_Read(t *testing.T, rootDir string, testFS FS) {
 	file := "file"
 	fileContents := []byte{1, 2, 3, 4}
-	err := os.WriteFile(path.Join(tmpDir, file), fileContents, 0o700)
+	err := os.WriteFile(path.Join(rootDir, file), fileContents, 0o700)
 	require.NoError(t, err)
 
 	dir := "dir"
-	dirRealPath := path.Join(tmpDir, dir)
+	dirRealPath := path.Join(rootDir, dir)
 	err = os.Mkdir(dirRealPath, 0o700)
 	require.NoError(t, err)
 
@@ -34,7 +59,7 @@ func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
 		_, err := testFS.OpenFile("nope", os.O_RDONLY, 0)
 
 		// We currently follow os.Open not syscall.Open, so the error is wrapped.
-		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
+		requireErrno(t, syscall.ENOENT, err)
 	})
 
 	t.Run("dir exists", func(t *testing.T) {
@@ -51,9 +76,10 @@ func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
 		require.False(t, e[0].IsDir())
 		require.Equal(t, file1, e[0].Name())
 
-		// Ensure it doesn't implement io.Writer
-		_, ok = f.(io.Writer)
-		require.False(t, ok)
+		if w, ok := f.(io.Writer); ok {
+			_, err := w.Write([]byte("hello"))
+			requireErrno(t, syscall.EBADF, err)
+		}
 	})
 
 	t.Run("file exists", func(t *testing.T) {
@@ -81,19 +107,24 @@ func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
 		require.NoError(t, err)
 		require.Equal(t, fileContents[1:], b)
 
-		// Ensure it doesn't implement io.Writer
-		_, ok = f.(io.Writer)
-		require.False(t, ok)
+		if w, ok := f.(io.Writer); ok {
+			_, err := w.Write([]byte("hello"))
+			if runtime.GOOS == "windows" {
+				requireErrno(t, syscall.EPERM, err)
+			} else {
+				requireErrno(t, syscall.EBADF, err)
+			}
+		}
 	})
 }
 
-func testFS_Utimes(t *testing.T, tmpDir string, testFS FS) {
+func testUtimes(t *testing.T, rootDir string, testFS FS) {
 	file := "file"
-	err := os.WriteFile(path.Join(tmpDir, file), []byte{}, 0o700)
+	err := os.WriteFile(path.Join(rootDir, file), []byte{}, 0o700)
 	require.NoError(t, err)
 
 	dir := "dir"
-	err = os.Mkdir(path.Join(tmpDir, dir), 0o700)
+	err = os.Mkdir(path.Join(rootDir, dir), 0o700)
 	require.NoError(t, err)
 
 	t.Run("doesn't exist", func(t *testing.T) {
@@ -152,7 +183,7 @@ func testFS_Utimes(t *testing.T, tmpDir string, testFS FS) {
 			err := testFS.Utimes(tc.path, tc.atimeNsec, tc.mtimeNsec)
 			require.NoError(t, err)
 
-			stat, err := os.Stat(path.Join(tmpDir, tc.path))
+			stat, err := os.Stat(path.Join(rootDir, tc.path))
 			require.NoError(t, err)
 
 			atimeNsec, mtimeNsec, _ := platform.StatTimes(stat)
@@ -162,4 +193,10 @@ func testFS_Utimes(t *testing.T, tmpDir string, testFS FS) {
 			require.Equal(t, mtimeNsec, tc.mtimeNsec)
 		})
 	}
+}
+
+// requireErrno should only be used for functions that wrap the underlying
+// syscall.Errno.
+func requireErrno(t *testing.T, expected syscall.Errno, actual error) {
+	require.True(t, errors.Is(actual, expected), "expected %v, but was %v", expected, actual)
 }


### PR DESCRIPTION
This ensures those who cannot use `writefs.DirFS` can use a `fs.FS` implementation that creates or opens files as read/write. This does so by making a hacked fs.FS and testing it.

```go
type hackFS string

func (dir hackFS) Open(name string) (fs.File, error) {
	path := ensureTrailingPathSeparator(string(dir)) + name

	if f, err := os.OpenFile(path, os.O_RDWR, 0); err == nil {
		return f, nil
	} else if errors.Is(err, syscall.EISDIR) {
		return os.OpenFile(path, os.O_RDONLY, 0)
	} else {
		return nil, err
	}
}
```

This also removes type filtering to ensure hacked filesystems aren't accidentally masked. Instead we get more specific on error codes returned by functions such as `os.File.Write`.

---

Note: This is meant to extend the life of fs.FS for custom implementations, though we expect eventually to have our own API. However, such an API will remain internal until at least the end of the month due to a lot of prerequisite work. See #1013 cc @wjam