### PR TITLE
logging: adds clock scope

### DIFF
--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -31,6 +31,8 @@ type LogScopes = logging.LogScopes
 const (
 	// LogScopeNone means nothing should be logged
 	LogScopeNone = logging.LogScopeNone
+	// LogScopeClock enables logging for functions such as `clock_time_get`.
+	LogScopeClock = logging.LogScopeClock
 	// LogScopeFilesystem enables logging for functions such as `path_open`.
 	// Note: This doesn't log writes to the console.
 	LogScopeFilesystem = logging.LogScopeFilesystem

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -36,8 +36,8 @@ func Test_clockResGet(t *testing.T) {
 			clockID:        ClockIDRealtime,
 			expectedMemory: expectedMemoryMicro,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_res_get(id=0,result.resolution=16)
-<== errno=ESUCCESS
+==> wasi_snapshot_preview1.clock_res_get(id=realtime)
+<== (resolution=1000,errno=ESUCCESS)
 `,
 		},
 		{
@@ -45,8 +45,8 @@ func Test_clockResGet(t *testing.T) {
 			clockID:        ClockIDMonotonic,
 			expectedMemory: expectedMemoryNano,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_res_get(id=1,result.resolution=16)
-<== errno=ESUCCESS
+==> wasi_snapshot_preview1.clock_res_get(id=monotonic)
+<== (resolution=1,errno=ESUCCESS)
 `,
 		},
 	}
@@ -85,8 +85,8 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			clockID:       2,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_res_get(id=2,result.resolution=16)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.clock_res_get(id=2)
+<== (resolution=,errno=EINVAL)
 `,
 		},
 		{
@@ -94,8 +94,8 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			clockID:       3,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_res_get(id=3,result.resolution=16)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.clock_res_get(id=3)
+<== (resolution=,errno=EINVAL)
 `,
 		},
 		{
@@ -103,12 +103,11 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			clockID:       100,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_res_get(id=100,result.resolution=16)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.clock_res_get(id=100)
+<== (resolution=,errno=EINVAL)
 `,
 		},
 	}
-
 	for _, tt := range tests {
 		tc := tt
 
@@ -141,8 +140,8 @@ func Test_clockTimeGet(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=16)
-<== errno=ESUCCESS
+==> wasi_snapshot_preview1.clock_time_get(id=realtime)
+<== (timestamp=1640995200000000000,errno=ESUCCESS)
 `,
 		},
 		{
@@ -154,8 +153,8 @@ func Test_clockTimeGet(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=1,precision=0,result.timestamp=16)
-<== errno=ESUCCESS
+==> wasi_snapshot_preview1.clock_time_get(id=monotonic)
+<== (timestamp=0,errno=ESUCCESS)
 `,
 		},
 	}
@@ -193,8 +192,8 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       2,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=2,precision=0,result.timestamp=16)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.clock_time_get(id=2)
+<== (timestamp=,errno=EINVAL)
 `,
 		},
 		{
@@ -202,8 +201,8 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       3,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=3,precision=0,result.timestamp=16)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.clock_time_get(id=3)
+<== (timestamp=,errno=EINVAL)
 `,
 		},
 		{
@@ -211,8 +210,8 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       100,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=100,precision=0,result.timestamp=16)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.clock_time_get(id=100)
+<== (timestamp=,errno=EINVAL)
 `,
 		},
 	}
@@ -245,16 +244,16 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 			name:            "resultTimestamp OOM",
 			resultTimestamp: memorySize,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65536)
-<== errno=EFAULT
+==> wasi_snapshot_preview1.clock_time_get(id=realtime)
+<== (timestamp=,errno=EFAULT)
 `,
 		},
 		{
 			name:            "resultTimestamp exceeds the maximum valid address by 1",
 			resultTimestamp: memorySize - 4 + 1, // 4 is the size of uint32, the type of the count of args
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=0,precision=0,result.timestamp=65533)
-<== errno=EFAULT
+==> wasi_snapshot_preview1.clock_time_get(id=realtime)
+<== (timestamp=,errno=EFAULT)
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -140,7 +140,7 @@ func Test_clockTimeGet(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=realtime)
+==> wasi_snapshot_preview1.clock_time_get(id=realtime,precision=0)
 <== (timestamp=1640995200000000000,errno=ESUCCESS)
 `,
 		},
