### PR TITLE
cli: add an option to force interpreter

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -114,6 +114,9 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 	var help bool
 	flags.BoolVar(&help, "h", false, "print usage")
 
+	var interp bool
+	flags.BoolVar(&interp, "interp", false, "force interpreter")
+
 	var envs sliceFlag
 	flags.Var(&envs, "env", "key=value pair of environment variable to expose to the binary. "+
 		"Can be specified multiple times.")
@@ -176,7 +179,12 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 
 	ctx := maybeHostLogging(context.Background(), logging.LogScopes(hostlogging), stdErr)
 
-	rtc := wazero.NewRuntimeConfig()
+	var rtc wazero.RuntimeConfig
+	if interp {
+		rtc = wazero.NewRuntimeConfigInterpreter()
+	} else {
+		rtc = wazero.NewRuntimeConfig()
+	}
 	if cache := maybeUseCacheDir(cacheDir, stdErr, exit); cache != nil {
 		rtc.WithCompilationCache(cache)
 	}


### PR DESCRIPTION
Background: I wanted to evaluate the interpreter like: https://github.com/yamt/toywasm/blob/5b7f8a870a2b8a7600330f0421b14bf01e2249d8/benchmark/ffmpeg.sh#L58-L61
But I couldn't find a convenient way.

Signed-off-by: YAMAMOTO Takashi <imuwoto@gmail.com>