### PR TITLE
sysfs: adds FS.Stat and companions in platform

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -234,6 +234,10 @@ jobs:
       - name: Install wazero
         run: go install ./cmd/wazero
 
+      # This runs the previously compiled TinyGo tests with wazero. If you need
+      # to troubleshoot one, you can add "-hostlogging=filesystem" and also a
+      # trailing argument narrowing which test to execute.
+      # e.g. "-test.run '^TestStatBadDir$'"
       - name: Run standard library tests
         run: |
           for bin in *.test; do

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,9 @@ check:
 # This makes sure the intepreter can be used. Most often the package that can
 # drift here is "platform" or "sysfs":
 #
-# Ensure we build on an arbitrary operating system
+# Ensure we build on windows:
+	@GOARCH=amd64 GOOS=windows go build ./...
+# Ensure we build on an arbitrary operating system:
 	@GOARCH=amd64 GOOS=dragonfly go build ./...
 # Ensure we build on linux arm for Dapr:
 #	gh release view -R dapr/dapr --json assets --jq 'first(.assets[] | select(.name = "daprd_linux_arm.tar.gz") | {url, downloadCount})'

--- a/imports/wasi_snapshot_preview1/args_test.go
+++ b/imports/wasi_snapshot_preview1/args_test.go
@@ -26,7 +26,7 @@ func Test_argsGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory)+int(argvBuf))
 
 	// Invoke argsGet and check the memory side effects.
-	requireErrno(t, ErrnoSuccess, mod, ArgsGetName, uint64(argv), uint64(argvBuf))
+	requireErrnoResult(t, ErrnoSuccess, mod, ArgsGetName, uint64(argv), uint64(argvBuf))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.args_get(argv=22,argv_buf=16)
 <== errno=ESUCCESS
