### PR TITLE
Holds most fields as slice of values, not ptrs in wasm.Module

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -58,7 +58,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -80,7 +80,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -103,7 +103,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -125,7 +125,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint64_uint32)},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -148,7 +148,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				},
 				FunctionSection: []wasm.Index{0, 1},
 				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32), wasm.MustParseGoReflectFuncCode(uint64_uint32)},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 					{Name: "2", Type: wasm.ExternTypeFunc, Index: 1},
 				},
@@ -173,7 +173,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				CodeSection: []*wasm.Code{
 					{IsHostFunction: true, GoFunc: gofunc1},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -197,7 +197,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				CodeSection: []*wasm.Code{
 					{IsHostFunction: true, GoFunc: gofunc1},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -225,7 +225,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 				CodeSection: []*wasm.Code{
 					{IsHostFunction: true, GoFunc: gofunc2},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
 				NameSection: &wasm.NameSection{
@@ -255,7 +255,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{IsHostFunction: true, GoFunc: gofunc1},
 					{IsHostFunction: true, GoFunc: gofunc2},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 					{Name: "2", Type: wasm.ExternTypeFunc, Index: 1},
 				},

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -43,7 +43,7 @@ func TestFunctionListenerFactory(t *testing.T) {
 	// Define a module with two functions
 	bin := binaryencoding.EncodeModule(&wasm.Module{
 		TypeSection:     []*wasm.FunctionType{{}},
-		ImportSection:   []*wasm.Import{{}},
+		ImportSection:   []wasm.Import{{}},
 		FunctionSection: []wasm.Index{0, 0},
 		CodeSection: []*wasm.Code{
 			// fn1
@@ -56,7 +56,7 @@ func TestFunctionListenerFactory(t *testing.T) {
 			// fn2
 			{Body: []byte{wasm.OpcodeEnd}},
 		},
-		ExportSection: []*wasm.Export{{Name: "fn1", Type: wasm.ExternTypeFunc, Index: 1}},
+		ExportSection: []wasm.Export{{Name: "fn1", Type: wasm.ExternTypeFunc, Index: 1}},
 		NameSection: &wasm.NameSection{
 			ModuleName: "test",
 			FunctionNames: wasm.NameMap{

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -18,11 +18,11 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			env := newCompilerEnvironment()
 			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
 				Signature: &wasm.FunctionType{},
-				Globals:   []*wasm.GlobalType{nil, {ValType: tp}},
+				Globals:   []wasm.GlobalType{{}, {ValType: tp}},
 			})
 
 			// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
-			globals := []*wasm.GlobalInstance{nil, {Val: globalValue, Type: &wasm.GlobalType{ValType: tp}}}
+			globals := []*wasm.GlobalInstance{nil, {Val: globalValue, Type: wasm.GlobalType{ValType: tp}}}
 			env.addGlobals(globals...)
 
 			// Emit the code.
@@ -65,11 +65,11 @@ func TestCompiler_compileGlobalGet_v128(t *testing.T) {
 	env := newCompilerEnvironment()
 	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
 		Signature: &wasm.FunctionType{},
-		Globals:   []*wasm.GlobalType{nil, {ValType: v128Type}},
+		Globals:   []wasm.GlobalType{{}, {ValType: v128Type}},
 	})
 
 	// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
-	globals := []*wasm.GlobalInstance{nil, {Val: 12345, ValHi: 6789, Type: &wasm.GlobalType{ValType: v128Type}}}
+	globals := []*wasm.GlobalInstance{nil, {Val: 12345, ValHi: 6789, Type: wasm.GlobalType{ValType: v128Type}}}
 	env.addGlobals(globals...)
 
 	// Emit the code.
@@ -117,11 +117,11 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			env := newCompilerEnvironment()
 			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
 				Signature: &wasm.FunctionType{},
-				Globals:   []*wasm.GlobalType{nil, {ValType: tp}},
+				Globals:   []wasm.GlobalType{{}, {ValType: tp}},
 			})
 
 			// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
-			env.addGlobals(nil, &wasm.GlobalInstance{Val: 40, Type: &wasm.GlobalType{ValType: tp}})
+			env.addGlobals(nil, &wasm.GlobalInstance{Val: 40, Type: wasm.GlobalType{ValType: tp}})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -170,11 +170,11 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 	env := newCompilerEnvironment()
 	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
 		Signature: &wasm.FunctionType{},
-		Globals:   []*wasm.GlobalType{nil, {ValType: v128Type}},
+		Globals:   []wasm.GlobalType{{}, {ValType: v128Type}},
 	})
 
 	// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
-	env.addGlobals(nil, &wasm.GlobalInstance{Val: 0, ValHi: 0, Type: &wasm.GlobalType{ValType: v128Type}})
+	env.addGlobals(nil, &wasm.GlobalInstance{Val: 0, ValHi: 0, Type: wasm.GlobalType{ValType: v128Type}})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -311,8 +311,8 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 			},
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}},
 		},
-		ImportSection: []*wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 1}},
-		ExportSection: []*wasm.Export{
+		ImportSection: []wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 1}},
+		ExportSection: []wasm.Export{
 			{Type: wasm.ExternTypeFunc, Index: 1, Name: stackCorruption},
 			{Type: wasm.ExternTypeFunc, Index: 2, Name: callStackCorruption},
 		},

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -102,7 +102,7 @@ func runInitializationBench(b *testing.B, r wazero.Runtime) {
 	defer compiled.Close(testCtx)
 	// Configure with real sources to avoid performance hit initializing fake ones. These sources are not used
 	// in the benchmark.
-	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader)
+	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader).WithStartFunctions()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mod, err := r.InstantiateModule(testCtx, compiled, config)

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -176,7 +176,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 				},
 			},
 		},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: "go", Type: wasm.ExternTypeFunc, Index: 0},
 			{Name: "go-reflect", Type: wasm.ExternTypeFunc, Index: 1},
 			{Name: "wasm", Type: wasm.ExternTypeFunc, Index: 2},
