### PR TITLE
compiler: pass runtimeValueLocationStack by values to reduce allocations

### DIFF
--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -34,7 +34,7 @@ func TestCompiler_releaseRegisterToStack(t *testing.T) {
 			require.NoError(t, err)
 
 			// Set up the location stack so that we push the const on the specified height.
-			s := &runtimeValueLocationStack{
+			s := runtimeValueLocationStack{
 				sp:                                tc.stackPointer,
 				stack:                             make([]runtimeValueLocation, tc.stackPointer),
 				usedRegisters:                     map[asm.Register]struct{}{},
@@ -51,7 +51,7 @@ func TestCompiler_releaseRegisterToStack(t *testing.T) {
 			}
 			require.NoError(t, err)
 			// Release the register allocated value to the memory stack so that we can see the value after exiting.
-			compiler.compileReleaseRegisterToStack(s.peek())
+			compiler.compileReleaseRegisterToStack(compiler.runtimeValueLocationStack().peek())
 			compiler.compileExitFromNativeCode(nativeCallStatusCodeReturned)
 
 			// Generate the code under test.

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -254,7 +254,7 @@ type compilerImpl interface {
 	getOnStackPointerCeilDeterminedCallBack() func(uint64)
 	setStackPointerCeil(uint64)
 	compileReleaseRegisterToStack(loc *runtimeValueLocation)
-	setRuntimeValueLocationStack(*runtimeValueLocationStack)
+	setRuntimeValueLocationStack(runtimeValueLocationStack)
 	compileEnsureOnRegister(loc *runtimeValueLocation) error
 	compileModuleContextInitialization() error
 }

--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -109,8 +109,8 @@ func (v *runtimeValueLocation) String() string {
 	return fmt.Sprintf("{type=%s,location=%s}", v.valueType, location)
 }
 
-func newRuntimeValueLocationStack() *runtimeValueLocationStack {
-	return &runtimeValueLocationStack{
+func newRuntimeValueLocationStack() runtimeValueLocationStack {
+	return runtimeValueLocationStack{
 		stack:                             make([]runtimeValueLocation, 10),
 		usedRegisters:                     map[asm.Register]struct{}{},
 		unreservedVectorRegisters:         unreservedVectorRegisters,
@@ -142,6 +142,10 @@ type runtimeValueLocationStack struct {
 	unreservedGeneralPurposeRegisters, unreservedVectorRegisters []asm.Register
 }
 
+func (v *runtimeValueLocationStack) initialized() bool {
+	return len(v.unreservedGeneralPurposeRegisters) > 0
+}
+
 func (v *runtimeValueLocationStack) reset() {
 	v.stackPointerCeil, v.sp = 0, 0
 	v.stack = v.stack[:0]
@@ -160,8 +164,8 @@ func (v *runtimeValueLocationStack) String() string {
 	return fmt.Sprintf("sp=%d, stack=[%s], used_registers=[%s]", v.sp, strings.Join(stackStr, ","), strings.Join(usedRegisters, ","))
 }
 
-func (v *runtimeValueLocationStack) clone() *runtimeValueLocationStack {
-	ret := &runtimeValueLocationStack{}
+func (v *runtimeValueLocationStack) clone() runtimeValueLocationStack {
+	ret := runtimeValueLocationStack{}
 	ret.sp = v.sp
 	ret.usedRegisters = make(map[asm.Register]struct{}, len(ret.usedRegisters))
 	for r := range v.usedRegisters {

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -589,6 +589,6 @@ func (c *amd64Compiler) setStackPointerCeil(v uint64) {
 }
 
 // compile implements compilerImpl.setRuntimeValueLocationStack for the amd64 architecture.
-func (c *amd64Compiler) setRuntimeValueLocationStack(s *runtimeValueLocationStack) {
+func (c *amd64Compiler) setRuntimeValueLocationStack(s runtimeValueLocationStack) {
 	c.locationStack = s
 }

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -113,6 +113,6 @@ func (c *arm64Compiler) setStackPointerCeil(v uint64) {
 }
 
 // compile implements compilerImpl.setRuntimeValueLocationStack for the amd64 architecture.
-func (c *arm64Compiler) setRuntimeValueLocationStack(s *runtimeValueLocationStack) {
+func (c *arm64Compiler) setRuntimeValueLocationStack(s runtimeValueLocationStack) {
 	c.locationStack = s
 }


### PR DESCRIPTION
```
name         old time/op    new time/op    delta
_compile-10     870ms ± 0%     863ms ± 1%  -0.79%  (p=0.000 n=18+20)

name         old alloc/op   new alloc/op   delta
_compile-10     589MB ± 0%     565MB ± 0%  -4.03%  (p=0.000 n=20+19)

name         old allocs/op  new allocs/op  delta
_compile-10     7.22M ± 0%     6.69M ± 0%  -7.24%  (p=0.000 n=20+19)
```