### PR TITLE
Documents api.Closer closes even if a context is canceled

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -189,10 +189,12 @@ type Module interface {
 }
 
 // Closer closes a resource.
-//
-// Note: This is an interface for decoupling, not third-party implementations. All implementations are in wazero.
 type Closer interface {
 	// Close closes the resource.
+	//
+	// Note: The context parameter is used for value lookup, such as for
+	// logging. A canceled or otherwise done context will not prevent Close
+	// from succeeding.
 	Close(context.Context) error
 }
 


### PR DESCRIPTION
We were missing documentation around our Closer, specifically that the context parameter won't obviate closing the resource. Thanks @ItalyPaleAle for drawing attention to this.