### PR TITLE
logging: adds exit scope and fixes mtim bug

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -127,7 +127,7 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 	var hostlogging logScopesFlag
 	flags.Var(&hostlogging, "hostlogging",
 		"A comma-separated list of host function scopes to log to stderr. "+
-			"This may be specified multiple times. Supported values: clock,filesystem,poll,random")
+			"This may be specified multiple times. Supported values: clock,exit,filesystem,poll,random")
 
 	cacheDir := cacheDirFlag(flags)
 
@@ -374,6 +374,8 @@ func (f *logScopesFlag) Set(input string) error {
 			continue
 		case "clock":
 			*f |= logScopesFlag(logging.LogScopeClock)
+		case "exit":
+			*f |= logScopesFlag(logging.LogScopeExit)
 		case "filesystem":
 			*f |= logScopesFlag(logging.LogScopeFilesystem)
 		case "poll":

--- a/imports/assemblyscript/assemblyscript.go
+++ b/imports/assemblyscript/assemblyscript.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	. "github.com/tetratelabs/wazero/internal/assemblyscript"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
@@ -42,10 +43,6 @@ import (
 
 const (
 	i32, f64 = wasm.ValueTypeI32, wasm.ValueTypeF64
-
-	functionAbort = "abort"
-	functionTrace = "trace"
-	functionSeed  = "seed"
 )
 
 // MustInstantiate calls Instantiate or panics on error.
@@ -141,7 +138,7 @@ func (e *functionExporter) ExportFunctions(builder wazero.HostModuleBuilder) {
 //
 // See https://github.com/AssemblyScript/assemblyscript/blob/v0.26.7/std/assembly/builtins.ts#L2508
 var abortMessageEnabled = &wasm.HostFunc{
-	ExportNames: []string{functionAbort},
+	ExportNames: []string{AbortName},
 	Name:        "~lib/builtins/abort",
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"message", "fileName", "lineNumber", "columnNumber"},
@@ -153,7 +150,7 @@ var abortMessageEnabled = &wasm.HostFunc{
 
 var abortMessageDisabled = abortMessageEnabled.WithGoModuleFunc(abort)
 
-// abortWithMessage implements functionAbort
+// abortWithMessage implements AbortName
 func abortWithMessage(ctx context.Context, mod api.Module, stack []uint64) {
 	fsc := mod.(*wasm.CallContext).Sys.FS()
 	mem := mod.Memory()
@@ -173,7 +170,7 @@ func abortWithMessage(ctx context.Context, mod api.Module, stack []uint64) {
 	abort(ctx, mod, stack)
 }
 
-// abortWithMessage implements functionAbort ignoring the message.
+// abortWithMessage implements AbortName ignoring the message.
 func abort(ctx context.Context, mod api.Module, _ []uint64) {
 	// AssemblyScript expects the exit code to be 255
 	// See https://github.com/AssemblyScript/wasi-shim/blob/v0.1.0/assembly/wasi_internal.ts#L59
@@ -191,7 +188,7 @@ var traceDisabled = traceStdout.WithWasm([]byte{wasm.OpcodeEnd})
 
 // traceStdout implements trace to the configured Stdout.
 var traceStdout = &wasm.HostFunc{
-	ExportNames: []string{functionTrace},
+	ExportNames: []string{TraceName},
 	Name:        "~lib/builtins/trace",
 	ParamTypes:  []api.ValueType{i32, i32, f64, f64, f64, f64, f64},
 	ParamNames:  []string{"message", "nArgs", "arg0", "arg1", "arg2", "arg3", "arg4"},
@@ -277,7 +274,7 @@ func formatFloat(f float64) string {
 //
 // See https://github.com/AssemblyScript/assemblyscript/blob/v0.26.7/std/assembly/builtins.ts#L2531
 var seed = &wasm.HostFunc{
-	ExportNames: []string{functionSeed},
+	ExportNames: []string{SeedName},
 	Name:        "~lib/builtins/seed",
 	ResultTypes: []api.ValueType{f64},
 	ResultNames: []string{"rand"},

--- a/internal/assemblyscript/logging/logging.go
+++ b/internal/assemblyscript/logging/logging.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"github.com/tetratelabs/wazero/api"
+	. "github.com/tetratelabs/wazero/internal/assemblyscript"
+	"github.com/tetratelabs/wazero/internal/logging"
+)
+
+func isExitFunction(fnd api.FunctionDefinition) bool {
+	return fnd.ExportNames()[0] == AbortName
+}
+
+func isRandomFunction(fnd api.FunctionDefinition) bool {
+	return fnd.ExportNames()[0] == SeedName
+}
+
+// IsInLogScope returns true if the current function is in any of the scopes.
+func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
+	if scopes.IsEnabled(logging.LogScopeExit) {
+		if isExitFunction(fnd) {
+			return true
+		}
+	}
+
+	if scopes.IsEnabled(logging.LogScopeRandom) {
+		if isRandomFunction(fnd) {
+			return true
+		}
+	}
+
+	return scopes == logging.LogScopeAll
+}
+
+func Config(fnd api.FunctionDefinition) (pSampler logging.ParamSampler, pLoggers []logging.ParamLogger, rLoggers []logging.ResultLogger) {
+	pLoggers, rLoggers = logging.Config(fnd)
+	return
+}

--- a/internal/assemblyscript/logging/logging_test.go
+++ b/internal/assemblyscript/logging/logging_test.go
@@ -1,0 +1,95 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/api"
+	. "github.com/tetratelabs/wazero/internal/assemblyscript"
+	"github.com/tetratelabs/wazero/internal/logging"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+type testFunctionDefinition struct {
+	name string
+	*wasm.FunctionDefinition
+}
+
+// ExportNames implements the same method as documented on api.FunctionDefinition.
+func (f *testFunctionDefinition) ExportNames() []string {
+	return []string{f.name}
+}
+
+func TestIsInLogScope(t *testing.T) {
+	abort := &testFunctionDefinition{name: AbortName}
+	seed := &testFunctionDefinition{name: SeedName}
+	tests := []struct {
+		name     string
+		fnd      api.FunctionDefinition
+		scopes   logging.LogScopes
+		expected bool
+	}{
+		{
+			name:     "abort in LogScopeExit",
+			fnd:      abort,
+			scopes:   logging.LogScopeExit,
+			expected: true,
+		},
+		{
+			name:     "abort not in LogScopeFilesystem",
+			fnd:      abort,
+			scopes:   logging.LogScopeFilesystem,
+			expected: false,
+		},
+		{
+			name:     "abort in LogScopeExit|LogScopeFilesystem",
+			fnd:      abort,
+			scopes:   logging.LogScopeExit | logging.LogScopeFilesystem,
+			expected: true,
+		},
+		{
+			name:     "abort in LogScopeAll",
+			fnd:      abort,
+			scopes:   logging.LogScopeAll,
+			expected: true,
+		},
+		{
+			name:     "abort not in LogScopeNone",
+			fnd:      abort,
+			scopes:   logging.LogScopeNone,
+			expected: false,
+		},
+		{
+			name:     "seed not in LogScopeFilesystem",
+			fnd:      seed,
+			scopes:   logging.LogScopeFilesystem,
+			expected: false,
+		},
+		{
+			name:     "seed in LogScopeRandom|LogScopeFilesystem",
+			fnd:      seed,
+			scopes:   logging.LogScopeRandom | logging.LogScopeFilesystem,
+			expected: true,
+		},
+		{
+			name:     "seed in LogScopeAll",
+			fnd:      seed,
+			scopes:   logging.LogScopeAll,
+			expected: true,
+		},
+		{
+			name:     "seed not in LogScopeNone",
+			fnd:      seed,
+			scopes:   logging.LogScopeNone,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, IsInLogScope(tc.fnd, tc.scopes))
+		})
+	}
+}

--- a/internal/assemblyscript/names.go
+++ b/internal/assemblyscript/names.go
@@ -1,0 +1,7 @@
+package assemblyscript
+
+const (
+	AbortName = "abort"
+	TraceName = "trace"
+	SeedName  = "seed"
+)

--- a/internal/gojs/logging/logging_test.go
+++ b/internal/gojs/logging/logging_test.go
@@ -22,6 +22,7 @@ func (f *testFunctionDefinition) Name() string {
 
 func TestIsInLogScope(t *testing.T) {
 	runtimeGetRandomData := &testFunctionDefinition{name: custom.NameRuntimeGetRandomData}
+	runtimeWasmExit := &testFunctionDefinition{name: custom.NameRuntimeWasmExit}
 	syscallValueCall := &testFunctionDefinition{name: custom.NameSyscallValueCall}
 	tests := []struct {
 		name     string
@@ -29,6 +30,36 @@ func TestIsInLogScope(t *testing.T) {
 		scopes   logging.LogScopes
 		expected bool
 	}{
+		{
+			name:     "runtimeWasmExit in LogScopeExit",
+			fnd:      runtimeWasmExit,
+			scopes:   logging.LogScopeExit,
+			expected: true,
+		},
+		{
+			name:     "runtimeWasmExit not in LogScopeFilesystem",
+			fnd:      runtimeWasmExit,
+			scopes:   logging.LogScopeFilesystem,
+			expected: false,
+		},
+		{
+			name:     "runtimeWasmExit in LogScopeExit|LogScopeFilesystem",
+			fnd:      runtimeWasmExit,
+			scopes:   logging.LogScopeExit | logging.LogScopeFilesystem,
+			expected: true,
+		},
+		{
+			name:     "runtimeWasmExit not in LogScopeNone",
+			fnd:      runtimeWasmExit,
+			scopes:   logging.LogScopeNone,
+			expected: false,
+		},
+		{
+			name:     "runtimeWasmExit in LogScopeAll",
+			fnd:      runtimeWasmExit,
+			scopes:   logging.LogScopeAll,
+			expected: true,
+		},
 		{
 			name:     "runtimeGetRandomData in LogScopeRandom",
 			fnd:      runtimeGetRandomData,

--- a/internal/gojs/misc_test.go
+++ b/internal/gojs/misc_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+func Test_exit(t *testing.T) {
+	t.Parallel()
+
+	var log bytes.Buffer
+	loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
+		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeExit))
+
+	stdout, stderr, err := compileAndRun(loggingCtx, "exit", wazero.NewModuleConfig())
+
+	require.EqualError(t, err, `module "" closed with exit_code(255)`)
+	require.Zero(t, stderr)
+	require.Zero(t, stdout)
+	require.Equal(t, `==> go.runtime.wasmExit(code=255)
+<==
+`, log.String()) // Note: gojs doesn't panic on exit, so you see "<=="
+}
+
 func Test_goroutine(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gojs/runtime.go
+++ b/internal/gojs/runtime.go
@@ -26,7 +26,7 @@ func wasmExit(ctx context.Context, mod api.Module, stack goarch.Stack) {
 	code := stack.ParamUint32(0)
 
 	getState(ctx).close()
-	_ = mod.CloseWithExitCode(ctx, code) // TODO: should ours be signed bit (like -1 == 255)?
+	_ = mod.CloseWithExitCode(ctx, code)
 }
 
 // WasmWrite implements runtime.wasmWrite which supports runtime.write and

--- a/internal/gojs/testdata/main.go
+++ b/internal/gojs/testdata/main.go
@@ -25,6 +25,8 @@ func main() {
 		argsenv.Main()
 	case "crypto":
 		crypto.Main()
+	case "exit":
+		os.Exit(255)
 	case "fs":
 		fs.Main()
 	case "testfs":

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -39,6 +39,7 @@ type LogScopes uint64
 const (
 	LogScopeNone            = LogScopes(0)
 	LogScopeClock LogScopes = 1 << iota
+	LogScopeExit
 	LogScopeFilesystem
 	LogScopePoll
 	LogScopeRandom
@@ -49,6 +50,8 @@ func scopeName(s LogScopes) string {
 	switch s {
 	case LogScopeClock:
 		return "clock"
+	case LogScopeExit:
+		return "exit"
 	case LogScopeFilesystem:
 		return "filesystem"
 	case LogScopePoll:

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -52,6 +52,7 @@ func TestLogScopes_String(t *testing.T) {
 		{name: "none", scopes: LogScopeNone, expected: ""},
 		{name: "any", scopes: LogScopeAll, expected: "all"},
 		{name: "clock", scopes: LogScopeClock, expected: "clock"},
+		{name: "exit", scopes: LogScopeExit, expected: "exit"},
 		{name: "filesystem", scopes: LogScopeFilesystem, expected: "filesystem"},
 		{name: "poll", scopes: LogScopePoll, expected: "poll"},
 		{name: "random", scopes: LogScopeRandom, expected: "random"},

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -18,6 +18,10 @@ func isClockFunction(fnd api.FunctionDefinition) bool {
 	return strings.HasPrefix(fnd.Name(), "clock_")
 }
 
+func isExitFunction(fnd api.FunctionDefinition) bool {
+	return fnd.Name() == ProcExitName
+}
+
 func isFilesystemFunction(fnd api.FunctionDefinition) bool {
 	switch {
 	case strings.HasPrefix(fnd.Name(), "path_"):
@@ -40,6 +44,12 @@ func isRandomFunction(fnd api.FunctionDefinition) bool {
 func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
 	if scopes.IsEnabled(logging.LogScopeClock) {
 		if isClockFunction(fnd) {
+			return true
+		}
+	}
+
+	if scopes.IsEnabled(logging.LogScopeExit) {
+		if isExitFunction(fnd) {
 			return true
 		}
 	}
@@ -210,7 +220,7 @@ func (i logFilestat) Log(_ context.Context, mod api.Module, w logging.Writer, pa
 		w.WriteString(",size=")              //nolint
 		writeI64(w, le.Uint64(buf[32:]))
 		w.WriteString(",mtim=") //nolint
-		writeI64(w, le.Uint64(buf[40:]))
+		writeI64(w, le.Uint64(buf[48:]))
 		w.WriteString("}") //nolint
 	}
 }

--- a/internal/wasi_snapshot_preview1/logging/logging_test.go
+++ b/internal/wasi_snapshot_preview1/logging/logging_test.go
@@ -24,6 +24,7 @@ func TestIsInLogScope(t *testing.T) {
 	clockTimeGet := &testFunctionDefinition{name: ClockTimeGetName}
 	fdRead := &testFunctionDefinition{name: FdReadName}
 	pollOneoff := &testFunctionDefinition{name: PollOneoffName}
+	procExit := &testFunctionDefinition{name: ProcExitName}
 	randomGet := &testFunctionDefinition{name: RandomGetName}
 	tests := []struct {
 		name     string
@@ -122,10 +123,34 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "randomGet in LogScopeRandom",
-			fnd:      randomGet,
-			scopes:   logging.LogScopeRandom,
+			name:     "procExit in LogScopeExit",
+			fnd:      procExit,
+			scopes:   logging.LogScopeExit,
 			expected: true,
+		},
+		{
+			name:     "procExit not in LogScopeFilesystem",
+			fnd:      procExit,
+			scopes:   logging.LogScopeFilesystem,
+			expected: false,
+		},
+		{
+			name:     "procExit in LogScopeExit|LogScopeFilesystem",
+			fnd:      procExit,
+			scopes:   logging.LogScopeExit | logging.LogScopeFilesystem,
+			expected: true,
+		},
+		{
+			name:     "procExit in LogScopeAll",
+			fnd:      procExit,
+			scopes:   logging.LogScopeAll,
+			expected: true,
+		},
+		{
+			name:     "procExit not in LogScopeNone",
+			fnd:      procExit,
+			scopes:   logging.LogScopeNone,
+			expected: false,
 		},
 		{
 			name:     "randomGet not in LogScopeFilesystem",


### PR DESCRIPTION
This allows you to specify the exit scope amongst existing logging scopes, both in API and the CLI.

e.g for the CLI.
```bash
$ wazero run --hostlogging=exit,filesystem --mount=.:/:ro cat.wasm
```

e.g. for Go
```go
loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
	logging.NewHostLoggingListenerFactory(&log, logging.LogScopeExit|logging.LogScopeFilesystem))
```

This is helpful to know if the wasm called exit or if it exited implicitly. This is one of the few host functions that exists in three places: assemblyscript, gojs and wasi.