### PR TITLE
Fix #1111.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ retract (
 	v1.0.0-beta.2
 	v1.0.0-beta.1
 )
+
+require github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ retract (
 	v1.0.0-beta.1
 )
 
-require github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb
+require github.com/zcalusic/sysinfo v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb h1:Fg0Y/RDZ6UPwl3o7/IzPbneDq8g9+gH6DPs42KFUsy8=
+github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb h1:Fg0Y/RDZ6UPwl3o7/IzPbneDq8g9+gH6DPs42KFUsy8=
-github.com/intel-go/cpuid v0.0.0-20220614022739-219e067757cb/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=
+github.com/zcalusic/sysinfo v0.9.5 h1:ivoHyj9aIAYkwzo1+8QgJ5s4oeE6Etx9FmZtqa4wJjQ=
+github.com/zcalusic/sysinfo v0.9.5/go.mod h1:Z/gPVufBrFc8X5sef3m6kkw3r3nlNFp+I6bvASfvBZQ=

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -8,7 +8,8 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"runtime"
+
+	"github.com/intel-go/cpuid"
 
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/asm/amd64"
@@ -1158,7 +1159,7 @@ func (c *amd64Compiler) compileClz(o *wazeroir.OperationClz) error {
 		return err
 	}
 
-	if runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" {
+	if cpuid.HasExtraFeature(cpuid.ABM) {
 		if o.Type == wazeroir.UnsignedInt32 {
 			c.assembler.CompileRegisterToRegister(amd64.LZCNTL, target.register, target.register)
 		} else {
@@ -1221,7 +1222,7 @@ func (c *amd64Compiler) compileCtz(o *wazeroir.OperationCtz) error {
 		return err
 	}
 
-	if runtime.GOOS != "darwin" && runtime.GOOS != "freebsd" {
+	if cpuid.HasExtraFeature(cpuid.ABM) {
 		if o.Type == wazeroir.UnsignedInt32 {
 			c.assembler.CompileRegisterToRegister(amd64.TZCNTL, target.register, target.register)
 		} else {


### PR DESCRIPTION
I know this can't go in because of the `cpuid` dependency, but maybe it helps.

I can confirm all tests pass on Windows+WSL on the affected machine, and on Windows+macOS+Linux on other machines.