### PR TITLE
Fixes races around {api.Module, wazero.Runtime}.CloseWithExitCode

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -672,7 +672,7 @@ func (ce *callEngine) Call(ctx context.Context, callCtx *wasm.CallContext, param
 	ce.initializeStack(tp, params)
 
 	if ce.fn.parent.withEnsureTermination {
-		done := callCtx.SetExitCodeOnCanceledOrTimeout(ctx)
+		done := callCtx.CloseModuleOnCanceledOrTimeout(ctx)
 		defer done()
 	}
 

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -816,7 +816,7 @@ func (ce *callEngine) call(ctx context.Context, callCtx *wasm.CallContext, tf *f
 	}
 
 	if ce.compiled.parent.ensureTermination {
-		done := callCtx.SetExitCodeOnCanceledOrTimeout(ctx)
+		done := callCtx.CloseModuleOnCanceledOrTimeout(ctx)
 		defer done()
 	}
 

--- a/internal/wasm/call_context.go
+++ b/internal/wasm/call_context.go
@@ -67,27 +67,29 @@ func (m *CallContext) FailIfClosed() (err error) {
 	return nil
 }
 
-// SetExitCodeOnCanceledOrTimeout take a context `ctx`, which might be a Cancel or Timeout context,
+// CloseModuleOnCanceledOrTimeout take a context `ctx`, which might be a Cancel or Timeout context,
 // and spawns the Goroutine to check the context is canceled ot deadline exceeded. If it reaches
 // one of the conditions, it sets the appropriate exit code.
 //
 // Callers of this function must invoke the returned context.CancelFunc to release the spawned Goroutine.
-func (m *CallContext) SetExitCodeOnCanceledOrTimeout(ctx context.Context) context.CancelFunc {
+func (m *CallContext) CloseModuleOnCanceledOrTimeout(ctx context.Context) context.CancelFunc {
 	goroutineDone, cancelFn := context.WithCancel(context.Background())
-	go m.setExitCodeOnCanceledOrTimeoutClosure(ctx, goroutineDone)()
+	go m.closeModuleOnCanceledOrTimeoutClosure(ctx, goroutineDone)()
 	return cancelFn
 }
 
-// setExitCodeOnCanceledOrTimeoutClosure is extracted from SetExitCodeOnCanceledOrTimeout for testing.
-func (m *CallContext) setExitCodeOnCanceledOrTimeoutClosure(ctx, goroutineDone context.Context) func() {
+// closeModuleOnCanceledOrTimeoutClosure is extracted from CloseModuleOnCanceledOrTimeout for testing.
+func (m *CallContext) closeModuleOnCanceledOrTimeoutClosure(ctx, goroutineDone context.Context) func() {
 	return func() {
 		for {
 			select {
 			case <-ctx.Done():
 				if errors.Is(ctx.Err(), context.Canceled) {
-					m.setExitCode(sys.ExitCodeContextCanceled)
+					// TODO: figure out how to report error here.
+					_ = m.CloseWithExitCode(ctx, sys.ExitCodeContextCanceled)
 				} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					m.setExitCode(sys.ExitCodeDeadlineExceeded)
+					// TODO: figure out how to report error here.
+					_ = m.CloseWithExitCode(ctx, sys.ExitCodeDeadlineExceeded)
 				}
 				return
 			case <-goroutineDone.Done():
@@ -122,14 +124,24 @@ func (m *CallContext) Close(ctx context.Context) (err error) {
 
 // CloseWithExitCode implements the same method as documented on api.Module.
 func (m *CallContext) CloseWithExitCode(ctx context.Context, exitCode uint32) (err error) {
-	m.setExitCode(exitCode)
+	if !m.setExitCode(exitCode) {
+		return nil
+	}
 	_ = m.s.deleteModule(m.Name())
 	return m.ensureResourcesClosed(ctx)
 }
 
-func (m *CallContext) setExitCode(exitCode uint32) {
+// closeWithExitCode is the same as CloseWithExitCode besides this doesn't delete it from Store.moduleList.
+func (m *CallContext) closeWithExitCode(ctx context.Context, exitCode uint32) (err error) {
+	if !m.setExitCode(exitCode) {
+		return nil
+	}
+	return m.ensureResourcesClosed(ctx)
+}
+
+func (m *CallContext) setExitCode(exitCode uint32) bool {
 	closed := uint64(1) + uint64(exitCode)<<32 // Store exitCode as high-order bits.
-	atomic.CompareAndSwapUint64(m.Closed, 0, closed)
+	return atomic.CompareAndSwapUint64(m.Closed, 0, closed)
 }
 
 // ensureResourcesClosed ensures that resources assigned to CallContext is released.

--- a/internal/wasm/call_context.go
+++ b/internal/wasm/call_context.go
@@ -125,7 +125,7 @@ func (m *CallContext) Close(ctx context.Context) (err error) {
 // CloseWithExitCode implements the same method as documented on api.Module.
 func (m *CallContext) CloseWithExitCode(ctx context.Context, exitCode uint32) (err error) {
 	if !m.setExitCode(exitCode) {
-		return nil
+		return nil // not an error to have already closed
 	}
 	_ = m.s.deleteModule(m.Name())
 	return m.ensureResourcesClosed(ctx)
@@ -134,7 +134,7 @@ func (m *CallContext) CloseWithExitCode(ctx context.Context, exitCode uint32) (e
 // closeWithExitCode is the same as CloseWithExitCode besides this doesn't delete it from Store.moduleList.
 func (m *CallContext) closeWithExitCode(ctx context.Context, exitCode uint32) (err error) {
 	if !m.setExitCode(exitCode) {
-		return nil
+		return nil // not an error to have already closed
 	}
 	return m.ensureResourcesClosed(ctx)
 }

--- a/internal/wasm/call_context_test.go
+++ b/internal/wasm/call_context_test.go
@@ -167,9 +167,8 @@ func TestCallContext_Close(t *testing.T) {
 				require.True(t, ok, "sysCtx.openedFiles was empty")
 
 				// Closing should not err.
-				var wg sync.WaitGroup
 				if concurrent {
-					hammer.NewHammer(t, 4, 100).Run(func(name string) {
+					hammer.NewHammer(t, 100, 10).Run(func(name string) {
 						require.NoError(t, m.Close(testCtx))
 						// closeWithExitCode is the one called during Store.CloseWithExitCode.
 						require.NoError(t, m.closeWithExitCode(testCtx, 0))
@@ -180,7 +179,6 @@ func TestCallContext_Close(t *testing.T) {
 				} else {
 					require.NoError(t, m.Close(testCtx))
 				}
-				wg.Wait()
 
 				// Verify our intended side-effect
 				_, ok = fsCtx.LookupFile(3)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -631,12 +631,11 @@ func (s *Store) CloseWithExitCode(ctx context.Context, exitCode uint32) (err err
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	// Close modules in reverse initialization order.
-	// Close modules in reverse initialization order.
 	for node := s.moduleList; node != nil; node = node.next {
 		// If closing this module errs, proceed anyway to close the others.
 		if m := node.module; m != nil {
-			m.CallCtx.setExitCode(exitCode)
-			if e := m.CallCtx.ensureResourcesClosed(ctx); e != nil && err == nil {
+			if e := m.CallCtx.closeWithExitCode(ctx, exitCode); e != nil && err == nil {
+				// TODO: use multiple errors handling in Go 1.20.
 				err = e // first error
 			}
 		}


### PR DESCRIPTION
This is a regression introduced in #1108 and hasn't been well covered in the unit tests with -race.
Thanks to @ckaznocha for reporting this!

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>