### PR TITLE
dirfs: corrects path joining bug when mounting root

### DIFF
--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -16,7 +16,7 @@ func NewDirFS(dir string) FS {
 }
 
 func ensureTrailingPathSeparator(dir string) string {
-	if dir[len(dir)-1] != os.PathSeparator {
+	if !os.IsPathSeparator(dir[len(dir)-1]) {
 		return dir + string(os.PathSeparator)
 	}
 	return dir

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -139,6 +139,9 @@ func (d *dirFS) Truncate(path string, size int64) error {
 func (d *dirFS) join(path string) string {
 	switch path {
 	case "", ".", "/":
+		if d.cleanedDir == "/" {
+			return "/"
+		}
 		// cleanedDir includes an unnecessary delimiter for the root path.
 		return d.cleanedDir[:len(d.cleanedDir)-1]
 	}

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -50,7 +50,7 @@ func TestDirFS_join(t *testing.T) {
 	require.Equal(t, ".", testFS.join(""))
 	require.Equal(t, ".", testFS.join("."))
 	require.Equal(t, ".", testFS.join("/"))
-	require.Equal(t, "./tmp", testFS.join("tmp"))
+	require.Equal(t, "."+string(os.PathSeparator)+"tmp", testFS.join("tmp"))
 }
 
 func TestDirFS_String(t *testing.T) {

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -39,6 +39,20 @@ func TestNewDirFS(t *testing.T) {
 	})
 }
 
+func TestDirFS_join(t *testing.T) {
+	testFS := NewDirFS("/").(*dirFS)
+	require.Equal(t, "/", testFS.join(""))
+	require.Equal(t, "/", testFS.join("."))
+	require.Equal(t, "/", testFS.join("/"))
+	require.Equal(t, "/tmp", testFS.join("tmp"))
+
+	testFS = NewDirFS(".").(*dirFS)
+	require.Equal(t, ".", testFS.join(""))
+	require.Equal(t, ".", testFS.join("."))
+	require.Equal(t, ".", testFS.join("/"))
+	require.Equal(t, "./tmp", testFS.join("tmp"))
+}
+
 func TestDirFS_String(t *testing.T) {
 	testFS := NewDirFS(".")
 


### PR DESCRIPTION
Before, we created invalid directory paths when the host directory was "/", and now we don't!

This brings tests left failing on GOOS=js to 7
```bash
$ wazero run -mount=/:/ --experimental-workdir=$(go env GOROOT)/src/os os.wasm| grep '^--- FAIL'|wc -l
       7
```

See #1222