### PR TITLE
implements lstat and fixes inode stat on windows go 1.20

### DIFF
--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -46,6 +46,8 @@ func OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
 	}
 
 	switch err {
+	// To match expectations of WASI, e.g. TinyGo TestStatBadDir, return
+	// ENOENT, not ENOTDIR.
 	case syscall.ENOTDIR:
 		err = syscall.ENOENT
 	case syscall.ENOENT:

--- a/internal/platform/stat_bsd.go
+++ b/internal/platform/stat_bsd.go
@@ -3,34 +3,45 @@
 package platform
 
 import (
+	"io/fs"
 	"os"
 	"syscall"
 )
 
-func stat(path string, st *Stat_t) (err error) {
-	t, err := os.Stat(path)
-	if err = UnwrapOSError(err); err == nil {
-		fillStatFromSys(st, t)
+func lstat(path string, st *Stat_t) (err error) {
+	var t fs.FileInfo
+	if t, err = os.Lstat(path); err == nil {
+		fillStatFromFileInfo(st, t)
 	}
 	return
 }
 
-func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
-	fillStatFromSys(stat, t)
+func stat(path string, st *Stat_t) (err error) {
+	var t fs.FileInfo
+	if t, err = os.Stat(path); err == nil {
+		fillStatFromFileInfo(st, t)
+	}
 	return
 }
 
-func fillStatFromSys(stat *Stat_t, t os.FileInfo) {
-	d := t.Sys().(*syscall.Stat_t)
-	stat.Ino = d.Ino
-	stat.Dev = uint64(d.Dev)
-	stat.Mode = t.Mode()
-	stat.Nlink = uint64(d.Nlink)
-	stat.Size = d.Size
-	atime := d.Atimespec
-	stat.Atim = atime.Sec*1e9 + atime.Nsec
-	mtime := d.Mtimespec
-	stat.Mtim = mtime.Sec*1e9 + mtime.Nsec
-	ctime := d.Ctimespec
-	stat.Ctim = ctime.Sec*1e9 + ctime.Nsec
+func statFile(f fs.File, st *Stat_t) error {
+	return defaultStatFile(f, st)
+}
+
+func fillStatFromFileInfo(st *Stat_t, t fs.FileInfo) {
+	if d, ok := t.Sys().(*syscall.Stat_t); ok {
+		st.Ino = d.Ino
+		st.Dev = uint64(d.Dev)
+		st.Mode = t.Mode()
+		st.Nlink = uint64(d.Nlink)
+		st.Size = d.Size
+		atime := d.Atimespec
+		st.Atim = atime.Sec*1e9 + atime.Nsec
+		mtime := d.Mtimespec
+		st.Mtim = mtime.Sec*1e9 + mtime.Nsec
+		ctime := d.Ctimespec
+		st.Ctim = ctime.Sec*1e9 + ctime.Nsec
+	} else {
+		fillStatFromDefaultFileInfo(st, t)
+	}
 }

--- a/internal/platform/stat_test.go
+++ b/internal/platform/stat_test.go
@@ -1,9 +1,11 @@
 package platform
 
 import (
+	"io/fs"
 	"os"
-	"path"
+	pathutil "path"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -11,33 +13,125 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+func TestLstat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var stat Stat_t
+	require.EqualErrno(t, syscall.ENOENT, Lstat(pathutil.Join(tmpDir, "cat"), &stat))
+	require.EqualErrno(t, syscall.ENOENT, Lstat(pathutil.Join(tmpDir, "sub/cat"), &stat))
+
+	t.Run("dir", func(t *testing.T) {
+		err := Lstat(tmpDir, &stat)
+		require.NoError(t, err)
+		require.True(t, stat.Mode.IsDir())
+		require.NotEqual(t, uint64(0), stat.Ino)
+	})
+
+	file := pathutil.Join(tmpDir, "file")
+	var statFile Stat_t
+
+	t.Run("file", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(file, []byte{1, 2}, 0o400))
+		require.NoError(t, Lstat(file, &statFile))
+		require.Zero(t, statFile.Mode.Type())
+		require.Equal(t, int64(2), statFile.Size)
+		require.NotEqual(t, uint64(0), statFile.Ino)
+	})
+
+	t.Run("link to file", func(t *testing.T) {
+		requireLinkStat(t, file, &statFile)
+	})
+
+	subdir := pathutil.Join(tmpDir, "sub")
+	var statSubdir Stat_t
+	t.Run("subdir", func(t *testing.T) {
+		require.NoError(t, os.Mkdir(subdir, 0o500))
+
+		require.NoError(t, Lstat(subdir, &statSubdir))
+		require.True(t, statSubdir.Mode.IsDir())
+		require.NotEqual(t, uint64(0), statSubdir.Ino)
+	})
+
+	t.Run("link to dir", func(t *testing.T) {
+		requireLinkStat(t, subdir, &statSubdir)
+	})
+
+	t.Run("link to dir link", func(t *testing.T) {
+		pathLink := subdir + "-link"
+		var statLink Stat_t
+		require.NoError(t, Lstat(pathLink, &statLink))
+
+		requireLinkStat(t, pathLink, &statLink)
+	})
+}
+
+func requireLinkStat(t *testing.T, path string, stat *Stat_t) {
+	link := path + "-link"
+	var linkStat Stat_t
+	require.NoError(t, os.Symlink(path, link))
+
+	require.NoError(t, Lstat(link, &linkStat))
+	require.NotEqual(t, uint64(0), linkStat.Ino)
+	require.NotEqual(t, stat.Ino, linkStat.Ino) // inodes are not equal
+	require.Equal(t, fs.ModeSymlink, linkStat.Mode.Type())
+	// From https://linux.die.net/man/2/lstat:
+	// The size of a symbolic link is the length of the pathname it
+	// contains, without a terminating null byte.
+	if runtime.GOOS == "windows" { // size is zero, not the path length
+		require.Zero(t, linkStat.Size)
+	} else {
+		require.Equal(t, int64(len(path)), linkStat.Size)
+	}
+}
+
 func TestStat(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	var stat Stat_t
-	require.EqualErrno(t, syscall.ENOENT, Stat(path.Join(tmpDir, "cat"), &stat))
-	require.EqualErrno(t, syscall.ENOENT, Stat(path.Join(tmpDir, "sub/cat"), &stat))
+	require.EqualErrno(t, syscall.ENOENT, Stat(pathutil.Join(tmpDir, "cat"), &stat))
+	require.EqualErrno(t, syscall.ENOENT, Stat(pathutil.Join(tmpDir, "sub/cat"), &stat))
 
 	t.Run("dir", func(t *testing.T) {
 		err := Stat(tmpDir, &stat)
 		require.NoError(t, err)
 		require.True(t, stat.Mode.IsDir())
+		require.NotEqual(t, uint64(0), stat.Ino)
 	})
+
+	file := pathutil.Join(tmpDir, "file")
+	var statFile Stat_t
 
 	t.Run("file", func(t *testing.T) {
-		file := path.Join(tmpDir, "file")
 		require.NoError(t, os.WriteFile(file, nil, 0o400))
-
-		require.NoError(t, Stat(file, &stat))
-		require.False(t, stat.Mode.IsDir())
+		require.NoError(t, Stat(file, &statFile))
+		require.False(t, statFile.Mode.IsDir())
+		require.NotEqual(t, uint64(0), stat.Ino)
 	})
 
+	t.Run("link to file", func(t *testing.T) {
+		link := pathutil.Join(tmpDir, "file-link")
+		require.NoError(t, os.Symlink(file, link))
+
+		require.NoError(t, Stat(link, &stat))
+		require.Equal(t, statFile, stat) // resolves to the file
+	})
+
+	subdir := pathutil.Join(tmpDir, "sub")
+	var statSubdir Stat_t
 	t.Run("subdir", func(t *testing.T) {
-		subdir := path.Join(tmpDir, "sub")
 		require.NoError(t, os.Mkdir(subdir, 0o500))
 
-		require.NoError(t, Stat(subdir, &stat))
-		require.True(t, stat.Mode.IsDir())
+		require.NoError(t, Stat(subdir, &statSubdir))
+		require.True(t, statSubdir.Mode.IsDir())
+		require.NotEqual(t, uint64(0), stat.Ino)
+	})
+
+	t.Run("link to dir", func(t *testing.T) {
+		link := pathutil.Join(tmpDir, "dir-link")
+		require.NoError(t, os.Symlink(subdir, link))
+
+		require.NoError(t, Stat(link, &stat))
+		require.Equal(t, statSubdir, stat) // resolves to the dir
 	})
 }
 
@@ -54,16 +148,19 @@ func TestStatFile(t *testing.T) {
 		err = StatFile(tmpDirF, &stat)
 		require.NoError(t, err)
 		require.True(t, stat.Mode.IsDir())
+		requireDirectoryDevIno(t, stat)
 	})
 
-	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
+	// Windows allows you to stat a closed dir because it is accessed by path,
+	// not by file descriptor.
+	if runtime.GOOS != "windows" {
 		t.Run("closed dir", func(t *testing.T) {
 			require.NoError(t, tmpDirF.Close())
 			require.EqualErrno(t, syscall.EBADF, StatFile(tmpDirF, &stat))
 		})
 	}
 
-	file := path.Join(tmpDir, "file")
+	file := pathutil.Join(tmpDir, "file")
 	require.NoError(t, os.WriteFile(file, nil, 0o400))
 	fileF, err := OpenFile(file, syscall.O_RDONLY, 0)
 	require.NoError(t, err)
@@ -73,14 +170,16 @@ func TestStatFile(t *testing.T) {
 		err = StatFile(fileF, &stat)
 		require.NoError(t, err)
 		require.False(t, stat.Mode.IsDir())
+		require.NotEqual(t, uint64(0), stat.Ino)
 	})
 
 	t.Run("closed file", func(t *testing.T) {
 		require.NoError(t, fileF.Close())
 		require.EqualErrno(t, syscall.EBADF, StatFile(fileF, &stat))
+		require.NotEqual(t, uint64(0), stat.Ino)
 	})
 
