### PR TITLE
fix typo in wazero.HostFunctionBuilder.WithFunc documentation

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -86,7 +86,7 @@ type HostFunctionBuilder interface {
 	//
 	// Except for the context.Context and optional api.Module, all parameters
 	// or result types must map to WebAssembly numeric value types. This means
-	// uint32, int32, uint64, int32 float32 or float64.
+	// uint32, int32, uint64, int64, float32 or float64.
 	//
 	// api.Module may be specified as the second parameter, usually to access
 	// memory. This is important because there are only numeric types in Wasm.


### PR DESCRIPTION
It seems `int32` was repeated twice, based on the pattern I assumed the second occurrence was meant to be `int64`.