### PR TITLE
wasi: adds platform.Dirent in preparation of inode fetching

### DIFF
--- a/internal/platform/dir.go
+++ b/internal/platform/dir.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"io"
 	"io/fs"
 	"syscall"
 )
@@ -21,11 +22,60 @@ func Readdirnames(f fs.File, n int) (names []string, err error) {
 	case fs.ReadDirFile:
 		var entries []fs.DirEntry
 		entries, err = f.ReadDir(n)
-		if err == nil {
-			names = make([]string, 0, len(entries))
-			for _, e := range entries {
-				names = append(names, e.Name())
-			}
+		if err != nil {
+			break
+		}
+		names = make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+	default:
+		err = syscall.ENOTDIR
+	}
+	err = UnwrapOSError(err)
+	return
+}
+
+// Dirent is an entry read from a directory.
+//
+// This is a portable variant of syscall.Dirent containing fields needed for
+// WebAssembly ABI including WASI snapshot-01 and wasi-filesystem. Unlike
+// fs.DirEntry, this may include the Ino.
+type Dirent struct {
+	// Name is the base name of the directory entry.
+	Name string
+
+	// Ino is the file serial number, or zero if not available.
+	Ino uint64
+
+	// Type is fs.FileMode masked on fs.ModeType. For example, zero is a
+	// regular file, fs.ModeDir is a directory and fs.ModeIrregular is unknown.
+	Type fs.FileMode
+}
+
+// IsDir returns true if the Type is fs.ModeDir.
+func (d *Dirent) IsDir() bool {
+	return d.Type == fs.ModeDir
+}
+
+// Readdir is like the function on os.File, but for fs.File. This returns
+// syscall.ENOTDIR if not a directory or syscall.EIO if closed or read
+// redundantly.
+func Readdir(f fs.File, n int) (dirents []*Dirent, err error) {
+	switch f := f.(type) {
+	case fs.ReadDirFile:
+		var entries []fs.DirEntry
+		entries, err = f.ReadDir(n)
+		if err == io.EOF {
+			err = nil
+		}
+		if err != nil {
+			break
+		}
+		dirents = make([]*Dirent, 0, len(entries))
+		for _, e := range entries {
+			// By default, we don't attempt to read inode data
+			dirents = append(dirents, &Dirent{Name: e.Name(), Type: e.Type()})
 		}
 	default:
 		err = syscall.ENOTDIR

--- a/internal/platform/dir.go
+++ b/internal/platform/dir.go
@@ -42,6 +42,8 @@ func Readdirnames(f fs.File, n int) (names []string, err error) {
 // WebAssembly ABI including WASI snapshot-01 and wasi-filesystem. Unlike
 // fs.DirEntry, this may include the Ino.
 type Dirent struct {
+	// ^^ Dirent name matches syscall.Dirent
+
 	// Name is the base name of the directory entry.
 	Name string
 
@@ -58,10 +60,17 @@ func (d *Dirent) IsDir() bool {
 	return d.Type == fs.ModeDir
 }
 
-// Readdir is like the function on os.File, but for fs.File. This returns
-// syscall.ENOTDIR if not a directory or syscall.EIO if closed or read
-// redundantly.
+// Readdir reads the contents of the directory associated with file and returns
+// a slice of up to n Dirent values in an arbitrary order. This is a stateful
+// function, so subsequent calls return any next values.
+//
+// If n > 0, Readdir returns at most n entries or an error.
+// If n <= 0, Readdir returns all remaining entries or an error.
+//
+// Note: The error will be nil or a syscall.Errno. No error is returned on EOF.
 func Readdir(f fs.File, n int) (dirents []*Dirent, err error) {
+	// ^^ case format is to match POSIX and similar to os.File.Readdir
+
 	switch f := f.(type) {
 	case fs.ReadDirFile:
 		var entries []fs.DirEntry

--- a/internal/platform/dir_test.go
+++ b/internal/platform/dir_test.go
@@ -77,3 +77,84 @@ func TestReaddirnames(t *testing.T) {
 		})
 	}
 }
+
+func TestReaddir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, fstest.WriteTestFiles(tmpDir))
+	dirFS := os.DirFS(tmpDir)
+
+	tests := []struct {
+		name string
+		fs   fs.FS
+	}{
+		{name: "os.DirFS", fs: dirFS},         // To test readdirFile
+		{name: "fstest.MapFS", fs: fstest.FS}, // To test adaptation of ReadDirFile
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			dirF, err := tc.fs.Open(".")
+			require.NoError(t, err)
+			defer dirF.Close()
+
+			t.Run("dir", func(t *testing.T) {
+				dirents, err := platform.Readdir(dirF, -1)
+				require.NoError(t, err)
+				sort.Slice(dirents, func(i, j int) bool { return dirents[i].Name < dirents[j].Name })
+
+				require.Equal(t, 5, len(dirents))
+				require.Equal(t, "animals.txt", dirents[0].Name)
+				require.Zero(t, dirents[0].Type)
+				require.Equal(t, "dir", dirents[1].Name)
+				require.Equal(t, fs.ModeDir, dirents[1].Type)
+				require.Equal(t, "empty.txt", dirents[2].Name)
+				require.Zero(t, dirents[2].Type)
+				require.Equal(t, "emptydir", dirents[3].Name)
+				require.Equal(t, fs.ModeDir, dirents[3].Type)
+				require.Equal(t, "sub", dirents[4].Name)
+				require.Equal(t, fs.ModeDir, dirents[4].Type)
+
+				// read again even though it is exhausted
+				dirents, err = platform.Readdir(dirF, 100)
+				require.NoError(t, err)
+				require.Zero(t, len(dirents))
+			})
+
+			// windows and fstest.MapFS allow you to read a closed dir
+			if runtime.GOOS != "windows" && tc.name != "fstest.MapFS" {
+				t.Run("closed dir", func(t *testing.T) {
+					require.NoError(t, dirF.Close())
+					_, err := platform.Readdir(dirF, -1)
+					require.EqualErrno(t, syscall.EIO, err)
+				})
+			}
+
+			fileF, err := tc.fs.Open("empty.txt")
+			require.NoError(t, err)
+			defer fileF.Close()
+
+			t.Run("file", func(t *testing.T) {
+				_, err := platform.Readdir(fileF, -1)
+				require.EqualErrno(t, syscall.ENOTDIR, err)
+			})
+
+			subdirF, err := tc.fs.Open("sub")
+			require.NoError(t, err)
+			defer subdirF.Close()
+
+			t.Run("subdir", func(t *testing.T) {
+				dirents, err := platform.Readdir(subdirF, -1)
+				require.NoError(t, err)
+				sort.Slice(dirents, func(i, j int) bool { return dirents[i].Name < dirents[j].Name })
+
+				require.Equal(t, 1, len(dirents))
+				require.Equal(t, "test.txt", dirents[0].Name)
+				require.Zero(t, dirents[0].Type)
+			})
+		})
+	}
+}

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -187,20 +187,20 @@ func (f *FileEntry) IsDir() bool {
 }
 
 // Stat returns the underlying stat of this file.
