### PR TITLE
fs: allows non-root only mounts

### DIFF
--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -234,6 +234,13 @@ func TestRun(t *testing.T) {
 			stdOut:     "pooh\n",
 		},
 		{
+			name:       "wasi non root",
+			wasm:       wasmCat,
+			wazeroOpts: []string{fmt.Sprintf("--mount=%s:/animals:ro", bearDir)},
+			wasmArgs:   []string{"/animals/bear.txt"},
+			stdOut:     "pooh\n",
+		},
+		{
 			name:       "wasi logging",
 			wasm:       wasmWasiFd,
 			wazeroOpts: []string{"--hostlogging=filesystem", fmt.Sprintf("--mount=%s:/", bearDir)},


### PR DESCRIPTION
This adds syntax needed for wasi-testsuite, which mounts a path like below without mounting anything for "/".

```
-mount=./tests/c/testsuite/fs-tests.dir:/fs-tests.dir
```

Basically, this creates a virtual root path with fake stat.

With this in, https://github.com/WebAssembly/wasi-testsuite/compare/prod/testsuite-base...codefromthecrypt:wazero?expand=1 passes 100pct cc @achille-roussel 

```bash
$ python3 test-runner/wasi_test_runner.py -t ./tests/assemblyscript/testsuite/  ./tests/c/testsuite/ -r adapters/wazero.sh
Test environ_get-multiple-variables passed
Test fd_write-to-invalid-fd passed
Test environ_sizes_get-multiple-variables passed
Test args_sizes_get-no-arguments passed
Test proc_exit-success passed
Test proc_exit-failure passed
Test args_get-multiple-arguments passed
Test args_sizes_get-multiple-arguments passed
Test fd_write-to-stdout passed
Test random_get-non-zero-length passed
Test environ_sizes_get-no-variables passed
Test random_get-zero-length passed
Test lseek passed
Test clock_getres-realtime passed
Test clock_gettime-monotonic passed
Test clock_getres-monotonic passed
Test fopen-with-access passed
Test stat-dev-ino passed
Test fdopendir-with-access passed
Test clock_gettime-realtime passed
Test pwrite-with-access passed
Test fopen-with-no-access passed
Test pread-with-access passed

===== Test results =====
Runtime: wazero v0.0.0
Suite: WASI Assemblyscript tests
  Total: 12
  Passed:  12
  Failed:  0

Suite: WASI C tests
  Total: 11
  Passed:  11
  Failed:  0

Test suites: 2 passed, 0 total
Tests:       23 passed, 0 total

```