### PR TITLE
dirfs: use os.ReadLink instead of syscall variant

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -81,7 +81,7 @@ jobs:
 
       # Run tests with -race only on main branch push.
       - run: make test go_test_options='-timeout 10m -race -short'
-        if: ${{ github.event_name  == 'push' }}
+#        if: ${{ github.event_name  == 'push' }}
 
       - name: "Generate coverage report"  # only once (not per OS)
         if: runner.os == 'Linux'

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -81,7 +81,7 @@ jobs:
 
       # Run tests with -race only on main branch push.
       - run: make test go_test_options='-timeout 10m -race -short'
-#        if: ${{ github.event_name  == 'push' }}
+        if: ${{ github.event_name  == 'push' }}
 
       - name: "Generate coverage report"  # only once (not per OS)
         if: runner.os == 'Linux'

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -75,7 +75,7 @@ func (d *dirFS) Readlink(path string, buf []byte) (n int, err error) {
 	// We need to copy here, but syscall.Readlink does copy internally, so the cost is the same.
 	copy(buf, res)
 	n = len(res)
-	if n < len(buf) {
+	if n > len(buf) {
 		n = len(buf)
 	}
 	platform.SanitizeSeparator(buf[:n])


### PR DESCRIPTION
This fixes the race found on the current main branch.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>