### PR TITLE
path_filestat_get: interpret LOOKUP_SYMLINK_FOLLOW

### DIFF
--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -61,6 +61,19 @@ func (a *adapter) Stat(path string, stat *platform.Stat_t) error {
 	return platform.StatFile(f, stat)
 }
 
+// Lstat implements FS.Lstat
+func (a *adapter) Lstat(path string, stat *platform.Stat_t) error {
+	// At this time, we make the assumption that fs.FS instances do not support
+	// symbolic links, therefore Lstat is the same as Stat. This is obviously
+	// not true but until fs.FS has a solid story for how to handle symlinks we
+	// are better off not making a decision that would be difficult to revert
+	// later on.
+	//
+	// For further discussions on the topic, see:
+	// https://github.com/golang/go/issues/49580
+	return a.Stat(path, stat)
+}
+
 func cleanPath(name string) string {
 	if len(name) == 0 {
 		return name

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"testing"
@@ -116,8 +117,6 @@ func TestAdapt_Open_Read(t *testing.T) {
 	})
 }
 
-// TestAdapt_Lstat is unsupported because the Lstat() function is not implemented
-// on os.File.
 func TestAdapt_Lstat(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, fstest.WriteTestFiles(tmpDir))
@@ -128,7 +127,7 @@ func TestAdapt_Lstat(t *testing.T) {
 		linkPath := joinPath(tmpDir, path+"-link")
 		require.NoError(t, os.Symlink(fullPath, linkPath))
 		var stat platform.Stat_t
-		require.EqualErrno(t, syscall.ENOSYS, testFS.Lstat(linkPath, &stat))
+		require.NoError(t, testFS.Lstat(filepath.Base(linkPath), &stat))
 	}
 }
 


### PR DESCRIPTION
This PR adds support for passing lookup flags to `path_filestat_get`. The motivation came from the work on https://github.com/golang/go/issues/58141, especially implementing `syscall.Lstat`.

Without this change, an alternative implementation is possible using `path_open` + `fd_filestat_get` + `fd_close` because wazero allows passing stats, however, this fails on OSX because `LOOKUP_SYMLINK_FOLLOW` is translated to `O_NOFOLLOW` which causes `open` to fail with `ELOOP` because wazero doesn't set `O_SYMLINK` (I can follow up with a fix for that in a different PR).

I updates the tests to use the `LOOKUP_SYMLINK_FOLLOW` flag since that was the historical behavior being tested; however, I haven't found a paved path for testing with symbolic links. The tests use `fstest.FS` which ends up creating an internal adapter between `fs.FS` and `sysfs.FS` and always returns `ENOSYS` on calls to `Lstat`.

It seems that we would want tests that actually work on a local file system (e.g. something in `testdata`) so we can exercise an actual call to `lstat`, I wanted to get feedback before making too many changes to the test suite. Let me know what you would recommend!

Signed-off-by: Achille Roussel <achille.roussel@gmail.com>
