### PR TITLE
Implements fd_datasync in WASI and sync in GOOS=js

### DIFF
--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -69,6 +69,10 @@ func Main() {
 	if err = f.Truncate(2); err != nil {
 		log.Panicln(err)
 	}
+	// Next, sync it.
+	if err = f.Sync(); err != nil {
+		log.Panicln(err)
+	}
 	if err = f.Close(); err != nil {
 		log.Panicln(err)
 	}

--- a/internal/platform/sync.go
+++ b/internal/platform/sync.go
@@ -1,0 +1,7 @@
+package platform
+
+// Fdatasync is like syscall.Fdatasync except that's only defined in linux.
+// This returns syscall.ENOSYS when unimplemented.
+func Fdatasync(fd uintptr) (err error) {
+	return fdatasync(fd)
+}

--- a/internal/platform/sync_linux.go
+++ b/internal/platform/sync_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package platform
+
+import "syscall"
+
+func fdatasync(fd uintptr) error {
+	return syscall.Fdatasync(int(fd))
+}

--- a/internal/platform/sync_test.go
+++ b/internal/platform/sync_test.go
@@ -1,0 +1,44 @@
+package platform
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+// Test_Fdatasync doesn't guarantee sync works because the operating system may
+// sync anyway. There is no test in Go for syscall.Fdatasync, but closest is
+// similar to below. Effectively, this only tests that things don't error.
+func Test_Fdatasync(t *testing.T) {
+	f, err := os.CreateTemp("", t.Name())
+	require.NoError(t, err)
+	defer f.Close()
+
+	expected := "hello world!"
+
+	// Write the expected data
+	_, err = f.Write([]byte(expected))
+	require.NoError(t, err)
+
+	// Sync the data.
+	if err = Fdatasync(f.Fd()); err == syscall.ENOSYS {
+		return // don't continue if it isn't supported.
+	}
+	require.NoError(t, err)
+
+	// Rewind while the file is still open.
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	// Read data from the file
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, f)
+	require.NoError(t, err)
+
+	// It may be the case that sync worked.
+	require.Equal(t, expected, buf.String())
+}

--- a/internal/platform/sync_unsupported.go
+++ b/internal/platform/sync_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package platform
+
+import "syscall"
+
+func fdatasync(fd uintptr) error {
+	return syscall.ENOSYS
+}

--- a/site/content/specs.md
+++ b/site/content/specs.md
@@ -90,12 +90,12 @@ Notes:
 | environ_sizes_get       |   ✅    |          TinyGo |
 | clock_res_get           |   ✅    |                 |
 | clock_time_get          |   ✅    |          TinyGo |
-| fd_advise               |   ❌    |                 |
-| fd_allocate             |   ❌    |                 |
+| fd_advise               |   👷   |                 |
+| fd_allocate             |   ✅    |            Rust |
 | fd_close                |   ✅    |          TinyGo |
-| fd_datasync             |   ❌    |                 |
+| fd_datasync             |   ✅    |            Rust |
 | fd_fdstat_get           |   ✅    |          TinyGo |
-| fd_fdstat_set_flags     |   ❌    |                 |
+| fd_fdstat_set_flags     |   ✅    |            Rust |
 | fd_fdstat_set_rights    |   💀   |                 |
 | fd_filestat_get         |   ✅    |             Zig |
 | fd_filestat_set_size    |   ✅    |        Rust,Zig |
@@ -106,10 +106,10 @@ Notes:
 | fd_pwrite               |   ✅    |        Rust,Zig |
 | fd_read                 |   ✅    | Rust,TinyGo,Zig |
 | fd_readdir              |   ✅    |        Rust,Zig |
-| fd_renumber             |   ❌    |                 |
+| fd_renumber             |   ✅    |            libc |
 | fd_seek                 |   ✅    |          TinyGo |
-| fd_sync                 |   ❌    |                 |
-| fd_tell                 |   ❌    |                 |
+| fd_sync                 |   ✅    |              Go |
+| fd_tell                 |   ✅    |            Rust |
 | fd_write                |   ✅    | Rust,TinyGo,Zig |
 | path_create_directory   |   ✅    | Rust,TinyGo,Zig |
 | path_filestat_get       |   ✅    | Rust,TinyGo,Zig |


### PR DESCRIPTION
This implements `fd_datasync` in WASI, falling back to normal `File.Sync` when unsupported. This also backfills missing usage of sync in GOOS=js. Finally, this updates the WASI status chart based on what's implemented.