### PR TITLE
gojs: implements chown

### DIFF
--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -575,8 +575,8 @@ func (jsfsChown) invoke(ctx context.Context, mod api.Module, args ...interface{}
 	gid := goos.ValueToUint32(args[2])
 	callback := args[3].(funcWrapper)
 
-	_, _, _ = path, uid, gid // TODO
-	var err error = syscall.ENOSYS
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+	err := fsc.RootFS().Chown(path, int(uid), int(gid))
 
 	return jsfsInvoke(ctx, mod, callback, err)
 }
@@ -592,8 +592,14 @@ func (jsfsFchown) invoke(ctx context.Context, mod api.Module, args ...interface{
 	gid := goos.ValueToUint32(args[2])
 	callback := args[3].(funcWrapper)
 
-	_, _, _ = fd, uid, gid // TODO
-	var err error = syscall.ENOSYS
+	// Check to see if the file descriptor is available
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+	var err error
+	if f, ok := fsc.LookupFile(fd); !ok {
+		err = syscall.EBADF
+	} else {
+		err = platform.ChownFile(f.File, int(uid), int(gid))
+	}
 
 	return jsfsInvoke(ctx, mod, callback, err)
 }
@@ -609,8 +615,8 @@ func (jsfsLchown) invoke(ctx context.Context, mod api.Module, args ...interface{
 	gid := goos.ValueToUint32(args[2])
 	callback := args[3].(funcWrapper)
 
-	_, _, _ = path, uid, gid // TODO
-	var err error = syscall.ENOSYS
+	fsc := mod.(*wasm.CallContext).Sys.FS()
+	err := fsc.RootFS().Lchown(path, int(uid), int(gid))
 
 	return jsfsInvoke(ctx, mod, callback, err)
 }

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -83,6 +83,12 @@ func Main() {
 	} else if mode := stat.Mode() & fs.ModePerm; mode != 0o400 {
 		log.Panicln("expected mode = 0o400", mode)
 	}
+
+	// Invoke Chown in a way nothing changes, to ensure it doesn't panic.
+	if err = f.Chown(-1, -1); err != nil {
+		log.Panicln(err)
+	}
+
 	// Finally, close it.
 	if err = f.Close(); err != nil {
 		log.Panicln(err)
@@ -96,6 +102,11 @@ func Main() {
 	// Test stat
 	stat, err := os.Stat(file1)
 	if err != nil {
+		log.Panicln(err)
+	}
+
+	// Invoke Chown in a way nothing changes, to ensure it doesn't panic.
+	if err = os.Chown(file1, -1, -1); err != nil {
 		log.Panicln(err)
 	}
 
@@ -169,6 +180,11 @@ func Main() {
 	// A symbolic link isn't the same file as what it points to.
 	if os.SameFile(file1Stat, symlinkStat) {
 		log.Panicln("expected file != link stat", file1Stat, symlinkStat)
+	}
+
+	// Invoke Lchown in a way nothing changes, to ensure it doesn't panic.
+	if err = os.Lchown(symlink, -1, -1); err != nil {
+		log.Panicln(err)
 	}
 
 	// Test removing a non-empty empty directory

--- a/internal/platform/chown.go
+++ b/internal/platform/chown.go
@@ -1,0 +1,40 @@
+package platform
+
+import (
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// Chown is like os.Chown, except it returns a syscall.Errno, not a
+// fs.PathError. For example, this returns syscall.ENOENT if the path doesn't
+// exist. See https://linux.die.net/man/3/chown
+//
+// Note: This always returns syscall.ENOSYS on windows.
+func Chown(path string, uid, gid int) error {
+	err := os.Chown(path, uid, gid)
+	return UnwrapOSError(err)
+}
+
+// Lchown is like os.Lchown, except it returns a syscall.Errno, not a
+// fs.PathError. For example, this returns syscall.ENOENT if the path doesn't
+// exist. See https://linux.die.net/man/3/lchown
+//
+// Note: This always returns syscall.ENOSYS on windows.
+func Lchown(path string, uid, gid int) error {
+	err := os.Lchown(path, uid, gid)
+	return UnwrapOSError(err)
+}
+
+// ChownFile is like syscall.Fchown, but for nanosecond precision and
+// fs.File instead of a file descriptor. This returns syscall.EBADF if the file
+// or directory was closed. See https://linux.die.net/man/3/fchown
+//
+// Note: This always returns syscall.ENOSYS on windows.
+func ChownFile(f fs.File, uid, gid int) error {
+	if f, ok := f.(fdFile); ok {
+		err := fchown(f.Fd(), uid, gid)
+		return UnwrapOSError(err)
+	}
+	return syscall.ENOSYS
+}

--- a/internal/platform/chown_unix.go
+++ b/internal/platform/chown_unix.go
@@ -1,4 +1,4 @@
-//go:build unix || (js && wasm)
+//go:build !windows
 
 package platform
 

--- a/internal/platform/chown_unix.go
+++ b/internal/platform/chown_unix.go
@@ -1,0 +1,9 @@
+//go:build unix || (js && wasm)
+
+package platform
+
+import "syscall"
+
+func fchown(fd uintptr, uid, gid int) error {
+	return syscall.Fchown(int(fd), uid, gid)
+}

--- a/internal/platform/chown_unix_test.go
+++ b/internal/platform/chown_unix_test.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build !windows
 
 package platform
 

--- a/internal/platform/chown_unix_test.go
+++ b/internal/platform/chown_unix_test.go
@@ -1,0 +1,174 @@
+//go:build unix
+
+package platform
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestChown(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := path.Join(tmpDir, "dir")
+	require.NoError(t, os.Mkdir(dir, 0o0777))
+	dirF, err := OpenFile(dir, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	dirStat, err := dirF.Stat()
+	require.NoError(t, err)
+	dirSys := dirStat.Sys().(*syscall.Stat_t)
+
+	// Similar to TestChown in os_unix_test.go, we can't expect to change
+	// owner unless root, and with another user. Instead, test gid.
+	gid := os.Getgid()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+
+	t.Run("-1 parameters means leave alone", func(t *testing.T) {
+		require.NoError(t, Chown(dir, -1, -1))
+		checkUidGid(t, dir, dirSys.Uid, dirSys.Gid)
+	})
+
+	t.Run("change gid, but not uid", func(t *testing.T) {
+		require.NoError(t, Chown(dir, -1, gid))
+		checkUidGid(t, dir, dirSys.Uid, uint32(gid))
+	})
+
+	// Now, try any other groups of the current user.
+	for _, g := range groups {
+		g := g
+		t.Run(fmt.Sprintf("change to gid %d", g), func(t *testing.T) {
+			// Test using our Chown
+			require.NoError(t, Chown(dir, -1, g))
+			checkUidGid(t, dir, dirSys.Uid, uint32(g))
+
+			// Revert back with os.File.Chown
+			require.NoError(t, dirF.Chown(-1, gid))
+			checkUidGid(t, dir, dirSys.Uid, uint32(gid))
+		})
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		require.EqualErrno(t, syscall.ENOENT, Chown(path.Join(tmpDir, "a"), -1, gid))
+	})
+}
+
+func TestChownFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := path.Join(tmpDir, "dir")
+	require.NoError(t, os.Mkdir(dir, 0o0777))
+	dirF, err := OpenFile(dir, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	dirStat, err := dirF.Stat()
+	require.NoError(t, err)
+	dirSys := dirStat.Sys().(*syscall.Stat_t)
+
+	// Similar to TestChownFile in os_unix_test.go, we can't expect to change
+	// owner unless root, and with another user. Instead, test gid.
+	gid := os.Getgid()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+
+	t.Run("-1 parameters means leave alone", func(t *testing.T) {
+		require.NoError(t, ChownFile(dirF, -1, -1))
+		checkUidGid(t, dir, dirSys.Uid, dirSys.Gid)
+	})
+
+	t.Run("change gid, but not uid", func(t *testing.T) {
+		require.NoError(t, ChownFile(dirF, -1, gid))
+		checkUidGid(t, dir, dirSys.Uid, uint32(gid))
+	})
+
+	// Now, try any other groups of the current user.
+	for _, g := range groups {
+		g := g
+		t.Run(fmt.Sprintf("change to gid %d", g), func(t *testing.T) {
+			// Test using our ChownFile
+			require.NoError(t, ChownFile(dirF, -1, g))
+			checkUidGid(t, dir, dirSys.Uid, uint32(g))
+
+			// Revert back with os.File.Chown
+			require.NoError(t, dirF.Chown(-1, gid))
+			checkUidGid(t, dir, dirSys.Uid, uint32(gid))
+		})
+	}
+
+	t.Run("closed", func(t *testing.T) {
+		require.NoError(t, dirF.Close())
+		require.EqualErrno(t, syscall.EBADF, ChownFile(dirF, -1, gid))
+	})
+}
+
+func TestLchown(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir := path.Join(tmpDir, "dir")
+	require.NoError(t, os.Mkdir(dir, 0o0777))
+	dirF, err := OpenFile(dir, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	dirStat, err := dirF.Stat()
+	require.NoError(t, err)
+	dirSys := dirStat.Sys().(*syscall.Stat_t)
+
+	link := path.Join(tmpDir, "link")
+	require.NoError(t, os.Symlink(dir, link))
+	linkF, err := OpenFile(link, syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	linkStat, err := linkF.Stat()
+	require.NoError(t, err)
+	linkSys := linkStat.Sys().(*syscall.Stat_t)
+
+	// Similar to TestLchown in os_unix_test.go, we can't expect to change
+	// owner unless root, and with another user. Instead, test gid.
+	gid := os.Getgid()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+
+	t.Run("-1 parameters means leave alone", func(t *testing.T) {
+		require.NoError(t, Lchown(link, -1, -1))
+		checkUidGid(t, link, linkSys.Uid, linkSys.Gid)
+	})
+
+	t.Run("change gid, but not uid", func(t *testing.T) {
+		require.NoError(t, Chown(dir, -1, gid))
+		checkUidGid(t, link, linkSys.Uid, uint32(gid))
+		// Make sure the target didn't change.
+		checkUidGid(t, dir, dirSys.Uid, dirSys.Gid)
+	})
+
+	// Now, try any other groups of the current user.
+	for _, g := range groups {
+		g := g
+		t.Run(fmt.Sprintf("change to gid %d", g), func(t *testing.T) {
+			// Test using our Lchown
+			require.NoError(t, Lchown(link, -1, g))
+			checkUidGid(t, link, linkSys.Uid, uint32(g))
+			// Make sure the target didn't change.
+			checkUidGid(t, dir, dirSys.Uid, dirSys.Gid)
+
+			// Revert back with syscall.Lchown
+			require.NoError(t, syscall.Lchown(link, -1, gid))
+			checkUidGid(t, link, linkSys.Uid, uint32(gid))
+		})
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		require.EqualErrno(t, syscall.ENOENT, Lchown(path.Join(tmpDir, "a"), -1, gid))
+	})
+}
+
+// checkUidGid uses lstat to ensure the comparison is against the file, not the
+// target of a symbolic link.
+func checkUidGid(t *testing.T, path string, uid, gid uint32) {
+	ls, err := os.Lstat(path)
+	require.NoError(t, err)
+	sys := ls.Sys().(*syscall.Stat_t)
+	require.Equal(t, uid, sys.Uid)
+	require.Equal(t, gid, sys.Gid)
+}

--- a/internal/platform/chown_unsupported.go
+++ b/internal/platform/chown_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !unix && !(js && wasm)
+//go:build windows
 
 package platform
 

--- a/internal/platform/chown_unsupported.go
+++ b/internal/platform/chown_unsupported.go
@@ -1,3 +1,5 @@
+//go:build !unix && !(js && wasm)
+
 package platform
 
 import "syscall"

--- a/internal/platform/chown_windows.go
+++ b/internal/platform/chown_windows.go
@@ -1,0 +1,9 @@
+package platform
+
+import "syscall"
+
+// fchown is not supported on windows. For example, syscall.Fchown returns
+// syscall.EWINDOWS, which is the same as syscall.ENOSYS.
+func fchown(fd uintptr, uid, gid int) error {
+	return syscall.ENOSYS
+}

--- a/internal/sysfs/dirfs_unix_test.go
+++ b/internal/sysfs/dirfs_unix_test.go
@@ -1,0 +1,127 @@
+//go:build unix
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestDirFS_Chown(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFS := NewDirFS(tmpDir)
+
+	require.NoError(t, testFS.Mkdir("dir", 0o0777))
+	dirF, err := testFS.OpenFile("dir", syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	dirStat, err := dirF.Stat()
+	require.NoError(t, err)
+	dirSys := dirStat.Sys().(*syscall.Stat_t)
+
+	// Similar to TestChown in os_unix_test.go, we can't expect to change
+	// owner unless root, and with another user. Instead, test gid.
+	gid := os.Getgid()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+
+	t.Run("-1 parameters means leave alone", func(t *testing.T) {
+		require.NoError(t, testFS.Chown("dir", -1, -1))
+		checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, dirSys.Gid)
+	})
+
+	t.Run("change gid, but not uid", func(t *testing.T) {
+		require.NoError(t, testFS.Chown("dir", -1, gid))
+		checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, uint32(gid))
+	})
+
+	// Now, try any other groups of the current user.
+	for _, g := range groups {
+		g := g
+		t.Run(fmt.Sprintf("change to gid %d", g), func(t *testing.T) {
+			// Test using our Chown
+			require.NoError(t, testFS.Chown("dir", -1, g))
+			checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, uint32(g))
+
+			// Revert back with platform.ChownFile
+			require.NoError(t, platform.ChownFile(dirF, -1, gid))
+			checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, uint32(gid))
+		})
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		require.EqualErrno(t, syscall.ENOENT, testFS.Chown("a", -1, gid))
+	})
+}
+
+func TestDirFS_Lchown(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFS := NewDirFS(tmpDir)
+
+	require.NoError(t, testFS.Mkdir("dir", 0o0777))
+	dirF, err := testFS.OpenFile("dir", syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	dirStat, err := dirF.Stat()
+	require.NoError(t, err)
+	dirSys := dirStat.Sys().(*syscall.Stat_t)
+
+	require.NoError(t, testFS.Symlink("dir", "link"))
+	linkF, err := testFS.OpenFile("link", syscall.O_RDONLY, 0)
+	require.NoError(t, err)
+	linkStat, err := linkF.Stat()
+	require.NoError(t, err)
+	linkSys := linkStat.Sys().(*syscall.Stat_t)
+
+	// Similar to TestLchown in os_unix_test.go, we can't expect to change
+	// owner unless root, and with another user. Instead, test gid.
+	gid := os.Getgid()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+
+	t.Run("-1 parameters means leave alone", func(t *testing.T) {
+		require.NoError(t, testFS.Lchown("link", -1, -1))
+		checkUidGid(t, path.Join(tmpDir, "link"), linkSys.Uid, linkSys.Gid)
+	})
+
+	t.Run("change gid, but not uid", func(t *testing.T) {
+		require.NoError(t, testFS.Chown("dir", -1, gid))
+		checkUidGid(t, path.Join(tmpDir, "link"), linkSys.Uid, uint32(gid))
+		// Make sure the target didn't change.
+		checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, dirSys.Gid)
+	})
+
+	// Now, try any other groups of the current user.
+	for _, g := range groups {
+		g := g
+		t.Run(fmt.Sprintf("change to gid %d", g), func(t *testing.T) {
+			// Test using our Lchown
+			require.NoError(t, testFS.Lchown("link", -1, g))
+			checkUidGid(t, path.Join(tmpDir, "link"), linkSys.Uid, uint32(g))
+			// Make sure the target didn't change.
+			checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, dirSys.Gid)
+
+			// Revert back with syscall.Lchown
+			require.NoError(t, syscall.Lchown(path.Join(tmpDir, "link"), -1, gid))
+			checkUidGid(t, path.Join(tmpDir, "link"), linkSys.Uid, uint32(gid))
+		})
+	}
+
+	t.Run("not found", func(t *testing.T) {
+		require.EqualErrno(t, syscall.ENOENT, testFS.Lchown("a", -1, gid))
+	})
+}
+
+// checkUidGid uses lstat to ensure the comparison is against the file, not the
+// target of a symbolic link.
+func checkUidGid(t *testing.T, path string, uid, gid uint32) {
+	ls, err := os.Lstat(path)
+	require.NoError(t, err)
+	sys := ls.Sys().(*syscall.Stat_t)
+	require.Equal(t, uid, sys.Uid)
+	require.Equal(t, gid, sys.Gid)
+}

--- a/internal/sysfs/sysfs.go
+++ b/internal/sysfs/sysfs.go
@@ -128,6 +128,37 @@ type FS interface {
 	// ^^ TODO: Consider syscall.Chmod, though this implies defining and
 	// coercing flags and perms similar to what is done in os.Chmod.
 
+	// Chown is like os.Chown except the path is relative to this file
+	// system, and syscall.Errno are returned instead of an os.PathError.
+	//
+	// # Errors
+	//
+	// The following errors are expected:
+	//   - syscall.EINVAL: `path` is invalid.
+	//   - syscall.ENOENT: `path` does not exist.
+	//
+	// # Notes
+	//
+	//   - Windows will always return syscall.ENOSYS
+	//   - This is similar to https://linux.die.net/man/3/chown
+	Chown(path string, uid, gid int) error
+
+	// Lchown is like os.Lchown except the path is relative to this file
+	// system, and syscall.Errno are returned instead of a os.PathError.
+	//	See https://linux.die.net/man/3/lchown
+	//
+	// # Errors
+	//
+	// The following errors are expected:
+	//   - syscall.EINVAL: `path` is invalid.
+	//   - syscall.ENOENT: `path` does not exist.
+	//
+	// # Notes
+	//
+	//   - Windows will always return syscall.ENOSYS
+	//   - This is similar to https://linux.die.net/man/3/lchown
+	Lchown(path string, uid, gid int) error
+
 	// Rename is similar to syscall.Rename, except the path is relative to this
 	// file system.
 	//

--- a/internal/sysfs/unsupported.go
+++ b/internal/sysfs/unsupported.go
@@ -46,6 +46,16 @@ func (UnimplementedFS) Chmod(path string, perm fs.FileMode) error {
 	return syscall.ENOSYS
 }
 
+// Chown implements FS.Chown
+func (UnimplementedFS) Chown(path string, uid, gid int) error {
+	return syscall.ENOSYS
+}
+
+// Lchown implements FS.Lchown
+func (UnimplementedFS) Lchown(path string, uid, gid int) error {
+	return syscall.ENOSYS
+}
+
 // Rename implements FS.Rename
 func (UnimplementedFS) Rename(from, to string) error {
 	return syscall.ENOSYS


### PR DESCRIPTION
This finishes the last remaining syscalls in `GOOS=js`. After this is merged, further bugs are easier to hunt down as we know ENOSYS is not expected on writeable file systems.