-func (f *FileEntry) Stat(stat *platform.Stat_t) (err error) {
-	err = platform.StatFile(f.File, stat)
-	if err == nil && stat.Mode.IsDir() {
-		f.isDirectory = true
+func (f *FileEntry) Stat(st *platform.Stat_t) (err error) {
+	err = platform.StatFile(f.File, st)
+	if err == nil {
+		f.isDirectory = st.Mode.IsDir()
 	}
 	return
 }
 
 // ReadDir is the status of a prior fs.ReadDirFile call.
 type ReadDir struct {
-	// CountRead is the total count of files read including Entries.
+	// CountRead is the total count of files read including Dirents.
 	CountRead uint64
 
-	// Entries is the contents of the last fs.ReadDirFile call. Notably,
+	// Dirents is the contents of the last platform.Readdir call. Notably,
 	// directory listing are not rewindable, so we keep entries around in case
 	// the caller mis-estimated their buffer and needs a few still cached.
 	//
@@ -208,7 +208,7 @@ type ReadDir struct {
 	// In wasi preview1, dot and dot-dot entries are required to exist, but the
 	// reverse is true for preview2. More importantly, preview2 holds separate
 	// stateful dir-entry-streams per file.
-	Entries []fs.DirEntry
+	Dirents []*platform.Dirent
 }
 
 type FSContext struct {
@@ -333,7 +333,7 @@ func (c *FSContext) ReOpenDir(fd uint32) (*FileEntry, error) {
 		return f, err
 	}
 
-	f.ReadDir.CountRead, f.ReadDir.Entries = 0, nil
+	f.ReadDir.CountRead, f.ReadDir.Dirents = 0, nil
 	return f, nil
 }
 
@@ -454,46 +454,3 @@ func WriterForFile(fsc *FSContext, fd uint32) (writer io.Writer) {
 	}
 	return
 }
-
-// DotEntries returns "." and "..", where "." has a real stat because
-// wasi-testsuite does inode validation.
-func DotEntries(f fs.File) ([]fs.DirEntry, error) {
-	var st platform.Stat_t
-	if err := platform.StatFile(f, &st); err != nil {
-		return nil, err
-	}
-	return []fs.DirEntry{&dotEntry{stat: &st}, dotDotEntry{}}, nil
-}
-
-// dotEntry is a fs.DirEntry representing the directory being listed.
-type dotEntry struct {
-	// stat is the stat of the opened directory
-	stat *platform.Stat_t
-}
-
-func (i *dotEntry) Name() string               { return "." }
-func (i *dotEntry) Type() fs.FileMode          { return i.stat.Mode.Type() }
-func (i *dotEntry) Info() (fs.FileInfo, error) { return i, nil }
-func (i *dotEntry) Size() int64                { return i.stat.Size }
-func (i *dotEntry) Mode() fs.FileMode          { return i.stat.Mode }
-func (i *dotEntry) ModTime() time.Time {
-	return time.Unix(i.stat.Mtim/1e9, i.stat.Mtim%1e9)
-}
-func (i *dotEntry) IsDir() bool      { return true }
-func (i *dotEntry) Sys() interface{} { return nil }
-
-// dotDotEntry is a fake entry for dot-dot (".."), added to satisfy WASI tests.
-//
-// Note: This is intentionally invalid as WASI decided that it must be present
-// on any list, including the root directory: No values are tested apart from
-// the name.
-type dotDotEntry struct{}
-
-func (dotDotEntry) Name() string               { return ".." }
-func (dotDotEntry) Type() fs.FileMode          { return fs.ModeDir }
-func (dotDotEntry) Info() (fs.FileInfo, error) { return dotDotEntry{}, nil }
-func (dotDotEntry) Size() int64                { return 0 }
-func (dotDotEntry) Mode() fs.FileMode          { return fs.ModeDir }
-func (dotDotEntry) ModTime() time.Time         { return time.Unix(0, 0) }
-func (dotDotEntry) IsDir() bool                { return true }
-func (dotDotEntry) Sys() interface{}           { return nil }

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/sysfs"
 	testfs "github.com/tetratelabs/wazero/internal/testing/fs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -240,7 +241,7 @@ func TestFSContext_ReOpenDir(t *testing.T) {
 		require.True(t, ok)
 
 		// Set arbitrary state.
-		ent.ReadDir = &ReadDir{Entries: make([]fs.DirEntry, 10), CountRead: 12345}
+		ent.ReadDir = &ReadDir{Dirents: make([]*platform.Dirent, 10), CountRead: 12345}
 
 		// Then reopen the same file descriptor.
 		ent, err = fsc.ReOpenDir(dirFd)


### PR DESCRIPTION
wasi_snapshot_preview1 recently requires fd_readdir to return actual inode values. On zero, wasi-libc will call fdstat to retrieve them.

This introduces our own `platform.Dirent` type and `Readdir` function which a later change will allow fetching of inodes.

See https://github.com/WebAssembly/wasi-libc/pull/345