### PR TITLE
fs: decouples sysfs from fs.FS and consolidates guest path logic

### DIFF
--- a/experimental/writefs/writefs.go
+++ b/experimental/writefs/writefs.go
@@ -34,7 +34,7 @@ import (
 //
 // Do not attempt to use the result as a fs.FS, as it will panic. This is a
 // bridge to a future filesystem abstraction made for wazero.
-func NewDirFS(hostDir string) (fs.FS, error) {
+func NewDirFS(dir string) fs.FS {
 	// sysfs.DirFS is intentionally internal as it is still evolving
-	return sysfs.NewDirFS(hostDir, "/")
+	return &sysfs.FSHolder{FS: sysfs.NewDirFS(dir)}
 }

--- a/experimental/writefs/writefs_example_test.go
+++ b/experimental/writefs/writefs_example_test.go
@@ -2,7 +2,6 @@ package writefs_test
 
 import (
 	_ "embed"
-	"log"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/experimental/writefs"
@@ -13,9 +12,6 @@ var config wazero.ModuleConfig //nolint
 // This shows how to use writefs.NewDirFS to map paths relative to "/work/appA",
 // as "/". Unlike os.DirFS, these paths will be writable.
 func Example_dirFS() {
-	fs, err := writefs.NewDirFS("/work/appA")
-	if err != nil {
-		log.Panicln(err)
-	}
+	fs := writefs.NewDirFS("/work/appA")
 	config = wazero.NewModuleConfig().WithFS(fs)
 }

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1366,7 +1366,7 @@ func preopenPath(fsc *sys.FSContext, dirFD uint32) (string, Errno) {
 		return "", ErrnoBadf
 	} else {
 		// TODO: multiple pre-opens
-		return fsc.FS().GuestDir(), ErrnoSuccess
+		return "/", ErrnoSuccess
 	}
 }
 

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
-	"github.com/tetratelabs/wazero/internal/sysfs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
 )
@@ -51,11 +50,11 @@ func Test_fdReaddir_ls(t *testing.T) {
 func testFdReaddirLs(t *testing.T, bin []byte) {
 	// TODO: make a subfs
 	moduleConfig := wazero.NewModuleConfig().
-		WithFS(sysfs.Adapt(fstest.MapFS{
+		WithFS(fstest.MapFS{
 			"-":   {},
 			"a-":  {Mode: fs.ModeDir},
 			"ab-": {},
-		}, "/"))
+		})
 
 	t.Run("empty directory", func(t *testing.T) {
 		console := compileAndRun(t, moduleConfig.WithArgs("wasi", "ls", "./a-"), bin)
@@ -87,7 +86,7 @@ ENOTDIR
 		for i := 0; i < count; i++ {
 			testFS[strconv.Itoa(i)] = &fstest.MapFile{}
 		}
-		config := wazero.NewModuleConfig().WithFS(sysfs.Adapt(testFS, "/")).WithArgs("wasi", "ls", ".")
+		config := wazero.NewModuleConfig().WithFS(testFS).WithArgs("wasi", "ls", ".")
 		console := compileAndRun(t, config, bin)
 
 		lines := strings.Split(console, "\n")
@@ -112,7 +111,7 @@ func Test_fdReaddir_stat(t *testing.T) {
 func testFdReaddirStat(t *testing.T, bin []byte) {
 	moduleConfig := wazero.NewModuleConfig().WithArgs("wasi", "stat")
 
-	console := compileAndRun(t, moduleConfig.WithFS(sysfs.Adapt(fstest.MapFS{}, "/")), bin)
+	console := compileAndRun(t, moduleConfig.WithFS(fstest.MapFS{}), bin)
 
 	// TODO: switch this to a real stat test
 	require.Equal(t, `

--- a/internal/gojs/fs_test.go
+++ b/internal/gojs/fs_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tetratelabs/wazero/experimental/writefs"
 	"github.com/tetratelabs/wazero/internal/fstest"
 	"github.com/tetratelabs/wazero/internal/platform"
-	"github.com/tetratelabs/wazero/internal/sysfs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
@@ -45,10 +44,9 @@ func Test_testfs(t *testing.T) {
 	require.NoError(t, os.Mkdir(testfsDir, 0o700))
 	require.NoError(t, fstest.WriteTestFiles(testfsDir))
 
-	rootFS, err := sysfs.NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := writefs.NewDirFS(tmpDir)
 
-	stdout, stderr, err := compileAndRun(testCtx, "testfs", wazero.NewModuleConfig().WithFS(rootFS))
+	stdout, stderr, err := compileAndRun(testCtx, "testfs", wazero.NewModuleConfig().WithFS(testFS))
 
 	require.Zero(t, stderr)
 	require.EqualError(t, err, `module "" closed with exit_code(0)`)
@@ -58,13 +56,12 @@ func Test_testfs(t *testing.T) {
 func Test_writefs(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	fs, err := writefs.NewDirFS(tmpDir)
-	require.NoError(t, err)
+	testFS := writefs.NewDirFS(tmpDir)
 
 	// test expects to write under /tmp
 	require.NoError(t, os.Mkdir(path.Join(tmpDir, "tmp"), 0o700))
 
-	stdout, stderr, err := compileAndRun(testCtx, "writefs", wazero.NewModuleConfig().WithFS(fs))
+	stdout, stderr, err := compileAndRun(testCtx, "writefs", wazero.NewModuleConfig().WithFS(testFS))
 
 	require.Zero(t, stderr)
 	require.EqualError(t, err, `module "" closed with exit_code(0)`)

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -31,8 +31,7 @@ func TestNewFSContext(t *testing.T) {
 	embedFS, err := fs.Sub(testdata, "testdata")
 	require.NoError(t, err)
 
-	dirfs, err := sysfs.NewDirFS(".", "/")
-	require.NoError(t, err)
+	dirfs := sysfs.NewDirFS(".")
 
 	// Test various usual configuration for the file system.
 	tests := []struct {
@@ -41,7 +40,7 @@ func TestNewFSContext(t *testing.T) {
 	}{
 		{
 			name: "embed.FS",
-			fs:   sysfs.Adapt(embedFS, "/"),
+			fs:   sysfs.Adapt(embedFS),
 		},
 		{
 			name: "sysfs.NewDirFS",
@@ -55,7 +54,7 @@ func TestNewFSContext(t *testing.T) {
 		},
 		{
 			name: "fstest.MapFS",
-			fs:   sysfs.Adapt(fstest.MapFS{}, "/"),
+			fs:   sysfs.Adapt(fstest.MapFS{}),
 		},
 	}
 
@@ -68,7 +67,7 @@ func TestNewFSContext(t *testing.T) {
 			defer fsc.Close(testCtx)
 
 			preopenedDir, _ := fsc.openedFiles.Lookup(FdPreopen)
-			preopenedPath := fsc.fs.GuestDir()
+			preopenedPath := "/"
 			require.Equal(t, tc.fs, fsc.fs)
 			require.NotNil(t, preopenedDir)
 			require.Equal(t, "", preopenedDir.Name)
@@ -114,7 +113,7 @@ func TestUnimplementedFSContext(t *testing.T) {
 }
 
 func TestContext_Close(t *testing.T) {
-	testFS := sysfs.Adapt(testfs.FS{"foo": &testfs.File{}}, "/")
+	testFS := sysfs.Adapt(testfs.FS{"foo": &testfs.File{}})
 
 	fsc, err := NewFSContext(nil, nil, nil, testFS)
 	require.NoError(t, err)
@@ -139,7 +138,7 @@ func TestContext_Close(t *testing.T) {
 func TestContext_Close_Error(t *testing.T) {
 	file := &testfs.File{CloseErr: errors.New("error closing")}
 
-	testFS := sysfs.Adapt(testfs.FS{"foo": file}, "/")
+	testFS := sysfs.Adapt(testfs.FS{"foo": file})
 
 	fsc, err := NewFSContext(nil, nil, nil, testFS)
 	require.NoError(t, err)

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -108,7 +108,7 @@ func (eofReader) Read([]byte) (int, error) {
 	return 0, io.EOF
 }
 
-// DefaultContext returns Context with no values set except a possibly nil fs.FS
+// DefaultContext returns Context with no values set except a possible nil fs.FS
 func DefaultContext(fs fs.FS) *Context {
 	if sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, nil, fs); err != nil {
 		panic(fmt.Errorf("BUG: DefaultContext should never error: %w", err))
@@ -182,7 +182,7 @@ func NewContext(
 	}
 
 	if fs != nil {
-		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, sysfs.Adapt(fs, "/"))
+		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, sysfs.Adapt(fs))
 	} else {
 		sysCtx.fsc, err = NewFSContext(stdin, stdout, stderr, sysfs.UnimplementedFS{})
 	}

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestContext_FS(t *testing.T) {
-	sysCtx := DefaultContext(sysfs.UnimplementedFS{})
+	sysCtx := DefaultContext(nil)
 
 	fsc, err := NewFSContext(nil, nil, nil, sysfs.UnimplementedFS{})
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, &ns, sysCtx.nanosleep)
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
 
-	testFS := sysfs.Adapt(testfs.FS{}, "/")
+	testFS := sysfs.Adapt(testfs.FS{})
 	expectedFS, _ := NewFSContext(nil, nil, nil, testFS)
 
 	expectedOpenedFiles := FileTable{}

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -14,27 +14,21 @@ import (
 // flags as there is no parameter to pass them through with. Moreover, fs.FS
 // documentation does not require the file to be present. In summary, we can't
 // enforce flag behavior.
-func Adapt(fs fs.FS, guestDir string) FS {
-	if sys, ok := fs.(FS); ok {
-		return sys
+func Adapt(fs fs.FS) FS {
+	if sys, ok := fs.(*FSHolder); ok {
+		return sys.FS
 	}
-	return &adapter{fs: fs, guestDir: guestDir}
+	return &adapter{fs: fs}
 }
 
 type adapter struct {
 	UnimplementedFS
-	fs       fs.FS
-	guestDir string
+	fs fs.FS
 }
 
 // String implements fmt.Stringer
 func (a *adapter) String() string {
-	return fmt.Sprintf("%v:%s:ro", a.fs, a.guestDir)
-}
-
-// GuestDir implements FS.GuestDir
-func (a *adapter) GuestDir() string {
-	return a.guestDir
+	return fmt.Sprintf("%v", a.fs)
 }
 
 // OpenFile implements FS.OpenFile

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 func TestAdapt_String(t *testing.T) {
-	testFS := Adapt(os.DirFS("."), "/tmp")
-	require.Equal(t, ".:/tmp:ro", testFS.String())
+	testFS := Adapt(os.DirFS("."))
+	require.Equal(t, ".", testFS.String())
 }
 
 func TestAdapt_MkDir(t *testing.T) {
-	testFS := Adapt(os.DirFS(t.TempDir()), "/")
+	testFS := Adapt(os.DirFS(t.TempDir()))
 
 	err := testFS.Mkdir("mkdir", fs.ModeDir)
 	require.Equal(t, syscall.ENOSYS, err)
@@ -27,7 +27,7 @@ func TestAdapt_MkDir(t *testing.T) {
 
 func TestAdapt_Rename(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt(os.DirFS(tmpDir), "/")
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	file1 := "file1"
 	file1Path := pathutil.Join(tmpDir, file1)
@@ -47,7 +47,7 @@ func TestAdapt_Rename(t *testing.T) {
 
 func TestAdapt_Rmdir(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt(os.DirFS(tmpDir), "/")
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	path := "rmdir"
 	realPath := pathutil.Join(tmpDir, path)
@@ -59,7 +59,7 @@ func TestAdapt_Rmdir(t *testing.T) {
 
 func TestAdapt_Unlink(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt(os.DirFS(tmpDir), "/")
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	path := "unlink"
 	realPath := pathutil.Join(tmpDir, path)
@@ -71,7 +71,7 @@ func TestAdapt_Unlink(t *testing.T) {
 
 func TestAdapt_Utimes(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt(os.DirFS(tmpDir), "/")
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	path := "utimes"
 	realPath := pathutil.Join(tmpDir, path)
@@ -86,7 +86,7 @@ func TestAdapt_Open_Read(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDir = pathutil.Join(tmpDir, t.Name())
 	require.NoError(t, os.Mkdir(tmpDir, 0o700))
-	testFS := Adapt(os.DirFS(tmpDir), "/")
+	testFS := Adapt(os.DirFS(tmpDir))
 
 	testOpen_Read(t, tmpDir, testFS)
 
@@ -120,7 +120,7 @@ func (dir hackFS) Open(name string) (fs.File, error) {
 // fs.FS contract.
 func TestAdapt_HackedWrites(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS := Adapt(hackFS(tmpDir), "/")
+	testFS := Adapt(hackFS(tmpDir))
 
 	testOpen_O_RDWR(t, tmpDir, testFS)
 }
@@ -156,7 +156,7 @@ func TestAdapt_TestFS(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Adapt a normal fs.FS to sysfs.FS
-			testFS := Adapt(tc.fs, "/")
+			testFS := Adapt(tc.fs)
 
 			// Adapt it back to fs.FS and run the tests
 			require.NoError(t, fstest.TestFS(&testFSAdapter{testFS}))

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -78,8 +78,9 @@ func (d *dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
 }
 
 func (d *dirFS) join(name string) string {
-	if name == "." {
-		return d.cleanedDir
+	switch name {
+	case "", ".", "/":
+		return d.cleanedDir[:len(d.cleanedDir)-1]
 	}
 	// TODO: Enforce similar to safefilepath.FromFS(name), but be careful as
 	// relative path inputs are allowed. e.g. dir or name == ../

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -1,26 +1,16 @@
 package sysfs
 
 import (
-	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"syscall"
 )
 
-func NewDirFS(hostDir, guestDir string) (FS, error) {
-	ret := &dirFS{
-		hostDir:        hostDir,
-		guestDir:       guestDir,
-		cleanedHostDir: ensureTrailingPathSeparator(hostDir),
+func NewDirFS(dir string) FS {
+	return &dirFS{
+		dir:        dir,
+		cleanedDir: ensureTrailingPathSeparator(dir),
 	}
-
-	if stat, err := os.Stat(hostDir); err != nil {
-		return nil, fmt.Errorf("%s invalid: %v", ret, errors.Unwrap(err))
-	} else if !stat.IsDir() {
-		return nil, fmt.Errorf("%s invalid: %s is not a directory", ret, hostDir)
-	}
-	return ret, nil
 }
 
 func ensureTrailingPathSeparator(dir string) string {
@@ -32,20 +22,15 @@ func ensureTrailingPathSeparator(dir string) string {
 
 type dirFS struct {
 	UnimplementedFS
-	hostDir, guestDir string
-	// cleanedHostDir is for easier OS-specific concatenation, as it always has
+	dir string
+	// cleanedDir is for easier OS-specific concatenation, as it always has
 	// a trailing path separator.
-	cleanedHostDir string
+	cleanedDir string
 }
 
 // String implements fmt.Stringer
 func (d *dirFS) String() string {
-	return d.hostDir + ":" + d.guestDir
-}
-
-// GuestDir implements FS.GuestDir
-func (d *dirFS) GuestDir() string {
-	return d.guestDir
+	return d.dir
 }
 
 // OpenFile implements FS.OpenFile
@@ -94,9 +79,9 @@ func (d *dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
 
 func (d *dirFS) join(name string) string {
 	if name == "." {
-		return d.cleanedHostDir
+		return d.cleanedDir
 	}
 	// TODO: Enforce similar to safefilepath.FromFS(name), but be careful as
 	// relative path inputs are allowed. e.g. dir or name == ../
-	return d.cleanedHostDir + name
+	return d.cleanedDir + name
 }

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -80,6 +80,7 @@ func (d *dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
 func (d *dirFS) join(name string) string {
 	switch name {
 	case "", ".", "/":
+		// cleanedDir includes an unnecessary delimiter for the root path.
 		return d.cleanedDir[:len(d.cleanedDir)-1]
 	}
 	// TODO: Enforce similar to safefilepath.FromFS(name), but be careful as

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -2,7 +2,6 @@ package sysfs
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	pathutil "path"
@@ -15,45 +14,37 @@ import (
 )
 
 func TestNewDirFS(t *testing.T) {
-	testFS, err := NewDirFS(".", "/tmp")
-	require.NoError(t, err)
-
-	// String doesn't include the fake name
-	require.Equal(t, ".:/tmp", testFS.String())
+	testFS := NewDirFS(".")
 
 	// Guest can look up /
 	f, err := testFS.OpenFile("/", os.O_RDONLY, 0)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	t.Run("not found", func(t *testing.T) {
-		_, err := NewDirFS("a", "/tmp")
-
-		// get the os-dependent error string. This is needed for windows, e.g.
-		// "no such file or directory" vs "The system cannot find the file specified."
-		_, statErr := os.Stat("a")
-		expectedErrString := errors.Unwrap(statErr).Error()
-
-		require.EqualError(t, err, "a:/tmp invalid: "+expectedErrString)
+	t.Run("host path not found", func(t *testing.T) {
+		testFS := NewDirFS("a")
+		_, err = testFS.OpenFile(".", os.O_RDONLY, 0)
+		require.Equal(t, syscall.ENOENT, err)
 	})
-	t.Run("not a directory", func(t *testing.T) {
-		f := os.Args[0] // should be safe in scratch tests which don't have the source mounted.
-		_, err := NewDirFS(f, "/tmp")
-		require.EqualError(t, err, fmt.Sprintf("%[1]s:/tmp invalid: %[1]s is not a directory", f))
+	t.Run("host path not a directory", func(t *testing.T) {
+		arg0 := os.Args[0] // should be safe in scratch tests which don't have the source mounted.
+
+		testFS := NewDirFS(arg0)
+		_, err = testFS.OpenFile(".", os.O_RDONLY, 0)
+		require.Equal(t, syscall.ENOTDIR, err)
 	})
 }
 
 func TestDirFS_String(t *testing.T) {
-	testFS, err := NewDirFS(".", "/tmp")
-	require.NoError(t, err)
+	testFS := NewDirFS(".")
 
-	require.Equal(t, ".:/tmp", testFS.String())
+	// String has the name of the path entered
+	require.Equal(t, ".", testFS.String())
 }
 
 func TestDirFS_MkDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	testFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := NewDirFS(tmpDir)
 
 	name := "mkdir"
 	realPath := pathutil.Join(tmpDir, name)
@@ -83,12 +74,11 @@ func TestDirFS_MkDir(t *testing.T) {
 func TestDirFS_Rename(t *testing.T) {
 	t.Run("from doesn't exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		file1 := "file1"
 		file1Path := pathutil.Join(tmpDir, file1)
-		err = os.WriteFile(file1Path, []byte{1}, 0o600)
+		err := os.WriteFile(file1Path, []byte{1}, 0o600)
 		require.NoError(t, err)
 
 		err = testFS.Rename("file2", file1)
@@ -96,13 +86,12 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("file to non-exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		file1 := "file1"
 		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
-		err = os.WriteFile(file1Path, file1Contents, 0o600)
+		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		file2 := "file2"
@@ -120,8 +109,7 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("dir to non-exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		dir1 := "dir1"
 		dir1Path := pathutil.Join(tmpDir, dir1)
@@ -129,7 +117,7 @@ func TestDirFS_Rename(t *testing.T) {
 
 		dir2 := "dir2"
 		dir2Path := pathutil.Join(tmpDir, dir2)
-		err = testFS.Rename(dir1, dir2)
+		err := testFS.Rename(dir1, dir2)
 		require.NoError(t, err)
 
 		// Show the prior path no longer exists
@@ -142,8 +130,7 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("dir to file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		dir1 := "dir1"
 		dir1Path := pathutil.Join(tmpDir, dir1)
@@ -153,7 +140,7 @@ func TestDirFS_Rename(t *testing.T) {
 		dir2Path := pathutil.Join(tmpDir, dir2)
 
 		// write a file to that path
-		err = os.WriteFile(dir2Path, []byte{2}, 0o600)
+		err := os.WriteFile(dir2Path, []byte{2}, 0o600)
 		require.NoError(t, err)
 
 		err = testFS.Rename(dir1, dir2)
@@ -170,13 +157,12 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("file to dir", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		file1 := "file1"
 		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
-		err = os.WriteFile(file1Path, file1Contents, 0o600)
+		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		dir1 := "dir1"
@@ -188,8 +174,7 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("dir to dir", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		dir1 := "dir1"
 		dir1Path := pathutil.Join(tmpDir, dir1)
@@ -199,7 +184,7 @@ func TestDirFS_Rename(t *testing.T) {
 		file1 := "file1"
 		file1Path := pathutil.Join(dir1Path, file1)
 		file1Contents := []byte{1}
-		err = os.WriteFile(file1Path, file1Contents, 0o600)
+		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		dir2 := "dir2"
@@ -225,13 +210,12 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("file to file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		file1 := "file1"
 		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
-		err = os.WriteFile(file1Path, file1Contents, 0o600)
+		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		file2 := "file2"
@@ -254,14 +238,13 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("dir to itself", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		dir1 := "dir1"
 		dir1Path := pathutil.Join(tmpDir, dir1)
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
-		err = testFS.Rename(dir1, dir1)
+		err := testFS.Rename(dir1, dir1)
 		require.NoError(t, err)
 
 		s, err := os.Stat(dir1Path)
@@ -270,13 +253,12 @@ func TestDirFS_Rename(t *testing.T) {
 	})
 	t.Run("file to itself", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		testFS, err := NewDirFS(tmpDir, "/")
-		require.NoError(t, err)
+		testFS := NewDirFS(tmpDir)
 
 		file1 := "file1"
 		file1Path := pathutil.Join(tmpDir, file1)
 		file1Contents := []byte{1}
-		err = os.WriteFile(file1Path, file1Contents, 0o600)
+		err := os.WriteFile(file1Path, file1Contents, 0o600)
 		require.NoError(t, err)
 
 		err = testFS.Rename(file1, file1)
@@ -290,9 +272,7 @@ func TestDirFS_Rename(t *testing.T) {
 
 func TestDirFS_Rmdir(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	testFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := NewDirFS(tmpDir)
 
 	name := "rmdir"
 	realPath := pathutil.Join(tmpDir, name)
@@ -331,9 +311,7 @@ func TestDirFS_Rmdir(t *testing.T) {
 
 func TestDirFS_Unlink(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	testFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := NewDirFS(tmpDir)
 
 	name := "unlink"
 	realPath := pathutil.Join(tmpDir, name)
@@ -363,9 +341,7 @@ func TestDirFS_Unlink(t *testing.T) {
 
 func TestDirFS_Utimes(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	testFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := NewDirFS(tmpDir)
 
 	testUtimes(t, tmpDir, testFS)
 }
@@ -377,8 +353,7 @@ func TestDirFS_Open(t *testing.T) {
 	tmpDir = pathutil.Join(tmpDir, t.Name())
 	require.NoError(t, os.Mkdir(tmpDir, 0o700))
 
-	testFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := NewDirFS(tmpDir)
 
 	testOpen_Read(t, tmpDir, testFS)
 
@@ -400,8 +375,7 @@ func TestDirFS_TestFS(t *testing.T) {
 	require.NoError(t, fstest.WriteTestFiles(tmpDir))
 
 	// Create a writeable filesystem
-	testFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	testFS := NewDirFS(tmpDir)
 
 	// Run TestFS via the adapter
 	require.NoError(t, fstest.TestFS(&testFSAdapter{testFS}))

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -30,8 +30,10 @@ func TestNewDirFS(t *testing.T) {
 		arg0 := os.Args[0] // should be safe in scratch tests which don't have the source mounted.
 
 		testFS := NewDirFS(arg0)
-		_, err = testFS.OpenFile(".", os.O_RDONLY, 0)
-		require.Equal(t, syscall.ENOTDIR, err)
+		d, err := testFS.OpenFile(".", os.O_RDONLY, 0)
+		require.NoError(t, err)
+		_, err = d.(fs.ReadDirFile).ReadDir(-1)
+		require.Equal(t, syscall.ENOTDIR, errors.Unwrap(err))
 	})
 }
 

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -29,12 +29,7 @@ type readFS struct {
 
 // String implements fmt.Stringer
 func (r *readFS) String() string {
-	return r.fs.String() + ":ro"
-}
-
-// GuestDir implements FS.GuestDir
-func (r *readFS) GuestDir() string {
-	return r.fs.GuestDir()
+	return r.fs.String()
 }
 
 // OpenFile implements FS.OpenFile

--- a/internal/sysfs/sysfs_test.go
+++ b/internal/sysfs/sysfs_test.go
@@ -414,8 +414,7 @@ func TestReaderAtOffset_Unsupported(t *testing.T) {
 
 func TestWriterAtOffset(t *testing.T) {
 	tmpDir := t.TempDir()
-	dirFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	dirFS := NewDirFS(tmpDir)
 
 	// fs.FS doesn't support writes, and there is no other built-in
 	// implementation except os.File.
@@ -481,8 +480,7 @@ func TestWriterAtOffset(t *testing.T) {
 
 func TestWriterAtOffset_empty(t *testing.T) {
 	tmpDir := t.TempDir()
-	dirFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	dirFS := NewDirFS(tmpDir)
 
 	// fs.FS doesn't support writes, and there is no other built-in
 	// implementation except os.File.
@@ -523,8 +521,7 @@ func TestWriterAtOffset_empty(t *testing.T) {
 
 func TestWriterAtOffset_Unsupported(t *testing.T) {
 	tmpDir := t.TempDir()
-	dirFS, err := NewDirFS(tmpDir, "/")
-	require.NoError(t, err)
+	dirFS := NewDirFS(tmpDir)
 
 	f, err := dirFS.OpenFile(readerAtFile, os.O_RDWR|os.O_CREATE, 0o600)
 	require.NoError(t, err)

--- a/internal/sysfs/unsupported.go
+++ b/internal/sysfs/unsupported.go
@@ -1,7 +1,6 @@
 package sysfs
 
 import (
-	"fmt"
 	"io/fs"
 	"syscall"
 )
@@ -13,16 +12,6 @@ type UnimplementedFS struct{}
 // String implements fmt.Stringer
 func (UnimplementedFS) String() string {
 	return "Unimplemented:/"
-}
-
-// Open implements the same method as documented on fs.FS
-func (UnimplementedFS) Open(name string) (fs.File, error) {
-	panic(fmt.Errorf("unexpected to call fs.FS.Open(%s)", name))
-}
-
-// GuestDir implements FS.GuestDir
-func (UnimplementedFS) GuestDir() string {
-	return "/"
 }
 
 // OpenFile implements FS.OpenFile


### PR DESCRIPTION
This decouples sysfs.FS from fs.FS by introducing a temporary type FSHolder, which will be removed when we top-level FSConfig (shortly).

This further reduces complexity by consolidating guest path configuration into the only type that uses it: CompositeFS.

The next PR will add FSConfig and be a lot smaller due to extracting this stuff now.