### PR TITLE
wasi: removes constraint around closing a pre-open

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -164,11 +164,11 @@ func Test_fdClose(t *testing.T) {
 `, "\n"+log.String())
 	})
 	log.Reset()
-	t.Run("ErrnoNotsup for a preopen", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoNotsup, mod, FdCloseName, uint64(sys.FdPreopen))
+	t.Run("Can close a pre-open", func(t *testing.T) {
+		requireErrnoResult(t, ErrnoSuccess, mod, FdCloseName, uint64(sys.FdPreopen))
 		require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_close(fd=3)
-<== errno=ENOTSUP
+<== errno=ESUCCESS
 `, "\n"+log.String())
 	})
 }

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -447,10 +447,6 @@ func (c *FSContext) CloseFile(fd uint32) error {
 	f, ok := c.openedFiles.Lookup(fd)
 	if !ok {
 		return syscall.EBADF
-	} else if f.IsPreopen {
-		// WASI is the only user of pre-opens and wasi-testsuite disallows this
-		// See https://github.com/WebAssembly/wasi-testsuite/issues/50
-		return syscall.ENOTSUP
 	}
 	c.openedFiles.Delete(fd)
 	return f.File.Close()

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -125,8 +125,8 @@ func TestFSContext_CloseFile(t *testing.T) {
 	t.Run("EBADF for an invalid FD", func(t *testing.T) {
 		require.Equal(t, syscall.EBADF, fsc.CloseFile(42)) // 42 is an arbitrary invalid FD
 	})
-	t.Run("ENOTSUP for a preopen", func(t *testing.T) {
-		require.Equal(t, syscall.ENOTSUP, fsc.CloseFile(FdPreopen)) // 42 is an arbitrary invalid FD
+	t.Run("Can close a pre-open", func(t *testing.T) {
+		require.NoError(t, fsc.CloseFile(FdPreopen))
 	})
 }
 


### PR DESCRIPTION
wasi-testsuite changed its mind.

See https://github.com/WebAssembly/wasi-testsuite/pull/66