### PR TITLE
optimizes non-windows stat to avoid opening a file

### DIFF
--- a/internal/platform/open_file_js.go
+++ b/internal/platform/open_file_js.go
@@ -1,5 +1,3 @@
-//go:build js
-
 package platform
 
 import (

--- a/internal/platform/stat_bsd.go
+++ b/internal/platform/stat_bsd.go
@@ -7,7 +7,20 @@ import (
 	"syscall"
 )
 
+func stat(path string, st *Stat_t) (err error) {
+	t, err := os.Stat(path)
+	if err = UnwrapOSError(err); err == nil {
+		fillStatFromSys(st, t)
+	}
+	return
+}
+
 func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
+	fillStatFromSys(stat, t)
+	return
+}
+
+func fillStatFromSys(stat *Stat_t, t os.FileInfo) {
 	d := t.Sys().(*syscall.Stat_t)
 	stat.Ino = d.Ino
 	stat.Dev = uint64(d.Dev)
@@ -20,5 +33,4 @@ func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	stat.Mtim = mtime.Sec*1e9 + mtime.Nsec
 	ctime := d.Ctimespec
 	stat.Ctim = ctime.Sec*1e9 + ctime.Nsec
-	return
 }

--- a/internal/platform/stat_linux.go
+++ b/internal/platform/stat_linux.go
@@ -10,7 +10,20 @@ import (
 	"syscall"
 )
 
+func stat(path string, st *Stat_t) (err error) {
+	t, err := os.Stat(path)
+	if err = UnwrapOSError(err); err == nil {
+		fillStatFromSys(st, t)
+	}
+	return
+}
+
 func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
+	fillStatFromSys(stat, t)
+	return
+}
+
+func fillStatFromSys(stat *Stat_t, t os.FileInfo) {
 	d := t.Sys().(*syscall.Stat_t)
 	stat.Ino = uint64(d.Ino)
 	stat.Dev = uint64(d.Dev)
@@ -23,5 +36,4 @@ func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	stat.Mtim = mtime.Sec*1e9 + mtime.Nsec
 	ctime := d.Ctim
 	stat.Ctim = ctime.Sec*1e9 + ctime.Nsec
-	return
 }

--- a/internal/platform/stat_unsupported.go
+++ b/internal/platform/stat_unsupported.go
@@ -1,8 +1,16 @@
-//go:build !((amd64 || arm64 || riscv64) && linux) && !((amd64 || arm64) && (darwin || freebsd)) && !((amd64 || arm64) && windows)
+//go:build (!((amd64 || arm64 || riscv64) && linux) && !((amd64 || arm64) && (darwin || freebsd)) && !((amd64 || arm64) && windows)) || js
 
 package platform
 
 import "os"
+
+func stat(path string, st *Stat_t) (err error) {
+	t, err := os.Stat(path)
+	if err = UnwrapOSError(err); err == nil {
+		fillStatFromFileInfo(st, t)
+	}
+	return
+}
 
 func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	fillStatFromFileInfo(stat, t)

--- a/internal/platform/stat_windows.go
+++ b/internal/platform/stat_windows.go
@@ -7,6 +7,16 @@ import (
 	"syscall"
 )
 
+func stat(path string, st *Stat_t) (err error) {
+	// TODO: See if we can refactor to avoid opening a file first.
+	f, err := OpenFile(path, syscall.O_RDONLY, 0)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	return StatFile(f, st)
+}
+
 func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
 	d := t.Sys().(*syscall.Win32FileAttributeData)
 	handle := syscall.Handle(fd)


### PR DESCRIPTION
This ensures only windows needs to open a file in order to do a stat. Maybe one day it can also avoid that, but meanwhile darwin and linux should be faster.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1
                                       │   old.txt    │              new.txt               │
                                       │    sec/op    │    sec/op     vs base              │
_pathFilestat/embed.FS_fd=root-12        1.399µ ± ∞ ¹   1.388µ ± ∞ ¹       ~ (p=1.000 n=5)
_pathFilestat/embed.FS_fd=directory-12   1.448µ ± ∞ ¹   1.405µ ± ∞ ¹  -2.97% (p=0.008 n=5)
_pathFilestat/os.DirFS_fd=root-12        9.017µ ± ∞ ¹   8.886µ ± ∞ ¹       ~ (p=0.151 n=5)
_pathFilestat/os.DirFS_fd=directory-12   9.338µ ± ∞ ¹   9.375µ ± ∞ ¹       ~ (p=0.548 n=5)
geomean                                  3.614µ         3.570µ        -1.21%
```