### PR TITLE
ci: remove -short flag on main branch test

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ github.event_name  == 'pull_request' }}
 
       # Run tests with -race only on main branch push.
-      - run: make test go_test_options='-timeout 10m -race -short'
+      - run: make test go_test_options='-timeout 10m -race'
         if: ${{ github.event_name  == 'push' }}
 
       - name: "Generate coverage report"  # only once (not per OS)


### PR DESCRIPTION
why we have been using `-short` on main..