### PR TITLE
Holds wasm.Code as values on wasm.Module

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -237,7 +237,7 @@ func (h *hostFunctionBuilder) WithGoFunction(fn api.GoFunction, params, results 
 	h.fn = &wasm.HostFunc{
 		ParamTypes:  params,
 		ResultTypes: results,
-		Code:        &wasm.Code{GoFunc: fn},
+		Code:        wasm.Code{GoFunc: fn},
 	}
 	return h
 }
@@ -247,7 +247,7 @@ func (h *hostFunctionBuilder) WithGoModuleFunction(fn api.GoModuleFunction, para
 	h.fn = &wasm.HostFunc{
 		ParamTypes:  params,
 		ResultTypes: results,
-		Code:        &wasm.Code{GoFunc: fn},
+		Code:        wasm.Code{GoFunc: fn},
 	}
 	return h
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -57,7 +57,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
 				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
@@ -79,7 +79,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
 				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
@@ -102,7 +102,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32)},
 				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
@@ -124,7 +124,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint64_uint32)},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(uint64_uint32)},
 				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 				},
@@ -147,7 +147,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0, 1},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32), wasm.MustParseGoReflectFuncCode(uint64_uint32)},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(uint32_uint32), wasm.MustParseGoReflectFuncCode(uint64_uint32)},
 				ExportSection: []wasm.Export{
 					{Name: "1", Type: wasm.ExternTypeFunc, Index: 0},
 					{Name: "2", Type: wasm.ExternTypeFunc, Index: 1},
@@ -170,7 +170,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{
+				CodeSection: []wasm.Code{
 					{GoFunc: gofunc1},
 				},
 				ExportSection: []wasm.Export{
@@ -194,7 +194,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i32}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{
+				CodeSection: []wasm.Code{
 					{GoFunc: gofunc1},
 				},
 				ExportSection: []wasm.Export{
@@ -222,7 +222,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{
+				CodeSection: []wasm.Code{
 					{GoFunc: gofunc2},
 				},
 				ExportSection: []wasm.Export{
@@ -251,7 +251,7 @@ func TestNewHostModuleBuilder_Compile(t *testing.T) {
 					{Params: []api.ValueType{i64}, Results: []api.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0, 1},
-				CodeSection: []*wasm.Code{
+				CodeSection: []wasm.Code{
 					{GoFunc: gofunc1},
 					{GoFunc: gofunc2},
 				},
@@ -310,7 +310,7 @@ func TestNewHostModuleBuilder_Compile_Errors(t *testing.T) {
 					WithFunc(&wasm.HostFunc{
 						ExportNames: []string{"fn"},
 						ResultTypes: []wasm.ValueType{wasm.ValueTypeI32},
-						Code:        &wasm.Code{Body: []byte{wasm.OpcodeEnd}},
+						Code:        wasm.Code{Body: []byte{wasm.OpcodeEnd}},
 					}).Export("fn")
 			},
 			expectedErr: `invalid function[0] export["fn"]: not enough results

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -45,7 +45,7 @@ func TestFunctionListenerFactory(t *testing.T) {
 		TypeSection:     []wasm.FunctionType{{}},
 		ImportSection:   []wasm.Import{{}},
 		FunctionSection: []wasm.Index{0, 0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			// fn1
 			{Body: []byte{
 				// call fn2 twice

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -292,9 +292,9 @@ func Test_loggingListener(t *testing.T) {
 			}
 
 			if tc.isHostFunc {
-				m.CodeSection = []*wasm.Code{wasm.MustParseGoReflectFuncCode(fn)}
+				m.CodeSection = []wasm.Code{wasm.MustParseGoReflectFuncCode(fn)}
 			} else {
-				m.CodeSection = []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}}
+				m.CodeSection = []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}}
 			}
 			m.BuildFunctionDefinitions()
 			def := &m.FunctionDefinitionSection[0]
@@ -325,7 +325,7 @@ func Test_loggingListener_indentation(t *testing.T) {
 	m := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{{}},
 		FunctionSection: []wasm.Index{0, 0},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}},
+		CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}}},
 		NameSection: &wasm.NameSection{
 			ModuleName:    "test",
 			FunctionNames: wasm.NameMap{{Index: 0, Name: "fn1"}, {Index: 1, Name: "fn2"}},

--- a/imports/assemblyscript/assemblyscript.go
+++ b/imports/assemblyscript/assemblyscript.go
@@ -142,7 +142,7 @@ var abortMessageEnabled = &wasm.HostFunc{
 	Name:        "~lib/builtins/abort",
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"message", "fileName", "lineNumber", "columnNumber"},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(abortWithMessage)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(abortWithMessage)},
 }
 
 var abortMessageDisabled = abortMessageEnabled.WithGoModuleFunc(abort)
@@ -189,7 +189,7 @@ var traceStdout = &wasm.HostFunc{
 	Name:        "~lib/builtins/trace",
 	ParamTypes:  []api.ValueType{i32, i32, f64, f64, f64, f64, f64},
 	ParamNames:  []string{"message", "nArgs", "arg0", "arg1", "arg2", "arg3", "arg4"},
-	Code: &wasm.Code{
+	Code: wasm.Code{
 		GoFunc: api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
 			fsc := mod.(*wasm.CallContext).Sys.FS()
 			traceTo(mod, stack, internalsys.WriterForFile(fsc, internalsys.FdStdout))
@@ -274,7 +274,7 @@ var seed = &wasm.HostFunc{
 	Name:        "~lib/builtins/seed",
 	ResultTypes: []api.ValueType{f64},
 	ResultNames: []string{"rand"},
-	Code: &wasm.Code{
+	Code: wasm.Code{
 		GoFunc: api.GoModuleFunc(func(ctx context.Context, mod api.Module, stack []uint64) {
 			r := mod.(*wasm.CallContext).Sys.RandSource()
 			buf := make([]byte, 8)

--- a/imports/emscripten/emscripten.go
+++ b/imports/emscripten/emscripten.go
@@ -98,7 +98,7 @@ var notifyMemoryGrowth = &wasm.HostFunc{
 	Name:        functionNotifyMemoryGrowth,
 	ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
 	ParamNames:  []string{"memory_index"},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(func(context.Context, api.Module, []uint64) {})},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(func(context.Context, api.Module, []uint64) {})},
 }
 
 // All `invoke_` functions have an initial "index" parameter of
@@ -139,7 +139,7 @@ var invokeI = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"index"},
 	ResultTypes: []api.ValueType{i32},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeIFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeIFn)},
 }
 
 func invokeIFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -156,7 +156,7 @@ var invokeIi = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32},
 	ParamNames:  []string{"index", "a1"},
 	ResultTypes: []api.ValueType{i32},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeIiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeIiFn)},
 }
 
 func invokeIiFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -173,7 +173,7 @@ var invokeIii = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2"},
 	ResultTypes: []api.ValueType{i32},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeIiiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeIiiFn)},
 }
 
 func invokeIiiFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -190,7 +190,7 @@ var invokeIiii = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3"},
 	ResultTypes: []api.ValueType{i32},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeIiiiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeIiiiFn)},
 }
 
 func invokeIiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -207,7 +207,7 @@ var invokeIiiii = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 	ResultTypes: []api.ValueType{i32},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeIiiiiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeIiiiiFn)},
 }
 
 func invokeIiiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -224,7 +224,7 @@ var invokeV = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"index"},
 	ResultTypes: []api.ValueType{},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeVFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeVFn)},
 }
 
 func invokeVFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -240,7 +240,7 @@ var invokeVi = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32},
 	ParamNames:  []string{"index", "a1"},
 	ResultTypes: []api.ValueType{},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeViFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeViFn)},
 }
 
 func invokeViFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -256,7 +256,7 @@ var invokeVii = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2"},
 	ResultTypes: []api.ValueType{},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeViiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeViiFn)},
 }
 
 func invokeViiFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -272,7 +272,7 @@ var invokeViii = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3"},
 	ResultTypes: []api.ValueType{},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeViiiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeViiiFn)},
 }
 
 func invokeViiiFn(ctx context.Context, mod api.Module, stack []uint64) {
@@ -288,7 +288,7 @@ var invokeViiii = &wasm.HostFunc{
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 	ResultTypes: []api.ValueType{},
-	Code:        &wasm.Code{GoFunc: api.GoModuleFunc(invokeViiiiFn)},
+	Code:        wasm.Code{GoFunc: api.GoModuleFunc(invokeViiiiFn)},
 }
 
 func invokeViiiiFn(ctx context.Context, mod api.Module, stack []uint64) {

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -23,7 +23,7 @@ var procExit = &wasm.HostFunc{
 	Name:        ProcExitName,
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"rval"},
-	Code: &wasm.Code{
+	Code: wasm.Code{
 		GoFunc: api.GoModuleFunc(procExitFn),
 	},
 }

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -268,7 +268,7 @@ func newHostFunc(
 		ParamNames:  paramNames,
 		ResultTypes: []api.ValueType{i32},
 		ResultNames: []string{"errno"},
-		Code:        &wasm.Code{GoFunc: goFunc},
+		Code:        wasm.Code{GoFunc: goFunc},
 	}
 }
 
@@ -291,7 +291,7 @@ func stubFunction(name string, paramTypes []wasm.ValueType, paramNames ...string
 		ParamNames:  paramNames,
 		ResultTypes: []api.ValueType{i32},
 		ResultNames: []string{"errno"},
-		Code: &wasm.Code{
+		Code: wasm.Code{
 			GoFunc: api.GoModuleFunc(func(_ context.Context, _ api.Module, stack []uint64) { stack[0] = uint64(ErrnoNosys) }),
 		},
 	}

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -171,7 +171,7 @@ func TestCompiler_CompileModule(t *testing.T) {
 		okModule := &wasm.Module{
 			TypeSection:     []wasm.FunctionType{{}},
 			FunctionSection: []wasm.Index{0, 0, 0, 0},
-			CodeSection: []*wasm.Code{
+			CodeSection: []wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
@@ -201,7 +201,7 @@ func TestCompiler_CompileModule(t *testing.T) {
 		errModule := &wasm.Module{
 			TypeSection:     []wasm.FunctionType{{}},
 			FunctionSection: []wasm.Index{0, 0, 0},
-			CodeSection: []*wasm.Code{
+			CodeSection: []wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeCall}}, // Call instruction without immediate for call target index is invalid and should fail to compile.
@@ -283,7 +283,7 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 			wasm.Index(0),
 			wasm.Index(0),
 		},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{
 				// value_stack_corruption
 				Body: []byte{

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -510,7 +510,7 @@ func TestInterpreter_Compile(t *testing.T) {
 		errModule := &wasm.Module{
 			TypeSection:     []wasm.FunctionType{{}},
 			FunctionSection: []wasm.Index{0, 0, 0},
-			CodeSection: []*wasm.Code{
+			CodeSection: []wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeCall}}, // Call instruction without immediate for call target index is invalid and should fail to compile.
@@ -532,7 +532,7 @@ func TestInterpreter_Compile(t *testing.T) {
 		okModule := &wasm.Module{
 			TypeSection:     []wasm.FunctionType{{}},
 			FunctionSection: []wasm.Index{0, 0, 0, 0},
-			CodeSection: []*wasm.Code{
+			CodeSection: []wasm.Code{
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},
 				{Body: []byte{wasm.OpcodeEnd}},

--- a/internal/gojs/goarch/wasm.go
+++ b/internal/gojs/goarch/wasm.go
@@ -20,7 +20,7 @@ func StubFunction(name string) *wasm.HostFunc {
 		Name:        name,
 		ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
 		ParamNames:  []string{"sp"},
-		Code:        &wasm.Code{GoFunc: api.GoModuleFunc(func(ctx context.Context, _ api.Module, stack []uint64) {})},
+		Code:        wasm.Code{GoFunc: api.GoModuleFunc(func(ctx context.Context, _ api.Module, stack []uint64) {})},
 	}
 }
 

--- a/internal/gojs/util/util.go
+++ b/internal/gojs/util/util.go
@@ -41,6 +41,6 @@ func NewFunc(name string, goFunc api.GoModuleFunc) *wasm.HostFunc {
 		Name:        name,
 		ParamTypes:  []api.ValueType{api.ValueTypeI32},
 		ParamNames:  []string{"sp"},
-		Code:        &wasm.Code{GoFunc: goFunc},
+		Code:        wasm.Code{GoFunc: goFunc},
 	}
 }

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -138,7 +138,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 	hostModule := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0, 0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{
 				GoFunc: api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
 					ret, ok := mod.Memory().ReadUint32Le(uint32(stack[0]))
@@ -194,7 +194,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 			{Name: callGoHostName, Type: wasm.ExternTypeFunc, Index: 3},
 			{Name: callGoReflectHostName, Type: wasm.ExternTypeFunc, Index: 4},
 		},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Calling the index 0 = host.go.
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 1, wasm.OpcodeEnd}}, // Calling the index 1 = host.go-reflect.
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 2, wasm.OpcodeEnd}}, // Calling the index 2 = host.wasm.

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -492,7 +492,7 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 		ImportSection:   []wasm.Import{{Module: hostModule, Name: hostFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
 		ExportSection:   []wasm.Export{{Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, Index: 1}},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
+		CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
 		NameSection:     &wasm.NameSection{ModuleName: importingWasmModule},
 	}
 
@@ -501,7 +501,7 @@ func callHostFunctionIndirect(t *testing.T, r wazero.Runtime) {
 		ImportSection:   []wasm.Import{{Module: importingWasmModule, Name: importingWasmModuleFn, Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
 		ExportSection:   []wasm.Export{{Name: "origin", Type: wasm.ExternTypeFunc, Index: 1}},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
+		CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}},
 		NameSection:     &wasm.NameSection{ModuleName: originWasmModule},
 	}
 
@@ -552,7 +552,7 @@ func callReturnImportWasm(t *testing.T, importedModule, importingModule string, 
 			{Name: "call_return_input", Type: wasm.ExternTypeFunc, Index: 1},
 		},
 		// (func $call_return_input (param i32) (result i32) local.get 0 call $return_input)
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0, wasm.OpcodeEnd}},
 		},
 		NameSection: &wasm.NameSection{
@@ -583,7 +583,7 @@ func callOuterInnerWasm(t *testing.T, importedModule, importingModule string) []
 			// 	(export "inner" (func $call_inner))
 			{Name: "inner", Type: wasm.ExternTypeFunc, Index: 3},
 		},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			// (func $call_outer (param i32) (result i32) local.get 0 call $outer)
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0, wasm.OpcodeEnd}},
 			// (func $call_inner (param i32) (result i32) local.get 0 call $inner)
@@ -761,7 +761,7 @@ func testMultipleInstantiation(t *testing.T, r wazero.Runtime) {
 		TypeSection:     []wasm.FunctionType{{}},
 		FunctionSection: []wasm.Index{0},
 		MemorySection:   &wasm.Memory{Min: 1, Cap: 1, Max: 1, IsMaxEncoded: true},
-		CodeSection: []*wasm.Code{{
+		CodeSection: []wasm.Code{{
 			Body: []byte{
 				wasm.OpcodeI32Const, 1, // i32.const 1    ;; memory offset
 				wasm.OpcodeI64Const, 0xe8, 0x7, // i64.const 1000 ;; expected value

--- a/internal/integration_test/fuzz/wazerolib/nodiff.go
+++ b/internal/integration_test/fuzz/wazerolib/nodiff.go
@@ -179,7 +179,7 @@ func ensureDummyImports(r wazero.Runtime, origin *wasm.Module, requireNoError fu
 					}
 				}
 				body.WriteByte(wasm.OpcodeEnd)
-				m.CodeSection = append(m.CodeSection, &wasm.Code{Body: body.Bytes()})
+				m.CodeSection = append(m.CodeSection, wasm.Code{Body: body.Bytes()})
 			case wasm.ExternTypeGlobal:
 				index = uint32(len(m.GlobalSection))
 				var data []byte

--- a/internal/testing/binaryencoding/encoder_test.go
+++ b/internal/testing/binaryencoding/encoder_test.go
@@ -126,7 +126,7 @@ func TestModule_Encode(t *testing.T) {
 					{Params: []wasm.ValueType{i32, i32}, Results: []wasm.ValueType{i32}},
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{
+				CodeSection: []wasm.Code{
 					{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeI32Add, wasm.OpcodeEnd}},
 				},
 				ExportSection: []wasm.Export{
@@ -215,7 +215,7 @@ func TestModule_Encode_HostFunctionSection_Unsupported(t *testing.T) {
 	captured := require.CapturePanic(func() {
 		EncodeModule(&wasm.Module{
 			TypeSection: []wasm.FunctionType{{}},
-			CodeSection: []*wasm.Code{wasm.MustParseGoReflectFuncCode(fn)},
+			CodeSection: []wasm.Code{wasm.MustParseGoReflectFuncCode(fn)},
 		})
 	})
 	require.EqualError(t, captured, "BUG: GoFunction is not encodable")

--- a/internal/testing/binaryencoding/section.go
+++ b/internal/testing/binaryencoding/section.go
@@ -56,10 +56,11 @@ func EncodeFunctionSection(typeIndices []wasm.Index) []byte {
 //
 // See encodeCode
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#code-section%E2%91%A0
-func encodeCodeSection(code []*wasm.Code) []byte {
+func encodeCodeSection(code []wasm.Code) []byte {
 	contents := leb128.EncodeUint32(uint32(len(code)))
-	for _, i := range code {
-		contents = append(contents, encodeCode(i)...)
+	for i := range code {
+		c := &code[i]
+		contents = append(contents, encodeCode(c)...)
 	}
 	return encodeSection(wasm.SectionIDCode, contents)
 }

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -83,7 +83,7 @@ func RunTestEngine_MemoryGrowInRecursiveCall(t *testing.T, et EngineTester) {
 	m := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
 		FunctionSection: []wasm.Index{0, 0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{
 				Body: []byte{
 					// Calls the imported host function, which in turn calls the next in-Wasm function recursively.
@@ -153,7 +153,7 @@ func RunTestModuleEngine_Call(t *testing.T, et EngineTester) {
 			},
 		},
 		FunctionSection: []wasm.Index{0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeEnd}},
 		},
 	}
@@ -205,7 +205,7 @@ func RunTestModuleEngine_LookupFunction(t *testing.T, et EngineTester) {
 	mod := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{{}, {Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 		FunctionSection: []wasm.Index{0, 0, 0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{
 				Body: []byte{wasm.OpcodeEnd},
 			}, {Body: []byte{wasm.OpcodeEnd}}, {Body: []byte{wasm.OpcodeEnd}},
@@ -313,8 +313,8 @@ func RunTestModuleEngine_Call_HostFn(t *testing.T, et EngineTester) {
 		runTestModuleEngine_Call_HostFn(t, et, hostDivByWasm)
 	})
 	t.Run("go", func(t *testing.T) {
-		runTestModuleEngine_Call_HostFn(t, et, hostDivByGo)
-		runTestModuleEngine_Call_HostFn_Mem(t, et, hostReadMemGo)
+		runTestModuleEngine_Call_HostFn(t, et, &hostDivByGo)
+		runTestModuleEngine_Call_HostFn_Mem(t, et, &hostReadMemGo)
 	})
 }
 
@@ -374,7 +374,7 @@ func runTestModuleEngine_Call_HostFn(t *testing.T, et EngineTester, hostDivBy *w
 func RunTestModuleEngine_Call_Errors(t *testing.T, et EngineTester) {
 	e := et.NewEngine(api.CoreFeaturesV1)
 
-	_, imported, importing, done := setupCallTests(t, e, hostDivByGo, et.ListenerFactory())
+	_, imported, importing, done := setupCallTests(t, e, &hostDivByGo, et.ListenerFactory())
 	defer done()
 
 	tests := []struct {
@@ -497,7 +497,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 			},
 		},
 		DataCountSection: &one,
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{ // "grow"
 				wasm.OpcodeLocalGet, 0, // how many pages to grow (param)
 				wasm.OpcodeMemoryGrow, 0, // memory index zero
@@ -644,7 +644,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 	hostModule := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0},
-		CodeSection:     []*wasm.Code{divBy},
+		CodeSection:     []wasm.Code{*divBy},
 		ExportSection:   []wasm.Export{{Name: divByGoName, Type: wasm.ExternTypeFunc, Index: 0}},
 		NameSection: &wasm.NameSection{
 			ModuleName:    "host",
@@ -669,7 +669,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ImportSection:   []wasm.Import{{}},
 		TypeSection:     []wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0, 0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: divByWasm},
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, byte(0), // Calling imported host function ^.
 				wasm.OpcodeEnd}},
@@ -708,7 +708,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		TypeSection:     []wasm.FunctionType{ft},
 		ImportSection:   []wasm.Import{{}},
 		FunctionSection: []wasm.Index{0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeCall, 0 /* only one imported function */, wasm.OpcodeEnd}},
 		},
 		ExportSection: []wasm.Export{
@@ -749,7 +749,7 @@ func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code, fnlf exp
 	hostModule := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{ft},
 		FunctionSection: []wasm.Index{0},
-		CodeSection:     []*wasm.Code{readMem},
+		CodeSection:     []wasm.Code{*readMem},
 		ExportSection: []wasm.Export{
 			{Name: readMemName, Type: wasm.ExternTypeFunc, Index: 0},
 		},
@@ -781,7 +781,7 @@ func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code, fnlf exp
 		ExportSection: []wasm.Export{
 			{Name: callImportReadMemName, Type: wasm.ExternTypeFunc, Index: 1},
 		},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Calling the index 1 = readMemFn.
 		},
 		NameSection: &wasm.NameSection{

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -73,7 +73,7 @@ func NewModuleBinary(moduleName string, proxyTarget wazero.CompiledModule) []byt
 		body = append(body, wasm.OpcodeCall)
 		body = append(body, leb128.EncodeUint32(cnt)...)
 		body = append(body, wasm.OpcodeEnd)
-		proxyModule.CodeSection = append(proxyModule.CodeSection, &wasm.Code{Body: body})
+		proxyModule.CodeSection = append(proxyModule.CodeSection, wasm.Code{Body: body})
 
 		proxyFuncIndex := cnt + funcNum
 		// Assigns the same params name as the imported one.

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -161,20 +161,19 @@ func decodeElementSection(r *bytes.Reader, enabledFeatures api.CoreFeatures) ([]
 	return result, nil
 }
 
-func decodeCodeSection(r *bytes.Reader) ([]*wasm.Code, error) {
+func decodeCodeSection(r *bytes.Reader) ([]wasm.Code, error) {
 	codeSectionStart := uint64(r.Len())
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get size of vector: %w", err)
 	}
 
-	result := make([]*wasm.Code, vs)
+	result := make([]wasm.Code, vs)
 	for i := uint32(0); i < vs; i++ {
-		c, err := decodeCode(r, codeSectionStart)
+		err = decodeCode(r, codeSectionStart, &result[i])
 		if err != nil {
 			return nil, fmt.Errorf("read %d-th code segment: %v", i, err)
 		}
-		result[i] = c
 	}
 	return result, nil
 }

--- a/internal/wasm/counts_test.go
+++ b/internal/wasm/counts_test.go
@@ -253,7 +253,7 @@ func TestModule_SectionElementCount(t *testing.T) {
 			input: &Module{
 				TypeSection:     []FunctionType{{}},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{
+				CodeSection: []Code{
 					{Body: []byte{OpcodeLocalGet, 0, OpcodeLocalGet, 1, OpcodeI32Add, OpcodeEnd}},
 				},
 				ExportSection: []Export{

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -64,7 +64,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 	declaredFunctionIndexes map[Index]struct{},
 ) error {
 	functionType := &m.TypeSection[m.FunctionSection[idx]]
-	code := m.CodeSection[idx]
+	code := &m.CodeSection[idx]
 	body := code.Body
 	localTypes := code.LocalTypes
 

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -31,7 +31,7 @@ func TestModule_ValidateFunction_validateFunctionWithMaxStackValues(t *testing.T
 	m := &Module{
 		TypeSection:     []FunctionType{v_v},
 		FunctionSection: []Index{0},
-		CodeSection:     []*Code{{Body: body}},
+		CodeSection:     []Code{{Body: body}},
 	}
 
 	t.Run("not exceed", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestModule_ValidateFunction_SignExtensionOps(t *testing.T) {
 				m := &Module{
 					TypeSection:     []FunctionType{v_v},
 					FunctionSection: []Index{0},
-					CodeSection:     []*Code{{Body: []byte{tc.input}}},
+					CodeSection:     []Code{{Body: []byte{tc.input}}},
 				}
 				err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
 				require.EqualError(t, err, tc.expectedErrOnDisable)
@@ -97,7 +97,7 @@ func TestModule_ValidateFunction_SignExtensionOps(t *testing.T) {
 				m := &Module{
 					TypeSection:     []FunctionType{v_v},
 					FunctionSection: []Index{0},
-					CodeSection:     []*Code{{Body: body}},
+					CodeSection:     []Code{{Body: body}},
 				}
 				err := m.validateFunction(api.CoreFeatureSignExtensionOps, 0, []Index{0}, nil, nil, nil, nil)
 				require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 				m := &Module{
 					TypeSection:     []FunctionType{v_v},
 					FunctionSection: []Index{0},
-					CodeSection:     []*Code{{Body: []byte{OpcodeMiscPrefix, tc.input}}},
+					CodeSection:     []Code{{Body: []byte{OpcodeMiscPrefix, tc.input}}},
 				}
 				err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
 				require.EqualError(t, err, tc.expectedErrOnDisable)
@@ -170,7 +170,7 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 				m := &Module{
 					TypeSection:     []FunctionType{v_v},
 					FunctionSection: []Index{0},
-					CodeSection:     []*Code{{Body: body}},
+					CodeSection:     []Code{{Body: body}},
 				}
 				err := m.validateFunction(api.CoreFeatureNonTrappingFloatToIntConversion, 0, []Index{0}, nil, nil, nil, nil)
 				require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestModule_ValidateFunction_MultiValue(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_f64f64},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0, // (block (result f64 f64)
 					OpcodeF64Const, 0, 0, 0, 0, 0, 0, 0x10, 0x40, // (f64.const 4)
 					OpcodeF64Const, 0, 0, 0, 0, 0, 0, 0x14, 0x40, // (f64.const 5)
@@ -212,7 +212,7 @@ func TestModule_ValidateFunction_MultiValue(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{i32_i32}, // (func (param i32) (result i32)
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, // (i32.const 1)
 					OpcodeLocalGet, 0, OpcodeIf, 0, // (if (param i32) (result i32) (local.get 0)
 					OpcodeI32Const, 2, OpcodeI32Add, // (then (i32.const 2) (i32.add))
@@ -231,7 +231,7 @@ func TestModule_ValidateFunction_MultiValue(t *testing.T) {
 					i32i32_i32, // (if (param i32 i32) (result i32)
 				},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, // (i32.const 1)
 					OpcodeI32Const, 2, // (i32.const 2)
 					OpcodeLocalGet, 0, OpcodeIf, 1, // (if (param i32) (result i32) (local.get 0)
@@ -285,7 +285,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 				m := &Module{
 					TypeSection:      []FunctionType{v_v},
 					FunctionSection:  []Index{0},
-					CodeSection:      []*Code{{Body: body}},
+					CodeSection:      []Code{{Body: body}},
 					DataSection:      []DataSegment{{}},
 					ElementSection:   []ElementSegment{{}},
 					DataCountSection: &c,
@@ -646,7 +646,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 				m := &Module{
 					TypeSection:     []FunctionType{v_v},
 					FunctionSection: []Index{0},
-					CodeSection:     []*Code{{Body: tc.body}},
+					CodeSection:     []Code{{Body: tc.body}},
 					ElementSection:  tc.elementSection,
 					DataSection:     tc.dataSection,
 				}
@@ -696,7 +696,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_f64i32},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
+				CodeSection:     []Code{{Body: []byte{OpcodeEnd}}},
 			},
 			expectedErr: `not enough results
 	have ()
@@ -707,7 +707,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeNop, OpcodeEnd}}},
+				CodeSection:     []Code{{Body: []byte{OpcodeNop, OpcodeEnd}}},
 			},
 			expectedErr: `not enough results
 	have ()
@@ -718,7 +718,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeI32Const, 0, OpcodeI64Const, 0, OpcodeEnd}}},
+				CodeSection:     []Code{{Body: []byte{OpcodeI32Const, 0, OpcodeI64Const, 0, OpcodeEnd}}},
 			},
 			expectedErr: `too many results
 	have (i32, i64)
@@ -729,7 +729,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_f32f32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeEnd, // func
 				}}},
@@ -743,7 +743,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_f32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeF32Const, 0, 0, 0, 0, OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0) (f32.const 0)
 					OpcodeEnd, // func
 				}}},
