### PR TITLE
wasi: manually adds dot and dot-dot directory entries

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -297,5 +297,4 @@ jobs:
             -t ./tests/assemblyscript/testsuite/ \
             ./tests/c/testsuite/ \
             ./tests/rust/testsuite/ \
-            -f ./adapters/wazero_skip.json \
             -r ./adapters/wazero.py


### PR DESCRIPTION
This manually adds dot and dot-dot directory entries discarded by compilers like Go. Doing so complies with the latest interpretation of wasi preview1 without forcing us to do the same in preview2 or in GOOS=js. There's a cost penalty of one stat per directory list, which will be only measurable when using real file I/O.

This should result in us being able to remove the exclusion here https://github.com/WebAssembly/wasi-testsuite/pull/55/files#diff-8a3ffd323d75a12f8deb01b053f062876d83dda0b89c1fa24b293cee4195bcfd

See https://github.com/WebAssembly/wasi-testsuite/issues/52