### PR TITLE
Ensure `nil` is accepted as FS config

### DIFF
--- a/config.go
+++ b/config.go
@@ -667,7 +667,11 @@ func (c *moduleConfig) WithEnv(key, value string) ModuleConfig {
 
 // WithFS implements ModuleConfig.WithFS
 func (c *moduleConfig) WithFS(fs fs.FS) ModuleConfig {
-	return c.WithFSConfig(NewFSConfig().WithFSMount(fs, ""))
+	var config FSConfig
+	if fs != nil {
+		config = NewFSConfig().WithFSMount(fs, "")
+	}
+	return c.WithFSConfig(config)
 }
 
 // WithFSConfig implements ModuleConfig.WithFSConfig

--- a/config_test.go
+++ b/config_test.go
@@ -361,6 +361,24 @@ func TestModuleConfig_toSysContext(t *testing.T) {
 			),
 		},
 		{
+			name:  "WithFS nil",
+			input: base.WithFS(nil),
+			expected: requireSysContext(t,
+				math.MaxUint32, // max
+				nil,            // args
+				nil,            // environ
+				nil,            // stdin
+				nil,            // stdout
+				nil,            // stderr
+				nil,            // randSource
+				&wt, 1,         // walltime, walltimeResolution
+				&nt, 1, // nanotime, nanotimeResolution
+				nil, // nanosleep
+				nil, // osyield
+				nil, // fs
+			),
+		},
+		{
 			name:  "WithRandSource",
 			input: base.WithRandSource(rand.Reader),
 			expected: requireSysContext(t,

--- a/fsconfig_test.go
+++ b/fsconfig_test.go
@@ -36,6 +36,11 @@ func TestFSConfig(t *testing.T) {
 			expected: sysfs.Adapt(testFS2),
 		},
 		{
+			name:     "WithFsMount nil",
+			input:    base.WithFSMount(nil, "/"),
+			expected: sysfs.UnimplementedFS{},
+		},
+		{
 			name:     "WithDirMount overwrites",
 			input:    base.WithFSMount(testFS, "/").WithDirMount(".", "/"),
 			expected: sysfs.NewDirFS("."),

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -19,6 +19,9 @@ import (
 // documentation does not require the file to be present. In summary, we can't
 // enforce flag behavior.
 func Adapt(fs fs.FS) FS {
+	if fs == nil {
+		return UnimplementedFS{}
+	}
 	if sys, ok := fs.(FS); ok {
 		return sys
 	}

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+func TestAdapt_nil(t *testing.T) {
+	testFS := Adapt(nil)
+	_, ok := testFS.(UnimplementedFS)
+	require.True(t, ok)
+}
+
 func TestAdapt_String(t *testing.T) {
 	testFS := Adapt(os.DirFS("."))
 	require.Equal(t, ".", testFS.String())


### PR DESCRIPTION
In previous releases, passing a `nil` value as an FS config did not cause any error. However, in 1.0.0-rc.1 this leads
to the creation of an invalid `adapter{fs: nil}`, which eventually leads to a panic (nil):

    (f *FileEntry) Stat(st *platform.Stat_t) =>
        (r *lazyDir) file() =>
            r.fs.OpenFile(".", os.O_RDONLY, 0)

with fs == nil

The backwards-compatible fix is to make Adapt() return UnimplementedFS.

However, we may want to consider returning an error somewhere, because configuring a nil FS may be unintended.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
