### PR TITLE
logging: adds poll scope

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -127,7 +127,7 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 	var hostlogging logScopesFlag
 	flags.Var(&hostlogging, "hostlogging",
 		"A scope of host functions to log to stderr. "+
-			"This may be specified multiple times. Supported values: clock,filesystem,random")
+			"This may be specified multiple times. Supported values: clock,filesystem,poll,random")
 
 	cacheDir := cacheDirFlag(flags)
 

--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -374,6 +374,8 @@ func (f *logScopesFlag) Set(s string) error {
 		*f |= logScopesFlag(logging.LogScopeClock)
 	case "filesystem":
 		*f |= logScopesFlag(logging.LogScopeFilesystem)
+	case "poll":
+		*f |= logScopesFlag(logging.LogScopePoll)
 	case "random":
 		*f |= logScopesFlag(logging.LogScopeRandom)
 	default:

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -553,14 +553,19 @@ func Test_logScopesFlag(t *testing.T) {
 			expected: logging.LogScopeFilesystem,
 		},
 		{
+			name:     "poll",
+			values:   []string{"poll"},
+			expected: logging.LogScopePoll,
+		},
+		{
 			name:     "random",
 			values:   []string{"random"},
 			expected: logging.LogScopeRandom,
 		},
 		{
-			name:     "clock filesystem random",
-			values:   []string{"clock", "filesystem", "random"},
-			expected: logging.LogScopeClock | logging.LogScopeFilesystem | logging.LogScopeRandom,
+			name:     "clock filesystem poll random",
+			values:   []string{"clock", "filesystem", "poll", "random"},
+			expected: logging.LogScopeClock | logging.LogScopeFilesystem | logging.LogScopePoll | logging.LogScopeRandom,
 		},
 	}
 

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -36,6 +36,8 @@ const (
 	// LogScopeFilesystem enables logging for functions such as `path_open`.
 	// Note: This doesn't log writes to the console.
 	LogScopeFilesystem = logging.LogScopeFilesystem
+	// LogScopePoll enables logging for functions such as `poll_oneoff`.
+	LogScopePoll = logging.LogScopePoll
 	// LogScopeRandom enables logging for functions such as `random_get`.
 	LogScopeRandom = logging.LogScopeRandom
 	// LogScopeAll means all functions should be logged.

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -30,7 +30,6 @@ import (
 // # Notes
 //
 //   - Since the `out` pointer nests Errno, the result is always ErrnoSuccess.
-//   - importPollOneoff shows this signature in the WebAssembly 1.0 Text Format.
 //   - This is similar to `poll` in POSIX.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#poll_oneoff

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -42,8 +42,8 @@ func Test_pollOneoff(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, PollOneoffName, uint64(in), uint64(out), uint64(nsubscriptions),
 		uint64(resultNevents))
 	require.Equal(t, `
-==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-<== errno=ESUCCESS
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1)
+<== (nevents=1,errno=ESUCCESS)
 `, "\n"+log.String())
 
 	outMem, ok := mod.Memory().Read(out, uint32(len(expectedMem)))
@@ -75,8 +75,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			resultNevents:  512, // past out
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.poll_oneoff(in=65536,out=128,nsubscriptions=1,result.nevents=512)
-<== errno=EFAULT
+==> wasi_snapshot_preview1.poll_oneoff(in=65536,out=128,nsubscriptions=1)
+<== (nevents=,errno=EFAULT)
 `,
 		},
 		{
@@ -86,8 +86,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			nsubscriptions: 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.poll_oneoff(in=0,out=65536,nsubscriptions=1,result.nevents=512)
-<== errno=EFAULT
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=65536,nsubscriptions=1)
+<== (nevents=,errno=EFAULT)
 `,
 		},
 		{
@@ -96,8 +96,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			nsubscriptions: 1,
 			expectedErrno:  ErrnoFault,
 			expectedLog: `
-==> wasi_snapshot_preview1.poll_oneoff(in=0,out=0,nsubscriptions=1,result.nevents=65536)
-<== errno=EFAULT
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=0,nsubscriptions=1)
+<== (nevents=,errno=EFAULT)
 `,
 		},
 		{
@@ -106,8 +106,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 			resultNevents: 512, // past out
 			expectedErrno: ErrnoInval,
 			expectedLog: `
-==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=0,result.nevents=512)
-<== errno=EINVAL
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=0)
+<== (nevents=,errno=EINVAL)
 `,
 		},
 		{
@@ -129,8 +129,8 @@ func Test_pollOneoff_Errors(t *testing.T) {
 				'?', // stopped after encoding
 			},
 			expectedLog: `
-==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1,result.nevents=512)
-<== errno=ESUCCESS
+==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1)
+<== (nevents=1,errno=ESUCCESS)
 `,
 		},
 	}

