### PR TITLE
build: fix issue with GNU make vs BSD make

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:  # Use versions consistent with wazero's Go support policy.
-        os: [ubuntu-20.04, macos-12, windows-2022]  # TODO: update to 22.04 See #1171
+        os: [ubuntu-22.04, macos-12, windows-2022]
         go-version:
           - "1.20"  # Current Go version
           - "1.18"  # Floor Go version of wazero (current - 2)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
 
-# Make functions strip spaces and use commas to separate parameters. The below variables escape these characters.
-comma := ,
-space :=
-space +=
-
 gofumpt := mvdan.cc/gofumpt@v0.4.0
 gosimports := github.com/rinchsan/gosimports/cmd/gosimports@v0.3.5
 golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
@@ -180,7 +175,8 @@ test:
 	@cd internal/version/testdata && go test $(go_test_options) ./...
 
 .PHONY: coverage
-coverpkg = $(subst $(space),$(comma),$(main_packages))
+# replace spaces with commas
+coverpkg = $(main_packages: =,)
 coverage: ## Generate test coverage
 	@go test -coverprofile=coverage.txt -covermode=atomic --coverpkg=$(coverpkg) $(main_packages)
 	@go tool cover -func coverage.txt


### PR DESCRIPTION
It looks like $(subst from,to,text) works differently on BSD make
vs GNU make. The behavior we expected for

    $(subst,$(space),$(comma),$(var))

is instead the behavior of `$(patsubst ...)` on GNU Make.

The alternative syntax `$(var: =,)` seems portable across the two
and shows the same behavior.

(tested on Fedora 37, closes #1171)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