@@ -153,7 +153,7 @@ func Test_clockTimeGet(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=monotonic)
+==> wasi_snapshot_preview1.clock_time_get(id=monotonic,precision=0)
 <== (timestamp=0,errno=ESUCCESS)
 `,
 		},
@@ -192,7 +192,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       2,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=2)
+==> wasi_snapshot_preview1.clock_time_get(id=2,precision=0)
 <== (timestamp=,errno=EINVAL)
 `,
 		},
@@ -201,7 +201,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       3,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=3)
+==> wasi_snapshot_preview1.clock_time_get(id=3,precision=0)
 <== (timestamp=,errno=EINVAL)
 `,
 		},
@@ -210,7 +210,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			clockID:       100,
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=100)
+==> wasi_snapshot_preview1.clock_time_get(id=100,precision=0)
 <== (timestamp=,errno=EINVAL)
 `,
 		},
@@ -244,7 +244,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 			name:            "resultTimestamp OOM",
 			resultTimestamp: memorySize,
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=realtime)
+==> wasi_snapshot_preview1.clock_time_get(id=realtime,precision=0)
 <== (timestamp=,errno=EFAULT)
 `,
 		},
@@ -252,7 +252,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 			name:            "resultTimestamp exceeds the maximum valid address by 1",
 			resultTimestamp: memorySize - 4 + 1, // 4 is the size of uint32, the type of the count of args
 			expectedLog: `
