### PR TITLE
wasi: implements fd_filestat_set_size and fd_filestat_set_times

### DIFF
--- a/imports/wasi_snapshot_preview1/clock.go
+++ b/imports/wasi_snapshot_preview1/clock.go
@@ -2,7 +2,6 @@ package wasi_snapshot_preview1
 
 import (
 	"context"
-	"time"
 
 	"github.com/tetratelabs/wazero/api"
 	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
@@ -102,8 +101,7 @@ func clockTimeGetFn(_ context.Context, mod api.Module, params []uint64) Errno {
 	var val int64
 	switch id {
 	case ClockIDRealtime:
-		sec, nsec := sysCtx.Walltime()
-		val = (sec * time.Second.Nanoseconds()) + int64(nsec)
+		val = sysCtx.WalltimeNanos()
 	case ClockIDMonotonic:
 		val = sysCtx.Nanotime()
 	default:

--- a/imports/wasi_snapshot_preview1/wasi_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_test.go
@@ -145,5 +145,5 @@ func requireErrno(t *testing.T, expectedErrno Errno, mod api.Closer, funcName st
 	results, err := mod.(api.Module).ExportedFunction(funcName).Call(testCtx, params...)
 	require.NoError(t, err)
 	errno := Errno(results[0])
-	require.Equal(t, expectedErrno, errno, ErrnoName(errno))
+	require.Equal(t, expectedErrno, errno, "want %s but got %s", ErrnoName(expectedErrno), ErrnoName(errno))
 }

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -65,6 +65,28 @@ func Main() {
 		log.Panicln("unexpected contents:", string(bytes))
 	}
 
+	// Next, truncate it.
+	if err = f.Truncate(2); err != nil {
+		log.Panicln(err)
+	}
+	if err = f.Close(); err != nil {
+		log.Panicln(err)
+	}
+	if bytes, err := os.ReadFile(file1); err != nil {
+		log.Panicln(err)
+	} else if string(bytes) != "wa" {
+		log.Panicln("unexpected contents:", string(bytes))
+	}
+
+	// Now, truncate it by path
+	if err = os.Truncate(file1, 1); err != nil {
+		log.Panicln(err)
+	} else if bytes, err := os.ReadFile(file1); err != nil {
+		log.Panicln(err)
+	} else if string(bytes) != "w" {
+		log.Panicln("unexpected contents:", string(bytes))
+	}
+
 	// Test removing a non-empty empty directory
 	if err = syscall.Rmdir(dir); err != syscall.ENOTEMPTY {
 		log.Panicln("unexpected error", err)

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -298,10 +298,13 @@ func (c *FSContext) OpenFile(fs sysfs.FS, path string, flag int, perm fs.FileMod
 	if f, err := fs.OpenFile(path, flag, perm); err != nil {
 		return 0, err
 	} else {
+		fe := &FileEntry{FS: fs, File: f}
 		if path == "/" || path == "." {
-			path = ""
+			fe.Name = ""
+		} else {
+			fe.Name = path
 		}
-		newFD := c.openedFiles.Insert(&FileEntry{Name: path, FS: fs, File: f})
+		newFD := c.openedFiles.Insert(fe)
 		return newFD, nil
 	}
 }

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -62,9 +62,15 @@ func (c *Context) EnvironSize() uint32 {
 	return c.environSize
 }
 
-// Walltime implements sys.Walltime.
+// Walltime implements platform.Walltime.
 func (c *Context) Walltime() (sec int64, nsec int32) {
 	return (*(c.walltime))()
+}
+
+// WalltimeNanos returns platform.Walltime as epoch nanoseconds.
+func (c *Context) WalltimeNanos() int64 {
+	sec, nsec := c.Walltime()
+	return (sec * time.Second.Nanoseconds()) + int64(nsec)
 }
 
 // WalltimeResolution returns resolution of Walltime.

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -21,6 +21,12 @@ func TestContext_FS(t *testing.T) {
 	require.Equal(t, fsc, sysCtx.FS())
 }
 
+func TestContext_WalltimeNanos(t *testing.T) {
+	sysCtx := DefaultContext(nil)
+
+	require.Equal(t, int64(1640995200000000000), sysCtx.WalltimeNanos())
+}
+
 func TestDefaultSysContext(t *testing.T) {
 	testFS := sysfs.Adapt(testfs.FS{})
 

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -44,7 +44,7 @@ func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, er
 	f, err := a.fs.Open(path)
 
 	if err != nil {
-		return nil, unwrapPathError(err)
+		return nil, unwrapOSError(err)
 	} else if osF, ok := f.(*os.File); ok {
 		// If this is an OS file, it has same portability issues as dirFS.
 		return maybeWrapFile(osF), nil

--- a/internal/sysfs/rootfs.go
+++ b/internal/sysfs/rootfs.go
@@ -430,11 +430,10 @@ func (fakeRootDir) Read([]byte) (int, error) {
 
 type fakeRootDirInfo struct{}
 
-func (fakeRootDirInfo) Name() string       { return "/" }
-func (fakeRootDirInfo) Size() int64        { return 0 }
-func (fakeRootDirInfo) Mode() fs.FileMode  { return fs.ModeDir | 0o500 }
-func (fakeRootDirInfo) ModTime() time.Time { return time.Unix(0, 0) }
-func (fakeRootDirInfo) IsDir() bool        { return true }
-func (fakeRootDirInfo) Sys() interface{}   { return nil }
-
+func (fakeRootDirInfo) Name() string                               { return "/" }
+func (fakeRootDirInfo) Size() int64                                { return 0 }
+func (fakeRootDirInfo) Mode() fs.FileMode                          { return fs.ModeDir | 0o500 }
+func (fakeRootDirInfo) ModTime() time.Time                         { return time.Unix(0, 0) }
+func (fakeRootDirInfo) IsDir() bool                                { return true }
+func (fakeRootDirInfo) Sys() interface{}                           { return nil }
 func (fakeRootDir) ReadDir(int) (dirents []fs.DirEntry, err error) { return }

--- a/internal/sysfs/syscall.go
+++ b/internal/sysfs/syscall.go
@@ -12,6 +12,10 @@ func adjustRmdirError(err error) error {
 	return err
 }
 
+func adjustTruncateError(err error) error {
+	return err
+}
+
 func adjustUnlinkError(err error) error {
 	if err == syscall.EPERM {
 		return syscall.EISDIR

--- a/internal/sysfs/unsupported.go
+++ b/internal/sysfs/unsupported.go
@@ -48,3 +48,8 @@ func (UnimplementedFS) Unlink(path string) error {
 func (UnimplementedFS) Utimes(path string, atimeNsec, mtimeNsec int64) error {
 	return syscall.ENOSYS
 }
+
+// Truncate implements FS.Truncate
+func (UnimplementedFS) Truncate(string, int64) error {
+	return syscall.ENOSYS
+}

--- a/internal/wasi_snapshot_preview1/fs.go
+++ b/internal/wasi_snapshot_preview1/fs.go
@@ -133,3 +133,11 @@ var filetypeToString = [...]string{
 	"SOCKET_STREAM",
 	"SYMBOLIC_LINK",
 }
+
+// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#fstflags
+const (
+	FileStatAdjustFlagsAtim uint16 = 1 << iota
+	FileStatAdjustFlagsAtimNow
+	FileStatAdjustFlagsMtim
+	FileStatAdjustFlagsMtimNow
+)

--- a/site/content/specs.md
+++ b/site/content/specs.md
@@ -96,8 +96,8 @@ Note: C (via clang) supports the maximum WASI functions due to [wasi-libc][16].
 | fd_fdstat_set_flags     |   ❌    |                 |
 | fd_fdstat_set_rights    |   💀   |                 |
 | fd_filestat_get         |   ✅    |             Zig |
-| fd_filestat_set_size    |   ❌    |                 |
-| fd_filestat_set_times   |   ❌    |                 |
+| fd_filestat_set_size    |   ✅    |        Rust,Zig |
+| fd_filestat_set_times   |   ✅    |        Rust,Zig |
 | fd_pread                |   ✅    |             Zig |
 | fd_prestat_get          |   ✅    | Rust,TinyGo,Zig |
 | fd_prestat_dir_name     |   ✅    | Rust,TinyGo,Zig |


### PR DESCRIPTION
This implements fd_filestat_set_size and fd_filestat_set_times, which passes one more test in the rust wasi-testsuite.
