### PR TITLE
add support for querying cpuid

### DIFF
--- a/internal/platform/cpuid_amd64.go
+++ b/internal/platform/cpuid_amd64.go
@@ -1,0 +1,79 @@
+package platform
+
+const (
+	// CpuFeatureSSE3 is the flag to query CpuFeatureFlags.Has for SSEv3 capabilities
+	CpuFeatureSSE3 = uint64(1)
+	// CpuFeatureSSE4_1 is the flag to query CpuFeatureFlags.Has for SSEv4.1 capabilities
+	CpuFeatureSSE4_1 = uint64(1) << 19
+	// CpuFeatureSSE4_2 is the flag to query CpuFeatureFlags.Has for SSEv4.2 capabilities
+	CpuFeatureSSE4_2 = uint64(1) << 20
+)
+
+const (
+	// CpuExtraFeatureABM is the flag to query CpuFeatureFlags.HasExtra for Advanced Bit Manipulation capabilities (e.g. LZCNT)
+	CpuExtraFeatureABM = uint64(1) << 5
+)
+
+// CpuFeatures exposes the capabilities for this CPU, queried via the Has, HasExtra methods
+var CpuFeatures CpuFeatureFlags = loadCpuFeatureFlags()
+
+// CpuFeatureFlags exposes methods for querying CPU capabilities
+type CpuFeatureFlags interface {
+	// Has returns true when the specified flag (represented as uint64) is supported
+	Has(cpuFeature uint64) bool
+	// HasExtra returns true when the specified extraFlag (represented as uint64) is supported
+	HasExtra(cpuFeature uint64) bool
+}
+
+// cpuFeatureFlags implements CpuFeatureFlags interface
+type cpuFeatureFlags struct {
+	flags      uint64
+	extraFlags uint64
+}
+
+// cpuid exposes the CPUID instruction to the Go layer (https://www.amd.com/system/files/TechDocs/25481.pdf)
+// implemented in impl_amd64.s
+func cpuid(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
+
+// cpuidAsBitmap combines the result of invoking cpuid to uint64 bitmap
+func cpuidAsBitmap(arg1, arg2 uint32) uint64 {
+	_ /* eax */, _ /* ebx */, ecx, edx := cpuid(arg1, arg2)
+	return (uint64(edx) << 32) | uint64(ecx)
+}
+
+// loadStandardRange load flags from the standard range, panics otherwise
+func loadStandardRange(id uint32) uint64 {
+	// ensure that the id is in the valid range, returned by cpuid(0,0)
+	maxRange, _, _, _ := cpuid(0, 0)
+	if id > maxRange {
+		panic("cannot query standard CPU flags")
+	}
+	return cpuidAsBitmap(id, 0)
+}
+
+// loadStandardRange load flags from the extended range, panics otherwise
+func loadExtendedRange(id uint32) uint64 {
+	// ensure that the id is in the valid range, returned by cpuid(0x80000000,0)
+	maxRange, _, _, _ := cpuid(0x80000000, 0)
+	if id > maxRange {
+		panic("cannot query extended CPU flags")
+	}
+	return cpuidAsBitmap(id, 0)
+}
+
+func loadCpuFeatureFlags() CpuFeatureFlags {
+	return &cpuFeatureFlags{
+		flags:      loadStandardRange(1),
+		extraFlags: loadExtendedRange(0x80000001),
+	}
+}
+
+// Has implements the same method on the CpuFeatureFlags interface
+func (f *cpuFeatureFlags) Has(cpuFeature uint64) bool {
+	return (f.flags & cpuFeature) != 0
+}
+
+// HasExtra implements the same method on the CpuFeatureFlags interface
+func (f *cpuFeatureFlags) HasExtra(cpuFeature uint64) bool {
+	return (f.extraFlags & cpuFeature) != 0
+}

--- a/internal/platform/cpuid_amd64.s
+++ b/internal/platform/cpuid_amd64.s
@@ -1,0 +1,14 @@
+#include "textflag.h"
+
+// lifted from github.com/intel-go/cpuid and src/internal/cpu/cpu_x86.s
+// func cpuid(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32)
+TEXT ·cpuid(SB), NOSPLIT, $0-24
+	MOVL arg1+0(FP), AX
+	MOVL arg2+4(FP), CX
+	CPUID
+	MOVL AX, eax+8(FP)
+	MOVL BX, ebx+12(FP)
+	MOVL CX, ecx+16(FP)
+	MOVL DX, edx+20(FP)
+	RET
+

--- a/internal/platform/cpuid_amd64_test.go
+++ b/internal/platform/cpuid_amd64_test.go
@@ -1,0 +1,18 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestAmd64CpuId_cpuHasFeature(t *testing.T) {
+	flags := cpuFeatureFlags{
+		flags:      CpuFeatureSSE3,
+		extraFlags: CpuExtraFeatureABM,
+	}
+	require.True(t, flags.Has(CpuFeatureSSE3))
+	require.False(t, flags.Has(CpuFeatureSSE4_2))
+	require.True(t, flags.HasExtra(CpuExtraFeatureABM))
+	require.False(t, flags.HasExtra(1<<6)) // some other value
+}


### PR DESCRIPTION
fixes #1111, adds setup for fixing #580 

While I haven't tested this on a proper x86 machine (but I do have a dusty core duo laptop which may really be the thing I need, if I manage to turn it on :D) I have sketched a solution by putting together everyone's feedback (including @ncruces' 🚀). In the meantime I have also discovered that `GOARCH=amd64` has the ABM feature flag off on Rosetta2.

- this is in a new `cupid_amd64.{s,go}` because I felt it would pollute too much `impl` and `arch` didn't feel like the right place (that's for runtime)
- For now I have only added the constants that we use and/or plan to use (e.g. SSE3, 4.1, 4.2), and only the related bitmaps
- you still have to carefully pick the right set of flags because there is no proper type checking in place (all are uint64). Suggestions welcome for better ergonomics/idioms

Values are kept in a struct that is local to the compiler instance. This is re-inited at for each `amd64Compiler` -- TBF it may be created once and then copied over when necessary. I wanted to keep it local to the compiler instance, instead of global, to make sure we can properly test it.

Speaking of testing: the compiler test right now is kind of silly because it checks for the length of the generated byte array. The one reason is that I couldn't figure out how to decode or inspect the list of opcodes the right way. This is the main reason why this is draft.