@@ -757,7 +757,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_f32f32},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeReturn, OpcodeEnd}}},
+				CodeSection:     []Code{{Body: []byte{OpcodeReturn, OpcodeEnd}}},
 			},
 			expectedErr: `not enough results
 	have ()
@@ -768,7 +768,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i64},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeNop, OpcodeReturn, OpcodeEnd}}}, // (return (nop))
+				CodeSection:     []Code{{Body: []byte{OpcodeNop, OpcodeReturn, OpcodeEnd}}}, // (return (nop))
 			},
 			expectedErr: `not enough results
 	have ()
@@ -779,7 +779,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i64i64},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI64Const, 0, OpcodeReturn, // (return (i64.const 0))
 					OpcodeEnd, // func
 				}}},
@@ -797,7 +797,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeReturn, OpcodeI32Const, 1, OpcodeI32Const, 2,
 					OpcodeEnd, // func
 				}}},
@@ -815,7 +815,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeReturn, OpcodeI32Const, 2,
 					OpcodeEnd, // func
 				}}},
@@ -833,7 +833,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeNop, OpcodeReturn, // (return (nop))
 					OpcodeI32Const, 1, // (i32.const 1)
 					OpcodeEnd, // func
@@ -849,7 +849,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI64Const, 1, OpcodeReturn, // (return (i64.const 1))
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (i32.const 1) (i32.const 2)
 					OpcodeEnd, // func
