### PR TITLE
Fixes file type mapping problem identified in /dev/null

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -2,6 +2,7 @@ package wasi_snapshot_preview1
 
 import (
 	"io"
+	"os"
 	"syscall"
 	"testing"
 
@@ -421,4 +422,14 @@ func Test_openFlags(t *testing.T) {
 			require.Equal(t, tc.expectedOpenFlags, openFlags)
 		})
 	}
+}
+
+func Test_getWasiFiletype_DevNull(t *testing.T) {
+	st, err := os.Stat(os.DevNull)
+	require.NoError(t, err)
+
+	ft := getWasiFiletype(st.Mode())
+
+	// Should be a character device, and not contain permissions
+	require.Equal(t, FILETYPE_CHARACTER_DEVICE, ft)
 }

--- a/internal/gojs/fs_unit_test.go
+++ b/internal/gojs/fs_unit_test.go
@@ -1,0 +1,18 @@
+package gojs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func Test_getWasiFiletype_DevNull(t *testing.T) {
+	st, err := os.Stat(os.DevNull)
+	require.NoError(t, err)
+
+	fm := getJsMode(st.Mode())
+
+	// Should be a character device, and retain the permissions.
+	require.Equal(t, S_IFCHR|uint32(st.Mode().Perm()), fm)
+}


### PR DESCRIPTION
This fixes a file type mapping bug running go's `TestDevNullFile` test via gojs.

See #1222