### PR TITLE
cli: adds env-inherit flag for SCRATCH images

### DIFF
--- a/cmd/wazero/Dockerfile
+++ b/cmd/wazero/Dockerfile
@@ -13,4 +13,4 @@ RUN git clone --depth 1 https://github.com/tetratelabs/wazero.git \
 FROM scratch
 COPY --from=build /build/wazero/wazero /bin/wazero
 
-ENTRYPOINT ["/bin/wazero", "run", "-cachedir=/cache", "-mount=.:/"]
+ENTRYPOINT ["/bin/wazero", "run", "-env-inherit", "-cachedir=/cache", "-mount=.:/"]

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -194,8 +194,8 @@ func TestRun(t *testing.T) {
 
 	// Clear the environment first, so we can make strict assertions.
 	os.Clearenv()
-	os.Setenv("INHERITED", "wazero")
 	os.Setenv("ANIMAL", "kitten")
+	os.Setenv("INHERITED", "wazero")
 
 	tmpDir, oldwd := requireChdirToTemp(t)
 	defer os.Chdir(oldwd) //nolint
@@ -254,13 +254,13 @@ func TestRun(t *testing.T) {
 			name:           "env-inherit",
 			wasm:           wasmWasiEnv,
 			wazeroOpts:     []string{"-env-inherit"},
-			expectedStdout: "INHERITED=wazero\x00ANIMAL=kitten\x00",
+			expectedStdout: "ANIMAL=kitten\x00INHERITED=wazero\u0000",
 		},
 		{
 			name:           "env-inherit with env",
 			wasm:           wasmWasiEnv,
 			wazeroOpts:     []string{"-env-inherit", "--env=ANIMAL=bear"},
-			expectedStdout: "INHERITED=wazero\x00ANIMAL=bear\x00", // not ANIMAL=kitten
+			expectedStdout: "ANIMAL=bear\x00INHERITED=wazero\u0000", // not ANIMAL=kitten
 		},
 		{
 			name:           "interpreter",


### PR DESCRIPTION
This adds an `env-inherit` boolean flag which adds all variables to the guest ENV.

For example, the below `env-reader.wasm` guest will see the variable `STAR` and anything set via the runner (docker, podman, etc.):
```
--snip--
FROM scratch
COPY --from=build /build/wazero/wazero /bin/wazero

ENTRYPOINT ["/bin/wazero", "run", "-env-inherit", "-cachedir=/cache", "-mount=.:/"]

ENV STAR=wazero

COPY --from=wasm / .
CMD ["env-reader.wasm"]
```

Note: This isn't appropriate otherwise as it will also propagate variables like PATH and TMPDIR which aren't likely valid on the guest, or in worst case may risk crashing.