### PR TITLE
fs: implements WriterAtOffset for WASI and gojs

### DIFF
--- a/internal/syscallfs/syscall_windows.go
+++ b/internal/syscallfs/syscall_windows.go
@@ -97,8 +97,9 @@ func maybeWrapFile(f file) file {
 	return struct {
 		readFile
 		io.Writer
+		io.WriterAt // for pwrite
 		syncer
-	}{f, &windowsWriter{f}, f}
+	}{f, &windowsWriter{f}, f, f}
 }
 
 // windowsWriter translates error codes not mapped properly by Go.

--- a/internal/syscallfs/syscallfs.go
+++ b/internal/syscallfs/syscallfs.go
@@ -143,6 +143,7 @@ type readFile interface {
 type file interface {
 	readFile
 	io.Writer
+	io.WriterAt // for pwrite
 	syncer
 }
 

--- a/site/content/specs.md
+++ b/site/content/specs.md
@@ -101,7 +101,7 @@ Note: C (via clang) supports the maximum WASI functions due to [wasi-libc][16].
 | fd_pread                |   ✅    |             Zig |
 | fd_prestat_get          |   ✅    | Rust,TinyGo,Zig |
 | fd_prestat_dir_name     |   ✅    | Rust,TinyGo,Zig |
-| fd_pwrite               |   ❌    |                 |
+| fd_pwrite               |   ✅    |        Rust,Zig |
 | fd_read                 |   ✅    | Rust,TinyGo,Zig |
 | fd_readdir              |   ✅    |        Rust,Zig |
 | fd_renumber             |   ❌    |                 |


### PR DESCRIPTION
This implements WriterAtOffset, which supports WASI `fd_pwrite` and gojs `fs.write` with offset, which is used to implement `syscall.Pwrite`. I confirmed this passes the corresponding test in wasi-testsuite as well.

Dependent on #1037