-==> wasi_snapshot_preview1.clock_time_get(id=realtime)
+==> wasi_snapshot_preview1.clock_time_get(id=realtime,precision=0)
 <== (timestamp=,errno=EFAULT)
 `,
 		},

--- a/internal/gojs/crypto_test.go
+++ b/internal/gojs/crypto_test.go
@@ -25,21 +25,10 @@ func Test_crypto(t *testing.T) {
 	require.Equal(t, `7a0c9f9f0d
 `, stdout)
 
-	// TODO: Go 1.17 initializes randoms in a different order than Go 1.18,19
-	// When we move to 1.20, remove the workaround.
-	if log.String() != `==> go.runtime.getRandomData(r_len=32)
-<==
-==> go.runtime.getRandomData(r_len=8)
-<==
-==> go.syscall/js.valueCall(crypto.getRandomValues(r_len=5))
-<== (n=5)
-` {
-		require.Equal(t, `==> go.runtime.getRandomData(r_len=8)
-<==
-==> go.runtime.getRandomData(r_len=32)
-<==
-==> go.syscall/js.valueCall(crypto.getRandomValues(r_len=5))
-<== (n=5)
-`, log.String())
-	}
+	// Search for the two functions that should be in scope, flexibly, to pass
+	// go 1.17-19
+	require.Contains(t, log.String(), `go.runtime.getRandomData(r_len=32)
+<==`)
+	require.Contains(t, log.String(), `==> go.syscall/js.valueCall(crypto.getRandomValues(r_len=5))
+<== (n=5)`)
 }

--- a/internal/gojs/custom/date.go
+++ b/internal/gojs/custom/date.go
@@ -1,0 +1,17 @@
+package custom
+
+const (
+	NameDate                  = "Date"
+	NameDateGetTimezoneOffset = "getTimezoneOffset"
+)
+
+// DateNameSection are the functions defined in the object named NameDate.
+// Results here are those set to the current event object, but effectively are
+// results of the host function.
+var DateNameSection = map[string]*Names{
+	NameDateGetTimezoneOffset: {
+		Name:        NameDateGetTimezoneOffset,
+		ParamNames:  []string{},
+		ResultNames: []string{"tz"},
+	},
+}

--- a/internal/gojs/custom/names.go
+++ b/internal/gojs/custom/names.go
@@ -190,5 +190,6 @@ var NameSection = map[string]*Names{
 
 var NameSectionSyscallValueCall = map[string]map[string]*Names{
 	NameCrypto: CryptoNameSection,
+	NameDate:   DateNameSection,
 	NameFs:     FsNameSection,
 }

--- a/internal/gojs/time.go
+++ b/internal/gojs/time.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/gojs/custom"
 	"github.com/tetratelabs/wazero/internal/gojs/goos"
 )
 
@@ -11,12 +12,12 @@ var (
 	// jsDateConstructor returns jsDate.
 	//
 	// This is defined as `Get("Date")` in zoneinfo_js.go time.initLocal
-	jsDateConstructor = newJsVal(goos.RefJsDateConstructor, "Date")
+	jsDateConstructor = newJsVal(goos.RefJsDateConstructor, custom.NameDate)
 
 	// jsDate is used inline in zoneinfo_js.go for time.initLocal.
 	// `.Call("getTimezoneOffset").Int()` returns a timezone offset.
-	jsDate = newJsVal(goos.RefJsDate, "jsDate").
-		addFunction("getTimezoneOffset", jsDateGetTimezoneOffset{})
+	jsDate = newJsVal(goos.RefJsDate, custom.NameDate).
+		addFunction(custom.NameDateGetTimezoneOffset, jsDateGetTimezoneOffset{})
 )
 
 // jsDateGetTimezoneOffset implements jsFn

--- a/internal/gojs/time_test.go
+++ b/internal/gojs/time_test.go
@@ -1,20 +1,39 @@
 package gojs_test
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func Test_time(t *testing.T) {
 	t.Parallel()
 
-	stdout, stderr, err := compileAndRun(testCtx, "time", wazero.NewModuleConfig())
+	var log bytes.Buffer
+	loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
+		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeClock))
+
+	stdout, stderr, err := compileAndRun(loggingCtx, "time", wazero.NewModuleConfig())
 
 	require.EqualError(t, err, `module "" closed with exit_code(0)`)
 	require.Zero(t, stderr)
 	require.Equal(t, `Local
 1ms
 `, stdout)
+
+	// Search for the three functions that should be in scope, flexibly, to pass
+	// go 1.17-19
+	require.Contains(t, log.String(), `==> go.runtime.nanotime1()
+<== (nsec=0)`)
+	require.Contains(t, log.String(), `==> go.runtime.walltime()
+<== (sec=1640995200,nsec=0)
+`)
+	require.Contains(t, log.String(), `==> go.syscall/js.valueCall(Date.getTimezoneOffset())
+<== (tz=0)
+`)
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -37,14 +37,17 @@ const (
 type LogScopes uint64
 
 const (
-	LogScopeNone                 = LogScopes(0)
-	LogScopeFilesystem LogScopes = 1 << iota
+	LogScopeNone            = LogScopes(0)
+	LogScopeClock LogScopes = 1 << iota
+	LogScopeFilesystem
 	LogScopeRandom
 	LogScopeAll = LogScopes(0xffffffffffffffff)
 )
 
 func scopeName(s LogScopes) string {
 	switch s {
+	case LogScopeClock:
+		return "clock"
 	case LogScopeFilesystem:
 		return "filesystem"
 	case LogScopeRandom:

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -51,10 +51,11 @@ func TestLogScopes_String(t *testing.T) {
 	}{
 		{name: "none", scopes: LogScopeNone, expected: ""},
 		{name: "any", scopes: LogScopeAll, expected: "all"},
+		{name: "clock", scopes: LogScopeClock, expected: "clock"},
 		{name: "filesystem", scopes: LogScopeFilesystem, expected: "filesystem"},
 		{name: "random", scopes: LogScopeRandom, expected: "random"},
 		{name: "filesystem|random", scopes: LogScopeFilesystem | LogScopeRandom, expected: "filesystem|random"},
-		{name: "undefined", scopes: 1 << 3, expected: fmt.Sprintf("<unknown=%d>", (1 << 3))},
+		{name: "undefined", scopes: 1 << 14, expected: fmt.Sprintf("<unknown=%d>", 1<<14)},
 	}
 
 	for _, tt := range tests {

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -106,6 +106,9 @@ func Config(fnd api.FunctionDefinition) (pSampler logging.ParamSampler, pLoggers
 				name = resultParamName(name)
 				logger = logMemI64(idx).Log
 				rLoggers = append(rLoggers, resultParamLogger(name, logger))
+			default:
+				logger = logging.NewParamLogger(idx, name, fnd.ParamTypes()[idx])
+				pLoggers = append(pLoggers, logger)
 			}
 			continue
 		}

--- a/internal/wasi_snapshot_preview1/logging/logging_test.go
+++ b/internal/wasi_snapshot_preview1/logging/logging_test.go
@@ -21,8 +21,9 @@ func (f *testFunctionDefinition) Name() string {
 }
 
 func TestIsInLogScope(t *testing.T) {
-	randomGet := &testFunctionDefinition{name: RandomGetName}
+	clockTimeGet := &testFunctionDefinition{name: ClockTimeGetName}
 	fdRead := &testFunctionDefinition{name: FdReadName}
+	randomGet := &testFunctionDefinition{name: RandomGetName}
 	tests := []struct {
 		name     string
 		fnd      api.FunctionDefinition
@@ -30,32 +31,32 @@ func TestIsInLogScope(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "randomGet in LogScopeRandom",
-			fnd:      randomGet,
-			scopes:   logging.LogScopeRandom,
+			name:     "clockTimeGet in LogScopeClock",
+			fnd:      clockTimeGet,
+			scopes:   logging.LogScopeClock,
 			expected: true,
 		},
 		{
-			name:     "randomGet not in LogScopeFilesystem",
-			fnd:      randomGet,
+			name:     "clockTimeGet not in LogScopeFilesystem",
+			fnd:      clockTimeGet,
 			scopes:   logging.LogScopeFilesystem,
 			expected: false,
 		},
 		{
-			name:     "randomGet in LogScopeRandom|LogScopeFilesystem",
-			fnd:      randomGet,
-			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
+			name:     "clockTimeGet in LogScopeClock|LogScopeFilesystem",
+			fnd:      clockTimeGet,
+			scopes:   logging.LogScopeClock | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{
-			name:     "randomGet in LogScopeAll",
-			fnd:      randomGet,
+			name:     "clockTimeGet in LogScopeAll",
+			fnd:      clockTimeGet,
 			scopes:   logging.LogScopeAll,
 			expected: true,
 		},
 		{
-			name:     "randomGet not in LogScopeNone",
-			fnd:      randomGet,
+			name:     "clockTimeGet not in LogScopeNone",
+			fnd:      clockTimeGet,
 			scopes:   logging.LogScopeNone,
 			expected: false,
 		},
@@ -86,6 +87,36 @@ func TestIsInLogScope(t *testing.T) {
 		{
 			name:     "fdRead not in LogScopeNone",
 			fnd:      fdRead,
+			scopes:   logging.LogScopeNone,
+			expected: false,
+		},
+		{
+			name:     "randomGet in LogScopeRandom",
+			fnd:      randomGet,
+			scopes:   logging.LogScopeRandom,
+			expected: true,
+		},
+		{
+			name:     "randomGet not in LogScopeFilesystem",
+			fnd:      randomGet,
+			scopes:   logging.LogScopeFilesystem,
+			expected: false,
+		},
+		{
+			name:     "randomGet in LogScopeRandom|LogScopeFilesystem",
+			fnd:      randomGet,
+			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
+			expected: true,
+		},
+		{
+			name:     "randomGet in LogScopeAll",
+			fnd:      randomGet,
+			scopes:   logging.LogScopeAll,
+			expected: true,
+		},
+		{
+			name:     "randomGet not in LogScopeNone",
+			fnd:      randomGet,
 			scopes:   logging.LogScopeNone,
 			expected: false,
 		},


### PR DESCRIPTION
This allows you to specify the clock scope amongst existing logging scopes, both in API and the CLI.

e.g for the CLI.
```bash
$ wazero run --hostlogging=clock --hostlogging=filesystem --mount=.:/:ro cat.wasm
```

e.g. for Go
```go
loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
	logging.NewHostLoggingListenerFactory(&log, logging.LogScopeClock|logging.LogScopeFilesystem))
```
