### PR TITLE
Adjust the timeframe for 1.0 from late Feb to late March

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ go get github.com/tetratelabs/wazero@latest
 ```
 
 wazero will tag a new pre-release at least once a month until 1.0. 1.0 is
-scheduled for Feb 2023, following the release of Go 1.20. wazero 1.0 will build
-with Go 1.18 and above per the below policy.
+scheduled for March 2023 and will require minimally Go 1.18. Except
+experimental packages, wazero will not break API on subsequent minor versions.
 
 Meanwhile, please practice the current APIs to ensure they work for you, and
 give us a [star][15] if you are enjoying it so far!

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -32,7 +32,8 @@ go get github.com/tetratelabs/wazero@latest
 ```
 
 wazero will tag a new pre-release at least once a month until 1.0. 1.0 is
-scheduled for Feb 2023, following the release of Go 1.20.
+scheduled for March 2023 and will require minimally Go 1.18. Except
+experimental packages, wazero will not break API on subsequent minor versions.
 
 Meanwhile, please practice the current APIs to ensure they work for you, and
 give us a [star][3] if you are enjoying it so far!


### PR DESCRIPTION
This slips our 1.0 date a month while we try to get through implementation issues around filesystems and various bugs.

While not mentioned in the README, we will move our internal syscallfs to an experimental package so that people who are ok with drift can implement it while we try to target it for a 1.x release ideally by June. Meanwhile, our next pre-release will harden the permanent APIs around implementing filesystems with existing directories or go's `fs.FS` implementation.