### PR TITLE
Removes redundant Magic validation in runtime

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1,7 +1,6 @@
 package wazero
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -188,10 +187,6 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 
 	if binary == nil {
 		return nil, errors.New("binary == nil")
-	}
-
-	if len(binary) < 4 || !bytes.Equal(binary[0:4], binaryformat.Magic) {
-		return nil, errors.New("invalid binary")
 	}
 
 	internal, err := binaryformat.DecodeModule(binary, r.enabledFeatures,


### PR DESCRIPTION
If I'm not wrong, with current `Magic` validation in `runtime.CompileModule` never reach this code
https://github.com/tetratelabs/wazero/blob/e2ebce5d230eceff7d89e4d8677a166dd9ebabca/internal/wasm/binary/decoder.go#L29-L31

and will always send `errors.New("invalid binary")` in case of incorrect Magic in wasm .