### PR TITLE
gojs: fixes symlink

### DIFF
--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -711,7 +711,7 @@ func (jsfsLink) invoke(ctx context.Context, mod api.Module, args ...interface{})
 type jsfsSymlink struct{}
 
 func (jsfsSymlink) invoke(ctx context.Context, mod api.Module, args ...interface{}) (interface{}, error) {
-	path := resolvePath(ctx, args[0].(string))
+	path := args[0].(string)
 	link := resolvePath(ctx, args[1].(string))
 	callback := args[2].(funcWrapper)
 

--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -711,12 +711,12 @@ func (jsfsLink) invoke(ctx context.Context, mod api.Module, args ...interface{})
 type jsfsSymlink struct{}
 
 func (jsfsSymlink) invoke(ctx context.Context, mod api.Module, args ...interface{}) (interface{}, error) {
-	path := args[0].(string)
+	dst := args[0].(string) // The dst of a symlink must not be resolved, as it should be resolved during readLink.
 	link := resolvePath(ctx, args[1].(string))
 	callback := args[2].(funcWrapper)
 
 	fsc := mod.(*wasm.CallContext).Sys.FS()
-	err := fsc.RootFS().Symlink(path, link)
+	err := fsc.RootFS().Symlink(dst, link)
 
 	return jsfsInvoke(ctx, mod, callback, err)
 }

--- a/internal/gojs/testdata/writefs/main.go
+++ b/internal/gojs/testdata/writefs/main.go
@@ -282,4 +282,20 @@ func Main() {
 		return
 	}
 	defer os.Remove(dir)
+
+	// Symlink and Readlink tests.
+	s := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	from := "/symlink.txt"
+	err = os.Symlink(s, from)
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	r, err := os.Readlink(from)
+	if err != nil {
+		log.Fatalf("readlink %q failed: %v", from, err)
+	}
+	if r != s {
+		log.Fatalf("after symlink %q != %q", r, s)
+	}
 }


### PR DESCRIPTION
```
$ wazero run -mount=/:/ --experimental-workdir=$(go env GOROOT)/src/os os.wasm -test.run '^TestSymlink|^TestLongSymlink|^TestStatRelativeSymlink|^TestLongSymlink'
PASS
```