### PR TITLE
Readdir: handles io.EOF

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -855,10 +855,15 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) Errno {
 		if errno = ToErrno(err); errno != ErrnoSuccess {
 			return errno
 		}
-		dir.CountRead += uint64(len(l))
-		dirents = append(dirents, l...)
-		// Replace the cache with up to maxDirEntries, starting at cookie.
-		dir.Dirents = dirents
+
+		// Zero length read is possible on an empty directory or on io.EOF,
+		// which coerces to nil in WASI because there's no Errno for it.
+		if len(l) > 0 {
+			dir.CountRead += uint64(len(l))
+			dirents = append(dirents, l...)
+			// Replace the cache with up to maxDirEntries, starting at cookie.
+			dir.Dirents = dirents
+		}
 	}
 
 	// Determine how many dirents we can write, excluding a potentially

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2096,6 +2096,30 @@ func Test_fdReaddir(t *testing.T) {
 				Dirents:   testDirents[2:],
 			},
 		},
+		{
+			name: "read exhausted directory",
+			dir: func() *sys.FileEntry {
+				dir, err := fstest.FS.Open("dir")
+				require.NoError(t, err)
+				_, err = platform.Readdir(dir, 3)
+				require.NoError(t, err)
+
+				return &sys.FileEntry{
+					File: dir,
+					ReadDir: &sys.ReadDir{
+						CountRead: 5,
+						Dirents:   testDirents,
+					},
+				}
+			},
+			bufLen:          300, // length is long enough for third and more
+			cookie:          5,   // d_next after entries.
+			expectedBufused: 0,   // nothing read
+			expectedReadDir: &sys.ReadDir{
+				CountRead: 5,
+				Dirents:   testDirents,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/gojs/errno.go
+++ b/internal/gojs/errno.go
@@ -1,6 +1,7 @@
 package gojs
 
 import (
+	"io"
 	"syscall"
 
 	"github.com/tetratelabs/wazero/internal/platform"
@@ -60,6 +61,9 @@ var (
 //
 // This should match wasi_snapshot_preview1.ToErrno for maintenance ease.
 func ToErrno(err error) *Errno {
+	if err == nil || err == io.EOF {
+		return nil // io.EOF has no value in GOOS=js, and isn't an error.
+	}
 	errno := platform.UnwrapOSError(err)
 
 	switch errno {

--- a/internal/gojs/errno_test.go
+++ b/internal/gojs/errno_test.go
@@ -1,6 +1,7 @@
 package gojs
 
 import (
+	"io"
 	"syscall"
 	"testing"
 )
@@ -11,6 +12,13 @@ func TestToErrno(t *testing.T) {
 		input    error
 		expected *Errno
 	}{
+		{
+			name: "nil is not an error",
+		},
+		{
+			name:  "io.EOF is not an error",
+			input: io.EOF,
+		},
 		{
 			name:     "syscall.EACCES",
 			input:    syscall.EACCES,

--- a/internal/wasi_snapshot_preview1/errno.go
+++ b/internal/wasi_snapshot_preview1/errno.go
@@ -2,6 +2,7 @@ package wasi_snapshot_preview1
 
 import (
 	"fmt"
+	"io"
 	"syscall"
 
 	"github.com/tetratelabs/wazero/internal/platform"
@@ -266,8 +267,8 @@ var errnoToString = [...]string{
 // error codes. For example, wasi-filesystem and GOOS=js don't map to these
 // Errno.
 func ToErrno(err error) Errno {
-	if err == nil {
-		return ErrnoSuccess
+	if err == nil || err == io.EOF {
+		return ErrnoSuccess // io.EOF has no value in WASI, and isn't an error.
 	}
 	errno := platform.UnwrapOSError(err)
 

--- a/internal/wasi_snapshot_preview1/errno_test.go
+++ b/internal/wasi_snapshot_preview1/errno_test.go
@@ -1,6 +1,7 @@
 package wasi_snapshot_preview1
 
 import (
+	"io"
 	"syscall"
 	"testing"
 )
@@ -11,6 +12,15 @@ func TestToErrno(t *testing.T) {
 		input    error
 		expected Errno
 	}{
+		{
+			name:     "nil is not an error",
+			expected: ErrnoSuccess,
+		},
+		{
+			name:     "io.EOF is not an error",
+			input:    io.EOF,
+			expected: ErrnoSuccess,
+		},
 		{
 			name:     "syscall.EACCES",
 			input:    syscall.EACCES,


### PR DESCRIPTION
This handles EOF even if current and possibly future wasi don't have a way to propagate an EOF signal. This is mainly to match up with go semantics and ensure we don't have any error conditions (by adding tests).