### PR TITLE
wasi: makes fd_advise noop, instead of NoSys

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -24,13 +24,16 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-// Test_fdAdvise only tests it is stubbed for GrainLang per #271
 func Test_fdAdvise(t *testing.T) {
-	log := requireErrnoNosys(t, FdAdviseName, 0, 0, 0, 0)
-	require.Equal(t, `
---> wasi_snapshot_preview1.fd_advise(fd=0,offset=0,len=0,advice=0)
-<-- errno=ENOSYS
-`, log)
+	mod, r, _ := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
+	defer r.Close(testCtx)
+	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNormal))
+	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceSequential))
+	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceRandom))
+	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceWillNeed))
+	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceDontNeed))
+	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNoReuse))
+	requireErrno(t, ErrnoInval, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNoReuse+1))
 }
 
 // Test_fdAllocate only tests it is stubbed for GrainLang per #271
@@ -2096,7 +2099,6 @@ func Test_fdReaddir_Errors(t *testing.T) {
 	}
 }
 
-// Test_fdRenumber only tests it is stubbed for GrainLang per #271
 func Test_fdRenumber(t *testing.T) {
 	const preopenFd, fileFd, dirFd = 3, 4, 5
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -34,6 +34,7 @@ func Test_fdAdvise(t *testing.T) {
 	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceDontNeed))
 	requireErrno(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNoReuse))
 	requireErrno(t, ErrnoInval, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNoReuse+1))
+	requireErrno(t, ErrnoBadf, mod, FdAdviseName, uint64(1111111), 0, 0, uint64(FdAdviceNoReuse+1))
 }
 
 // Test_fdAllocate only tests it is stubbed for GrainLang per #271

--- a/internal/wasi_snapshot_preview1/fs.go
+++ b/internal/wasi_snapshot_preview1/fs.go
@@ -143,7 +143,6 @@ const (
 )
 
 // https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-advice-enumu8
-
 const (
 	FdAdviceNormal byte = 1 << iota
 	FdAdviceSequential

--- a/internal/wasi_snapshot_preview1/fs.go
+++ b/internal/wasi_snapshot_preview1/fs.go
@@ -141,3 +141,14 @@ const (
 	FileStatAdjustFlagsMtim
 	FileStatAdjustFlagsMtimNow
 )
+
+// https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-advice-enumu8
+
+const (
+	FdAdviceNormal byte = 1 << iota
+	FdAdviceSequential
+	FdAdviceRandom
+	FdAdviceWillNeed
+	FdAdviceDontNeed
+	FdAdviceNoReuse
+)

--- a/internal/wasi_snapshot_preview1/fs.go
+++ b/internal/wasi_snapshot_preview1/fs.go
@@ -144,7 +144,7 @@ const (
 
 // https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-advice-enumu8
 const (
-	FdAdviceNormal byte = 1 << iota
+	FdAdviceNormal byte = iota
 	FdAdviceSequential
 	FdAdviceRandom
 	FdAdviceWillNeed


### PR DESCRIPTION
part of #1036. `fd_advise.rs` is still failing due to the unimplemented `fd_allocate`. https://github.com/WebAssembly/wasi-testsuite/blob/main/tests/rust/src/bin/fd_advise.rs#L44-L50