@@ -202,14 +202,14 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 	// Build the importing module.
 	importingModule := &wasm.Module{
 		TypeSection: []*wasm.FunctionType{ft},
-		ImportSection: []*wasm.Import{
+		ImportSection: []wasm.Import{
 			// Placeholders for imports from hostModule.
 			{Type: wasm.ExternTypeFunc},
 			{Type: wasm.ExternTypeFunc},
 			{Type: wasm.ExternTypeFunc},
 		},
 		FunctionSection: []wasm.Index{0, 0, 0},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: callGoHostName, Type: wasm.ExternTypeFunc, Index: 3},
 			{Name: callGoReflectHostName, Type: wasm.ExternTypeFunc, Index: 4},
 			{Name: callWasmHostName, Type: wasm.ExternTypeFunc, Index: 5},

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -489,18 +489,18 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 	const hostFn, importingWasmModuleFn, originModuleFn = "host_fn", "call_host_func", "origin"
 	importingModule := &wasm.Module{
 		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
-		ImportSection:   []*wasm.Import{{Module: hostModule, Name: hostFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
+		ImportSection:   []wasm.Import{{Module: hostModule, Name: hostFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
-		ExportSection:   []*wasm.Export{{Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, Index: 1}},
+		ExportSection:   []wasm.Export{{Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, Index: 1}},
 		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
 		NameSection:     &wasm.NameSection{ModuleName: importingWasmModule},
 	}
 
 	originModule := &wasm.Module{
 		TypeSection:     []*wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
-		ImportSection:   []*wasm.Import{{Module: importingWasmModule, Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
+		ImportSection:   []wasm.Import{{Module: importingWasmModule, Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
-		ExportSection:   []*wasm.Export{{Name: "origin", Type: wasm.ExternTypeFunc, Index: 1}},
+		ExportSection:   []wasm.Export{{Name: "origin", Type: wasm.ExternTypeFunc, Index: 1}},
 		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
 		NameSection:     &wasm.NameSection{ModuleName: originWasmModule},
 	}
@@ -541,11 +541,11 @@ func callReturnImportWasm(t *testing.T, importedModule, importingModule string, 
 	module := &wasm.Module{
 		TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{vt}, Results: []wasm.ValueType{vt}}},
 		// (import "%[2]s" "return_input" (func $return_input (param i32) (result i32)))
-		ImportSection: []*wasm.Import{
+		ImportSection: []wasm.Import{
 			{Module: importedModule, Name: "return_input", Type: wasm.ExternTypeFunc, DescFunc: 0},
 		},
 		FunctionSection: []wasm.Index{0},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			// (export "return_input" (func $return_input))
 			{Name: "return_input", Type: wasm.ExternTypeFunc, Index: 0},
 			// (export "call_return_input" (func $call_return_input))
@@ -572,12 +572,12 @@ func callOuterInnerWasm(t *testing.T, importedModule, importingModule string) []
 		TypeSection: []*wasm.FunctionType{{Params: []wasm.ValueType{i32}, Results: []wasm.ValueType{i32}}},
 		// (import "%[2]s" "outer" (func $outer (param i32) (result i32)))
 		// (import "%[2]s" "inner" (func $inner (param i32) (result i32)))
-		ImportSection: []*wasm.Import{
+		ImportSection: []wasm.Import{
 			{Module: importedModule, Name: "outer", Type: wasm.ExternTypeFunc, DescFunc: 0},
 			{Module: importedModule, Name: "inner", Type: wasm.ExternTypeFunc, DescFunc: 0},
 		},
 		FunctionSection: []wasm.Index{0, 0},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			// (export "call->outer" (func $call_outer))
 			{Name: "call->outer", Type: wasm.ExternTypeFunc, Index: 2},
 			// 	(export "inner" (func $call_inner))
@@ -769,7 +769,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 				wasm.OpcodeEnd,
 			},
 		}},
-		ExportSection: []*wasm.Export{{Name: "store"}},
+		ExportSection: []wasm.Export{{Name: "store"}},
 	})
 	compiled, err := r.CompileModule(testCtx, bin)
 	require.NoError(t, err)

--- a/internal/integration_test/fuzz/wazerolib/nodiff.go
+++ b/internal/integration_test/fuzz/wazerolib/nodiff.go
@@ -126,7 +126,8 @@ func requireNoDiff(wasmBin []byte, checkMemory bool, requireNoError func(err err
 // ensureDummyImports instantiates the modules which are required imports by `origin` *wasm.Module.
 func ensureDummyImports(r wazero.Runtime, origin *wasm.Module, requireNoError func(err error)) (skip bool) {
 	impMods := make(map[string][]wasm.Import)
-	for _, imp := range origin.ImportSection {
+	for i := range origin.ImportSection {
+		imp := &origin.ImportSection[i]
 		impMods[imp.Module] = append(impMods[imp.Module], imp)
 	}
 

--- a/internal/integration_test/fuzz/wazerolib/nodiff.go
+++ b/internal/integration_test/fuzz/wazerolib/nodiff.go
@@ -126,8 +126,7 @@ func requireNoDiff(wasmBin []byte, checkMemory bool, requireNoError func(err err
 // ensureDummyImports instantiates the modules which are required imports by `origin` *wasm.Module.
 func ensureDummyImports(r wazero.Runtime, origin *wasm.Module, requireNoError func(err error)) (skip bool) {
 	impMods := make(map[string][]wasm.Import)
-	for i := range origin.ImportSection {
-		imp := &origin.ImportSection[i]
+	for _, imp := range origin.ImportSection {
 		impMods[imp.Module] = append(impMods[imp.Module], imp)
 	}
 

--- a/internal/integration_test/fuzz/wazerolib/nodiff.go
+++ b/internal/integration_test/fuzz/wazerolib/nodiff.go
@@ -125,7 +125,7 @@ func requireNoDiff(wasmBin []byte, checkMemory bool, requireNoError func(err err
 
 // ensureDummyImports instantiates the modules which are required imports by `origin` *wasm.Module.
 func ensureDummyImports(r wazero.Runtime, origin *wasm.Module, requireNoError func(err error)) (skip bool) {
-	impMods := make(map[string][]*wasm.Import)
+	impMods := make(map[string][]wasm.Import)
 	for _, imp := range origin.ImportSection {
 		impMods[imp.Module] = append(impMods[imp.Module], imp)
 	}

--- a/internal/integration_test/fuzz/wazerolib/nodiff.go
+++ b/internal/integration_test/fuzz/wazerolib/nodiff.go
@@ -207,8 +207,8 @@ func ensureDummyImports(r wazero.Runtime, origin *wasm.Module, requireNoError fu
 					opcode = wasm.OpcodeRefNull
 					data = []byte{wasm.RefTypeFuncref}
 				}
-				m.GlobalSection = append(m.GlobalSection, &wasm.Global{
-					Type: imp.DescGlobal, Init: &wasm.ConstantExpression{Opcode: opcode, Data: data},
+				m.GlobalSection = append(m.GlobalSection, wasm.Global{
+					Type: imp.DescGlobal, Init: wasm.ConstantExpression{Opcode: opcode, Data: data},
 				})
 			case wasm.ExternTypeMemory:
 				m.MemorySection = imp.DescMem
@@ -217,7 +217,7 @@ func ensureDummyImports(r wazero.Runtime, origin *wasm.Module, requireNoError fu
 				index = uint32(len(m.TableSection))
 				m.TableSection = append(m.TableSection, imp.DescTable)
 			}
-			m.ExportSection = append(m.ExportSection, &wasm.Export{Type: imp.Type, Name: imp.Name, Index: index})
+			m.ExportSection = append(m.ExportSection, wasm.Export{Type: imp.Type, Name: imp.Name, Index: index})
 		}
 		_, err := r.Instantiate(context.Background(), binaryencoding.EncodeModule(m))
 		requireNoError(err)

--- a/internal/integration_test/fuzzcases/fuzzcases_test.go
+++ b/internal/integration_test/fuzzcases/fuzzcases_test.go
@@ -356,19 +356,19 @@ func Test888(t *testing.T) {
 	run(t, func(t *testing.T, r wazero.Runtime) {
 		imported := binaryencoding.EncodeModule(&wasm.Module{
 			MemorySection: &wasm.Memory{Min: 0, Max: 5, IsMaxEncoded: true},
-			GlobalSection: []*wasm.Global{
+			GlobalSection: []wasm.Global{
 				{
-					Type: &wasm.GlobalType{
+					Type: wasm.GlobalType{
 						ValType: wasm.ValueTypeFuncref,
 						Mutable: false,
 					},
-					Init: &wasm.ConstantExpression{
+					Init: wasm.ConstantExpression{
 						Opcode: wasm.OpcodeRefNull,
 						Data:   []byte{wasm.ValueTypeFuncref},
 					},
 				},
 			},
-			ExportSection: []*wasm.Export{
+			ExportSection: []wasm.Export{
 				{Name: "", Type: wasm.ExternTypeGlobal, Index: 0},
 				{Name: "s", Type: wasm.ExternTypeMemory, Index: 0},
 			},

--- a/internal/testing/binaryencoding/const_expr.go
+++ b/internal/testing/binaryencoding/const_expr.go
@@ -4,7 +4,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func encodeConstantExpression(expr *wasm.ConstantExpression) (ret []byte) {
+func encodeConstantExpression(expr wasm.ConstantExpression) (ret []byte) {
 	ret = append(ret, expr.Opcode)
 	ret = append(ret, expr.Data...)
 	ret = append(ret, wasm.OpcodeEnd)

--- a/internal/testing/binaryencoding/data.go
+++ b/internal/testing/binaryencoding/data.go
@@ -8,7 +8,7 @@ import (
 func encodeDataSegment(d *wasm.DataSegment) (ret []byte) {
 	// Currently multiple memories are not supported.
 	ret = append(ret, leb128.EncodeInt32(0)...)
-	ret = append(ret, encodeConstantExpression(*d.OffsetExpression)...)
+	ret = append(ret, encodeConstantExpression(d.OffsetExpression)...)
 	ret = append(ret, leb128.EncodeUint32(uint32(len(d.Init)))...)
 	ret = append(ret, d.Init...)
 	return

--- a/internal/testing/binaryencoding/data.go
+++ b/internal/testing/binaryencoding/data.go
@@ -8,7 +8,7 @@ import (
 func encodeDataSegment(d *wasm.DataSegment) (ret []byte) {
 	// Currently multiple memories are not supported.
 	ret = append(ret, leb128.EncodeInt32(0)...)
-	ret = append(ret, encodeConstantExpression(d.OffsetExpression)...)
+	ret = append(ret, encodeConstantExpression(*d.OffsetExpression)...)
 	ret = append(ret, leb128.EncodeUint32(uint32(len(d.Init)))...)
 	ret = append(ret, d.Init...)
 	return

--- a/internal/testing/binaryencoding/element.go
+++ b/internal/testing/binaryencoding/element.go
@@ -25,7 +25,7 @@ func ensureElementKindFuncRef(r *bytes.Reader) error {
 func encodeElement(e *wasm.ElementSegment) (ret []byte) {
 	if e.Mode == wasm.ElementModeActive {
 		ret = append(ret, leb128.EncodeInt32(int32(e.TableIndex))...)
-		ret = append(ret, encodeConstantExpression(e.OffsetExpr)...)
+		ret = append(ret, encodeConstantExpression(*e.OffsetExpr)...)
 		ret = append(ret, leb128.EncodeUint32(uint32(len(e.Init)))...)
 		for _, idx := range e.Init {
 			ret = append(ret, leb128.EncodeInt32(int32(*idx))...)

--- a/internal/testing/binaryencoding/element.go
+++ b/internal/testing/binaryencoding/element.go
@@ -25,7 +25,7 @@ func ensureElementKindFuncRef(r *bytes.Reader) error {
 func encodeElement(e *wasm.ElementSegment) (ret []byte) {
 	if e.Mode == wasm.ElementModeActive {
 		ret = append(ret, leb128.EncodeInt32(int32(e.TableIndex))...)
-		ret = append(ret, encodeConstantExpression(*e.OffsetExpr)...)
+		ret = append(ret, encodeConstantExpression(e.OffsetExpr)...)
 		ret = append(ret, leb128.EncodeUint32(uint32(len(e.Init)))...)
 		for _, idx := range e.Init {
 			ret = append(ret, leb128.EncodeInt32(int32(*idx))...)

--- a/internal/testing/binaryencoding/encoder_test.go
+++ b/internal/testing/binaryencoding/encoder_test.go
@@ -56,7 +56,7 @@ func TestModule_Encode(t *testing.T) {
 					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
 					{Params: []wasm.ValueType{f32, f32}, Results: []wasm.ValueType{f32}},
 				},
-				ImportSection: []*wasm.Import{
+				ImportSection: []wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
 						Type:     wasm.ExternTypeFunc,
@@ -85,7 +85,7 @@ func TestModule_Encode(t *testing.T) {
 			name: "type function and start section",
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{{}},
-				ImportSection: []*wasm.Import{{
+				ImportSection: []wasm.Import{{
 					Module: "", Name: "hello",
 					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,
@@ -107,7 +107,7 @@ func TestModule_Encode(t *testing.T) {
 		{
 			name: "table and memory section",
 			input: &wasm.Module{
-				TableSection:  []*wasm.Table{{Min: 3, Type: wasm.RefTypeFuncref}},
+				TableSection:  []wasm.Table{{Min: 3, Type: wasm.RefTypeFuncref}},
 				MemorySection: &wasm.Memory{Min: 1, Max: 1, IsMaxEncoded: true},
 			},
 			expected: append(append(Magic, version...),
@@ -129,7 +129,7 @@ func TestModule_Encode(t *testing.T) {
 				CodeSection: []*wasm.Code{
 					{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "AddInt", Type: wasm.ExternTypeFunc, Index: wasm.Index(0)},
 				},
 				NameSection: &wasm.NameSection{
@@ -176,13 +176,13 @@ func TestModule_Encode(t *testing.T) {
 		{
 			name: "exported global var",
 			input: &wasm.Module{
-				GlobalSection: []*wasm.Global{
+				GlobalSection: []wasm.Global{
 					{
-						Type: &wasm.GlobalType{ValType: i32, Mutable: true},
-						Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: leb128.EncodeInt32(0)},
+						Type: wasm.GlobalType{ValType: i32, Mutable: true},
+						Init: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: leb128.EncodeInt32(0)},
 					},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Name: "sp", Type: wasm.ExternTypeGlobal, Index: wasm.Index(0)},
 				},
 			},

--- a/internal/testing/binaryencoding/global.go
+++ b/internal/testing/binaryencoding/global.go
@@ -7,7 +7,7 @@ import (
 // encodeGlobal returns the wasm.Global encoded in WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-section%E2%91%A0
-func encodeGlobal(g *wasm.Global) (data []byte) {
+func encodeGlobal(g wasm.Global) (data []byte) {
 	var mutable byte
 	if g.Type.Mutable {
 		mutable = 1

--- a/internal/testing/binaryencoding/global_test.go
+++ b/internal/testing/binaryencoding/global_test.go
@@ -11,14 +11,14 @@ import (
 func TestEncodeGlobal(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    *wasm.Global
+		input    wasm.Global
 		expected []byte
 	}{
 		{
 			name: "const",
-			input: &wasm.Global{
-				Type: &wasm.GlobalType{ValType: wasm.ValueTypeI32},
-				Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: leb128.EncodeInt32(1)},
+			input: wasm.Global{
+				Type: wasm.GlobalType{ValType: wasm.ValueTypeI32},
+				Init: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: leb128.EncodeInt32(1)},
 			},
 			expected: []byte{
 				wasm.ValueTypeI32, 0x00, // 0 == const
@@ -27,9 +27,9 @@ func TestEncodeGlobal(t *testing.T) {
 		},
 		{
 			name: "var",
-			input: &wasm.Global{
-				Type: &wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true},
-				Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: leb128.EncodeInt32(1)},
+			input: wasm.Global{
+				Type: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true},
+				Init: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: leb128.EncodeInt32(1)},
 			},
 			expected: []byte{
 				wasm.ValueTypeI32, 0x01, // 1 == var

--- a/internal/testing/binaryencoding/import_test.go
+++ b/internal/testing/binaryencoding/import_test.go
@@ -78,7 +78,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:       wasm.ExternTypeGlobal,
 				Module:     "math",
 				Name:       "pi",
-				DescGlobal: &wasm.GlobalType{ValType: wasm.ValueTypeF64},
+				DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeF64},
 			},
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
@@ -93,7 +93,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:       wasm.ExternTypeGlobal,
 				Module:     "math",
 				Name:       "pi",
-				DescGlobal: &wasm.GlobalType{ValType: wasm.ValueTypeF64, Mutable: true},
+				DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeF64, Mutable: true},
 			},
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
@@ -108,7 +108,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:      wasm.ExternTypeTable,
 				Module:    "my",
 				Name:      "table",
-				DescTable: &wasm.Table{Min: 1, Max: ptrOfUint32(2)},
+				DescTable: wasm.Table{Min: 1, Max: ptrOfUint32(2)},
 			},
 			expected: []byte{
 				0x02, 'm', 'y',

--- a/internal/testing/binaryencoding/section.go
+++ b/internal/testing/binaryencoding/section.go
@@ -29,10 +29,11 @@ func encodeTypeSection(types []*wasm.FunctionType) []byte {
 //
 // See EncodeImport
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#import-section%E2%91%A0
-func encodeImportSection(imports []*wasm.Import) []byte {
+func encodeImportSection(imports []wasm.Import) []byte {
 	contents := leb128.EncodeUint32(uint32(len(imports)))
-	for _, i := range imports {
-		contents = append(contents, EncodeImport(i)...)
+	for i := range imports {
+		imp := &imports[i]
+		contents = append(contents, EncodeImport(imp)...)
 	}
 	return encodeSection(wasm.SectionIDImport, contents)
 }
@@ -67,9 +68,10 @@ func encodeCodeSection(code []*wasm.Code) []byte {
 //
 // See EncodeTable
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#table-section%E2%91%A0
-func encodeTableSection(tables []*wasm.Table) []byte {
+func encodeTableSection(tables []wasm.Table) []byte {
 	var contents []byte = leb128.EncodeUint32(uint32(len(tables)))
-	for _, table := range tables {
+	for i := range tables {
+		table := &tables[i]
 		contents = append(contents, EncodeTable(table)...)
 	}
 	return encodeSection(wasm.SectionIDTable, contents)
@@ -90,7 +92,7 @@ func encodeMemorySection(memory *wasm.Memory) []byte {
 //
 // See encodeGlobal
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-section%E2%91%A0
-func encodeGlobalSection(globals []*wasm.Global) []byte {
+func encodeGlobalSection(globals []wasm.Global) []byte {
 	contents := leb128.EncodeUint32(uint32(len(globals)))
 	for _, g := range globals {
 		contents = append(contents, encodeGlobal(g)...)
@@ -103,9 +105,10 @@ func encodeGlobalSection(globals []*wasm.Global) []byte {
 //
 // See encodeExport
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#export-section%E2%91%A0
-func encodeExportSection(exports []*wasm.Export) []byte {
+func encodeExportSection(exports []wasm.Export) []byte {
 	contents := leb128.EncodeUint32(uint32(len(exports)))
-	for _, e := range exports {
+	for i := range exports {
+		e := &exports[i]
 		contents = append(contents, encodeExport(e)...)
 	}
 	return encodeSection(wasm.SectionIDExport, contents)

--- a/internal/testing/binaryencoding/section.go
+++ b/internal/testing/binaryencoding/section.go
@@ -123,9 +123,10 @@ func EncodeStartSection(funcidx wasm.Index) []byte {
 // Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#element-section%E2%91%A0
-func encodeElementSection(elements []*wasm.ElementSegment) []byte {
+func encodeElementSection(elements []wasm.ElementSegment) []byte {
 	contents := leb128.EncodeUint32(uint32(len(elements)))
-	for _, e := range elements {
+	for i := range elements {
+		e := &elements[i]
 		contents = append(contents, encodeElement(e)...)
 	}
 	return encodeSection(wasm.SectionIDElement, contents)
@@ -135,9 +136,10 @@ func encodeElementSection(elements []*wasm.ElementSegment) []byte {
 // Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#data-section%E2%91%A0
-func encodeDataSection(datum []*wasm.DataSegment) []byte {
+func encodeDataSection(datum []wasm.DataSegment) []byte {
 	contents := leb128.EncodeUint32(uint32(len(datum)))
-	for _, d := range datum {
+	for i := range datum {
+		d := &datum[i]
 		contents = append(contents, encodeDataSegment(d)...)
 	}
 	return encodeSection(wasm.SectionIDData, contents)

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -493,8 +493,8 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: 2},
 		DataSection: []wasm.DataSegment{
 			{
-				OffsetExpression: nil, // passive
-				Init:             []byte(wasmPhrase),
+				Passive: true,
+				Init:    []byte(wasmPhrase),
 			},
 		},
 		DataCountSection: &one,

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -101,7 +101,7 @@ func RunTestEngine_MemoryGrowInRecursiveCall(t *testing.T, et EngineTester) {
 			},
 		},
 		MemorySection: &wasm.Memory{Max: 1000},
-		ImportSection: []*wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 0}},
+		ImportSection: []wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 0}},
 	}
 	m.BuildFunctionDefinitions()
 	m.BuildMemoryDefinitions()
@@ -513,7 +513,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 				wasm.OpcodeEnd,
 			}},
 		},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: "grow", Type: wasm.ExternTypeFunc, Index: 0},
 			{Name: "init", Type: wasm.ExternTypeFunc, Index: 1},
 		},
@@ -652,7 +652,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		TypeSection:     []*wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0},
 		CodeSection:     []*wasm.Code{divBy},
-		ExportSection:   []*wasm.Export{{Name: divByGoName, Type: wasm.ExternTypeFunc, Index: 0}},
+		ExportSection:   []wasm.Export{{Name: divByGoName, Type: wasm.ExternTypeFunc, Index: 0}},
 		NameSection: &wasm.NameSection{
 			ModuleName:    "host",
 			FunctionNames: wasm.NameMap{{Index: wasm.Index(0), Name: divByName}},
@@ -673,7 +673,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 	linkModuleToEngine(host, hostME)
 
 	importedModule := &wasm.Module{
-		ImportSection:   []*wasm.Import{{}},
+		ImportSection:   []wasm.Import{{}},
 		TypeSection:     []*wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0, 0},
 		CodeSection: []*wasm.Code{
@@ -681,7 +681,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, byte(0), // Calling imported host function ^.
 				wasm.OpcodeEnd}},
 		},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: divByWasmName, Type: wasm.ExternTypeFunc, Index: 1},
 			{Name: callDivByGoName, Type: wasm.ExternTypeFunc, Index: 2},
 		},
@@ -713,12 +713,12 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 	// To test stack traces, call the same function from another module
 	importingModule := &wasm.Module{
 		TypeSection:     []*wasm.FunctionType{ft},
-		ImportSection:   []*wasm.Import{{}},
+		ImportSection:   []wasm.Import{{}},
 		FunctionSection: []wasm.Index{0},
 		CodeSection: []*wasm.Code{
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0 /* only one imported function */, wasm.OpcodeEnd}},
 		},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: callImportCallDivByGoName, Type: wasm.ExternTypeFunc, Index: 1},
 		},
 		NameSection: &wasm.NameSection{
@@ -757,7 +757,7 @@ func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code, fnlf exp
 		TypeSection:     []*wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0},
 		CodeSection:     []*wasm.Code{readMem},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: readMemName, Type: wasm.ExternTypeFunc, Index: 0},
 		},
 		NameSection: &wasm.NameSection{
@@ -780,12 +780,12 @@ func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code, fnlf exp
 
 	importingModule := &wasm.Module{
 		TypeSection: []*wasm.FunctionType{ft},
-		ImportSection: []*wasm.Import{
+		ImportSection: []wasm.Import{
 			// Placeholder for two import functions from `importedModule`.
 			{Type: wasm.ExternTypeFunc, DescFunc: 0},
 		},
 		FunctionSection: []wasm.Index{0},
-		ExportSection: []*wasm.Export{
+		ExportSection: []wasm.Export{
 			{Name: callImportReadMemName, Type: wasm.ExternTypeFunc, Index: 1},
 		},
 		CodeSection: []*wasm.Code{

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -491,7 +491,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 		TypeSection:     []*wasm.FunctionType{{Params: []api.ValueType{api.ValueTypeI32}, ParamNumInUint64: 1}, v_v},
 		FunctionSection: []wasm.Index{0, 1},
 		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: 2},
-		DataSection: []*wasm.DataSegment{
+		DataSection: []wasm.DataSegment{
 			{
 				OffsetExpression: nil, // passive
 				Init:             []byte(wasmPhrase),

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -43,7 +43,7 @@ func NewModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) []byt
 	funcNum := uint32(len(funcDefs))
 	proxyModule := &wasm.Module{
 		MemorySection: &wasm.Memory{Min: 1},
-		ExportSection: []*wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
+		ExportSection: []wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
 		NameSection:   &wasm.NameSection{ModuleName: proxyModuleName},
 	}
 	var cnt wasm.Index
@@ -54,7 +54,7 @@ func NewModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) []byt
 
 		// Imports the function.
 		name := def.ExportNames()[0]
-		proxyModule.ImportSection = append(proxyModule.ImportSection, &wasm.Import{
+		proxyModule.ImportSection = append(proxyModule.ImportSection, wasm.Import{
 			Module:   moduleName,
 			Name:     name,
 			DescFunc: cnt,
@@ -88,7 +88,7 @@ func NewModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) []byt
 			&wasm.NameAssoc{Index: proxyFuncIndex, Name: name})
 
 		// Finally, exports the proxy function with the same name as the imported one.
-		proxyModule.ExportSection = append(proxyModule.ExportSection, &wasm.Export{
+		proxyModule.ExportSection = append(proxyModule.ExportSection, wasm.Export{
 			Type:  wasm.ExternTypeFunc,
 			Name:  name,
 			Index: proxyFuncIndex,

--- a/internal/wasm/binary/const_expr.go
+++ b/internal/wasm/binary/const_expr.go
@@ -11,10 +11,10 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.ConstantExpression, error) {
+func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures, ret *wasm.ConstantExpression) error {
 	b, err := r.ReadByte()
 	if err != nil {
-		return wasm.ConstantExpression{}, fmt.Errorf("read opcode: %v", err)
+		return fmt.Errorf("read opcode: %v", err)
 	}
 
 	remainingBeforeData := int64(r.Len())
@@ -31,44 +31,44 @@ func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures)
 	case wasm.OpcodeF32Const:
 		buf := make([]byte, 4)
 		if _, err := io.ReadFull(r, buf); err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("read f32 constant: %v", err)
+			return fmt.Errorf("read f32 constant: %v", err)
 		}
 		_, err = ieee754.DecodeFloat32(buf)
 	case wasm.OpcodeF64Const:
 		buf := make([]byte, 8)
 		if _, err := io.ReadFull(r, buf); err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("read f64 constant: %v", err)
+			return fmt.Errorf("read f64 constant: %v", err)
 		}
 		_, err = ieee754.DecodeFloat64(buf)
 	case wasm.OpcodeGlobalGet:
 		_, _, err = leb128.DecodeUint32(r)
 	case wasm.OpcodeRefNull:
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("ref.null is not supported as %w", err)
+			return fmt.Errorf("ref.null is not supported as %w", err)
 		}
 		reftype, err := r.ReadByte()
 		if err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("read reference type for ref.null: %w", err)
+			return fmt.Errorf("read reference type for ref.null: %w", err)
 		} else if reftype != wasm.RefTypeFuncref && reftype != wasm.RefTypeExternref {
-			return wasm.ConstantExpression{}, fmt.Errorf("invalid type for ref.null: 0x%x", reftype)
+			return fmt.Errorf("invalid type for ref.null: 0x%x", reftype)
 		}
 	case wasm.OpcodeRefFunc:
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("ref.func is not supported as %w", err)
+			return fmt.Errorf("ref.func is not supported as %w", err)
 		}
 		// Parsing index.
 		_, _, err = leb128.DecodeUint32(r)
 	case wasm.OpcodeVecPrefix:
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureSIMD); err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("vector instructions are not supported as %w", err)
+			return fmt.Errorf("vector instructions are not supported as %w", err)
 		}
 		opcode, err = r.ReadByte()
 		if err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("read vector instruction opcode suffix: %w", err)
+			return fmt.Errorf("read vector instruction opcode suffix: %w", err)
 		}
 
 		if opcode != wasm.OpcodeVecV128Const {
-			return wasm.ConstantExpression{}, fmt.Errorf("invalid vector opcode for const expression: %#x", opcode)
+			return fmt.Errorf("invalid vector opcode for const expression: %#x", opcode)
 		}
 
 		remainingBeforeData = int64(r.Len())
@@ -76,30 +76,30 @@ func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures)
 
 		n, err := r.Read(make([]byte, 16))
 		if err != nil {
-			return wasm.ConstantExpression{}, fmt.Errorf("read vector const instruction immediates: %w", err)
+			return fmt.Errorf("read vector const instruction immediates: %w", err)
 		} else if n != 16 {
-			return wasm.ConstantExpression{}, fmt.Errorf("read vector const instruction immediates: needs 16 bytes but was %d bytes", n)
+			return fmt.Errorf("read vector const instruction immediates: needs 16 bytes but was %d bytes", n)
 		}
 	default:
-		return wasm.ConstantExpression{}, fmt.Errorf("%v for const expression opt code: %#x", ErrInvalidByte, b)
+		return fmt.Errorf("%v for const expression opt code: %#x", ErrInvalidByte, b)
 	}
 
 	if err != nil {
-		return wasm.ConstantExpression{}, fmt.Errorf("read value: %v", err)
+		return fmt.Errorf("read value: %v", err)
 	}
 
 	if b, err = r.ReadByte(); err != nil {
-		return wasm.ConstantExpression{}, fmt.Errorf("look for end opcode: %v", err)
+		return fmt.Errorf("look for end opcode: %v", err)
 	}
 
 	if b != wasm.OpcodeEnd {
-		return wasm.ConstantExpression{}, fmt.Errorf("constant expression has been not terminated")
+		return fmt.Errorf("constant expression has been not terminated")
 	}
 
-	data := make([]byte, remainingBeforeData-int64(r.Len())-1)
-	if _, err := r.ReadAt(data, offsetAtData); err != nil {
-		return wasm.ConstantExpression{}, fmt.Errorf("error re-buffering ConstantExpression.Data")
+	ret.Data = make([]byte, remainingBeforeData-int64(r.Len())-1)
+	if _, err = r.ReadAt(ret.Data, offsetAtData); err != nil {
+		return fmt.Errorf("error re-buffering ConstantExpression.Data")
 	}
-
-	return wasm.ConstantExpression{Opcode: opcode, Data: data}, nil
+	ret.Opcode = opcode
+	return nil
 }

--- a/internal/wasm/binary/const_expr.go
+++ b/internal/wasm/binary/const_expr.go
@@ -11,10 +11,10 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures) (*wasm.ConstantExpression, error) {
+func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.ConstantExpression, error) {
 	b, err := r.ReadByte()
 	if err != nil {
-		return nil, fmt.Errorf("read opcode: %v", err)
+		return wasm.ConstantExpression{}, fmt.Errorf("read opcode: %v", err)
 	}
 
 	remainingBeforeData := int64(r.Len())
@@ -31,44 +31,44 @@ func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures)
 	case wasm.OpcodeF32Const:
 		buf := make([]byte, 4)
 		if _, err := io.ReadFull(r, buf); err != nil {
-			return nil, fmt.Errorf("read f32 constant: %v", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("read f32 constant: %v", err)
 		}
 		_, err = ieee754.DecodeFloat32(buf)
 	case wasm.OpcodeF64Const:
 		buf := make([]byte, 8)
 		if _, err := io.ReadFull(r, buf); err != nil {
-			return nil, fmt.Errorf("read f64 constant: %v", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("read f64 constant: %v", err)
 		}
 		_, err = ieee754.DecodeFloat64(buf)
 	case wasm.OpcodeGlobalGet:
 		_, _, err = leb128.DecodeUint32(r)
 	case wasm.OpcodeRefNull:
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return nil, fmt.Errorf("ref.null is not supported as %w", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("ref.null is not supported as %w", err)
 		}
 		reftype, err := r.ReadByte()
 		if err != nil {
-			return nil, fmt.Errorf("read reference type for ref.null: %w", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("read reference type for ref.null: %w", err)
 		} else if reftype != wasm.RefTypeFuncref && reftype != wasm.RefTypeExternref {
-			return nil, fmt.Errorf("invalid type for ref.null: 0x%x", reftype)
+			return wasm.ConstantExpression{}, fmt.Errorf("invalid type for ref.null: 0x%x", reftype)
 		}
 	case wasm.OpcodeRefFunc:
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return nil, fmt.Errorf("ref.func is not supported as %w", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("ref.func is not supported as %w", err)
 		}
 		// Parsing index.
 		_, _, err = leb128.DecodeUint32(r)
 	case wasm.OpcodeVecPrefix:
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureSIMD); err != nil {
-			return nil, fmt.Errorf("vector instructions are not supported as %w", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("vector instructions are not supported as %w", err)
 		}
 		opcode, err = r.ReadByte()
 		if err != nil {
-			return nil, fmt.Errorf("read vector instruction opcode suffix: %w", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("read vector instruction opcode suffix: %w", err)
 		}
 
 		if opcode != wasm.OpcodeVecV128Const {
-			return nil, fmt.Errorf("invalid vector opcode for const expression: %#x", opcode)
+			return wasm.ConstantExpression{}, fmt.Errorf("invalid vector opcode for const expression: %#x", opcode)
 		}
 
 		remainingBeforeData = int64(r.Len())
@@ -76,30 +76,30 @@ func decodeConstantExpression(r *bytes.Reader, enabledFeatures api.CoreFeatures)
 
 		n, err := r.Read(make([]byte, 16))
 		if err != nil {
-			return nil, fmt.Errorf("read vector const instruction immediates: %w", err)
+			return wasm.ConstantExpression{}, fmt.Errorf("read vector const instruction immediates: %w", err)
 		} else if n != 16 {
-			return nil, fmt.Errorf("read vector const instruction immediates: needs 16 bytes but was %d bytes", n)
+			return wasm.ConstantExpression{}, fmt.Errorf("read vector const instruction immediates: needs 16 bytes but was %d bytes", n)
 		}
 	default:
-		return nil, fmt.Errorf("%v for const expression opt code: %#x", ErrInvalidByte, b)
+		return wasm.ConstantExpression{}, fmt.Errorf("%v for const expression opt code: %#x", ErrInvalidByte, b)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("read value: %v", err)
+		return wasm.ConstantExpression{}, fmt.Errorf("read value: %v", err)
 	}
 
 	if b, err = r.ReadByte(); err != nil {
-		return nil, fmt.Errorf("look for end opcode: %v", err)
+		return wasm.ConstantExpression{}, fmt.Errorf("look for end opcode: %v", err)
 	}
 
 	if b != wasm.OpcodeEnd {
-		return nil, fmt.Errorf("constant expression has been not terminated")
+		return wasm.ConstantExpression{}, fmt.Errorf("constant expression has been not terminated")
 	}
 
 	data := make([]byte, remainingBeforeData-int64(r.Len())-1)
 	if _, err := r.ReadAt(data, offsetAtData); err != nil {
-		return nil, fmt.Errorf("error re-buffering ConstantExpression.Data")
+		return wasm.ConstantExpression{}, fmt.Errorf("error re-buffering ConstantExpression.Data")
 	}
 
-	return &wasm.ConstantExpression{Opcode: opcode, Data: data}, nil
+	return wasm.ConstantExpression{Opcode: opcode, Data: data}, nil
 }

--- a/internal/wasm/binary/const_expr_test.go
+++ b/internal/wasm/binary/const_expr_test.go
@@ -84,8 +84,9 @@ func TestDecodeConstantExpression(t *testing.T) {
 	for i, tt := range tests {
 		tc := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := decodeConstantExpression(bytes.NewReader(tc.in),
-				api.CoreFeatureBulkMemoryOperations|api.CoreFeatureSIMD)
+			var actual wasm.ConstantExpression
+			err := decodeConstantExpression(bytes.NewReader(tc.in),
+				api.CoreFeatureBulkMemoryOperations|api.CoreFeatureSIMD, &actual)
 			require.NoError(t, err)
 			require.Equal(t, tc.exp, actual)
 		})
@@ -182,7 +183,8 @@ func TestDecodeConstantExpression_errors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.expectedErr, func(t *testing.T) {
-			_, err := decodeConstantExpression(bytes.NewReader(tc.in), tc.features)
+			var actual wasm.ConstantExpression
+			err := decodeConstantExpression(bytes.NewReader(tc.in), tc.features, &actual)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/binary/const_expr_test.go
+++ b/internal/wasm/binary/const_expr_test.go
@@ -13,7 +13,7 @@ import (
 func TestDecodeConstantExpression(t *testing.T) {
 	tests := []struct {
 		in  []byte
-		exp *wasm.ConstantExpression
+		exp wasm.ConstantExpression
 	}{
 		{
 			in: []byte{
@@ -21,7 +21,7 @@ func TestDecodeConstantExpression(t *testing.T) {
 				0x80, 0, // Multi byte zero.
 				wasm.OpcodeEnd,
 			},
-			exp: &wasm.ConstantExpression{
+			exp: wasm.ConstantExpression{
 				Opcode: wasm.OpcodeRefFunc,
 				Data:   []byte{0x80, 0},
 			},
@@ -32,7 +32,7 @@ func TestDecodeConstantExpression(t *testing.T) {
 				0x80, 0x80, 0x80, 0x4f, // 165675008 in varint encoding.
 				wasm.OpcodeEnd,
 			},
-			exp: &wasm.ConstantExpression{
+			exp: wasm.ConstantExpression{
 				Opcode: wasm.OpcodeRefFunc,
 				Data:   []byte{0x80, 0x80, 0x80, 0x4f},
 			},
@@ -43,7 +43,7 @@ func TestDecodeConstantExpression(t *testing.T) {
 				wasm.RefTypeFuncref,
 				wasm.OpcodeEnd,
 			},
-			exp: &wasm.ConstantExpression{
+			exp: wasm.ConstantExpression{
 				Opcode: wasm.OpcodeRefNull,
 				Data: []byte{
 					wasm.RefTypeFuncref,
@@ -56,7 +56,7 @@ func TestDecodeConstantExpression(t *testing.T) {
 				wasm.RefTypeExternref,
 				wasm.OpcodeEnd,
 			},
-			exp: &wasm.ConstantExpression{
+			exp: wasm.ConstantExpression{
 				Opcode: wasm.OpcodeRefNull,
 				Data: []byte{
 					wasm.RefTypeExternref,
@@ -71,7 +71,7 @@ func TestDecodeConstantExpression(t *testing.T) {
 				1, 1, 1, 1, 1, 1, 1, 1,
 				wasm.OpcodeEnd,
 			},
-			exp: &wasm.ConstantExpression{
+			exp: wasm.ConstantExpression{
 				Opcode: wasm.OpcodeVecV128Const,
 				Data: []byte{
 					1, 1, 1, 1, 1, 1, 1, 1,

--- a/internal/wasm/binary/data.go
+++ b/internal/wasm/binary/data.go
@@ -24,19 +24,20 @@ const (
 	dataSegmentPrefixActiveWithMemoryIndex dataSegmentPrefix = 0x2
 )
 
-func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.DataSegment, error) {
+func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (ret wasm.DataSegment, err error) {
 	dataSegmentPrefx, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return wasm.DataSegment{}, fmt.Errorf("read data segment prefix: %w", err)
+		err = fmt.Errorf("read data segment prefix: %w", err)
+		return
 	}
 
 	if dataSegmentPrefx != dataSegmentPrefixActive {
-		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return wasm.DataSegment{}, fmt.Errorf("non-zero prefix for data segment is invalid as %w", err)
+		if err = enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
+			err = fmt.Errorf("non-zero prefix for data segment is invalid as %w", err)
+			return
 		}
 	}
 
-	var expr *wasm.ConstantExpression
 	switch dataSegmentPrefx {
 	case dataSegmentPrefixActive,
 		dataSegmentPrefixActiveWithMemoryIndex:
@@ -45,35 +46,34 @@ func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.
 		if dataSegmentPrefx == 0x2 {
 			d, _, err := leb128.DecodeUint32(r)
 			if err != nil {
-				return wasm.DataSegment{}, fmt.Errorf("read memory index: %v", err)
+				return ret, fmt.Errorf("read memory index: %v", err)
 			} else if d != 0 {
-				return wasm.DataSegment{}, fmt.Errorf("memory index must be zero but was %d", d)
+				return ret, fmt.Errorf("memory index must be zero but was %d", d)
 			}
 		}
 
-		expr, err = decodeConstantExpression(r, enabledFeatures)
+		expr, err := decodeConstantExpression(r, enabledFeatures)
 		if err != nil {
-			return wasm.DataSegment{}, fmt.Errorf("read offset expression: %v", err)
+			return ret, fmt.Errorf("read offset expression: %v", err)
 		}
+		ret.OffsetExpression = &expr
 	case dataSegmentPrefixPassive:
 		// Passive data segment doesn't need const expr nor memory index encoded.
 		// https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/binary/modules.html#data-section
 	default:
-		return wasm.DataSegment{}, fmt.Errorf("invalid data segment prefix: 0x%x", dataSegmentPrefx)
+		err = fmt.Errorf("invalid data segment prefix: 0x%x", dataSegmentPrefx)
+		return
 	}
 
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return wasm.DataSegment{}, fmt.Errorf("get the size of vector: %v", err)
+		err = fmt.Errorf("get the size of vector: %v", err)
+		return
 	}
 
-	b := make([]byte, vs)
-	if _, err := io.ReadFull(r, b); err != nil {
-		return wasm.DataSegment{}, fmt.Errorf("read bytes for init: %v", err)
+	ret.Init = make([]byte, vs)
+	if _, err = io.ReadFull(r, ret.Init); err != nil {
+		err = fmt.Errorf("read bytes for init: %v", err)
 	}
-
-	return wasm.DataSegment{
-		OffsetExpression: expr,
-		Init:             b,
-	}, nil
+	return
 }

--- a/internal/wasm/binary/data.go
+++ b/internal/wasm/binary/data.go
@@ -24,15 +24,15 @@ const (
 	dataSegmentPrefixActiveWithMemoryIndex dataSegmentPrefix = 0x2
 )
 
-func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (*wasm.DataSegment, error) {
+func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.DataSegment, error) {
 	dataSegmentPrefx, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return nil, fmt.Errorf("read data segment prefix: %w", err)
+		return wasm.DataSegment{}, fmt.Errorf("read data segment prefix: %w", err)
 	}
 
 	if dataSegmentPrefx != dataSegmentPrefixActive {
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return nil, fmt.Errorf("non-zero prefix for data segment is invalid as %w", err)
+			return wasm.DataSegment{}, fmt.Errorf("non-zero prefix for data segment is invalid as %w", err)
 		}
 	}
 
@@ -45,34 +45,34 @@ func decodeDataSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (*wasm
 		if dataSegmentPrefx == 0x2 {
 			d, _, err := leb128.DecodeUint32(r)
 			if err != nil {
-				return nil, fmt.Errorf("read memory index: %v", err)
+				return wasm.DataSegment{}, fmt.Errorf("read memory index: %v", err)
 			} else if d != 0 {
-				return nil, fmt.Errorf("memory index must be zero but was %d", d)
+				return wasm.DataSegment{}, fmt.Errorf("memory index must be zero but was %d", d)
 			}
 		}
 
 		expr, err = decodeConstantExpression(r, enabledFeatures)
 		if err != nil {
-			return nil, fmt.Errorf("read offset expression: %v", err)
+			return wasm.DataSegment{}, fmt.Errorf("read offset expression: %v", err)
 		}
 	case dataSegmentPrefixPassive:
 		// Passive data segment doesn't need const expr nor memory index encoded.
 		// https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/binary/modules.html#data-section
 	default:
-		return nil, fmt.Errorf("invalid data segment prefix: 0x%x", dataSegmentPrefx)
+		return wasm.DataSegment{}, fmt.Errorf("invalid data segment prefix: 0x%x", dataSegmentPrefx)
 	}
 
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return nil, fmt.Errorf("get the size of vector: %v", err)
+		return wasm.DataSegment{}, fmt.Errorf("get the size of vector: %v", err)
 	}
 
 	b := make([]byte, vs)
 	if _, err := io.ReadFull(r, b); err != nil {
-		return nil, fmt.Errorf("read bytes for init: %v", err)
+		return wasm.DataSegment{}, fmt.Errorf("read bytes for init: %v", err)
 	}
 
-	return &wasm.DataSegment{
+	return wasm.DataSegment{
 		OffsetExpression: expr,
 		Init:             b,
 	}, nil

--- a/internal/wasm/binary/data_test.go
+++ b/internal/wasm/binary/data_test.go
@@ -13,7 +13,7 @@ import (
 func Test_decodeDataSegment(t *testing.T) {
 	tests := []struct {
 		in       []byte
-		exp      *wasm.DataSegment
+		exp      wasm.DataSegment
 		features api.CoreFeatures
 		expErr   string
 	}{
@@ -36,7 +36,7 @@ func Test_decodeDataSegment(t *testing.T) {
 				// Two initial data.
 				0x2, 0xf, 0xf,
 			},
-			exp: &wasm.DataSegment{
+			exp: wasm.DataSegment{
 				OffsetExpression: &wasm.ConstantExpression{
 					Opcode: wasm.OpcodeI32Const,
 					Data:   []byte{0x1},
@@ -61,7 +61,7 @@ func Test_decodeDataSegment(t *testing.T) {
 				// Two initial data.
 				0x2, 0xf, 0xf,
 			},
-			exp: &wasm.DataSegment{
+			exp: wasm.DataSegment{
 				OffsetExpression: nil,
 				Init:             []byte{0xf, 0xf},
 			},
@@ -76,7 +76,7 @@ func Test_decodeDataSegment(t *testing.T) {
 				// Two initial data.
 				0x2, 0xf, 0xf,
 			},
-			exp: &wasm.DataSegment{
+			exp: wasm.DataSegment{
 				OffsetExpression: &wasm.ConstantExpression{
 					Opcode: wasm.OpcodeI32Const,
 					Data:   []byte{0x1},

--- a/internal/wasm/binary/data_test.go
+++ b/internal/wasm/binary/data_test.go
@@ -37,7 +37,7 @@ func Test_decodeDataSegment(t *testing.T) {
 				0x2, 0xf, 0xf,
 			},
 			exp: wasm.DataSegment{
-				OffsetExpression: &wasm.ConstantExpression{
+				OffsetExpression: wasm.ConstantExpression{
 					Opcode: wasm.OpcodeI32Const,
 					Data:   []byte{0x1},
 				},
@@ -62,8 +62,8 @@ func Test_decodeDataSegment(t *testing.T) {
 				0x2, 0xf, 0xf,
 			},
 			exp: wasm.DataSegment{
-				OffsetExpression: nil,
-				Init:             []byte{0xf, 0xf},
+				Passive: true,
+				Init:    []byte{0xf, 0xf},
 			},
 			features: api.CoreFeatureBulkMemoryOperations,
 		},
@@ -77,7 +77,7 @@ func Test_decodeDataSegment(t *testing.T) {
 				0x2, 0xf, 0xf,
 			},
 			exp: wasm.DataSegment{
-				OffsetExpression: &wasm.ConstantExpression{
+				OffsetExpression: wasm.ConstantExpression{
 					Opcode: wasm.OpcodeI32Const,
 					Data:   []byte{0x1},
 				},
@@ -126,7 +126,8 @@ func Test_decodeDataSegment(t *testing.T) {
 	for i, tt := range tests {
 		tc := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := decodeDataSegment(bytes.NewReader(tc.in), tc.features)
+			var actual wasm.DataSegment
+			err := decodeDataSegment(bytes.NewReader(tc.in), tc.features, &actual)
 			if tc.expErr == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.exp, actual)

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -45,7 +45,7 @@ func TestDecodeModule(t *testing.T) {
 					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
 					{Params: []wasm.ValueType{f32, f32}, Results: []wasm.ValueType{f32}},
 				},
-				ImportSection: []*wasm.Import{
+				ImportSection: []wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
 						Type:     wasm.ExternTypeFunc,
@@ -61,7 +61,7 @@ func TestDecodeModule(t *testing.T) {
 		{
 			name: "table and memory section",
 			input: &wasm.Module{
-				TableSection:  []*wasm.Table{{Min: 3, Type: wasm.RefTypeFuncref}},
+				TableSection:  []wasm.Table{{Min: 3, Type: wasm.RefTypeFuncref}},
 				MemorySection: &wasm.Memory{Min: 1, Cap: 1, Max: 1, IsMaxEncoded: true},
 			},
 		},
@@ -69,7 +69,7 @@ func TestDecodeModule(t *testing.T) {
 			name: "type function and start section",
 			input: &wasm.Module{
 				TypeSection: []*wasm.FunctionType{{}},
-				ImportSection: []*wasm.Import{{
+				ImportSection: []wasm.Import{{
 					Module: "", Name: "hello",
 					Type:     wasm.ExternTypeFunc,
 					DescFunc: 0,

--- a/internal/wasm/binary/element.go
+++ b/internal/wasm/binary/element.go
@@ -45,7 +45,8 @@ func decodeElementConstExprVector(r *bytes.Reader, elemType wasm.RefType, enable
 	}
 	vec := make([]*wasm.Index, vs)
 	for i := range vec {
-		expr, err := decodeConstantExpression(r, enabledFeatures)
+		var expr wasm.ConstantExpression
+		err := decodeConstantExpression(r, enabledFeatures, &expr)
 		if err != nil {
 			return nil, err
 		}
@@ -102,15 +103,15 @@ const (
 	elementSegmentPrefixDeclarativeConstExprVector
 )
 
-func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.ElementSegment, error) {
+func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures, ret *wasm.ElementSegment) error {
 	prefix, _, err := leb128.DecodeUint32(r)
 	if err != nil {
-		return wasm.ElementSegment{}, fmt.Errorf("read element prefix: %w", err)
+		return fmt.Errorf("read element prefix: %w", err)
 	}
 
 	if prefix != elementSegmentPrefixLegacy {
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureBulkMemoryOperations); err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("non-zero prefix for element segment is invalid as %w", err)
+			return fmt.Errorf("non-zero prefix for element segment is invalid as %w", err)
 		}
 	}
 
@@ -118,166 +119,139 @@ func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wa
 	switch prefix {
 	case elementSegmentPrefixLegacy:
 		// Legacy prefix which is WebAssembly 1.0 compatible.
-		expr, err := decodeConstantExpression(r, enabledFeatures)
+		err = decodeConstantExpression(r, enabledFeatures, &ret.OffsetExpr)
 		if err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("read expr for offset: %w", err)
+			return fmt.Errorf("read expr for offset: %w", err)
 		}
 
-		init, err := decodeElementInitValueVector(r)
+		ret.Init, err = decodeElementInitValueVector(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
 
-		return wasm.ElementSegment{
-			OffsetExpr: &expr,
-			Init:       init,
-			Type:       wasm.RefTypeFuncref,
-			Mode:       wasm.ElementModeActive,
-			// Legacy prefix has the fixed table index zero.
-			TableIndex: 0,
-		}, nil
+		ret.Mode = wasm.ElementModeActive
+		ret.Type = wasm.RefTypeFuncref
+		return nil
 	case elementSegmentPrefixPassiveFuncrefValueVector:
 		// Prefix 1 requires funcref.
 		if err = ensureElementKindFuncRef(r); err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
 
-		init, err := decodeElementInitValueVector(r)
+		ret.Init, err = decodeElementInitValueVector(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		return wasm.ElementSegment{
-			Init: init,
-			Type: wasm.RefTypeFuncref,
-			Mode: wasm.ElementModePassive,
-		}, nil
+		ret.Mode = wasm.ElementModePassive
+		ret.Type = wasm.RefTypeFuncref
+		return nil
 	case elementSegmentPrefixActiveFuncrefValueVectorWithTableIndex:
-		tableIndex, _, err := leb128.DecodeUint32(r)
+		ret.TableIndex, _, err = leb128.DecodeUint32(r)
 		if err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("get size of vector: %w", err)
+			return fmt.Errorf("get size of vector: %w", err)
 		}
 
-		if tableIndex != 0 {
+		if ret.TableIndex != 0 {
 			if err := enabledFeatures.RequireEnabled(api.CoreFeatureReferenceTypes); err != nil {
-				return wasm.ElementSegment{}, fmt.Errorf("table index must be zero but was %d: %w", tableIndex, err)
+				return fmt.Errorf("table index must be zero but was %d: %w", ret.TableIndex, err)
 			}
 		}
 
-		expr, err := decodeConstantExpression(r, enabledFeatures)
+		err := decodeConstantExpression(r, enabledFeatures, &ret.OffsetExpr)
 		if err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("read expr for offset: %w", err)
+			return fmt.Errorf("read expr for offset: %w", err)
 		}
 
 		// Prefix 2 requires funcref.
 		if err = ensureElementKindFuncRef(r); err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
 
-		init, err := decodeElementInitValueVector(r)
+		ret.Init, err = decodeElementInitValueVector(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		return wasm.ElementSegment{
-			OffsetExpr: &expr,
-			Init:       init,
-			Type:       wasm.RefTypeFuncref,
-			Mode:       wasm.ElementModeActive,
-			TableIndex: tableIndex,
-		}, nil
+
+		ret.Mode = wasm.ElementModeActive
+		ret.Type = wasm.RefTypeFuncref
+		return nil
 	case elementSegmentPrefixDeclarativeFuncrefValueVector:
 		// Prefix 3 requires funcref.
 		if err = ensureElementKindFuncRef(r); err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		init, err := decodeElementInitValueVector(r)
+		ret.Init, err = decodeElementInitValueVector(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		return wasm.ElementSegment{
-			Init: init,
-			Type: wasm.RefTypeFuncref,
-			Mode: wasm.ElementModeDeclarative,
-		}, nil
+		ret.Type = wasm.RefTypeFuncref
+		ret.Mode = wasm.ElementModeDeclarative
+		return nil
 	case elementSegmentPrefixActiveFuncrefConstExprVector:
-		expr, err := decodeConstantExpression(r, enabledFeatures)
+		err := decodeConstantExpression(r, enabledFeatures, &ret.OffsetExpr)
 		if err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("read expr for offset: %w", err)
+			return fmt.Errorf("read expr for offset: %w", err)
 		}
 
-		init, err := decodeElementConstExprVector(r, wasm.RefTypeFuncref, enabledFeatures)
+		ret.Init, err = decodeElementConstExprVector(r, wasm.RefTypeFuncref, enabledFeatures)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-
-		return wasm.ElementSegment{
-			OffsetExpr: &expr,
-			Init:       init,
-			Type:       wasm.RefTypeFuncref,
-			Mode:       wasm.ElementModeActive,
-			TableIndex: 0,
-		}, nil
+		ret.Mode = wasm.ElementModeActive
+		ret.Type = wasm.RefTypeFuncref
+		return nil
 	case elementSegmentPrefixPassiveConstExprVector:
-		refType, err := decodeElementRefType(r)
+		ret.Type, err = decodeElementRefType(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		init, err := decodeElementConstExprVector(r, refType, enabledFeatures)
+		ret.Init, err = decodeElementConstExprVector(r, ret.Type, enabledFeatures)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		return wasm.ElementSegment{
-			Init: init,
-			Type: refType,
-			Mode: wasm.ElementModePassive,
-		}, nil
+		ret.Mode = wasm.ElementModePassive
+		return nil
 	case elementSegmentPrefixActiveConstExprVector:
-		tableIndex, _, err := leb128.DecodeUint32(r)
+		ret.TableIndex, _, err = leb128.DecodeUint32(r)
 		if err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("get size of vector: %w", err)
+			return fmt.Errorf("get size of vector: %w", err)
 		}
 
-		if tableIndex != 0 {
+		if ret.TableIndex != 0 {
 			if err := enabledFeatures.RequireEnabled(api.CoreFeatureReferenceTypes); err != nil {
-				return wasm.ElementSegment{}, fmt.Errorf("table index must be zero but was %d: %w", tableIndex, err)
+				return fmt.Errorf("table index must be zero but was %d: %w", ret.TableIndex, err)
 			}
 		}
-		expr, err := decodeConstantExpression(r, enabledFeatures)
+		err := decodeConstantExpression(r, enabledFeatures, &ret.OffsetExpr)
 		if err != nil {
-			return wasm.ElementSegment{}, fmt.Errorf("read expr for offset: %w", err)
+			return fmt.Errorf("read expr for offset: %w", err)
 		}
 
-		refType, err := decodeElementRefType(r)
+		ret.Type, err = decodeElementRefType(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
 
-		init, err := decodeElementConstExprVector(r, refType, enabledFeatures)
+		ret.Init, err = decodeElementConstExprVector(r, ret.Type, enabledFeatures)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
 
-		return wasm.ElementSegment{
-			OffsetExpr: &expr,
-			Init:       init,
-			Type:       refType,
-			Mode:       wasm.ElementModeActive,
-			TableIndex: tableIndex,
-		}, nil
+		ret.Mode = wasm.ElementModeActive
+		return nil
 	case elementSegmentPrefixDeclarativeConstExprVector:
-		refType, err := decodeElementRefType(r)
+		ret.Type, err = decodeElementRefType(r)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		init, err := decodeElementConstExprVector(r, refType, enabledFeatures)
+		ret.Init, err = decodeElementConstExprVector(r, ret.Type, enabledFeatures)
 		if err != nil {
-			return wasm.ElementSegment{}, err
+			return err
 		}
-		return wasm.ElementSegment{
-			Init: init,
-			Type: refType,
-			Mode: wasm.ElementModeDeclarative,
-		}, nil
+
+		ret.Mode = wasm.ElementModeDeclarative
+		return nil
 	default:
-		return wasm.ElementSegment{}, fmt.Errorf("invalid element segment prefix: 0x%x", prefix)
+		return fmt.Errorf("invalid element segment prefix: 0x%x", prefix)
 	}
 }

--- a/internal/wasm/binary/element.go
+++ b/internal/wasm/binary/element.go
@@ -129,7 +129,7 @@ func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wa
 		}
 
 		return wasm.ElementSegment{
-			OffsetExpr: expr,
+			OffsetExpr: &expr,
 			Init:       init,
 			Type:       wasm.RefTypeFuncref,
 			Mode:       wasm.ElementModeActive,
@@ -178,7 +178,7 @@ func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wa
 			return wasm.ElementSegment{}, err
 		}
 		return wasm.ElementSegment{
-			OffsetExpr: expr,
+			OffsetExpr: &expr,
 			Init:       init,
 			Type:       wasm.RefTypeFuncref,
 			Mode:       wasm.ElementModeActive,
@@ -210,7 +210,7 @@ func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wa
 		}
 
 		return wasm.ElementSegment{
-			OffsetExpr: expr,
+			OffsetExpr: &expr,
 			Init:       init,
 			Type:       wasm.RefTypeFuncref,
 			Mode:       wasm.ElementModeActive,
@@ -257,7 +257,7 @@ func decodeElementSegment(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wa
 		}
 
 		return wasm.ElementSegment{
-			OffsetExpr: expr,
+			OffsetExpr: &expr,
 			Init:       init,
 			Type:       refType,
 			Mode:       wasm.ElementModeActive,

--- a/internal/wasm/binary/element_test.go
+++ b/internal/wasm/binary/element_test.go
@@ -162,7 +162,7 @@ func TestDecodeElementSegment(t *testing.T) {
 	tests := []struct {
 		name     string
 		in       []byte
-		exp      *wasm.ElementSegment
+		exp      wasm.ElementSegment
 		expErr   string
 		features api.CoreFeatures
 	}{
@@ -175,7 +175,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				// Init vector.
 				5, 1, 2, 3, 4, 5,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{1}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
@@ -192,7 +192,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				// Init vector.
 				5, 1, 2, 3, 4, 5,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
@@ -208,7 +208,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				// Init vector.
 				5, 1, 2, 3, 4, 5,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				Init: []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode: wasm.ElementModePassive,
 				Type: wasm.RefTypeFuncref,
@@ -226,7 +226,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				// Init vector.
 				5, 1, 2, 3, 4, 5,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
@@ -245,7 +245,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				// Init vector.
 				5, 1, 2, 3, 4, 5,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
@@ -276,7 +276,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				// Init vector.
 				5, 1, 2, 3, 4, 5,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				Init: []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode: wasm.ElementModeDeclarative,
 				Type: wasm.RefTypeFuncref,
@@ -297,7 +297,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeEnd,
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
 				Init:       []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode:       wasm.ElementModeActive,
@@ -318,7 +318,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeEnd,
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				Init: []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode: wasm.ElementModePassive,
 				Type: wasm.RefTypeFuncref,
@@ -350,7 +350,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeEnd,
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
 				Init:       []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode:       wasm.ElementModeActive,
@@ -374,7 +374,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeEnd,
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
 				Init:       []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode:       wasm.ElementModeActive,
@@ -414,7 +414,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				0x80, 0x80, 0x80, 0x4f, // 165675008 in varint encoding.
 				wasm.OpcodeEnd,
 			},
-			exp: &wasm.ElementSegment{
+			exp: wasm.ElementSegment{
 				Init: []*wasm.Index{nil, uint32Ptr(165675008)},
 				Mode: wasm.ElementModeDeclarative,
 				Type: wasm.RefTypeFuncref,

--- a/internal/wasm/binary/element_test.go
+++ b/internal/wasm/binary/element_test.go
@@ -176,7 +176,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				5, 1, 2, 3, 4, 5,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{1}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{1}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -193,7 +193,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				5, 1, 2, 3, 4, 5,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -227,7 +227,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				5, 1, 2, 3, 4, 5,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -246,7 +246,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				5, 1, 2, 3, 4, 5,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 0}},
 				Init:       []*wasm.Index{uint32Ptr(1), uint32Ptr(2), uint32Ptr(3), uint32Ptr(4), uint32Ptr(5)},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -298,7 +298,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
 				Init:       []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -351,7 +351,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
 				Init:       []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -375,7 +375,7 @@ func TestDecodeElementSegment(t *testing.T) {
 				wasm.OpcodeRefNull, wasm.RefTypeFuncref, wasm.OpcodeEnd,
 			},
 			exp: wasm.ElementSegment{
-				OffsetExpr: &wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
+				OffsetExpr: wasm.ConstantExpression{Opcode: wasm.OpcodeI32Const, Data: []byte{0x80, 1}},
 				Init:       []*wasm.Index{nil, uint32Ptr(165675008), nil},
 				Mode:       wasm.ElementModeActive,
 				Type:       wasm.RefTypeFuncref,
@@ -426,7 +426,8 @@ func TestDecodeElementSegment(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := decodeElementSegment(bytes.NewReader(tc.in), tc.features)
+			var actual wasm.ElementSegment
+			err := decodeElementSegment(bytes.NewReader(tc.in), tc.features, &actual)
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
 			} else {
@@ -438,6 +439,7 @@ func TestDecodeElementSegment(t *testing.T) {
 }
 
 func TestDecodeElementSegment_errors(t *testing.T) {
-	_, err := decodeElementSegment(bytes.NewReader([]byte{1}), api.CoreFeatureMultiValue)
+	var actual wasm.ElementSegment
+	err := decodeElementSegment(bytes.NewReader([]byte{1}), api.CoreFeatureMultiValue, &actual)
 	require.EqualError(t, err, `non-zero prefix for element segment is invalid as feature "bulk-memory-operations" is disabled`)
 }

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -8,26 +8,25 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeExport(r *bytes.Reader) (i *wasm.Export, err error) {
-	i = &wasm.Export{}
-
+func decodeExport(r *bytes.Reader) (i wasm.Export, err error) {
 	if i.Name, _, err = decodeUTF8(r, "export name"); err != nil {
-		return nil, err
+		return
 	}
 
 	b, err := r.ReadByte()
 	if err != nil {
-		return nil, fmt.Errorf("error decoding export kind: %w", err)
+		err = fmt.Errorf("error decoding export kind: %w", err)
+		return
 	}
 
 	i.Type = b
 	switch i.Type {
 	case wasm.ExternTypeFunc, wasm.ExternTypeTable, wasm.ExternTypeMemory, wasm.ExternTypeGlobal:
 		if i.Index, _, err = leb128.DecodeUint32(r); err != nil {
-			return nil, fmt.Errorf("error decoding export index: %w", err)
+			err = fmt.Errorf("error decoding export index: %w", err)
 		}
 	default:
-		return nil, fmt.Errorf("%w: invalid byte for exportdesc: %#x", ErrInvalidByte, b)
+		err = fmt.Errorf("%w: invalid byte for exportdesc: %#x", ErrInvalidByte, b)
 	}
 	return
 }

--- a/internal/wasm/binary/export.go
+++ b/internal/wasm/binary/export.go
@@ -8,8 +8,8 @@ import (
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
-func decodeExport(r *bytes.Reader) (i wasm.Export, err error) {
-	if i.Name, _, err = decodeUTF8(r, "export name"); err != nil {
+func decodeExport(r *bytes.Reader, ret *wasm.Export) (err error) {
+	if ret.Name, _, err = decodeUTF8(r, "export name"); err != nil {
 		return
 	}
 
@@ -19,10 +19,10 @@ func decodeExport(r *bytes.Reader) (i wasm.Export, err error) {
 		return
 	}
 
-	i.Type = b
-	switch i.Type {
+	ret.Type = b
+	switch ret.Type {
 	case wasm.ExternTypeFunc, wasm.ExternTypeTable, wasm.ExternTypeMemory, wasm.ExternTypeGlobal:
-		if i.Index, _, err = leb128.DecodeUint32(r); err != nil {
+		if ret.Index, _, err = leb128.DecodeUint32(r); err != nil {
 			err = fmt.Errorf("error decoding export index: %w", err)
 		}
 	default:

--- a/internal/wasm/binary/global.go
+++ b/internal/wasm/binary/global.go
@@ -11,18 +11,14 @@ import (
 // decodeGlobal returns the api.Global decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-global
-func decodeGlobal(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.Global, error) {
-	gt, err := decodeGlobalType(r)
+func decodeGlobal(r *bytes.Reader, enabledFeatures api.CoreFeatures, ret *wasm.Global) (err error) {
+	ret.Type, err = decodeGlobalType(r)
 	if err != nil {
-		return wasm.Global{}, err
+		return err
 	}
 
-	init, err := decodeConstantExpression(r, enabledFeatures)
-	if err != nil {
-		return wasm.Global{}, err
-	}
-
-	return wasm.Global{Type: gt, Init: init}, nil
+	err = decodeConstantExpression(r, enabledFeatures, &ret.Init)
+	return
 }
 
 // decodeGlobalType returns the wasm.GlobalType decoded with the WebAssembly 1.0 (20191205) Binary Format.

--- a/internal/wasm/binary/global.go
+++ b/internal/wasm/binary/global.go
@@ -11,36 +11,36 @@ import (
 // decodeGlobal returns the api.Global decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-global
-func decodeGlobal(r *bytes.Reader, enabledFeatures api.CoreFeatures) (*wasm.Global, error) {
+func decodeGlobal(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.Global, error) {
 	gt, err := decodeGlobalType(r)
 	if err != nil {
-		return nil, err
+		return wasm.Global{}, err
 	}
 
 	init, err := decodeConstantExpression(r, enabledFeatures)
 	if err != nil {
-		return nil, err
+		return wasm.Global{}, err
 	}
 
-	return &wasm.Global{Type: gt, Init: init}, nil
+	return wasm.Global{Type: gt, Init: init}, nil
 }
 
 // decodeGlobalType returns the wasm.GlobalType decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-globaltype
-func decodeGlobalType(r *bytes.Reader) (*wasm.GlobalType, error) {
+func decodeGlobalType(r *bytes.Reader) (wasm.GlobalType, error) {
 	vt, err := decodeValueTypes(r, 1)
 	if err != nil {
-		return nil, fmt.Errorf("read value type: %w", err)
+		return wasm.GlobalType{}, fmt.Errorf("read value type: %w", err)
 	}
 
-	ret := &wasm.GlobalType{
+	ret := wasm.GlobalType{
 		ValType: vt[0],
 	}
 
 	b, err := r.ReadByte()
 	if err != nil {
-		return nil, fmt.Errorf("read mutablity: %w", err)
+		return wasm.GlobalType{}, fmt.Errorf("read mutablity: %w", err)
 	}
 
 	switch mut := b; mut {
@@ -48,7 +48,7 @@ func decodeGlobalType(r *bytes.Reader) (*wasm.GlobalType, error) {
 	case 0x01: // mutable
 		ret.Mutable = true
 	default:
-		return nil, fmt.Errorf("%w for mutability: %#x != 0x00 or 0x01", ErrInvalidByte, mut)
+		return wasm.GlobalType{}, fmt.Errorf("%w for mutability: %#x != 0x00 or 0x01", ErrInvalidByte, mut)
 	}
 	return ret, nil
 }

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -15,13 +15,14 @@ func decodeImport(
 	memorySizer memorySizer,
 	memoryLimitPages uint32,
 	enabledFeatures api.CoreFeatures,
-) (i wasm.Import, err error) {
-	if i.Module, _, err = decodeUTF8(r, "import module"); err != nil {
+	ret *wasm.Import,
+) (err error) {
+	if ret.Module, _, err = decodeUTF8(r, "import module"); err != nil {
 		err = fmt.Errorf("import[%d] error decoding module: %w", idx, err)
 		return
 	}
 
-	if i.Name, _, err = decodeUTF8(r, "import name"); err != nil {
+	if ret.Name, _, err = decodeUTF8(r, "import name"); err != nil {
 		err = fmt.Errorf("import[%d] error decoding name: %w", idx, err)
 		return
 	}
@@ -31,21 +32,21 @@ func decodeImport(
 		err = fmt.Errorf("import[%d] error decoding type: %w", idx, err)
 		return
 	}
-	i.Type = b
-	switch i.Type {
+	ret.Type = b
+	switch ret.Type {
 	case wasm.ExternTypeFunc:
-		i.DescFunc, _, err = leb128.DecodeUint32(r)
+		ret.DescFunc, _, err = leb128.DecodeUint32(r)
 	case wasm.ExternTypeTable:
-		i.DescTable, err = decodeTable(r, enabledFeatures)
+		err = decodeTable(r, enabledFeatures, &ret.DescTable)
 	case wasm.ExternTypeMemory:
-		i.DescMem, err = decodeMemory(r, memorySizer, memoryLimitPages)
+		ret.DescMem, err = decodeMemory(r, memorySizer, memoryLimitPages)
 	case wasm.ExternTypeGlobal:
-		i.DescGlobal, err = decodeGlobalType(r)
+		ret.DescGlobal, err = decodeGlobalType(r)
 	default:
 		err = fmt.Errorf("%w: invalid byte for importdesc: %#x", ErrInvalidByte, b)
 	}
 	if err != nil {
-		err = fmt.Errorf("import[%d] %s[%s.%s]: %w", idx, wasm.ExternTypeName(i.Type), i.Module, i.Name, err)
+		err = fmt.Errorf("import[%d] %s[%s.%s]: %w", idx, wasm.ExternTypeName(ret.Type), ret.Module, ret.Name, err)
 	}
 	return
 }

--- a/internal/wasm/binary/import.go
+++ b/internal/wasm/binary/import.go
@@ -15,19 +15,21 @@ func decodeImport(
 	memorySizer memorySizer,
 	memoryLimitPages uint32,
 	enabledFeatures api.CoreFeatures,
-) (i *wasm.Import, err error) {
-	i = &wasm.Import{}
+) (i wasm.Import, err error) {
 	if i.Module, _, err = decodeUTF8(r, "import module"); err != nil {
-		return nil, fmt.Errorf("import[%d] error decoding module: %w", idx, err)
+		err = fmt.Errorf("import[%d] error decoding module: %w", idx, err)
+		return
 	}
 
 	if i.Name, _, err = decodeUTF8(r, "import name"); err != nil {
-		return nil, fmt.Errorf("import[%d] error decoding name: %w", idx, err)
+		err = fmt.Errorf("import[%d] error decoding name: %w", idx, err)
+		return
 	}
 
 	b, err := r.ReadByte()
 	if err != nil {
-		return nil, fmt.Errorf("import[%d] error decoding type: %w", idx, err)
+		err = fmt.Errorf("import[%d] error decoding type: %w", idx, err)
+		return
 	}
 	i.Type = b
 	switch i.Type {
@@ -43,7 +45,7 @@ func decodeImport(
 		err = fmt.Errorf("%w: invalid byte for importdesc: %#x", ErrInvalidByte, b)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("import[%d] %s[%s.%s]: %w", idx, wasm.ExternTypeName(i.Type), i.Module, i.Name, err)
+		err = fmt.Errorf("import[%d] %s[%s.%s]: %w", idx, wasm.ExternTypeName(i.Type), i.Module, i.Name, err)
 	}
 	return
 }

--- a/internal/wasm/binary/import_test.go
+++ b/internal/wasm/binary/import_test.go
@@ -79,7 +79,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:       wasm.ExternTypeGlobal,
 				Module:     "math",
 				Name:       "pi",
-				DescGlobal: &wasm.GlobalType{ValType: wasm.ValueTypeF64},
+				DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeF64},
 			},
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
@@ -94,7 +94,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:       wasm.ExternTypeGlobal,
 				Module:     "math",
 				Name:       "pi",
-				DescGlobal: &wasm.GlobalType{ValType: wasm.ValueTypeF64, Mutable: true},
+				DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeF64, Mutable: true},
 			},
 			expected: []byte{
 				0x04, 'm', 'a', 't', 'h',
@@ -109,7 +109,7 @@ func TestEncodeImport(t *testing.T) {
 				Type:      wasm.ExternTypeTable,
 				Module:    "my",
 				Name:      "table",
-				DescTable: &wasm.Table{Min: 1, Max: ptrOfUint32(2)},
+				DescTable: wasm.Table{Min: 1, Max: ptrOfUint32(2)},
 			},
 			expected: []byte{
 				0x02, 'm', 'y',

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -38,7 +38,7 @@ func decodeImportSection(
 
 	result := make([]wasm.Import, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeImport(r, i, memorySizer, memoryLimitPages, enabledFeatures); err != nil {
+		if err = decodeImport(r, i, memorySizer, memoryLimitPages, enabledFeatures, &result[i]); err != nil {
 			return nil, err
 		}
 	}
@@ -73,7 +73,7 @@ func decodeTableSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]wa
 
 	ret := make([]wasm.Table, vs)
 	for i := range ret {
-		ret[i], err = decodeTable(r, enabledFeatures)
+		err = decodeTable(r, enabledFeatures, &ret[i])
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +108,7 @@ func decodeGlobalSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]w
 
 	result := make([]wasm.Global, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeGlobal(r, enabledFeatures); err != nil {
+		if err = decodeGlobal(r, enabledFeatures, &result[i]); err != nil {
 			return nil, fmt.Errorf("global[%d]: %w", i, err)
 		}
 	}
@@ -122,9 +122,10 @@ func decodeExportSection(r *bytes.Reader) ([]wasm.Export, error) {
 	}
 
 	usedName := make(map[string]struct{}, vs)
-	exportSection := make([]wasm.Export, 0, vs)
+	exportSection := make([]wasm.Export, vs)
 	for i := wasm.Index(0); i < vs; i++ {
-		export, err := decodeExport(r)
+		export := &exportSection[i]
+		err := decodeExport(r, export)
 		if err != nil {
 			return nil, fmt.Errorf("read export: %w", err)
 		}
@@ -133,7 +134,6 @@ func decodeExportSection(r *bytes.Reader) ([]wasm.Export, error) {
 		} else {
 			usedName[export.Name] = struct{}{}
 		}
-		exportSection = append(exportSection, export)
 	}
 	return exportSection, nil
 }
@@ -154,7 +154,7 @@ func decodeElementSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]
 
 	result := make([]wasm.ElementSegment, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeElementSegment(r, enabledFeatures); err != nil {
+		if err = decodeElementSegment(r, enabledFeatures, &result[i]); err != nil {
 			return nil, fmt.Errorf("read element: %w", err)
 		}
 	}
@@ -187,7 +187,7 @@ func decodeDataSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]was
 
 	result := make([]wasm.DataSegment, vs)
 	for i := uint32(0); i < vs; i++ {
-		if result[i], err = decodeDataSegment(r, enabledFeatures); err != nil {
+		if err = decodeDataSegment(r, enabledFeatures, &result[i]); err != nil {
 			return nil, fmt.Errorf("read data segment: %w", err)
 		}
 	}

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -147,13 +147,13 @@ func decodeStartSection(r *bytes.Reader) (*wasm.Index, error) {
 	return &vs, nil
 }
 
-func decodeElementSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*wasm.ElementSegment, error) {
+func decodeElementSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]wasm.ElementSegment, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
-	result := make([]*wasm.ElementSegment, vs)
+	result := make([]wasm.ElementSegment, vs)
 	for i := uint32(0); i < vs; i++ {
 		if result[i], err = decodeElementSegment(r, enabledFeatures); err != nil {
 			return nil, fmt.Errorf("read element: %w", err)
@@ -180,13 +180,13 @@ func decodeCodeSection(r *bytes.Reader) ([]*wasm.Code, error) {
 	return result, nil
 }
 
-func decodeDataSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*wasm.DataSegment, error) {
+func decodeDataSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]wasm.DataSegment, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
-	result := make([]*wasm.DataSegment, vs)
+	result := make([]wasm.DataSegment, vs)
 	for i := uint32(0); i < vs; i++ {
 		if result[i], err = decodeDataSegment(r, enabledFeatures); err != nil {
 			return nil, fmt.Errorf("read data segment: %w", err)

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -30,13 +30,13 @@ func decodeImportSection(
 	memorySizer memorySizer,
 	memoryLimitPages uint32,
 	enabledFeatures api.CoreFeatures,
-) ([]*wasm.Import, error) {
+) ([]wasm.Import, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
-	result := make([]*wasm.Import, vs)
+	result := make([]wasm.Import, vs)
 	for i := uint32(0); i < vs; i++ {
 		if result[i], err = decodeImport(r, i, memorySizer, memoryLimitPages, enabledFeatures); err != nil {
 			return nil, err
@@ -60,7 +60,7 @@ func decodeFunctionSection(r *bytes.Reader) ([]uint32, error) {
 	return result, err
 }
 
-func decodeTableSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*wasm.Table, error) {
+func decodeTableSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]wasm.Table, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("error reading size")
@@ -71,13 +71,12 @@ func decodeTableSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*w
 		}
 	}
 
-	ret := make([]*wasm.Table, vs)
+	ret := make([]wasm.Table, vs)
 	for i := range ret {
-		table, err := decodeTable(r, enabledFeatures)
+		ret[i], err = decodeTable(r, enabledFeatures)
 		if err != nil {
 			return nil, err
 		}
-		ret[i] = table
 	}
 	return ret, nil
 }
@@ -101,13 +100,13 @@ func decodeMemorySection(
 	return decodeMemory(r, memorySizer, memoryLimitPages)
 }
 
-func decodeGlobalSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*wasm.Global, error) {
+func decodeGlobalSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]wasm.Global, error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
-	result := make([]*wasm.Global, vs)
+	result := make([]wasm.Global, vs)
 	for i := uint32(0); i < vs; i++ {
 		if result[i], err = decodeGlobal(r, enabledFeatures); err != nil {
 			return nil, fmt.Errorf("global[%d]: %w", i, err)
@@ -116,14 +115,14 @@ func decodeGlobalSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]*
 	return result, nil
 }
 
-func decodeExportSection(r *bytes.Reader) ([]*wasm.Export, error) {
+func decodeExportSection(r *bytes.Reader) ([]wasm.Export, error) {
 	vs, _, sizeErr := leb128.DecodeUint32(r)
 	if sizeErr != nil {
 		return nil, fmt.Errorf("get size of vector: %v", sizeErr)
 	}
 
 	usedName := make(map[string]struct{}, vs)
-	exportSection := make([]*wasm.Export, 0, vs)
+	exportSection := make([]wasm.Export, 0, vs)
 	for i := wasm.Index(0); i < vs; i++ {
 		export, err := decodeExport(r)
 		if err != nil {

--- a/internal/wasm/binary/section_test.go
+++ b/internal/wasm/binary/section_test.go
@@ -15,7 +15,7 @@ func TestTableSection(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    []byte
-		expected []*wasm.Table
+		expected []wasm.Table
 	}{
 		{
 			name: "min and min with max",
@@ -23,7 +23,7 @@ func TestTableSection(t *testing.T) {
 				0x01,                            // 1 table
 				wasm.RefTypeFuncref, 0x01, 2, 3, // (table 2 3)
 			},
-			expected: []*wasm.Table{{Min: 2, Max: &three, Type: wasm.RefTypeFuncref}},
+			expected: []wasm.Table{{Min: 2, Max: &three, Type: wasm.RefTypeFuncref}},
 		},
 		{
 			name: "min and min with max - three tables",
@@ -33,7 +33,7 @@ func TestTableSection(t *testing.T) {
 				wasm.RefTypeExternref, 0x01, 2, 3, // (table 2 3)
 				wasm.RefTypeFuncref, 0x01, 2, 3, // (table 2 3)
 			},
-			expected: []*wasm.Table{
+			expected: []wasm.Table{
 				{Min: 2, Max: &three, Type: wasm.RefTypeFuncref},
 				{Min: 2, Max: &three, Type: wasm.RefTypeExternref},
 				{Min: 2, Max: &three, Type: wasm.RefTypeFuncref},
@@ -144,7 +144,7 @@ func TestDecodeExportSection(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    []byte
-		expected []*wasm.Export
+		expected []wasm.Export
 	}{
 		{
 			name: "empty and non-empty name",
@@ -155,7 +155,7 @@ func TestDecodeExportSection(t *testing.T) {
 				0x01, 'a', // Size of name, name
 				wasm.ExternTypeFunc, 0x01, // func[1]
 			},
-			expected: []*wasm.Export{
+			expected: []wasm.Export{
 				{Name: "", Type: wasm.ExternTypeFunc, Index: wasm.Index(2)},
 				{Name: "a", Type: wasm.ExternTypeFunc, Index: wasm.Index(1)},
 			},

--- a/internal/wasm/binary/table.go
+++ b/internal/wasm/binary/table.go
@@ -11,29 +11,29 @@ import (
 // decodeTable returns the wasm.Table decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-table
-func decodeTable(r *bytes.Reader, enabledFeatures api.CoreFeatures) (*wasm.Table, error) {
+func decodeTable(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.Table, error) {
 	tableType, err := r.ReadByte()
 	if err != nil {
-		return nil, fmt.Errorf("read leading byte: %v", err)
+		return wasm.Table{}, fmt.Errorf("read leading byte: %v", err)
 	}
 
 	if tableType != wasm.RefTypeFuncref {
 		if err := enabledFeatures.RequireEnabled(api.CoreFeatureReferenceTypes); err != nil {
-			return nil, fmt.Errorf("table type funcref is invalid: %w", err)
+			return wasm.Table{}, fmt.Errorf("table type funcref is invalid: %w", err)
 		}
 	}
 
 	min, max, err := decodeLimitsType(r)
 	if err != nil {
-		return nil, fmt.Errorf("read limits: %v", err)
+		return wasm.Table{}, fmt.Errorf("read limits: %v", err)
 	}
 	if min > wasm.MaximumFunctionIndex {
-		return nil, fmt.Errorf("table min must be at most %d", wasm.MaximumFunctionIndex)
+		return wasm.Table{}, fmt.Errorf("table min must be at most %d", wasm.MaximumFunctionIndex)
 	}
 	if max != nil {
 		if *max < min {
-			return nil, fmt.Errorf("table size minimum must not be greater than maximum")
+			return wasm.Table{}, fmt.Errorf("table size minimum must not be greater than maximum")
 		}
 	}
-	return &wasm.Table{Min: min, Max: max, Type: tableType}, nil
+	return wasm.Table{Min: min, Max: max, Type: tableType}, nil
 }

--- a/internal/wasm/binary/table.go
+++ b/internal/wasm/binary/table.go
@@ -11,29 +11,29 @@ import (
 // decodeTable returns the wasm.Table decoded with the WebAssembly 1.0 (20191205) Binary Format.
 //
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#binary-table
-func decodeTable(r *bytes.Reader, enabledFeatures api.CoreFeatures) (wasm.Table, error) {
-	tableType, err := r.ReadByte()
+func decodeTable(r *bytes.Reader, enabledFeatures api.CoreFeatures, ret *wasm.Table) (err error) {
+	ret.Type, err = r.ReadByte()
 	if err != nil {
-		return wasm.Table{}, fmt.Errorf("read leading byte: %v", err)
+		return fmt.Errorf("read leading byte: %v", err)
 	}
 
-	if tableType != wasm.RefTypeFuncref {
-		if err := enabledFeatures.RequireEnabled(api.CoreFeatureReferenceTypes); err != nil {
-			return wasm.Table{}, fmt.Errorf("table type funcref is invalid: %w", err)
+	if ret.Type != wasm.RefTypeFuncref {
+		if err = enabledFeatures.RequireEnabled(api.CoreFeatureReferenceTypes); err != nil {
+			return fmt.Errorf("table type funcref is invalid: %w", err)
 		}
 	}
 
-	min, max, err := decodeLimitsType(r)
+	ret.Min, ret.Max, err = decodeLimitsType(r)
 	if err != nil {
-		return wasm.Table{}, fmt.Errorf("read limits: %v", err)
+		return fmt.Errorf("read limits: %v", err)
 	}
-	if min > wasm.MaximumFunctionIndex {
-		return wasm.Table{}, fmt.Errorf("table min must be at most %d", wasm.MaximumFunctionIndex)
+	if ret.Min > wasm.MaximumFunctionIndex {
+		return fmt.Errorf("table min must be at most %d", wasm.MaximumFunctionIndex)
 	}
-	if max != nil {
-		if *max < min {
-			return wasm.Table{}, fmt.Errorf("table size minimum must not be greater than maximum")
+	if ret.Max != nil {
+		if *ret.Max < ret.Min {
+			return fmt.Errorf("table size minimum must not be greater than maximum")
 		}
 	}
-	return wasm.Table{Min: min, Max: max, Type: tableType}, nil
+	return
 }

--- a/internal/wasm/binary/table_test.go
+++ b/internal/wasm/binary/table_test.go
@@ -17,37 +17,37 @@ func TestTableType(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		input    *wasm.Table
+		input    wasm.Table
 		expected []byte
 	}{
 		{
 			name:     "min 0 - funcref",
-			input:    &wasm.Table{Type: wasm.RefTypeFuncref},
+			input:    wasm.Table{Type: wasm.RefTypeFuncref},
 			expected: []byte{wasm.RefTypeFuncref, 0x0, 0},
 		},
 		{
 			name:     "min 0 - externref",
-			input:    &wasm.Table{Type: wasm.RefTypeExternref},
+			input:    wasm.Table{Type: wasm.RefTypeExternref},
 			expected: []byte{wasm.RefTypeExternref, 0x0, 0},
 		},
 		{
 			name:     "min 0, max 0",
-			input:    &wasm.Table{Max: &zero, Type: wasm.RefTypeFuncref},
+			input:    wasm.Table{Max: &zero, Type: wasm.RefTypeFuncref},
 			expected: []byte{wasm.RefTypeFuncref, 0x1, 0, 0},
 		},
 		{
 			name:     "min largest",
-			input:    &wasm.Table{Min: max, Type: wasm.RefTypeFuncref},
+			input:    wasm.Table{Min: max, Type: wasm.RefTypeFuncref},
 			expected: []byte{wasm.RefTypeFuncref, 0x0, 0x80, 0x80, 0x80, 0x40},
 		},
 		{
 			name:     "min 0, max largest",
-			input:    &wasm.Table{Max: &max, Type: wasm.RefTypeFuncref},
+			input:    wasm.Table{Max: &max, Type: wasm.RefTypeFuncref},
 			expected: []byte{wasm.RefTypeFuncref, 0x1, 0, 0x80, 0x80, 0x80, 0x40},
 		},
 		{
 			name:     "min largest max largest",
-			input:    &wasm.Table{Min: max, Max: &max, Type: wasm.RefTypeFuncref},
+			input:    wasm.Table{Min: max, Max: &max, Type: wasm.RefTypeFuncref},
 			expected: []byte{wasm.RefTypeFuncref, 0x1, 0x80, 0x80, 0x80, 0x40, 0x80, 0x80, 0x80, 0x40},
 		},
 	}
@@ -55,7 +55,7 @@ func TestTableType(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 
-		b := binaryencoding.EncodeTable(tc.input)
+		b := binaryencoding.EncodeTable(&tc.input)
 		t.Run(fmt.Sprintf("encode - %s", tc.name), func(t *testing.T) {
 			require.Equal(t, tc.expected, b)
 		})

--- a/internal/wasm/binary/table_test.go
+++ b/internal/wasm/binary/table_test.go
@@ -61,7 +61,8 @@ func TestTableType(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("decode - %s", tc.name), func(t *testing.T) {
-			decoded, err := decodeTable(bytes.NewReader(b), api.CoreFeatureReferenceTypes)
+			var decoded wasm.Table
+			err := decodeTable(bytes.NewReader(b), api.CoreFeatureReferenceTypes, &decoded)
 			require.NoError(t, err)
 			require.Equal(t, decoded, tc.input)
 		})
@@ -97,7 +98,8 @@ func TestDecodeTableType_Errors(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := decodeTable(bytes.NewReader(tc.input), tc.features)
+			var decoded wasm.Table
+			err := decodeTable(bytes.NewReader(tc.input), tc.features, &decoded)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}

--- a/internal/wasm/counts.go
+++ b/internal/wasm/counts.go
@@ -29,8 +29,9 @@ func (m *Module) ImportGlobalCount() uint32 {
 // importCount returns the count of a specific type of import. This is important because it is easy to mistake the
 // length of the import section with the count of a specific kind of import.
 func (m *Module) importCount(et ExternType) (res uint32) {
-	for _, im := range m.ImportSection {
-		if im.Type == et {
+	for i := range m.ImportSection {
+		imp := &m.ImportSection[i]
+		if imp.Type == et {
 			res++
 		}
 	}

--- a/internal/wasm/counts_test.go
+++ b/internal/wasm/counts_test.go
@@ -22,22 +22,22 @@ func TestModule_ImportFuncCount(t *testing.T) {
 		},
 		{
 			name:     "one",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeFunc}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeFunc}}},
 			expected: 1,
 		},
 		{
 			name:     "one with function section",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeFunc}}, FunctionSection: []Index{0}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeFunc}}, FunctionSection: []Index{0}},
 			expected: 1,
 		},
 		{
 			name:     "one with other imports",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeFunc}, {Type: ExternTypeMemory}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeFunc}, {Type: ExternTypeMemory}}},
 			expected: 1,
 		},
 		{
 			name:     "two",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeFunc}, {Type: ExternTypeFunc}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeFunc}, {Type: ExternTypeFunc}}},
 			expected: 2,
 		},
 	}
@@ -63,29 +63,29 @@ func TestModule_ImportTableCount(t *testing.T) {
 		},
 		{
 			name:  "none with table section",
-			input: &Module{TableSection: []*Table{{Min: 1, Max: nil}}},
+			input: &Module{TableSection: []Table{{Min: 1, Max: nil}}},
 		},
 		{
 			name:     "one",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeTable}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeTable}}},
 			expected: 1,
 		},
 		{
 			name: "one with table section",
 			input: &Module{
-				ImportSection: []*Import{{Type: ExternTypeTable}},
-				TableSection:  []*Table{{Min: 1, Max: nil}},
+				ImportSection: []Import{{Type: ExternTypeTable}},
+				TableSection:  []Table{{Min: 1, Max: nil}},
 			},
 			expected: 1,
 		},
 		{
 			name:     "one with other imports",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeTable}, {Type: ExternTypeMemory}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeTable}, {Type: ExternTypeMemory}}},
 			expected: 1,
 		},
 		{
 			name:     "two",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeTable}, {Type: ExternTypeTable}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeTable}, {Type: ExternTypeTable}}},
 			expected: 2,
 		},
 	}
@@ -116,25 +116,25 @@ func TestModule_ImportMemoryCount(t *testing.T) {
 		},
 		{
 			name:     "one",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeMemory}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeMemory}}},
 			expected: 1,
 		},
 		{
 			name: "one with memory section",
 			input: &Module{
-				ImportSection: []*Import{{Type: ExternTypeMemory}},
+				ImportSection: []Import{{Type: ExternTypeMemory}},
 				MemorySection: &Memory{Min: 1},
 			},
 			expected: 1,
 		},
 		{
 			name:     "one with other imports",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeMemory}, {Type: ExternTypeTable}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeMemory}, {Type: ExternTypeTable}}},
 			expected: 1,
 		},
 		{
 			name:     "two",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeMemory}, {Type: ExternTypeMemory}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeMemory}, {Type: ExternTypeMemory}}},
 			expected: 2,
 		},
 	}
@@ -160,29 +160,29 @@ func TestModule_ImportGlobalCount(t *testing.T) {
 		},
 		{
 			name:  "none with global section",
-			input: &Module{GlobalSection: []*Global{{Type: &GlobalType{ValType: ValueTypeI64}}}},
+			input: &Module{GlobalSection: []Global{{Type: GlobalType{ValType: ValueTypeI64}}}},
 		},
 		{
 			name:     "one",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeGlobal}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeGlobal}}},
 			expected: 1,
 		},
 		{
 			name: "one with global section",
 			input: &Module{
-				ImportSection: []*Import{{Type: ExternTypeGlobal}},
-				GlobalSection: []*Global{{Type: &GlobalType{ValType: ValueTypeI64}}},
+				ImportSection: []Import{{Type: ExternTypeGlobal}},
+				GlobalSection: []Global{{Type: GlobalType{ValType: ValueTypeI64}}},
 			},
 			expected: 1,
 		},
 		{
 			name:     "one with other imports",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeGlobal}, {Type: ExternTypeMemory}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeGlobal}, {Type: ExternTypeMemory}}},
 			expected: 1,
 		},
 		{
 			name:     "two",
-			input:    &Module{ImportSection: []*Import{{Type: ExternTypeGlobal}, {Type: ExternTypeGlobal}}},
+			input:    &Module{ImportSection: []Import{{Type: ExternTypeGlobal}, {Type: ExternTypeGlobal}}},
 			expected: 2,
 		},
 	}
@@ -234,7 +234,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 					{Params: []ValueType{i32, i32}, Results: []ValueType{i32}},
 					{Params: []ValueType{f32, f32}, Results: []ValueType{f32}},
 				},
-				ImportSection: []*Import{
+				ImportSection: []Import{
 					{
 						Module: "Math", Name: "Mul",
 						Type:     ExternTypeFunc,
@@ -256,7 +256,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 				CodeSection: []*Code{
 					{Body: []byte{OpcodeLocalGet, 0, OpcodeLocalGet, 1, OpcodeI32Add, OpcodeEnd}},
 				},
-				ExportSection: []*Export{
+				ExportSection: []Export{
 					{Name: "AddInt", Type: ExternTypeFunc, Index: Index(0)},
 				},
 				StartSection: &zero,
@@ -274,7 +274,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 		{
 			name: "TableSection and ElementSection",
 			input: &Module{
-				TableSection:   []*Table{{Min: 1}},
+				TableSection:   []Table{{Min: 1}},
 				ElementSection: []ElementSegment{{OffsetExpr: empty}},
 			},
 			expected: map[string]uint32{"element": 1, "table": 1},
@@ -282,7 +282,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 		{
 			name: "TableSection (multiple tables) and ElementSection",
 			input: &Module{
-				TableSection:   []*Table{{Min: 1}, {Min: 2}},
+				TableSection:   []Table{{Min: 1}, {Min: 2}},
 				ElementSection: []ElementSegment{{OffsetExpr: empty}},
 			},
 			expected: map[string]uint32{"element": 1, "table": 2},

--- a/internal/wasm/counts_test.go
+++ b/internal/wasm/counts_test.go
@@ -199,7 +199,7 @@ func TestModule_ImportGlobalCount(t *testing.T) {
 func TestModule_SectionElementCount(t *testing.T) {
 	i32, f32 := ValueTypeI32, ValueTypeF32
 	zero := uint32(0)
-	empty := &ConstantExpression{Opcode: OpcodeI32Const, Data: const0}
+	empty := ConstantExpression{Opcode: OpcodeI32Const, Data: const0}
 
 	tests := []struct {
 		name     string

--- a/internal/wasm/counts_test.go
+++ b/internal/wasm/counts_test.go
@@ -267,7 +267,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 			name: "MemorySection and DataSection",
 			input: &Module{
 				MemorySection: &Memory{Min: 1},
-				DataSection:   []*DataSegment{{OffsetExpression: empty}},
+				DataSection:   []DataSegment{{OffsetExpression: empty}},
 			},
 			expected: map[string]uint32{"data": 1, "memory": 1},
 		},
@@ -275,7 +275,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 			name: "TableSection and ElementSection",
 			input: &Module{
 				TableSection:   []*Table{{Min: 1}},
-				ElementSection: []*ElementSegment{{OffsetExpr: empty}},
+				ElementSection: []ElementSegment{{OffsetExpr: empty}},
 			},
 			expected: map[string]uint32{"element": 1, "table": 1},
 		},
@@ -283,7 +283,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 			name: "TableSection (multiple tables) and ElementSection",
 			input: &Module{
 				TableSection:   []*Table{{Min: 1}, {Min: 2}},
-				ElementSection: []*ElementSegment{{OffsetExpr: empty}},
+				ElementSection: []ElementSegment{{OffsetExpr: empty}},
 			},
 			expected: map[string]uint32{"element": 1, "table": 2},
 		},

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -27,7 +27,7 @@ const maximumValuesOnStack = 1 << 27
 // Returns an error if the instruction sequence is not valid,
 // or potentially it can exceed the maximum number of values on the stack.
 func (m *Module) validateFunction(enabledFeatures api.CoreFeatures, idx Index, functions []Index,
-	globals []*GlobalType, memory *Memory, tables []*Table, declaredFunctionIndexes map[Index]struct{},
+	globals []GlobalType, memory *Memory, tables []Table, declaredFunctionIndexes map[Index]struct{},
 ) error {
 	return m.validateFunctionWithMaxStackValues(enabledFeatures, idx, functions, globals, memory, tables, maximumValuesOnStack, declaredFunctionIndexes)
 }
@@ -57,9 +57,9 @@ func (m *Module) validateFunctionWithMaxStackValues(
 	enabledFeatures api.CoreFeatures,
 	idx Index,
 	functions []Index,
-	globals []*GlobalType,
+	globals []GlobalType,
 	memory *Memory,
-	tables []*Table,
+	tables []Table,
 	maxStackValues int,
 	declaredFunctionIndexes map[Index]struct{},
 ) error {
@@ -576,9 +576,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 			}
 
 			table := tables[tableIndex]
-			if table == nil {
-				return fmt.Errorf("table not given while having %s", OpcodeCallIndirectName)
-			} else if table.Type != RefTypeFuncref {
+			if table.Type != RefTypeFuncref {
 				return fmt.Errorf("table is not funcref type but was %s for %s", RefTypeName(table.Type), OpcodeCallIndirectName)
 			}
 

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -286,8 +286,8 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 					TypeSection:      []*FunctionType{v_v},
 					FunctionSection:  []Index{0},
 					CodeSection:      []*Code{{Body: body}},
-					DataSection:      []*DataSegment{{}},
-					ElementSection:   []*ElementSegment{{}},
+					DataSection:      []DataSegment{{}},
+					ElementSection:   []ElementSegment{{}},
 					DataCountSection: &c,
 				}
 				err := m.validateFunction(api.CoreFeatureBulkMemoryOperations, 0, []Index{0}, nil, &Memory{}, []*Table{{}, {}}, nil)
@@ -298,8 +298,8 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		tests := []struct {
 			body                []byte
-			dataSection         []*DataSegment
-			elementSection      []*ElementSegment
+			dataSection         []DataSegment
+			elementSection      []ElementSegment
 			dataCountSectionNil bool
 			memory              *Memory
 			tables              []*Table
@@ -334,42 +334,42 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscMemoryInit, 100 /* data section out of range */},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "index 100 out of range of data section(len=1)",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscMemoryInit, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "failed to read memory index for memory.init: EOF",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscMemoryInit, 0, 1},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "memory.init reserved byte must be zero encoded with 1 byte",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscMemoryInit, 0, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "cannot pop the operand for memory.init: i32 missing",
 			},
 			{
 				body:        []byte{OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscMemoryInit, 0, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "cannot pop the operand for memory.init: i32 missing",
 			},
 			{
 				body:        []byte{OpcodeI32Const, 0, OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscMemoryInit, 0, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "cannot pop the operand for memory.init: i32 missing",
 			},
 			// data.drop
@@ -395,7 +395,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscDataDrop, 100 /* data section out of range */},
 				flag:        api.CoreFeatureBulkMemoryOperations,
 				memory:      &Memory{},
-				dataSection: []*DataSegment{{}},
+				dataSection: []DataSegment{{}},
 				expectedErr: "index 100 out of range of data section(len=1)",
 			},
 			// memory.copy
@@ -505,56 +505,56 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 100 /* data section out of range */},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "index 100 out of range of element section(len=1)",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "failed to read source table index for table.init: EOF",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 10},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "source table index must be zero for table.init as feature \"reference-types\" is disabled",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 10},
 				flag:           api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "table of index 10 not found",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 1},
 				flag:           api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
 				tables:         []*Table{{}, {Type: RefTypeExternref}},
-				elementSection: []*ElementSegment{{Type: RefTypeFuncref}},
+				elementSection: []ElementSegment{{Type: RefTypeFuncref}},
 				expectedErr:    "type mismatch for table.init: element type funcref does not match table type externref",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "cannot pop the operand for table.init: i32 missing",
 			},
 			{
 				body:           []byte{OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "cannot pop the operand for table.init: i32 missing",
 			},
 			{
 				body:           []byte{OpcodeI32Const, 0, OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "cannot pop the operand for table.init: i32 missing",
 			},
 			// elem.drop
@@ -574,7 +574,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscElemDrop, 100 /* element section out of range */},
 				flag:           api.CoreFeatureBulkMemoryOperations,
 				tables:         []*Table{{}},
-				elementSection: []*ElementSegment{{}},
+				elementSection: []ElementSegment{{}},
 				expectedErr:    "index 100 out of range of element section(len=1)",
 			},
 			// table.copy

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -290,7 +290,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 					ElementSection:   []ElementSegment{{}},
 					DataCountSection: &c,
 				}
-				err := m.validateFunction(api.CoreFeatureBulkMemoryOperations, 0, []Index{0}, nil, &Memory{}, []*Table{{}, {}}, nil)
+				err := m.validateFunction(api.CoreFeatureBulkMemoryOperations, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
 				require.NoError(t, err)
 			})
 		}
@@ -302,7 +302,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 			elementSection      []ElementSegment
 			dataCountSectionNil bool
 			memory              *Memory
-			tables              []*Table
+			tables              []Table
 			flag                api.CoreFeatures
 			expectedErr         string
 		}{
@@ -492,68 +492,68 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableInit},
 				flag:        api.CoreFeaturesV1,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: `table.init invalid as feature "bulk-memory-operations" is disabled`,
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableInit},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: "failed to read element segment index for table.init: EOF",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 100 /* data section out of range */},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "index 100 out of range of element section(len=1)",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "failed to read source table index for table.init: EOF",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 10},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "source table index must be zero for table.init as feature \"reference-types\" is disabled",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 10},
 				flag:           api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "table of index 10 not found",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 1},
 				flag:           api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
-				tables:         []*Table{{}, {Type: RefTypeExternref}},
+				tables:         []Table{{}, {Type: RefTypeExternref}},
 				elementSection: []ElementSegment{{Type: RefTypeFuncref}},
 				expectedErr:    "type mismatch for table.init: element type funcref does not match table type externref",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "cannot pop the operand for table.init: i32 missing",
 			},
 			{
 				body:           []byte{OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "cannot pop the operand for table.init: i32 missing",
 			},
 			{
 				body:           []byte{OpcodeI32Const, 0, OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscTableInit, 0, 0},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "cannot pop the operand for table.init: i32 missing",
 			},
@@ -561,19 +561,19 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscElemDrop},
 				flag:        api.CoreFeaturesV1,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: `elem.drop invalid as feature "bulk-memory-operations" is disabled`,
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscElemDrop},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: "failed to read element segment index for elem.drop: EOF",
 			},
 			{
 				body:           []byte{OpcodeMiscPrefix, OpcodeMiscElemDrop, 100 /* element section out of range */},
 				flag:           api.CoreFeatureBulkMemoryOperations,
-				tables:         []*Table{{}},
+				tables:         []Table{{}},
 				elementSection: []ElementSegment{{}},
 				expectedErr:    "index 100 out of range of element section(len=1)",
 			},
@@ -581,61 +581,61 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy},
 				flag:        api.CoreFeaturesV1,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: `table.copy invalid as feature "bulk-memory-operations" is disabled`,
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: `failed to read destination table index for table.copy: EOF`,
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy, 10},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: "destination table index must be zero for table.copy as feature \"reference-types\" is disabled",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy, 3},
 				flag:        api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
-				tables:      []*Table{{}, {}},
+				tables:      []Table{{}, {}},
 				expectedErr: "table of index 3 not found",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy, 3},
 				flag:        api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
-				tables:      []*Table{{}, {}, {}, {}},
+				tables:      []Table{{}, {}, {}, {}},
 				expectedErr: "failed to read source table index for table.copy: EOF",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy, 0, 3},
 				flag:        api.CoreFeatureBulkMemoryOperations, // Multiple tables require api.CoreFeatureReferenceTypes.
-				tables:      []*Table{{}, {}, {}, {}},
+				tables:      []Table{{}, {}, {}, {}},
 				expectedErr: "source table index must be zero for table.copy as feature \"reference-types\" is disabled",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy, 3, 1},
 				flag:        api.CoreFeatureBulkMemoryOperations | api.CoreFeatureReferenceTypes,
-				tables:      []*Table{{}, {Type: RefTypeFuncref}, {}, {Type: RefTypeExternref}},
+				tables:      []Table{{}, {Type: RefTypeFuncref}, {}, {Type: RefTypeExternref}},
 				expectedErr: "table type mismatch for table.copy: funcref (src) != externref (dst)",
 			},
 			{
 				body:        []byte{OpcodeMiscPrefix, OpcodeMiscTableCopy, 0, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: "cannot pop the operand for table.copy: i32 missing",
 			},
 			{
 				body:        []byte{OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscTableCopy, 0, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: "cannot pop the operand for table.copy: i32 missing",
 			},
 			{
 				body:        []byte{OpcodeI32Const, 0, OpcodeI32Const, 0, OpcodeMiscPrefix, OpcodeMiscTableCopy, 0, 0},
 				flag:        api.CoreFeatureBulkMemoryOperations,
-				tables:      []*Table{{}},
+				tables:      []Table{{}},
 				expectedErr: "cannot pop the operand for table.copy: i32 missing",
 			},
 		}
@@ -2199,7 +2199,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 				OpcodeEnd,
 			}}},
 		}
-		err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []*Table{{Type: RefTypeFuncref}}, nil)
+		err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeFuncref}}, nil)
 		require.NoError(t, err)
 	})
 	t.Run("non zero table index", func(t *testing.T) {
@@ -2213,11 +2213,11 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 			}}},
 		}
 		t.Run("disabled", func(t *testing.T) {
-			err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, &Memory{}, []*Table{{}, {}}, nil)
+			err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
 			require.EqualError(t, err, "table index must be zero but was 100: feature \"reference-types\" is disabled")
 		})
 		t.Run("enabled but out of range", func(t *testing.T) {
-			err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []*Table{{}, {}}, nil)
+			err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
 			require.EqualError(t, err, "unknown table index: 100")
 		})
 	})
@@ -2231,7 +2231,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 				OpcodeEnd,
 			}}},
 		}
-		err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []*Table{{Type: RefTypeExternref}}, nil)
+		err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeExternref}}, nil)
 		require.EqualError(t, err, "table is not funcref type but was externref for call_indirect")
 	})
 }
@@ -2337,7 +2337,7 @@ func TestModule_funcValidation_RefTypes(t *testing.T) {
 }
 
 func TestModule_funcValidation_TableGrowSizeFill(t *testing.T) {
-	tables := []*Table{{Type: RefTypeFuncref}, {Type: RefTypeExternref}}
+	tables := []Table{{Type: RefTypeFuncref}, {Type: RefTypeExternref}}
 	tests := []struct {
 		name        string
 		body        []byte
@@ -2505,7 +2505,7 @@ func TestModule_funcValidation_TableGrowSizeFill(t *testing.T) {
 }
 
 func TestModule_funcValidation_TableGetSet(t *testing.T) {
-	tables := []*Table{{Type: RefTypeFuncref}, {Type: RefTypeExternref}}
+	tables := []Table{{Type: RefTypeFuncref}, {Type: RefTypeExternref}}
 	tests := []struct {
 		name        string
 		body        []byte

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -52,15 +52,16 @@ func (m *Module) BuildFunctionDefinitions() {
 	m.FunctionDefinitionSection = make([]*FunctionDefinition, 0, importCount+uint32(len(m.FunctionSection)))
 
 	importFuncIdx := Index(0)
-	for _, i := range m.ImportSection {
-		if i.Type != ExternTypeFunc {
+	for i := range m.ImportSection {
+		imp := &m.ImportSection[i]
+		if imp.Type != ExternTypeFunc {
 			continue
 		}
 
 		m.FunctionDefinitionSection = append(m.FunctionDefinitionSection, &FunctionDefinition{
-			importDesc: &[2]string{i.Module, i.Name},
+			importDesc: &[2]string{imp.Module, imp.Name},
 			index:      importFuncIdx,
-			funcType:   m.TypeSection[i.DescFunc],
+			funcType:   m.TypeSection[imp.DescFunc],
 		})
 		importFuncIdx++
 	}
@@ -96,7 +97,8 @@ func (m *Module) BuildFunctionDefinitions() {
 		d.paramNames = paramNames(localNames, funcIdx, len(d.funcType.Params))
 		d.resultNames = paramNames(resultNames, funcIdx, len(d.funcType.Results))
 
-		for _, e := range m.ExportSection {
+		for i := range m.ExportSection {
+			e := &m.ExportSection[i]
 			if e.Type == ExternTypeFunc && e.Index == funcIdx {
 				d.exportNames = append(d.exportNames, e.Name)
 			}

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -25,8 +25,8 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 		{
 			name: "no functions",
 			m: &Module{
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Index: 0}},
-				GlobalSection: []*Global{{}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Index: 0}},
+				GlobalSection: []Global{{}},
 			},
 			expectedExports: map[string]api.FunctionDefinition{},
 		},
@@ -60,13 +60,13 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 		{
 			name: "without imports",
 			m: &Module{
-				ExportSection: []*Export{
+				ExportSection: []Export{
 					{Name: "function_index=0", Type: ExternTypeFunc, Index: 0},
 					{Name: "function_index=2", Type: ExternTypeFunc, Index: 2},
 					{Name: "", Type: ExternTypeGlobal, Index: 0},
 					{Name: "function_index=1", Type: ExternTypeFunc, Index: 1},
 				},
-				GlobalSection:   []*Global{{}},
+				GlobalSection:   []Global{{}},
 				FunctionSection: []Index{1, 2, 0},
 				CodeSection: []*Code{
 					{Body: []byte{OpcodeEnd}},
@@ -123,11 +123,11 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 		{
 			name: "with imports",
 			m: &Module{
-				ImportSection: []*Import{{
+				ImportSection: []Import{{
 					Type:     ExternTypeFunc,
 					DescFunc: 2, // Index of type.
 				}},
-				ExportSection: []*Export{
+				ExportSection: []Export{
 					{Name: "imported_function", Type: ExternTypeFunc, Index: 0},
 					{Name: "function_index=1", Type: ExternTypeFunc, Index: 1},
 					{Name: "function_index=2", Type: ExternTypeFunc, Index: 2},
@@ -196,7 +196,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 			name: "with names",
 			m: &Module{
 				TypeSection:   []*FunctionType{v_v},
-				ImportSection: []*Import{{Module: "i", Name: "f", Type: ExternTypeFunc}},
+				ImportSection: []Import{{Module: "i", Name: "f", Type: ExternTypeFunc}},
 				NameSection: &NameSection{
 					ModuleName: "module",
 					FunctionNames: NameMap{

--- a/internal/wasm/global_test.go
+++ b/internal/wasm/global_test.go
@@ -79,7 +79,7 @@ func TestGlobalTypes(t *testing.T) {
 		{
 			name: "i32 - mutable",
 			global: &mutableGlobal{g: &GlobalInstance{
-				Type: &GlobalType{ValType: ValueTypeI32, Mutable: true},
+				Type: GlobalType{ValType: ValueTypeI32, Mutable: true},
 				Val:  1,
 			}},
 			expectedType:    ValueTypeI32,
@@ -90,7 +90,7 @@ func TestGlobalTypes(t *testing.T) {
 		{
 			name: "i64 - mutable",
 			global: &mutableGlobal{g: &GlobalInstance{
-				Type: &GlobalType{ValType: ValueTypeI64, Mutable: true},
+				Type: GlobalType{ValType: ValueTypeI64, Mutable: true},
 				Val:  1,
 			}},
 			expectedType:    ValueTypeI64,
@@ -101,7 +101,7 @@ func TestGlobalTypes(t *testing.T) {
 		{
 			name: "f32 - mutable",
 			global: &mutableGlobal{g: &GlobalInstance{
-				Type: &GlobalType{ValType: ValueTypeF32, Mutable: true},
+				Type: GlobalType{ValType: ValueTypeF32, Mutable: true},
 				Val:  api.EncodeF32(1.0),
 			}},
 			expectedType:    ValueTypeF32,
@@ -112,7 +112,7 @@ func TestGlobalTypes(t *testing.T) {
 		{
 			name: "f64 - mutable",
 			global: &mutableGlobal{g: &GlobalInstance{
-				Type: &GlobalType{ValType: ValueTypeF64, Mutable: true},
+				Type: GlobalType{ValType: ValueTypeF64, Mutable: true},
 				Val:  api.EncodeF64(1.0),
 			}},
 			expectedType:    ValueTypeF64,
@@ -156,10 +156,10 @@ func TestPublicModule_Global(t *testing.T) {
 		{
 			name: "global not exported",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeI32},
-						Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
+						Type: GlobalType{ValType: ValueTypeI32},
+						Init: ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
 					},
 				},
 			},
@@ -167,125 +167,125 @@ func TestPublicModule_Global(t *testing.T) {
 		{
 			name: "global exported - immutable I32",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeI32},
-						Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
+						Type: GlobalType{ValType: ValueTypeI32},
+						Init: ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: globalI32(1),
 		},
 		{
 			name: "global exported - immutable I64",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeI64},
-						Init: &ConstantExpression{Opcode: OpcodeI64Const, Data: leb128.EncodeInt64(1)},
+						Type: GlobalType{ValType: ValueTypeI64},
+						Init: ConstantExpression{Opcode: OpcodeI64Const, Data: leb128.EncodeInt64(1)},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: globalI64(1),
 		},
 		{
 			name: "global exported - immutable F32",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeF32},
-						Init: &ConstantExpression{
+						Type: GlobalType{ValType: ValueTypeF32},
+						Init: ConstantExpression{
 							Opcode: OpcodeF32Const,
 							Data:   u64.LeBytes(api.EncodeF32(1.0)),
 						},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: globalF32(api.EncodeF32(1.0)),
 		},
 		{
 			name: "global exported - immutable F64",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeF64},
-						Init: &ConstantExpression{
+						Type: GlobalType{ValType: ValueTypeF64},
+						Init: ConstantExpression{
 							Opcode: OpcodeF64Const,
 							Data:   u64.LeBytes(api.EncodeF64(1.0)),
 						},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: globalF64(api.EncodeF64(1.0)),
 		},
 		{
 			name: "global exported - mutable I32",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeI32, Mutable: true},
-						Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(1)},
+						Type: GlobalType{ValType: ValueTypeI32, Mutable: true},
+						Init: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(1)},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: &mutableGlobal{
-				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeI32, Mutable: true}, Val: 1},
+				g: &GlobalInstance{Type: GlobalType{ValType: ValueTypeI32, Mutable: true}, Val: 1},
 			},
 		},
 		{
 			name: "global exported - mutable I64",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeI64, Mutable: true},
-						Init: &ConstantExpression{Opcode: OpcodeI64Const, Data: leb128.EncodeInt64(1)},
+						Type: GlobalType{ValType: ValueTypeI64, Mutable: true},
+						Init: ConstantExpression{Opcode: OpcodeI64Const, Data: leb128.EncodeInt64(1)},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: &mutableGlobal{
-				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeI64, Mutable: true}, Val: 1},
+				g: &GlobalInstance{Type: GlobalType{ValType: ValueTypeI64, Mutable: true}, Val: 1},
 			},
 		},
 		{
 			name: "global exported - mutable F32",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeF32, Mutable: true},
-						Init: &ConstantExpression{
+						Type: GlobalType{ValType: ValueTypeF32, Mutable: true},
+						Init: ConstantExpression{
 							Opcode: OpcodeF32Const,
 							Data:   u64.LeBytes(api.EncodeF32(1.0)),
 						},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: &mutableGlobal{
-				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeF32, Mutable: true}, Val: api.EncodeF32(1.0)},
+				g: &GlobalInstance{Type: GlobalType{ValType: ValueTypeF32, Mutable: true}, Val: api.EncodeF32(1.0)},
 			},
 		},
 		{
 			name: "global exported - mutable F64",
 			module: &Module{
-				GlobalSection: []*Global{
+				GlobalSection: []Global{
 					{
-						Type: &GlobalType{ValType: ValueTypeF64, Mutable: true},
-						Init: &ConstantExpression{
+						Type: GlobalType{ValType: ValueTypeF64, Mutable: true},
+						Init: ConstantExpression{
 							Opcode: OpcodeF64Const,
 							Data:   u64.LeBytes(api.EncodeF64(1.0)),
 						},
 					},
 				},
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Name: "global"}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Name: "global"}},
 			},
 			expected: &mutableGlobal{
-				g: &GlobalInstance{Type: &GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: api.EncodeF64(1.0)},
+				g: &GlobalInstance{Type: GlobalType{ValType: ValueTypeF64, Mutable: true}, Val: api.EncodeF64(1.0)},
 			},
 		},
 	}

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -98,7 +98,7 @@ func NewHostModule(
 	}
 
 	if exportCount := uint32(len(nameToGoFunc)); exportCount > 0 {
-		m.ExportSection = make([]*Export, 0, exportCount)
+		m.ExportSection = make([]Export, 0, exportCount)
 		if err = addFuncs(m, nameToGoFunc, funcToNames, enabledFeatures); err != nil {
 			return
 		}
@@ -193,7 +193,7 @@ func addFuncs(
 		m.FunctionSection = append(m.FunctionSection, typeIdx)
 		m.CodeSection = append(m.CodeSection, hf.Code)
 		for _, export := range hf.ExportNames {
-			m.ExportSection = append(m.ExportSection, &Export{Type: ExternTypeFunc, Name: export, Index: idx})
+			m.ExportSection = append(m.ExportSection, Export{Type: ExternTypeFunc, Name: export, Index: idx})
 		}
 		m.NameSection.FunctionNames = append(m.NameSection.FunctionNames, &NameAssoc{Index: idx, Name: hf.Name})
 

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -65,7 +65,7 @@ func TestNewHostModule(t *testing.T) {
 				},
 				FunctionSection: []Index{0, 1},
 				CodeSection:     []*Code{MustParseGoReflectFuncCode(argsSizesGet), MustParseGoReflectFuncCode(fdWrite)},
-				ExportSection: []*Export{
+				ExportSection: []Export{
 					{Name: ArgsSizesGetName, Type: ExternTypeFunc, Index: 0},
 					{Name: FdWriteName, Type: ExternTypeFunc, Index: 1},
 				},
@@ -105,7 +105,7 @@ func TestNewHostModule(t *testing.T) {
 				TypeSection:     []*FunctionType{{Params: []ValueType{i32, i32}, Results: []ValueType{i32, i32}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{MustParseGoReflectFuncCode(swap)},
-				ExportSection:   []*Export{{Name: "swap", Type: ExternTypeFunc, Index: 0}},
+				ExportSection:   []Export{{Name: "swap", Type: ExternTypeFunc, Index: 0}},
 				NameSection:     &NameSection{ModuleName: "swapper", FunctionNames: NameMap{{Index: 0, Name: "swap"}}},
 			},
 		},

--- a/internal/wasm/memory_definition.go
+++ b/internal/wasm/memory_definition.go
@@ -44,15 +44,16 @@ func (m *Module) BuildMemoryDefinitions() {
 
 	m.MemoryDefinitionSection = make([]*MemoryDefinition, 0, memoryCount)
 	importMemIdx := Index(0)
-	for _, i := range m.ImportSection {
-		if i.Type != ExternTypeMemory {
+	for i := range m.ImportSection {
+		imp := &m.ImportSection[i]
+		if imp.Type != ExternTypeMemory {
 			continue
 		}
 
 		m.MemoryDefinitionSection = append(m.MemoryDefinitionSection, &MemoryDefinition{
-			importDesc: &[2]string{i.Module, i.Name},
+			importDesc: &[2]string{imp.Module, imp.Name},
 			index:      importMemIdx,
-			memory:     i.DescMem,
+			memory:     imp.DescMem,
 		})
 		importMemIdx++
 	}
@@ -66,7 +67,8 @@ func (m *Module) BuildMemoryDefinitions() {
 
 	for _, d := range m.MemoryDefinitionSection {
 		d.moduleName = moduleName
-		for _, e := range m.ExportSection {
+		for i := range m.ExportSection {
+			e := &m.ExportSection[i]
 			if e.Type == ExternTypeMemory && e.Index == d.index {
 				d.exportNames = append(d.exportNames, e.Name)
 			}

--- a/internal/wasm/memory_definition_test.go
+++ b/internal/wasm/memory_definition_test.go
@@ -23,8 +23,8 @@ func TestModule_BuildMemoryDefinitions(t *testing.T) {
 		{
 			name: "no memories",
 			m: &Module{
-				ExportSection: []*Export{{Type: ExternTypeGlobal, Index: 0}},
-				GlobalSection: []*Global{{}},
+				ExportSection: []Export{{Type: ExternTypeGlobal, Index: 0}},
+				GlobalSection: []Global{{}},
 			},
 			expectedExports: map[string]api.MemoryDefinition{},
 		},
@@ -37,11 +37,11 @@ func TestModule_BuildMemoryDefinitions(t *testing.T) {
 		{
 			name: "exports defined memory{2,3}",
 			m: &Module{
-				ExportSection: []*Export{
+				ExportSection: []Export{
 					{Name: "memory_index=0", Type: ExternTypeMemory, Index: 0},
 					{Name: "", Type: ExternTypeGlobal, Index: 0},
 				},
-				GlobalSection: []*Global{{}},
+				GlobalSection: []Global{{}},
 				MemorySection: &Memory{Min: 2, Max: 3, IsMaxEncoded: true},
 			},
 			expected: []*MemoryDefinition{
@@ -62,11 +62,11 @@ func TestModule_BuildMemoryDefinitions(t *testing.T) {
 		{ // NOTE: not yet supported https://github.com/WebAssembly/multi-memory
 			name: "exports imported memory{0,} and defined memory{2,3}",
 			m: &Module{
-				ImportSection: []*Import{{
+				ImportSection: []Import{{
 					Type:    ExternTypeMemory,
 					DescMem: &Memory{Min: 0},
 				}},
-				ExportSection: []*Export{
+				ExportSection: []Export{
 					{Name: "imported_memory", Type: ExternTypeMemory, Index: 0},
 					{Name: "memory_index=1", Type: ExternTypeMemory, Index: 1},
 				},

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -446,7 +446,7 @@ func (m *Module) validateMemory(memory *Memory, globals []GlobalType, _ api.Core
 	for i := range m.DataSection {
 		d := &m.DataSection[i]
 		if !d.IsPassive() {
-			if err := validateConstExpression(importedGlobals, 0, d.OffsetExpression, ValueTypeI32); err != nil {
+			if err := validateConstExpression(importedGlobals, 0, &d.OffsetExpression, ValueTypeI32); err != nil {
 				return fmt.Errorf("calculate offset: %w", err)
 			}
 		}
@@ -866,8 +866,9 @@ type Code struct {
 }
 
 type DataSegment struct {
-	OffsetExpression *ConstantExpression
+	OffsetExpression ConstantExpression
 	Init             []byte
+	Passive          bool
 }
 
 // IsPassive returns true if this data segment is "passive" in the sense that memory offset and
@@ -876,7 +877,7 @@ type DataSegment struct {
 //
 // See https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/appendix/changes.html#bulk-memory-and-table-instructions
 func (d *DataSegment) IsPassive() bool {
-	return d.OffsetExpression == nil
+	return d.Passive
 }
 
 // NameSection represent the known custom name subsections defined in the WebAssembly Binary Format

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -131,7 +131,7 @@ type Module struct {
 	StartSection *Index
 
 	// Note: In the Binary Format, this is SectionIDElement.
-	ElementSection []*ElementSegment
+	ElementSection []ElementSegment
 
 	// CodeSection is index-correlated with FunctionSection and contains each
 	// function's locals and body.
@@ -144,7 +144,7 @@ type Module struct {
 	CodeSection []*Code
 
 	// Note: In the Binary Format, this is SectionIDData.
-	DataSection []*DataSegment
+	DataSection []DataSegment
 
 	// NameSection is set when the SectionIDCustom "name" was successfully decoded from the binary format.
 	//

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -537,14 +537,14 @@ func TestModule_validateFunctions(t *testing.T) {
 
 func TestModule_validateMemory(t *testing.T) {
 	t.Run("active data segment exits but memory not declared", func(t *testing.T) {
-		m := Module{DataSection: []DataSegment{{OffsetExpression: &ConstantExpression{}}}}
+		m := Module{DataSection: []DataSegment{{OffsetExpression: ConstantExpression{}}}}
 		err := m.validateMemory(nil, nil, api.CoreFeaturesV1)
 		require.Error(t, err)
 		require.Contains(t, "unknown memory", err.Error())
 	})
 	t.Run("invalid const expr", func(t *testing.T) {
 		m := Module{DataSection: []DataSegment{{
-			OffsetExpression: &ConstantExpression{
+			OffsetExpression: ConstantExpression{
 				Opcode: OpcodeUnreachable, // Invalid!
 			},
 		}}}
@@ -554,7 +554,7 @@ func TestModule_validateMemory(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		m := Module{DataSection: []DataSegment{{
 			Init: []byte{0x1},
-			OffsetExpression: &ConstantExpression{
+			OffsetExpression: ConstantExpression{
 				Opcode: OpcodeI32Const,
 				Data:   leb128.EncodeInt32(1),
 			},

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -537,13 +537,13 @@ func TestModule_validateFunctions(t *testing.T) {
 
 func TestModule_validateMemory(t *testing.T) {
 	t.Run("active data segment exits but memory not declared", func(t *testing.T) {
-		m := Module{DataSection: []*DataSegment{{OffsetExpression: &ConstantExpression{}}}}
+		m := Module{DataSection: []DataSegment{{OffsetExpression: &ConstantExpression{}}}}
 		err := m.validateMemory(nil, nil, api.CoreFeaturesV1)
 		require.Error(t, err)
 		require.Contains(t, "unknown memory", err.Error())
 	})
 	t.Run("invalid const expr", func(t *testing.T) {
-		m := Module{DataSection: []*DataSegment{{
+		m := Module{DataSection: []DataSegment{{
 			OffsetExpression: &ConstantExpression{
 				Opcode: OpcodeUnreachable, // Invalid!
 			},
@@ -552,7 +552,7 @@ func TestModule_validateMemory(t *testing.T) {
 		require.EqualError(t, err, "calculate offset: invalid opcode for const expression: 0x0")
 	})
 	t.Run("ok", func(t *testing.T) {
-		m := Module{DataSection: []*DataSegment{{
+		m := Module{DataSection: []DataSegment{{
 			Init: []byte{0x1},
 			OffsetExpression: &ConstantExpression{
 				Opcode: OpcodeI32Const,
@@ -858,11 +858,11 @@ func TestModule_validateDataCountSection(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		for _, m := range []*Module{
 			{
-				DataSection:      []*DataSegment{},
+				DataSection:      []DataSegment{},
 				DataCountSection: nil,
 			},
 			{
-				DataSection:      []*DataSegment{{}, {}},
+				DataSection:      []DataSegment{{}, {}},
 				DataCountSection: nil,
 			},
 		} {
@@ -874,11 +874,11 @@ func TestModule_validateDataCountSection(t *testing.T) {
 		count := uint32(1)
 		for _, m := range []*Module{
 			{
-				DataSection:      []*DataSegment{},
+				DataSection:      []DataSegment{},
 				DataCountSection: &count,
 			},
 			{
-				DataSection:      []*DataSegment{{}, {}},
+				DataSection:      []DataSegment{{}, {}},
 				DataCountSection: &count,
 			},
 		} {
@@ -923,7 +923,7 @@ func TestModule_declaredFunctionIndexes(t *testing.T) {
 		{
 			name: "element",
 			mod: &Module{
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						Mode: ElementModeActive,
 						Init: []*Index{uint32Ptr(0), nil, uint32Ptr(5)},
@@ -961,7 +961,7 @@ func TestModule_declaredFunctionIndexes(t *testing.T) {
 						},
 					},
 				},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						Mode: ElementModeActive,
 						Init: []*Index{uint32Ptr(0), nil, uint32Ptr(5)},

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -220,7 +220,7 @@ func (m *ModuleInstance) validateData(data []DataSegment) (err error) {
 	for i := range data {
 		d := &data[i]
 		if !d.IsPassive() {
-			offset := int(executeConstExpression(m.Globals, d.OffsetExpression).(int32))
+			offset := int(executeConstExpression(m.Globals, &d.OffsetExpression).(int32))
 			ceil := offset + len(d.Init)
 			if offset < 0 || ceil > len(m.Memory.Buffer) {
 				return fmt.Errorf("%s[%d]: out of bounds memory access", SectionIDName(SectionIDData), i)
@@ -239,7 +239,7 @@ func (m *ModuleInstance) applyData(data []DataSegment) error {
 		d := &data[i]
 		m.DataInstances[i] = d.Init
 		if !d.IsPassive() {
-			offset := executeConstExpression(m.Globals, d.OffsetExpression).(int32)
+			offset := executeConstExpression(m.Globals, &d.OffsetExpression).(int32)
 			if offset < 0 || int(offset)+len(d.Init) > len(m.Memory.Buffer) {
 				return fmt.Errorf("%s[%d]: out of bounds memory access", SectionIDName(SectionIDData), i)
 			}

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -292,8 +292,9 @@ func (s *Store) Instantiate(
 ) (*CallContext, error) {
 	// Collect any imported modules to avoid locking the store too long.
 	importedModuleNames := map[string]struct{}{}
-	for _, i := range module.ImportSection {
-		importedModuleNames[i.Module] = struct{}{}
+	for i := range module.ImportSection {
+		imp := &module.ImportSection[i]
+		importedModuleNames[imp.Module] = struct{}{}
 	}
 
 	// Read-Lock the store and ensure imports needed are present.

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -156,7 +156,7 @@ func (m *ModuleInstance) addSections(module *Module, importedGlobals, globals []
 	m.BuildExports(module.ExportSection)
 }
 
-func (m *ModuleInstance) buildElementInstances(elements []*ElementSegment) {
+func (m *ModuleInstance) buildElementInstances(elements []ElementSegment) {
 	m.ElementInstances = make([]ElementInstance, len(elements))
 	for i, elm := range elements {
 		if elm.Type == RefTypeFuncref && elm.Mode == ElementModePassive {
@@ -216,8 +216,9 @@ func (m *ModuleInstance) BuildExports(exports []*Export) {
 
 // validateData ensures that data segments are valid in terms of memory boundary.
 // Note: this is used only when bulk-memory/reference type feature is disabled.
-func (m *ModuleInstance) validateData(data []*DataSegment) (err error) {
-	for i, d := range data {
+func (m *ModuleInstance) validateData(data []DataSegment) (err error) {
+	for i := range data {
+		d := &data[i]
 		if !d.IsPassive() {
 			offset := int(executeConstExpression(m.Globals, d.OffsetExpression).(int32))
 			ceil := offset + len(d.Init)
@@ -232,9 +233,10 @@ func (m *ModuleInstance) validateData(data []*DataSegment) (err error) {
 // applyData uses the given data segments and mutate the memory according to the initial contents on it
 // and populate the `DataInstances`. This is called after all the validation phase passes and out of
 // bounds memory access error here is not a validation error, but rather a runtime error.
-func (m *ModuleInstance) applyData(data []*DataSegment) error {
+func (m *ModuleInstance) applyData(data []DataSegment) error {
 	m.DataInstances = make([][]byte, len(data))
-	for i, d := range data {
+	for i := range data {
+		d := &data[i]
 		m.DataInstances[i] = d.Init
 		if !d.IsPassive() {
 			offset := executeConstExpression(m.Globals, d.OffsetExpression).(int32)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -125,7 +125,7 @@ type (
 	// GlobalInstance represents a global instance in a store.
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#global-instances%E2%91%A0
 	GlobalInstance struct {
-		Type *GlobalType
+		Type GlobalType
 		// Val holds a 64-bit representation of the actual value.
 		Val uint64
 		// ValHi is only used for vector type globals, and holds the higher bits of the vector.
@@ -206,7 +206,7 @@ func (m *ModuleInstance) applyTableInits(tables []*TableInstance, tableInits []t
 	}
 }
 
-func (m *ModuleInstance) BuildExports(exports []*Export) {
+func (m *ModuleInstance) BuildExports(exports []Export) {
 	m.Exports = make(map[string]ExportInstance, len(exports))
 	for _, exp := range exports {
 		// We already validated the duplicates during module validation phase.
@@ -408,7 +408,8 @@ func resolveImports(module *Module, modules map[string]*ModuleInstance) (
 	importedMemory *MemoryInstance,
 	err error,
 ) {
-	for idx, i := range module.ImportSection {
+	for idx := range module.ImportSection {
+		i := &module.ImportSection[idx]
 		m, ok := modules[i.Module]
 		if !ok {
 			err = fmt.Errorf("module[%s] not instantiated", i.Module)

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -825,26 +825,26 @@ func TestModuleInstance_validateData(t *testing.T) {
 	m := &ModuleInstance{Memory: &MemoryInstance{Buffer: make([]byte, 5)}}
 	tests := []struct {
 		name   string
-		data   []*DataSegment
+		data   []DataSegment
 		expErr string
 	}{
 		{
 			name: "ok",
-			data: []*DataSegment{
+			data: []DataSegment{
 				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []byte{0}},
 				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []byte{0}},
 			},
 		},
 		{
 			name: "out of bounds - single one byte",
-			data: []*DataSegment{
+			data: []DataSegment{
 				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(5)}, Init: []byte{0}},
 			},
 			expErr: "data[0]: out of bounds memory access",
 		},
 		{
 			name: "out of bounds - multi bytes",
-			data: []*DataSegment{
+			data: []DataSegment{
 				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(0)}, Init: []byte{0}},
 				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(3)}, Init: []byte{0, 1, 2}},
 			},
@@ -868,7 +868,7 @@ func TestModuleInstance_validateData(t *testing.T) {
 func TestModuleInstance_applyData(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		m := &ModuleInstance{Memory: &MemoryInstance{Buffer: make([]byte, 10)}}
-		err := m.applyData([]*DataSegment{
+		err := m.applyData([]DataSegment{
 			{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []byte{0xa, 0xf}},
 			{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeUint32(8)}, Init: []byte{0x1, 0x5}},
 		})
@@ -878,7 +878,7 @@ func TestModuleInstance_applyData(t *testing.T) {
 	})
 	t.Run("error", func(t *testing.T) {
 		m := &ModuleInstance{Memory: &MemoryInstance{Buffer: make([]byte, 5)}}
-		err := m.applyData([]*DataSegment{
+		err := m.applyData([]DataSegment{
 			{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeUint32(8)}, Init: []byte{}},
 		})
 		require.EqualError(t, err, "data[0]: out of bounds memory access")

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -831,22 +831,22 @@ func TestModuleInstance_validateData(t *testing.T) {
 		{
 			name: "ok",
 			data: []DataSegment{
-				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []byte{0}},
-				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []byte{0}},
+				{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []byte{0}},
+				{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []byte{0}},
 			},
 		},
 		{
 			name: "out of bounds - single one byte",
 			data: []DataSegment{
-				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(5)}, Init: []byte{0}},
+				{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(5)}, Init: []byte{0}},
 			},
 			expErr: "data[0]: out of bounds memory access",
 		},
 		{
 			name: "out of bounds - multi bytes",
 			data: []DataSegment{
-				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(0)}, Init: []byte{0}},
-				{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(3)}, Init: []byte{0, 1, 2}},
+				{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(0)}, Init: []byte{0}},
+				{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(3)}, Init: []byte{0, 1, 2}},
 			},
 			expErr: "data[1]: out of bounds memory access",
 		},
@@ -869,8 +869,8 @@ func TestModuleInstance_applyData(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		m := &ModuleInstance{Memory: &MemoryInstance{Buffer: make([]byte, 10)}}
 		err := m.applyData([]DataSegment{
-			{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []byte{0xa, 0xf}},
-			{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeUint32(8)}, Init: []byte{0x1, 0x5}},
+			{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []byte{0xa, 0xf}},
+			{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeUint32(8)}, Init: []byte{0x1, 0x5}},
 		})
 		require.NoError(t, err)
 		require.Equal(t, []byte{0xa, 0xf, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x5}, m.Memory.Buffer)
@@ -879,7 +879,7 @@ func TestModuleInstance_applyData(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := &ModuleInstance{Memory: &MemoryInstance{Buffer: make([]byte, 5)}}
 		err := m.applyData([]DataSegment{
-			{OffsetExpression: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeUint32(8)}, Init: []byte{}},
+			{OffsetExpression: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeUint32(8)}, Init: []byte{}},
 		})
 		require.EqualError(t, err, "data[0]: out of bounds memory access")
 	})

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -40,7 +40,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			input: &Module{
 				MemorySection:           &Memory{Min: 1, Cap: 1},
 				MemoryDefinitionSection: []*MemoryDefinition{{}},
-				ExportSection:           []*Export{{Type: ExternTypeMemory, Name: "momory", Index: 0}},
+				ExportSection:           []Export{{Type: ExternTypeMemory, Name: "momory", Index: 0}},
 			},
 		},
 		{
@@ -48,7 +48,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			input: &Module{
 				MemorySection:           &Memory{},
 				MemoryDefinitionSection: []*MemoryDefinition{{}},
-				ExportSection:           []*Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
+				ExportSection:           []Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected: true,
 		},
@@ -57,7 +57,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			input: &Module{
 				MemorySection:           &Memory{Min: 1, Cap: 1},
 				MemoryDefinitionSection: []*MemoryDefinition{{}},
-				ExportSection:           []*Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
+				ExportSection:           []Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
 			expectedLen: 65536,
@@ -67,7 +67,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 			input: &Module{
 				MemorySection:           &Memory{Min: 2, Cap: 2},
 				MemoryDefinitionSection: []*MemoryDefinition{{}},
-				ExportSection:           []*Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
+				ExportSection:           []Export{{Type: ExternTypeMemory, Name: "memory", Index: 0}},
 			},
 			expected:    true,
 			expectedLen: 65536 * 2,
@@ -148,18 +148,18 @@ func TestStore_CloseWithExitCode(t *testing.T) {
 				TypeSection:               []*FunctionType{v_v},
 				FunctionSection:           []uint32{0},
 				CodeSection:               []*Code{{Body: []byte{OpcodeEnd}}},
-				ExportSection:             []*Export{{Type: ExternTypeFunc, Index: 0, Name: "fn"}},
+				ExportSection:             []Export{{Type: ExternTypeFunc, Index: 0, Name: "fn"}},
 				FunctionDefinitionSection: []*FunctionDefinition{{funcType: v_v}},
 			}, importedModuleName, nil, []FunctionTypeID{0})
 			require.NoError(t, err)
 
 			m2, err := s.Instantiate(testCtx, &Module{
 				TypeSection:             []*FunctionType{v_v},
-				ImportSection:           []*Import{{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
+				ImportSection:           []Import{{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
 				MemorySection:           &Memory{Min: 1, Cap: 1},
 				MemoryDefinitionSection: []*MemoryDefinition{{}},
-				GlobalSection:           []*Global{{Type: &GlobalType{}, Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
-				TableSection:            []*Table{{Min: 10}},
+				GlobalSection:           []Global{{Type: GlobalType{}, Init: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}}},
+				TableSection:            []Table{{Min: 10}},
 			}, importingModuleName, nil, []FunctionTypeID{0})
 			require.NoError(t, err)
 
@@ -199,12 +199,12 @@ func TestStore_hammer(t *testing.T) {
 		CodeSection:             []*Code{{Body: []byte{OpcodeEnd}}},
 		MemorySection:           &Memory{Min: 1, Cap: 1},
 		MemoryDefinitionSection: []*MemoryDefinition{{}},
-		GlobalSection: []*Global{{
-			Type: &GlobalType{ValType: ValueTypeI32},
-			Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(1)},
+		GlobalSection: []Global{{
+			Type: GlobalType{ValType: ValueTypeI32},
+			Init: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(1)},
 		}},
-		TableSection: []*Table{{Min: 10}},
-		ImportSection: []*Import{
+		TableSection: []Table{{Min: 10}},
+		ImportSection: []Import{
 			{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 		},
 	}
@@ -253,12 +253,12 @@ func TestStore_hammer_close(t *testing.T) {
 		CodeSection:             []*Code{{Body: []byte{OpcodeEnd}}},
 		MemorySection:           &Memory{Min: 1, Cap: 1},
 		MemoryDefinitionSection: []*MemoryDefinition{{}},
-		GlobalSection: []*Global{{
-			Type: &GlobalType{ValType: ValueTypeI32},
-			Init: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(1)},
+		GlobalSection: []Global{{
+			Type: GlobalType{ValType: ValueTypeI32},
+			Init: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(1)},
 		}},
-		TableSection: []*Table{{Min: 10}},
-		ImportSection: []*Import{
+		TableSection: []Table{{Min: 10}},
+		ImportSection: []Import{
 			{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 		},
 	}
@@ -319,7 +319,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 
 		_, err = s.Instantiate(testCtx, &Module{
 			TypeSection: []*FunctionType{v_v},
-			ImportSection: []*Import{
+			ImportSection: []Import{
 				// The first import resolve succeeds -> increment hm.dependentCount.
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 				// But the second one tries to import uninitialized-module ->
@@ -348,7 +348,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 				{Body: []byte{OpcodeEnd}},
 				{Body: []byte{OpcodeEnd}},
 			},
-			ImportSection: []*Import{
+			ImportSection: []Import{
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 			},
 		}
@@ -375,7 +375,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 			FunctionSection: []uint32{0},
 			CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
 			StartSection:    &startFuncIndex,
-			ImportSection: []*Import{
+			ImportSection: []Import{
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 			},
 		}
@@ -612,7 +612,7 @@ func TestExecuteConstExpression(t *testing.T) {
 			t.Run(ValueTypeName(tc.valueType), func(t *testing.T) {
 				// The index specified in Data equals zero.
 				expr := &ConstantExpression{Data: []byte{0}, Opcode: OpcodeGlobalGet}
-				globals := []*GlobalInstance{{Val: tc.val, ValHi: tc.valHi, Type: &GlobalType{ValType: tc.valueType}}}
+				globals := []*GlobalInstance{{Val: tc.val, ValHi: tc.valHi, Type: GlobalType{ValType: tc.valueType}}}
 
 				val := executeConstExpression(globals, expr)
 				require.NotNil(t, val)
@@ -668,14 +668,14 @@ func Test_resolveImports(t *testing.T) {
 
 	t.Run("module not instantiated", func(t *testing.T) {
 		modules := map[string]*ModuleInstance{}
-		_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: "unknown", Name: "unknown"}}}, modules)
+		_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: "unknown", Name: "unknown"}}}, modules)
 		require.EqualError(t, err, "module[unknown] not instantiated")
 	})
 	t.Run("export instance not found", func(t *testing.T) {
 		modules := map[string]*ModuleInstance{
 			moduleName: {Exports: map[string]ExportInstance{}, Name: moduleName},
 		}
-		_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: "unknown"}}}, modules)
+		_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: "unknown"}}}, modules)
 		require.EqualError(t, err, "\"unknown\" is not exported in module \"test\"")
 	})
 	t.Run("func", func(t *testing.T) {
@@ -696,7 +696,7 @@ func Test_resolveImports(t *testing.T) {
 			}
 			m := &Module{
 				TypeSection: []*FunctionType{{Results: []ValueType{ValueTypeF32}}, {Results: []ValueType{ValueTypeI32}}},
-				ImportSection: []*Import{
+				ImportSection: []Import{
 					{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 0},
 					{Module: moduleName, Name: "", Type: ExternTypeFunc, DescFunc: 1},
 				},
@@ -710,7 +710,7 @@ func Test_resolveImports(t *testing.T) {
 			modules := map[string]*ModuleInstance{
 				moduleName: {Exports: map[string]ExportInstance{name: {}}, Name: moduleName},
 			}
-			_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 100}}}, modules)
+			_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 100}}}, modules)
 			require.EqualError(t, err, "import[0] func[test.target]: function type out of range")
 		})
 		t.Run("signature mismatch", func(t *testing.T) {
@@ -724,7 +724,7 @@ func Test_resolveImports(t *testing.T) {
 			modules := map[string]*ModuleInstance{moduleName: externMod}
 			m := &Module{
 				TypeSection:   []*FunctionType{{Results: []ValueType{ValueTypeF32}}},
-				ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 0}},
+				ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 0}},
 			}
 			_, _, _, _, err := resolveImports(m, modules)
 			require.EqualError(t, err, "import[0] func[test.target]: signature mismatch: v_f32 != v_v")
@@ -732,21 +732,21 @@ func Test_resolveImports(t *testing.T) {
 	})
 	t.Run("global", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
-			g := &GlobalInstance{Type: &GlobalType{ValType: ValueTypeI32}}
+			g := &GlobalInstance{Type: GlobalType{ValType: ValueTypeI32}}
 			modules := map[string]*ModuleInstance{
 				moduleName: {
 					Globals: []*GlobalInstance{g},
 					Exports: map[string]ExportInstance{name: {Type: ExternTypeGlobal, Index: 0}}, Name: moduleName,
 				},
 			}
-			_, globals, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeGlobal, DescGlobal: g.Type}}}, modules)
+			_, globals, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeGlobal, DescGlobal: g.Type}}}, modules)
 			require.NoError(t, err)
 			require.True(t, globalsContain(globals, g), "expected to find %v in %v", g, globals)
 		})
 		t.Run("mutability mismatch", func(t *testing.T) {
 			modules := map[string]*ModuleInstance{
 				moduleName: {
-					Globals: []*GlobalInstance{{Type: &GlobalType{Mutable: false}}},
+					Globals: []*GlobalInstance{{Type: GlobalType{Mutable: false}}},
 					Exports: map[string]ExportInstance{name: {
 						Type:  ExternTypeGlobal,
 						Index: 0,
@@ -754,13 +754,13 @@ func Test_resolveImports(t *testing.T) {
 					Name: moduleName,
 				},
 			}
-			_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeGlobal, DescGlobal: &GlobalType{Mutable: true}}}}, modules)
+			_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeGlobal, DescGlobal: GlobalType{Mutable: true}}}}, modules)
 			require.EqualError(t, err, "import[0] global[test.target]: mutability mismatch: true != false")
 		})
 		t.Run("type mismatch", func(t *testing.T) {
 			modules := map[string]*ModuleInstance{
 				moduleName: {
-					Globals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}}},
+					Globals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}}},
 					Exports: map[string]ExportInstance{name: {
 						Type:  ExternTypeGlobal,
 						Index: 0,
@@ -768,7 +768,7 @@ func Test_resolveImports(t *testing.T) {
 					Name: moduleName,
 				},
 			}
-			_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeF64}}}}, modules)
+			_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeF64}}}}, modules)
 			require.EqualError(t, err, "import[0] global[test.target]: value type mismatch: f64 != i32")
 		})
 	})
@@ -785,7 +785,7 @@ func Test_resolveImports(t *testing.T) {
 					Name: moduleName,
 				},
 			}
-			_, _, _, memory, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: &Memory{Max: max}}}}, modules)
+			_, _, _, memory, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: &Memory{Max: max}}}}, modules)
 			require.NoError(t, err)
 			require.Equal(t, memory, memoryInst)
 		})
@@ -800,7 +800,7 @@ func Test_resolveImports(t *testing.T) {
 					Name: moduleName,
 				},
 			}
-			_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}}, modules)
+			_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}}, modules)
 			require.EqualError(t, err, "import[0] memory[test.target]: minimum size mismatch: 2 > 1")
 		})
 		t.Run("maximum size mismatch", func(t *testing.T) {
@@ -815,7 +815,7 @@ func Test_resolveImports(t *testing.T) {
 					Name: moduleName,
 				},
 			}
-			_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}}, modules)
+			_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeMemory, DescMem: importMemoryType}}}, modules)
 			require.EqualError(t, err, "import[0] memory[test.target]: maximum size mismatch: 10 < 65536")
 		})
 	})

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -159,7 +159,8 @@ func (m *Module) validateTable(enabledFeatures api.CoreFeatures, tables []Table,
 
 	// Now, we have to figure out which table elements can be resolved before instantiation and also fail early if there
 	// are any imported globals that are known to be invalid by their declarations.
-	for i, elem := range m.ElementSection {
+	for i := range m.ElementSection {
+		elem := &m.ElementSection[i]
 		idx := Index(i)
 		initCount := uint32(len(elem.Init))
 
@@ -247,7 +248,8 @@ func (m *Module) validateTable(enabledFeatures api.CoreFeatures, tables []Table,
 func (m *Module) buildTables(importedTables []*TableInstance, importedGlobals []*GlobalInstance, skipBoundCheck bool) (tables []*TableInstance, inits []tableInitEntry, err error) {
 	tables = importedTables
 
-	for _, tsec := range m.TableSection {
+	for i := range m.TableSection {
+		tsec := &m.TableSection[i]
 		// The module defining the table is the one that sets its Min/Max etc.
 		tables = append(tables, &TableInstance{
 			References: make([]Reference, tsec.Min), Min: tsec.Min, Max: tsec.Max,
@@ -321,11 +323,12 @@ func checkSegmentBounds(min uint32, requireMin uint64, idx Index) error { // uin
 
 func (m *Module) verifyImportGlobalI32(sectionID SectionID, sectionIdx Index, idx uint32) error {
 	ig := uint32(math.MaxUint32) // +1 == 0
-	for i, im := range m.ImportSection {
-		if im.Type == ExternTypeGlobal {
+	for i := range m.ImportSection {
+		imp := &m.ImportSection[i]
+		if imp.Type == ExternTypeGlobal {
 			ig++
 			if ig == idx {
-				if im.DescGlobal.ValType != ValueTypeI32 {
+				if imp.DescGlobal.ValType != ValueTypeI32 {
 					return fmt.Errorf("%s[%d] (global.get %d): import[%d].global.ValType != i32", SectionIDName(sectionID), sectionIdx, idx, i)
 				}
 				return nil

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -58,8 +58,7 @@ const (
 type ElementSegment struct {
 	// OffsetExpr returns the table element offset to apply to Init indices.
 	// Note: This can be validated prior to instantiation unless it includes OpcodeGlobalGet (an imported global).
-	// Note: This is only set when Mode is active.
-	OffsetExpr *ConstantExpression
+	OffsetExpr ConstantExpression
 
 	// TableIndex is the table's index to which this element segment is applied.
 	// Note: This is used if and only if the Mode is active.

--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -141,7 +141,7 @@ type validatedActiveElementSegment struct {
 
 // validateTable ensures any ElementSegment is valid. This caches results via Module.validatedActiveElementSegments.
 // Note: limitsType are validated by decoders, so not re-validated here.
-func (m *Module) validateTable(enabledFeatures api.CoreFeatures, tables []*Table, maximumTableIndex uint32) ([]*validatedActiveElementSegment, error) {
+func (m *Module) validateTable(enabledFeatures api.CoreFeatures, tables []Table, maximumTableIndex uint32) ([]*validatedActiveElementSegment, error) {
 	if len(tables) > int(maximumTableIndex) {
 		return nil, fmt.Errorf("too many tables in a module: %d given with limit %d", len(tables), maximumTableIndex)
 	}

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -27,13 +27,13 @@ func Test_resolveImports_table(t *testing.T) {
 				Name:    moduleName,
 			},
 		}
-		_, _, tables, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeTable, DescTable: &Table{Max: &max}}}}, modules)
+		_, _, tables, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeTable, DescTable: Table{Max: &max}}}}, modules)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(tables))
 		require.Equal(t, tables[0], tableInst)
 	})
 	t.Run("minimum size mismatch", func(t *testing.T) {
-		importTableType := &Table{Min: 2}
+		importTableType := Table{Min: 2}
 		modules := map[string]*ModuleInstance{
 			moduleName: {
 				Tables:  []*TableInstance{{Min: importTableType.Min - 1}},
@@ -41,12 +41,12 @@ func Test_resolveImports_table(t *testing.T) {
 				Name:    moduleName,
 			},
 		}
-		_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeTable, DescTable: importTableType}}}, modules)
+		_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeTable, DescTable: importTableType}}}, modules)
 		require.EqualError(t, err, "import[0] table[test.target]: minimum size mismatch: 2 > 1")
 	})
 	t.Run("maximum size mismatch", func(t *testing.T) {
 		max := uint32(10)
-		importTableType := &Table{Max: &max}
+		importTableType := Table{Max: &max}
 		modules := map[string]*ModuleInstance{
 			moduleName: {
 				Tables:  []*TableInstance{{Min: importTableType.Min - 1}},
@@ -54,7 +54,7 @@ func Test_resolveImports_table(t *testing.T) {
 				Name:    moduleName,
 			},
 		}
-		_, _, _, _, err := resolveImports(&Module{ImportSection: []*Import{{Module: moduleName, Name: name, Type: ExternTypeTable, DescTable: importTableType}}}, modules)
+		_, _, _, _, err := resolveImports(&Module{ImportSection: []Import{{Module: moduleName, Name: name, Type: ExternTypeTable, DescTable: importTableType}}}, modules)
 		require.EqualError(t, err, "import[0] table[test.target]: maximum size mismatch: 10, but actual has no max")
 	})
 }
@@ -76,24 +76,24 @@ func TestModule_validateTable(t *testing.T) {
 		},
 		{
 			name:     "min zero",
-			input:    &Module{TableSection: []*Table{{}}},
+			input:    &Module{TableSection: []Table{{}}},
 			expected: []*validatedActiveElementSegment{},
 		},
 		{
 			name:     "maximum number of tables",
-			input:    &Module{TableSection: []*Table{{}, {}, {}, {}, {}}},
+			input:    &Module{TableSection: []Table{{}, {}, {}, {}, {}}},
 			expected: []*validatedActiveElementSegment{},
 		},
 		{
 			name:     "min/max",
-			input:    &Module{TableSection: []*Table{{Min: 1, Max: &three}}},
+			input:    &Module{TableSection: []Table{{Min: 1, Max: &three}}},
 			expected: []*validatedActiveElementSegment{},
 		},
 		{ // See: https://github.com/WebAssembly/spec/issues/1427
 			name: "constant derived element offset=0 and no index",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -109,7 +109,7 @@ func TestModule_validateTable(t *testing.T) {
 			name: "constant derived element offset=0 and one index",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -128,7 +128,7 @@ func TestModule_validateTable(t *testing.T) {
 			name: "constant derived element offset - ignores min on imported table",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{Type: RefTypeFuncref}}},
+				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{Type: RefTypeFuncref}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -147,7 +147,7 @@ func TestModule_validateTable(t *testing.T) {
 			name: "constant derived element offset=0 and one index - imported table",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{Min: 1, Type: RefTypeFuncref}}},
+				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{Min: 1, Type: RefTypeFuncref}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -166,7 +166,7 @@ func TestModule_validateTable(t *testing.T) {
 			name: "constant derived element offset and two indices",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 3, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
@@ -185,10 +185,10 @@ func TestModule_validateTable(t *testing.T) {
 			name: "imported global derived element offset and no index",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -204,10 +204,10 @@ func TestModule_validateTable(t *testing.T) {
 			name: "imported global derived element offset and one index",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -226,9 +226,9 @@ func TestModule_validateTable(t *testing.T) {
 			name: "imported global derived element offset and one index - imported table",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeTable, DescTable: &Table{Min: 1, Type: RefTypeFuncref}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeTable, DescTable: Table{Min: 1, Type: RefTypeFuncref}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
@@ -248,9 +248,9 @@ func TestModule_validateTable(t *testing.T) {
 			name: "imported global derived element offset - ignores min on imported table",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeTable, DescTable: &Table{Type: RefTypeFuncref}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeTable, DescTable: Table{Type: RefTypeFuncref}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
@@ -270,11 +270,11 @@ func TestModule_validateTable(t *testing.T) {
 			name: "imported global derived element offset - two indices",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI64}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI64}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 3, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
@@ -293,11 +293,11 @@ func TestModule_validateTable(t *testing.T) {
 			name: "mixed elementSegments - const before imported global",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI64}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI64}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 3, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
@@ -350,14 +350,14 @@ func TestModule_validateTable_Errors(t *testing.T) {
 		{
 			name: "too many tables",
 			input: &Module{
-				TableSection: []*Table{{}, {}, {}, {}, {}, {}},
+				TableSection: []Table{{}, {}, {}, {}, {}, {}},
 			},
 			expectedErr: "too many tables in a module: 6 given with limit 5",
 		},
 		{
 			name: "type mismatch: unknown ref type",
 			input: &Module{
-				TableSection: []*Table{{Type: RefTypeFuncref}},
+				TableSection: []Table{{Type: RefTypeFuncref}},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
@@ -373,7 +373,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 		{
 			name: "type mismatch: funcref elem on extern table",
 			input: &Module{
-				TableSection: []*Table{{Type: RefTypeExternref}},
+				TableSection: []Table{{Type: RefTypeExternref}},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
@@ -389,7 +389,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 		{
 			name: "type mismatch: extern elem on funcref table",
 			input: &Module{
-				TableSection: []*Table{{Type: RefTypeFuncref}},
+				TableSection: []Table{{Type: RefTypeFuncref}},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
@@ -405,7 +405,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 		{
 			name: "non-nil externref",
 			input: &Module{
-				TableSection: []*Table{{Type: RefTypeFuncref}},
+				TableSection: []Table{{Type: RefTypeFuncref}},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
@@ -423,7 +423,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "constant derived element offset - decode error",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Type: RefTypeFuncref}},
+				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -443,7 +443,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "constant derived element offset - wrong ValType",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Type: RefTypeFuncref}},
+				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -474,7 +474,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "constant derived element offset exceeds table min",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -490,7 +490,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "constant derived element offset puts init beyond table min",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 2, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 2, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -510,7 +510,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "constant derived element offset beyond table min - no init elements",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
+				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -526,7 +526,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "constant derived element offset - funcidx out of range",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 1}},
+				TableSection:    []Table{{Min: 1}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -542,8 +542,8 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "imported global derived element offset - missing table",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
@@ -560,10 +560,10 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "imported global derived element offset - funcidx out of range",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 1}},
+				TableSection:    []Table{{Min: 1}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -579,10 +579,10 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "imported global derived element offset - wrong ValType",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI64}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI64}},
 				},
-				TableSection:    []*Table{{Type: RefTypeFuncref}},
+				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -598,10 +598,10 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "imported global derived element offset - decode error",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Type: RefTypeFuncref}},
+				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -621,9 +621,9 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "imported global derived element offset - no imports",
 			input: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Type: RefTypeFuncref}},
+				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				GlobalSection:   []*Global{{Type: &GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
+				GlobalSection:   []Global{{Type: GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
@@ -638,12 +638,12 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "imported global derived element offset - no imports are globals",
 			input: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
+				ImportSection: []Import{
 					{Type: ExternTypeFunc, DescFunc: 0},
 				},
-				TableSection:    []*Table{{Type: RefTypeFuncref}},
+				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				GlobalSection:   []*Global{{Type: &GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
+				GlobalSection:   []Global{{Type: GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
@@ -692,7 +692,7 @@ func TestModule_buildTables(t *testing.T) {
 		{
 			name: "min zero",
 			module: &Module{
-				TableSection:                   []*Table{{Type: RefTypeFuncref}},
+				TableSection:                   []Table{{Type: RefTypeFuncref}},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{},
 			},
 			expectedTables: []*TableInstance{{References: make([]Reference, 0), Min: 0, Type: RefTypeFuncref}},
@@ -700,7 +700,7 @@ func TestModule_buildTables(t *testing.T) {
 		{
 			name: "min/max",
 			module: &Module{
-				TableSection:                   []*Table{{Min: 1, Max: &three}},
+				TableSection:                   []Table{{Min: 1, Max: &three}},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{},
 			},
 			expectedTables: []*TableInstance{{References: make([]Reference, 1), Min: 1, Max: &three}},
@@ -709,7 +709,7 @@ func TestModule_buildTables(t *testing.T) {
 			name: "constant derived element offset=0 and no index",
 			module: &Module{
 				TypeSection:                    []*FunctionType{{}},
-				TableSection:                   []*Table{{Min: 1}},
+				TableSection:                   []Table{{Min: 1}},
 				FunctionSection:                []Index{0},
 				CodeSection:                    []*Code{codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{},
@@ -719,7 +719,7 @@ func TestModule_buildTables(t *testing.T) {
 		{
 			name: "null extern refs",
 			module: &Module{
-				TableSection: []*Table{{Min: 10, Type: RefTypeExternref}},
+				TableSection: []Table{{Min: 10, Type: RefTypeExternref}},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{
 					{opcode: OpcodeI32Const, arg: 5, init: []*Index{nil, nil, nil}}, // three null refs.
 				},
@@ -731,7 +731,7 @@ func TestModule_buildTables(t *testing.T) {
 			name: "constant derived element offset=0 and one index",
 			module: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 1}},
+				TableSection:    []Table{{Min: 1}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{
@@ -759,7 +759,7 @@ func TestModule_buildTables(t *testing.T) {
 			name: "constant derived element offset=0 and one index - imported table",
 			module: &Module{
 				TypeSection:     []*FunctionType{{}},
-				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{Min: 1}}},
+				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{Min: 1}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{
@@ -774,7 +774,7 @@ func TestModule_buildTables(t *testing.T) {
 			name: "constant derived element offset and two indices",
 			module: &Module{
 				TypeSection:     []*FunctionType{{}},
-				TableSection:    []*Table{{Min: 3}},
+				TableSection:    []Table{{Min: 3}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{
@@ -788,32 +788,32 @@ func TestModule_buildTables(t *testing.T) {
 			name: "imported global derived element offset and no index",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:                   []*Table{{Min: 1}},
+				TableSection:                   []Table{{Min: 1}},
 				FunctionSection:                []Index{0},
 				CodeSection:                    []*Code{codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{},
 			},
-			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
+			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 1}},
 			expectedTables:  []*TableInstance{{References: make([]Reference, 1), Min: 1}},
 		},
 		{
 			name: "imported global derived element offset and one index",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 2}},
+				TableSection:    []Table{{Min: 2}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
 			},
-			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
+			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 1}},
 			expectedTables:  []*TableInstance{{References: make([]Reference, 2), Min: 2}},
 			expectedInit:    []tableInitEntry{{tableIndex: 0, offset: 1, functionIndexes: []*Index{uint32Ptr(0)}}},
 		},
@@ -821,9 +821,9 @@ func TestModule_buildTables(t *testing.T) {
 			name: "imported global derived element offset and one index - imported table",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeTable, DescTable: &Table{Min: 1}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeTable, DescTable: Table{Min: 1}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
@@ -831,7 +831,7 @@ func TestModule_buildTables(t *testing.T) {
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
 			},
-			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
+			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 1}},
 			importedTables:  []*TableInstance{{References: make([]Reference, 2), Min: 2}},
 			expectedTables:  []*TableInstance{{Min: 2, References: []Reference{0, 0}}},
 			expectedInit:    []tableInitEntry{{tableIndex: 0, offset: 1, functionIndexes: []*Index{uint32Ptr(0)}}},
@@ -840,9 +840,9 @@ func TestModule_buildTables(t *testing.T) {
 			name: "imported global derived element offset - ignores min on imported table",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeTable, DescTable: &Table{}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeTable, DescTable: Table{}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
@@ -850,7 +850,7 @@ func TestModule_buildTables(t *testing.T) {
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
 			},
-			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1}},
+			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 1}},
 			importedTables:  []*TableInstance{{References: make([]Reference, 2), Min: 2}},
 			expectedTables:  []*TableInstance{{Min: 2, References: []Reference{0, 0}}},
 			expectedInit:    []tableInitEntry{{tableIndex: 0, offset: 1, functionIndexes: []*Index{uint32Ptr(0)}}},
@@ -859,11 +859,11 @@ func TestModule_buildTables(t *testing.T) {
 			name: "imported global derived element offset - two indices",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI64}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI64}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 3}, {Min: 100}},
+				TableSection:    []Table{{Min: 3}, {Min: 100}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
@@ -884,8 +884,8 @@ func TestModule_buildTables(t *testing.T) {
 				},
 			},
 			importedGlobals: []*GlobalInstance{
-				{Type: &GlobalType{ValType: ValueTypeI64}, Val: 3},
-				{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1},
+				{Type: GlobalType{ValType: ValueTypeI64}, Val: 3},
+				{Type: GlobalType{ValType: ValueTypeI32}, Val: 1},
 			},
 			expectedTables: []*TableInstance{
 				{References: make([]Reference, 3), Min: 3},
@@ -900,11 +900,11 @@ func TestModule_buildTables(t *testing.T) {
 			name: "mixed elementSegments - const before imported global",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI64}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI64}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 3}},
+				TableSection:    []Table{{Min: 3}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				validatedActiveElementSegments: []*validatedActiveElementSegment{
@@ -913,8 +913,8 @@ func TestModule_buildTables(t *testing.T) {
 				},
 			},
 			importedGlobals: []*GlobalInstance{
-				{Type: &GlobalType{ValType: ValueTypeI64}, Val: 3},
-				{Type: &GlobalType{ValType: ValueTypeI32}, Val: 1},
+				{Type: GlobalType{ValType: ValueTypeI64}, Val: 3},
+				{Type: GlobalType{ValType: ValueTypeI32}, Val: 1},
 			},
 			expectedTables: []*TableInstance{{References: make([]Reference, 3), Min: 3}},
 			expectedInit: []tableInitEntry{
@@ -950,7 +950,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 			name: "constant derived element offset exceeds table min - imported table",
 			module: &Module{
 				TypeSection:     []*FunctionType{{}},
-				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{}}},
+				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -970,10 +970,10 @@ func TestModule_buildTable_Errors(t *testing.T) {
 			name: "imported global derived element offset exceeds table min",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 2}},
+				TableSection:    []Table{{Min: 2}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -986,18 +986,18 @@ func TestModule_buildTable_Errors(t *testing.T) {
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
 			},
-			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 2}},
+			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 2}},
 			expectedErr:     "element[0].init exceeds min table size",
 		},
 		{
 			name: "imported global derived element offset exceeds table min imported table",
 			module: &Module{
 				TypeSection: []*FunctionType{{}},
-				ImportSection: []*Import{
-					{Type: ExternTypeTable, DescTable: &Table{}},
-					{Type: ExternTypeGlobal, DescGlobal: &GlobalType{ValType: ValueTypeI32}},
+				ImportSection: []Import{
+					{Type: ExternTypeTable, DescTable: Table{}},
+					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
-				TableSection:    []*Table{{Min: 2}},
+				TableSection:    []Table{{Min: 2}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
@@ -1011,7 +1011,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				},
 			},
 			importedTables:  []*TableInstance{{References: make([]Reference, 2), Min: 2}},
-			importedGlobals: []*GlobalInstance{{Type: &GlobalType{ValType: ValueTypeI32}, Val: 2}},
+			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 2}},
 			expectedErr:     "element[0].init exceeds min table size",
 		},
 	}

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -96,7 +96,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Type:       RefTypeFuncref,
@@ -112,7 +112,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
@@ -131,7 +131,7 @@ func TestModule_validateTable(t *testing.T) {
 				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{Type: RefTypeFuncref}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
@@ -150,7 +150,7 @@ func TestModule_validateTable(t *testing.T) {
 				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{Min: 1, Type: RefTypeFuncref}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
@@ -169,7 +169,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
@@ -191,7 +191,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Type:       RefTypeFuncref,
@@ -210,7 +210,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
@@ -232,7 +232,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
@@ -254,7 +254,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
@@ -277,7 +277,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
@@ -300,7 +300,7 @@ func TestModule_validateTable(t *testing.T) {
 				TableSection:    []*Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
@@ -358,7 +358,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "type mismatch: unknown ref type",
 			input: &Module{
 				TableSection: []*Table{{Type: RefTypeFuncref}},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
 							Opcode: OpcodeI32Const,
@@ -374,7 +374,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "type mismatch: funcref elem on extern table",
 			input: &Module{
 				TableSection: []*Table{{Type: RefTypeExternref}},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
 							Opcode: OpcodeI32Const,
@@ -390,7 +390,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "type mismatch: extern elem on funcref table",
 			input: &Module{
 				TableSection: []*Table{{Type: RefTypeFuncref}},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
 							Opcode: OpcodeI32Const,
@@ -406,7 +406,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			name: "non-nil externref",
 			input: &Module{
 				TableSection: []*Table{{Type: RefTypeFuncref}},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
 							Opcode: OpcodeI32Const,
@@ -426,7 +426,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
 							Opcode: OpcodeI32Const,
@@ -446,7 +446,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI64Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -461,7 +461,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []*FunctionType{{}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -477,7 +477,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -493,7 +493,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 2, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -513,7 +513,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)},
 						Type:       RefTypeFuncref,
@@ -529,7 +529,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 1}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
 						Type: RefTypeFuncref,
@@ -547,7 +547,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -566,7 +566,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 1}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
 						Type: RefTypeFuncref,
@@ -585,7 +585,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -604,7 +604,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{
 							Opcode: OpcodeGlobalGet,
@@ -625,7 +625,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				FunctionSection: []Index{0},
 				GlobalSection:   []*Global{{Type: &GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -645,7 +645,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				FunctionSection: []Index{0},
 				GlobalSection:   []*Global{{Type: &GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
@@ -866,7 +866,7 @@ func TestModule_buildTables(t *testing.T) {
 				TableSection:    []*Table{{Min: 3}, {Min: 100}},
 				FunctionSection: []Index{0, 0, 0, 0},
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{nil, uint32Ptr(2)},
@@ -953,7 +953,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				ImportSection:   []*Import{{Type: ExternTypeTable, DescTable: &Table{}}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
@@ -976,7 +976,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 2}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
@@ -1000,7 +1000,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				TableSection:    []*Table{{Min: 2}},
 				FunctionSection: []Index{0},
 				CodeSection:     []*Code{codeEnd},
-				ElementSection: []*ElementSegment{
+				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -98,7 +98,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Type:       RefTypeFuncref,
 					},
 				},
@@ -114,7 +114,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
 						Type:       RefTypeFuncref,
 					},
@@ -133,7 +133,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
 						Type:       RefTypeFuncref,
 					},
@@ -152,7 +152,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
 						Type:       RefTypeFuncref,
 					},
@@ -171,7 +171,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
 						Type:       RefTypeFuncref,
 					},
@@ -193,7 +193,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Type:       RefTypeFuncref,
 					},
 				},
@@ -212,7 +212,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
 						Type:       RefTypeFuncref,
 					},
@@ -234,7 +234,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
 						Type:       RefTypeFuncref,
 					},
@@ -256,7 +256,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
 						Type:       RefTypeFuncref,
 					},
@@ -279,7 +279,7 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
 						Type:       RefTypeFuncref,
 					},
@@ -302,12 +302,12 @@ func TestModule_validateTable(t *testing.T) {
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
 						Type:       RefTypeFuncref,
 					},
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
 						Init:       []*Index{uint32Ptr(1), uint32Ptr(2)},
 						Type:       RefTypeFuncref,
 					},
@@ -360,7 +360,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection: []Table{{Type: RefTypeFuncref}},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{
+						OffsetExpr: ConstantExpression{
 							Opcode: OpcodeI32Const,
 							Data:   leb128.EncodeUint64(math.MaxUint64),
 						},
@@ -376,7 +376,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection: []Table{{Type: RefTypeExternref}},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{
+						OffsetExpr: ConstantExpression{
 							Opcode: OpcodeI32Const,
 							Data:   leb128.EncodeUint64(math.MaxUint64),
 						},
@@ -392,7 +392,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection: []Table{{Type: RefTypeFuncref}},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{
+						OffsetExpr: ConstantExpression{
 							Opcode: OpcodeI32Const,
 							Data:   leb128.EncodeUint64(math.MaxUint64),
 						},
@@ -408,7 +408,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection: []Table{{Type: RefTypeFuncref}},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{
+						OffsetExpr: ConstantExpression{
 							Opcode: OpcodeI32Const,
 							Data:   leb128.EncodeUint64(math.MaxUint64),
 						},
@@ -428,7 +428,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{
+						OffsetExpr: ConstantExpression{
 							Opcode: OpcodeI32Const,
 							Data:   leb128.EncodeUint64(math.MaxUint64),
 						},
@@ -448,7 +448,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI64Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI64Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -463,7 +463,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -479,7 +479,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -495,11 +495,11 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0), uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0), uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -515,7 +515,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)},
 						Type:       RefTypeFuncref,
 					},
 				},
@@ -531,7 +531,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -549,7 +549,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -568,7 +568,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -587,7 +587,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -606,7 +606,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{
+						OffsetExpr: ConstantExpression{
 							Opcode: OpcodeGlobalGet,
 							Data:   leb128.EncodeUint64(math.MaxUint64),
 						},
@@ -627,7 +627,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -647,7 +647,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
 						Type: RefTypeFuncref,
 					},
 				},
@@ -868,12 +868,12 @@ func TestModule_buildTables(t *testing.T) {
 				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{nil, uint32Ptr(2)},
 						TableIndex: 1,
 					},
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
 						Init:       []*Index{uint32Ptr(0), uint32Ptr(2)},
 						TableIndex: 0,
 					},
@@ -955,7 +955,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
 						Init:       []*Index{uint32Ptr(0)},
 					},
 				},
@@ -978,7 +978,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
 					},
 				},
@@ -1002,7 +1002,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				CodeSection:     []*Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
-						OffsetExpr: &ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
+						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
 						Init:       []*Index{uint32Ptr(0)},
 					},
 				},

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -175,10 +175,10 @@ type compiler struct {
 
 	// types hold all the function types in the module where the targe function exists.
 	types []*wasm.FunctionType
-	// funcs holds the type indexes for all declard functions in the module where the targe function exists.
+	// funcs holds the type indexes for all declared functions in the module where the target function exists.
 	funcs []uint32
-	// globals holds the global types for all declard globas in the module where the targe function exists.
-	globals []*wasm.GlobalType
+	// globals holds the global types for all declared globals in the module where the target function exists.
+	globals []wasm.GlobalType
 
 	// needSourceOffset is true if this module requires DWARF based stack trace.
 	needSourceOffset bool
@@ -242,7 +242,7 @@ type CompilationResult struct {
 	// Signature is the function type of the compilation target function.
 	Signature *wasm.FunctionType
 	// Globals holds all the declarations of globals in the module from which this function is compiled.
-	Globals []*wasm.GlobalType
+	Globals []wasm.GlobalType
 	// Functions holds all the declarations of function in the module from which this function is compiled, including itself.
 	Functions []wasm.Index
 	// Types holds all the types in the module from which this function is compiled.
@@ -337,7 +337,8 @@ func compile(enabledFeatures api.CoreFeatures,
 	body []byte,
 	localTypes []wasm.ValueType,
 	types []*wasm.FunctionType,
-	functions []uint32, globals []*wasm.GlobalType,
+	functions []uint32,
+	globals []wasm.GlobalType,
 	bodyOffsetInCodeSection uint64,
 	needSourceOffset bool,
 	ensureTermination bool,

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -321,7 +321,7 @@ func TestCompile_BulkMemoryOperations(t *testing.T) {
 		TypeSection:     []*wasm.FunctionType{v_v},
 		FunctionSection: []wasm.Index{0},
 		MemorySection:   &wasm.Memory{Min: 1},
-		DataSection: []*wasm.DataSegment{
+		DataSection: []wasm.DataSegment{
 			{
 				OffsetExpression: &wasm.ConstantExpression{
 					Opcode: wasm.OpcodeI32Const,

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -752,7 +752,7 @@ func TestCompile_CallIndirectNonZeroTableIndex(t *testing.T) {
 			5, // Non-zero table index for call_indirect.
 			wasm.OpcodeEnd,
 		}}},
-		TableSection: []*wasm.Table{
+		TableSection: []wasm.Table{
 			{Type: wasm.RefTypeExternref},
 			{Type: wasm.RefTypeFuncref},
 			{Type: wasm.RefTypeFuncref},
@@ -935,7 +935,7 @@ func TestCompile_TableGetOrSet(t *testing.T) {
 				TypeSection:     []*wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: tc.body}},
-				TableSection:    []*wasm.Table{{}},
+				TableSection:    []wasm.Table{{}},
 			}
 			res, err := CompileFunctions(api.CoreFeaturesV2, 0, module, false)
 			require.NoError(t, err)
@@ -1004,7 +1004,7 @@ func TestCompile_TableGrowFillSize(t *testing.T) {
 				TypeSection:     []*wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: tc.body}},
-				TableSection:    []*wasm.Table{{}},
+				TableSection:    []wasm.Table{{}},
 			}
 			res, err := CompileFunctions(api.CoreFeaturesV2, 0, module, false)
 			require.NoError(t, err)

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -323,15 +323,15 @@ func TestCompile_BulkMemoryOperations(t *testing.T) {
 		MemorySection:   &wasm.Memory{Min: 1},
 		DataSection: []wasm.DataSegment{
 			{
-				OffsetExpression: &wasm.ConstantExpression{
+				OffsetExpression: wasm.ConstantExpression{
 					Opcode: wasm.OpcodeI32Const,
 					Data:   []byte{0x00},
 				},
 				Init: []byte("hello"),
 			},
 			{
-				OffsetExpression: nil, // passive
-				Init:             []byte("goodbye"),
+				Passive: true,
+				Init:    []byte("goodbye"),
 			},
 		},
 		DataCountSection: &two,

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -81,7 +81,7 @@ func TestRuntime_CompileModule(t *testing.T) {
 				TypeSection:     []*wasm.FunctionType{{Params: []api.ValueType{api.ValueTypeI32}}},
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
-				ExportSection: []*wasm.Export{{
+				ExportSection: []wasm.Export{{
 					Type:  wasm.ExternTypeFunc,
 					Name:  "function",
 					Index: 0,
@@ -107,7 +107,7 @@ func TestRuntime_CompileModule(t *testing.T) {
 			name: "MemorySection exported",
 			wasm: &wasm.Module{
 				MemorySection: &wasm.Memory{Min: 2, Max: 3, IsMaxEncoded: true},
-				ExportSection: []*wasm.Export{{
+				ExportSection: []wasm.Export{{
 					Type:  wasm.ExternTypeMemory,
 					Name:  "memory",
 					Index: 0,
@@ -202,7 +202,7 @@ func TestModule_Memory(t *testing.T) {
 			name: "memory exported, one page",
 			wasm: binaryencoding.EncodeModule(&wasm.Module{
 				MemorySection: &wasm.Memory{Min: 1},
-				ExportSection: []*wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
+				ExportSection: []wasm.Export{{Name: "memory", Type: api.ExternTypeMemory}},
 			}),
 			expected:    true,
 			expectedLen: 65536,
@@ -251,10 +251,10 @@ func TestModule_Global(t *testing.T) {
 		{
 			name: "global not exported",
 			module: &wasm.Module{
-				GlobalSection: []*wasm.Global{
+				GlobalSection: []wasm.Global{
 					{
-						Type: &wasm.GlobalType{ValType: wasm.ValueTypeI64, Mutable: true},
-						Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI64Const, Data: leb128.EncodeInt64(globalVal)},
+						Type: wasm.GlobalType{ValType: wasm.ValueTypeI64, Mutable: true},
+						Init: wasm.ConstantExpression{Opcode: wasm.OpcodeI64Const, Data: leb128.EncodeInt64(globalVal)},
 					},
 				},
 			},
@@ -262,13 +262,13 @@ func TestModule_Global(t *testing.T) {
 		{
 			name: "global exported",
 			module: &wasm.Module{
-				GlobalSection: []*wasm.Global{
+				GlobalSection: []wasm.Global{
 					{
-						Type: &wasm.GlobalType{ValType: wasm.ValueTypeI64},
-						Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI64Const, Data: leb128.EncodeInt64(globalVal)},
+						Type: wasm.GlobalType{ValType: wasm.ValueTypeI64},
+						Init: wasm.ConstantExpression{Opcode: wasm.OpcodeI64Const, Data: leb128.EncodeInt64(globalVal)},
 					},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Type: wasm.ExternTypeGlobal, Name: "global"},
 				},
 			},
@@ -277,13 +277,13 @@ func TestModule_Global(t *testing.T) {
 		{
 			name: "global exported and mutable",
 			module: &wasm.Module{
-				GlobalSection: []*wasm.Global{
+				GlobalSection: []wasm.Global{
 					{
-						Type: &wasm.GlobalType{ValType: wasm.ValueTypeI64, Mutable: true},
-						Init: &wasm.ConstantExpression{Opcode: wasm.OpcodeI64Const, Data: leb128.EncodeInt64(globalVal)},
+						Type: wasm.GlobalType{ValType: wasm.ValueTypeI64, Mutable: true},
+						Init: wasm.ConstantExpression{Opcode: wasm.OpcodeI64Const, Data: leb128.EncodeInt64(globalVal)},
 					},
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Type: wasm.ExternTypeGlobal, Name: "global"},
 				},
 			},
@@ -344,7 +344,7 @@ func TestRuntime_InstantiateModule_UsesContext(t *testing.T) {
 	one := uint32(1)
 	binary := binaryencoding.EncodeModule(&wasm.Module{
 		TypeSection:     []*wasm.FunctionType{{}},
-		ImportSection:   []*wasm.Import{{Module: "env", Name: "start", Type: wasm.ExternTypeFunc, DescFunc: 0}},
+		ImportSection:   []wasm.Import{{Module: "env", Name: "start", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
 		CodeSection: []*wasm.Code{
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Call the imported env.start.
@@ -374,7 +374,7 @@ func TestRuntime_Instantiate_DoesntEnforce_Start(t *testing.T) {
 
 	binary := binaryencoding.EncodeModule(&wasm.Module{
 		MemorySection: &wasm.Memory{Min: 1},
-		ExportSection: []*wasm.Export{{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0}},
+		ExportSection: []wasm.Export{{Name: "memory", Type: wasm.ExternTypeMemory, Index: 0}},
 	})
 
 	mod, err := r.Instantiate(testCtx, binary)
@@ -473,7 +473,7 @@ func TestRuntime_InstantiateModule_ExitError(t *testing.T) {
 	one := uint32(1)
 	binary := binaryencoding.EncodeModule(&wasm.Module{
 		TypeSection:     []*wasm.FunctionType{{}},
-		ImportSection:   []*wasm.Import{{Module: "env", Name: "exit", Type: wasm.ExternTypeFunc, DescFunc: 0}},
+		ImportSection:   []wasm.Import{{Module: "env", Name: "exit", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
 		CodeSection: []*wasm.Code{
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Call the imported env.start.
@@ -494,7 +494,7 @@ func TestRuntime_CloseWithExitCode(t *testing.T) {
 		TypeSection:     []*wasm.FunctionType{{}},
 		FunctionSection: []wasm.Index{0},
 		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
-		ExportSection:   []*wasm.Export{{Type: wasm.ExternTypeFunc, Index: 0, Name: "func"}},
+		ExportSection:   []wasm.Export{{Type: wasm.ExternTypeFunc, Index: 0, Name: "func"}},
 	})
 
 	tests := []struct {
@@ -604,7 +604,7 @@ func TestHostFunctionWithCustomContext(t *testing.T) {
 			startFnIndex := uint32(2)
 			binary := binaryencoding.EncodeModule(&wasm.Module{
 				TypeSection: []*wasm.FunctionType{{}},
-				ImportSection: []*wasm.Import{
+				ImportSection: []wasm.Import{
 					{Module: "env", Name: "host", Type: wasm.ExternTypeFunc, DescFunc: 0},
 					{Module: "env", Name: "host2", Type: wasm.ExternTypeFunc, DescFunc: 0},
 				},
@@ -613,7 +613,7 @@ func TestHostFunctionWithCustomContext(t *testing.T) {
 					{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Call the imported env.host.
 					{Body: []byte{wasm.OpcodeCall, 1, wasm.OpcodeEnd}}, // Call the imported env.host.
 				},
-				ExportSection: []*wasm.Export{
+				ExportSection: []wasm.Export{
 					{Type: api.ExternTypeFunc, Name: "callHost", Index: uint32(3)},
 				},
 				StartSection: &startFnIndex,


### PR DESCRIPTION
This changes wasm.Module's fields, make most of them stored as a slice of values, not ptrs.
As a consequence, this improves not only compilation but also the instantiation perf.

```
$ benchstat aa_old.txt new.txt
name                                    old time/op    new time/op    delta
Initialization/interpreter-32             51.1µs ± 1%    39.3µs ± 4%  -23.11%  (p=0.000 n=10+9)
Initialization/interpreter-multiple-32    37.4µs ± 6%    37.8µs ± 5%     ~     (p=0.579 n=10+10)
Initialization/compiler-32                32.0µs ± 2%    30.1µs ± 1%   -5.88%  (p=0.000 n=10+9)
Initialization/compiler-multiple-32       24.8µs ± 5%    24.6µs ± 5%     ~     (p=0.684 n=10+10)
Compilation/with_extern_cache-32           206µs ± 1%     205µs ± 1%     ~     (p=0.247 n=10+10)
Compilation/without_extern_cache-32       6.12ms ± 1%    6.09ms ± 1%     ~     (p=0.089 n=10+10)

name                                    old alloc/op   new alloc/op   delta
Initialization/interpreter-32              137kB ± 0%     136kB ± 0%   -0.31%  (p=0.000 n=10+10)
Initialization/interpreter-multiple-32     137kB ± 0%     137kB ± 0%     ~     (p=0.134 n=9+8)
Initialization/compiler-32                 141kB ± 0%     137kB ± 0%   -3.07%  (p=0.000 n=9+9)
Initialization/compiler-multiple-32        142kB ± 0%     142kB ± 0%     ~     (p=0.518 n=8+9)
Compilation/with_extern_cache-32          55.7kB ± 0%    55.5kB ± 0%   -0.23%  (p=0.000 n=9+10)
Compilation/without_extern_cache-32       2.00MB ± 0%    2.00MB ± 0%     ~     (p=0.053 n=9+10)

name                                    old allocs/op  new allocs/op  delta
Initialization/interpreter-32               51.0 ± 0%      38.0 ± 0%  -25.49%  (p=0.000 n=10+10)
Initialization/interpreter-multiple-32      57.0 ± 0%      57.0 ± 0%     ~     (all equal)
Initialization/compiler-32                  41.0 ± 0%      38.0 ± 0%   -7.32%  (p=0.000 n=10+10)
Initialization/compiler-multiple-32         47.0 ± 0%      47.0 ± 0%     ~     (all equal)
Compilation/with_extern_cache-32           1.10k ± 0%     1.08k ± 0%   -1.99%  (p=0.000 n=10+10)
Compilation/without_extern_cache-32        33.6k ± 0%     33.6k ± 0%   -0.06%  (p=0.000 n=7+10)
```