### PR TITLE
wasi: implements fd_allocate

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -85,6 +85,9 @@ func fdAllocateFn(_ context.Context, mod api.Module, params []uint64) Errno {
 	}
 
 	tail := int64(offset + length)
+	if tail < 0 {
+		return ErrnoInval
+	}
 
 	st, err := f.Stat()
 	if err != nil {

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -96,6 +96,8 @@ func fdAllocateFn(_ context.Context, mod api.Module, params []uint64) Errno {
 		return ErrnoSuccess
 	}
 
+	// This is implemented the implementation of fs.File by all platforms.
+	// TODO: this should be removed once we have fs.File.
 	type truncatable interface {
 		Truncate(size int64) error
 	}
@@ -105,9 +107,6 @@ func fdAllocateFn(_ context.Context, mod api.Module, params []uint64) Errno {
 		return ErrnoBadf
 	}
 
-	// Note: invalid tails (i.e. negative or extremely large) will be
-	// raised as EINVAL/EIO from the underlying implementations, so we do not need to
-	// do the validation here.
 	if err = osf.Truncate(tail); err != nil {
 		return ToErrno(err)
 	}

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -67,10 +67,10 @@ func Test_fdAllocate(t *testing.T) {
 
 	t.Run("errors", func(t *testing.T) {
 		requireErrno(t, ErrnoBadf, mod, FdAllocateName, uint64(12345), 0, 0)
-		// Read only file shouldn't be modified.
-		ro, err := fsc.OpenFile(preopen, fileName, os.O_RDONLY, 0)
-		require.NoError(t, err)
-		requireErrno(t, ErrnoInval, mod, FdAllocateName, uint64(ro), 0, 1234)
+		minusOne := int64(-1)
+		requireErrno(t, ErrnoInval, mod, FdAllocateName, uint64(fd), uint64(minusOne), uint64(minusOne))
+		requireErrno(t, ErrnoInval, mod, FdAllocateName, uint64(fd), 0, uint64(minusOne))
+		requireErrno(t, ErrnoInval, mod, FdAllocateName, uint64(fd), uint64(minusOne), 0)
 	})
 
 	t.Run("do not change size", func(t *testing.T) {
@@ -102,7 +102,11 @@ func Test_fdAllocate(t *testing.T) {
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_allocate(fd=12345,offset=0,len=0)
 <== errno=EBADF
-==> wasi_snapshot_preview1.fd_allocate(fd=5,offset=0,len=1234)
+==> wasi_snapshot_preview1.fd_allocate(fd=4,offset=-1,len=-1)
+<== errno=EINVAL
+==> wasi_snapshot_preview1.fd_allocate(fd=4,offset=0,len=-1)
+<== errno=EINVAL
+==> wasi_snapshot_preview1.fd_allocate(fd=4,offset=-1,len=0)
 <== errno=EINVAL
 ==> wasi_snapshot_preview1.fd_allocate(fd=4,offset=0,len=10)
 <== errno=ESUCCESS


### PR DESCRIPTION
part of #1036. With this only one case left:
> Test suites: 1 failed, 0 total
Tests:       1 failed, 9 passed, 1 skipped, 1 total
