### PR TITLE
ci: GH release job in response to tag creations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,6 +85,7 @@ jobs:
 
   # pre_release_test tests the artifacts built by pre_release in the OS dependent way.
   pre_release_test:
+    if: github.event_name != 'push' || !contains(github.ref, 'refs/tags/')
     needs: pre_release
     name: Pre-release test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -140,7 +141,7 @@ jobs:
   # Triggers only on the tag creation.
   release:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: pre_release_test
+    needs: pre_release
     name: Release
     # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,13 +7,11 @@ on:
       - 'site/**'
       - 'netlify.toml'
   push:
-    branches: [main]
+    branches: [more3]
     paths-ignore:  # ignore docs as they are built with Netlify.
       - '**/*.md'
       - 'site/**'
       - 'netlify.toml'
-
-  # TODO: add tag trigger
 
 env: # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.20"  # 1.xx == latest patch of 1.xx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,7 @@ jobs:
          # Check if the version was correctly inserted with VERSION variable
         if: runner.os == 'Linux'
         run: |
+          ls dist
           tar xf dist/wazero_${{ needs.pre_release.outputs.VERSION }}_linux_amd64.tar.gz
           ./wazero version | grep ${{ needs.pre_release.outputs.VERSION }}
 
@@ -127,6 +128,7 @@ jobs:
         # Check if the version was correctly inserted with VERSION variable
         if: runner.os == 'macOS'
         run: |
+          ls dist
           tar xf dist/wazero_${{ needs.pre_release.outputs.VERSION }}_darwin_amd64.tar.gz
           ./wazero version | grep ${{ needs.pre_release.outputs.VERSION }}
 
@@ -135,6 +137,7 @@ jobs:
       - name: Test Windows Installer
         if: runner.os == 'Windows'
         run: |
+          ls dist
           set MSI_FILE="dist\wazero_${{ needs.pre_release.outputs.VERSION }}_windows_amd64.msi"
           call packaging\msi\verify_msi.cmd
         shell: cmd
@@ -167,6 +170,8 @@ jobs:
             dist/
 
       - name: Create draft release
