### PR TITLE
wasi: enforce EPERM on malformed paths

### DIFF
--- a/.github/wasi_testsuite_skip.json
+++ b/.github/wasi_testsuite_skip.json
@@ -1,5 +1,4 @@
 {
   "WASI Rust tests": {
-    "interesting_paths": "config is broken, and after fixing it forbids leading slash with EPERM"
   }
 }

--- a/internal/platform/errno_windows.go
+++ b/internal/platform/errno_windows.go
@@ -16,6 +16,10 @@ const (
 	// instead of syscall.EEXIST
 	ERROR_FILE_EXISTS = syscall.Errno(0x50)
 
+	// ERROR_INVALID_NAME is a Windows error returned by open when a file
+	// path has a trailing slash
+	ERROR_INVALID_NAME = syscall.Errno(0x7B)
+
 	// ERROR_NEGATIVE_SEEK is a Windows error returned by os.Truncate
 	// instead of syscall.EINVAL
 	ERROR_NEGATIVE_SEEK = syscall.Errno(0x83)
@@ -27,10 +31,6 @@ const (
 	// ERROR_ALREADY_EXISTS is a Windows error returned by os.Mkdir
 	// instead of syscall.EEXIST
 	ERROR_ALREADY_EXISTS = syscall.Errno(0xB7)
-
-	// ERROR_INVALID_NAME is a Windows error returned by open when a file
-	// path has a trailing slash
-	ERROR_INVALID_NAME = syscall.Errno(0xFE)
 
 	// ERROR_DIRECTORY is a Windows error returned by syscall.Rmdir
 	// instead of syscall.ENOTDIR

--- a/internal/platform/errno_windows.go
+++ b/internal/platform/errno_windows.go
@@ -28,6 +28,10 @@ const (
 	// instead of syscall.EEXIST
 	ERROR_ALREADY_EXISTS = syscall.Errno(0xB7)
 
+	// ERROR_INVALID_NAME is a Windows error returned by open when a file
+	// path has a trailing slash
+	ERROR_INVALID_NAME = syscall.Errno(0xFE)
+
 	// ERROR_DIRECTORY is a Windows error returned by syscall.Rmdir
 	// instead of syscall.ENOTDIR
 	ERROR_DIRECTORY = syscall.Errno(0x10B)
@@ -57,7 +61,7 @@ func adjustErrno(err syscall.Errno) syscall.Errno {
 		return syscall.EBADF
 	case ERROR_ACCESS_DENIED, ERROR_PRIVILEGE_NOT_HELD:
 		return syscall.EPERM
-	case ERROR_NEGATIVE_SEEK:
+	case ERROR_NEGATIVE_SEEK, ERROR_INVALID_NAME:
 		return syscall.EINVAL
 	}
 	return err

--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"io/fs"
 	"os"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -53,6 +54,11 @@ func openFile(path string, flag int, perm fs.FileMode) (*os.File, syscall.Errno)
 	}
 
 	switch errno {
+	case syscall.EINVAL:
+		// WASI expects ENOTDIR for a file path with a trailing slash.
+		if strings.HasSuffix(path, "/") {
+			errno = syscall.ENOTDIR
+		}
 	// To match expectations of WASI, e.g. TinyGo TestStatBadDir, return
 	// ENOENT, not ENOTDIR.
 	case syscall.ENOTDIR:


### PR DESCRIPTION
It seems WASI now forbids root and relative paths on the at file descriptor and returns EPERM otherwise. This enforces the following:

* require EPERM when you escape a directory (../)
* require EPERM if you add a leading slash (absolute path)
* require ENOENT if you add a trailing slash to a file
* require success if you add a trailing slash to a directory

See https://github.com/WebAssembly/wasi-testsuite/pull/67