### PR TITLE
gojs: ensures Mkdir(path, 0) works

### DIFF
--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -454,6 +454,10 @@ func (jsfsMkdir) invoke(ctx context.Context, mod api.Module, args ...interface{}
 
 	var fd uint32
 	var err error
+	// We need at least read access to open the file descriptor
+	if perm == 0 {
+		perm = 0o0500
+	}
 	if err = root.Mkdir(path, fs.FileMode(perm)); err == nil {
 		fd, err = fsc.OpenFile(root, path, os.O_RDONLY, 0)
 	}

--- a/internal/gojs/logging/logging.go
+++ b/internal/gojs/logging/logging.go
@@ -286,6 +286,10 @@ func writeVal(w logging.Writer, name string, val interface{}) {
 		w.WriteString(name)                  //nolint
 		w.WriteString("_len=")               //nolint
 		writeI32(w, uint32(len(b.Unwrap()))) //nolint
+	} else if name == "perm" {
+		w.WriteString("perm=") //nolint
+		perm := goos.ValueToUint32(val)
+		w.WriteString(fs.FileMode(perm).String()) //nolint
 	} else {
 		w.WriteString(name)                   //nolint
 		w.WriteByte('=')                      //nolint

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -15,8 +15,7 @@ func Main() {
 	// Create a test directory
 	dir := path.Join(os.TempDir(), "dir")
 	dir1 := path.Join(os.TempDir(), "dir1")
-	err := os.Mkdir(dir, 0o700)
-	if err != nil {
+	if err := os.Mkdir(dir, 0o700); err != nil {
 		log.Panicln(err)
 		return
 	}
@@ -25,8 +24,7 @@ func Main() {
 	// Create a test file in that directory
 	file := path.Join(dir, "file")
 	file1 := path.Join(os.TempDir(), "file1")
-	err = os.WriteFile(file, []byte{}, 0o600)
-	if err != nil {
+	if err := os.WriteFile(file, []byte{}, 0o600); err != nil {
 		log.Panicln(err)
 		return
 	}
@@ -277,4 +275,11 @@ func Main() {
 		log.Panicln(err)
 		return
 	}
+
+	// ensure we can use zero as is used in TestRemoveReadOnlyDir
+	if err = os.Mkdir(dir1, 0); err != nil {
+		log.Panicln(err)
+		return
+	}
+	defer os.Remove(dir)
 }


### PR DESCRIPTION
Go has a test that forces us to handle Mkdir with zero as its permissions. In GOOS=js, the result of fs.mkdir is a file descriptor, and to open that, we can't use literally 0. Hence, to solve this we need to coerce 0 to 0500 in GOOS=js.