### PR TITLE
Removes redundant exit code check

### DIFF
--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -380,10 +380,6 @@ func compile(enabledFeatures api.CoreFeatures,
 		kind:      controlFrameKindFunction,
 	})
 
-	if c.ensureTermination {
-		c.emit(OperationBuiltinFunctionCheckExitCode{})
-	}
-
 	// Now, enter the function body.
 	for !c.controlFrames.empty() && c.pc < uint64(len(c.body)) {
 		if err := c.handleInstruction(); err != nil {

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -3160,7 +3160,6 @@ func Test_ensureTermination(t *testing.T) {
 		{
 			ensureTermination: true,
 			exp: `.entrypoint
-	BuiltinFunctionCheckExitCode
 	ConstI32 0x0
 	Br .L2
 .L2


### PR DESCRIPTION
realized that the check at the function preamble is not necessary to prevent the infinite loop,
as there's already a guard to check call stack overflow on that point.