--- a/internal/gojs/runtime.go
+++ b/internal/gojs/runtime.go
@@ -53,7 +53,7 @@ func wasmWrite(_ context.Context, mod api.Module, stack goarch.Stack) {
 // See https://github.com/golang/go/blob/go1.19/src/runtime/mem_js.go#L82
 var ResetMemoryDataView = goarch.NewFunc(custom.NameRuntimeResetMemoryDataView, resetMemoryDataView)
 
-func resetMemoryDataView(ctx context.Context, _ api.Module, _ goarch.Stack) {
+func resetMemoryDataView(context.Context, api.Module, goarch.Stack) {
 	// context state does not cache a memory view, and all byte slices used
 	// are safely copied. Also, user-defined functions are not supported.
 	// Hence, there's currently no known reason to reset anything.

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -40,6 +40,7 @@ const (
 	LogScopeNone            = LogScopes(0)
 	LogScopeClock LogScopes = 1 << iota
 	LogScopeFilesystem
+	LogScopePoll
 	LogScopeRandom
 	LogScopeAll = LogScopes(0xffffffffffffffff)
 )
@@ -50,6 +51,8 @@ func scopeName(s LogScopes) string {
 		return "clock"
 	case LogScopeFilesystem:
 		return "filesystem"
+	case LogScopePoll:
+		return "poll"
 	case LogScopeRandom:
 		return "random"
 	default:

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -53,6 +53,7 @@ func TestLogScopes_String(t *testing.T) {
 		{name: "any", scopes: LogScopeAll, expected: "all"},
 		{name: "clock", scopes: LogScopeClock, expected: "clock"},
 		{name: "filesystem", scopes: LogScopeFilesystem, expected: "filesystem"},
+		{name: "poll", scopes: LogScopePoll, expected: "poll"},
 		{name: "random", scopes: LogScopeRandom, expected: "random"},
 		{name: "filesystem|random", scopes: LogScopeFilesystem | LogScopeRandom, expected: "filesystem|random"},
 		{name: "undefined", scopes: 1 << 14, expected: fmt.Sprintf("<unknown=%d>", 1<<14)},

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -28,6 +28,10 @@ func isFilesystemFunction(fnd api.FunctionDefinition) bool {
 	return false
 }
 
+func isPollFunction(fnd api.FunctionDefinition) bool {
+	return fnd.Name() == PollOneoffName
+}
+
 func isRandomFunction(fnd api.FunctionDefinition) bool {
 	return fnd.Name() == RandomGetName
 }
@@ -42,6 +46,12 @@ func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
 
 	if scopes.IsEnabled(logging.LogScopeFilesystem) {
 		if isFilesystemFunction(fnd) {
+			return true
+		}
+	}
+
+	if scopes.IsEnabled(logging.LogScopePoll) {
+		if isPollFunction(fnd) {
 			return true
 		}
 	}
@@ -122,7 +132,7 @@ func Config(fnd api.FunctionDefinition) (pSampler logging.ParamSampler, pLoggers
 			logger = logFsRightsBase(idx).Log
 		case "fs_rights_inheriting":
 			logger = logFsRightsInheriting(idx).Log
-		case "result.nread", "result.nwritten", "result.opened_fd":
+		case "result.nread", "result.nwritten", "result.opened_fd", "result.nevents":
 			name = resultParamName(name)
 			logger = logMemI32(idx).Log
 			rLoggers = append(rLoggers, resultParamLogger(name, logger))

--- a/internal/wasi_snapshot_preview1/logging/logging_test.go
+++ b/internal/wasi_snapshot_preview1/logging/logging_test.go
@@ -23,6 +23,7 @@ func (f *testFunctionDefinition) Name() string {
 func TestIsInLogScope(t *testing.T) {
 	clockTimeGet := &testFunctionDefinition{name: ClockTimeGetName}
 	fdRead := &testFunctionDefinition{name: FdReadName}
+	pollOneoff := &testFunctionDefinition{name: PollOneoffName}
 	randomGet := &testFunctionDefinition{name: RandomGetName}
 	tests := []struct {
 		name     string
@@ -87,6 +88,36 @@ func TestIsInLogScope(t *testing.T) {
 		{
 			name:     "fdRead not in LogScopeNone",
 			fnd:      fdRead,
+			scopes:   logging.LogScopeNone,
+			expected: false,
+		},
+		{
+			name:     "pollOneoff in LogScopePoll",
+			fnd:      pollOneoff,
+			scopes:   logging.LogScopePoll,
+			expected: true,
+		},
+		{
+			name:     "pollOneoff not in LogScopeFilesystem",
+			fnd:      pollOneoff,
+			scopes:   logging.LogScopeFilesystem,
+			expected: false,
+		},
+		{
+			name:     "pollOneoff in LogScopePoll|LogScopeFilesystem",
+			fnd:      pollOneoff,
+			scopes:   logging.LogScopePoll | logging.LogScopeFilesystem,
+			expected: true,
+		},
+		{
+			name:     "pollOneoff in LogScopeAll",
+			fnd:      pollOneoff,
+			scopes:   logging.LogScopeAll,
+			expected: true,
+		},
+		{
+			name:     "pollOneoff not in LogScopeNone",
+			fnd:      pollOneoff,
 			scopes:   logging.LogScopeNone,
 			expected: false,
 		},


### PR DESCRIPTION
This allows you to specify the poll scope amongst existing logging scopes, both in API and the CLI.

e.g for the CLI.
```bash
$ wazero run --hostlogging=poll --hostlogging=filesystem --mount=.:/:ro cat.wasm
```

e.g. for Go
```go
loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
	logging.NewHostLoggingListenerFactory(&log, logging.LogScopePoll|logging.LogScopeFilesystem))
```

This is particularly helpful to understand side-effects of GC. For example, in `GOOS=js` GC will trigger events and these have been tricky to troubleshoot in the past.