### PR TITLE
site: fixes example bug

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -18,7 +18,7 @@ execute WebAssembly Modules (Wasm), which are most often binaries with a
 
 ```bash
 $ curl https://wazero.io/install.sh | sh
-$ wazero run app.wasm
+$ ./bin/wazero run app.wasm
 ```
 
 **Embed wazero** in your Go project and extend any app


### PR DESCRIPTION
the installer goes to ./bin by default

to do something else you need something like

`| bash -s -- -b /usr/local/bin`