### PR TITLE
interpret RIGHT_FD_WRITE to set O_RDWR on files opened by wazero

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -416,7 +416,7 @@ func Test_openFlags(t *testing.T) {
 		{
 			name:              "rights=FD_WRITE",
 			rights:            RIGHT_FD_WRITE,
-			expectedOpenFlags: syscall.O_NOFOLLOW | syscall.O_RDWR,
+			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDWR,
 		},
 	}
 

--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -371,6 +371,7 @@ func Test_openFlags(t *testing.T) {
 	tests := []struct {
 		name                      string
 		dirflags, oflags, fdflags uint16
+		rights                    uint32
 		expectedOpenFlags         int
 	}{
 		{
@@ -412,13 +413,18 @@ func Test_openFlags(t *testing.T) {
 			dirflags:          LOOKUP_SYMLINK_FOLLOW,
 			expectedOpenFlags: syscall.O_RDONLY,
 		},
+		{
+			name:              "rights=FD_WRITE",
+			rights:            RIGHT_FD_WRITE,
+			expectedOpenFlags: syscall.O_NOFOLLOW | syscall.O_RDWR,
+		},
 	}
 
 	for _, tt := range tests {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			openFlags := openFlags(tc.dirflags, tc.oflags, tc.fdflags)
+			openFlags := openFlags(tc.dirflags, tc.oflags, tc.fdflags, tc.rights)
 			require.Equal(t, tc.expectedOpenFlags, openFlags)
 		})
 	}


### PR DESCRIPTION
Following up from our conversation on Slack, this PR demonstrate a fix which can be used to allow client programs to open files in write mode when they provided none of the O_CREATE, O_APPEND, or O_TRUNC flags.
