### PR TITLE
data segment: encode the right prefix if a const expr is missing

### DIFF
--- a/internal/wasm/binary/data.go
+++ b/internal/wasm/binary/data.go
@@ -79,9 +79,13 @@ func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (*wasm
 }
 
 func encodeDataSegment(d *wasm.DataSegment) (ret []byte) {
-	// Currently multiple memories are not supported.
-	ret = append(ret, leb128.EncodeInt32(0)...)
-	ret = append(ret, encodeConstantExpression(d.OffsetExpression)...)
+	if d.OffsetExpression == nil {
+		ret = append(ret, leb128.EncodeInt32(int32(dataSegmentPrefixPassive))...)
+	} else {
+		// Currently multiple memories are not supported.
+		ret = append(ret, leb128.EncodeInt32(int32(dataSegmentPrefixActive))...)
+		ret = append(ret, encodeConstantExpression(d.OffsetExpression)...)
+	}
 	ret = append(ret, leb128.EncodeUint32(uint32(len(d.Init)))...)
 	ret = append(ret, d.Init...)
 	return


### PR DESCRIPTION
If `OffsetExpression` is nil, we assume passive mode and use `0x1`

0x2 is only for the cases where the memory index is >=0,
i.e. even though 0 is a valid value, it only makes sense to use
when it is > 0. However, currently the spec does not support indices > 0.

So, for the time being, we only do the simple thing and correctly encode
passive segments as 0x1, otherwise defaulting to 0x0

This is a port of the patch at https://github.com/tetratelabs/wabin/pull/7

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
