### PR TITLE
compiler(amd64): return false on SSE4 unsupported CPUs

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -10,6 +10,9 @@ import (
 	"runtime"
 )
 
+// archRequirementsVerified is set by platform-specific init to true if the platform is supported
+var archRequirementsVerified = false
+
 // CompilerSupported is exported for tests and includes constraints here and also the assembler.
 func CompilerSupported() bool {
 	switch runtime.GOOS {
@@ -18,13 +21,7 @@ func CompilerSupported() bool {
 		return false
 	}
 
-	switch runtime.GOARCH {
-	case "amd64", "arm64":
-	default:
-		return false
-	}
-
-	return true
+	return archRequirementsVerified
 }
 
 // MmapCodeSegment copies the code into the executable region and returns the byte slice of the region.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -11,7 +11,7 @@ import (
 )
 
 // archRequirementsVerified is set by platform-specific init to true if the platform is supported
-var archRequirementsVerified = false
+var archRequirementsVerified bool
 
 // CompilerSupported is exported for tests and includes constraints here and also the assembler.
 func CompilerSupported() bool {

--- a/internal/platform/platform_amd64.go
+++ b/internal/platform/platform_amd64.go
@@ -1,0 +1,7 @@
+package platform
+
+// init verifies that the current CPU supports the required AMD64 instructions
+func init() {
+	// ensure SSE4.1 is supported
+	archRequirementsVerified = CpuFeatures.Has(CpuFeatureSSE4_1)
+}

--- a/internal/platform/platform_amd64.go
+++ b/internal/platform/platform_amd64.go
@@ -2,6 +2,6 @@ package platform
 
 // init verifies that the current CPU supports the required AMD64 instructions
 func init() {
-	// ensure SSE4.1 is supported
+	// Ensure SSE4.1 is supported.
 	archRequirementsVerified = CpuFeatures.Has(CpuFeatureSSE4_1)
 }

--- a/internal/platform/platform_arm64.go
+++ b/internal/platform/platform_arm64.go
@@ -2,6 +2,6 @@ package platform
 
 // init verifies that the current CPU supports the required ARM64 features
 func init() {
-	// no further checks currently needed
+	// No further checks currently needed.
 	archRequirementsVerified = true
 }

--- a/internal/platform/platform_arm64.go
+++ b/internal/platform/platform_arm64.go
@@ -1,0 +1,7 @@
+package platform
+
+// init verifies that the current CPU supports the required ARM64 features
+func init() {
+	// no further checks currently needed
+	archRequirementsVerified = true
+}


### PR DESCRIPTION
I am not sure whether we should also add some test case to exercise this code path. Maybe enabling emulated tests as suggested in #581? Even my old Window laptop is newer and passes :D

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>


Fixes #580 

