### PR TITLE
returns EBADF when attempting to write to STDIN

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1295,8 +1295,9 @@ func fdWriteOrPwrite(mod api.Module, params []uint64, isPwrite bool) Errno {
 		offset := int64(params[3])
 		writer = sysfs.WriterAtOffset(f.File, offset)
 		resultNwritten = uint32(params[4])
+	} else if writer, ok = f.File.(io.Writer); !ok {
+		return ErrnoBadf
 	} else {
-		writer = f.File.(io.Writer)
 		resultNwritten = uint32(params[3])
 	}
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2861,6 +2861,12 @@ func Test_fdWrite_Errors(t *testing.T) {
 `,
 		},
 		{
+			name:          "not writable FD",
+			fd:            sys.FdStdin,
+			expectedErrno: ErrnoBadf,
+			expectedLog:   "\n", // stdin is not sampled
+		},
+		{
 			name:          "out-of-memory reading iovs[0].offset",
 			fd:            fd,
 			iovs:          memSize - 2,

--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -297,8 +297,12 @@ func syscallWrite(mod api.Module, fd uint32, offset interface{}, p []byte) (n ui
 		err = syscall.EBADF
 	} else if offset != nil {
 		writer = sysfs.WriterAtOffset(f.File, toInt64(offset))
-	} else {
-		writer = f.File.(io.Writer)
+	} else if writer, ok = f.File.(io.Writer); !ok {
+		err = syscall.EBADF
+	}
+
+	if err != nil {
+		return
 	}
 
 	if nWritten, e := writer.Write(p); e == nil || e == io.EOF {

--- a/internal/gojs/testdata/stdio/main.go
+++ b/internal/gojs/testdata/stdio/main.go
@@ -1,9 +1,11 @@
 package stdio
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 )
 
 func Main() {
@@ -12,6 +14,9 @@ func Main() {
 		panic(err)
 	}
 
+	if _, err = fmt.Fprintln(os.Stdin, " "); errors.Unwrap(err) != syscall.EBADF {
+		panic(fmt.Sprint(err.Error(), "!=", syscall.EBADF))
+	}
 	printToFile("stdout", os.Stdout, len(b))
 	printToFile("stderr", os.Stderr, len(b))
 }

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -476,8 +476,10 @@ func (c *FSContext) Close(context.Context) (err error) {
 // WriterForFile returns a writer for the given file descriptor or nil if not
 // opened or not writeable (e.g. a directory or a file not opened for writes).
 func WriterForFile(fsc *FSContext, fd uint32) (writer io.Writer) {
-	if f, ok := fsc.LookupFile(fd); ok {
-		writer = f.File.(io.Writer)
+	if f, ok := fsc.LookupFile(fd); !ok {
+		return
+	} else if w, ok := f.File.(io.Writer); ok {
+		writer = w
 	}
 	return
 }

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -347,3 +347,13 @@ func TestFSContext_ChangeOpenFlag(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, f2.openFlag&syscall.O_APPEND, 0)
 }
+
+func TestWriterForFile(t *testing.T) {
+	testFS, err := NewFSContext(nil, nil, nil, sysfs.UnimplementedFS{})
+	require.NoError(t, err)
+
+	require.Nil(t, WriterForFile(testFS, FdStdin))
+	require.Equal(t, noopStdout.File, WriterForFile(testFS, FdStdout))
+	require.Equal(t, noopStderr.File, WriterForFile(testFS, FdStderr))
+	require.Nil(t, WriterForFile(testFS, FdPreopen))
+}


### PR DESCRIPTION
Found this problem while troubleshooting #1232 because fd zero == stdin, so a logic error can show up as a problem writing to stdin.