### PR TITLE
wasi(windows): fixes readdir on written-after-opened directories 

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -3904,11 +3904,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	dirFd, err := fsc.OpenFile(preopen, readDirTarget, os.O_RDONLY, 0)
 	require.NoError(t, err)
 
-	// Then write two files.
-	const adir = "adir"
-	err = os.Mkdir(path.Join(root, readDirTarget, adir), 0o700)
-	require.NoError(t, err)
-
+	// Then write a file to the directory.
 	f, err := os.Create(path.Join(root, readDirTarget, "afile"))
 	require.NoError(t, err)
 	defer f.Close()
@@ -3924,11 +3920,6 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	results, _ := mem.Read(buf, used)
 	require.Equal(t, []byte{
 		1, 0, 0, 0, 0, 0, 0, 0, // d_next = 1
-		0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
-		4, 0, 0, 0, // d_namlen = 4 character
-		3, 0, 0, 0, // d_type = dir
-		'a', 'd', 'i', 'r', // name
-		2, 0, 0, 0, 0, 0, 0, 0, // d_next = 2
 		0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
 		5, 0, 0, 0, // d_namlen = 4 character
 		4, 0, 0, 0, // d_type = regular_file

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -3879,3 +3879,59 @@ func requireOpenFile(t *testing.T, tmpDir string, pathName string, data []byte, 
 
 	return mod, fd, log, r
 }
+
+// Test_fdReaddir_opened_file_written ensures that writing files to the already-opened directory
+// is visible. This is significant on Windows.
+// https://github.com/ziglang/zig/blob/2ccff5115454bab4898bae3de88f5619310bc5c1/lib/std/fs/test.zig#L156-L184
+func Test_fdReaddir_opened_file_written(t *testing.T) {
+	root := t.TempDir()
+	mod, r, _ := requireProxyModule(t, wazero.NewModuleConfig().
+		WithFSConfig(wazero.NewFSConfig().WithDirMount(root, "/")),
+	)
+	defer r.Close(testCtx)
+
+	mem := mod.Memory()
+
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+	preopen := fsc.RootFS()
+
+	const readDirTarget = "dir"
+	mem.Write(0, []byte(readDirTarget))
+	requireErrno(t, ErrnoSuccess, mod, PathCreateDirectoryName,
+		uint64(sys.FdPreopen), uint64(0), uint64(len(readDirTarget)))
+
+	// Open the directory, before writing files!
+	dirFd, err := fsc.OpenFile(preopen, readDirTarget, os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	// Then write two files.
+	const adir = "adir"
+	err = os.Mkdir(path.Join(root, readDirTarget, adir), 0o700)
+	require.NoError(t, err)
+
+	f, err := os.Create(path.Join(root, readDirTarget, "afile"))
+	require.NoError(t, err)
+	defer f.Close()
+
+	// Try list them!
+	resultBufused := uint32(0) // where to write the amount used out of bufLen
+	buf := uint32(8)           // where to start the dirents
+	requireErrno(t, ErrnoSuccess, mod, FdReaddirName,
+		uint64(dirFd), uint64(buf), uint64(0x2000), 0, uint64(resultBufused))
+
+	used, _ := mem.ReadUint32Le(resultBufused)
+
+	results, _ := mem.Read(buf, used)
+	require.Equal(t, []byte{
+		1, 0, 0, 0, 0, 0, 0, 0, // d_next = 1
+		0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
+		4, 0, 0, 0, // d_namlen = 4 character
+		3, 0, 0, 0, // d_type = dir
+		'a', 'd', 'i', 'r', // name
+		2, 0, 0, 0, 0, 0, 0, 0, // d_next = 2
+		0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
+		5, 0, 0, 0, // d_namlen = 4 character
+		4, 0, 0, 0, // d_type = regular_file
+		'a', 'f', 'i', 'l', 'e', // name
+	}, results)
+}

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -47,7 +47,7 @@ func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, er
 		return nil, unwrapOSError(err)
 	} else if osF, ok := f.(*os.File); ok {
 		// If this is an OS file, it has same portability issues as dirFS.
-		return maybeWrapFile(osF), nil
+		return maybeWrapFile(osF, a, path, flag, perm), nil
 	}
 	return f, nil
 }

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -46,7 +46,7 @@ func (d *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, erro
 	if err != nil {
 		return nil, unwrapOSError(err)
 	}
-	return maybeWrapFile(f), nil
+	return maybeWrapFile(f, d, name, flag, perm), nil
 }
 
 // Mkdir implements FS.Mkdir

--- a/internal/sysfs/syscall.go
+++ b/internal/sysfs/syscall.go
@@ -2,7 +2,10 @@
 
 package sysfs
 
-import "syscall"
+import (
+	"io/fs"
+	"syscall"
+)
 
 func adjustMkdirError(err error) error {
 	return err
@@ -23,6 +26,6 @@ func adjustUnlinkError(err error) error {
 	return err
 }
 
-func maybeWrapFile(f file) file {
+func maybeWrapFile(f file, _ FS, _ string, _ int, _ fs.FileMode) file {
 	return f
 }

--- a/internal/sysfs/syscall_windows.go
+++ b/internal/sysfs/syscall_windows.go
@@ -104,7 +104,7 @@ func rename(old, new string) (err error) {
 // We aren't doing that yet, as mapping problems are generally contained to
 // Windows. Hence, file is intentionally not exported.
 func maybeWrapFile(f file, fs FS, path string, flag int, perm fs.FileMode) file {
-	return &windowsWrappedFile{f, f, f, f, f, f, fs, path, flag, perm, false}
+	return &windowsWrappedFile{f, f, f, f, f, fs, path, flag, perm, false}
 }
 
 type windowsWrappedFile struct {
@@ -113,7 +113,6 @@ type windowsWrappedFile struct {
 	io.WriterAt // for pwrite
 	syncer
 	truncater
-	fder
 	fs                 FS
 	path               string
 	flag               int

--- a/internal/sysfs/syscall_windows.go
+++ b/internal/sysfs/syscall_windows.go
@@ -2,7 +2,6 @@ package sysfs
 
 import (
 	"errors"
-	"io"
 	"io/fs"
 	"os"
 	"syscall"
@@ -104,15 +103,11 @@ func rename(old, new string) (err error) {
 // We aren't doing that yet, as mapping problems are generally contained to
 // Windows. Hence, file is intentionally not exported.
 func maybeWrapFile(f file, fs FS, path string, flag int, perm fs.FileMode) file {
-	return &windowsWrappedFile{f, f, f, f, f, fs, path, flag, perm, false}
+	return &windowsWrappedFile{f, fs, path, flag, perm, false}
 }
 
 type windowsWrappedFile struct {
-	readFile
-	io.Writer
-	io.WriterAt // for pwrite
-	syncer
-	truncater
+	file
 	fs                 FS
 	path               string
 	flag               int

--- a/internal/sysfs/syscall_windows.go
+++ b/internal/sysfs/syscall_windows.go
@@ -103,24 +103,44 @@ func rename(old, new string) (err error) {
 // same. This approach is an alternative to making our own fs.File public type.
 // We aren't doing that yet, as mapping problems are generally contained to
 // Windows. Hence, file is intentionally not exported.
-func maybeWrapFile(f file) file {
-	return struct {
-		readFile
-		io.Writer
-		io.WriterAt // for pwrite
-		syncer
-		truncater
-	}{f, &windowsWriter{f}, f, f, f}
+func maybeWrapFile(f file, fs FS, path string, flag int, perm fs.FileMode) file {
+	return &windowsWrappedFile{f, f, f, f, f, f, fs, path, flag, perm, false}
 }
 
-// windowsWriter translates error codes not mapped properly by Go.
-type windowsWriter struct {
-	w io.Writer
+type windowsWrappedFile struct {
+	readFile
+	io.Writer
+	io.WriterAt // for pwrite
+	syncer
+	truncater
+	fder
+	fs                 FS
+	path               string
+	flag               int
+	perm               fs.FileMode
+	readDirInitialized bool
+}
+
+// ReadDir implements fs.ReadDirFile.
+func (w *windowsWrappedFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if !w.readDirInitialized {
+		if err := w.Close(); err != nil {
+			return nil, err
+		}
+		newW, err := w.fs.OpenFile(w.path, w.flag, w.perm)
+		if err != nil {
+			return nil, err
+		}
+
+		*w = *newW.(*windowsWrappedFile)
+		w.readDirInitialized = true
+	}
+	return w.readFile.ReadDir(n)
 }
 
 // Write implements io.Writer
-func (w windowsWriter) Write(p []byte) (n int, err error) {
-	n, err = w.w.Write(p)
+func (w *windowsWrappedFile) Write(p []byte) (n int, err error) {
+	n, err = w.Writer.Write(p)
 	if err == nil {
 		return
 	}

--- a/internal/sysfs/syscall_windows.go
+++ b/internal/sysfs/syscall_windows.go
@@ -132,12 +132,12 @@ func (w *windowsWrappedFile) ReadDir(n int) ([]fs.DirEntry, error) {
 		*w = *newW.(*windowsWrappedFile)
 		w.readDirInitialized = true
 	}
-	return w.readFile.ReadDir(n)
+	return w.file.ReadDir(n)
 }
 
 // Write implements io.Writer
 func (w *windowsWrappedFile) Write(p []byte) (n int, err error) {
-	n, err = w.Writer.Write(p)
+	n, err = w.file.Write(p)
 	if err == nil {
 		return
 	}

--- a/internal/sysfs/syscall_windows.go
+++ b/internal/sysfs/syscall_windows.go
@@ -123,6 +123,10 @@ type windowsWrappedFile struct {
 // ReadDir implements fs.ReadDirFile.
 func (w *windowsWrappedFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	if !w.readDirInitialized {
+		// On Windows, once the directory is opened, changes to the directory
+		// is not visible on ReadDir on that already-opened file handle.
+		//
+		// In order to provide consistent behavior with other platforms, we re-open it.
 		if err := w.Close(); err != nil {
 			return nil, err
 		}
@@ -130,7 +134,6 @@ func (w *windowsWrappedFile) ReadDir(n int) ([]fs.DirEntry, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		*w = *newW.(*windowsWrappedFile)
 		w.readDirInitialized = true
 	}


### PR DESCRIPTION
extracted from #1057 