-        run: gh release create ${tag} --draft --title ${GITHUB_REF#refs/tags/} ./dist/*
+        run: |
+          ls dist
+          gh release create ${tag} --draft --title ${GITHUB_REF#refs/tags/} ./dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       - 'site/**'
       - 'netlify.toml'
   push:
-    branches: [more3]
+    branches: [main]
     tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
 
 env: # Update this prior to requiring a higher minor version in go.mod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,8 @@ jobs:
     name: Pre-release build
     # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
     runs-on: ubuntu-22.04
+    outputs:
+      VERSION: ${{ steps.output-version.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v3
 
@@ -55,17 +57,23 @@ jobs:
         if: github.event_name != 'push' || !contains(github.ref, 'refs/tags/')
         env:
           WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
-        run: | # Checks artifacts are buildable.
-          make dist VERSION=${{ github.sha }}
+        run: |
+          VERSION=${{ github.sha }}
+          make dist VERSION=$VERSION
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Make artifacts
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         env:
           WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
-        run: | # Checks artifacts are buildable.
+        run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           MSI_VERSION=${VERSION//-/.}
           make dist VERSION=$VERSION MSI_VERSION=$MSI_VERSION
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - id: output-version
+        run: echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # In order to share the built artifacts in the subsequent tests, we use cache instead of actions/upload-artifacts.
       # The reason is that upload-artifacts are not globally consistent and sometimes pre_release_test won't be able to
@@ -85,7 +93,6 @@ jobs:
 
   # pre_release_test tests the artifacts built by pre_release in the OS dependent way.
   pre_release_test:
-    if: github.event_name != 'push' || !contains(github.ref, 'refs/tags/')
     needs: pre_release
     name: Pre-release test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -111,22 +118,22 @@ jobs:
          # Check if the version was correctly inserted with VERSION variable
         if: runner.os == 'Linux'
         run: |
-          tar xf dist/wazero_${{ github.sha }}_linux_amd64.tar.gz
-          ./wazero version | grep ${{ github.sha }}
+          tar xf dist/wazero_${{ needs.pre_release.outputs.VERSION }}_linux_amd64.tar.gz
+          ./wazero version | grep ${{ needs.pre_release.outputs.VERSION }}
 
       - name: Test (darwin)
         # Check if the version was correctly inserted with VERSION variable
         if: runner.os == 'macOS'
         run: |
-          tar xf dist/wazero_${{ github.sha }}_darwin_amd64.tar.gz
-          ./wazero version | grep ${{ github.sha }}
+          tar xf dist/wazero_${{ needs.pre_release.outputs.VERSION }}_darwin_amd64.tar.gz
+          ./wazero version | grep ${{ needs.pre_release.outputs.VERSION }}
 
       # This only checks the installer when built on Windows as it is simpler than switching OS.
       # refreshenv is from choco, and lets you reload ENV variables (used here for PATH).
       - name: Test Windows Installer
         if: runner.os == 'Windows'
         run: |
-          set MSI_FILE="dist\wazero_${{ github.sha }}_windows_amd64.msi"
+          set MSI_FILE="dist\wazero_${{ needs.pre_release.outputs.VERSION }}_windows_amd64.msi"
           call packaging\msi\verify_msi.cmd
         shell: cmd
 
@@ -135,13 +142,13 @@ jobs:
       - name: Test winget manifest generation
         if: runner.os == 'Windows'
         run: |
-          ./packaging/msi/winget_manifest.sh ${{ github.sha }} "dist\wazero_${{ github.sha }}_windows_amd64.msi" > Tetrate.wazero.yaml
+          ./packaging/msi/winget_manifest.sh ${{ needs.pre_release.outputs.VERSION }} "dist\wazero_${{ needs.pre_release.outputs.VERSION }}_windows_amd64.msi" > Tetrate.wazero.yaml
           yamllint -sd '{extends: default, rules: {line-length: disable}}' Tetrate.wazero.yaml
 
   # Triggers only on the tag creation.
   release:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: pre_release
+    needs: pre_release_test
     name: Release
     # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
     name: Pre-release build
     # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
     runs-on: ubuntu-22.04
+    # This allows us to test in the following job regardless of the event (tag or not).
     outputs:
       VERSION: ${{ steps.output-version.outputs.VERSION }}
     steps:
@@ -63,15 +64,17 @@ jobs:
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Make artifacts
+        # Triggers only on tag creation.
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         env:
           WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
-        run: |
+        run: | # Note: MSI_VERSION requires . as a separator, so replace "-" in the tag with ".".
           VERSION=${GITHUB_REF#refs/tags/v}
           MSI_VERSION=${VERSION//-/.}
           make dist VERSION=$VERSION MSI_VERSION=$MSI_VERSION
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
+      # This allows us to test in the following job regardless of the event (tag or not).
       - id: output-version
         run: echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -150,7 +153,6 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: pre_release_test
     name: Release
-    # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,7 @@ jobs:
           VERSION=${{ github.sha }}
           make dist VERSION=$VERSION
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          ls dist
 
       - name: Make artifacts
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
@@ -71,6 +72,7 @@ jobs:
           MSI_VERSION=${VERSION//-/.}
           make dist VERSION=$VERSION MSI_VERSION=$MSI_VERSION
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          ls dist
 
       - id: output-version
         run: echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,6 +140,7 @@ jobs:
   # Triggers only on the tag creation.
   release:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: pre_release_test
     name: Release
     # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,7 @@ on:
       - 'netlify.toml'
   push:
     branches: [more3]
-    paths-ignore:  # ignore docs as they are built with Netlify.
-      - '**/*.md'
-      - 'site/**'
-      - 'netlify.toml'
+    tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
 
 env: # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.20"  # 1.xx == latest patch of 1.xx
@@ -54,11 +51,21 @@ jobs:
           echo ${{ secrets.WINDOWS_CODESIGN_P12_BASE64 }} | base64 --decode > windows-certificate.p12
           echo "WINDOWS_CODESIGN_P12=windows-certificate.p12" >> $GITHUB_ENV
 
-      - name: Make artifacts
+      - name: Make artifacts (test)
+        if: github.event_name != 'push' || !contains(github.ref, 'refs/tags/')
         env:
           WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
         run: | # Checks artifacts are buildable.
           make dist VERSION=${{ github.sha }}
+
+      - name: Make artifacts
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        env:
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
+        run: | # Checks artifacts are buildable.
+          VERSION=${GITHUB_REF#refs/tags/v}
+          MSI_VERSION=${VERSION//-/.}
+          make dist VERSION=$VERSION MSI_VERSION=$MSI_VERSION
 
       # In order to share the built artifacts in the subsequent tests, we use cache instead of actions/upload-artifacts.
       # The reason is that upload-artifacts are not globally consistent and sometimes pre_release_test won't be able to
@@ -71,7 +78,7 @@ jobs:
         with:
           # Use share the cache containing archives across OSes.
           enableCrossOsArchive: true
-          # Note: this creates a cache per run. we delete the post tests.
+          # Note: this creates a cache per run.
           key: release-artifacts-${{ github.run_id }}
           path:
             dist/
@@ -130,4 +137,25 @@ jobs:
           ./packaging/msi/winget_manifest.sh ${{ github.sha }} "dist\wazero_${{ github.sha }}_windows_amd64.msi" > Tetrate.wazero.yaml
           yamllint -sd '{extends: default, rules: {line-length: disable}}' Tetrate.wazero.yaml
 
-  # TODO: release creation job depending on pre_release_test, which is only run on tag creation event.
+  # Triggers only on the tag creation.
+  release:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    name: Release
+    # This only runs on ubuntu so that we can simplify the installation of necessary toolchain to build artifacts.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          fail-on-cache-miss: true
+          enableCrossOsArchive: true
+          key: release-artifacts-${{ github.run_id }}
+          path:
+            dist/
+
+      - name: Create draft release
+        run: gh release create ${tag} --draft --title ${GITHUB_REF#refs/tags/} ./dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,6 @@ jobs:
           VERSION=${{ github.sha }}
           make dist VERSION=$VERSION
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          ls dist
 
       - name: Make artifacts
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
@@ -72,7 +71,6 @@ jobs:
           MSI_VERSION=${VERSION//-/.}
           make dist VERSION=$VERSION MSI_VERSION=$MSI_VERSION
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          ls dist
 
       - id: output-version
         run: echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -120,7 +118,6 @@ jobs:
          # Check if the version was correctly inserted with VERSION variable
         if: runner.os == 'Linux'
         run: |
-          ls dist
           tar xf dist/wazero_${{ needs.pre_release.outputs.VERSION }}_linux_amd64.tar.gz
           ./wazero version | grep ${{ needs.pre_release.outputs.VERSION }}
 
@@ -128,7 +125,6 @@ jobs:
         # Check if the version was correctly inserted with VERSION variable
         if: runner.os == 'macOS'
         run: |
-          ls dist
           tar xf dist/wazero_${{ needs.pre_release.outputs.VERSION }}_darwin_amd64.tar.gz
           ./wazero version | grep ${{ needs.pre_release.outputs.VERSION }}
 
@@ -137,7 +133,6 @@ jobs:
       - name: Test Windows Installer
         if: runner.os == 'Windows'
         run: |
-          ls dist
           set MSI_FILE="dist\wazero_${{ needs.pre_release.outputs.VERSION }}_windows_amd64.msi"
           call packaging\msi\verify_msi.cmd
         shell: cmd
@@ -172,6 +167,8 @@ jobs:
       - name: Create draft release
         run: |
           ls dist
-          gh release create ${tag} --draft --title ${GITHUB_REF#refs/tags/} ./dist/*
+          tag="${GITHUB_REF#refs/tags/}"
+          ./.github/workflows/release_notes.sh ${tag} > release-notes.txt
+          gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/} ./dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_notes.sh
+++ b/.github/workflows/release_notes.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -ue
+#
+# This script generates the release notes "wazero" for a specific release tag.
+# .github/workflows/release_notes.sh v1.3.0
+
+tag=$1
+prior_tag=$(git tag -l 'v*'|sed "/${tag}/,+10d"|tail -1)
+if [ -n "${prior_tag}" ]; then
+  range="${prior_tag}..${tag}"
+else
+  range=${tag}
+fi
+
+git config log.mailmap true
+changelog=$(git log --format='%h %s %aN, %(trailers:key=co-authored-by)' "${range}")
+
+# strip the v off the tag name more shell portable than ${tag:1}
+version=$(echo "${tag}" | cut -c2-100) || exit 1
+cat <<EOF
+wazero ${version} supports X and Y and notably fixes Z
+
+TODO: classify the below into up to 4 major headings and the rest as bulleted items in minor changes
+The published release notes should only include the summary statement in this section.
+
+${changelog}
+
+## X packages
+
+Don't forget to cite who was involved and why
+
+## wazero Y
+
+## Minor changes
+
+TODO: don't add trivial things like fixing spaces or non-concerns like build glitches
+
+* Z is now fixed thanks to Yogi Bear
+
+EOF

--- a/Makefile
+++ b/Makefile
@@ -262,11 +262,12 @@ fuzz:
 #### CLI release related ####
 
 VERSION ?= dev
-# Default to a dummy version 0.0.1, which is always lower than a real release.
-# This must be in the form of [0-255].[0-255].[0-65535] as opposed to VERSION which can be arbitrary.
+# Default to a dummy version 0.0.1.rc1, which is always lower than a real release.
+# This must be in the form of [0-255].[0-255].[0-65535] plus optional fourth .[0-65532] which will be ignored.
+# We use the fourth field to represent the rc portion of release tag (e.g. rc1 of 1.0.0-rc2).
 # https://learn.microsoft.com/en-us/windows/win32/msi/productversion?redirectedfrom=MSDN
 # https://stackoverflow.com/questions/9312221/msi-version-numbers
-MIS_VERSION ?= 0.0.1
+MSI_VERSION ?= 0.0.1.rc1
 non_windows_platforms := darwin_amd64 darwin_arm64 linux_amd64 linux_arm64
 non_windows_archives  := $(non_windows_platforms:%=dist/wazero_$(VERSION)_%.tar.gz)
 windows_platforms     := windows_amd64 # TODO: add arm64 windows once we start testing on it.
@@ -328,7 +329,7 @@ endef
 dist/wazero_$(VERSION)_%.msi: build/wazero_%/wazero.exe.signed
 	@echo msi "building $@"
 	@mkdir -p $(@D)
-	@wixl -a $(call msi-arch,$@) -D Version=$(MIS_VERSION) -D Bin=$(<:.signed=) -o $@ packaging/msi/wazero.wxs
+	@wixl -a $(call msi-arch,$@) -D Version=$(MSI_VERSION) -D Bin=$(<:.signed=) -o $@ packaging/msi/wazero.wxs
 	$(call codesign,$@)
 	@echo msi "ok"
 

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ fuzz:
 
 VERSION ?= dev
 # Default to a dummy version 0.0.1.rc1, which is always lower than a real release.
-# This must be in the form of [0-255].[0-255].[0-65535] plus optional fourth .[0-65532] which will be ignored.
+# This must be in the form of [0-255].[0-255].[0-65535] plus optional fourth element which will be ignored.
 # We use the fourth field to represent the rc portion of release tag (e.g. rc1 of 1.0.0-rc2).
 # https://learn.microsoft.com/en-us/windows/win32/msi/productversion?redirectedfrom=MSDN
 # https://stackoverflow.com/questions/9312221/msi-version-numbers


### PR DESCRIPTION
The adds a job to create a GH release in response to the tag creation event.


This has been verified to work (I did in the private repo) both for rcN tag and real tags:

# real tags
![image](https://user-images.githubusercontent.com/13513977/222343978-aa5790de-e336-4c28-824d-a0a648e52c72.png)

![image](https://user-images.githubusercontent.com/13513977/222344081-fa9f7c2b-9843-4cbd-a5c6-1c783dc0ef48.png)




# rc tags

![image](https://user-images.githubusercontent.com/13513977/222344013-2dfd8b8c-43c8-4cec-9a08-6dbc390aae39.png)

![image](https://user-images.githubusercontent.com/13513977/222343601-c9e1f9e6-3375-42be-964f-64898525d6ae.png)




# non tag event (release job skipped)

![image](https://user-images.githubusercontent.com/13513977/222344249-0806c1e4-d352-4c2d-a2d3-5b3faf646d1d.png)

