### PR TITLE
wazeroir: removes allocations in wasmOpcodeSignature asymptotically

### DIFF
--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -591,12 +591,15 @@ func (c *compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature
 	}
 }
 
+// funcTypeToIRSignatures is the central cache for a module to get the *signature
+// for function calls.
 type funcTypeToIRSignatures struct {
 	directCalls   []*signature
 	indirectCalls []*signature
 	wasmTypes     []*wasm.FunctionType
 }
 
+// get returns the *signature for the direct or indirect function call against functions whose type is at `typeIndex`.
 func (f *funcTypeToIRSignatures) get(typeIndex wasm.Index, indirect bool) *signature {
 	var sig *signature
 	if indirect {

--- a/internal/wazeroir/signature_test.go
+++ b/internal/wazeroir/signature_test.go
@@ -100,3 +100,24 @@ func TestCompiler_wasmOpcodeSignature(t *testing.T) {
 		})
 	}
 }
+
+func Test_funcTypeToIRSignatures(t *testing.T) {
+	f := &funcTypeToIRSignatures{
+		wasmTypes:     []*wasm.FunctionType{v_v, i32_i32, v_f64f64},
+		directCalls:   make([]*signature, 3),
+		indirectCalls: make([]*signature, 3),
+	}
+
+	require.Equal(t, &signature{in: make([]UnsignedType, 0), out: make([]UnsignedType, 0)}, f.get(0, false))
+	require.Equal(t, &signature{in: []UnsignedType{UnsignedTypeI32}, out: make([]UnsignedType, 0)}, f.get(0, true))
+	require.NotNil(t, f.directCalls[0])
+	require.NotNil(t, f.indirectCalls[0])
+	require.Equal(t, &signature{in: []UnsignedType{UnsignedTypeI32}, out: []UnsignedType{UnsignedTypeI32}}, f.get(1, false))
+	require.Equal(t, &signature{in: []UnsignedType{UnsignedTypeI32, UnsignedTypeI32}, out: []UnsignedType{UnsignedTypeI32}}, f.get(1, true))
+	require.NotNil(t, f.directCalls[1])
+	require.NotNil(t, f.indirectCalls[1])
+	require.Equal(t, &signature{in: make([]UnsignedType, 0), out: []UnsignedType{UnsignedTypeF64, UnsignedTypeF64}}, f.get(2, false))
+	require.Equal(t, &signature{in: []UnsignedType{UnsignedTypeI32}, out: []UnsignedType{UnsignedTypeF64, UnsignedTypeF64}}, f.get(2, true))
+	require.NotNil(t, f.directCalls[2])
+	require.NotNil(t, f.indirectCalls[2])
+}


### PR DESCRIPTION
```
name         old time/op    new time/op    delta
_compile-10     897ms ± 2%     891ms ± 1%  -0.66%  (p=0.000 n=43+49)

name         old alloc/op   new alloc/op   delta
_compile-10     599MB ± 0%     597MB ± 0%  -0.47%  (p=0.000 n=50+50)

name         old allocs/op  new allocs/op  delta
_compile-10     7.53M ± 0%     7.40M ± 0%  -1.70%  (p=0.000 n=50+49)
```