### PR TITLE
logging: rename crypto scope to random

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -126,7 +126,7 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 	var hostlogging sliceFlag
 	flags.Var(&hostlogging, "hostlogging",
 		"A scope of host functions to log to stderr. "+
-			"This may be specified multiple times. Supported values: crypto,filesystem")
+			"This may be specified multiple times. Supported values: filesystem,random")
 
 	cacheDir := cacheDirFlag(flags)
 
@@ -299,8 +299,8 @@ func maybeHostLogging(ctx context.Context, hostLogging []string, stdErr logging.
 	for _, h := range hostLogging {
 		switch h {
 		case "":
-		case "crypto":
-			scopes |= logging.LogScopeCrypto
+		case "random":
+			scopes |= logging.LogScopeRandom
 		case "filesystem":
 			scopes |= logging.LogScopeFilesystem
 		default:

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -247,9 +247,9 @@ func TestRun(t *testing.T) {
 			expectedStdout: "pooh\n",
 		},
 		{
-			name:       "wasi hostlogging=crypto",
+			name:       "wasi hostlogging=random",
 			wasm:       wasmWasiRandomGet,
-			wazeroOpts: []string{"--hostlogging=crypto"},
+			wazeroOpts: []string{"--hostlogging=random"},
 			expectedStderr: `==> wasi_snapshot_preview1.random_get(buf=0,buf_len=1000)
 <== errno=ESUCCESS
 `,
@@ -354,9 +354,9 @@ func TestRun(t *testing.T) {
 	}
 
 	cryptoTest := test{
-		name:       "GOARCH=wasm GOOS=js hostlogging=crypto and filesystem",
+		name:       "GOARCH=wasm GOOS=js hostlogging=random and filesystem",
 		wasm:       wasmCat,
-		wazeroOpts: []string{"--hostlogging=crypto", "--hostlogging=filesystem"},
+		wazeroOpts: []string{"--hostlogging=random", "--hostlogging=filesystem"},
 		wasmArgs:   []string{"/bear.txt"},
 		expectedStderr: `==> go.runtime.getRandomData(r_len=32)
 <==

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -18,12 +18,12 @@ type Writer interface {
 	io.StringWriter
 }
 
-// LogScopes is a bit flag of host function groups to log. e.g. LogScopeCrypto.
+// LogScopes is a bit flag of host function groups to log. e.g. LogScopeRandom.
 //
 // To specify all scopes, use LogScopeAll. For multiple scopes, OR them
 // together like this:
 //
-//	scope = logging.LogScopeCrypto | logging.LogScopeFilesystem
+//	scope = logging.LogScopeRandom | logging.LogScopeFilesystem
 //
 // Note: Numeric values are not intended to be interpreted except as bit flags.
 type LogScopes = logging.LogScopes
@@ -34,8 +34,8 @@ const (
 	// LogScopeFilesystem enables logging for functions such as `path_open`.
 	// Note: This doesn't log writes to the console.
 	LogScopeFilesystem = logging.LogScopeFilesystem
-	// LogScopeCrypto enables logging for functions such as `random_get`.
-	LogScopeCrypto = logging.LogScopeCrypto
+	// LogScopeRandom enables logging for functions such as `random_get`.
+	LogScopeRandom = logging.LogScopeRandom
 	// LogScopeAll means all functions should be logged.
 	LogScopeAll = logging.LogScopeAll
 )
@@ -106,7 +106,7 @@ func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experim
 		pSampler, pLoggers, rLoggers = gologging.Config(fnd, f.scopes)
 	case "env":
 		// Special-case AssemblyScript which has only one relevant function.
-		if fnd.ExportNames()[0] == "seed" && !f.scopes.IsEnabled(LogScopeCrypto) {
+		if fnd.ExportNames()[0] == "seed" && !f.scopes.IsEnabled(LogScopeRandom) {
 			return nil
 		}
 		pLoggers, rLoggers = logging.Config(fnd)

--- a/imports/assemblyscript/assemblyscript_test.go
+++ b/imports/assemblyscript/assemblyscript_test.go
@@ -128,7 +128,7 @@ func TestSeed(t *testing.T) {
 	}{
 		{
 			name:   "logs to crypto scope",
-			scopes: logging.LogScopeCrypto,
+			scopes: logging.LogScopeRandom,
 			expectedLog: `
 ==> env.~lib/builtins/seed()
 <== rand=4.958153677776298e-175

--- a/internal/gojs/crypto_test.go
+++ b/internal/gojs/crypto_test.go
@@ -16,7 +16,7 @@ func Test_crypto(t *testing.T) {
 
 	var log bytes.Buffer
 	loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
-		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeCrypto))
+		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeRandom))
 
 	stdout, stderr, err := compileAndRun(loggingCtx, "crypto", wazero.NewModuleConfig())
 

--- a/internal/gojs/logging/logging.go
+++ b/internal/gojs/logging/logging.go
@@ -18,7 +18,7 @@ import (
 
 // IsInLogScope returns true if the current function is in any of the scopes.
 func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
-	if scopes.IsEnabled(logging.LogScopeCrypto) {
+	if scopes.IsEnabled(logging.LogScopeRandom) {
 		switch fnd.Name() {
 		case custom.NameRuntimeGetRandomData:
 			return true
@@ -82,7 +82,7 @@ func (s *syscallValueCallParamSampler) isSampled(ctx context.Context, mod api.Mo
 		}
 		return true
 	case goos.RefJsCrypto:
-		return logging.LogScopeCrypto.IsEnabled(s.scopes)
+		return logging.LogScopeRandom.IsEnabled(s.scopes)
 	}
 
 	return s.scopes == logging.LogScopeAll

--- a/internal/gojs/logging/logging_test.go
+++ b/internal/gojs/logging/logging_test.go
@@ -30,9 +30,9 @@ func TestIsInLogScope(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "runtimeGetRandomData in LogScopeCrypto",
+			name:     "runtimeGetRandomData in LogScopeRandom",
 			fnd:      runtimeGetRandomData,
-			scopes:   logging.LogScopeCrypto,
+			scopes:   logging.LogScopeRandom,
 			expected: true,
 		},
 		{
@@ -42,9 +42,9 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "runtimeGetRandomData in LogScopeCrypto|LogScopeFilesystem",
+			name:     "runtimeGetRandomData in LogScopeRandom|LogScopeFilesystem",
 			fnd:      runtimeGetRandomData,
-			scopes:   logging.LogScopeCrypto | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{
@@ -66,15 +66,15 @@ func TestIsInLogScope(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "syscallValueCall in LogScopeCrypto",
+			name:     "syscallValueCall in LogScopeRandom",
 			fnd:      syscallValueCall,
-			scopes:   logging.LogScopeCrypto,
+			scopes:   logging.LogScopeRandom,
 			expected: true,
 		},
 		{
-			name:     "syscallValueCall in LogScopeCrypto|LogScopeFilesystem",
+			name:     "syscallValueCall in LogScopeRandom|LogScopeFilesystem",
 			fnd:      syscallValueCall,
-			scopes:   logging.LogScopeCrypto | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -39,7 +39,7 @@ type LogScopes uint64
 const (
 	LogScopeNone                 = LogScopes(0)
 	LogScopeFilesystem LogScopes = 1 << iota
-	LogScopeCrypto
+	LogScopeRandom
 	LogScopeAll = LogScopes(0xffffffffffffffff)
 )
 
@@ -47,8 +47,8 @@ func scopeName(s LogScopes) string {
 	switch s {
 	case LogScopeFilesystem:
 		return "filesystem"
-	case LogScopeCrypto:
-		return "crypto"
+	case LogScopeRandom:
+		return "random"
 	default:
 		return fmt.Sprintf("<unknown=%d>", s)
 	}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -52,8 +52,8 @@ func TestLogScopes_String(t *testing.T) {
 		{name: "none", scopes: LogScopeNone, expected: ""},
 		{name: "any", scopes: LogScopeAll, expected: "all"},
 		{name: "filesystem", scopes: LogScopeFilesystem, expected: "filesystem"},
-		{name: "crypto", scopes: LogScopeCrypto, expected: "crypto"},
-		{name: "filesystem|crypto", scopes: LogScopeFilesystem | LogScopeCrypto, expected: "filesystem|crypto"},
+		{name: "random", scopes: LogScopeRandom, expected: "random"},
+		{name: "filesystem|random", scopes: LogScopeFilesystem | LogScopeRandom, expected: "filesystem|random"},
 		{name: "undefined", scopes: 1 << 3, expected: fmt.Sprintf("<unknown=%d>", (1 << 3))},
 	}
 

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -24,14 +24,14 @@ func isFilesystemFunction(fnd api.FunctionDefinition) bool {
 	return false
 }
 
-func isCryptoFunction(fnd api.FunctionDefinition) bool {
+func isRandomFunction(fnd api.FunctionDefinition) bool {
 	return fnd.Name() == RandomGetName
 }
 
 // IsInLogScope returns true if the current function is in any of the scopes.
 func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
-	if scopes.IsEnabled(logging.LogScopeCrypto) {
-		if isCryptoFunction(fnd) {
+	if scopes.IsEnabled(logging.LogScopeRandom) {
+		if isRandomFunction(fnd) {
 			return true
 		}
 	}

--- a/internal/wasi_snapshot_preview1/logging/logging_test.go
+++ b/internal/wasi_snapshot_preview1/logging/logging_test.go
@@ -30,9 +30,9 @@ func TestIsInLogScope(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "randomGet in LogScopeCrypto",
+			name:     "randomGet in LogScopeRandom",
 			fnd:      randomGet,
-			scopes:   logging.LogScopeCrypto,
+			scopes:   logging.LogScopeRandom,
 			expected: true,
 		},
 		{
@@ -42,9 +42,9 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "randomGet in LogScopeCrypto|LogScopeFilesystem",
+			name:     "randomGet in LogScopeRandom|LogScopeFilesystem",
 			fnd:      randomGet,
-			scopes:   logging.LogScopeCrypto | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{
@@ -66,15 +66,15 @@ func TestIsInLogScope(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "fdRead not in LogScopeCrypto",
+			name:     "fdRead not in LogScopeRandom",
 			fnd:      fdRead,
-			scopes:   logging.LogScopeCrypto,
+			scopes:   logging.LogScopeRandom,
 			expected: false,
 		},
 		{
-			name:     "fdRead in LogScopeCrypto|LogScopeFilesystem",
+			name:     "fdRead in LogScopeRandom|LogScopeFilesystem",
 			fnd:      fdRead,
-			scopes:   logging.LogScopeCrypto | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{


### PR DESCRIPTION
This is to avoid a collision with an emerging wasi-crypto. They will have both wasi-random and wasi-crypto
