### PR TITLE
Reduces allocations in func validation

### DIFF
--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -74,6 +74,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 	// Create the valueTypeStack to track the state of Wasm value stacks at anypoint of execution.
 	valueTypeStack := &valueTypeStack{}
 
+	r := bytes.NewReader(nil)
+
 	// Now start walking through all the instructions in the body while tracking
 	// control blocks and value types to check the validity of all instructions.
 	for pc := uint64(0); pc < uint64(len(body)); pc++ {
@@ -436,7 +438,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			}
 		} else if op == OpcodeBrTable {
 			pc++
-			r := bytes.NewReader(body[pc:])
+			r.Reset(body[pc:])
 			nl, num, err := leb128.DecodeUint32(r)
 			if err != nil {
 				return fmt.Errorf("read immediate: %w", err)
@@ -1389,7 +1391,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 				return fmt.Errorf("TODO: SIMD instruction %s will be implemented in #506", vectorInstructionName[vecOpcode])
 			}
 		} else if op == OpcodeBlock {
-			bt, num, err := DecodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
+			r.Reset(body[pc+1:])
+			bt, num, err := DecodeBlockType(types, r, enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -1408,7 +1411,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			valueTypeStack.pushStackLimit(len(bt.Params))
 			pc += num
 		} else if op == OpcodeLoop {
-			bt, num, err := DecodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
+			r.Reset(body[pc+1:])
+			bt, num, err := DecodeBlockType(types, r, enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -1428,7 +1432,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			valueTypeStack.pushStackLimit(len(bt.Params))
 			pc += num
 		} else if op == OpcodeIf {
-			bt, num, err := DecodeBlockType(types, bytes.NewReader(body[pc+1:]), enabledFeatures)
+			r.Reset(body[pc+1:])
+			bt, num, err := DecodeBlockType(types, r, enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -74,7 +74,9 @@ func (m *Module) validateFunctionWithMaxStackValues(
 	// Create the valueTypeStack to track the state of Wasm value stacks at anypoint of execution.
 	valueTypeStack := &valueTypeStack{}
 
-	r := bytes.NewReader(nil)
+	// Create bytes.Reader once as it causes allocation, and
+	// we frequently need it (e.g. on every If instruction).
+	br := bytes.NewReader(nil)
 
 	// Now start walking through all the instructions in the body while tracking
 	// control blocks and value types to check the validity of all instructions.
@@ -438,22 +440,22 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			}
 		} else if op == OpcodeBrTable {
 			pc++
-			r.Reset(body[pc:])
-			nl, num, err := leb128.DecodeUint32(r)
+			br.Reset(body[pc:])
+			nl, num, err := leb128.DecodeUint32(br)
 			if err != nil {
 				return fmt.Errorf("read immediate: %w", err)
 			}
 
 			list := make([]uint32, nl)
 			for i := uint32(0); i < nl; i++ {
-				l, n, err := leb128.DecodeUint32(r)
+				l, n, err := leb128.DecodeUint32(br)
 				if err != nil {
 					return fmt.Errorf("read immediate: %w", err)
 				}
 				num += n
 				list[i] = l
 			}
-			ln, n, err := leb128.DecodeUint32(r)
+			ln, n, err := leb128.DecodeUint32(br)
 			if err != nil {
 				return fmt.Errorf("read immediate: %w", err)
 			} else if int(ln) >= len(controlBlockStack) {
@@ -1391,8 +1393,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 				return fmt.Errorf("TODO: SIMD instruction %s will be implemented in #506", vectorInstructionName[vecOpcode])
 			}
 		} else if op == OpcodeBlock {
-			r.Reset(body[pc+1:])
-			bt, num, err := DecodeBlockType(types, r, enabledFeatures)
+			br.Reset(body[pc+1:])
+			bt, num, err := DecodeBlockType(types, br, enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -1411,8 +1413,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			valueTypeStack.pushStackLimit(len(bt.Params))
 			pc += num
 		} else if op == OpcodeLoop {
-			r.Reset(body[pc+1:])
-			bt, num, err := DecodeBlockType(types, r, enabledFeatures)
+			br.Reset(body[pc+1:])
+			bt, num, err := DecodeBlockType(types, br, enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}
@@ -1432,8 +1434,8 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			valueTypeStack.pushStackLimit(len(bt.Params))
 			pc += num
 		} else if op == OpcodeIf {
-			r.Reset(body[pc+1:])
-			bt, num, err := DecodeBlockType(types, r, enabledFeatures)
+			br.Reset(body[pc+1:])
+			bt, num, err := DecodeBlockType(types, br, enabledFeatures)
 			if err != nil {
 				return fmt.Errorf("read block: %w", err)
 			}


### PR DESCRIPTION
Avoids allocating `bytes.Reader` a lot, but instead use the one `bytes.Reader` at the top.


The following is the bench result for gojs binary.

```
name         old time/op    new time/op    delta
_compile-10     1.12s ± 4%     1.10s ± 3%  -1.67%  (p=0.005 n=20+20)

name         old alloc/op   new alloc/op   delta
_compile-10     672MB ± 0%     665MB ± 0%  -1.07%  (p=0.000 n=18+19)

name         old allocs/op  new allocs/op  delta
_compile-10     13.5M ± 0%     13.3M ± 0%  -1.11%  (p=0.000 n=19+20)

name          old time/op    new time/op    delta
_validate-10    56.9ms ± 2%    52.6ms ± 2%   -7.60%  (p=0.000 n=19+20)

name          old alloc/op   new alloc/op   delta
_validate-10    36.1MB ± 0%    28.9MB ± 0%  -19.94%  (p=0.000 n=16+19)

name          old allocs/op  new allocs/op  delta
_validate-10      747k ± 0%      597k ± 0%  -20.03%  (p=0.000 n=20+20)

```