### PR TITLE
sysfs: adds chmod

### DIFF
--- a/internal/gojs/errno.go
+++ b/internal/gojs/errno.go
@@ -21,6 +21,8 @@ func (e *Errno) Error() string {
 // This order match constants from wasi_snapshot_preview1.ErrnoSuccess for
 // easier maintenance.
 var (
+	// ErrnoAcces Permission denied.
+	ErrnoAcces = &Errno{"EACCES"}
 	// ErrnoAgain Resource unavailable, or operation would block.
 	ErrnoAgain = &Errno{"EAGAIN"}
 	// ErrnoBadf Bad file descriptor.
@@ -61,6 +63,8 @@ func ToErrno(err error) *Errno {
 	errno := sysfs.UnwrapOSError(err)
 
 	switch errno {
+	case syscall.EACCES:
+		return ErrnoAcces
 	case syscall.EAGAIN:
 		return ErrnoAgain
 	case syscall.EBADF:

--- a/internal/gojs/errno_test.go
+++ b/internal/gojs/errno_test.go
@@ -14,6 +14,11 @@ func TestToErrno(t *testing.T) {
 		expected *Errno
 	}{
 		{
+			name:     "syscall.EACCES",
+			input:    syscall.EACCES,
+			expected: ErrnoAcces,
+		},
+		{
 			name:     "syscall.EAGAIN",
 			input:    syscall.EAGAIN,
 			expected: ErrnoAgain,

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -24,6 +24,13 @@ func TestAdapt_MkDir(t *testing.T) {
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
+func TestAdapt_Chmod(t *testing.T) {
+	testFS := Adapt(os.DirFS(t.TempDir()))
+
+	err := testFS.Chmod("chmod", fs.ModeDir)
+	require.Equal(t, syscall.ENOSYS, err)
+}
+
 func TestAdapt_Rename(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFS := Adapt(os.DirFS(tmpDir))
@@ -110,6 +117,8 @@ func (dir hackFS) Open(name string) (fs.File, error) {
 		return f, nil
 	} else if errors.Is(err, syscall.EISDIR) {
 		return os.OpenFile(path, os.O_RDONLY, 0)
+	} else if errors.Is(err, syscall.ENOENT) {
+		return os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0o444)
 	} else {
 		return nil, err
 	}

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -1,7 +1,6 @@
 package sysfs
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"syscall"
@@ -51,11 +50,17 @@ func (d *dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, erro
 }
 
 // Mkdir implements FS.Mkdir
-func (d *dirFS) Mkdir(name string, perm fs.FileMode) error {
-	err := os.Mkdir(d.join(name), perm)
-	if errors.Is(err, syscall.ENOTDIR) {
-		return syscall.ENOENT
+func (d *dirFS) Mkdir(name string, perm fs.FileMode) (err error) {
+	err = os.Mkdir(d.join(name), perm)
+	if err = UnwrapOSError(err); err == syscall.ENOTDIR {
+		err = syscall.ENOENT
 	}
+	return
+}
+
+// Chmod implements FS.Chmod
+func (d *dirFS) Chmod(name string, perm fs.FileMode) error {
+	err := os.Chmod(d.join(name), perm)
 	return UnwrapOSError(err)
 }
 

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -97,15 +97,15 @@ func TestDirFS_MkDir(t *testing.T) {
 }
 
 func testChmod(t *testing.T, testFS FS, path string) {
-	// test base case
+	// Test base case, using 0o444 not 0o400 for read-back on windows.
 	requireMode(t, testFS, path, 0o444)
 
-	// test we can mark owner writeable
+	// Test adding write, using 0o666 not 0o600 for read-back on windows.
 	require.NoError(t, testFS.Chmod(path, 0o666))
 	requireMode(t, testFS, path, 0o666)
 
 	if runtime.GOOS != "windows" {
-		// test we can mark owner executable
+		// Test clearing group and world, setting owner read+execute.
 		require.NoError(t, testFS.Chmod(path, 0o500))
 		requireMode(t, testFS, path, 0o500)
 	}

--- a/internal/sysfs/readfs_test.go
+++ b/internal/sysfs/readfs_test.go
@@ -41,6 +41,14 @@ func TestReadFS_MkDir(t *testing.T) {
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
+func TestReadFS_Chmod(t *testing.T) {
+	writeable := NewDirFS(t.TempDir())
+	testFS := NewReadFS(writeable)
+
+	err := testFS.Chmod("chmod", fs.ModeDir)
+	require.Equal(t, syscall.ENOSYS, err)
+}
+
 func TestReadFS_Rename(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeable := NewDirFS(tmpDir)

--- a/internal/sysfs/unsupported.go
+++ b/internal/sysfs/unsupported.go
@@ -29,6 +29,11 @@ func (UnimplementedFS) Mkdir(path string, perm fs.FileMode) error {
 	return syscall.ENOSYS
 }
 
+// Chmod implements FS.Chmod
+func (UnimplementedFS) Chmod(path string, perm fs.FileMode) error {
+	return syscall.ENOSYS
+}
+
 // Rename implements FS.Rename
 func (UnimplementedFS) Rename(from, to string) error {
 	return syscall.ENOSYS

--- a/internal/wasi_snapshot_preview1/errno.go
+++ b/internal/wasi_snapshot_preview1/errno.go
@@ -268,8 +268,9 @@ var errnoToString = [...]string{
 func ToErrno(err error) Errno {
 	errno := sysfs.UnwrapOSError(err)
 
-	// The below Errno have references in existing WASI code.
 	switch errno {
+	case syscall.EACCES:
+		return ErrnoAcces
 	case syscall.EAGAIN:
 		return ErrnoAgain
 	case syscall.EBADF:

--- a/internal/wasi_snapshot_preview1/errno_test.go
+++ b/internal/wasi_snapshot_preview1/errno_test.go
@@ -14,6 +14,11 @@ func TestToErrno(t *testing.T) {
 		expected Errno
 	}{
 		{
+			name:     "syscall.EACCES",
+			input:    syscall.EACCES,
+			expected: ErrnoAcces,
+		},
+		{
 			name:     "syscall.EAGAIN",
 			input:    syscall.EAGAIN,
 			expected: ErrnoAgain,


### PR DESCRIPTION
This adds `FS.Chmod` and implements it for `GOOS=js`. This function isn't defined in WASI snapshot01, but it is in [wasi-filesystem](https://github.com/WebAssembly/wasi-filesystem), e.g. [change-file-permissions-at](https://github.com/WebAssembly/wasi-filesystem/blob/main/wasi-filesystem.md#-change-file-permissions-at).