### PR TITLE
Pass correct api.Module to host functions

### DIFF
--- a/internal/engine/compiler/arch_arm64.s
+++ b/internal/engine/compiler/arch_arm64.s
@@ -8,8 +8,8 @@ TEXT ·nativecall(SB), NOSPLIT|NOFRAME, $0-24
 
 	// In arm64, return address is stored in R30 after jumping into the code.
 	// We save the return address value into archContext.compilerReturnAddress in Engine.
-	// Note that the const 136 drifts after editting Engine or archContext struct. See TestArchContextOffsetInEngine.
-	MOVD R30, 136(R0)
+	// Note that the const 144 drifts after editting Engine or archContext struct. See TestArchContextOffsetInEngine.
+	MOVD R30, 144(R0)
 
 	// Load the address of *wasm.ModuleInstance into arm64CallingConventionModuleInstanceAddressRegister.
 	MOVD moduleInstanceAddress+16(FP), R29

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -17,6 +17,8 @@ func TestCompiler_compileHostFunction(t *testing.T) {
 	err := compiler.compileGoDefinedHostFunction()
 	require.NoError(t, err)
 
+	// Get the location of caller function's location stored in the stack, which depends on the type.
+	// In this test, the host function has empty sig.
 	_, _, callerFuncLoc := compiler.runtimeValueLocationStack().getCallFrameLocations(&wasm.FunctionType{})
 
 	// Generate the machine code for the test.

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -19,7 +19,7 @@ func TestCompiler_compileHostFunction(t *testing.T) {
 
 	_, _, callerFuncLoc := compiler.runtimeValueLocationStack().getCallFrameLocations(&wasm.FunctionType{})
 
-	// Generate and for the test.
+	// Generate the machine code for the test.
 	code, _, err := compiler.compile()
 	require.NoError(t, err)
 

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -58,6 +58,7 @@ func init() {
 	requireEqual(int(unsafe.Offsetof(ce.statusCode)), callEngineExitContextNativeCallStatusCodeOffset, "callEngineExitContextNativeCallStatusCodeOffset")
 	requireEqual(int(unsafe.Offsetof(ce.builtinFunctionCallIndex)), callEngineExitContextBuiltinFunctionCallIndexOffset, "callEngineExitContextBuiltinFunctionCallIndexOffset")
 	requireEqual(int(unsafe.Offsetof(ce.returnAddress)), callEngineExitContextReturnAddressOffset, "callEngineExitContextReturnAddressOffset")
+	requireEqual(int(unsafe.Offsetof(ce.callerFunctionInstance)), callEngineExitContextCallerFunctionInstanceOffset, "callEngineExitContextCallerFunctionInstanceOffset")
 
 	// Size and offsets for callFrame.
 	var frame callFrame

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -230,6 +230,7 @@ type (
 		// after executing a builtin function or host function.
 		returnAddress uintptr
 
+		// callerFunctionInstance holds the caller's wasm.FunctionInstance, and is only valid if currently executing a host function.
 		callerFunctionInstance *wasm.FunctionInstance
 	}
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -929,7 +929,7 @@ entry:
 			fn := calleeHostFunction.parent.goFunc
 			switch fn := fn.(type) {
 			case api.GoModuleFunction:
-				fn.Call(ce.ctx, ce.callerFunctionInstance.Module.CallCtx.WithMemory(ce.memoryInstance), stack)
+				fn.Call(ce.ctx, ce.callerFunctionInstance.Module.CallCtx, stack)
 			case api.GoFunction:
 				fn.Call(ce.ctx, stack)
 			}

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -229,6 +229,8 @@ type (
 		// returnAddress is the return address which the engine jumps into
 		// after executing a builtin function or host function.
 		returnAddress uintptr
+
+		callerFunctionInstance *wasm.FunctionInstance
 	}
 
 	// callFrame holds the information to which the caller function can return.
@@ -331,6 +333,7 @@ const (
 	callEngineExitContextNativeCallStatusCodeOffset     = 120
 	callEngineExitContextBuiltinFunctionCallIndexOffset = 124
 	callEngineExitContextReturnAddressOffset            = 128
+	callEngineExitContextCallerFunctionInstanceOffset   = 136
 
 	// Offsets for function.
 	functionCodeInitialAddressOffset    = 0
@@ -925,7 +928,7 @@ entry:
 			fn := calleeHostFunction.parent.goFunc
 			switch fn := fn.(type) {
 			case api.GoModuleFunction:
-				fn.Call(ce.ctx, callCtx.WithMemory(ce.memoryInstance), stack)
+				fn.Call(ce.ctx, ce.callerFunctionInstance.Module.CallCtx.WithMemory(ce.memoryInstance), stack)
 			case api.GoFunction:
 				fn.Call(ce.ctx, stack)
 			}

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -934,7 +934,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 				frame.pc = op.us[0]
 			}
 		case wazeroir.OperationKindCall:
-			ce.callFunction(ctx, callCtx, &functions[op.us[0]])
+			ce.callFunction(ctx, f.source.Module.CallCtx, &functions[op.us[0]])
 			frame.pc++
 		case wazeroir.OperationKindCallIndirect:
 			offset := ce.popValue()
@@ -952,7 +952,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, callCtx *wasm.CallCont
 				panic(wasmruntime.ErrRuntimeIndirectCallTypeMismatch)
 			}
 
-			ce.callFunction(ctx, callCtx, tf)
+			ce.callFunction(ctx, f.source.Module.CallCtx, tf)
 			frame.pc++
 		case wazeroir.OperationKindDrop:
 			ce.drop(op.rs[0])

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -859,7 +859,6 @@ func (ce *callEngine) callFunction(ctx context.Context, callCtx *wasm.CallContex
 
 func (ce *callEngine) callGoFunc(ctx context.Context, callCtx *wasm.CallContext, f *function, stack []uint64) {
 	lsn := f.parent.listener
-	callCtx = callCtx.WithMemory(ce.callerMemory())
 	if lsn != nil {
 		params := stack[:f.source.Type.ParamNumInUint64]
 		ctx = lsn.Before(ctx, callCtx, f.source.Definition, params)

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -526,6 +526,7 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 		}).
 		Export(hostFn).
 		Instantiate(testCtx)
+	require.NoError(t, err)
 
 	_, err = r.Instantiate(testCtx, importingModuleBytes)
 	require.NoError(t, err)

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -479,15 +479,6 @@ func testHostFunctionNumericParameter(t *testing.T, r wazero.Runtime) {
 	}
 }
 
-// TODO: delete, this is just for local development.
-func Test_callHostFunctionIndirect(t *testing.T) {
-	r := wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfigInterpreter().WithCloseOnContextDone(true))
-	callHostFunctionIndirect(t, r)
-
-	r = wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfigCompiler().WithCloseOnContextDone(true))
-	callHostFunctionIndirect(t, r)
-}
-
 func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 	// With the following call graph,
 	//  originWasmModule -- call --> importingWasmModule -- call --> hostModule

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -484,9 +484,8 @@ func Test_callHostFunctionIndirect(t *testing.T) {
 	r := wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfigInterpreter().WithCloseOnContextDone(true))
 	callHostFunctionIndirect(t, r)
 