@@ -868,7 +868,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI64Const, 1, OpcodeReturn, // (return (i64.const 1))
 					OpcodeI32Const, 1, OpcodeI32Const, 2, OpcodeReturn, // (return (i32.const 1) (i32.const 2))
 					OpcodeEnd, // func
@@ -883,7 +883,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 0, OpcodeBr, 0, // (br 0 (i32.const 0))
 					OpcodeEnd, // func
 				}}},
@@ -901,7 +901,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBr, 0, // (br 0)
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (i32.const 1) (i32.const 2)
 					OpcodeEnd, // func
@@ -920,7 +920,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeBr, 0, // (br 0 (i32.const 1))
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (i32.const 1) (i32.const 2)
 					OpcodeEnd, // func
@@ -939,7 +939,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, OpcodeBr, 0x01, OpcodeEnd, // (block (br 1))
 					OpcodeI32Const, 1, OpcodeI32Const, 2, OpcodeBr, 0, // (br 0 (i32.const 1) (i32.const 2))
 					OpcodeEnd, // func
@@ -958,7 +958,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, OpcodeNop, OpcodeBr, 0x01, OpcodeEnd, // (block (br 1 (nop)))
 					OpcodeI32Const, 1, OpcodeI32Const, 2, OpcodeBr, 0, // (br 0 (i32.const 1) (i32.const 2))
 					OpcodeEnd, // func
