### PR TITLE
cli: adds an example Dockerfile

### DIFF
--- a/cmd/wazero/Dockerfile
+++ b/cmd/wazero/Dockerfile
@@ -13,4 +13,4 @@ RUN git clone --depth 1 https://github.com/tetratelabs/wazero.git \
 FROM scratch
 COPY --from=build /build/wazero/wazero /bin/wazero
 
-ENTRYPOINT ["/bin/wazero", "run", "-cachedir=/cache", "-hostlogging=filesystem", "-mount=.:/"]
+ENTRYPOINT ["/bin/wazero", "run", "-cachedir=/cache", "-mount=.:/"]

--- a/cmd/wazero/Dockerfile
+++ b/cmd/wazero/Dockerfile
@@ -1,0 +1,16 @@
+# This is an example Dockerfile used to show a way to integrate wasm.
+FROM golang:1.20-alpine AS build
+
+RUN apk add --no-cache git
+
+WORKDIR /build
+
+# wazero doesn't publish a Docker image or binary, yet, so build on on demand.
+RUN git clone --depth 1 https://github.com/tetratelabs/wazero.git \
+  && (cd wazero; go build -o wazero -ldflags "-w -s" ./cmd/wazero)
+
+# wazero has no dependencies, so it can run on scratch
+FROM scratch
+COPY --from=build /build/wazero/wazero /bin/wazero
+
+ENTRYPOINT ["/bin/wazero", "run", "-cachedir=/cache", "-hostlogging=filesystem", "-mount=.:/"]

--- a/cmd/wazero/README.md
+++ b/cmd/wazero/README.md
@@ -19,3 +19,17 @@ wazero run calc.wasm 1 + 2
 
 In addition to arguments, the WebAssembly binary has access to stdout, stderr,
 and stdin.
+
+
+### Docker / Podman
+
+wazero doesn't currently publish binaries, but you can make your own with our
+example [Dockerfile](Dockerfile). It should amount to about 4.5MB total.
+
+```bash
+# build the image
+$ docker build -t wazero:latest -f Dockerfile .
+# volume mount wasi or GOOS=js wasm you are interested in, and run it.
+$ docker run -v ./testdata/:/wasm wazero:latest /wasm/wasi_arg.wasm 1 2 3
+wasi_arg.wasm123
+```


### PR DESCRIPTION
It is important for understanding the recent trends in Docker and WebAssembly to see what a Dockerfile looks like in wazero right now. By seeing what they are now, it is easier to understand what's different.

For example, things that natively support wasm right now can take off the 4.5MB our binary costs, as well hide some of the configuration you can see, such as coercing arguments or ENV.

That said, wasm isn't quite prime time in Docker, I suspect some will be happy to see what things look like. This will get even easier in March when we release 1.0, as we'll have formal packages and such.