### PR TITLE
ci: supports building with Go 1.20 and raises floor version to 1.18

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -64,8 +64,8 @@ jobs:
       matrix:  # Use versions consistent with wazero's Go support policy.
         os: [ubuntu-20.04, macos-12, windows-2022]
         go-version:
-          - "1.19"  # Current Go version
-          - "1.17"  # Floor Go version of wazero (current - 2)
+          - "1.20"  # Current Go version
+          - "1.18"  # Floor Go version of wazero (current - 2)
 
     steps:
 
@@ -100,8 +100,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.19"  # Current Go version
-          - "1.17"  # Floor Go version of wazero (current - 2)
+          - "1.20"  # Current Go version
+          - "1.18"  # Floor Go version of wazero (current - 2)
         arch:
           - "amd64"
           - "arm64"

--- a/.github/workflows/spectest.yaml
+++ b/.github/workflows/spectest.yaml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.19"  # Current Go version
-          - "1.17"  # Floor Go version of wazero (current - 2)
+          - "1.20"  # Current Go version
+          - "1.18"  # Floor Go version of wazero (current - 2)
         spec-version:
           - "v1"
           - "v2"
@@ -53,8 +53,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.19"  # Current Go version
-          - "1.17"  # Floor Go version of wazero (current - 2)
+          - "1.20"  # Current Go version
+          - "1.18"  # Floor Go version of wazero (current - 2)
         arch:
           - "arm64"
           - "riscv64"

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ space :=
 space +=
 
 gofumpt := mvdan.cc/gofumpt@v0.4.0
-gosimports := github.com/rinchsan/gosimports/cmd/gosimports@v0.3.4
-golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+gosimports := github.com/rinchsan/gosimports/cmd/gosimports@v0.3.5
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
 # sync this with netlify.toml!
