### PR TITLE
fs: adds string for better error experience

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -261,9 +261,9 @@ func validateMounts(mounts sliceFlag, stdErr logging.Writer, exit func(code int)
 			host = abs
 		}
 
-		next, err := syscallfs.NewDirFS(guest, host)
+		next, err := syscallfs.NewDirFS(host, guest)
 		if err != nil {
-			fmt.Fprintf(stdErr, "invalid mount: host path %q invalid: %v\n", host, err)
+			fmt.Fprintf(stdErr, "invalid mount: %v\n", err)
 			exit(1)
 		} else {
 			if readOnly {
@@ -273,7 +273,7 @@ func validateMounts(mounts sliceFlag, stdErr logging.Writer, exit func(code int)
 		}
 	}
 	if fs, err := syscallfs.NewRootFS(fs...); err != nil {
-		fmt.Fprintf(stdErr, "invalid mounts: %v\n", err)
+		fmt.Fprintf(stdErr, "invalid mounts %v: %v\n", fs, err)
 		exit(1)
 		return nil
 	} else {

--- a/experimental/writefs/writefs.go
+++ b/experimental/writefs/writefs.go
@@ -36,5 +36,5 @@ import (
 // bridge to a future filesystem abstraction made for wazero.
 func NewDirFS(hostDir string) (fs.FS, error) {
 	// syscallfs.DirFS is intentionally internal as it is still evolving
-	return syscallfs.NewDirFS("/", hostDir)
+	return syscallfs.NewDirFS(hostDir, "/")
 }

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -719,7 +719,7 @@ func Test_fdPread_Errors(t *testing.T) {
 }
 
 func Test_fdPrestatGet(t *testing.T) {
-	testfs, err := syscallfs.NewDirFS("/", t.TempDir())
+	testfs, err := syscallfs.NewDirFS(t.TempDir(), "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testfs))
@@ -806,7 +806,7 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 }
 
 func Test_fdPrestatDirName(t *testing.T) {
-	testfs, err := syscallfs.NewDirFS("/", t.TempDir())
+	testfs, err := syscallfs.NewDirFS(t.TempDir(), "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(testfs))
@@ -2204,7 +2204,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 
 func Test_pathCreateDirectory(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -2235,7 +2235,7 @@ func Test_pathCreateDirectory(t *testing.T) {
 
 func Test_pathCreateDirectory_Errors(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -2523,7 +2523,7 @@ func Test_pathLink(t *testing.T) {
 
 func Test_pathOpen(t *testing.T) {
 	dir := t.TempDir() // open before loop to ensure no locking problems.
-	writeFS, err := syscallfs.NewDirFS("/", dir)
+	writeFS, err := syscallfs.NewDirFS(dir, "/")
 	require.NoError(t, err)
 	readFS := syscallfs.NewReadFS(writeFS)
 
@@ -2814,7 +2814,7 @@ func writeFile(t *testing.T, tmpDir, file string, contents []byte) {
 
 func Test_pathOpen_Errors(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -2958,7 +2958,7 @@ func Test_pathReadlink(t *testing.T) {
 
 func Test_pathRemoveDirectory(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -2991,7 +2991,7 @@ func Test_pathRemoveDirectory(t *testing.T) {
 
 func Test_pathRemoveDirectory_Errors(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -3129,7 +3129,7 @@ func Test_pathSymlink(t *testing.T) {
 
 func Test_pathRename(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -3173,7 +3173,7 @@ func Test_pathRename(t *testing.T) {
 
 func Test_pathRename_Errors(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -3349,7 +3349,7 @@ func Test_pathRename_Errors(t *testing.T) {
 
 func Test_pathUnlinkFile(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -3382,7 +3382,7 @@ func Test_pathUnlinkFile(t *testing.T) {
 
 func Test_pathUnlinkFile_Errors(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
-	fs, err := syscallfs.NewDirFS("/", tmpDir)
+	fs, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fs))
@@ -3493,7 +3493,7 @@ func requireOpenFile(t *testing.T, tmpDir string, pathName string, data []byte, 
 		require.NoError(t, os.WriteFile(realPath, data, 0o600))
 	}
 
-	writeFS, err := syscallfs.NewDirFS("/", tmpDir)
+	writeFS, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	testFS := writeFS

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -51,11 +51,11 @@ func Test_fdReaddir_ls(t *testing.T) {
 func testFdReaddirLs(t *testing.T, bin []byte) {
 	// TODO: make a subfs
 	moduleConfig := wazero.NewModuleConfig().
-		WithFS(syscallfs.Adapt("/", fstest.MapFS{
+		WithFS(syscallfs.Adapt(fstest.MapFS{
 			"-":   {},
 			"a-":  {Mode: fs.ModeDir},
 			"ab-": {},
-		}))
+		}, "/"))
 
 	t.Run("empty directory", func(t *testing.T) {
 		console := compileAndRun(t, moduleConfig.WithArgs("wasi", "ls", "./a-"), bin)
@@ -87,7 +87,7 @@ ENOTDIR
 		for i := 0; i < count; i++ {
 			testFS[strconv.Itoa(i)] = &fstest.MapFile{}
 		}
-		config := wazero.NewModuleConfig().WithFS(syscallfs.Adapt("/", testFS)).WithArgs("wasi", "ls", ".")
+		config := wazero.NewModuleConfig().WithFS(syscallfs.Adapt(testFS, "/")).WithArgs("wasi", "ls", ".")
 		console := compileAndRun(t, config, bin)
 
 		lines := strings.Split(console, "\n")
@@ -112,7 +112,7 @@ func Test_fdReaddir_stat(t *testing.T) {
 func testFdReaddirStat(t *testing.T, bin []byte) {
 	moduleConfig := wazero.NewModuleConfig().WithArgs("wasi", "stat")
 
-	console := compileAndRun(t, moduleConfig.WithFS(syscallfs.Adapt("/", fstest.MapFS{})), bin)
+	console := compileAndRun(t, moduleConfig.WithFS(syscallfs.Adapt(fstest.MapFS{}, "/")), bin)
 
 	// TODO: switch this to a real stat test
 	require.Equal(t, `

--- a/internal/gojs/fs_test.go
+++ b/internal/gojs/fs_test.go
@@ -45,7 +45,7 @@ func Test_testfs(t *testing.T) {
 	require.NoError(t, os.Mkdir(testfsDir, 0o700))
 	require.NoError(t, fstest.WriteTestFiles(testfsDir))
 
-	rootFS, err := syscallfs.NewDirFS("/", tmpDir)
+	rootFS, err := syscallfs.NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	stdout, stderr, err := compileAndRun(testCtx, "testfs", wazero.NewModuleConfig().WithFS(rootFS))

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -31,7 +31,7 @@ func TestNewFSContext(t *testing.T) {
 	embedFS, err := fs.Sub(testdata, "testdata")
 	require.NoError(t, err)
 
-	dirfs, err := syscallfs.NewDirFS("/", ".")
+	dirfs, err := syscallfs.NewDirFS(".", "/")
 	require.NoError(t, err)
 
 	// Test various usual configuration for the file system.
@@ -41,7 +41,7 @@ func TestNewFSContext(t *testing.T) {
 	}{
 		{
 			name: "embed.FS",
-			fs:   syscallfs.Adapt("/", embedFS),
+			fs:   syscallfs.Adapt(embedFS, "/"),
 		},
 		{
 			name: "syscallfs.NewDirFS",
@@ -55,7 +55,7 @@ func TestNewFSContext(t *testing.T) {
 		},
 		{
 			name: "fstest.MapFS",
-			fs:   syscallfs.Adapt("/", fstest.MapFS{}),
+			fs:   syscallfs.Adapt(fstest.MapFS{}, "/"),
 		},
 	}
 
@@ -114,7 +114,7 @@ func TestEmptyFSContext(t *testing.T) {
 }
 
 func TestContext_Close(t *testing.T) {
-	testFS := syscallfs.Adapt("/", testfs.FS{"foo": &testfs.File{}})
+	testFS := syscallfs.Adapt(testfs.FS{"foo": &testfs.File{}}, "/")
 
 	fsc, err := NewFSContext(nil, nil, nil, testFS)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestContext_Close(t *testing.T) {
 func TestContext_Close_Error(t *testing.T) {
 	file := &testfs.File{CloseErr: errors.New("error closing")}
 
-	testFS := syscallfs.Adapt("/", testfs.FS{"foo": file})
+	testFS := syscallfs.Adapt(testfs.FS{"foo": file}, "/")
 
 	fsc, err := NewFSContext(nil, nil, nil, testFS)
 	require.NoError(t, err)

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -182,7 +182,7 @@ func NewContext(
 	}
 
 	if fs != nil {
-		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, syscallfs.Adapt("/", fs))
+		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, syscallfs.Adapt(fs, "/"))
 	} else {
 		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, syscallfs.EmptyFS)
 	}

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -51,7 +51,7 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, &ns, sysCtx.nanosleep)
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
 
-	testFS := syscallfs.Adapt("/", testfs.FS{})
+	testFS := syscallfs.Adapt(testfs.FS{}, "/")
 	expectedFS, _ := NewFSContext(nil, nil, nil, testFS)
 
 	expectedOpenedFiles := FileTable{}

--- a/internal/syscallfs/adapter.go
+++ b/internal/syscallfs/adapter.go
@@ -15,16 +15,21 @@ import (
 // flags as there is no parameter to pass them through with. Moreover, fs.FS
 // documentation does not require the file to be present. In summary, we can't
 // enforce flag behavior.
-func Adapt(guestDir string, fs fs.FS) FS {
+func Adapt(fs fs.FS, guestDir string) FS {
 	if sys, ok := fs.(FS); ok {
 		return sys
 	}
-	return &adapter{guestDir, fs}
+	return &adapter{fs, guestDir}
 }
 
 type adapter struct {
-	guestDir string
 	fs       fs.FS
+	guestDir string
+}
+
+// String implements fmt.Stringer
+func (a *adapter) String() string {
+	return fmt.Sprintf("%v:%s:ro", a.fs, a.guestDir)
 }
 
 // Open implements the same method as documented on fs.FS

--- a/internal/syscallfs/adapter_test.go
+++ b/internal/syscallfs/adapter_test.go
@@ -13,8 +13,13 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+func TestAdapt_String(t *testing.T) {
+	testFS := Adapt(os.DirFS("."), "/tmp")
+	require.Equal(t, ".:/tmp:ro", testFS.String())
+}
+
 func TestAdapt_MkDir(t *testing.T) {
-	testFS := Adapt("/", os.DirFS(t.TempDir()))
+	testFS := Adapt(os.DirFS(t.TempDir()), "/")
 
 	err := testFS.Mkdir("mkdir", fs.ModeDir)
 	require.Equal(t, syscall.ENOSYS, err)
@@ -22,7 +27,7 @@ func TestAdapt_MkDir(t *testing.T) {
 
 func TestAdapt_Rename(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt("/", os.DirFS(tmpDir))
+	testFS := Adapt(os.DirFS(tmpDir), "/")
 
 	file1 := "file1"
 	file1Path := pathutil.Join(tmpDir, file1)
@@ -42,7 +47,7 @@ func TestAdapt_Rename(t *testing.T) {
 
 func TestAdapt_Rmdir(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt("/", os.DirFS(tmpDir))
+	testFS := Adapt(os.DirFS(tmpDir), "/")
 
 	path := "rmdir"
 	realPath := pathutil.Join(tmpDir, path)
@@ -54,7 +59,7 @@ func TestAdapt_Rmdir(t *testing.T) {
 
 func TestAdapt_Unlink(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt("/", os.DirFS(tmpDir))
+	testFS := Adapt(os.DirFS(tmpDir), "/")
 
 	path := "unlink"
 	realPath := pathutil.Join(tmpDir, path)
@@ -66,7 +71,7 @@ func TestAdapt_Unlink(t *testing.T) {
 
 func TestAdapt_Utimes(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt("/", os.DirFS(tmpDir))
+	testFS := Adapt(os.DirFS(tmpDir), "/")
 
 	path := "utimes"
 	realPath := pathutil.Join(tmpDir, path)
@@ -81,7 +86,7 @@ func TestAdapt_Open_Read(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDir = pathutil.Join(tmpDir, t.Name())
 	require.NoError(t, os.Mkdir(tmpDir, 0o700))
-	testFS := Adapt("/", os.DirFS(tmpDir))
+	testFS := Adapt(os.DirFS(tmpDir), "/")
 
 	testOpen_Read(t, tmpDir, testFS)
 
@@ -115,7 +120,7 @@ func (dir hackFS) Open(name string) (fs.File, error) {
 // fs.FS contract.
 func TestAdapt_HackedWrites(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt("/", hackFS(tmpDir))
+	testFS := Adapt(hackFS(tmpDir), "/")
 
 	testOpen_O_RDWR(t, tmpDir, testFS)
 }
@@ -151,7 +156,7 @@ func TestAdapt_TestFS(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Adapt a normal fs.FS to syscallfs.FS
-			testFS := Adapt("/", tc.fs)
+			testFS := Adapt(tc.fs, "/")
 
 			// Adapt it back to fs.FS and run the tests
 			require.NoError(t, fstest.TestFS(&testFSAdapter{testFS}))

--- a/internal/syscallfs/emptyfs.go
+++ b/internal/syscallfs/emptyfs.go
@@ -12,6 +12,11 @@ var EmptyFS FS = empty{}
 
 type empty struct{}
 
+// String implements fmt.Stringer
+func (empty) String() string {
+	return "empty:/:ro"
+}
+
 // Open implements the same method as documented on fs.FS
 func (empty) Open(name string) (fs.File, error) {
 	panic(fmt.Errorf("unexpected to call fs.FS.Open(%s)", name))

--- a/internal/syscallfs/emptyfs_test.go
+++ b/internal/syscallfs/emptyfs_test.go
@@ -1,0 +1,11 @@
+package syscallfs
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestEmptyFS_String(t *testing.T) {
+	require.Equal(t, "empty:/:ro", EmptyFS.String())
+}

--- a/internal/syscallfs/readfs.go
+++ b/internal/syscallfs/readfs.go
@@ -15,11 +15,20 @@ import (
 func NewReadFS(fs FS) FS {
 	if _, ok := fs.(*readFS); ok {
 		return fs
+	} else if _, ok = fs.(*adapter); ok {
+		return fs // fs.FS is always read-only
+	} else if _, ok = fs.(empty); ok {
+		return fs // empty is always read-only
 	}
 	return &readFS{fs}
 }
 
 type readFS struct{ fs FS }
+
+// String implements fmt.Stringer
+func (r *readFS) String() string {
+	return r.fs.String() + ":ro"
+}
 
 // Open implements the same method as documented on fs.FS
 func (r *readFS) Open(name string) (fs.File, error) {
@@ -28,7 +37,7 @@ func (r *readFS) Open(name string) (fs.File, error) {
 
 // GuestDir implements FS.GuestDir
 func (r *readFS) GuestDir() string {
-	return "/"
+	return r.fs.GuestDir()
 }
 
 // OpenFile implements FS.OpenFile

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -11,22 +11,50 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func TestReadFS_MkDir(t *testing.T) {
+func TestNewReadFS(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := NewReadFS(Adapt("/", hackFS(tmpDir)))
 
-	err := testFS.Mkdir("mkdir", fs.ModeDir)
+	// Doesn't double-wrap file systems that are already read-only
+	adapted := Adapt(os.DirFS(tmpDir), "/")
+	require.Equal(t, adapted, NewReadFS(adapted))
+	require.Equal(t, EmptyFS, NewReadFS(EmptyFS))
+
+	// Wraps a writeable file system
+	writeable, err := NewDirFS(tmpDir, "/tmp")
+	require.NoError(t, err)
+	readFS := NewReadFS(writeable)
+	require.NotEqual(t, writeable, readFS)
+	require.Equal(t, writeable.GuestDir(), readFS.GuestDir())
+}
+
+func TestReadFS_String(t *testing.T) {
+	writeable, err := NewDirFS(".", "/tmp")
+	require.NoError(t, err)
+
+	readFS := NewReadFS(writeable)
+	require.NotEqual(t, writeable, readFS)
+	require.Equal(t, ".:/tmp:ro", readFS.String())
+}
+
+func TestReadFS_MkDir(t *testing.T) {
+	writeable, err := NewDirFS(t.TempDir(), "/")
+	require.NoError(t, err)
+	testFS := NewReadFS(writeable)
+
+	err = testFS.Mkdir("mkdir", fs.ModeDir)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Rename(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := NewReadFS(Adapt("/", hackFS(tmpDir)))
+	writeable, err := NewDirFS(tmpDir, "/")
+	require.NoError(t, err)
+	testFS := NewReadFS(writeable)
 
 	file1 := "file1"
 	file1Path := pathutil.Join(tmpDir, file1)
 	file1Contents := []byte{1}
-	err := os.WriteFile(file1Path, file1Contents, 0o600)
+	err = os.WriteFile(file1Path, file1Contents, 0o600)
 	require.NoError(t, err)
 
 	file2 := "file2"
@@ -41,43 +69,51 @@ func TestReadFS_Rename(t *testing.T) {
 
 func TestReadFS_Rmdir(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := NewReadFS(Adapt("/", hackFS(tmpDir)))
+	writeable, err := NewDirFS(tmpDir, "/")
+	require.NoError(t, err)
+	testFS := NewReadFS(writeable)
 
 	path := "rmdir"
 	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.Mkdir(realPath, 0o700))
 
-	err := testFS.Rmdir(path)
+	err = testFS.Rmdir(path)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Unlink(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := NewReadFS(Adapt("/", hackFS(tmpDir)))
+	writeable, err := NewDirFS(tmpDir, "/")
+	require.NoError(t, err)
+	testFS := NewReadFS(writeable)
 
 	path := "unlink"
 	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
-	err := testFS.Unlink(path)
+	err = testFS.Unlink(path)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Utimes(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := NewReadFS(Adapt("/", hackFS(tmpDir)))
+	writeable, err := NewDirFS(tmpDir, "/")
+	require.NoError(t, err)
+	testFS := NewReadFS(writeable)
 
 	path := "utimes"
 	realPath := pathutil.Join(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
-	err := testFS.Utimes(path, 1, 1)
+	err = testFS.Utimes(path, 1, 1)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Open_Read(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := NewReadFS(Adapt("/", hackFS(tmpDir)))
+	writeable, err := NewDirFS(tmpDir, "/")
+	require.NoError(t, err)
+	testFS := NewReadFS(writeable)
 
 	testOpen_Read(t, tmpDir, testFS)
 }
@@ -90,7 +126,7 @@ func TestReadFS_TestFS(t *testing.T) {
 	require.NoError(t, fstest.WriteTestFiles(tmpDir))
 
 	// Create a writeable filesystem
-	testFS, err := NewDirFS("/", tmpDir)
+	testFS, err := NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	// Wrap it as read-only

--- a/internal/syscallfs/syscallfs.go
+++ b/internal/syscallfs/syscallfs.go
@@ -14,6 +14,18 @@ import (
 //
 // See https://github.com/golang/go/issues/45757
 type FS interface {
+	// String should return a human-readable format of the filesystem:
+	//   - If read-only, $host:$guestDir:ro
+	//   - If read-write, $host:$guestDir
+	//
+	// For example, if this filesystem is backed by the real directory
+	// "/tmp/wasm" and the GuestDir is "/", the expected value is
+	// "/var/tmp:/tmp".
+	//
+	// When the host filesystem isn't a real filesystem, substitute a symbolic,
+	// human-readable name. e.g. "virtual:/"
+	String() string
+
 	// GuestDir is the name of the path the guest should use this filesystem
 	// for, or root ("/") for any files.
 	//

--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -414,7 +414,7 @@ func TestReaderAtOffset_Unsupported(t *testing.T) {
 
 func TestWriterAtOffset(t *testing.T) {
 	tmpDir := t.TempDir()
-	dirFS, err := NewDirFS("/", tmpDir)
+	dirFS, err := NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	// fs.FS doesn't support writes, and there is no other built-in
@@ -481,7 +481,7 @@ func TestWriterAtOffset(t *testing.T) {
 
 func TestWriterAtOffset_empty(t *testing.T) {
 	tmpDir := t.TempDir()
-	dirFS, err := NewDirFS("/", tmpDir)
+	dirFS, err := NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	// fs.FS doesn't support writes, and there is no other built-in
@@ -523,7 +523,7 @@ func TestWriterAtOffset_empty(t *testing.T) {
 
 func TestWriterAtOffset_Unsupported(t *testing.T) {
 	tmpDir := t.TempDir()
-	dirFS, err := NewDirFS("/", tmpDir)
+	dirFS, err := NewDirFS(tmpDir, "/")
 	require.NoError(t, err)
 
 	f, err := dirFS.OpenFile(readerAtFile, os.O_RDWR|os.O_CREATE, 0o600)


### PR DESCRIPTION
This prepares for pseudo-root when the CLI doesn't provide one by improving the error messages in general, as well being consistent about parameter order.
