### PR TITLE
fix file type of directory entries

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1022,7 +1022,7 @@ func writeDirents(
 		e := dirents[i]
 		nameLen := uint32(len(e.Name))
 
-		writeDirent(buf[pos:], d_next, e.Ino, nameLen, e.IsDir())
+		writeDirent(buf[pos:], d_next, e.Ino, nameLen, e.Type)
 		pos += DirentSize
 
 		copy(buf[pos:], e.Name)
@@ -1037,22 +1037,18 @@ func writeDirents(
 	// Write a dirent without its name
 	dirent := make([]byte, DirentSize)
 	e := dirents[i]
-	writeDirent(dirent, d_next, e.Ino, uint32(len(e.Name)), e.IsDir())
+	writeDirent(dirent, d_next, e.Ino, uint32(len(e.Name)), e.Type)
 
 	// Potentially truncate it
 	copy(buf[pos:], dirent)
 }
 
 // writeDirent writes DirentSize bytes
-func writeDirent(buf []byte, dNext uint64, ino uint64, dNamlen uint32, dType bool) {
+func writeDirent(buf []byte, dNext uint64, ino uint64, dNamlen uint32, dType fs.FileMode) {
 	le.PutUint64(buf, dNext)        // d_next
 	le.PutUint64(buf[8:], ino)      // d_ino
 	le.PutUint32(buf[16:], dNamlen) // d_namlen
-
-	filetype := FILETYPE_REGULAR_FILE
-	if dType {
-		filetype = FILETYPE_DIRECTORY
-	}
+	filetype := getWasiFiletype(dType)
 	le.PutUint32(buf[20:], uint32(filetype)) //  d_type
 }
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -1857,7 +1857,24 @@ var (
 		'a', 'b', '-', // name
 	}
 
-	dirents = append(append(append(append(direntDot, direntDotDot...), dirent1...), dirent2...), dirent3...)
+	// TODO: this entry is intended to test reading of a symbolic link entry,
+	// tho it requires modifying fstest.FS to contain this file.
+	dirent4 = []byte{
+		6, 0, 0, 0, 0, 0, 0, 0, // d_next = 6
+		0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
+		2, 0, 0, 0, // d_namlen = 2 characters
+		7, 0, 0, 0, // d_type = symbolic_link
+		'l', 'n', // name
+	}
+
+	dirents = bytes.Join([][]byte{
+		direntDot,
+		direntDotDot,
+		dirent1,
+		dirent2,
+		dirent3,
+		//dirent4,
+	}, nil)
 )
 
 func Test_fdReaddir(t *testing.T) {

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -1859,13 +1859,13 @@ var (
 
 	// TODO: this entry is intended to test reading of a symbolic link entry,
 	// tho it requires modifying fstest.FS to contain this file.
-	dirent4 = []byte{
-		6, 0, 0, 0, 0, 0, 0, 0, // d_next = 6
-		0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
-		2, 0, 0, 0, // d_namlen = 2 characters
-		7, 0, 0, 0, // d_type = symbolic_link
-		'l', 'n', // name
-	}
+	// dirent4 = []byte{
+	// 	6, 0, 0, 0, 0, 0, 0, 0, // d_next = 6
+	// 	0, 0, 0, 0, 0, 0, 0, 0, // d_ino = 0
+	// 	2, 0, 0, 0, // d_namlen = 2 characters
+	// 	7, 0, 0, 0, // d_type = symbolic_link
+	// 	'l', 'n', // name
+	// }
 
 	dirents = bytes.Join([][]byte{
 		direntDot,

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -1873,7 +1873,7 @@ var (
 		dirent1,
 		dirent2,
 		dirent3,
-		//dirent4,
+		// dirent4,
 	}, nil)
 )
 


### PR DESCRIPTION
Prior to this change, when reading directory entries, wazero would assume that all files are regular files except directories. This causes issues in client applications that work with symbolic links for example.

The issue was detected while working on passing the `testing/fstest` tests as part of the implementation of https://github.com/golang/go/issues/58141 because `fstest.TestFS` validates that the file type seen by `fs.DirEntry.Type()` and `fs.FileInfo.Mode().Type()` are the same.

Regarding testing this change, to reuse the existing test suite would likely require updating `internal/fstest.FS` to contain a symbolic link, but this fixture object is used in so many places that it may be difficult to land the fix. An alternative could be to make a local copy of `fstest.FS` and add the symbolic link there, but it defeats the documented intent of `fstest` to reduce drift between systems. Let me know how you would prefer to proceed!

Signed-off-by: Achille Roussel <achille.roussel@gmail.com>