### PR TITLE
cli: enable debug (DWARF) by default

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -21,6 +21,9 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 )
 
+var rtc = wazero.NewRuntimeConfig().
+	WithDebugInfoEnabled(true) // for better stack traces.
+
 func main() {
 	doMain(os.Stdout, os.Stderr, os.Exit)
 }
@@ -90,9 +93,9 @@ func doCompile(args []string, stdErr io.Writer, exit func(code int)) {
 		exit(1)
 	}
 
-	c := wazero.NewRuntimeConfig()
+	c := rtc
 	if cache := maybeUseCacheDir(cacheDir, stdErr, exit); cache != nil {
-		c.WithCompilationCache(cache)
+		c = c.WithCompilationCache(cache)
 	}
 
 	ctx := context.Background()
@@ -173,12 +176,12 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 
 	ctx := maybeHostLogging(context.Background(), hostLogging, stdErr, exit)
 
-	rtc := wazero.NewRuntimeConfig()
+	c := rtc
 	if cache := maybeUseCacheDir(cacheDir, stdErr, exit); cache != nil {
-		rtc.WithCompilationCache(cache)
+		c = c.WithCompilationCache(cache)
 	}
 
-	rt := wazero.NewRuntimeWithConfig(ctx, rtc)
+	rt := wazero.NewRuntimeWithConfig(ctx, c)
 	defer rt.Close(ctx)
 
 	// Because we are running a binary directly rather than embedding in an application,


### PR DESCRIPTION
This enables debug traces by default, especially while we hunt down various sources of glitches.

```bash
$ ./build/tinygo test -target wasi -c -o os.wasm os
$ wazero run -hostlogging=filesystem -mount=$(go env GOROOT)/src/os:/ os.wasm -test.v
--snip--
<== (stat={filetype=DIRECTORY,fdflags=,fs_rights_base=,fs_rights_inheriting=},errno=ESUCCESS)
==> wasi_snapshot_preview1.path_open(fd=3,dirflags=SYMLINK_FOLLOW,path=tmp/TestFd.txt266626407,oflags=CREAT|EXCL,fs_rights_base=,fs_rights_inheriting=,fdflags=)
<== (opened_fd=,errno=ENOENT)
panic: runtime error: nil pointer dereference
error instantiating wasm binary: module[] function[_start] failed: wasm error: unreachable
wasm stack trace:
	.runtime.runtimePanic(i32,i32)
		0x9541: /Users/adrian/oss/tinygo/src/runtime/runtime_tinygowasm.go:72:6 (inlined)
		        /Users/adrian/oss/tinygo/src/runtime/panic.go:59:7
	.runtime.nilPanic()
		0x5d7f: /Users/adrian/oss/tinygo/src/runtime/panic.go:122:14 (inlined)
		        /Users/adrian/oss/tinygo/src/runtime/gc_stack_portable.go:46:21
	.(*os.File).Name(i32,i32)
		0x3452d: /Users/adrian/oss/tinygo/src/os/file.go:71:2 (inlined)
		         <Go interface method> (inlined)
```