-hugo          := github.com/gohugoio/hugo@v0.105.0
+hugo          := github.com/gohugoio/hugo@v0.110.0
 
 # Make 3.81 doesn't support '**' globbing: Set explicitly instead of recursion.
 all_sources   := $(wildcard *.go */*.go */*/*.go */*/*/*.go */*/*/*.go */*/*/*/*.go)

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -424,22 +424,7 @@ func TestRun(t *testing.T) {
 			args = append(args, tc.wasmArgs...)
 			exitCode, stdOut, stdErr := runMain(t, args)
 
-			// TODO: Go 1.17 initializes randoms in a different order than Go 1.18,19
-			// When we move to 1.20, remove the workaround.
-			if tc.name == cryptoTest.name {
-				if tc.expectedStderr != stdErr {
-					require.Equal(t, `==> go.runtime.getRandomData(r_len=8)
-<==
-==> go.runtime.getRandomData(r_len=32)
-<==
-==> go.syscall/js.valueCall(fs.open(path=/bear.txt,flags=,perm=----------))
-<== (err=function not implemented,fd=0)
-`, stdErr)
-				}
-			} else {
-				require.Equal(t, tc.expectedStderr, stdErr)
-			}
-
+			require.Equal(t, tc.expectedStderr, stdErr)
 			require.Equal(t, tc.expectedExitCode, exitCode, stdErr)
 			require.Equal(t, tc.expectedStdout, stdOut)
 			if test := tc.test; test != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/tetratelabs/wazero
 
 // Floor Go version of wazero (current - 2)
-go 1.17
+go 1.18
 
 // All the beta tags are retracted and replaced with "pre" to prevent users
 // from accidentally upgrading into the broken beta 1.

--- a/imports/go/example/stars/go.mod
+++ b/imports/go/example/stars/go.mod
@@ -1,3 +1,3 @@
 module github.com/tetratelabs/wazero/examples/gojs/stars
 
-go 1.17
+go 1.18

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -362,7 +362,7 @@ const (
 
 	// Offsets for Go's interface.
 	// https://research.swtch.com/interfaces
-	// https://github.com/golang/go/blob/release-branch.go1.17/src/runtime/runtime2.go#L207-L210
+	// https://github.com/golang/go/blob/release-branch.go1.20/src/runtime/runtime2.go#L207-L210
 	interfaceDataOffset = 8
 
 	// Consts for wasm.DataInstance.

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4957,7 +4957,7 @@ func (c *amd64Compiler) compileModuleContextInitialization() error {
 		// implementation of interface. This case, we extract "data" pointer as *moduleEngine.
 		// See the following references for detail:
 		// * https://research.swtch.com/interfaces
-		// * https://github.com/golang/go/blob/release-branch.go1.17/src/runtime/runtime2.go#L207-L210
+		// * https://github.com/golang/go/blob/release-branch.go1.20/src/runtime/runtime2.go#L207-L210
 		c.assembler.CompileMemoryToRegister(amd64.MOVQ, amd64CallingConventionDestinationFunctionModuleInstanceAddressRegister, moduleInstanceEngineOffset+interfaceDataOffset, tmpRegister)
 
 		// "tmpRegister = [tmpRegister + moduleEnginecodesOffset] (== &moduleEngine.codes[0])"

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -4153,7 +4153,7 @@ func (c *arm64Compiler) compileModuleContextInitialization() error {
 		// implementation of interface. This case, we extract "data" pointer as *moduleEngine.
 		// See the following references for detail:
 		// * https://research.swtch.com/interfaces
-		// * https://github.com/golang/go/blob/release-branch.go1.17/src/runtime/runtime2.go#L207-L210
+		// * https://github.com/golang/go/blob/release-branch.go1.20/src/runtime/runtime2.go#L207-L210
 		c.assembler.CompileMemoryToRegister(
 			arm64.LDRD,
 			arm64CallingConventionModuleInstanceAddressRegister, moduleInstanceEngineOffset+interfaceDataOffset,

--- a/internal/gojs/crypto_test.go
+++ b/internal/gojs/crypto_test.go
@@ -24,11 +24,11 @@ func Test_crypto(t *testing.T) {
 	require.EqualError(t, err, `module "" closed with exit_code(0)`)
 	require.Equal(t, `7a0c9f9f0d
 `, stdout)
-
-	// Search for the two functions that should be in scope, flexibly, to pass
-	// go 1.17-19
-	require.Contains(t, log.String(), `go.runtime.getRandomData(r_len=32)
-<==`)
-	require.Contains(t, log.String(), `==> go.syscall/js.valueCall(crypto.getRandomValues(r_len=5))
-<== (n=5)`)
+	require.Equal(t, `==> go.runtime.getRandomData(r_len=32)
+<==
+==> go.runtime.getRandomData(r_len=8)
+<==
+==> go.syscall/js.valueCall(crypto.getRandomValues(r_len=5))
+<== (n=5)
+`, log.String())
 }

--- a/internal/gojs/syscall_test.go
+++ b/internal/gojs/syscall_test.go
@@ -21,6 +21,6 @@ syscall.Getgid()=0
 syscall.Geteuid()=0
 syscall.Umask(0077)=0o77
 syscall.Getgroups()=[0]
-os.FindProcess(pid)=&{1 0 0 {{0 0} 0 0 0 0}}
+os.FindProcess(1).Pid=1
 `, stdout)
 }

--- a/internal/gojs/testdata/syscall/main.go
+++ b/internal/gojs/testdata/syscall/main.go
@@ -20,9 +20,10 @@ func Main() {
 		fmt.Printf("syscall.Getgroups()=%v\n", g)
 	}
 
-	if p, err := os.FindProcess(syscall.Getpid()); err != nil {
+	pid := syscall.Getpid()
+	if p, err := os.FindProcess(pid); err != nil {
 		log.Panicln(err)
 	} else {
-		fmt.Printf("os.FindProcess(pid)=%v\n", p)
+		fmt.Printf("os.FindProcess(%d).Pid=%d\n", pid, p.Pid)
 	}
 }

--- a/internal/gojs/time_test.go
+++ b/internal/gojs/time_test.go
@@ -26,8 +26,8 @@ func Test_time(t *testing.T) {
 1ms
 `, stdout)
 
-	// Search for the three functions that should be in scope, flexibly, to pass
-	// go 1.17-19
+	// To avoid multiple similar assertions, just check three functions we
+	// expect were called.
 	require.Contains(t, log.String(), `==> go.runtime.nanotime1()
 <== (nsec=0)`)
 	require.Contains(t, log.String(), `==> go.runtime.walltime()

--- a/internal/integration_test/vs/time/go.mod
+++ b/internal/integration_test/vs/time/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/clock
 
-go 1.17
+go 1.18
 
 require golang.org/x/sys v0.1.0
 

--- a/internal/integration_test/vs/wasmedge/go.mod
+++ b/internal/integration_test/vs/wasmedge/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmedge
 
-go 1.17
+go 1.18
 
 require (
 	github.com/second-state/WasmEdge-go v0.11.2

--- a/internal/integration_test/vs/wasmer/go.mod
+++ b/internal/integration_test/vs/wasmer/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmer
 
-go 1.17
+go 1.18
 
 require (
 	github.com/tetratelabs/wazero v0.0.0

--- a/internal/integration_test/vs/wasmtime/go.mod
+++ b/internal/integration_test/vs/wasmtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmtime
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bytecodealliance/wasmtime-go/v5 v5.0.0

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -7,7 +7,6 @@ import (
 	pathutil "path"
 	"syscall"
 	"testing"
-	gofstest "testing/fstest"
 
 	"github.com/tetratelabs/wazero/internal/fstest"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -128,15 +127,6 @@ func TestAdapt_HackedWrites(t *testing.T) {
 func TestAdapt_TestFS(t *testing.T) {
 	t.Parallel()
 
-	// Make a new fs.FS, noting the Go 1.17 fstest doesn't automatically filter
-	// "." entries in a directory. TODO: remove when we remove 1.17
-	mapFS := make(gofstest.MapFS, len(fstest.FS)-1)
-	for k, v := range fstest.FS {
-		if k != "." {
-			mapFS[k] = v
-		}
-	}
-
 	tmpDir := t.TempDir()
 	require.NoError(t, fstest.WriteTestFiles(tmpDir))
 	dirFS := os.DirFS(tmpDir)
@@ -148,7 +138,7 @@ func TestAdapt_TestFS(t *testing.T) {
 		fs   fs.FS
 	}{
 		{name: "os.DirFS", fs: dirFS},
-		{name: "fstest.MapFS", fs: mapFS},
+		{name: "fstest.MapFS", fs: fstest.FS},
 	}
 
 	for _, tc := range tests {

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -497,6 +497,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	// Open the directory, before writing files!
 	dirFile, err := testFS.OpenFile(readDirTarget, os.O_RDONLY, 0)
 	require.NoError(t, err)
+	defer dirFile.Close()
 
 	// Then write a file to the directory.
 	f, err := os.Create(pathutil.Join(root, readDirTarget, "my-file"))

--- a/internal/version/testdata/go.mod
+++ b/internal/version/testdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/version/testdata
 
-go 1.17
+go 1.18
 
 require github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1 // indirect
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.105.0"
+  HUGO_VERSION = "0.110.0"
 
 [context.production]
   command = "git submodule update --init && hugo --gc --minify"


### PR DESCRIPTION
This moves our floor version to the same we'll release 1.0 with: 1.18. This is congruent with our version policy which is current-2.

Fixes #921