### PR TITLE
fs: fixes timebomb on or'd flags with O_RDONLY

### DIFF
--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -116,6 +116,17 @@ func testOpen_Read(t *testing.T, tmpDir string, testFS FS) {
 			}
 		}
 	})
+
+	// Make sure O_RDONLY isn't treated bitwise as it is usually zero.
+	t.Run("or'd flag", func(t *testing.T) {
+		// Example of a flag that can be or'd into O_RDONLY even if not
+		// currently supported in WASI or GOOS=js
+		const O_NOATIME = 0x40000
+
+		f, err := testFS.OpenFile(file, os.O_RDONLY|O_NOATIME, 0)
+		require.NoError(t, err)
+		defer f.Close()
+	})
 }
 
 func testUtimes(t *testing.T, tmpDir string, testFS FS) {


### PR DESCRIPTION
@achille-roussel mentioned on chat that we have an accident waiting to happen. This fixes it and backfills the missing test.