-	subdir := path.Join(tmpDir, "sub")
+	subdir := pathutil.Join(tmpDir, "sub")
 	require.NoError(t, os.Mkdir(subdir, 0o500))
 	subdirF, err := OpenFile(subdir, syscall.O_RDONLY, 0)
 	require.NoError(t, err)
@@ -90,6 +189,7 @@ func TestStatFile(t *testing.T) {
 		err = StatFile(subdirF, &stat)
 		require.NoError(t, err)
 		require.True(t, stat.Mode.IsDir())
+		requireDirectoryDevIno(t, stat)
 	})
 
 	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
@@ -103,7 +203,7 @@ func TestStatFile(t *testing.T) {
 func Test_StatFile_times(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	file := path.Join(tmpDir, "file")
+	file := pathutil.Join(tmpDir, "file")
 	err := os.WriteFile(file, []byte{}, 0o700)
 	require.NoError(t, err)
 
@@ -153,36 +253,56 @@ func Test_StatFile_times(t *testing.T) {
 
 func TestStatFile_dev_inode(t *testing.T) {
 	tmpDir := t.TempDir()
+	d, err := os.Open(tmpDir)
+	require.NoError(t, err)
+	defer d.Close()
 
-	path1 := path.Join(tmpDir, "1")
+	path1 := pathutil.Join(tmpDir, "1")
 	f1, err := os.Create(path1)
 	require.NoError(t, err)
+	defer f1.Close()
 
-	path2 := path.Join(tmpDir, "2")
+	path2 := pathutil.Join(tmpDir, "2")
 	f2, err := os.Create(path2)
 	require.NoError(t, err)
+	defer f2.Close()
 
+	pathLink2 := pathutil.Join(tmpDir, "link2")
+	err = os.Symlink(path2, pathLink2)
+	require.NoError(t, err)
+	l2, err := os.Open(pathLink2)
+	require.NoError(t, err)
+	defer l2.Close()
+
+	// First, stat the directory
 	var stat1 Stat_t
+	require.NoError(t, StatFile(d, &stat1))
+	requireDirectoryDevIno(t, stat1)
+
+	// Now, stat the files in it
 	require.NoError(t, StatFile(f1, &stat1))
 
 	var stat2 Stat_t
 	require.NoError(t, StatFile(f2, &stat2))
 
+	var stat3 Stat_t
+	require.NoError(t, StatFile(l2, &stat3))
+
 	// The files should be on the same device, but different inodes
 	require.Equal(t, stat1.Dev, stat2.Dev)
 	require.NotEqual(t, stat1.Ino, stat2.Ino)
+	require.Equal(t, stat2, stat3) // stat on a link is for its target
 
 	// Redoing stat should result in the same inodes
 	var stat1Again Stat_t
 	require.NoError(t, StatFile(f1, &stat1Again))
-
 	require.Equal(t, stat1.Dev, stat1Again.Dev)
-	require.Equal(t, stat1.Ino, stat1Again.Ino)
 
 	// On Windows, we cannot rename while opening.
 	// So we manually close here before renaming.
 	require.NoError(t, f1.Close())
 	require.NoError(t, f2.Close())
+	require.NoError(t, l2.Close())
 
 	// Renaming a file shouldn't change its inodes.
 	require.NoError(t, Rename(path1, path2))
@@ -193,4 +313,15 @@ func TestStatFile_dev_inode(t *testing.T) {
 	require.NoError(t, StatFile(f1, &stat1Again))
 	require.Equal(t, stat1.Dev, stat1Again.Dev)
 	require.Equal(t, stat1.Ino, stat1Again.Ino)
+}
+
+func requireDirectoryDevIno(t *testing.T, st Stat_t) {
+	// windows before go 1.20 has trouble reading the inode information on directories.
+	if runtime.GOOS != "windows" || strings.HasPrefix(runtime.Version(), "go1.20") {
+		require.NotEqual(t, uint64(0), st.Dev)
+		require.NotEqual(t, uint64(0), st.Ino)
+	} else {
+		require.Zero(t, st.Dev)
+		require.Zero(t, st.Ino)
+	}
 }

--- a/internal/platform/stat_unsupported.go
+++ b/internal/platform/stat_unsupported.go
@@ -2,7 +2,18 @@
 
 package platform
 
-import "os"
+import (
+	"io/fs"
+	"os"
+)
+
+func lstat(path string, st *Stat_t) (err error) {
+	t, err := os.Lstat(path)
+	if err = UnwrapOSError(err); err == nil {
+		fillStatFromFileInfo(st, t)
+	}
+	return
+}
 
 func stat(path string, st *Stat_t) (err error) {
 	t, err := os.Stat(path)
@@ -12,7 +23,15 @@ func stat(path string, st *Stat_t) (err error) {
 	return
 }
 
-func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
-	fillStatFromFileInfo(stat, t)
+func statFile(f fs.File, st *Stat_t) error {
+	return defaultStatFile(f, st)
+}
+
+func fillStatFromFileInfo(st *Stat_t, t fs.FileInfo) {
+	fillStatFromDefaultFileInfo(st, t)
+}
+
+func fillStatFromOpenFile(st *Stat_t, fd uintptr, t os.FileInfo) (err error) {
+	fillStatFromFileInfo(st, t)
 	return
 }

--- a/internal/platform/stat_windows.go
+++ b/internal/platform/stat_windows.go
@@ -3,46 +3,119 @@
 package platform
 
 import (
-	"os"
+	"io/fs"
 	"syscall"
 )
 
-func stat(path string, st *Stat_t) (err error) {
-	// TODO: See if we can refactor to avoid opening a file first.
-	f, err := OpenFile(path, syscall.O_RDONLY, 0)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	return StatFile(f, st)
+func lstat(path string, st *Stat_t) error {
+	attrs := uint32(syscall.FILE_FLAG_BACKUP_SEMANTICS)
+	// Use FILE_FLAG_OPEN_REPARSE_POINT, otherwise CreateFile will follow symlink.
+	// See https://docs.microsoft.com/en-us/windows/desktop/FileIO/symbolic-link-effects-on-file-systems-functions#createfile-and-createfiletransacted
+	attrs |= syscall.FILE_FLAG_OPEN_REPARSE_POINT
+	return statPath(attrs, path, st)
 }
 
-func fillStatFromOpenFile(stat *Stat_t, fd uintptr, t os.FileInfo) (err error) {
-	d := t.Sys().(*syscall.Win32FileAttributeData)
-	handle := syscall.Handle(fd)
-	var info syscall.ByHandleFileInformation
-	if err = syscall.GetFileInformationByHandle(handle, &info); err != nil {
-		// If the file descriptor is already closed, we have to re-open just like
-		// os.Stat does to allow the results on the closed files.
-		// https://github.com/golang/go/blob/go1.20/src/os/stat_windows.go#L86
-		//
-		// TODO: once we have our File/Stat type, this shouldn't be necessary.
-		// But for now, ignore the error to pass the std library test for bad file descriptor.
-		// https://github.com/ziglang/zig/blob/master/lib/std/os/test.zig#L167-L170
-		if err == syscall.Errno(6) {
-			err = nil
+func stat(path string, st *Stat_t) error {
+	attrs := uint32(syscall.FILE_FLAG_BACKUP_SEMANTICS)
+	return statPath(attrs, path, st)
+}
+
+func statPath(createFileAttrs uint32, path string, st *Stat_t) (err error) {
+	if len(path) == 0 {
+		return syscall.ENOENT
+	}
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return syscall.EINVAL
+	}
+
+	// open the file handle
+	h, err := syscall.CreateFile(pathp, 0, 0, nil,
+		syscall.OPEN_EXISTING, createFileAttrs, 0)
+	if err != nil {
+		// To match expectations of WASI, e.g. TinyGo TestStatBadDir, return
+		// ENOENT, not ENOTDIR.
+		if err == syscall.ENOTDIR {
+			err = syscall.ENOENT
 		}
+		return err
+	}
+	defer syscall.CloseHandle(h)
+
+	return statHandle(h, st)
+}
+
+// fdFile is implemented by os.File in file_unix.go and file_windows.go
+// Note: we use this until we finalize our own FD-scoped file.
+type fdFile interface{ Fd() (fd uintptr) }
+
+func statFile(f fs.File, st *Stat_t) (err error) {
+	if of, ok := f.(fdFile); ok {
+		// Attempt to get the stat by handle, which works for normal files
+		err = statHandle(syscall.Handle(of.Fd()), st)
+
+		// ERROR_INVALID_HANDLE happens before Go 1.20. Don't fail as we only
+		// use that approach to fill in inode data, which is not critical.
+		if err != ERROR_INVALID_HANDLE {
+			return
+		}
+	}
+	return defaultStatFile(f, st)
+}
+
+func fillStatFromFileInfo(st *Stat_t, t fs.FileInfo) {
+	if d, ok := t.Sys().(*syscall.Win32FileAttributeData); ok {
+		st.Ino = 0 // not in Win32FileAttributeData
+		st.Dev = 0 // not in Win32FileAttributeData
+		st.Mode = t.Mode()
+		st.Nlink = 1 // not in Win32FileAttributeData
+		st.Size = t.Size()
+		st.Atim = d.LastAccessTime.Nanoseconds()
+		st.Mtim = d.LastWriteTime.Nanoseconds()
+		st.Ctim = d.CreationTime.Nanoseconds()
+	} else {
+		fillStatFromDefaultFileInfo(st, t)
+	}
+}
+
+func statHandle(h syscall.Handle, st *Stat_t) (err error) {
+	winFt, err := syscall.GetFileType(h)
+	if err != nil {
+		return err
+	}
+
+	var fi syscall.ByHandleFileInformation
+	if err = syscall.GetFileInformationByHandle(h, &fi); err != nil {
+		return err
+	}
+
+	var m fs.FileMode
+	if fi.FileAttributes&syscall.FILE_ATTRIBUTE_READONLY != 0 {
+		m |= 0o444
+	} else {
+		m |= 0o666
+	}
+
+	switch { // check whether this is a symlink first
+	case fi.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0:
+		m |= fs.ModeSymlink
+	case winFt == syscall.FILE_TYPE_PIPE:
+		m |= fs.ModeNamedPipe
+	case winFt == syscall.FILE_TYPE_CHAR:
+		m |= fs.ModeDevice | fs.ModeCharDevice
+	case fi.FileAttributes&syscall.FILE_ATTRIBUTE_DIRECTORY != 0:
+		m |= fs.ModeDir | 0o111 // e.g. 0o444 -> 0o555
 	}
 
 	// FileIndex{High,Low} can be combined and used as a unique identifier like inode.
 	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
-	stat.Ino = (uint64(info.FileIndexHigh) << 32) | uint64(info.FileIndexLow)
-	stat.Dev = uint64(info.VolumeSerialNumber)
-	stat.Mode = t.Mode()
-	stat.Nlink = uint64(info.NumberOfLinks)
-	stat.Size = t.Size()
-	stat.Atim = d.LastAccessTime.Nanoseconds()
-	stat.Mtim = d.LastWriteTime.Nanoseconds()
-	stat.Ctim = d.CreationTime.Nanoseconds()
+	st.Dev = uint64(fi.VolumeSerialNumber)
+	st.Ino = (uint64(fi.FileIndexHigh) << 32) | uint64(fi.FileIndexLow)
+	st.Mode = m
+	st.Nlink = uint64(fi.NumberOfLinks)
+	st.Size = int64(fi.FileSizeHigh)<<32 + int64(fi.FileSizeLow)
+	st.Atim = fi.LastAccessTime.Nanoseconds()
+	st.Mtim = fi.LastWriteTime.Nanoseconds()
+	st.Ctim = fi.CreationTime.Nanoseconds()
 	return
 }

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -3,6 +3,8 @@ package sys
 import (
 	"bytes"
 	"io/fs"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,9 +112,20 @@ func TestFileEntry_cachedStat(t *testing.T) {
 			ino, ft, err := f.CachedStat()
 			require.NoError(t, err)
 			require.Equal(t, fs.ModeDir, ft)
+			if !canReadDirInode() {
+				tc.expectedIno = 0
+			}
 			require.Equal(t, tc.expectedIno, ino)
 			require.Equal(t, &cachedStat{Ino: tc.expectedIno, Type: fs.ModeDir}, f.cachedStat)
 		})
+	}
+}
+
+func canReadDirInode() bool {
+	if runtime.GOOS != "windows" {
+		return true
+	} else {
+		return strings.HasPrefix(runtime.Version(), "go1.20")
 	}
 }
 

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -49,6 +49,11 @@ func (d *dirFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, erro
 	}
 }
 
+// Lstat implements FS.Lstat
+func (d *dirFS) Lstat(path string, stat *platform.Stat_t) error {
+	return platform.Lstat(d.join(path), stat)
+}
+
 // Stat implements FS.Stat
 func (d *dirFS) Stat(path string, stat *platform.Stat_t) error {
 	return platform.Stat(d.join(path), stat)

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -45,6 +45,18 @@ func TestDirFS_String(t *testing.T) {
 	require.Equal(t, ".", testFS.String())
 }
 
+func TestDirFS_Lstat(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, fstest.WriteTestFiles(tmpDir))
+
+	testFS := NewDirFS(tmpDir)
+	for _, path := range []string{"animals.txt", "sub", "sub-link"} {
+		require.NoError(t, testFS.Symlink(path, path+"-link"))
+	}
+
+	testLstat(t, testFS)
+}
+
 func TestDirFS_MkDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	testFS := NewDirFS(tmpDir)

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -128,6 +128,11 @@ func maskForReads(f fs.File) fs.File {
 	}
 }
 
+// Lstat implements FS.Lstat
+func (r *readFS) Lstat(path string, lstat *platform.Stat_t) error {
+	return r.fs.Lstat(path, lstat)
+}
+
 // Stat implements FS.Stat
 func (r *readFS) Stat(path string, stat *platform.Stat_t) error {
 	return r.fs.Stat(path, stat)

--- a/internal/sysfs/readfs_test.go
+++ b/internal/sysfs/readfs_test.go
@@ -33,6 +33,20 @@ func TestReadFS_String(t *testing.T) {
 	require.Equal(t, "/tmp", readFS.String())
 }
 
+func TestReadFS_Lstat(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, fstest.WriteTestFiles(tmpDir))
+
+	writeable := NewDirFS(tmpDir)
+	for _, path := range []string{"animals.txt", "sub", "sub-link"} {
+		require.NoError(t, writeable.Symlink(path, path+"-link"))
+	}
+
+	testFS := NewReadFS(writeable)
+
+	testLstat(t, testFS)
+}
+
 func TestReadFS_MkDir(t *testing.T) {
 	writeable := NewDirFS(t.TempDir())
 	testFS := NewReadFS(writeable)

--- a/internal/sysfs/sysfs.go
+++ b/internal/sysfs/sysfs.go
@@ -61,6 +61,22 @@ type FS interface {
 	// ^^ TODO: Consider syscall.Open, though this implies defining and
 	// coercing flags and perms similar to what is done in os.OpenFile.
 
+	// Lstat is similar to syscall.Lstat, except the path is relative to this
+	// file system.
+	//
+	// # Errors
+	//
+	// The following errors are expected:
+	//   - syscall.ENOENT: `path` doesn't exist.
+	//
+	// # Notes
+	//
+	//   - An fs.FileInfo backed implementation sets atim, mtim and ctim to the
+	//     same value.
+	//   - When the path is a symbolic link, the stat returned is for the link,
+	//     not the file it refers to.
+	Lstat(path string, stat *platform.Stat_t) error
+
 	// Stat is similar to syscall.Stat, except the path is relative to this
 	// file system.
 	//
@@ -73,6 +89,8 @@ type FS interface {
 	//
 	//   - An fs.FileInfo backed implementation sets atim, mtim and ctim to the
 	//     same value.
+	//   - When the path is a symbolic link, the stat returned is for the file
+	//     it refers to.
 	Stat(path string, stat *platform.Stat_t) error
 
 	// Mkdir is similar to os.Mkdir, except the path is relative to this file

--- a/internal/sysfs/unsupported.go
+++ b/internal/sysfs/unsupported.go
@@ -26,6 +26,11 @@ func (UnimplementedFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.Fil
 	return nil, syscall.ENOSYS
 }
 
+// Lstat implements FS.Lstat
+func (UnimplementedFS) Lstat(path string, stat *platform.Stat_t) error {
+	return syscall.ENOSYS
+}
+
 // Stat implements FS.Stat
 func (UnimplementedFS) Stat(path string, stat *platform.Stat_t) error {
 	return syscall.ENOSYS


### PR DESCRIPTION
This implements platform.Lstat and uses it in GOOS=js. Notably, directory listings need to run lstat on their entries to get the correct inodes back. In GOOS=js, directories are a fan-out of names, then lstat.

This also fixes stat for inodes on directories. We were missing a test so we didn't know it was broken on windows. The approach used now is reliable on go 1.20, and we should suggest anyone using windows to compile with go 1.20.