### PR TITLE
wasi: shares more cached stat info to reduce impact of inode requirement

### DIFF
--- a/internal/wasi_snapshot_preview1/errno.go
+++ b/internal/wasi_snapshot_preview1/errno.go
@@ -266,6 +266,9 @@ var errnoToString = [...]string{
 // error codes. For example, wasi-filesystem and GOOS=js don't map to these
 // Errno.
 func ToErrno(err error) Errno {
+	if err == nil {
+		return ErrnoSuccess
+	}
 	errno := platform.UnwrapOSError(err)
 
 	switch errno {

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -145,7 +145,7 @@ func Config(fnd api.FunctionDefinition) (pSampler logging.ParamSampler, pLoggers
 			logger = logFsRightsBase(idx).Log
 		case "fs_rights_inheriting":
 			logger = logFsRightsInheriting(idx).Log
-		case "result.nread", "result.nwritten", "result.opened_fd", "result.nevents":
+		case "result.nread", "result.nwritten", "result.opened_fd", "result.nevents", "result.bufused":
 			name = resultParamName(name)
 			logger = logMemI32(idx).Log
 			rLoggers = append(rLoggers, resultParamLogger(name, logger))


### PR DESCRIPTION
We formerly cached only the directory type, to avoid re-stat'ing the same directory many times. Since we are there, we can also cache the inode, which is strictly required by wasi and costly to fetch. Note: this only affects the directory: its contents still need a potential fan-out of stats which will be handled in another change.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1
                                      │    old.txt    │               new.txt                │
                                      │    sec/op     │    sec/op     vs base                │
_fdReaddir/embed.FS-12                   1.607µ ± ∞ ¹   1.547µ ± ∞ ¹  -3.73% (p=0.032 n=5)
_fdReaddir/embed.FS_-_continued-12       1.119µ ± ∞ ¹   1.125µ ± ∞ ¹       ~ (p=0.690 n=5)
_fdReaddir/os.DirFS-12                  10.377µ ± ∞ ¹   9.777µ ± ∞ ¹  -5.78% (p=0.008 n=5)
_fdReaddir/os.DirFS_-_continued-12       2.648µ ± ∞ ¹   2.555µ ± ∞ ¹       ~ (p=0.151 n=5)
_fdReaddir/sysfs.DirFS-12                10.46µ ± ∞ ¹
_fdReaddir/sysfs.DirFS_-_continued-12    2.594µ ± ∞ ¹
geomean                                  3.320µ         2.568µ        -3.15%               ²

                                      │    old.txt    │                new.txt                │
                                      │     B/op      │     B/op       vs base                │
_fdReaddir/embed.FS-12                    784.0 ± ∞ ¹     784.0 ± ∞ ¹       ~ (p=1.000 n=5) ²
_fdReaddir/embed.FS_-_continued-12        592.0 ± ∞ ¹     592.0 ± ∞ ¹       ~ (p=1.000 n=5) ²
_fdReaddir/os.DirFS-12                  3.180Ki ± ∞ ¹   2.977Ki ± ∞ ¹  -6.39% (p=0.008 n=5)
_fdReaddir/os.DirFS_-_continued-12      2.477Ki ± ∞ ¹   2.477Ki ± ∞ ¹       ~ (p=1.000 n=5) ²
_fdReaddir/sysfs.DirFS-12               3.180Ki ± ∞ ¹
_fdReaddir/sysfs.DirFS_-_continued-12   2.477Ki ± ∞ ¹
geomean                                 1.737Ki         1.344Ki        -1.64%               ³

                                      │   old.txt   │               new.txt               │
                                      │  allocs/op  │  allocs/op   vs base                │
_fdReaddir/embed.FS-12                  18.00 ± ∞ ¹   18.00 ± ∞ ¹       ~ (p=1.000 n=5) ²
_fdReaddir/embed.FS_-_continued-12      13.00 ± ∞ ¹   13.00 ± ∞ ¹       ~ (p=1.000 n=5) ²
_fdReaddir/os.DirFS-12                  44.00 ± ∞ ¹   43.00 ± ∞ ¹  -2.27% (p=0.008 n=5)
_fdReaddir/os.DirFS_-_continued-12      34.00 ± ∞ ¹   34.00 ± ∞ ¹       ~ (p=1.000 n=5) ²
_fdReaddir/sysfs.DirFS-12               44.00 ± ∞ ¹
_fdReaddir/sysfs.DirFS_-_continued-12   34.00 ± ∞ ¹
geomean                                 28.39         24.18        -0.57%               ³
```