@@ -95,7 +95,7 @@ func Test_argsGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrno(t, ErrnoFault, mod, ArgsGetName, uint64(tc.argv), uint64(tc.argvBuf))
+			requireErrnoResult(t, ErrnoFault, mod, ArgsGetName, uint64(tc.argv), uint64(tc.argvBuf))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -118,7 +118,7 @@ func Test_argsSizesGet(t *testing.T) {
 	maskMemory(t, mod, int(resultArgc)+len(expectedMemory))
 
 	// Invoke argsSizesGet and check the memory side effects.
-	requireErrno(t, ErrnoSuccess, mod, ArgsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
+	requireErrnoResult(t, ErrnoSuccess, mod, ArgsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=16,result.argv_len=21)
 <== errno=ESUCCESS
@@ -185,7 +185,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrno(t, ErrnoFault, mod, ArgsSizesGetName, uint64(tc.argc), uint64(tc.argvLen))
+			requireErrnoResult(t, ErrnoFault, mod, ArgsSizesGetName, uint64(tc.argc), uint64(tc.argvLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -60,7 +60,7 @@ func Test_clockResGet(t *testing.T) {
 			resultResolution := 16 // arbitrary offset
 			maskMemory(t, mod, resultResolution+len(tc.expectedMemory))
 
-			requireErrno(t, ErrnoSuccess, mod, ClockResGetName, uint64(tc.clockID), uint64(resultResolution))
+			requireErrnoResult(t, ErrnoSuccess, mod, ClockResGetName, uint64(tc.clockID), uint64(resultResolution))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(uint32(resultResolution-1), uint32(len(tc.expectedMemory)))
@@ -115,7 +115,7 @@ func Test_clockResGet_Unsupported(t *testing.T) {
 			defer log.Reset()
 
 			resultResolution := 16 // arbitrary offset
-			requireErrno(t, tc.expectedErrno, mod, ClockResGetName, uint64(tc.clockID), uint64(resultResolution))
+			requireErrnoResult(t, tc.expectedErrno, mod, ClockResGetName, uint64(tc.clockID), uint64(resultResolution))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -167,7 +167,7 @@ func Test_clockTimeGet(t *testing.T) {
 			resultTimestamp := 16 // arbitrary offset
 			maskMemory(t, mod, resultTimestamp+len(tc.expectedMemory))
 
-			requireErrno(t, ErrnoSuccess, mod, ClockTimeGetName, uint64(tc.clockID), 0 /* TODO: precision */, uint64(resultTimestamp))
+			requireErrnoResult(t, ErrnoSuccess, mod, ClockTimeGetName, uint64(tc.clockID), 0 /* TODO: precision */, uint64(resultTimestamp))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(uint32(resultTimestamp-1), uint32(len(tc.expectedMemory)))
@@ -186,7 +186,7 @@ func Test_clockTimeGet_monotonic(t *testing.T) {
 
 	getMonotonicTime := func() uint64 {
 		const offset uint32 = 0
-		requireErrno(t, ErrnoSuccess, mod, ClockTimeGetName, uint64(ClockIDMonotonic),
+		requireErrnoResult(t, ErrnoSuccess, mod, ClockTimeGetName, uint64(ClockIDMonotonic),
 			0 /* TODO: precision */, uint64(offset))
 		timestamp, ok := mod.Memory().ReadUint64Le(offset)
 		require.True(t, ok)
@@ -249,7 +249,7 @@ func Test_clockTimeGet_Unsupported(t *testing.T) {
 			defer log.Reset()
 
 			resultTimestamp := 16 // arbitrary offset
-			requireErrno(t, tc.expectedErrno, mod, ClockTimeGetName, uint64(tc.clockID), uint64(0) /* TODO: precision */, uint64(resultTimestamp))
+			requireErrnoResult(t, tc.expectedErrno, mod, ClockTimeGetName, uint64(tc.clockID), uint64(0) /* TODO: precision */, uint64(resultTimestamp))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -290,7 +290,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrno(t, ErrnoFault, mod, ClockTimeGetName, uint64(0) /* TODO: id */, uint64(0) /* TODO: precision */, uint64(tc.resultTimestamp))
+			requireErrnoResult(t, ErrnoFault, mod, ClockTimeGetName, uint64(0) /* TODO: id */, uint64(0) /* TODO: precision */, uint64(tc.resultTimestamp))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/environ_test.go
+++ b/imports/wasi_snapshot_preview1/environ_test.go
@@ -28,7 +28,7 @@ func Test_environGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory)+int(resultEnvironBuf))
 
 	// Invoke environGet and check the memory side effects.
-	requireErrno(t, ErrnoSuccess, mod, EnvironGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
+	requireErrnoResult(t, ErrnoSuccess, mod, EnvironGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.environ_get(environ=26,environ_buf=16)
 <== errno=ESUCCESS
@@ -98,7 +98,7 @@ func Test_environGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrno(t, ErrnoFault, mod, EnvironGetName, uint64(tc.environ), uint64(tc.environBuf))
+			requireErrnoResult(t, ErrnoFault, mod, EnvironGetName, uint64(tc.environ), uint64(tc.environBuf))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -122,7 +122,7 @@ func Test_environSizesGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory)+int(resultEnvironc))
 
 	// Invoke environSizesGet and check the memory side effects.
-	requireErrno(t, ErrnoSuccess, mod, EnvironSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
+	requireErrnoResult(t, ErrnoSuccess, mod, EnvironSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=16,result.environv_len=21)
 <== errno=ESUCCESS
@@ -190,7 +190,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrno(t, ErrnoFault, mod, EnvironSizesGetName, uint64(tc.environc), uint64(tc.environLen))
+			requireErrnoResult(t, ErrnoFault, mod, EnvironSizesGetName, uint64(tc.environc), uint64(tc.environLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -39,7 +39,7 @@ func Test_pollOneoff(t *testing.T) {
 	maskMemory(t, mod, 1024)
 	mod.Memory().Write(in, mem)
 
-	requireErrno(t, ErrnoSuccess, mod, PollOneoffName, uint64(in), uint64(out), uint64(nsubscriptions),
+	requireErrnoResult(t, ErrnoSuccess, mod, PollOneoffName, uint64(in), uint64(out), uint64(nsubscriptions),
 		uint64(resultNevents))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.poll_oneoff(in=0,out=128,nsubscriptions=1)
@@ -146,7 +146,7 @@ func Test_pollOneoff_Errors(t *testing.T) {
 				mod.Memory().Write(tc.in, tc.mem)
 			}
 
-			requireErrno(t, tc.expectedErrno, mod, PollOneoffName, uint64(tc.in), uint64(tc.out),
+			requireErrnoResult(t, tc.expectedErrno, mod, PollOneoffName, uint64(tc.in), uint64(tc.out),
 				uint64(tc.nsubscriptions), uint64(tc.resultNevents))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 

--- a/imports/wasi_snapshot_preview1/random_test.go
+++ b/imports/wasi_snapshot_preview1/random_test.go
@@ -28,7 +28,7 @@ func Test_randomGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory))
 
 	// Invoke randomGet and check the memory side effects!
-	requireErrno(t, ErrnoSuccess, mod, RandomGetName, uint64(offset), uint64(length))
+	requireErrnoResult(t, ErrnoSuccess, mod, RandomGetName, uint64(offset), uint64(length))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
 <== errno=ESUCCESS
@@ -76,7 +76,7 @@ func Test_randomGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrno(t, ErrnoFault, mod, RandomGetName, uint64(tc.offset), uint64(tc.length))
+			requireErrnoResult(t, ErrnoFault, mod, RandomGetName, uint64(tc.offset), uint64(tc.length))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -113,7 +113,7 @@ func Test_randomGet_SourceError(t *testing.T) {
 				WithRandSource(tc.randSource))
 			defer r.Close(testCtx)
 
-			requireErrno(t, ErrnoIo, mod, RandomGetName, uint64(1), uint64(5)) // arbitrary offset and length
+			requireErrnoResult(t, ErrnoIo, mod, RandomGetName, uint64(1), uint64(5)) // arbitrary offset and length
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/sched_test.go
+++ b/imports/wasi_snapshot_preview1/sched_test.go
@@ -15,7 +15,7 @@ func Test_schedYield(t *testing.T) {
 			yielded = true
 		}))
 	defer r.Close(testCtx)
-	requireErrno(t, ErrnoSuccess, mod, SchedYieldName)
+	requireErrnoResult(t, ErrnoSuccess, mod, SchedYieldName)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.sched_yield()
 <== errno=ESUCCESS

--- a/imports/wasi_snapshot_preview1/wasi_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_test.go
@@ -137,11 +137,11 @@ func requireErrnoNosys(t *testing.T, funcName string, params ...uint64) string {
 	mod, err := r.InstantiateModule(ctx, proxyCompiled, wazero.NewModuleConfig())
 	require.NoError(t, err)
 
-	requireErrno(t, ErrnoNosys, mod, funcName, params...)
+	requireErrnoResult(t, ErrnoNosys, mod, funcName, params...)
 	return "\n" + log.String()
 }
 
-func requireErrno(t *testing.T, expectedErrno Errno, mod api.Closer, funcName string, params ...uint64) {
+func requireErrnoResult(t *testing.T, expectedErrno Errno, mod api.Closer, funcName string, params ...uint64) {
 	results, err := mod.(api.Module).ExportedFunction(funcName).Call(testCtx, params...)
 	require.NoError(t, err)
 	errno := Errno(results[0])

--- a/internal/fstest/fstest.go
+++ b/internal/fstest/fstest.go
@@ -100,17 +100,16 @@ func WriteTestFiles(tmpDir string) (err error) {
 			}
 
 			// os.Stat uses GetFileInformationByHandle internally.
-			stat, err := os.Stat(path)
-			if err != nil {
+			var stat platform.Stat_t
+			if err = platform.Stat(path, &stat); err != nil {
 				return err
 			}
-			if stat.ModTime() == info.ModTime() {
+			if stat.Mtim == info.ModTime().UnixNano() {
 				return nil // synced!
 			}
 
 			// Otherwise, we need to sync the timestamps.
-			atimeNsec, mtimeNsec, _ := platform.StatTimes(stat)
-			return os.Chtimes(path, time.Unix(0, atimeNsec), time.Unix(0, mtimeNsec))
+			return os.Chtimes(path, time.Unix(0, stat.Atim), time.Unix(0, stat.Mtim))
 		})
 	}
 	return

--- a/internal/gojs/errno.go
+++ b/internal/gojs/errno.go
@@ -3,7 +3,7 @@ package gojs
 import (
 	"syscall"
 
-	"github.com/tetratelabs/wazero/internal/sysfs"
+	"github.com/tetratelabs/wazero/internal/platform"
 )
 
 // Errno is a (GOARCH=wasm) error, which must match a key in mapJSError.
@@ -60,7 +60,7 @@ var (
 //
 // This should match wasi_snapshot_preview1.ToErrno for maintenance ease.
 func ToErrno(err error) *Errno {
-	errno := sysfs.UnwrapOSError(err)
+	errno := platform.UnwrapOSError(err)
 
 	switch errno {
 	case syscall.EACCES:

--- a/internal/gojs/errno_test.go
+++ b/internal/gojs/errno_test.go
@@ -3,8 +3,6 @@ package gojs
 import (
 	"syscall"
 	"testing"
-
-	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestToErrno(t *testing.T) {
@@ -103,8 +101,9 @@ func TestToErrno(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			errno := ToErrno(tc.input)
-			require.Equal(t, tc.expected, errno)
+			if errno := ToErrno(tc.input); errno != tc.expected {
+				t.Fatalf("expected %#v but was %#v", tc.expected, errno)
+			}
 		})
 	}
 }

--- a/internal/platform/errno.go
+++ b/internal/platform/errno.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package platform
+
+func adjustErrno(err error) error {
+	return err
+}

--- a/internal/platform/errno_windows.go
+++ b/internal/platform/errno_windows.go
@@ -1,0 +1,64 @@
+package platform
+
+import "syscall"
+
+// See https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+const (
+	// ERROR_ACCESS_DENIED is a Windows error returned by syscall.Unlink
+	// instead of syscall.EPERM
+	ERROR_ACCESS_DENIED = syscall.Errno(5)
+
+	// ERROR_INVALID_HANDLE is a Windows error returned by syscall.Write
+	// instead of syscall.EBADF
+	ERROR_INVALID_HANDLE = syscall.Errno(6)
+
+	// ERROR_FILE_EXISTS is a Windows error returned by os.OpenFile
+	// instead of syscall.EEXIST
+	ERROR_FILE_EXISTS = syscall.Errno(0x50)
+
+	// ERROR_NEGATIVE_SEEK is a Windows error returned by os.Truncate
+	// instead of syscall.EINVAL
+	ERROR_NEGATIVE_SEEK = syscall.Errno(0x83)
+
+	// ERROR_DIR_NOT_EMPTY is a Windows error returned by syscall.Rmdir
+	// instead of syscall.ENOTEMPTY
+	ERROR_DIR_NOT_EMPTY = syscall.Errno(0x91)
+
+	// ERROR_ALREADY_EXISTS is a Windows error returned by os.Mkdir
+	// instead of syscall.EEXIST
+	ERROR_ALREADY_EXISTS = syscall.Errno(0xB7)
+
+	// ERROR_DIRECTORY is a Windows error returned by syscall.Rmdir
+	// instead of syscall.ENOTDIR
+	ERROR_DIRECTORY = syscall.Errno(0x10B)
+)
+
+// See https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
+const (
+	// ERROR_PRIVILEGE_NOT_HELD is a Windows error returned by os.Symlink
+	// instead of syscall.EPERM.
+	//
+	// Note: This can happen when trying to create symlinks w/o admin perms.
+	ERROR_PRIVILEGE_NOT_HELD = syscall.Errno(0x522)
+)
+
+func adjustErrno(err syscall.Errno) error {
+	// Note: In windows, ERROR_PATH_NOT_FOUND(0x3) maps to syscall.ENOTDIR
+	switch err {
+	case ERROR_ALREADY_EXISTS:
+		return syscall.EEXIST
+	case ERROR_DIRECTORY:
+		return syscall.ENOTDIR
+	case ERROR_DIR_NOT_EMPTY:
+		return syscall.ENOTEMPTY
+	case ERROR_FILE_EXISTS:
+		return syscall.EEXIST
+	case ERROR_INVALID_HANDLE:
+		return syscall.EBADF
+	case ERROR_ACCESS_DENIED, ERROR_PRIVILEGE_NOT_HELD:
+		return syscall.EPERM
+	case ERROR_NEGATIVE_SEEK:
+		return syscall.EINVAL
+	}
+	return err
+}

--- a/internal/platform/error.go
+++ b/internal/platform/error.go
@@ -1,0 +1,50 @@
+package platform
+
+import (
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// UnwrapOSError returns a syscall.Errno or nil if the input is nil.
+func UnwrapOSError(err error) error {
+	if err == nil {
+		return nil
+	}
+	err = underlyingError(err)
+	if se, ok := err.(syscall.Errno); ok {
+		return adjustErrno(se)
+	}
+	// Below are all the fs.ErrXXX in fs.go.
+	//
+	// Note: Once we have our own file type, we should never see these.
+	switch err {
+	case nil:
+	case fs.ErrInvalid:
+		return syscall.EINVAL
+	case fs.ErrPermission:
+		return syscall.EPERM
+	case fs.ErrExist:
+		return syscall.EEXIST
+	case fs.ErrNotExist:
+		return syscall.ENOENT
+	case fs.ErrClosed:
+		return syscall.EBADF
+	}
+	return syscall.EIO
+}
+
+// underlyingError returns the underlying error if a well-known OS error type.
+//
+// This impl is basically the same as os.underlyingError in os/error.go
+func underlyingError(err error) error {
+	switch err := err.(type) {
+	case *os.PathError:
+		return err.Err
+	case *os.LinkError:
+		return err.Err
+	case *os.SyscallError:
+		return err.Err
+	}
+	return err
+}

--- a/internal/platform/error_test.go
+++ b/internal/platform/error_test.go
@@ -1,0 +1,83 @@
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestUnwrapOSError(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    error
+		expected syscall.Errno
+	}{
+		{
+			name:     "LinkError ErrInvalid",
+			input:    &os.LinkError{Err: fs.ErrInvalid},
+			expected: syscall.EINVAL,
+		},
+		{
+			name:     "PathError ErrInvalid",
+			input:    &os.PathError{Err: fs.ErrInvalid},
+			expected: syscall.EINVAL,
+		},
+		{
+			name:     "SyscallError ErrInvalid",
+			input:    &os.SyscallError{Err: fs.ErrInvalid},
+			expected: syscall.EINVAL,
+		},
+		{
+			name:     "PathError ErrPermission",
+			input:    &os.PathError{Err: os.ErrPermission},
+			expected: syscall.EPERM,
+		},
+		{
+			name:     "PathError ErrExist",
+			input:    &os.PathError{Err: os.ErrExist},
+			expected: syscall.EEXIST,
+		},
+		{
+			name:     "PathError syscall.ErrnotExist",
+			input:    &os.PathError{Err: os.ErrNotExist},
+			expected: syscall.ENOENT,
+		},
+		{
+			name:     "PathError ErrClosed",
+			input:    &os.PathError{Err: os.ErrClosed},
+			expected: syscall.EBADF,
+		},
+		{
+			name:     "PathError unknown == syscall.EIO",
+			input:    &os.PathError{Err: errors.New("ice cream")},
+			expected: syscall.EIO,
+		},
+		{
+			name:     "unknown == syscall.EIO",
+			input:    errors.New("ice cream"),
+			expected: syscall.EIO,
+		},
+		{
+			name:     "very wrapped unknown == syscall.EIO",
+			input:    fmt.Errorf("%w", fmt.Errorf("%w", fmt.Errorf("%w", errors.New("ice cream")))),
+			expected: syscall.EIO,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			errno := UnwrapOSError(tc.input)
+			require.EqualErrno(t, tc.expected, errno)
+		})
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		require.Nil(t, UnwrapOSError(nil))
+	})
+}

--- a/internal/platform/open_file.go
+++ b/internal/platform/open_file.go
@@ -15,6 +15,9 @@ const (
 	O_NOFOLLOW  = syscall.O_NOFOLLOW
 )
 
-func OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
-	return os.OpenFile(name, flag, perm)
+// OpenFile is like os.OpenFile except it returns syscall.Errno
+func OpenFile(name string, flag int, perm fs.FileMode) (f *os.File, err error) {
+	f, err = os.OpenFile(name, flag, perm)
+	err = UnwrapOSError(err)
+	return
 }

--- a/internal/platform/open_file_js.go
+++ b/internal/platform/open_file_js.go
@@ -13,7 +13,9 @@ const (
 	O_NOFOLLOW  = 1 << 30
 )
 
-func OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
+func OpenFile(name string, flag int, perm fs.FileMode) (f *os.File, err error) {
 	flag &= ^(O_DIRECTORY | O_NOFOLLOW) // erase placeholders
-	return os.OpenFile(name, flag, perm)
+	f, err = os.OpenFile(name, flag, perm)
+	err = UnwrapOSError(err)
+	return
 }

--- a/internal/platform/open_file_test.go
+++ b/internal/platform/open_file_test.go
@@ -15,7 +15,7 @@ func TestOpenFile_Errors(t *testing.T) {
 
 	t.Run("not found must be ENOENT", func(t *testing.T) {
 		_, err := OpenFile(path.Join(tmp, "not-really-exist.txt"), os.O_RDONLY, 0o600)
-		require.ErrorIs(t, err, syscall.ENOENT)
+		require.EqualErrno(t, syscall.ENOENT, err)
 	})
 
 	// This is the same as https://github.com/ziglang/zig/blob/d24ebf1d12cf66665b52136a2807f97ff021d78d/lib/std/os/test.zig#L105-L112
@@ -26,7 +26,7 @@ func TestOpenFile_Errors(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
-		require.ErrorIs(t, err, syscall.EEXIST)
+		require.EqualErrno(t, syscall.EEXIST, err)
 	})
 
 	// This is similar to https://github.com/WebAssembly/wasi-testsuite/blob/dc7f8d27be1030cd4788ebdf07d9b57e5d23441e/tests/rust/src/bin/dangling_symlink.rs
@@ -38,9 +38,9 @@ func TestOpenFile_Errors(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = OpenFile(symlink, O_DIRECTORY|O_NOFOLLOW, 0o0666)
-		require.ErrorIs(t, err, syscall.ENOTDIR)
+		require.EqualErrno(t, syscall.ENOTDIR, err)
 
 		_, err = OpenFile(symlink, O_NOFOLLOW, 0o0666)
-		require.ErrorIs(t, err, syscall.ELOOP)
+		require.EqualErrno(t, syscall.ELOOP, err)
 	})
 }

--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"syscall"
@@ -32,39 +31,42 @@ func OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
 	isDir := flag&O_DIRECTORY > 0
 	flag &= ^(O_DIRECTORY | O_NOFOLLOW) // erase placeholders
 
+	// TODO: document why we are opening twice
 	fd, err := open(name, flag|syscall.O_CLOEXEC, uint32(perm))
 	if err == nil {
 		return os.NewFile(uintptr(fd), name), nil
 	}
+
 	// TODO: Set FILE_SHARE_DELETE for directory as well.
 	f, err := os.OpenFile(name, flag, perm)
-	if err != nil {
-		if errors.Is(err, syscall.ENOTDIR) {
-			err = syscall.ENOENT
-		} else if errors.Is(err, syscall.ERROR_FILE_EXISTS) {
-			err = syscall.EEXIST
-		} else if notFound := errors.Is(err, syscall.ERROR_FILE_NOT_FOUND); notFound && isDir {
-			// Either symlink or hard link directory not found. We change the returned errno depending on
-			// if it is symlink or not to have consistent behavior across OSes.
-			st, e := os.Lstat(name)
-			if e == nil && st.Mode()&os.ModeSymlink != 0 {
-				// Dangling symlink dir must raise ENOTIDR.
+	if err = UnwrapOSError(err); err == nil {
+		return f, nil
+	}
+
+	switch err {
+	case syscall.ENOTDIR:
+		err = syscall.ENOENT
+	case syscall.ENOENT:
+		if isSymlink(name) {
+			// Either symlink or hard link not found. We change the returned
+			// errno depending on if it is symlink or not to have consistent
+			// behavior across OSes.
+			if isDir {
+				// Dangling symlink dir must raise ENOTDIR.
 				err = syscall.ENOTDIR
 			} else {
-				err = syscall.ENOENT
-			}
-		} else if notFound {
-			// Either symlink or hard link file not found. We change the returned errno depending on
-			// if it is symlink or not to have consistent behavior across OSes.
-			st, e := os.Lstat(name)
-			if e == nil && st.Mode()&os.ModeSymlink != 0 {
 				err = syscall.ELOOP
-			} else {
-				err = syscall.ENOENT
 			}
 		}
 	}
 	return f, err
+}
+
+func isSymlink(path string) bool {
+	if st, e := os.Lstat(path); e == nil && st.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	return false
 }
 
 // The following is lifted from syscall_windows.go to add support for setting FILE_SHARE_DELETE.

--- a/internal/platform/rename_test.go
+++ b/internal/platform/rename_test.go
@@ -19,7 +19,7 @@ func TestRename(t *testing.T) {
 		require.NoError(t, err)
 
 		err = Rename(path.Join(tmpDir, "non-exist"), file1Path)
-		require.Equal(t, syscall.ENOENT, err)
+		require.EqualErrno(t, syscall.ENOENT, err)
 	})
 	t.Run("file to non-exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -35,7 +35,7 @@ func TestRename(t *testing.T) {
 
 		// Show the prior path no longer exists
 		_, err = os.Stat(file1Path)
-		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
+		require.EqualErrno(t, syscall.ENOENT, errors.Unwrap(err))
 
 		s, err := os.Stat(file2Path)
 		require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestRename(t *testing.T) {
 
 		// Show the prior path no longer exists
 		_, err = os.Stat(dir1Path)
-		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
+		require.EqualErrno(t, syscall.ENOENT, errors.Unwrap(err))
 
 		s, err := os.Stat(dir2Path)
 		require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestRename(t *testing.T) {
 		require.NoError(t, err)
 
 		err = Rename(dir1Path, dir2Path)
-		require.Equal(t, syscall.ENOTDIR, err)
+		require.EqualErrno(t, syscall.ENOTDIR, err)
 	})
 	t.Run("file to dir", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -86,7 +86,7 @@ func TestRename(t *testing.T) {
 		require.NoError(t, os.Mkdir(dir1Path, 0o700))
 
 		err = Rename(file1Path, dir1Path)
-		require.Equal(t, syscall.EISDIR, err)
+		require.EqualErrno(t, syscall.EISDIR, err)
 	})
 
 	// Similar to https://github.com/ziglang/zig/blob/0.10.1/lib/std/fs/test.zig#L567-L582
@@ -112,7 +112,7 @@ func TestRename(t *testing.T) {
 
 		// Show the prior path no longer exists
 		_, err = os.Stat(dir1Path)
-		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
+		require.EqualErrno(t, syscall.ENOENT, errors.Unwrap(err))
 
 		// Show the file inside that directory moved
 		s, err := os.Stat(path.Join(dir2Path, file1))
@@ -142,7 +142,7 @@ func TestRename(t *testing.T) {
 		require.NoError(t, err)
 
 		err = Rename(dir1Path, dir2Path)
-		require.ErrorIs(t, syscall.ENOTEMPTY, err)
+		require.EqualErrno(t, syscall.ENOTEMPTY, err)
 	})
 
 	t.Run("file to file", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestRename(t *testing.T) {
 
 		// Show the prior path no longer exists
 		_, err = os.Stat(file1Path)
-		require.Equal(t, syscall.ENOENT, errors.Unwrap(err))
+		require.EqualErrno(t, syscall.ENOENT, errors.Unwrap(err))
 
 		// Show the file1 overwrote file2
 		b, err := os.ReadFile(file2Path)

--- a/internal/platform/stat.go
+++ b/internal/platform/stat.go
@@ -2,32 +2,91 @@ package platform
 
 import (
 	"io/fs"
-	"os"
+	"syscall"
 )
 
-// StatTimes returns platform-specific values if os.FileInfo Sys is available.
-// Otherwise, it returns the mod time for all values.
-func StatTimes(t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64) {
-	if t.Sys() == nil { // possibly fake filesystem
-		atimeNsec, mtimeNsec, ctimeNsec = mtimes(t)
-		return
-	}
-	return statTimes(t)
+// Stat_t is similar to syscall.Stat_t, and fields frequently used by
+// WebAssembly ABI including WASI snapshot-01, GOOS=js and wasi-filesystem.
+//
+// # Note
+//
+// Zero values may be returned where not available. For example, fs.FileInfo
+// implementations may not be able to provide Ino values.
+type Stat_t struct {
+	// Dev is the device ID of device containing the file.
+	Dev uint64
+
+	// Ino is the file serial number.
+	Ino uint64
+
+	// Mode is the same as Mode on fs.FileInfo containing bits to identify the
+	// type of the file and its permissions (fs.ModePerm).
+	Mode fs.FileMode
+
+	/// Nlink is the number of hard links to the file.
+	Nlink uint64
+	// ^^ uint64 not uint16 to accept widest syscall.Stat_t.Nlink
+
+	// Size is the length in bytes for regular files. For symbolic links, this
+	// is length in bytes of the pathname contained in the symbolic link.
+	Size int64
+	// ^^ int64 not uint64 to defer to fs.FileInfo
+
+	// Atim is the last data access timestamp in epoch nanoseconds.
+	Atim int64
+
+	// Mtim is the last data modification timestamp in epoch nanoseconds.
+	Mtim int64
+
+	// Ctim is the last file status change timestamp in epoch nanoseconds.
+	Ctim int64
 }
 
-// Stat returns platform-specific values if os.FileInfo Sys is available.
-func Stat(f fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlink, dev, inode uint64, err error) {
-	if t.Sys() == nil { // possibly fake filesystem
-		atimeNsec, mtimeNsec, ctimeNsec = mtimes(t)
-		nlink = 1
+// Stat is like syscall.Stat. This returns syscall.ENOENT if the path doesn't
+// exist.
+func Stat(path string, stat *Stat_t) (err error) {
+	// TODO: The current windows needs the file to be an open handle. See if
+	// we can avoid this and call os.Stat instead.
+	f, err := OpenFile(path, syscall.O_RDONLY, 0)
+	if err != nil {
 		return
 	}
-	return stat(f, t)
+	defer f.Close()
+	return StatFile(f, stat)
 }
 
-func mtimes(t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64) {
-	mtimeNsec = t.ModTime().UnixNano()
-	atimeNsec = mtimeNsec
-	ctimeNsec = mtimeNsec
+// StatFile is like syscall.Fstat, but for fs.File instead of a file
+// descriptor. This returns syscall.EIO if the file or directory was closed.
+// Note: windows allows you to stat a closed directory.
+func StatFile(f fs.File, stat *Stat_t) (err error) {
+	t, err := f.Stat()
+	if err = UnwrapOSError(err); err != nil {
+		return
+	}
+	return fillStat(stat, f, t)
+}
+
+// fder is implemented by os.File in file_unix.go and file_windows.go
+// Note: we use this until we finalize our own FD-scoped file.
+type fder interface{ Fd() (fd uintptr) }
+
+func fillStat(stat *Stat_t, f fs.File, t fs.FileInfo) (err error) {
+	if of, ok := f.(fder); !ok { // possibly fake filesystem
+		fillStatFromFileInfo(stat, t)
+	} else {
+		err = fillStatFromOpenFile(stat, of.Fd(), t)
+	}
 	return
+}
+
+func fillStatFromFileInfo(stat *Stat_t, t fs.FileInfo) {
+	stat.Ino = 0
+	stat.Dev = 0
+	stat.Mode = t.Mode()
+	stat.Nlink = 1
+	stat.Size = t.Size()
+	mtim := t.ModTime().UnixNano() // Set all times to the mod time
+	stat.Atim = mtim
+	stat.Mtim = mtim
+	stat.Ctim = mtim
 }

--- a/internal/platform/stat_bsd.go
+++ b/internal/platform/stat_bsd.go
@@ -3,24 +3,22 @@
 package platform
 
 import (
-	"io/fs"
 	"os"
 	"syscall"
 )
 
-func statTimes(t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64) {
+func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	d := t.Sys().(*syscall.Stat_t)
+	stat.Ino = d.Ino
+	stat.Dev = uint64(d.Dev)
+	stat.Mode = t.Mode()
+	stat.Nlink = uint64(d.Nlink)
+	stat.Size = d.Size
 	atime := d.Atimespec
+	stat.Atim = atime.Sec*1e9 + atime.Nsec
 	mtime := d.Mtimespec
+	stat.Mtim = mtime.Sec*1e9 + mtime.Nsec
 	ctime := d.Ctimespec
-	return atime.Sec*1e9 + atime.Nsec, mtime.Sec*1e9 + mtime.Nsec, ctime.Sec*1e9 + ctime.Nsec
-}
-
-func stat(_ fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlink, dev, inode uint64, err error) {
-	d := t.Sys().(*syscall.Stat_t)
-	atime := d.Atimespec
-	mtime := d.Mtimespec
-	ctime := d.Ctimespec
-	return atime.Sec*1e9 + atime.Nsec, mtime.Sec*1e9 + mtime.Nsec, ctime.Sec*1e9 + ctime.Nsec,
-		uint64(d.Nlink), uint64(d.Dev), uint64(d.Ino), nil
+	stat.Ctim = ctime.Sec*1e9 + ctime.Nsec
+	return
 }

--- a/internal/platform/stat_linux.go
+++ b/internal/platform/stat_linux.go
@@ -6,23 +6,22 @@
 package platform
 
 import (
-	"io/fs"
 	"os"
 	"syscall"
 )
 
-func statTimes(t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64) {
+func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	d := t.Sys().(*syscall.Stat_t)
+	stat.Ino = uint64(d.Ino)
+	stat.Dev = uint64(d.Dev)
+	stat.Mode = t.Mode()
+	stat.Nlink = uint64(d.Nlink)
+	stat.Size = d.Size
 	atime := d.Atim
+	stat.Atim = atime.Sec*1e9 + atime.Nsec
 	mtime := d.Mtim
+	stat.Mtim = mtime.Sec*1e9 + mtime.Nsec
 	ctime := d.Ctim
-	return atime.Sec*1e9 + atime.Nsec, mtime.Sec*1e9 + mtime.Nsec, ctime.Sec*1e9 + ctime.Nsec
-}
-
-func stat(_ fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlink, dev, inode uint64, err error) {
-	d := t.Sys().(*syscall.Stat_t)
-	atime := d.Atim
-	mtime := d.Mtim
-	ctime := d.Ctim
-	return atime.Sec*1e9 + atime.Nsec, mtime.Sec*1e9 + mtime.Nsec, ctime.Sec*1e9 + ctime.Nsec, uint64(d.Nlink), uint64(d.Dev), uint64(d.Ino), nil
+	stat.Ctim = ctime.Sec*1e9 + ctime.Nsec
+	return
 }

--- a/internal/platform/stat_test.go
+++ b/internal/platform/stat_test.go
@@ -4,13 +4,109 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func Test_Stat(t *testing.T) {
+func TestStat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var stat Stat_t
+	require.EqualErrno(t, syscall.ENOENT, Stat(path.Join(tmpDir, "cat"), &stat))
+	require.EqualErrno(t, syscall.ENOENT, Stat(path.Join(tmpDir, "sub/cat"), &stat))
+
+	t.Run("dir", func(t *testing.T) {
+		err := Stat(tmpDir, &stat)
+		require.NoError(t, err)
+		require.True(t, stat.Mode.IsDir())
+	})
+
+	t.Run("file", func(t *testing.T) {
+		file := path.Join(tmpDir, "file")
+		require.NoError(t, os.WriteFile(file, nil, 0o400))
+
+		require.NoError(t, Stat(file, &stat))
+		require.False(t, stat.Mode.IsDir())
+	})
+
+	t.Run("subdir", func(t *testing.T) {
+		subdir := path.Join(tmpDir, "sub")
+		require.NoError(t, os.Mkdir(subdir, 0o500))
+
+		require.NoError(t, Stat(subdir, &stat))
+		require.True(t, stat.Mode.IsDir())
+	})
+}
+
+func TestStatFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var stat Stat_t
+
+	tmpDirF, err := OpenFile(tmpDir, syscall.O_RDONLY, 0)
+	if err != nil {
+		return
+	}
+	defer tmpDirF.Close()
+
+	t.Run("dir", func(t *testing.T) {
+		err = StatFile(tmpDirF, &stat)
+		require.NoError(t, err)
+		require.True(t, stat.Mode.IsDir())
+	})
+
+	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
+		t.Run("closed dir", func(t *testing.T) {
+			require.NoError(t, tmpDirF.Close())
+			require.EqualErrno(t, syscall.EIO, StatFile(tmpDirF, &stat))
+		})
+	}
+
+	file := path.Join(tmpDir, "file")
+	require.NoError(t, os.WriteFile(file, nil, 0o400))
+	fileF, err := OpenFile(file, syscall.O_RDONLY, 0)
+	if err != nil {
+		return
+	}
+	defer fileF.Close()
+
+	t.Run("file", func(t *testing.T) {
+		err = StatFile(fileF, &stat)
+		require.NoError(t, err)
+		require.False(t, stat.Mode.IsDir())
+	})
+
+	t.Run("closed file", func(t *testing.T) {
+		require.NoError(t, fileF.Close())
+		require.EqualErrno(t, syscall.EIO, StatFile(fileF, &stat))
+	})
+
+	subdir := path.Join(tmpDir, "sub")
+	require.NoError(t, os.Mkdir(subdir, 0o500))
+	subdirF, err := OpenFile(subdir, syscall.O_RDONLY, 0)
+	if err != nil {
+		return
+	}
+	defer subdirF.Close()
+
+	t.Run("subdir", func(t *testing.T) {
+		err = StatFile(subdirF, &stat)
+		require.NoError(t, err)
+		require.True(t, stat.Mode.IsDir())
+	})
+
+	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
+		t.Run("closed subdir", func(t *testing.T) {
+			require.NoError(t, subdirF.Close())
+			require.EqualErrno(t, syscall.EIO, StatFile(subdirF, &stat))
+		})
+	}
+}
+
+func Test_StatFile_times(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	file := path.Join(tmpDir, "file")
@@ -49,63 +145,58 @@ func Test_Stat(t *testing.T) {
 			err := os.Chtimes(file, time.UnixMicro(tc.atimeNsec/1e3), time.UnixMicro(tc.mtimeNsec/1e3))
 			require.NoError(t, err)
 
-			stat, err := os.Stat(file)
+			file, err := os.Open(file)
 			require.NoError(t, err)
+			defer file.Close()
 
-			atimeNsec, mtimeNsec, _ := StatTimes(stat)
-			require.Equal(t, atimeNsec, tc.atimeNsec)
-			require.Equal(t, mtimeNsec, tc.mtimeNsec)
+			var stat Stat_t
+			require.NoError(t, StatFile(file, &stat))
+			require.Equal(t, stat.Atim, tc.atimeNsec)
+			require.Equal(t, stat.Mtim, tc.mtimeNsec)
 		})
 	}
 }
 
-func TestStat_dev_inode(t *testing.T) {
+func TestStatFile_dev_inode(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	path1 := path.Join(tmpDir, "1")
-	fa, err := os.Create(path1)
+	f1, err := os.Create(path1)
 	require.NoError(t, err)
 
 	path2 := path.Join(tmpDir, "2")
-	fb, err := os.Create(path2)
+	f2, err := os.Create(path2)
 	require.NoError(t, err)
 
-	stat1, err := fa.Stat()
-	require.NoError(t, err)
-	_, _, _, _, device1, inode1, err := Stat(fa, stat1)
-	require.NoError(t, err)
+	var stat1 Stat_t
+	require.NoError(t, StatFile(f1, &stat1))
 
-	stat2, err := fb.Stat()
-	require.NoError(t, err)
-	_, _, _, _, device2, inode2, err := Stat(fb, stat2)
-	require.NoError(t, err)
+	var stat2 Stat_t
+	require.NoError(t, StatFile(f2, &stat2))
 
 	// The files should be on the same device, but different inodes
-	require.Equal(t, device1, device2)
-	require.NotEqual(t, inode1, inode2)
+	require.Equal(t, stat1.Dev, stat2.Dev)
+	require.NotEqual(t, stat1.Ino, stat2.Ino)
 
 	// Redoing stat should result in the same inodes
-	stat1Again, err := os.Stat(path1)
-	require.NoError(t, err)
-	_, _, _, _, device1Again, inode1Again, err := Stat(fa, stat1Again)
-	require.NoError(t, err)
-	require.Equal(t, device1, device1Again)
-	require.Equal(t, inode1, inode1Again)
+	var stat1Again Stat_t
+	require.NoError(t, StatFile(f1, &stat1Again))
+
+	require.Equal(t, stat1.Dev, stat1Again.Dev)
+	require.Equal(t, stat1.Ino, stat1Again.Ino)
 
 	// On Windows, we cannot rename while opening.
 	// So we manually close here before renaming.
-	require.NoError(t, fa.Close())
-	require.NoError(t, fb.Close())
+	require.NoError(t, f1.Close())
+	require.NoError(t, f2.Close())
 
 	// Renaming a file shouldn't change its inodes.
 	require.NoError(t, Rename(path1, path2))
-	fa, err = os.Open(path2)
+	f1, err = os.Open(path2)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, fa.Close()) }()
-	stat1Again, err = os.Stat(path2)
-	require.NoError(t, err)
-	_, _, _, _, device1Again, inode1Again, err = Stat(fa, stat1Again)
-	require.NoError(t, err)
-	require.Equal(t, device1, device1Again)
-	require.Equal(t, inode1, inode1Again)
+	defer f1.Close()
+
+	require.NoError(t, StatFile(f1, &stat1Again))
+	require.Equal(t, stat1.Dev, stat1Again.Dev)
+	require.Equal(t, stat1.Ino, stat1Again.Ino)
 }

--- a/internal/platform/stat_test.go
+++ b/internal/platform/stat_test.go
@@ -61,7 +61,7 @@ func TestStatFile(t *testing.T) {
 	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
 		t.Run("closed dir", func(t *testing.T) {
 			require.NoError(t, tmpDirF.Close())
-			require.EqualErrno(t, syscall.EIO, StatFile(tmpDirF, &stat))
+			require.EqualErrno(t, syscall.EBADF, StatFile(tmpDirF, &stat))
 		})
 	}
 
@@ -81,7 +81,7 @@ func TestStatFile(t *testing.T) {
 
 	t.Run("closed file", func(t *testing.T) {
 		require.NoError(t, fileF.Close())
-		require.EqualErrno(t, syscall.EIO, StatFile(fileF, &stat))
+		require.EqualErrno(t, syscall.EBADF, StatFile(fileF, &stat))
 	})
 
 	subdir := path.Join(tmpDir, "sub")
@@ -101,7 +101,7 @@ func TestStatFile(t *testing.T) {
 	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
 		t.Run("closed subdir", func(t *testing.T) {
 			require.NoError(t, subdirF.Close())
-			require.EqualErrno(t, syscall.EIO, StatFile(subdirF, &stat))
+			require.EqualErrno(t, syscall.EBADF, StatFile(subdirF, &stat))
 		})
 	}
 }

--- a/internal/platform/stat_unsupported.go
+++ b/internal/platform/stat_unsupported.go
@@ -2,17 +2,9 @@
 
 package platform
 
-import (
-	"io/fs"
-	"os"
-)
+import "os"
 
-func statTimes(t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64) {
-	atimeNsec, mtimeNsec, ctimeNsec = mtimes(t)
-	return
-}
-
-func stat(_ fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlink, dev, inode uint64, err error) {
-	atimeNsec, mtimeNsec, ctimeNsec = mtimes(t)
+func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
+	fillStatFromFileInfo(stat, t)
 	return
 }

--- a/internal/platform/stat_windows.go
+++ b/internal/platform/stat_windows.go
@@ -3,37 +3,13 @@
 package platform
 
 import (
-	"io/fs"
 	"os"
 	"syscall"
 )
 
-// The following interfaces are used until we finalize our own FD-scoped file.
-type (
-	// fder is implemented by os.File in file_unix.go and file_windows.go
-	fder interface{ Fd() (fd uintptr) }
-)
-
-func statTimes(t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64) {
+func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	d := t.Sys().(*syscall.Win32FileAttributeData)
-	atimeNsec = d.LastAccessTime.Nanoseconds()
-	mtimeNsec = d.LastWriteTime.Nanoseconds()
-	ctimeNsec = d.CreationTime.Nanoseconds()
-	return
-}
-
-func stat(f fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlink, dev, inode uint64, err error) {
-	d := t.Sys().(*syscall.Win32FileAttributeData)
-	atimeNsec = d.LastAccessTime.Nanoseconds()
-	mtimeNsec = d.LastWriteTime.Nanoseconds()
-	ctimeNsec = d.CreationTime.Nanoseconds()
-
-	of, ok := f.(fder)
-	if !ok {
-		return
-	}
-
-	handle := syscall.Handle(of.Fd())
+	handle := syscall.Handle(fd)
 	var info syscall.ByHandleFileInformation
 	if err = syscall.GetFileInformationByHandle(handle, &info); err != nil {
 		// If the file descriptor is already closed, we have to re-open just like
@@ -47,9 +23,16 @@ func stat(f fs.File, t os.FileInfo) (atimeNsec, mtimeNsec, ctimeNsec int64, nlin
 			err = nil
 		}
 	}
-	nlink, dev = uint64(info.NumberOfLinks), uint64(info.VolumeSerialNumber)
+
 	// FileIndex{High,Low} can be combined and used as a unique identifier like inode.
 	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
-	inode = (uint64(info.FileIndexHigh) << 32) | uint64(info.FileIndexLow)
+	stat.Ino = (uint64(info.FileIndexHigh) << 32) | uint64(info.FileIndexLow)
+	stat.Dev = uint64(info.VolumeSerialNumber)
+	stat.Mode = t.Mode()
+	stat.Nlink = uint64(info.NumberOfLinks)
+	stat.Size = t.Size()
+	stat.Atim = d.LastAccessTime.Nanoseconds()
+	stat.Mtim = d.LastWriteTime.Nanoseconds()
+	stat.Ctim = d.CreationTime.Nanoseconds()
 	return
 }

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -181,17 +181,18 @@ func (f *FileEntry) IsDir() bool {
 	if f.isDirectory {
 		return true
 	}
-	_, _ = f.Stat() // Maybe the file hasn't had stat yet.
+	var stat platform.Stat_t
+	_ = f.Stat(&stat) // Maybe the file hasn't had stat yet.
 	return f.isDirectory
 }
 
 // Stat returns the underlying stat of this file.
-func (f *FileEntry) Stat() (stat fs.FileInfo, err error) {
-	stat, err = sysfs.StatFile(f.File)
-	if err == nil && stat.IsDir() {
+func (f *FileEntry) Stat(stat *platform.Stat_t) (err error) {
+	err = platform.StatFile(f.File, stat)
+	if err == nil && stat.Mode.IsDir() {
 		f.isDirectory = true
 	}
-	return stat, err
+	return
 }
 
 // ReadDir is the status of a prior fs.ReadDirFile call.

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -21,14 +21,14 @@ func TestAdapt_MkDir(t *testing.T) {
 	testFS := Adapt(os.DirFS(t.TempDir()))
 
 	err := testFS.Mkdir("mkdir", fs.ModeDir)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestAdapt_Chmod(t *testing.T) {
 	testFS := Adapt(os.DirFS(t.TempDir()))
 
 	err := testFS.Chmod("chmod", fs.ModeDir)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestAdapt_Rename(t *testing.T) {
@@ -48,7 +48,7 @@ func TestAdapt_Rename(t *testing.T) {
 	require.NoError(t, err)
 
 	err = testFS.Rename(file1, file2)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestAdapt_Rmdir(t *testing.T) {
@@ -60,7 +60,7 @@ func TestAdapt_Rmdir(t *testing.T) {
 	require.NoError(t, os.Mkdir(realPath, 0o700))
 
 	err := testFS.Rmdir(path)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestAdapt_Unlink(t *testing.T) {
@@ -72,7 +72,7 @@ func TestAdapt_Unlink(t *testing.T) {
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Unlink(path)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestAdapt_Utimes(t *testing.T) {
@@ -84,7 +84,7 @@ func TestAdapt_Utimes(t *testing.T) {
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Utimes(path, 1, 1)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestAdapt_Open_Read(t *testing.T) {
@@ -100,8 +100,16 @@ func TestAdapt_Open_Read(t *testing.T) {
 		_, err := testFS.OpenFile("../foo", os.O_RDONLY, 0)
 
 		// fs.FS doesn't allow relative path lookups
-		require.Equal(t, syscall.EINVAL, err)
+		require.EqualErrno(t, syscall.EINVAL, err)
 	})
+}
+
+func TestAdapt_Stat(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, fstest.WriteTestFiles(tmpDir))
+
+	testFS := Adapt(os.DirFS(tmpDir))
+	testStat(t, testFS)
 }
 
 // hackFS cheats the fs.FS contract by opening for write (os.O_RDWR).

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"os"
 	"syscall"
+
+	"github.com/tetratelabs/wazero/internal/platform"
 )
 
 // NewReadFS is used to mask an existing FS for reads. Notably, this allows
@@ -124,4 +126,9 @@ func maskForReads(f fs.File) fs.File {
 	default:
 		panic("BUG: unhandled pattern")
 	}
+}
+
+// Stat implements FS.Stat
+func (r *readFS) Stat(path string, stat *platform.Stat_t) error {
+	return r.fs.Stat(path, stat)
 }

--- a/internal/sysfs/readfs_test.go
+++ b/internal/sysfs/readfs_test.go
@@ -38,7 +38,7 @@ func TestReadFS_MkDir(t *testing.T) {
 	testFS := NewReadFS(writeable)
 
 	err := testFS.Mkdir("mkdir", fs.ModeDir)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Chmod(t *testing.T) {
@@ -46,7 +46,7 @@ func TestReadFS_Chmod(t *testing.T) {
 	testFS := NewReadFS(writeable)
 
 	err := testFS.Chmod("chmod", fs.ModeDir)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Rename(t *testing.T) {
@@ -67,7 +67,7 @@ func TestReadFS_Rename(t *testing.T) {
 	require.NoError(t, err)
 
 	err = testFS.Rename(file1, file2)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Rmdir(t *testing.T) {
@@ -80,7 +80,7 @@ func TestReadFS_Rmdir(t *testing.T) {
 	require.NoError(t, os.Mkdir(realPath, 0o700))
 
 	err := testFS.Rmdir(path)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Unlink(t *testing.T) {
@@ -93,7 +93,7 @@ func TestReadFS_Unlink(t *testing.T) {
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Unlink(path)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Utimes(t *testing.T) {
@@ -106,7 +106,7 @@ func TestReadFS_Utimes(t *testing.T) {
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
 	err := testFS.Utimes(path, 1, 1)
-	require.Equal(t, syscall.ENOSYS, err)
+	require.EqualErrno(t, syscall.ENOSYS, err)
 }
 
 func TestReadFS_Open_Read(t *testing.T) {
@@ -115,6 +115,15 @@ func TestReadFS_Open_Read(t *testing.T) {
 	testFS := NewReadFS(writeable)
 
 	testOpen_Read(t, tmpDir, testFS)
+}
+
+func TestReadFS_Stat(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, fstest.WriteTestFiles(tmpDir))
+
+	writeable := NewDirFS(tmpDir)
+	testFS := NewReadFS(writeable)
+	testStat(t, testFS)
 }
 
 func TestReadFS_TestFS(t *testing.T) {

--- a/internal/sysfs/syscall.go
+++ b/internal/sysfs/syscall.go
@@ -6,18 +6,6 @@ import (
 	"io/fs"
 )
 
-func adjustErrno(err error) error {
-	return err
-}
-
-func adjustRmdirError(err error) error {
-	return err
-}
-
-func adjustTruncateError(err error) error {
-	return err
-}
-
 func maybeWrapFile(f file, _ FS, _ string, _ int, _ fs.FileMode) file {
 	return f
 }

--- a/internal/sysfs/unsupported.go
+++ b/internal/sysfs/unsupported.go
@@ -3,6 +3,8 @@ package sysfs
 import (
 	"io/fs"
 	"syscall"
+
+	"github.com/tetratelabs/wazero/internal/platform"
 )
 
 // UnimplementedFS is an FS that returns syscall.ENOSYS for all functions,
@@ -22,6 +24,11 @@ func (UnimplementedFS) Open(name string) (fs.File, error) {
 // OpenFile implements FS.OpenFile
 func (UnimplementedFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
 	return nil, syscall.ENOSYS
+}
+
+// Stat implements FS.Stat
+func (UnimplementedFS) Stat(path string, stat *platform.Stat_t) error {
+	return syscall.ENOSYS
 }
 
 // Mkdir implements FS.Mkdir

--- a/internal/testing/require/require.go
+++ b/internal/testing/require/require.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"syscall"
 	"unicode"
 	"unicode/utf8"
 )
@@ -123,6 +124,19 @@ func EqualError(t TestingT, err error, expected string, formatWithArgs ...interf
 func Error(t TestingT, err error, formatWithArgs ...interface{}) {
 	if err == nil {
 		fail(t, "expected an error, but was nil", "", formatWithArgs...)
+	}
+}
+
+// EqualErrno should be used for functions that return syscall.Errno or nil.
+func EqualErrno(t TestingT, expected syscall.Errno, err error, formatWithArgs ...interface{}) {
+	if err == nil {
+		fail(t, "expected a syscall.Errno, but was nil", "", formatWithArgs...)
+		return
+	}
+	if se, ok := err.(syscall.Errno); !ok {
+		fail(t, fmt.Sprintf("expected %v to be a syscall.Errno", err), "", formatWithArgs...)
+	} else if se != expected {
+		fail(t, fmt.Sprintf("expected Errno %#[1]v(%[1]s), but was %#[2]v(%[2]s)", expected, err), "", formatWithArgs...)
 	}
 }
 

--- a/internal/testing/require/require_errno_test.go
+++ b/internal/testing/require/require_errno_test.go
@@ -1,0 +1,66 @@
+package require
+
+import (
+	"io"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestEqualErrno(t *testing.T) {
+	// This specifically chooses ENOENT and EIO as outside windows, they tend
+	// to have the same errno literal and text message.
+	if runtime.GOOS == "windows" {
+		t.Skipf("error literals are different on windows")
+	}
+
+	tests := []struct {
+		name        string
+		require     func(TestingT)
+		expectedLog string
+	}{
+		{
+			name: "EqualErrno passes on equal",
+			require: func(t TestingT) {
+				EqualErrno(t, syscall.ENOENT, syscall.ENOENT)
+			},
+		},
+		{
+			name: "EqualErrno fails on nil",
+			require: func(t TestingT) {
+				EqualErrno(t, syscall.ENOENT, nil)
+			},
+			expectedLog: "expected a syscall.Errno, but was nil",
+		},
+		{
+			name: "EqualErrno fails on not Errno",
+			require: func(t TestingT) {
+				EqualErrno(t, syscall.ENOENT, io.EOF)
+			},
+			expectedLog: `expected EOF to be a syscall.Errno`,
+		},
+		{
+			name: "EqualErrno fails on not equal",
+			require: func(t TestingT) {
+				EqualErrno(t, syscall.ENOENT, syscall.EIO)
+			},
+			expectedLog: `expected Errno 0x2(no such file or directory), but was 0x5(input/output error)`,
+		},
+		{
+			name: "EqualErrno fails on not equal with format",
+			require: func(t TestingT) {
+				EqualErrno(t, syscall.ENOENT, syscall.EIO, "pay me %d", 5)
+			},
+			expectedLog: `expected Errno 0x2(no such file or directory), but was 0x5(input/output error): pay me 5`,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			m := &mockT{t: t}
+			tc.require(m)
+			m.require(tc.expectedLog)
+		})
+	}
+}

--- a/internal/wasi_snapshot_preview1/errno.go
+++ b/internal/wasi_snapshot_preview1/errno.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/tetratelabs/wazero/internal/sysfs"
+	"github.com/tetratelabs/wazero/internal/platform"
 )
 
 // Errno is neither uint16 nor an alias for parity with wasm.ValueType.
@@ -266,7 +266,7 @@ var errnoToString = [...]string{
 // error codes. For example, wasi-filesystem and GOOS=js don't map to these
 // Errno.
 func ToErrno(err error) Errno {
-	errno := sysfs.UnwrapOSError(err)
+	errno := platform.UnwrapOSError(err)
 
 	switch errno {
 	case syscall.EACCES:

--- a/internal/wasi_snapshot_preview1/errno_test.go
+++ b/internal/wasi_snapshot_preview1/errno_test.go
@@ -3,8 +3,6 @@ package wasi_snapshot_preview1
 import (
 	"syscall"
 	"testing"
-
-	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestToErrno(t *testing.T) {
@@ -94,7 +92,7 @@ func TestToErrno(t *testing.T) {
 			expected: ErrnoPerm,
 		},
 		{
-			name:     "syscall.Errno unexpected == ErrnoIo",
+			name:     "syscall.EqualErrno unexpected == ErrnoIo",
 			input:    syscall.Errno(0xfe),
 			expected: ErrnoIo,
 		},
@@ -103,8 +101,9 @@ func TestToErrno(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			errno := ToErrno(tc.input)
-			require.Equal(t, tc.expected, errno)
+			if errno := ToErrno(tc.input); errno != tc.expected {
+				t.Fatalf("expected %s but got %s", ErrnoName(tc.expected), ErrnoName(errno))
+			}
 		})
 	}
 }


### PR DESCRIPTION
This centralizes filestat logic by making our own `Stat_t` similar to `syscall.Stat_t`. This exposes utilities in the platform package and adds a new function `FS.Stat` which avoids having to use `fs.File` to get the same info. Doing so at the FS abstraction allows us to optimize how it is implemented internally using portable means (e.g. `os.StatFile`) or OS-specific means where necessary, e.g. in windows.

This also ensures `platform.OpenFile` returns syscall.Errno and centralizes error checking with a new `require.EqualErrno` test.