### PR TITLE
wasi: implements filestatset

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -162,7 +162,22 @@ func writeFdstat(buf []byte, filetype uint8, fdflags uint16) {
 // adjusts the flags associated with a file descriptor.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_flagsfd-fd-flags-fdflags---errnoand is stubbed for GrainLang per #271
-var fdFdstatSetFlags = stubFunction(FdFdstatSetFlagsName, []wasm.ValueType{i32, i32}, "fd", "flags")
+var fdFdstatSetFlags = newHostFunc(FdFdstatSetFlagsName, fdFdstatSetFlagsFn, []wasm.ValueType{i32, i32}, "fd", "flags")
+
+func fdFdstatSetFlagsFn(_ context.Context, mod api.Module, params []uint64) Errno {
+	fd, flag := uint32(params[0]), uint16(params[1])
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+
+	// We can only support APPEND flag.
+	if FD_DSYNC&flag != 0 || FD_NONBLOCK&flag != 0 || FD_RSYNC&flag != 0 || FD_SYNC&flag != 0 {
+		return ErrnoInval
+	}
+
+	if err := fsc.ChangeOpenFlag(fd, int(flag)); err != nil {
+		return ToErrno(err)
+	}
+	return ErrnoSuccess
+}
 
 // fdFdstatSetRights will not be implemented as rights were removed from WASI.
 //

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -160,8 +160,6 @@ func writeFdstat(buf []byte, filetype uint8, fdflags uint16) {
 
 // fdFdstatSetFlags is the WASI function named FdFdstatSetFlagsName which
 // adjusts the flags associated with a file descriptor.
-//
-// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-fd_fdstat_set_flagsfd-fd-flags-fdflags---errnoand is stubbed for GrainLang per #271
 var fdFdstatSetFlags = newHostFunc(FdFdstatSetFlagsName, fdFdstatSetFlagsFn, []wasm.ValueType{i32, i32}, "fd", "flags")
 
 func fdFdstatSetFlagsFn(_ context.Context, mod api.Module, params []uint64) Errno {

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -298,7 +298,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 		require.Equal(t, exp, string(buf))
 	}
 
-	// with O_APPEND flag, the content is appended to buffer.
+	// with O_APPEND flag, the data is appended to buffer.
 	writeWazero()
 	requireFileContent("0123456789" + "wazero")
 
@@ -310,7 +310,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 `, "\n"+log.String())
 	log.Reset()
 
-	// with O_APPEND flag, the content is appended to buffer.
+	// Without O_APPEND flag, the data is written at the beginning.
 	writeWazero()
 	requireFileContent("wazero6789" + "wazero")
 
@@ -322,9 +322,18 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 `, "\n"+log.String())
 	log.Reset()
 
-	// with O_APPEND flag, the content is appended to buffer.
+	// with O_APPEND flag, the data is appended to buffer.
 	writeWazero()
 	requireFileContent("wazero6789" + "wazero" + "wazero")
+
+	t.Run("errors", func(t *testing.T) {
+		requireErrno(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_DSYNC))
+		requireErrno(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_NONBLOCK))
+		requireErrno(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_RSYNC))
+		requireErrno(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_SYNC))
+		requireErrno(t, ErrnoBadf, mod, FdFdstatSetFlagsName, uint64(12345), uint64(FD_APPEND))
+		requireErrno(t, ErrnoIsdir, mod, FdFdstatSetFlagsName, uint64(3) /* preopen */, uint64(FD_APPEND))
+	})
 }
 
 // Test_fdFdstatSetRights only tests it is stubbed for GrainLang per #271

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -246,13 +246,85 @@ func Test_fdFdstatGet(t *testing.T) {
 	}
 }
 
