### PR TITLE
benchmark: bumps vs tests wasmtime and wasmedge to latest

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -154,7 +154,7 @@ jobs:
         # The version here is coupled to internal/integration_test/go.mod, but it
         # isn't always the same as sometimes the Go layer has a broken release.
         env:
-          WASMEDGE_VERSION: 0.11.1
+          WASMEDGE_VERSION: 0.11.2
 
       - uses: actions/checkout@v3
 

--- a/internal/integration_test/vs/wasmedge/go.mod
+++ b/internal/integration_test/vs/wasmedge/go.mod
@@ -3,7 +3,7 @@ module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmedge
 go 1.17
 
 require (
-	github.com/second-state/WasmEdge-go v0.11.1
+	github.com/second-state/WasmEdge-go v0.11.2
 	github.com/tetratelabs/wazero v0.0.0
 )
 

--- a/internal/integration_test/vs/wasmedge/go.sum
+++ b/internal/integration_test/vs/wasmedge/go.sum
@@ -1,2 +1,2 @@
-github.com/second-state/WasmEdge-go v0.11.1 h1:ggf9mFJrnx+eD/7bQf3vF8hYVyCMTzXTXi2MNKljhC8=
-github.com/second-state/WasmEdge-go v0.11.1/go.mod h1:HyBf9hVj1sRAjklsjc1Yvs9b5RcmthPG9z99dY78TKg=
+github.com/second-state/WasmEdge-go v0.11.2 h1:4RZhxKvay9uBM9uzE0jrB/26t1ncQG3LbNQOooKjrHA=
+github.com/second-state/WasmEdge-go v0.11.2/go.mod h1:HyBf9hVj1sRAjklsjc1Yvs9b5RcmthPG9z99dY78TKg=

--- a/internal/integration_test/vs/wasmtime/go.mod
+++ b/internal/integration_test/vs/wasmtime/go.mod
@@ -3,7 +3,7 @@ module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmtime
 go 1.17
 
 require (
-	github.com/bytecodealliance/wasmtime-go v1.0.0
+	github.com/bytecodealliance/wasmtime-go/v5 v5.0.0
 	github.com/tetratelabs/wazero v0.0.0
 )
 

--- a/internal/integration_test/vs/wasmtime/go.sum
+++ b/internal/integration_test/vs/wasmtime/go.sum
@@ -1,5 +1,5 @@
-github.com/bytecodealliance/wasmtime-go v1.0.0 h1:9u9gqaUiaJeN5IoD1L7egD8atOnTGyJcNp8BhkL9cUU=
-github.com/bytecodealliance/wasmtime-go v1.0.0/go.mod h1:jjlqQbWUfVSbehpErw3UoWFndBXRRMvfikYH6KsCwOg=
+github.com/bytecodealliance/wasmtime-go/v5 v5.0.0 h1:Ue3eBDElMrdzWoUtr7uPr7NeDZriuR5oIivp5EHknQU=
+github.com/bytecodealliance/wasmtime-go/v5 v5.0.0/go.mod h1:KcecyOqumZrvLnlaEIMFRbBaQeUYNvsbPjAEVho1Fcs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
I tried to run wasmedge locally as they publish arm64 os/x now, but it fails like below even sourcing their env. I left that alone for now

```
dyld[88003]: Library not loaded: @rpath/libwasmedge.0.dylib
  Referenced from: <B1821F61-C84A-38EE-BC33-F3DFB1837BEB> /private/var/folders/vd/1cf8zdb1721f4z5rjggy8bp40000gn/T/go-build1872793839/b001/wasmedge.test
  Reason: tried: '/System/Volumes/Preboot/Cryptexes/OS@rpath/libwasmedge.0.dylib' (no such file), '/usr/local/lib/libwasmedge.0.dylib' (no such file), '/usr/lib/libwasmedge.0.dylib' (no such file, not in dyld cache)
signal: abort trap
FAIL	github.com/tetratelabs/wazero/internal/integration_test/vs/wasmedge	0.240s
FAIL
```