### PR TITLE
renames exit log scope to proc and resolves gojs files to cwd

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -434,8 +434,8 @@ func (f *logScopesFlag) Set(input string) error {
 			continue
 		case "clock":
 			*f |= logScopesFlag(logging.LogScopeClock)
-		case "exit":
-			*f |= logScopesFlag(logging.LogScopeExit)
+		case "proc":
+			*f |= logScopesFlag(logging.LogScopeProc)
 		case "filesystem":
 			*f |= logScopesFlag(logging.LogScopeFilesystem)
 		case "memory":

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -295,9 +295,9 @@ func TestRun(t *testing.T) {
 			expectedStdout: "pooh\n",
 		},
 		{
-			name:       "wasi hostlogging=exit",
+			name:       "wasi hostlogging=proc",
 			wasm:       wasmCatTinygo,
-			wazeroOpts: []string{"--hostlogging=exit", fmt.Sprintf("--mount=%s:/animals:ro", bearDir)},
+			wazeroOpts: []string{"--hostlogging=proc", fmt.Sprintf("--mount=%s:/animals:ro", bearDir)},
 			wasmArgs:   []string{"/animals/not-bear.txt"},
 			expectedStderr: `==> wasi_snapshot_preview1.proc_exit(rval=1)
 `, // ^^ proc_exit panics, which short-circuits the logger. Hence, no "<==".
@@ -352,9 +352,9 @@ func TestRun(t *testing.T) {
 			expectedStdout: "pooh\n",
 		},
 		{
-			name:       "GOARCH=wasm GOOS=js hostlogging=exit",
+			name:       "GOARCH=wasm GOOS=js hostlogging=proc",
 			wasm:       wasmCatGo,
-			wazeroOpts: []string{"--hostlogging=exit", fmt.Sprintf("--mount=%s:/animals:ro", bearDir)},
+			wazeroOpts: []string{"--hostlogging=proc", fmt.Sprintf("--mount=%s:/animals:ro", bearDir)},
 			wasmArgs:   []string{"/animals/not-bear.txt"},
 			expectedStderr: `==> go.runtime.wasmExit(code=1)
 <==

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -34,10 +34,10 @@ const (
 	LogScopeNone = logging.LogScopeNone
 	// LogScopeClock enables logging for functions such as `clock_time_get`.
 	LogScopeClock = logging.LogScopeClock
-	// LogScopeExit enables logging for functions such as `proc_exit`.
+	// LogScopeProc enables logging for functions such as `proc_exit`.
 	//
 	// Note: This includes functions that both log and exit. e.g. `abort`.
-	LogScopeExit = logging.LogScopeExit
+	LogScopeProc = logging.LogScopeProc
 	// LogScopeFilesystem enables logging for functions such as `path_open`.
 	//
 	// Note: This doesn't log writes to the console.

--- a/imports/assemblyscript/assemblyscript_test.go
+++ b/imports/assemblyscript/assemblyscript_test.go
@@ -50,7 +50,7 @@ func TestAbort(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			var stderr bytes.Buffer
-			mod, r, log := requireProxyModule(t, tc.exporter, wazero.NewModuleConfig().WithStderr(&stderr), logging.LogScopeExit)
+			mod, r, log := requireProxyModule(t, tc.exporter, wazero.NewModuleConfig().WithStderr(&stderr), logging.LogScopeProc)
 			defer r.Close(testCtx)
 
 			messageOff, filenameOff := writeAbortMessageAndFileName(t, mod.Memory(), encodeUTF16("message"), encodeUTF16("filename"))

--- a/internal/assemblyscript/logging/logging.go
+++ b/internal/assemblyscript/logging/logging.go
@@ -6,7 +6,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/logging"
 )
 
-func isExitFunction(fnd api.FunctionDefinition) bool {
+func isProcFunction(fnd api.FunctionDefinition) bool {
 	return fnd.ExportNames()[0] == AbortName
 }
 
@@ -16,8 +16,8 @@ func isRandomFunction(fnd api.FunctionDefinition) bool {
 
 // IsInLogScope returns true if the current function is in any of the scopes.
 func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
-	if scopes.IsEnabled(logging.LogScopeExit) {
-		if isExitFunction(fnd) {
+	if scopes.IsEnabled(logging.LogScopeProc) {
+		if isProcFunction(fnd) {
 			return true
 		}
 	}

--- a/internal/assemblyscript/logging/logging_test.go
+++ b/internal/assemblyscript/logging/logging_test.go
@@ -30,9 +30,9 @@ func TestIsInLogScope(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "abort in LogScopeExit",
+			name:     "abort in LogScopeProc",
 			fnd:      abort,
-			scopes:   logging.LogScopeExit,
+			scopes:   logging.LogScopeProc,
 			expected: true,
 		},
 		{
@@ -42,9 +42,9 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "abort in LogScopeExit|LogScopeFilesystem",
+			name:     "abort in LogScopeProc|LogScopeFilesystem",
 			fnd:      abort,
-			scopes:   logging.LogScopeExit | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeProc | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{

--- a/internal/gojs/builtin.go
+++ b/internal/gojs/builtin.go
@@ -3,6 +3,7 @@ package gojs
 import (
 	"net/http"
 
+	"github.com/tetratelabs/wazero/internal/gojs/custom"
 	"github.com/tetratelabs/wazero/internal/gojs/goos"
 )
 
@@ -43,18 +44,18 @@ var (
 	arrayConstructor = newJsVal(goos.RefArrayConstructor, "Array")
 
 	// jsProcess = js.Global().Get("process") // fs_js.go init
-	jsProcess = newJsVal(goos.RefJsProcess, "process").
+	jsProcess = newJsVal(goos.RefJsProcess, custom.NameProcess).
 			addProperties(map[string]interface{}{
 			"pid":  float64(1),        // Get("pid").Int() in syscall_js.go for syscall.Getpid
 			"ppid": goos.RefValueZero, // Get("ppid").Int() in syscall_js.go for syscall.Getppid
 		}).
-		addFunction("cwd", processCwd{}).              // syscall.Cwd in fs_js.go
-		addFunction("chdir", processChdir{}).          // syscall.Chdir in fs_js.go
-		addFunction("getuid", returnZero{}).           // syscall.Getuid in syscall_js.go
-		addFunction("getgid", returnZero{}).           // syscall.Getgid in syscall_js.go
-		addFunction("geteuid", returnZero{}).          // syscall.Geteuid in syscall_js.go
-		addFunction("getgroups", returnSliceOfZero{}). // syscall.Getgroups in syscall_js.go
-		addFunction("umask", returnArg0{})             // syscall.Umask in syscall_js.go
+		addFunction(custom.NameProcessCwd, processCwd{}).              // syscall.Cwd in fs_js.go
+		addFunction(custom.NameProcessChdir, processChdir{}).          // syscall.Chdir in fs_js.go
+		addFunction(custom.NameProcessGetuid, returnZero{}).           // syscall.Getuid in syscall_js.go
+		addFunction(custom.NameProcessGetgid, returnZero{}).           // syscall.Getgid in syscall_js.go
+		addFunction(custom.NameProcessGeteuid, returnZero{}).          // syscall.Geteuid in syscall_js.go
+		addFunction(custom.NameProcessGetgroups, returnSliceOfZero{}). // syscall.Getgroups in syscall_js.go
+		addFunction(custom.NameProcessUmask, returnArg0{})             // syscall.Umask in syscall_js.go
 
 	// uint8ArrayConstructor = js.Global().Get("Uint8Array")
 	//	// fs_js.go, rand_js.go, roundtrip_js.go init

--- a/internal/gojs/custom/names.go
+++ b/internal/gojs/custom/names.go
@@ -189,7 +189,8 @@ var NameSection = map[string]*Names{
 }
 
 var NameSectionSyscallValueCall = map[string]map[string]*Names{
-	NameCrypto: CryptoNameSection,
-	NameDate:   DateNameSection,
-	NameFs:     FsNameSection,
+	NameCrypto:  CryptoNameSection,
+	NameDate:    DateNameSection,
+	NameFs:      FsNameSection,
+	NameProcess: ProcessNameSection,
 }

--- a/internal/gojs/custom/process.go
+++ b/internal/gojs/custom/process.go
@@ -1,0 +1,53 @@
+package custom
+
+const (
+	NameProcess          = "process"
+	NameProcessCwd       = "cwd"
+	NameProcessChdir     = "chdir"
+	NameProcessGetuid    = "getuid"
+	NameProcessGetgid    = "getgid"
+	NameProcessGeteuid   = "geteuid"
+	NameProcessGetgroups = "getgroups"
+	NameProcessUmask     = "umask"
+)
+
+// ProcessNameSection are the functions defined in the object named NameProcess.
+// Results here are those set to the current event object, but effectively are
+// results of the host function.
+var ProcessNameSection = map[string]*Names{
+	NameProcessCwd: {
+		Name:        NameProcessCwd,
+		ParamNames:  []string{},
+		ResultNames: []string{"cwd"},
+	},
+	NameProcessChdir: {
+		Name:        NameProcessChdir,
+		ParamNames:  []string{"path"},
+		ResultNames: []string{"err"},
+	},
+	NameProcessGetuid: {
+		Name:        NameProcessGetuid,
+		ParamNames:  []string{},
+		ResultNames: []string{"uid"},
+	},
+	NameProcessGetgid: {
+		Name:        NameProcessGetgid,
+		ParamNames:  []string{},
+		ResultNames: []string{"gid"},
+	},
+	NameProcessGeteuid: {
+		Name:        NameProcessGeteuid,
+		ParamNames:  []string{},
+		ResultNames: []string{"euid"},
+	},
+	NameProcessGetgroups: {
+		Name:        NameProcessGetgroups,
+		ParamNames:  []string{},
+		ResultNames: []string{"groups"},
+	},
+	NameProcessUmask: {
+		Name:        NameProcessUmask,
+		ParamNames:  []string{"mask"},
+		ResultNames: []string{"oldmask"},
+	},
+}

--- a/internal/gojs/logging/logging_test.go
+++ b/internal/gojs/logging/logging_test.go
@@ -32,9 +32,9 @@ func TestIsInLogScope(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "runtimeWasmExit in LogScopeExit",
+			name:     "runtimeWasmExit in LogScopeProc",
 			fnd:      runtimeWasmExit,
-			scopes:   logging.LogScopeExit,
+			scopes:   logging.LogScopeProc,
 			expected: true,
 		},
 		{
@@ -44,9 +44,9 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "runtimeWasmExit in LogScopeExit|LogScopeFilesystem",
+			name:     "runtimeWasmExit in LogScopeProc|LogScopeFilesystem",
 			fnd:      runtimeWasmExit,
-			scopes:   logging.LogScopeExit | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeProc | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{

--- a/internal/gojs/misc_test.go
+++ b/internal/gojs/misc_test.go
@@ -18,7 +18,7 @@ func Test_exit(t *testing.T) {
 
 	var log bytes.Buffer
 	loggingCtx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
-		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeExit))
+		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeProc))
 
 	stdout, stderr, err := compileAndRun(loggingCtx, "exit", wazero.NewModuleConfig())
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -39,7 +39,7 @@ type LogScopes uint64
 const (
 	LogScopeNone            = LogScopes(0)
 	LogScopeClock LogScopes = 1 << iota
-	LogScopeExit
+	LogScopeProc
 	LogScopeFilesystem
 	LogScopeMemory
 	LogScopePoll
@@ -51,8 +51,8 @@ func scopeName(s LogScopes) string {
 	switch s {
 	case LogScopeClock:
 		return "clock"
-	case LogScopeExit:
-		return "exit"
+	case LogScopeProc:
+		return "proc"
 	case LogScopeFilesystem:
 		return "filesystem"
 	case LogScopeMemory:

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -52,7 +52,7 @@ func TestLogScopes_String(t *testing.T) {
 		{name: "none", scopes: LogScopeNone, expected: ""},
 		{name: "any", scopes: LogScopeAll, expected: "all"},
 		{name: "clock", scopes: LogScopeClock, expected: "clock"},
-		{name: "exit", scopes: LogScopeExit, expected: "exit"},
+		{name: "proc", scopes: LogScopeProc, expected: "proc"},
 		{name: "filesystem", scopes: LogScopeFilesystem, expected: "filesystem"},
 		{name: "poll", scopes: LogScopePoll, expected: "poll"},
 		{name: "random", scopes: LogScopeRandom, expected: "random"},

--- a/internal/sysfs/rootfs.go
+++ b/internal/sysfs/rootfs.go
@@ -321,7 +321,7 @@ func (c *CompositeFS) Symlink(oldName, link string) (err error) {
 	if fromFS != toFS {
 		return syscall.ENOSYS // not yet anyway
 	}
-	return c.fs[fromFS].Link(oldNamePath, linkPath)
+	return c.fs[fromFS].Symlink(oldNamePath, linkPath)
 }
 
 // Truncate implements FS.Truncate

--- a/internal/wasi_snapshot_preview1/logging/logging.go
+++ b/internal/wasi_snapshot_preview1/logging/logging.go
@@ -18,7 +18,7 @@ func isClockFunction(fnd api.FunctionDefinition) bool {
 	return strings.HasPrefix(fnd.Name(), "clock_")
 }
 
-func isExitFunction(fnd api.FunctionDefinition) bool {
+func isProcFunction(fnd api.FunctionDefinition) bool {
 	return fnd.Name() == ProcExitName
 }
 
@@ -48,8 +48,8 @@ func IsInLogScope(fnd api.FunctionDefinition, scopes logging.LogScopes) bool {
 		}
 	}
 
-	if scopes.IsEnabled(logging.LogScopeExit) {
-		if isExitFunction(fnd) {
+	if scopes.IsEnabled(logging.LogScopeProc) {
+		if isProcFunction(fnd) {
 			return true
 		}
 	}

--- a/internal/wasi_snapshot_preview1/logging/logging_test.go
+++ b/internal/wasi_snapshot_preview1/logging/logging_test.go
@@ -123,9 +123,9 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "procExit in LogScopeExit",
+			name:     "procExit in LogScopeProc",
 			fnd:      procExit,
-			scopes:   logging.LogScopeExit,
+			scopes:   logging.LogScopeProc,
 			expected: true,
 		},
 		{
@@ -135,9 +135,9 @@ func TestIsInLogScope(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "procExit in LogScopeExit|LogScopeFilesystem",
+			name:     "procExit in LogScopeProc|LogScopeFilesystem",
 			fnd:      procExit,
-			scopes:   logging.LogScopeExit | logging.LogScopeFilesystem,
+			scopes:   logging.LogScopeProc | logging.LogScopeFilesystem,
 			expected: true,
 		},
 		{


### PR DESCRIPTION
Many tests failed in gojs due to needing to be resolved against the CWD, which is atypically stored host side. This fixes that and renames the "exit" scope to "proc" so we can use it for other proc concerns besides exit.

This reduces known failures on GOOS=js from 23 to 14:
```bash
$ wazero run -mount=/usr/local/go/src/os:/:ro -mount=/tmp:/tmp -mount=/etc:/etc:ro -mount=/usr:/usr:ro -mount=/dev:/dev:ro os.wasm |grep '^--- FAIL'|wc -l
      14
```

See #1222