@@ -977,7 +977,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x7f, OpcodeI32Const, 1, OpcodeBr, 1, OpcodeEnd, // (block (result i32) (br 1 (i32.const 1)))
 					OpcodeI32Const, 1, OpcodeI32Const, 2, OpcodeBr, 0, // (br 0 (i32.const 1) (i32.const 2))
 					OpcodeEnd, // func
@@ -999,7 +999,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, // (i32.const 1)
 					OpcodeI32Const, 0, OpcodeIf, 0, // (if (type $sig) (i32.const 0)
 					OpcodeEnd, // if
@@ -1019,7 +1019,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x40, // (if (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (then (i32.const 1) (i32.const 2))
 					OpcodeEnd, // if
@@ -1039,7 +1039,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x40, // (if (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (then (i32.const 1) (i32.const 2))
 					OpcodeElse, // (else)
@@ -1060,7 +1060,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x40, // (if (i32.const 1) (then)
 					OpcodeElse, OpcodeI32Const, 1, OpcodeI32Const, 2, // (else (i32.const 1) (i32.const 2))
 					OpcodeEnd, // if
@@ -1080,7 +1080,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x40, // (if (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (then (i32.const 1) (i32.const 2))
 					OpcodeElse, OpcodeI32Const, 2, OpcodeI32Const, 1, // (else (i32.const 2) (i32.const 1))
@@ -1101,7 +1101,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (result i32 i32) (i32.const 1) (then)
 					OpcodeElse, OpcodeI32Const, 0, OpcodeI32Const, 2, // (else (i32.const 0) (i32.const 2)))
 					OpcodeEnd, // if
@@ -1121,7 +1121,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 0, OpcodeI32Const, 2, // (then (i32.const 0) (i32.const 1))
 					OpcodeElse, // (else)
@@ -1142,7 +1142,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (result i32 i32) (i32.const 1) (then)
 					OpcodeElse, // (else)
 					OpcodeEnd,  // if
@@ -1162,7 +1162,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeEnd, // if
@@ -1182,7 +1182,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (result i32 i32) (i32.const 1)
 					OpcodeNop,                                        // (then (nop))
 					OpcodeElse, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (i32.const 1) (i32.const 1))
@@ -1203,7 +1203,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 0, OpcodeI32Const, 0, // (then (i32.const 0) (i32.const 0))
 					OpcodeElse, OpcodeNop, // (else (nop))
@@ -1224,7 +1224,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeNop,             // (then (nop))
 					OpcodeElse, OpcodeNop, // (else (nop))
@@ -1245,7 +1245,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, // (then (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (i32.const 1) (i32.const 1)))
@@ -1266,7 +1266,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, // (else (i32.const 1)))
@@ -1287,7 +1287,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, // (then (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, // (else (i32.const 1)))
@@ -1309,7 +1309,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 0, // (i32.const 0) - NOTE: this is outside the (if)
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, // (then (i32.const 1))
@@ -1332,7 +1332,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 0, // (i32.const 0) - NOTE: this is outside the (if)
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
@@ -1355,7 +1355,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 0, // (i32.const 0) - NOTE: this is outside the (if)
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, // (then (i32.const 1))
@@ -1377,7 +1377,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, // (else (i32.const 1))
@@ -1398,7 +1398,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32) (i32.const 1)
 					OpcodeI32Const, 1, // (then (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (i32.const 1) (i32.const 1))
@@ -1419,7 +1419,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (i32.const 1) (i32.const 1))
@@ -1440,7 +1440,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeI32Const, 1, // (else (i32.const 1))
@@ -1461,7 +1461,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeBr, 0, // (then (br 0))
 					OpcodeElse, OpcodeI32Const, 1, // (else (i32.const 1) (i32.const 1)))
@@ -1482,7 +1482,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeBr, 0, // (else (br 0))
@@ -1506,7 +1506,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeBr, 0, OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (br 0) (i32.const 1) (i32.const 1))
 					// ^^ NOTE: consts are outside the br block
@@ -1531,7 +1531,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeBr, 0, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (br 0) (i32.const 1) (i32.const 1))
@@ -1556,7 +1556,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeNop, OpcodeBr, 0, OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (br 0 (nop)) (i32.const 1) (i32.const 1))
 					// ^^ NOTE: consts are outside the br block
@@ -1581,7 +1581,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeNop, OpcodeBr, 0, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (br 0 (nop)) (i32.const 1) (i32.const 1))
@@ -1606,7 +1606,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI64Const, 1, OpcodeBr, 0, OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (br 0 (i64.const 1)) (i32.const 1) (i32.const 1))
 					// ^^ NOTE: only one (incorrect) const is inside the br block
@@ -1631,7 +1631,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeI32Const, 1, // (then (i32.const 1) (i32.const 1))
 					OpcodeElse, OpcodeI64Const, 1, OpcodeBr, 0, OpcodeI32Const, 1, OpcodeI32Const, 1, // (else (br 0 (i64.const 1)) (i32.const 1) (i32.const 1))
@@ -1657,7 +1657,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, // (i32.const 1)
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI64Const, 1, OpcodeBr, 0, OpcodeI32Const, 1, // (then (br 0 (i64.const 1)) (i32.const 1))
@@ -1684,7 +1684,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, // (i32.const 1)
 					OpcodeI32Const, 1, OpcodeIf, 0x00, // (if (result i32 i32) (i32.const 1)
 					OpcodeI32Const, 1, // (then (i32.const 1))
@@ -1707,7 +1707,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param i32) (i32.const 1)
 					OpcodeDrop, // (then (drop)))
 					OpcodeEnd,  // if
@@ -1727,7 +1727,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32f64_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param i32 f64) (i32.const 1)
 					OpcodeI32Const, 1, OpcodeDrop, // (then (drop) (drop))
 					OpcodeEnd, // if
@@ -1747,7 +1747,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param i32) (i32.const 1)
 					OpcodeDrop, // (then (drop))
@@ -1766,7 +1766,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, f32i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param f32 i32) (i32.const 1)
 					OpcodeDrop, OpcodeDrop, // (then (drop) (drop))
@@ -1787,7 +1787,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param i32) (i32.const 1)
 					OpcodeDrop, // (then (drop))
@@ -1809,7 +1809,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32f64_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param i32 f64) (i32.const 1)
 					OpcodeDrop, // (then (drop) (drop))
@@ -1831,7 +1831,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param i32) (i32.const 1)
@@ -1852,7 +1852,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, f32i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeI32Const, 1, OpcodeIf, 0x01, // (if (param f32 i32) (i32.const 1)
@@ -1878,7 +1878,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0, OpcodeI32Const, 0, // (loop (type $sig) (i32.const 0))
 					OpcodeEnd, // loop
 					OpcodeEnd, // func
@@ -1897,7 +1897,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x40, OpcodeI32Const, 1, OpcodeI32Const, 2, // (loop (i32.const 1) (i32.const 2))
 					OpcodeEnd, // loop
 					OpcodeEnd, // func
@@ -1916,7 +1916,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x0, // (loop (result i32 i32)) - matches existing func type
 					OpcodeEnd, // loop
 					OpcodeEnd, // func
@@ -1935,7 +1935,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x0, // (loop (result i32 i32) - matches existing func type
 					OpcodeNop, // (nop)
 					OpcodeEnd, // loop
@@ -1955,7 +1955,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x0, // (loop (result i32 i32) - matches existing func type
 					OpcodeI32Const, 0, // (i32.const 0)
 					OpcodeEnd, // loop
@@ -1975,7 +1975,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeI32Const, 1, // (i32.const 1) - NOTE: outside the loop!
 					OpcodeLoop, 0x0, // (loop (result i32 i32) - matches existing func type
 					OpcodeI32Const, 2, // (i32.const 2)
@@ -1996,7 +1996,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_i32},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x0, // (loop (result i32) - matches existing func type
 					OpcodeI32Const, 1, OpcodeI32Const, 2, // (i32.const 1) (i32.const 2))
 					OpcodeEnd, // loop
@@ -2016,7 +2016,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x1, // (loop (param i32)
 					OpcodeDrop, // (drop)
 					OpcodeEnd,  // loop
@@ -2036,7 +2036,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32f64_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeLoop, 0x1, // (loop (param i32 f64)
 					OpcodeDrop, // (drop)
 					OpcodeDrop, // (drop)
@@ -2057,7 +2057,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeLoop, 0x1, // (loop (param i32)
 					OpcodeDrop, // (drop)
@@ -2076,7 +2076,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, f32i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeLoop, 0x1, // (loop (param f32 i32)
 					OpcodeDrop, OpcodeDrop, // (drop) (drop)
@@ -2097,7 +2097,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeLoop, 0x1, // (loop (param i32)
 					OpcodeDrop, // (drop)
@@ -2119,7 +2119,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32f64_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeLoop, 0x1, // (loop (param i32 f64)
 					OpcodeDrop, OpcodeDrop, // (drop) (drop)
