### PR TITLE
Deletes callContext.withMemory

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -946,9 +946,9 @@ entry:
 			case builtinFunctionIndexTableGrow:
 				ce.builtinFunctionTableGrow(caller.source.Module.Tables)
 			case builtinFunctionIndexFunctionListenerBefore:
-				ce.builtinFunctionFunctionListenerBefore(ce.ctx, callCtx.WithMemory(ce.memoryInstance), caller)
+				ce.builtinFunctionFunctionListenerBefore(ce.ctx, callCtx, caller)
 			case builtinFunctionIndexFunctionListenerAfter:
-				ce.builtinFunctionFunctionListenerAfter(ce.ctx, callCtx.WithMemory(ce.memoryInstance), caller)
+				ce.builtinFunctionFunctionListenerAfter(ce.ctx, callCtx, caller)
 			case builtinFunctionIndexCheckExitCode:
 				// Note: this operation must be done in Go, not native code. The reason is that
 				// native code cannot be preempted and that means it can block forever if there are not

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -4367,9 +4367,6 @@ func i32Abs(v uint32) uint32 {
 }
 
 func (ce *callEngine) callNativeFuncWithListener(ctx context.Context, callCtx *wasm.CallContext, f *function, fnl experimental.FunctionListener) context.Context {
-	if f.parent.isHostFunction {
-		callCtx = callCtx.WithMemory(ce.callerMemory())
-	}
 	ctx = fnl.Before(ctx, callCtx, f.source.Definition, ce.peekValues(len(f.source.Type.Params)))
 	ce.callNativeFunc(ctx, callCtx, f)
 	// TODO: This doesn't get the error due to use of panic to propagate them.

--- a/internal/wasm/call_context.go
+++ b/internal/wasm/call_context.go
@@ -120,14 +120,6 @@ func (m *CallContext) Name() string {
 	return m.module.Name
 }
 
-// WithMemory allows overriding memory without re-allocation when the result would be the same.
-func (m *CallContext) WithMemory(memory *MemoryInstance) *CallContext {
-	if memory != nil && memory != m.memory { // only re-allocate if it will change the effective memory
-		return &CallContext{module: m.module, memory: memory, Sys: m.Sys, Closed: m.Closed}
-	}
-	return m
-}
-
 // String implements the same method as documented on api.Module
 func (m *CallContext) String() string {
 	return fmt.Sprintf("Module[%s]", m.Name())

--- a/internal/wasm/call_context_test.go
+++ b/internal/wasm/call_context_test.go
@@ -16,54 +16,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func TestCallContext_WithMemory(t *testing.T) {
-	tests := []struct {
-		name       string
-		mod        *CallContext
-		mem        *MemoryInstance
-		expectSame bool
-	}{
-		{
-			name:       "nil->nil: same",
-			mod:        &CallContext{},
-			mem:        nil,
-			expectSame: true,
-		},
-		{
-			name:       "nil->mem: not same",
-			mod:        &CallContext{},
-			mem:        &MemoryInstance{},
-			expectSame: false,
-		},
-		{
-			name:       "mem->nil: same",
-			mod:        &CallContext{memory: &MemoryInstance{}},
-			mem:        nil,
-			expectSame: true,
-		},
-		{
-			name:       "mem1->mem2: not same",
-			mod:        &CallContext{memory: &MemoryInstance{}},
-			mem:        &MemoryInstance{},
-			expectSame: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			mod2 := tc.mod.WithMemory(tc.mem)
-			if tc.expectSame {
-				require.Same(t, tc.mod, mod2)
-			} else {
-				require.NotSame(t, tc.mod, mod2)
-				require.Equal(t, tc.mem, mod2.memory)
-			}
-		})
-	}
-}
-
 func TestCallContext_String(t *testing.T) {
 	s := newStore()
 


### PR DESCRIPTION
Follow up on #1213. We no longer need withMemory.