-	// TODO: pass compiler
-	// r := wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfigInterpreter().WithCloseOnContextDone(true))
-	// callHostFunctionIndirect(t, r)
+	r = wazero.NewRuntimeWithConfig(testCtx, wazero.NewRuntimeConfigCompiler().WithCloseOnContextDone(true))
+	callHostFunctionIndirect(t, r)
 }
 
 func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
@@ -501,7 +500,7 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 		ImportSection:   []*wasm.Import{{Module: hostModule, Name: hostFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
 		ExportSection:   []*wasm.Export{{Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, Index: 1}},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
+		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeUnreachable, wasm.OpcodeEnd}}},
 		NameSection:     &wasm.NameSection{ModuleName: importingWasmModule},
 	}
 

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -500,7 +500,7 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 		ImportSection:   []*wasm.Import{{Module: hostModule, Name: hostFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
 		ExportSection:   []*wasm.Export{{Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, Index: 1}},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeUnreachable, wasm.OpcodeEnd}}},
+		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
 		NameSection:     &wasm.NameSection{ModuleName: importingWasmModule},
 	}
 

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -494,7 +494,7 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 	// this ensures that hostModule's hostFn only has access importingWasmModule, not originWasmModule.
 
 	const hostModule, importingWasmModule, originWasmModule = "host", "importing", "origin"
-	const hostFn, importingWasmModuleFn, originModuleFn = "get_caller_module_name", "call_host_func", "origin"
+	const hostFn, importingWasmModuleFn, originModuleFn = "host_fn", "call_host_func", "origin"
 	importingModule := &wasm.Module{
 		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
 		ImportSection:   []*wasm.Import{{Module: hostModule, Name: hostFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},

--- a/internal/wasmdebug/debug.go
+++ b/internal/wasmdebug/debug.go
@@ -113,7 +113,7 @@ type stackTrace struct {
 }
 
 func (s *stackTrace) FromRecovered(recovered interface{}) error {
-	if true {
+	if false {
 		debug.PrintStack()
 	}
 

--- a/internal/wasmdebug/debug.go
+++ b/internal/wasmdebug/debug.go
@@ -113,7 +113,7 @@ type stackTrace struct {
 }
 
 func (s *stackTrace) FromRecovered(recovered interface{}) error {
-	if false {
+	if true {
 		debug.PrintStack()
 	}
 


### PR DESCRIPTION
Fixes #1211 


Previously, host functions are getting `api.Module` for the "originating" module, which is the module for api.Function currently invoked, except that the api.Module is modified withMemory for the caller's memory instance, therefore there haven't been no problem. The only issues were the methods except `Memory()` of api.Module, and this commit fixes them.
