### PR TITLE
fs: fixes windows fstest.FS and consolidates more

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -7,9 +7,9 @@ import (
 	"io/fs"
 	"math"
 	"testing"
-	"testing/fstest"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/fstest"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	testfs "github.com/tetratelabs/wazero/internal/testing/fs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -553,7 +553,7 @@ func TestModuleConfig_clone(t *testing.T) {
 	cloned := mc.clone()
 
 	// Make post-clone changes
-	mc.fs = fstest.MapFS{}
+	mc.fs = fstest.FS
 	mc.environKeys["2"] = 2
 
 	cloned.environKeys["1"] = 1

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/syscallfs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
 )
@@ -48,12 +49,13 @@ func Test_fdReaddir_ls(t *testing.T) {
 }
 
 func testFdReaddirLs(t *testing.T, bin []byte) {
+	// TODO: make a subfs
 	moduleConfig := wazero.NewModuleConfig().
-		WithFS(fstest.MapFS{
+		WithFS(syscallfs.Adapt(fstest.MapFS{
 			"-":   {},
 			"a-":  {Mode: fs.ModeDir},
 			"ab-": {},
-		})
+		}))
 
 	t.Run("empty directory", func(t *testing.T) {
 		console := compileAndRun(t, moduleConfig.WithArgs("wasi", "ls", "./a-"), bin)
@@ -85,7 +87,7 @@ ENOTDIR
 		for i := 0; i < count; i++ {
 			testFS[strconv.Itoa(i)] = &fstest.MapFile{}
 		}
-		config := wazero.NewModuleConfig().WithFS(testFS).WithArgs("wasi", "ls", ".")
+		config := wazero.NewModuleConfig().WithFS(syscallfs.Adapt(testFS)).WithArgs("wasi", "ls", ".")
 		console := compileAndRun(t, config, bin)
 
 		lines := strings.Split(console, "\n")
@@ -110,7 +112,7 @@ func Test_fdReaddir_stat(t *testing.T) {
 func testFdReaddirStat(t *testing.T, bin []byte) {
 	moduleConfig := wazero.NewModuleConfig().WithArgs("wasi", "stat")
 
-	console := compileAndRun(t, moduleConfig.WithFS(fstest.MapFS{}), bin)
+	console := compileAndRun(t, moduleConfig.WithFS(syscallfs.Adapt(fstest.MapFS{})), bin)
 
 	// TODO: switch this to a real stat test
 	require.Equal(t, `

--- a/internal/fstest/fstest.go
+++ b/internal/fstest/fstest.go
@@ -65,7 +65,7 @@ human
 }
 
 // FS includes all test files.
-var FS = func() fs.ReadDirFS {
+var FS = func() fstest.MapFS {
 	testFS := make(fstest.MapFS, len(files))
 	for _, nf := range files {
 		testFS[nf.name] = nf.file

--- a/internal/syscallfs/dirfs.go
+++ b/internal/syscallfs/dirfs.go
@@ -87,6 +87,9 @@ func (dir dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
 }
 
 func (dir dirFS) join(name string) string {
+	if name == "." {
+		return string(dir)
+	}
 	// TODO: Enforce similar to safefilepath.FromFS(name), but be careful as
 	// relative path inputs are allowed. e.g. dir or name == ../
 	return string(dir) + name

--- a/internal/syscallfs/dirfs_test.go
+++ b/internal/syscallfs/dirfs_test.go
@@ -356,10 +356,6 @@ func TestDirFS_Open(t *testing.T) {
 }
 
 func TestDirFS_TestFS(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO: windows")
-	}
-
 	t.Parallel()
 
 	// Set up the test files

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -4,7 +4,6 @@ import (
 	"io/fs"
 	"os"
 	pathutil "path"
-	"runtime"
 	"syscall"
 	"testing"
 
@@ -84,10 +83,6 @@ func TestReadFS_Open_Read(t *testing.T) {
 }
 
 func TestReadFS_TestFS(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO: windows")
-	}
-
 	t.Parallel()
 
 	// Set up the test files

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -138,7 +138,7 @@ func (i logFilestat) Log(_ context.Context, mod api.Module, w logging.Writer, pa
 		w.WriteString(",size=")              //nolint
 		writeI64(w, le.Uint64(buf[32:]))
 		w.WriteString(",mtim=") //nolint
-		writeI64(w, le.Uint64(buf[40:]))
+		writeU64(w, le.Uint64(buf[40:]))
 		w.WriteString("}") //nolint
 	}
 }
@@ -242,4 +242,8 @@ func writeI32(w logging.Writer, v uint32) {
 
 func writeI64(w logging.Writer, v uint64) {
 	w.WriteString(strconv.FormatInt(int64(v), 10)) //nolint
+}
+
+func writeU64(w logging.Writer, v uint64) {
+	w.WriteString(strconv.FormatUint(v, 10)) //nolint
 }

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -138,7 +138,7 @@ func (i logFilestat) Log(_ context.Context, mod api.Module, w logging.Writer, pa
 		w.WriteString(",size=")              //nolint
 		writeI64(w, le.Uint64(buf[32:]))
 		w.WriteString(",mtim=") //nolint
-		writeU64(w, le.Uint64(buf[40:]))
+		writeI64(w, le.Uint64(buf[40:]))
 		w.WriteString("}") //nolint
 	}
 }
@@ -242,8 +242,4 @@ func writeI32(w logging.Writer, v uint32) {
 
 func writeI64(w logging.Writer, v uint64) {
 	w.WriteString(strconv.FormatInt(int64(v), 10)) //nolint
-}
-
-func writeU64(w logging.Writer, v uint64) {
-	w.WriteString(strconv.FormatUint(v, 10)) //nolint
 }


### PR DESCRIPTION
This works around a known glitch in windows where directory entry stat doesn't match its corresponding file stat (namely times don't). It consolidates more test files, in the process, to ensure we are more likely to trigger issues like this earlier.

Future work will finish the last couple places where we still use go's fstest.MapFS internally, as well introduce stat tests at the syscallfs abstraction: right now, most tests are still only defined in WASI.