### PR TITLE
wasi: skips fd_readdir until fixed upstream

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -282,7 +282,7 @@ jobs:
       - name: Initialize Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10' # latest version of python 3
+          python-version: '3.11' # latest version of python 3
           cache: pip
 
       - name: Install dependencies
@@ -297,18 +297,13 @@ jobs:
           toolchain: stable
           target: wasm32-wasi
 
-      # TODO: Remove after https://github.com/WebAssembly/wasi-testsuite/issues/49
-      - name: Compile rust tests
-        working-directory: tests/rust
-        run: |
-          ./build.sh
-
       - name: Run all wasi-testsuite
         run: |
           python3 test-runner/wasi_test_runner.py \
             -t ./tests/assemblyscript/testsuite/ \
             ./tests/c/testsuite/ \
             ./tests/rust/testsuite/ \
+            -f .github/workflows/wasi_test_runner-skip.json \
             -r adapters/wazero.sh
         # TODO: remove when #1036 is complete
         continue-on-error: true

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -297,6 +297,12 @@ jobs:
           toolchain: stable
           target: wasm32-wasi
 
+      # TODO: Remove after https://github.com/WebAssembly/wasi-testsuite/issues/49
+      - name: Compile rust tests
+        working-directory: tests/rust
+        run: |
+          ./build.sh
+
       - name: Run all wasi-testsuite
         run: |
           python3 test-runner/wasi_test_runner.py \

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -309,7 +309,7 @@ jobs:
             -t ./tests/assemblyscript/testsuite/ \
             ./tests/c/testsuite/ \
             ./tests/rust/testsuite/ \
-            -f .github/workflows/wasi_test_runner-skip.json \
-            -r adapters/wazero.sh
+            -f ./tests/rust/skip.json \
+            -r ./adapters/wazero.sh
         # TODO: remove when #1036 is complete
         continue-on-error: true

--- a/.github/workflows/wasi_test_runner-skip.json
+++ b/.github/workflows/wasi_test_runner-skip.json
@@ -1,0 +1,5 @@
+{
+  "WASI Rust tests": {
+    "fd_readdir": "too strict on dot or dot-dot: https://github.com/WebAssembly/wasi-testsuite/issues/52"
+  }
+}

--- a/.github/workflows/wasi_test_runner-skip.json
+++ b/.github/workflows/wasi_test_runner-skip.json
@@ -1,5 +1,0 @@
-{
-  "WASI Rust tests": {
-    "fd_readdir": "too strict on dot or dot-dot: https://github.com/WebAssembly/wasi-testsuite/issues/52"
-  }
-}


### PR DESCRIPTION
The current fd_readdir test is invalid as it requires dot and dot-dot entries, which both aren't required by POSIX nor returned by go. Once this is addressed upstream, we can remove the skip.

See https://github.com/WebAssembly/wasi-testsuite/issues/52
See #1036