-// Test_fdFdstatSetFlags only tests it is stubbed for GrainLang per #271
 func Test_fdFdstatSetFlags(t *testing.T) {
-	log := requireErrnoNosys(t, FdFdstatSetFlagsName, 0, 0)
+	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
+	const fileName = "file.txt"
+
+	// Create the target file.
+	realPath := path.Join(tmpDir, fileName)
+	require.NoError(t, os.WriteFile(realPath, []byte("0123456789"), 0o600))
+
+	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFSConfig(wazero.NewFSConfig().
+		WithDirMount(tmpDir, "/")))
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+	preopen := fsc.RootFS()
+	defer r.Close(testCtx)
+
+	// First, open it with O_APPEND.
+	fd, err := fsc.OpenFile(preopen, fileName, os.O_RDWR|os.O_APPEND, 0)
+	require.NoError(t, err)
+
+	writeWazero := func() {
+		iovs := uint32(1) // arbitrary offset
+		initialMemory := []byte{
+			'?',         // `iovs` is after this
+			18, 0, 0, 0, // = iovs[0].offset
+			4, 0, 0, 0, // = iovs[0].length
+			23, 0, 0, 0, // = iovs[1].offset
+			2, 0, 0, 0, // = iovs[1].length
+			'?',                // iovs[0].offset is after this
+			'w', 'a', 'z', 'e', // iovs[0].length bytes
+			'?',      // iovs[1].offset is after this
+			'r', 'o', // iovs[1].length bytes
+			'?',
+		}
+		iovsCount := uint32(2)       // The count of iovs
+		resultNwritten := uint32(26) // arbitrary offset
+
+		ok := mod.Memory().Write(0, initialMemory)
+		require.True(t, ok)
+
+		requireErrno(t, ErrnoSuccess, mod, FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
+		require.Equal(t, `
+==> wasi_snapshot_preview1.fd_write(fd=4,iovs=1,iovs_len=2)
+<== (nwritten=6,errno=ESUCCESS)
+`, "\n"+log.String())
+		log.Reset()
+	}
+
+	requireFileContent := func(exp string) {
+		buf, err := os.ReadFile(path.Join(tmpDir, fileName))
+		require.NoError(t, err)
+		require.Equal(t, exp, string(buf))
+	}
+
+	// with O_APPEND flag, the content is appended to buffer.
+	writeWazero()
+	requireFileContent("0123456789" + "wazero")
+
+	// Let's remove O_APPEND.
+	requireErrno(t, ErrnoSuccess, mod, FdFdstatSetFlagsName, uint64(fd), uint64(0))
 	require.Equal(t, `
---> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=0,flags=0)
-<-- errno=ENOSYS
-`, log)
+==> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=4,flags=0)
+<== errno=ESUCCESS
+`, "\n"+log.String())
+	log.Reset()
+
+	// with O_APPEND flag, the content is appended to buffer.
+	writeWazero()
+	requireFileContent("wazero6789" + "wazero")
+
+	// Restore the O_APPEND flag.
+	requireErrno(t, ErrnoSuccess, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_APPEND))
+	require.Equal(t, `
+==> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=4,flags=1)
+<== errno=ESUCCESS
+`, "\n"+log.String())
+	log.Reset()
+
+	// with O_APPEND flag, the content is appended to buffer.
+	writeWazero()
+	requireFileContent("wazero6789" + "wazero" + "wazero")
 }
 
 // Test_fdFdstatSetRights only tests it is stubbed for GrainLang per #271

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -353,6 +353,8 @@ func (c *FSContext) ChangeOpenFlag(fd uint32, flag int) error {
 	f, ok := c.LookupFile(fd)
 	if !ok {
 		return syscall.EBADF
+	} else if f.IsDir() {
+		return syscall.EISDIR
 	}
 
 	if flag&syscall.O_APPEND != 0 {
@@ -373,10 +375,6 @@ func (c *FSContext) ChangeOpenFlag(fd uint32, flag int) error {
 	// TODO: this might be improved once we have our own File type.
 	if err := c.reopen(f); err != nil {
 		return err
-	}
-
-	if f.isDirectory {
-		f.ReadDir.CountRead, f.ReadDir.Entries = 0, nil
 	}
 	return nil
 }


### PR DESCRIPTION
Part of #1036. With this, only two cases are left to pass 
> Test suites: 1 failed, 0 total
Tests:       2 failed, 8 passed, 1 skipped, 1 total


Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>