### PR TITLE
build: correctly replace space with comma regardless GNU/BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ test:
 # replace spaces with commas
 coverpkg = $(shell echo $(main_packages) | tr ' ' ',')
 coverage: ## Generate test coverage
-	@go test -coverpkg=$(coverpkg) -coverprofile=coverage.txt -covermode=atomic $(main_packages)
+	@go test -coverprofile=coverage.txt -covermode=atomic --coverpkg=$(coverpkg) $(main_packages)
 	@go tool cover -func coverage.txt
 
 .PHONY: spectest

--- a/Makefile
+++ b/Makefile
@@ -176,9 +176,9 @@ test:
 
 .PHONY: coverage
 # replace spaces with commas
-coverpkg = $(main_packages: =,)
+coverpkg = $(shell echo $(main_packages) | tr ' ' ',')
 coverage: ## Generate test coverage
-	@go test -coverprofile=coverage.txt -covermode=atomic --coverpkg=$(coverpkg) $(main_packages)
+	@go test -coverpkg=$(coverpkg) -coverprofile=coverage.txt -covermode=atomic $(main_packages)
 	@go tool cover -func coverage.txt
 
 .PHONY: spectest


### PR DESCRIPTION
The fix #1195 was incorrect and resulted in insufficient coverage results (you can check by comparing [before 1995](https://github.com/tetratelabs/wazero/actions/runs/4319671295/jobs/7539103651) and [after](https://github.com/tetratelabs/wazero/actions/runs/4488542958/jobs/7893279544)). Notably, the current main only produces the coverage result of the top `wazero` package.