@@ -2141,7 +2141,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeLoop, 0x1, // (loop (param i32)
@@ -2162,7 +2162,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{v_v, f32i32_v},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{{Body: []byte{
+				CodeSection: []Code{{Body: []byte{
 					OpcodeBlock, 0x40, // (block
 					OpcodeF32Const, 0, 0, 0, 0, // (f32.const 0)
 					OpcodeLoop, 0x1, // (loop (param f32 i32)
@@ -2193,7 +2193,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 		m := &Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{0},
-			CodeSection: []*Code{{Body: []byte{
+			CodeSection: []Code{{Body: []byte{
 				OpcodeI32Const, 1,
 				OpcodeCallIndirect, 0, 0,
 				OpcodeEnd,
@@ -2206,7 +2206,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 		m := &Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{0},
-			CodeSection: []*Code{{Body: []byte{
+			CodeSection: []Code{{Body: []byte{
 				OpcodeI32Const, 1,
 				OpcodeCallIndirect, 0, 100,
 				OpcodeEnd,
@@ -2225,7 +2225,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 		m := &Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{0},
-			CodeSection: []*Code{{Body: []byte{
+			CodeSection: []Code{{Body: []byte{
 				OpcodeI32Const, 1,
 				OpcodeCallIndirect, 0, 0,
 				OpcodeEnd,
@@ -2324,7 +2324,7 @@ func TestModule_funcValidation_RefTypes(t *testing.T) {
 			m := &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, nil, tc.declaredFunctionIndexes)
 			if tc.expectedErr != "" {
@@ -2492,7 +2492,7 @@ func TestModule_funcValidation_TableGrowSizeFill(t *testing.T) {
 			m := &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, tables, nil)
 			if tc.expectedErr != "" {
@@ -2604,7 +2604,7 @@ func TestModule_funcValidation_TableGetSet(t *testing.T) {
 			m := &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, tables, nil)
 			if tc.expectedErr != "" {
@@ -2661,7 +2661,7 @@ func TestModule_funcValidation_Select_error(t *testing.T) {
 			m := &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, nil, nil)
 			require.EqualError(t, err, tc.expectedErr)
@@ -3146,7 +3146,7 @@ func TestModule_funcValidation_SIMD(t *testing.T) {
 			m := &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(api.CoreFeatureSIMD, 0, []Index{0}, nil, &Memory{}, nil, nil)
 			require.NoError(t, err)
@@ -3291,7 +3291,7 @@ func TestModule_funcValidation_SIMD_error(t *testing.T) {
 			m := &Module{
 				TypeSection:     []FunctionType{v_v},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, &Memory{}, nil, nil)
 			require.EqualError(t, err, tc.expectedErr)
@@ -3373,7 +3373,7 @@ func TestFuncValidation_UnreachableBrTable_NotModifyTypes(t *testing.T) {
 			m: &Module{
 				TypeSection:     []FunctionType{funcType},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{
+				CodeSection: []Code{
 					{Body: []byte{
 						OpcodeUnreachable,
 						// Having br_table in unreachable state.
@@ -3391,7 +3391,7 @@ func TestFuncValidation_UnreachableBrTable_NotModifyTypes(t *testing.T) {
 			m: &Module{
 				TypeSection:     []FunctionType{funcType},
 				FunctionSection: []Index{0},
-				CodeSection: []*Code{
+				CodeSection: []Code{
 					{Body: []byte{
 						OpcodeUnreachable,
 						OpcodeLoop, 0, // indicates that loop has funcType as its block type
@@ -3532,7 +3532,7 @@ func TestModule_funcValidation_loopWithParams(t *testing.T) {
 					i32_v,
 				},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{{Body: tc.body}},
+				CodeSection:     []Code{{Body: tc.body}},
 			}
 			err := m.validateFunction(api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
 			if tc.expErr != "" {
@@ -3549,7 +3549,7 @@ func TestFunctionValidation_redundantEnd(t *testing.T) {
 	m := &Module{
 		TypeSection:     []FunctionType{{}},
 		FunctionSection: []Index{0},
-		CodeSection:     []*Code{{Body: []byte{OpcodeEnd, OpcodeEnd}}},
+		CodeSection:     []Code{{Body: []byte{OpcodeEnd, OpcodeEnd}}},
 	}
 	err := m.validateFunction(api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
 	require.EqualError(t, err, "redundant End instruction at 0x1")
@@ -3560,7 +3560,7 @@ func TestFunctionValidation_redundantElse(t *testing.T) {
 	m := &Module{
 		TypeSection:     []FunctionType{{}},
 		FunctionSection: []Index{0},
-		CodeSection:     []*Code{{Body: []byte{OpcodeEnd, OpcodeElse}}},
+		CodeSection:     []Code{{Body: []byte{OpcodeEnd, OpcodeElse}}},
 	}
 	err := m.validateFunction(api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
 	require.EqualError(t, err, "redundant Else instruction at 0x1")

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -68,7 +68,7 @@ func (m *Module) BuildFunctionDefinitions() {
 	}
 
 	for codeIndex, typeIndex := range m.FunctionSection {
-		code := m.CodeSection[codeIndex]
+		code := &m.CodeSection[codeIndex]
 		idx := importFuncIdx + Index(codeIndex)
 		def := &m.FunctionDefinitionSection[idx]
 		def.index = idx

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -13,7 +13,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 		DescFunc: 2, // Index of type.
 	}
 
-	nopCode := &Code{Body: []byte{OpcodeEnd}}
+	nopCode := Code{Body: []byte{OpcodeEnd}}
 	fn := func(uint32) uint32 { return 1 }
 	tests := []struct {
 		name            string
@@ -40,7 +40,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 			m: &Module{
 				TypeSection:     []FunctionType{i32_i32},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{MustParseGoReflectFuncCode(fn)},
+				CodeSection:     []Code{MustParseGoReflectFuncCode(fn)},
 				NameSection: &NameSection{
 					ModuleName:    "m",
 					FunctionNames: NameMap{{Index: Index(0), Name: "fn"}},
@@ -73,7 +73,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 				},
 				GlobalSection:   []Global{{}},
 				FunctionSection: []Index{1, 2, 0},
-				CodeSection: []*Code{
+				CodeSection: []Code{
 					{Body: []byte{OpcodeEnd}},
 					{Body: []byte{OpcodeEnd}},
 					{Body: []byte{OpcodeEnd}},
@@ -135,7 +135,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					{Name: "function_index=2", Type: ExternTypeFunc, Index: 2},
 				},
 				FunctionSection: []Index{1, 0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}, {Body: []byte{OpcodeEnd}}},
+				CodeSection:     []Code{{Body: []byte{OpcodeEnd}}, {Body: []byte{OpcodeEnd}}},
 				TypeSection: []FunctionType{
 					v_v,
 					{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
@@ -208,7 +208,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					},
 				},
 				FunctionSection: []Index{0, 0, 0, 0, 0},
-				CodeSection:     []*Code{nopCode, nopCode, nopCode, nopCode, nopCode},
+				CodeSection:     []Code{nopCode, nopCode, nopCode, nopCode, nopCode},
 			},
 			expected: []FunctionDefinition{
 				{moduleName: "module", index: 0, debugName: "module.$0", importDesc: &Import{Module: "i", Name: "f"}, funcType: &v_v},

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -175,7 +175,7 @@ func newModuleVal(m api.Module) reflect.Value {
 //
 // Exposing this simplifies FunctionDefinition of host functions in built-in host
 // modules and tests.
-func MustParseGoReflectFuncCode(fn interface{}) *Code {
+func MustParseGoReflectFuncCode(fn interface{}) Code {
 	_, _, code, err := parseGoReflectFunc(fn)
 	if err != nil {
 		panic(err)
@@ -183,7 +183,7 @@ func MustParseGoReflectFuncCode(fn interface{}) *Code {
 	return code
 }
 
-func parseGoReflectFunc(fn interface{}) (params, results []ValueType, code *Code, err error) {
+func parseGoReflectFunc(fn interface{}) (params, results []ValueType, code Code, err error) {
 	fnV := reflect.ValueOf(fn)
 	p := fnV.Type()
 
@@ -254,7 +254,7 @@ func parseGoReflectFunc(fn interface{}) (params, results []ValueType, code *Code
 		return
 	}
 
-	code = &Code{}
+	code = Code{}
 	if pk == paramsKindContextModule {
 		code.GoFunc = &reflectGoModuleFunction{fn: &fnV, params: params, results: results}
 	} else {

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -34,7 +34,7 @@ type HostFunc struct {
 	ResultNames []string
 
 	// Code is the equivalent function in the SectionIDCode.
-	Code *Code
+	Code Code
 }
 
 // MustGoReflectFunc calls WithGoReflectFunc or panics on error.
@@ -49,14 +49,14 @@ func (f *HostFunc) MustGoReflectFunc(fn interface{}) *HostFunc {
 // WithGoFunc returns a copy of the function, replacing its Code.GoFunc.
 func (f *HostFunc) WithGoFunc(fn api.GoFunc) *HostFunc {
 	ret := *f
-	ret.Code = &Code{GoFunc: fn}
+	ret.Code.GoFunc = fn
 	return &ret
 }
 
 // WithGoModuleFunc returns a copy of the function, replacing its Code.GoFunc.
 func (f *HostFunc) WithGoModuleFunc(fn api.GoModuleFunc) *HostFunc {
 	ret := *f
-	ret.Code = &Code{GoFunc: fn}
+	ret.Code.GoFunc = fn
 	return &ret
 }
 
@@ -169,7 +169,7 @@ func addFuncs(
 	funcCount := uint32(len(nameToFunc))
 	m.NameSection.FunctionNames = make([]*NameAssoc, 0, funcCount)
 	m.FunctionSection = make([]Index, 0, funcCount)
-	m.CodeSection = make([]*Code, 0, funcCount)
+	m.CodeSection = make([]Code, 0, funcCount)
 	m.FunctionDefinitionSection = make([]FunctionDefinition, 0, funcCount)
 
 	idx := Index(0)

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -64,7 +64,7 @@ func TestNewHostModule(t *testing.T) {
 					{Params: []ValueType{i32, i32, i32, i32}, Results: []ValueType{i32}},
 				},
 				FunctionSection: []Index{0, 1},
-				CodeSection:     []*Code{MustParseGoReflectFuncCode(argsSizesGet), MustParseGoReflectFuncCode(fdWrite)},
+				CodeSection:     []Code{MustParseGoReflectFuncCode(argsSizesGet), MustParseGoReflectFuncCode(fdWrite)},
 				ExportSection: []Export{
 					{Name: ArgsSizesGetName, Type: ExternTypeFunc, Index: 0},
 					{Name: FdWriteName, Type: ExternTypeFunc, Index: 1},
@@ -104,7 +104,7 @@ func TestNewHostModule(t *testing.T) {
 			expected: &Module{
 				TypeSection:     []FunctionType{{Params: []ValueType{i32, i32}, Results: []ValueType{i32, i32}}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{MustParseGoReflectFuncCode(swap)},
+				CodeSection:     []Code{MustParseGoReflectFuncCode(swap)},
 				ExportSection:   []Export{{Name: "swap", Type: ExternTypeFunc, Index: 0}},
 				NameSection:     &NameSection{ModuleName: "swapper", FunctionNames: NameMap{{Index: 0, Name: "swap"}}},
 			},

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -141,7 +141,7 @@ type Module struct {
 	// Note: In the Binary Format, this is SectionIDCode.
 	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#code-section%E2%91%A0
-	CodeSection []*Code
+	CodeSection []Code
 
 	// Note: In the Binary Format, this is SectionIDData.
 	DataSection []DataSegment
@@ -348,7 +348,8 @@ func (m *Module) validateFunctions(enabledFeatures api.CoreFeatures, functions [
 		if typeIndex >= typeCount {
 			return fmt.Errorf("invalid %s: type section index %d out of range", m.funcDesc(SectionIDFunction, Index(idx)), typeIndex)
 		}
-		if m.CodeSection[idx].GoFunc != nil {
+		c := &m.CodeSection[idx]
+		if c.GoFunc != nil {
 			continue
 		}
 		if err = m.validateFunction(enabledFeatures, Index(idx), functions, globals, memory, tables, declaredFuncIndexes); err != nil {

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -335,7 +335,7 @@ func TestModule_Validate_Errors(t *testing.T) {
 			input: &Module{
 				TypeSection:     nil,
 				FunctionSection: []uint32{0},
-				CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
+				CodeSection:     []Code{{Body: []byte{OpcodeEnd}}},
 				StartSection:    &zero,
 			},
 			expectedErr: "invalid start function: func[0] has an invalid type",
@@ -455,7 +455,7 @@ func TestModule_validateFunctions(t *testing.T) {
 		m := Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []uint32{0},
-			CodeSection:     []*Code{{Body: []byte{OpcodeI32Const, 0, OpcodeDrop, OpcodeEnd}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeI32Const, 0, OpcodeDrop, OpcodeEnd}}},
 		}
 		err := m.validateFunctions(api.CoreFeaturesV1, nil, nil, nil, nil, MaximumFunctionIndex)
 		require.NoError(t, err)
@@ -480,7 +480,7 @@ func TestModule_validateFunctions(t *testing.T) {
 		m := Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{1},
-			CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeEnd}}},
 		}
 		err := m.validateFunctions(api.CoreFeaturesV1, nil, nil, nil, nil, MaximumFunctionIndex)
 		require.Error(t, err)
@@ -490,7 +490,7 @@ func TestModule_validateFunctions(t *testing.T) {
 		m := Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{0},
-			CodeSection:     []*Code{{Body: []byte{OpcodeF32Abs}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeF32Abs}}},
 		}
 		err := m.validateFunctions(api.CoreFeaturesV1, nil, nil, nil, nil, MaximumFunctionIndex)
 		require.Error(t, err)
@@ -500,7 +500,7 @@ func TestModule_validateFunctions(t *testing.T) {
 		m := Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{0},
-			CodeSection:     []*Code{{Body: []byte{OpcodeF32Abs}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeF32Abs}}},
 			ExportSection:   []Export{{Name: "f1", Type: ExternTypeFunc, Index: 0}},
 		}
 		err := m.validateFunctions(api.CoreFeaturesV1, nil, nil, nil, nil, MaximumFunctionIndex)
@@ -512,7 +512,7 @@ func TestModule_validateFunctions(t *testing.T) {
 			TypeSection:     []FunctionType{v_v},
 			ImportSection:   []Import{{Type: ExternTypeFunc}},
 			FunctionSection: []Index{0},
-			CodeSection:     []*Code{{Body: []byte{OpcodeF32Abs}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeF32Abs}}},
 			ExportSection:   []Export{{Name: "f1", Type: ExternTypeFunc, Index: 1}},
 		}
 		err := m.validateFunctions(api.CoreFeaturesV1, nil, nil, nil, nil, MaximumFunctionIndex)
@@ -523,7 +523,7 @@ func TestModule_validateFunctions(t *testing.T) {
 		m := Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []Index{0},
-			CodeSection:     []*Code{{Body: []byte{OpcodeF32Abs}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeF32Abs}}},
 			ExportSection: []Export{
 				{Name: "f1", Type: ExternTypeFunc, Index: 0},
 				{Name: "f2", Type: ExternTypeFunc, Index: 0},
@@ -809,12 +809,12 @@ func TestModule_buildGlobals(t *testing.T) {
 }
 
 func TestModule_buildFunctions(t *testing.T) {
-	nopCode := &Code{Body: []byte{OpcodeEnd}}
+	nopCode := Code{Body: []byte{OpcodeEnd}}
 	m := &Module{
 		TypeSection:     []FunctionType{v_v},
 		ImportSection:   []Import{{Type: ExternTypeFunc}},
 		FunctionSection: []Index{0, 0, 0, 0, 0},
-		CodeSection:     []*Code{nopCode, nopCode, nopCode, nopCode, nopCode},
+		CodeSection:     []Code{nopCode, nopCode, nopCode, nopCode, nopCode},
 		FunctionDefinitionSection: []FunctionDefinition{
 			{index: 0, funcType: &v_v},
 			{index: 1, funcType: &v_v},

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -147,7 +147,7 @@ func TestStore_CloseWithExitCode(t *testing.T) {
 			_, err := s.Instantiate(testCtx, &Module{
 				TypeSection:               []FunctionType{v_v},
 				FunctionSection:           []uint32{0},
-				CodeSection:               []*Code{{Body: []byte{OpcodeEnd}}},
+				CodeSection:               []Code{{Body: []byte{OpcodeEnd}}},
 				ExportSection:             []Export{{Type: ExternTypeFunc, Index: 0, Name: "fn"}},
 				FunctionDefinitionSection: []FunctionDefinition{{funcType: &v_v}},
 			}, importedModuleName, nil, []FunctionTypeID{0})
@@ -196,7 +196,7 @@ func TestStore_hammer(t *testing.T) {
 	importingModule := &Module{
 		TypeSection:             []FunctionType{v_v},
 		FunctionSection:         []uint32{0},
-		CodeSection:             []*Code{{Body: []byte{OpcodeEnd}}},
+		CodeSection:             []Code{{Body: []byte{OpcodeEnd}}},
 		MemorySection:           &Memory{Min: 1, Cap: 1},
 		MemoryDefinitionSection: []MemoryDefinition{{}},
 		GlobalSection: []Global{{
@@ -250,7 +250,7 @@ func TestStore_hammer_close(t *testing.T) {
 	importingModule := &Module{
 		TypeSection:             []FunctionType{v_v},
 		FunctionSection:         []uint32{0},
-		CodeSection:             []*Code{{Body: []byte{OpcodeEnd}}},
+		CodeSection:             []Code{{Body: []byte{OpcodeEnd}}},
 		MemorySection:           &Memory{Min: 1, Cap: 1},
 		MemoryDefinitionSection: []MemoryDefinition{{}},
 		GlobalSection: []Global{{
@@ -344,7 +344,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 		importingModule := &Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []uint32{0, 0},
-			CodeSection: []*Code{
+			CodeSection: []Code{
 				{Body: []byte{OpcodeEnd}},
 				{Body: []byte{OpcodeEnd}},
 			},
@@ -373,7 +373,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 		importingModule := &Module{
 			TypeSection:     []FunctionType{v_v},
 			FunctionSection: []uint32{0},
-			CodeSection:     []*Code{{Body: []byte{OpcodeEnd}}},
+			CodeSection:     []Code{{Body: []byte{OpcodeEnd}}},
 			StartSection:    &startFuncIndex,
 			ImportSection: []Import{
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -59,7 +59,7 @@ func Test_resolveImports_table(t *testing.T) {
 	})
 }
 
-var codeEnd = &Code{Body: []byte{OpcodeEnd}}
+var codeEnd = Code{Body: []byte{OpcodeEnd}}
 
 func TestModule_validateTable(t *testing.T) {
 	const maxTableIndex = 5
@@ -95,7 +95,7 @@ func TestModule_validateTable(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
@@ -111,7 +111,7 @@ func TestModule_validateTable(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
@@ -130,7 +130,7 @@ func TestModule_validateTable(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{Type: RefTypeFuncref}}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
@@ -149,7 +149,7 @@ func TestModule_validateTable(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{Min: 1, Type: RefTypeFuncref}}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
@@ -168,7 +168,7 @@ func TestModule_validateTable(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
-				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
+				CodeSection:     []Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
@@ -190,7 +190,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
@@ -209,7 +209,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
@@ -231,7 +231,7 @@ func TestModule_validateTable(t *testing.T) {
 					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
@@ -253,7 +253,7 @@ func TestModule_validateTable(t *testing.T) {
 					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
@@ -276,7 +276,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
-				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
+				CodeSection:     []Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x1}},
@@ -299,7 +299,7 @@ func TestModule_validateTable(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 3, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0, 0, 0, 0},
-				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
+				CodeSection:     []Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1},
@@ -425,7 +425,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{
@@ -445,7 +445,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI64Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
@@ -460,7 +460,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 			input: &Module{
 				TypeSection:     []FunctionType{{}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0}, Init: []*Index{uint32Ptr(0)},
@@ -476,7 +476,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)}, Init: []*Index{uint32Ptr(0)},
@@ -492,7 +492,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 2, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0)},
@@ -512,7 +512,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 1, Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: leb128.EncodeInt32(2)},
@@ -528,7 +528,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 1}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const1}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
@@ -546,7 +546,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
@@ -565,7 +565,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 1}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0), uint32Ptr(1)},
@@ -584,7 +584,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				},
 				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
@@ -603,7 +603,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				},
 				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{
@@ -624,7 +624,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				GlobalSection:   []Global{{Type: GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
@@ -644,7 +644,7 @@ func TestModule_validateTable_Errors(t *testing.T) {
 				TableSection:    []Table{{Type: RefTypeFuncref}},
 				FunctionSection: []Index{0},
 				GlobalSection:   []Global{{Type: GlobalType{ValType: ValueTypeI32}}}, // ignored as not imported
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}}, Init: []*Index{uint32Ptr(0)},
@@ -711,7 +711,7 @@ func TestModule_buildTables(t *testing.T) {
 				TypeSection:                    []FunctionType{{}},
 				TableSection:                   []Table{{Min: 1}},
 				FunctionSection:                []Index{0},
-				CodeSection:                    []*Code{codeEnd},
+				CodeSection:                    []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{},
 			},
 			expectedTables: []*TableInstance{{References: make([]Reference, 1), Min: 1}},
@@ -733,7 +733,7 @@ func TestModule_buildTables(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 1}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeI32Const, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
@@ -746,7 +746,7 @@ func TestModule_buildTables(t *testing.T) {
 			module: &Module{
 				TypeSection:     []FunctionType{{}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeI32Const, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
@@ -761,7 +761,7 @@ func TestModule_buildTables(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{Min: 1}}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeI32Const, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
@@ -776,7 +776,7 @@ func TestModule_buildTables(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				TableSection:    []Table{{Min: 3}},
 				FunctionSection: []Index{0, 0, 0, 0},
-				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
+				CodeSection:     []Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeI32Const, arg: 1, init: []*Index{uint32Ptr(0), uint32Ptr(2)}},
 				},
@@ -793,7 +793,7 @@ func TestModule_buildTables(t *testing.T) {
 				},
 				TableSection:                   []Table{{Min: 1}},
 				FunctionSection:                []Index{0},
-				CodeSection:                    []*Code{codeEnd},
+				CodeSection:                    []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{},
 			},
 			importedGlobals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}, Val: 1}},
@@ -808,7 +808,7 @@ func TestModule_buildTables(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 2}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
@@ -826,7 +826,7 @@ func TestModule_buildTables(t *testing.T) {
 					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
@@ -845,7 +845,7 @@ func TestModule_buildTables(t *testing.T) {
 					{Type: ExternTypeGlobal, DescGlobal: GlobalType{ValType: ValueTypeI32}},
 				},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeGlobalGet, arg: 0, init: []*Index{uint32Ptr(0)}},
 				},
@@ -865,7 +865,7 @@ func TestModule_buildTables(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 3}, {Min: 100}},
 				FunctionSection: []Index{0, 0, 0, 0},
-				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
+				CodeSection:     []Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
@@ -906,7 +906,7 @@ func TestModule_buildTables(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 3}},
 				FunctionSection: []Index{0, 0, 0, 0},
-				CodeSection:     []*Code{codeEnd, codeEnd, codeEnd, codeEnd},
+				CodeSection:     []Code{codeEnd, codeEnd, codeEnd, codeEnd},
 				validatedActiveElementSegments: []validatedActiveElementSegment{
 					{opcode: OpcodeI32Const, arg: 1, init: []*Index{uint32Ptr(0), uint32Ptr(2)}},
 					{opcode: OpcodeGlobalGet, arg: 1, init: []*Index{uint32Ptr(1), uint32Ptr(2)}},
@@ -952,7 +952,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				TypeSection:     []FunctionType{{}},
 				ImportSection:   []Import{{Type: ExternTypeTable, DescTable: Table{}}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeI32Const, Data: const0},
@@ -975,7 +975,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 2}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},
@@ -999,7 +999,7 @@ func TestModule_buildTable_Errors(t *testing.T) {
 				},
 				TableSection:    []Table{{Min: 2}},
 				FunctionSection: []Index{0},
-				CodeSection:     []*Code{codeEnd},
+				CodeSection:     []Code{codeEnd},
 				ElementSection: []ElementSegment{
 					{
 						OffsetExpr: ConstantExpression{Opcode: OpcodeGlobalGet, Data: []byte{0x0}},

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -286,7 +286,7 @@ func CompileFunctions(enabledFeatures api.CoreFeatures, callFrameStackSizeInUint
 	for funcIndex := range module.FunctionSection {
 		typeID := module.FunctionSection[funcIndex]
 		sig := &types[typeID]
-		code := module.CodeSection[funcIndex]
+		code := &module.CodeSection[funcIndex]
 		if code.GoFunc != nil {
 			// Assume the function might use memory if it has a parameter for the api.Module
 			_, usesMemory := code.GoFunc.(api.GoModuleFunction)

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -45,7 +45,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
+				CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
 			},
 			expected: &CompilationResult{
 				Operations: []Operation{ // begin with params: []
@@ -63,7 +63,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
+				CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
 			},
 			expected: &CompilationResult{
 				Operations: []Operation{ // begin with params: []
@@ -81,7 +81,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(func() {})},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(func() {})},
 			},
 			expected: &CompilationResult{},
 		},
@@ -90,7 +90,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{wasm.MustParseGoReflectFuncCode(func(context.Context, api.Module) {})},
+				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(func(context.Context, api.Module) {})},
 			},
 			expected: &CompilationResult{UsesMemory: true},
 		},
@@ -99,7 +99,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{i32_i32},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
+				CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd}}},
 			},
 			expected: &CompilationResult{
 				Operations: []Operation{ // begin with params: [$x]
@@ -129,7 +129,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeI32Const, 8, // memory offset to load
 					wasm.OpcodeI32Load, 0x2, 0x0, // load alignment=2 (natural alignment) staticOffset=0
 					wasm.OpcodeDrop,
@@ -156,7 +156,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeI32Const, 8, // memory offset to load
 					wasm.OpcodeI32Load, 0x2, 0x0, // load alignment=2 (natural alignment) staticOffset=0
 					wasm.OpcodeDrop,
@@ -183,7 +183,7 @@ func TestCompile(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{i32_i32},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeLocalGet, 0, wasm.OpcodeMemoryGrow, 0, wasm.OpcodeEnd,
 				}}},
 			},
@@ -250,7 +250,7 @@ func TestCompile_Block(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeBlock, 0x40,
 					wasm.OpcodeBr, 0,
 					wasm.OpcodeI32Add,
@@ -332,7 +332,7 @@ func TestCompile_BulkMemoryOperations(t *testing.T) {
 			},
 		},
 		DataCountSection: &two,
-		CodeSection: []*wasm.Code{{Body: []byte{
+		CodeSection: []wasm.Code{{Body: []byte{
 			wasm.OpcodeI32Const, 16,
 			wasm.OpcodeI32Const, 0,
 			wasm.OpcodeI32Const, 7,
@@ -390,7 +390,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{i32i32_i32i32},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					// (func (param $x i32) (param $y i32) (result i32 i32) local.get 1 local.get 0)
 					wasm.OpcodeLocalGet, 1, wasm.OpcodeLocalGet, 0, wasm.OpcodeEnd,
 				}}},
@@ -414,7 +414,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_f64f64},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeBlock, 0, // (block (result f64 f64)
 					wasm.OpcodeF64Const, 0, 0, 0, 0, 0, 0, 0x10, 0x40, // (f64.const 4)
 					wasm.OpcodeF64Const, 0, 0, 0, 0, 0, 0, 0x14, 0x40, // (f64.const 5)
@@ -457,7 +457,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{_i32i64},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					//  (func $const-i32-i64 (result i32 i64) i32.const 306 i64.const 356)
 					wasm.OpcodeI32Const, 0xb2, 0x2, wasm.OpcodeI64Const, 0xe4, 0x2, wasm.OpcodeEnd,
 				}}},
@@ -480,7 +480,7 @@ func TestCompile_MultiValue(t *testing.T) {
 			module: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{i32_i32}, // (func (param i32) (result i32)
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeI32Const, 1, // (i32.const 1)
 					wasm.OpcodeLocalGet, 0, wasm.OpcodeIf, 0, // (if (param i32) (result i32) (local.get 0)
 					wasm.OpcodeI32Const, 2, wasm.OpcodeI32Add, // (then (i32.const 2) (i32.add))
@@ -536,7 +536,7 @@ func TestCompile_MultiValue(t *testing.T) {
 					i32i32_i32, // (if (param i32 i32) (result i32)
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeI32Const, 1, // (i32.const 1)
 					wasm.OpcodeI32Const, 2, // (i32.const 2)
 					wasm.OpcodeLocalGet, 0, wasm.OpcodeIf, 1, // (if (param i32) (result i32) (local.get 0)
@@ -593,7 +593,7 @@ func TestCompile_MultiValue(t *testing.T) {
 					i32i32_i32, // (if (param i32 i32) (result i32)
 				},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeI32Const, 1, // (i32.const 1)
 					wasm.OpcodeI32Const, 2, // (i32.const 2)
 					wasm.OpcodeLocalGet, 0, wasm.OpcodeIf, 1, // (if (param i32) (result i32) (local.get 0)
@@ -668,7 +668,7 @@ func TestCompile_NonTrappingFloatToIntConversion(t *testing.T) {
 		TypeSection:     []wasm.FunctionType{f32_i32},
 		FunctionSection: []wasm.Index{0},
 		// (func (param f32) (result i32) local.get 0 i32.trunc_sat_f32_s)
-		CodeSection: []*wasm.Code{{Body: []byte{
+		CodeSection: []wasm.Code{{Body: []byte{
 			wasm.OpcodeLocalGet, 0, wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI32TruncSatF32S, wasm.OpcodeEnd,
 		}}},
 	}
@@ -703,7 +703,7 @@ func TestCompile_SignExtensionOps(t *testing.T) {
 	module := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{i32_i32},
 		FunctionSection: []wasm.Index{0},
-		CodeSection: []*wasm.Code{{Body: []byte{
+		CodeSection: []wasm.Code{{Body: []byte{
 			wasm.OpcodeLocalGet, 0, wasm.OpcodeI32Extend8S, wasm.OpcodeEnd,
 		}}},
 	}
@@ -742,7 +742,7 @@ func TestCompile_CallIndirectNonZeroTableIndex(t *testing.T) {
 	module := &wasm.Module{
 		TypeSection:     []wasm.FunctionType{v_v, v_v, v_v},
 		FunctionSection: []wasm.Index{0},
-		CodeSection: []*wasm.Code{{Body: []byte{
+		CodeSection: []wasm.Code{{Body: []byte{
 			wasm.OpcodeI32Const, 0, // call indirect offset
 			wasm.OpcodeCallIndirect,
 			2, // Type index for call_indirect.
@@ -863,7 +863,7 @@ func TestCompile_Refs(t *testing.T) {
 			module := &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: tc.body}},
+				CodeSection:     []wasm.Code{{Body: tc.body}},
 			}
 			res, err := CompileFunctions(api.CoreFeaturesV2, 0, module, false)
 			require.NoError(t, err)
@@ -931,7 +931,7 @@ func TestCompile_TableGetOrSet(t *testing.T) {
 			module := &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: tc.body}},
+				CodeSection:     []wasm.Code{{Body: tc.body}},
 				TableSection:    []wasm.Table{{}},
 			}
 			res, err := CompileFunctions(api.CoreFeaturesV2, 0, module, false)
@@ -1000,7 +1000,7 @@ func TestCompile_TableGrowFillSize(t *testing.T) {
 			module := &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: tc.body}},
+				CodeSection:     []wasm.Code{{Body: tc.body}},
 				TableSection:    []wasm.Table{{}},
 			}
 			res, err := CompileFunctions(api.CoreFeaturesV2, 0, module, false)
@@ -1022,7 +1022,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeLocalGet, 0,
 					wasm.OpcodeEnd,
 				}}},
@@ -1038,7 +1038,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeI64}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeLocalGet, 0,
 					wasm.OpcodeEnd,
 				}}},
@@ -1054,7 +1054,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{
+				CodeSection: []wasm.Code{{
 					Body: []byte{
 						wasm.OpcodeLocalGet, 0,
 						wasm.OpcodeEnd,
@@ -1074,7 +1074,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix, wasm.OpcodeVecV128Const, // [] -> [0x01, 0x02]
 					1, 0, 0, 0, 0, 0, 0, 0,
 					2, 0, 0, 0, 0, 0, 0, 0,
@@ -1096,7 +1096,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeI32}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeI32Const, 0x1, // [] -> [0x01]
 					wasm.OpcodeLocalSet, 0, // [0x01] -> []
 					wasm.OpcodeEnd,
@@ -1114,7 +1114,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{
+				CodeSection: []wasm.Code{{
 					Body: []byte{
 						wasm.OpcodeVecPrefix, wasm.OpcodeVecV128Const, // [] -> [0x01, 0x02]
 						1, 0, 0, 0, 0, 0, 0, 0,
@@ -1140,7 +1140,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeV128}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix, wasm.OpcodeVecV128Const, // [] -> [0x01, 0x02]
 					1, 0, 0, 0, 0, 0, 0, 0,
 					2, 0, 0, 0, 0, 0, 0, 0,
@@ -1164,7 +1164,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{wasm.ValueTypeF32}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeF32Const, 1, 0, 0, 0,
 					wasm.OpcodeLocalTee, 0, // [0x01, 0x02] ->  [0x01, 0x02]
 					wasm.OpcodeEnd,
@@ -1183,7 +1183,7 @@ func TestCompile_Locals(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{
+				CodeSection: []wasm.Code{{
 					Body: []byte{
 						wasm.OpcodeVecPrefix, wasm.OpcodeVecV128Const, // [] -> [0x01, 0x02]
 						1, 0, 0, 0, 0, 0, 0, 0,
@@ -2785,7 +2785,7 @@ func TestCompile_Vec(t *testing.T) {
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
 				MemorySection:   &wasm.Memory{},
-				CodeSection:     []*wasm.Code{{Body: tc.body}},
+				CodeSection:     []wasm.Code{{Body: tc.body}},
 			}
 			res, err := CompileFunctions(api.CoreFeaturesV2, 0, module, false)
 			require.NoError(t, err)
@@ -2818,7 +2818,7 @@ func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeBr, 0, // Return the function -> the followings are unreachable.
 					wasm.OpcodeBlock, 0,
 					wasm.OpcodeBr, 1,
@@ -2833,7 +2833,7 @@ func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeBr, 0, // Return the function -> the followings are unreachable.
 					wasm.OpcodeBlock, 0,
 					wasm.OpcodeI32Const, 1,
@@ -2849,7 +2849,7 @@ func TestCompile_unreachable_Br_BrIf_BrTable(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeBr, 0, // Return the function -> the followings are unreachable.
 					wasm.OpcodeBlock, 0,
 					wasm.OpcodeBrTable, 2, 2, 3,
@@ -2884,7 +2884,7 @@ func TestCompile_drop_vectors(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix,
 					wasm.OpcodeVecV128Const, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0,
 					wasm.OpcodeDrop,
@@ -2922,7 +2922,7 @@ func TestCompile_select_vectors(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix,
 					wasm.OpcodeVecV128Const, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0,
 					wasm.OpcodeVecPrefix,
@@ -2948,7 +2948,7 @@ func TestCompile_select_vectors(t *testing.T) {
 			mod: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{Body: []byte{
+				CodeSection: []wasm.Code{{Body: []byte{
 					wasm.OpcodeVecPrefix,
 					wasm.OpcodeVecV128Const, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0,
 					wasm.OpcodeVecPrefix,
@@ -3199,7 +3199,7 @@ func Test_ensureTermination(t *testing.T) {
 			mod := &wasm.Module{
 				TypeSection:     []wasm.FunctionType{v_v},
 				FunctionSection: []wasm.Index{0},
-				CodeSection: []*wasm.Code{{
+				CodeSection: []wasm.Code{{
 					Body: []byte{
 						wasm.OpcodeI32Const, 0,
 						wasm.OpcodeLoop, 0, wasm.OpcodeI32Const, 1, wasm.OpcodeBrIf, 0, wasm.OpcodeEnd,

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -68,7 +68,7 @@ func TestRuntime_CompileModule(t *testing.T) {
 			wasm: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []api.ValueType{api.ValueTypeI32}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
+				CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
 			},
 			expected: func(compiled CompiledModule) {
 				require.Nil(t, compiled.ImportedFunctions())
@@ -80,7 +80,7 @@ func TestRuntime_CompileModule(t *testing.T) {
 			wasm: &wasm.Module{
 				TypeSection:     []wasm.FunctionType{{Params: []api.ValueType{api.ValueTypeI32}}},
 				FunctionSection: []wasm.Index{0},
-				CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
+				CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
 				ExportSection: []wasm.Export{{
 					Type:  wasm.ExternTypeFunc,
 					Name:  "function",
@@ -346,7 +346,7 @@ func TestRuntime_InstantiateModule_UsesContext(t *testing.T) {
 		TypeSection:     []wasm.FunctionType{{}},
 		ImportSection:   []wasm.Import{{Module: "env", Name: "start", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Call the imported env.start.
 		},
 		StartSection: &one,
@@ -475,7 +475,7 @@ func TestRuntime_InstantiateModule_ExitError(t *testing.T) {
 		TypeSection:     []wasm.FunctionType{{}},
 		ImportSection:   []wasm.Import{{Module: "env", Name: "exit", Type: wasm.ExternTypeFunc, DescFunc: 0}},
 		FunctionSection: []wasm.Index{0},
-		CodeSection: []*wasm.Code{
+		CodeSection: []wasm.Code{
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Call the imported env.start.
 		},
 		StartSection: &one,
@@ -493,7 +493,7 @@ func TestRuntime_CloseWithExitCode(t *testing.T) {
 	bin := binaryencoding.EncodeModule(&wasm.Module{
 		TypeSection:     []wasm.FunctionType{{}},
 		FunctionSection: []wasm.Index{0},
-		CodeSection:     []*wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
+		CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
 		ExportSection:   []wasm.Export{{Type: wasm.ExternTypeFunc, Index: 0, Name: "func"}},
 	})
 
@@ -609,7 +609,7 @@ func TestHostFunctionWithCustomContext(t *testing.T) {
 					{Module: "env", Name: "host2", Type: wasm.ExternTypeFunc, DescFunc: 0},
 				},
 				FunctionSection: []wasm.Index{0, 0},
-				CodeSection: []*wasm.Code{
+				CodeSection: []wasm.Code{
 					{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}}, // Call the imported env.host.
 					{Body: []byte{wasm.OpcodeCall, 1, wasm.OpcodeEnd}}, // Call the imported env.host.
 				},


### PR DESCRIPTION
```
$ benchstat old.txt new.txt
name                                    old time/op    new time/op    delta
Initialization/interpreter-32             35.9µs ± 1%    35.9µs ± 2%    ~     (p=0.528 n=25+26)
Initialization/interpreter-multiple-32    39.7µs ± 8%    39.6µs ± 9%    ~     (p=0.668 n=30+29)
Initialization/compiler-32                29.4µs ± 7%    28.8µs ± 6%  -2.06%  (p=0.014 n=28+30)
Initialization/compiler-multiple-32       25.3µs ±12%    25.7µs ± 9%    ~     (p=0.329 n=30+30)
Compilation/with_extern_cache-32           198µs ± 2%     201µs ± 2%  +1.14%  (p=0.000 n=28+30)
Compilation/without_extern_cache-32       5.97ms ± 1%    5.88ms ± 1%  -1.63%  (p=0.000 n=30+30)

name                                    old alloc/op   new alloc/op   delta
Initialization/interpreter-32              136kB ± 0%     136kB ± 0%  -0.00%  (p=0.008 n=19+30)
Initialization/interpreter-multiple-32     137kB ± 0%     137kB ± 0%    ~     (p=0.949 n=26+27)
Initialization/compiler-32                 137kB ± 0%     137kB ± 0%    ~     (p=0.313 n=30+30)
Initialization/compiler-multiple-32        142kB ± 0%     142kB ± 0%  -0.00%  (p=0.018 n=23+24)
Compilation/with_extern_cache-32          55.2kB ± 0%    54.6kB ± 0%  -1.00%  (p=0.000 n=30+30)
Compilation/without_extern_cache-32       1.99MB ± 0%    1.99MB ± 0%  -0.03%  (p=0.000 n=30+30)

name                                    old allocs/op  new allocs/op  delta
Initialization/interpreter-32               38.0 ± 0%      38.0 ± 0%    ~     (all equal)
Initialization/interpreter-multiple-32      57.0 ± 0%      57.0 ± 0%    ~     (all equal)
Initialization/compiler-32                  38.0 ± 0%      38.0 ± 0%    ~     (all equal)
Initialization/compiler-multiple-32         47.0 ± 0%      47.0 ± 0%    ~     (all equal)
Compilation/with_extern_cache-32           1.02k ± 0%     0.98k ± 0%  -3.96%  (p=0.000 n=28+30)
Compilation/without_extern_cache-32        32.7k ± 0%     32.6k ± 0%  -0.13%  (p=0.000 n=30+30)

```