### PR TITLE
Generates typeIDs at compilation time

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -328,6 +328,7 @@ func (b *hostModuleBuilder) Compile(ctx context.Context) (CompiledModule, error)
 		return nil, err
 	}
 
+	// typeIDs are static and compile-time known.
 	typeIDs, err := b.r.store.GetFunctionTypeIDs(module.TypeSection)
 	if err != nil {
 		return nil, err

--- a/builder.go
+++ b/builder.go
@@ -328,6 +328,12 @@ func (b *hostModuleBuilder) Compile(ctx context.Context) (CompiledModule, error)
 		return nil, err
 	}
 
+	typeIDs, err := b.r.store.GetFunctionTypeIDs(module.TypeSection)
+	if err != nil {
+		return nil, err
+	}
+	c.typeIDs = typeIDs
+
 	return c, nil
 }
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -353,6 +353,7 @@ func requireHostModuleEquals(t *testing.T, expected, actual *wasm.Module) {
 	// `require.Equal(t, expected, actual)` fails reflect pointers don't match, so brute compare:
 	for _, tp := range expected.TypeSection {
 		tp.CacheNumInUint64()
+		_ = tp.String()
 	}
 	require.Equal(t, expected.TypeSection, actual.TypeSection)
 	require.Equal(t, expected.ImportSection, actual.ImportSection)

--- a/builder_test.go
+++ b/builder_test.go
@@ -279,6 +279,11 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 
 			require.Equal(t, b.r.store.Engine, m.compiledEngine)
 
+			// TypeIDs must be assigned to compiledModule.
+			expTypeIDs, err := b.r.store.GetFunctionTypeIDs(tc.expected.TypeSection)
+			require.NoError(t, err)
+			require.Equal(t, expTypeIDs, m.typeIDs)
+
 			// Built module must be instantiable by Engine.
 			mod, err := b.r.InstantiateModule(testCtx, m, NewModuleConfig())
 			require.NoError(t, err)
@@ -353,6 +358,7 @@ func requireHostModuleEquals(t *testing.T, expected, actual *wasm.Module) {
 	// `require.Equal(t, expected, actual)` fails reflect pointers don't match, so brute compare:
 	for _, tp := range expected.TypeSection {
 		tp.CacheNumInUint64()
+		// When creating the compiled module, we get the type IDs for types, which results in caching type keys.
 		_ = tp.String()
 	}
 	require.Equal(t, expected.TypeSection, actual.TypeSection)

--- a/cache_test.go
+++ b/cache_test.go
@@ -29,11 +29,12 @@ func TestCompilationCache(t *testing.T) {
 
 		// Create a different type id on the bar's store so that we can emulate that bar instantiated the module before facWasm.
 		_, err := bar.store.GetFunctionTypeIDs(
+			// Arbitrary one is fine as long as it is not used in facWasm.
 			[]*wasm.FunctionType{{Params: []wasm.ValueType{
 				wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32,
-				wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32,
-				wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32,
-				wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32,
+				wasm.ValueTypeI32, wasm.ValueTypeV128, wasm.ValueTypeI32, wasm.ValueTypeV128, wasm.ValueTypeI32, wasm.ValueTypeI32,
+				wasm.ValueTypeI32, wasm.ValueTypeV128, wasm.ValueTypeI32, wasm.ValueTypeV128, wasm.ValueTypeI32, wasm.ValueTypeI32,
+				wasm.ValueTypeI32, wasm.ValueTypeV128, wasm.ValueTypeI32, wasm.ValueTypeV128, wasm.ValueTypeI32, wasm.ValueTypeI32,
 				wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32, wasm.ValueTypeI32,
 			}}})
 		require.NoError(t, err)

--- a/config.go
+++ b/config.go
@@ -333,6 +333,7 @@ type compiledModule struct {
 	compiledEngine wasm.Engine
 	// closeWithModule prevents leaking compiled code when a module is compiled implicitly.
 	closeWithModule bool
+	typeIDs         []wasm.FunctionTypeID
 }
 
 // Name implements CompiledModule.Name

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -264,7 +264,10 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 	err = s.Engine.CompileModule(testCtx, hm, nil, false)
 	require.NoError(t, err)
 
-	_, err = s.Instantiate(testCtx, hm, hostModuleName, nil)
+	typeIDs, err := s.GetFunctionTypeIDs(hm.TypeSection)
+	require.NoError(t, err)
+
+	_, err = s.Instantiate(testCtx, hm, hostModuleName, nil, typeIDs)
 	require.NoError(t, err)
 
 	const stackCorruption = "value_stack_corruption"
@@ -320,7 +323,10 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 	err = s.Engine.CompileModule(testCtx, m, nil, false)
 	require.NoError(t, err)
 
-	mi, err := s.Instantiate(testCtx, m, t.Name(), nil)
+	typeIDs, err = s.GetFunctionTypeIDs(m.TypeSection)
+	require.NoError(t, err)
+
+	mi, err := s.Instantiate(testCtx, m, t.Name(), nil, typeIDs)
 	require.NoError(t, err)
 
 	for _, fnName := range []string{stackCorruption, callStackCorruption} {

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -337,7 +337,10 @@ func addSpectestModule(t *testing.T, ctx context.Context, s *wasm.Store, enabled
 	err = s.Engine.CompileModule(ctx, mod, nil, false)
 	require.NoError(t, err)
 
-	_, err = s.Instantiate(ctx, mod, mod.NameSection.ModuleName, sys.DefaultContext(nil))
+	typeIDs, err := s.GetFunctionTypeIDs(mod.TypeSection)
+	require.NoError(t, err)
+
+	_, err = s.Instantiate(ctx, mod, mod.NameSection.ModuleName, sys.DefaultContext(nil), typeIDs)
 	require.NoError(t, err)
 }
 
@@ -404,7 +407,10 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Ca
 						err = s.Engine.CompileModule(ctx, mod, nil, false)
 						require.NoError(t, err, msg)
 
-						_, err = s.Instantiate(ctx, mod, moduleName, nil)
+						typeIDs, err := s.GetFunctionTypeIDs(mod.TypeSection)
+						require.NoError(t, err)
+
+						_, err = s.Instantiate(ctx, mod, moduleName, nil, typeIDs)
 						lastInstantiatedModuleName = moduleName
 						require.NoError(t, err)
 					case "register":
@@ -542,7 +548,10 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Ca
 							err = s.Engine.CompileModule(ctx, mod, nil, false)
 							require.NoError(t, err, msg)
 
-							_, err = s.Instantiate(ctx, mod, t.Name(), nil)
+							typeIDs, err := s.GetFunctionTypeIDs(mod.TypeSection)
+							require.NoError(t, err)
+
+							_, err = s.Instantiate(ctx, mod, t.Name(), nil, typeIDs)
 							require.NoError(t, err, msg)
 						} else {
 							requireInstantiationError(t, ctx, s, buf, msg)
@@ -578,7 +587,10 @@ func requireInstantiationError(t *testing.T, ctx context.Context, s *wasm.Store,
 		return
 	}
 
-	_, err = s.Instantiate(ctx, mod, t.Name(), nil)
+	typeIDs, err := s.GetFunctionTypeIDs(mod.TypeSection)
+	require.NoError(t, err)
+
+	_, err = s.Instantiate(ctx, mod, t.Name(), nil, typeIDs)
 	require.Error(t, err, msg)
 }
 

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -74,7 +74,10 @@ func RunTestEngine_MemoryGrowInRecursiveCall(t *testing.T, et EngineTester) {
 	err = s.Engine.CompileModule(testCtx, hm, nil, false)
 	require.NoError(t, err)
 
-	_, err = s.Instantiate(testCtx, hm, hostModuleName, nil)
+	typeIDs, err := s.GetFunctionTypeIDs(hm.TypeSection)
+	require.NoError(t, err)
+
+	_, err = s.Instantiate(testCtx, hm, hostModuleName, nil, typeIDs)
 	require.NoError(t, err)
 
 	m := &wasm.Module{
@@ -106,7 +109,10 @@ func RunTestEngine_MemoryGrowInRecursiveCall(t *testing.T, et EngineTester) {
 	err = s.Engine.CompileModule(testCtx, m, nil, false)
 	require.NoError(t, err)
 
-	inst, err := s.Instantiate(testCtx, m, t.Name(), nil)
+	typeIDs, err = s.GetFunctionTypeIDs(m.TypeSection)
+	require.NoError(t, err)
+
+	inst, err := s.Instantiate(testCtx, m, t.Name(), nil, typeIDs)
 	require.NoError(t, err)
 
 	growFn = inst.Function(2)

--- a/internal/wasm/call_context_test.go
+++ b/internal/wasm/call_context_test.go
@@ -39,7 +39,7 @@ func TestCallContext_String(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			// Ensure paths that can create the host module can see the name.
-			m, err := s.Instantiate(testCtx, &Module{}, tc.moduleName, nil)
+			m, err := s.Instantiate(testCtx, &Module{}, tc.moduleName, nil, nil)
 			defer m.Close(testCtx) //nolint
 
 			require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestCallContext_Close(t *testing.T) {
 		t.Run(fmt.Sprintf("%s calls ns.CloseWithExitCode(module.name))", tc.name), func(t *testing.T) {
 			for _, ctx := range []context.Context{nil, testCtx} { // Ensure it doesn't crash on nil!
 				moduleName := t.Name()
-				m, err := s.Instantiate(ctx, &Module{}, moduleName, nil)
+				m, err := s.Instantiate(ctx, &Module{}, moduleName, nil, nil)
 				require.NoError(t, err)
 
 				// We use side effects to see if Close called ns.CloseWithExitCode (without repeating store_test.go).
@@ -107,7 +107,7 @@ func TestCallContext_Close(t *testing.T) {
 		_, err := fsCtx.OpenFile(testFS, "/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
-		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx)
+		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx, nil)
 		require.NoError(t, err)
 
 		// We use side effects to determine if Close in fact called Context.Close (without repeating sys_test.go).
@@ -142,7 +142,7 @@ func TestCallContext_Close(t *testing.T) {
 		_, err := fsCtx.OpenFile(testFS, "/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
-		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx)
+		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx, nil)
 		require.NoError(t, err)
 
 		require.EqualError(t, m.Close(testCtx), "error closing")
@@ -182,7 +182,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		t.Run(fmt.Sprintf("%s calls ns.CloseWithExitCode(module.name))", tc.name), func(t *testing.T) {
 			for _, ctx := range []context.Context{nil, testCtx} { // Ensure it doesn't crash on nil!
 				moduleName := t.Name()
-				m, err := s.Instantiate(ctx, &Module{}, moduleName, nil)
+				m, err := s.Instantiate(ctx, &Module{}, moduleName, nil, nil)
 				require.NoError(t, err)
 
 				// We use side effects to see if Close called ns.CloseWithExitCode (without repeating store_test.go).
@@ -211,7 +211,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		_, err := fsCtx.OpenFile(testFS, "/foo", os.O_RDONLY, 0)
 		require.NoError(t, err)
 
-		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx)
+		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx, nil)
 		require.NoError(t, err)
 
 		// We use side effects to determine if Close in fact called Context.Close (without repeating sys_test.go).
@@ -240,7 +240,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 		_, err := fsCtx.OpenFile(testFS, path, os.O_RDONLY, 0)
 		require.NoError(t, err)
 
-		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx)
+		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx, nil)
 		require.NoError(t, err)
 
 		require.EqualError(t, m.Close(testCtx), "error closing")

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -296,7 +296,7 @@ func TestPublicModule_Global(t *testing.T) {
 		s := newStore()
 		t.Run(tc.name, func(t *testing.T) {
 			// Instantiate the module and get the export of the above global
-			module, err := s.Instantiate(context.Background(), tc.module, t.Name(), nil)
+			module, err := s.Instantiate(context.Background(), tc.module, t.Name(), nil, nil)
 			require.NoError(t, err)
 
 			if global := module.ExportedGlobal("global"); tc.expected != nil {

--- a/runtime.go
+++ b/runtime.go
@@ -203,6 +203,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 
 	c := &compiledModule{module: internal, compiledEngine: r.store.Engine}
 
+	// typeIDs are static and compile-time known.
 	typeIDs, err := r.store.GetFunctionTypeIDs(internal.TypeSection)
 	if err != nil {
 		return nil, err

--- a/runtime.go
+++ b/runtime.go
@@ -203,6 +203,12 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 
 	c := &compiledModule{module: internal, compiledEngine: r.store.Engine}
 
+	typeIDs, err := r.store.GetFunctionTypeIDs(internal.TypeSection)
+	if err != nil {
+		return nil, err
+	}
+	c.typeIDs = typeIDs
+
 	listeners, err := buildListeners(ctx, internal)
 	if err != nil {
 		return nil, err
@@ -276,7 +282,7 @@ func (r *runtime) InstantiateModule(
 	}
 
 	// Instantiate the module.
-	mod, err = r.store.Instantiate(ctx, code.module, name, sysCtx)
+	mod, err = r.store.Instantiate(ctx, code.module, name, sysCtx, code.typeIDs)
 	if err != nil {
 		// If there was an error, don't leak the compiled module.
 		if code.closeWithModule {


### PR DESCRIPTION
Previously we generated the typeIDs for function types unnecessarily at each instantiation time. 
TypeIDs are unique per Runtime/Store, and we don't need to create slice []FunctionTypeID for each instance.
When generating a typeID, we need to take a lock on store in order to keep uniqueness across
instances and this caused the lock contention on the instantiation heavy use-cases.

tldr is that this improves the concurrent instantiation performance!

```
$ benchstat main.txt new.txt
name                                    old time/op    new time/op    delta
Initialization/interpreter-10             29.9µs ± 3%    29.6µs ± 1%     ~     (p=0.151 n=5+5)
Initialization/interpreter-multiple-10    17.1µs ± 7%    13.2µs ± 9%  -23.13%  (p=0.008 n=5+5)
Initialization/compiler-10                35.1µs ± 3%    27.2µs ±47%     ~     (p=0.905 n=4+5)
Initialization/compiler-multiple-10       14.8µs ±15%    13.0µs ± 6%  -12.50%  (p=0.008 n=5+5)
Compilation/with_extern_cache-10           148µs ± 1%     152µs ± 3%     ~     (p=0.056 n=5+5)
Compilation/without_extern_cache-10       2.76ms ± 1%    2.74ms ± 2%     ~     (p=0.151 n=5+5)

name                                    old alloc/op   new alloc/op   delta
Initialization/interpreter-10              137kB ± 0%     137kB ± 0%   -0.04%  (p=0.000 n=5+4)
Initialization/interpreter-multiple-10     137kB ± 0%     137kB ± 0%     ~     (p=0.159 n=4+5)
Initialization/compiler-10                 141kB ± 0%     141kB ± 0%   -0.03%  (p=0.029 n=4+4)
Initialization/compiler-multiple-10        142kB ± 0%     142kB ± 0%   -0.10%  (p=0.008 n=5+5)
Compilation/with_extern_cache-10          55.4kB ± 0%    55.5kB ± 0%   +0.22%  (p=0.008 n=5+5)
Compilation/without_extern_cache-10       1.12MB ± 0%    1.12MB ± 0%     ~     (p=1.000 n=5+5)

name                                    old allocs/op  new allocs/op  delta
Initialization/interpreter-10               52.0 ± 0%      51.0 ± 0%   -1.92%  (p=0.008 n=5+5)
Initialization/interpreter-multiple-10      58.0 ± 0%      57.0 ± 0%   -1.72%  (p=0.029 n=4+4)
Initialization/compiler-10                  42.0 ± 0%      41.0 ± 0%   -2.38%  (p=0.008 n=5+5)
Initialization/compiler-multiple-10         48.0 ± 0%      47.0 ± 0%   -2.08%  (p=0.008 n=5+5)
Compilation/with_extern_cache-10           1.10k ± 0%     1.10k ± 0%   +0.18%  (p=0.008 n=5+5)
Compilation/without_extern_cache-10        11.4k ± 0%     11.4k ± 0%     ~     (p=0.079 n=5+5)
```