### PR TITLE
fs: fd_prestat_get return EBADF for not pre-opened

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1370,7 +1370,7 @@ func preopenPath(fsc *sys.FSContext, dirFD uint32) (string, Errno) {
 	if f, ok := fsc.LookupFile(dirFD); !ok {
 		return "", ErrnoBadf // closed
 	} else if !f.IsPreopen {
-		return "", ErrnoInval
+		return "", ErrnoBadf
 	} else {
 		// TODO: multiple pre-opens
 		return fsc.FS().GuestDir(), ErrnoSuccess

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -766,10 +766,10 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			name:          "not pre-opened FD",
 			fd:            dirFD,
 			resultPrestat: 0, // valid offset
-			expectedErrno: ErrnoInval,
+			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_get(fd=4)
-<== (prestat=,errno=EINVAL)
+<== (prestat=,errno=EBADF)
 `,
 		},
 		{
@@ -890,10 +890,10 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			fd:            dirFD,
 			path:          validAddress,
 			pathLen:       pathLen,
-			expectedErrno: ErrnoInval,
+			expectedErrno: ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=4)
-<== (path=,errno=EINVAL)
+<== (path=,errno=EBADF)
 `,
 		},
 	}


### PR DESCRIPTION
This fixes #1027.

WASI-libc prestats every fd from 3 until one returns EBADF. If any other error is returned, the process exits with code 71 (EX_OSERR).