### PR TITLE
sysfs: consolidates errno coersion and maps EAGAIN and EINTR

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1407,7 +1407,7 @@ func pathFilestatGetFn(_ context.Context, mod api.Module, params []uint64) Errno
 	if err != nil {
 		return ToErrno(err)
 	}
-	stat, err := f.Stat()
+	stat, err := sysfs.StatFile(f)
 	if err != nil {
 		return ToErrno(err)
 	}

--- a/internal/gojs/errno_test.go
+++ b/internal/gojs/errno_test.go
@@ -1,10 +1,6 @@
 package gojs
 
 import (
-	"errors"
-	"fmt"
-	"io/fs"
-	"os"
 	"syscall"
 	"testing"
 
@@ -18,6 +14,11 @@ func TestToErrno(t *testing.T) {
 		expected *Errno
 	}{
 		{
+			name:     "syscall.EAGAIN",
+			input:    syscall.EAGAIN,
+			expected: ErrnoAgain,
+		},
+		{
 			name:     "syscall.EBADF",
 			input:    syscall.EBADF,
 			expected: ErrnoBadf,
@@ -26,6 +27,11 @@ func TestToErrno(t *testing.T) {
 			name:     "syscall.EEXIST",
 			input:    syscall.EEXIST,
 			expected: ErrnoExist,
+		},
+		{
+			name:     "syscall.EINTR",
+			input:    syscall.EINTR,
+			expected: ErrnoIntr,
 		},
 		{
 			name:     "syscall.EINVAL",
@@ -85,46 +91,6 @@ func TestToErrno(t *testing.T) {
 		{
 			name:     "syscall.Errno unexpected == ErrnoIo",
 			input:    syscall.Errno(0xfe),
-			expected: ErrnoIo,
-		},
-		{
-			name:     "PathError ErrInvalid",
-			input:    &os.PathError{Err: fs.ErrInvalid},
-			expected: ErrnoInval,
-		},
-		{
-			name:     "PathError ErrPermission",
-			input:    &os.PathError{Err: fs.ErrPermission},
-			expected: ErrnoPerm,
-		},
-		{
-			name:     "PathError ErrExist",
-			input:    &os.PathError{Err: fs.ErrExist},
-			expected: ErrnoExist,
-		},
-		{
-			name:     "PathError ErrNotExist",
-			input:    &os.PathError{Err: fs.ErrNotExist},
-			expected: ErrnoNoent,
-		},
-		{
-			name:     "PathError ErrClosed",
-			input:    &os.PathError{Err: fs.ErrClosed},
-			expected: ErrnoBadf,
-		},
-		{
-			name:     "PathError unknown == ErrnoIo",
-			input:    &os.PathError{Err: errors.New("ice cream")},
-			expected: ErrnoIo,
-		},
-		{
-			name:     "unknown == ErrnoIo",
-			input:    errors.New("ice cream"),
-			expected: ErrnoIo,
-		},
-		{
-			name:     "very wrapped unknown == ErrnoIo",
-			input:    fmt.Errorf("%w", fmt.Errorf("%w", fmt.Errorf("%w", errors.New("ice cream")))),
 			expected: ErrnoIo,
 		},
 	}

--- a/internal/platform/open_file_test.go
+++ b/internal/platform/open_file_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestOpenFile_Errors(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("not found must be ENOENT", func(t *testing.T) {
+		_, err := OpenFile(path.Join(tmp, "not-really-exist.txt"), os.O_RDONLY, 0o600)
+		require.ErrorIs(t, err, syscall.ENOENT)
+	})
+
+	// This is the same as https://github.com/ziglang/zig/blob/d24ebf1d12cf66665b52136a2807f97ff021d78d/lib/std/os/test.zig#L105-L112
+	t.Run("try creating on existing file must be EEXIST", func(t *testing.T) {
+		filepath := path.Join(tmp, "file.txt")
+		f, err := OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+		defer require.NoError(t, f.Close())
+		require.NoError(t, err)
+
+		_, err = OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+		require.ErrorIs(t, err, syscall.EEXIST)
+	})
+}

--- a/internal/platform/stat_windows.go
+++ b/internal/platform/stat_windows.go
@@ -47,7 +47,7 @@ func stat(f fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlin
 		// os.Stat does to allow the results on the closed files.
 		// https://github.com/golang/go/blob/go1.20/src/os/stat_windows.go#L86
 		//
-		// TODO: once we have our File/Sta type, this shouldn't be necessary.
+		// TODO: once we have our File/Stat type, this shouldn't be necessary.
 		// But for now, ignore the error to pass the std library test for bad file descriptor.
 		// https://github.com/ziglang/zig/blob/master/lib/std/os/test.zig#L167-L170
 		if err == syscall.Errno(6) {

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -187,7 +187,7 @@ func (f *FileEntry) IsDir() bool {
 
 // Stat returns the underlying stat of this file.
 func (f *FileEntry) Stat() (stat fs.FileInfo, err error) {
-	stat, err = f.File.Stat()
+	stat, err = sysfs.StatFile(f.File)
 	if err == nil && stat.IsDir() {
 		f.isDirectory = true
 	}

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -44,7 +44,7 @@ func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, er
 	f, err := a.fs.Open(path)
 
 	if err != nil {
-		return nil, unwrapOSError(err)
+		return nil, UnwrapOSError(err)
 	} else if osF, ok := f.(*os.File); ok {
 		// If this is an OS file, it has same portability issues as dirFS.
 		return maybeWrapFile(osF, a, path, flag, perm), nil

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -44,7 +44,7 @@ func (d *dirFS) Open(name string) (fs.File, error) {
 func (d *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
 	f, err := platform.OpenFile(d.join(name), flag, perm)
 	if err != nil {
-		return nil, unwrapOSError(err)
+		return nil, UnwrapOSError(err)
 	}
 	return maybeWrapFile(f, d, name, flag, perm), nil
 }
@@ -52,14 +52,14 @@ func (d *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, erro
 // Mkdir implements FS.Mkdir
 func (d *dirFS) Mkdir(name string, perm fs.FileMode) error {
 	err := os.Mkdir(d.join(name), perm)
-	err = unwrapOSError(err)
-	return adjustMkdirError(err)
+	return UnwrapOSError(err)
 }
 
 // Rename implements FS.Rename
 func (d *dirFS) Rename(from, to string) error {
 	from, to = d.join(from), d.join(to)
-	return platform.Rename(from, to)
+	err := platform.Rename(from, to)
+	return UnwrapOSError(err)
 }
 
 // Readlink implements FS.Readlink
@@ -68,7 +68,7 @@ func (d *dirFS) Readlink(path string, buf []byte) (n int, err error) {
 	// In any case, syscall.Readlink does almost the same logic as os.Readlink.
 	res, err := os.Readlink(d.join(path))
 	if err != nil {
-		err = unwrapOSError(err)
+		err = UnwrapOSError(err)
 		return
 	}
 
@@ -83,47 +83,50 @@ func (d *dirFS) Readlink(path string, buf []byte) (n int, err error) {
 }
 
 // Link implements FS.Link.
-func (d *dirFS) Link(oldName, newName string) (err error) {
-	err = os.Link(d.join(oldName), d.join(newName))
-	err = unwrapOSError(err)
-	return
+func (d *dirFS) Link(oldName, newName string) error {
+	err := os.Link(d.join(oldName), d.join(newName))
+	return UnwrapOSError(err)
 }
 
 // Rmdir implements FS.Rmdir
 func (d *dirFS) Rmdir(name string) error {
 	err := syscall.Rmdir(d.join(name))
+	err = UnwrapOSError(err)
 	return adjustRmdirError(err)
 }
 
 // Unlink implements FS.Unlink
-func (d *dirFS) Unlink(name string) error {
-	err := syscall.Unlink(d.join(name))
-	return adjustUnlinkError(err)
+func (d *dirFS) Unlink(name string) (err error) {
+	err = syscall.Unlink(d.join(name))
+	if err = UnwrapOSError(err); err == syscall.EPERM {
+		err = syscall.EISDIR
+	}
+	return
 }
 
 // Symlink implements FS.Symlink
-func (d *dirFS) Symlink(oldName, link string) error {
+func (d *dirFS) Symlink(oldName, link string) (err error) {
 	// Note: do not resolve `oldName` relative to this dirFS. The link result is always resolved
 	// when dereference the `link` on its usage (e.g. readlink, read, etc).
 	// https://github.com/bytecodealliance/cap-std/blob/v1.0.4/cap-std/src/fs/dir.rs#L404-L409
-	err := os.Symlink(oldName, d.join(link))
-	err = unwrapOSError(err)
-	return err
+	err = os.Symlink(oldName, d.join(link))
+	return UnwrapOSError(err)
 }
 
 // Utimes implements FS.Utimes
 func (d *dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
-	return syscall.UtimesNano(d.join(name), []syscall.Timespec{
+	err := syscall.UtimesNano(d.join(name), []syscall.Timespec{
 		syscall.NsecToTimespec(atimeNsec),
 		syscall.NsecToTimespec(mtimeNsec),
 	})
+	return UnwrapOSError(err)
 }
 
 // Truncate implements FS.Truncate
 func (d *dirFS) Truncate(name string, size int64) error {
 	// Use os.Truncate as syscall.Truncate doesn't exist on Windows.
 	err := os.Truncate(d.join(name), size)
-	err = unwrapOSError(err)
+	err = UnwrapOSError(err)
 	return adjustTruncateError(err)
 }
 

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -1,6 +1,7 @@
 package sysfs
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"syscall"
@@ -52,6 +53,9 @@ func (d *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, erro
 // Mkdir implements FS.Mkdir
 func (d *dirFS) Mkdir(name string, perm fs.FileMode) error {
 	err := os.Mkdir(d.join(name), perm)
+	if errors.Is(err, syscall.ENOTDIR) {
+		return syscall.ENOENT
+	}
 	return UnwrapOSError(err)
 }
 

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -71,6 +71,11 @@ func TestDirFS_MkDir(t *testing.T) {
 		err := testFS.Mkdir(name, fs.ModeDir)
 		require.Equal(t, syscall.EEXIST, err)
 	})
+	t.Run("try creating on file", func(t *testing.T) {
+		filePath := pathutil.Join("non-existing-dir", "foo.txt")
+		err := testFS.Mkdir(filePath, fs.ModeDir)
+		require.Equal(t, syscall.ENOENT, err)
+	})
 }
 
 func TestDirFS_Rename(t *testing.T) {

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -577,8 +577,8 @@ func TestDirFS_Readlink(t *testing.T) {
 
 	buf := make([]byte, 200)
 	for _, tl := range testLinks {
-		err := os.Symlink(pathutil.Join(tl.old), pathutil.Join(tmpDir, tl.dst))
-		require.NoError(t, err)
+		err := testFS.Symlink(tl.old, tl.dst) // not os.Symlink for windows compat
+		require.NoError(t, err, "%v", tl)
 
 		n, err := testFS.Readlink(tl.dst, buf)
 		require.NoError(t, err)

--- a/internal/sysfs/syscall.go
+++ b/internal/sysfs/syscall.go
@@ -4,10 +4,9 @@ package sysfs
 
 import (
 	"io/fs"
-	"syscall"
 )
 
-func adjustMkdirError(err error) error {
+func adjustErrno(err error) error {
 	return err
 }
 
@@ -16,13 +15,6 @@ func adjustRmdirError(err error) error {
 }
 
 func adjustTruncateError(err error) error {
-	return err
-}
-
-func adjustUnlinkError(err error) error {
-	if err == syscall.EPERM {
-		return syscall.EISDIR
-	}
 	return err
 }
 

--- a/internal/sysfs/sysfs_test.go
+++ b/internal/sysfs/sysfs_test.go
@@ -68,6 +68,13 @@ func testOpen_Read(t *testing.T, tmpDir string, testFS FS) {
 		require.Equal(t, syscall.ENOENT, err)
 	})
 
+	t.Run("doesn't exist", func(t *testing.T) {
+		_, err := testFS.OpenFile(path.Join(dir, "/really-not-exist"), os.O_RDONLY, 0)
+
+		// We currently follow os.Open not syscall.Open, so the error is wrapped.
+		require.Equal(t, syscall.ENOENT, err)
+	})
+
 	t.Run(". opens root", func(t *testing.T) {
 		f, err := testFS.OpenFile(".", os.O_RDONLY, 0)
 		require.NoError(t, err)

--- a/internal/sysfs/sysfs_test.go
+++ b/internal/sysfs/sysfs_test.go
@@ -68,13 +68,6 @@ func testOpen_Read(t *testing.T, tmpDir string, testFS FS) {
 		require.Equal(t, syscall.ENOENT, err)
 	})
 
-	t.Run("doesn't exist", func(t *testing.T) {
-		_, err := testFS.OpenFile(path.Join(dir, "/really-not-exist"), os.O_RDONLY, 0)
-
-		// We currently follow os.Open not syscall.Open, so the error is wrapped.
-		require.Equal(t, syscall.ENOENT, err)
-	})
-
 	t.Run(". opens root", func(t *testing.T) {
 		f, err := testFS.OpenFile(".", os.O_RDONLY, 0)
 		require.NoError(t, err)

--- a/internal/wasi_snapshot_preview1/errno_test.go
+++ b/internal/wasi_snapshot_preview1/errno_test.go
@@ -89,16 +89,6 @@ func TestToErrno(t *testing.T) {
 			expected: ErrnoPerm,
 		},
 		{
-			name:     "syscall.ENOTDIR",
-			input:    syscall.ENOTDIR,
-			expected: ErrnoNotdir,
-		},
-		{
-			name:     "syscall.ENOENT",
-			input:    syscall.ENOENT,
-			expected: ErrnoNoent,
-		},
-		{
 			name:     "syscall.Errno unexpected == ErrnoIo",
 			input:    syscall.Errno(0xfe),
 			expected: ErrnoIo,

--- a/internal/wasi_snapshot_preview1/errno_test.go
+++ b/internal/wasi_snapshot_preview1/errno_test.go
@@ -1,10 +1,6 @@
 package wasi_snapshot_preview1
 
 import (
-	"errors"
-	"fmt"
-	"io/fs"
-	"os"
 	"syscall"
 	"testing"
 
@@ -18,6 +14,11 @@ func TestToErrno(t *testing.T) {
 		expected Errno
 	}{
 		{
+			name:     "syscall.EAGAIN",
+			input:    syscall.EAGAIN,
+			expected: ErrnoAgain,
+		},
+		{
 			name:     "syscall.EBADF",
 			input:    syscall.EBADF,
 			expected: ErrnoBadf,
@@ -26,6 +27,11 @@ func TestToErrno(t *testing.T) {
 			name:     "syscall.EEXIST",
 			input:    syscall.EEXIST,
 			expected: ErrnoExist,
+		},
+		{
+			name:     "syscall.EINTR",
+			input:    syscall.EINTR,
+			expected: ErrnoIntr,
 		},
 		{
 			name:     "syscall.EINVAL",
@@ -85,46 +91,6 @@ func TestToErrno(t *testing.T) {
 		{
 			name:     "syscall.Errno unexpected == ErrnoIo",
 			input:    syscall.Errno(0xfe),
-			expected: ErrnoIo,
-		},
-		{
-			name:     "PathError ErrInvalid",
-			input:    &os.PathError{Err: fs.ErrInvalid},
-			expected: ErrnoInval,
-		},
-		{
-			name:     "PathError ErrPermission",
-			input:    &os.PathError{Err: fs.ErrPermission},
-			expected: ErrnoPerm,
-		},
-		{
-			name:     "PathError ErrExist",
-			input:    &os.PathError{Err: fs.ErrExist},
-			expected: ErrnoExist,
-		},
-		{
-			name:     "PathError ErrNotExist",
-			input:    &os.PathError{Err: fs.ErrNotExist},
-			expected: ErrnoNoent,
-		},
-		{
-			name:     "PathError ErrClosed",
-			input:    &os.PathError{Err: fs.ErrClosed},
-			expected: ErrnoBadf,
-		},
-		{
-			name:     "PathError unknown == ErrnoIo",
-			input:    &os.PathError{Err: errors.New("ice cream")},
-			expected: ErrnoIo,
-		},
-		{
-			name:     "unknown == ErrnoIo",
-			input:    errors.New("ice cream"),
-			expected: ErrnoIo,
-		},
-		{
-			name:     "very wrapped unknown == ErrnoIo",
-			input:    fmt.Errorf("%w", fmt.Errorf("%w", fmt.Errorf("%w", errors.New("ice cream")))),
 			expected: ErrnoIo,
 		},
 	}

--- a/internal/wasi_snapshot_preview1/errno_test.go
+++ b/internal/wasi_snapshot_preview1/errno_test.go
@@ -89,6 +89,16 @@ func TestToErrno(t *testing.T) {
 			expected: ErrnoPerm,
 		},
 		{
+			name:     "syscall.ENOTDIR",
+			input:    syscall.ENOTDIR,
+			expected: ErrnoNotdir,
+		},
+		{
+			name:     "syscall.ENOENT",
+			input:    syscall.ENOENT,
+			expected: ErrnoNoent,
+		},
+		{
 			name:     "syscall.Errno unexpected == ErrnoIo",
 			input:    syscall.Errno(0xfe),
 			expected: ErrnoIo,


### PR DESCRIPTION
This consolidates the sharable code around syscall.Errno conversion from wasi and gojs and backfills test for the consolidated part.

This also unwraps os.SyscallErr and handles EAGAIN and EINTR.
