### PR TITLE
renames internal wasi package to wasip1 and removes dot imports

### DIFF
--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
@@ -35,7 +35,7 @@ func (u uniqGoFuncs) callees() []string {
 }
 
 // NewListener implements FunctionListenerFactory.NewListener
-func (u uniqGoFuncs) NewListener(def api.FunctionDefinition) FunctionListener {
+func (u uniqGoFuncs) NewListener(def api.FunctionDefinition) experimental.FunctionListener {
 	if def.GoFunction() == nil {
 		return nil // only track go funcs
 	}
@@ -56,7 +56,7 @@ func Example_customListenerFactory() {
 	u := uniqGoFuncs{}
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(context.Background(), FunctionListenerFactoryKey{}, u)
+	ctx := context.WithValue(context.Background(), experimental.FunctionListenerFactoryKey{}, u)
 
 	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx) // This closes everything this Runtime created.

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 // compile-time check to ensure recorder implements FunctionListenerFactory
-var _ FunctionListenerFactory = &recorder{}
+var _ experimental.FunctionListenerFactory = &recorder{}
 
 type recorder struct {
 	m                       map[string]struct{}
@@ -30,7 +30,7 @@ func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefini
 	r.afterNames = append(r.afterNames, def.DebugName())
 }
 
-func (r *recorder) NewListener(definition api.FunctionDefinition) FunctionListener {
+func (r *recorder) NewListener(definition api.FunctionDefinition) experimental.FunctionListener {
 	r.m[definition.Name()] = struct{}{}
 	return r
 }
@@ -38,7 +38,7 @@ func (r *recorder) NewListener(definition api.FunctionDefinition) FunctionListen
 func TestFunctionListenerFactory(t *testing.T) {
 	// Set context to one that has an experimental listener
 	factory := &recorder{m: map[string]struct{}{}}
-	ctx := context.WithValue(context.Background(), FunctionListenerFactoryKey{}, factory)
+	ctx := context.WithValue(context.Background(), experimental.FunctionListenerFactoryKey{}, factory)
 
 	// Define a module with two functions
 	bin := binaryencoding.EncodeModule(&wasm.Module{

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -10,8 +10,8 @@ import (
 	aslogging "github.com/tetratelabs/wazero/internal/assemblyscript/logging"
 	gologging "github.com/tetratelabs/wazero/internal/gojs/logging"
 	"github.com/tetratelabs/wazero/internal/logging"
-	"github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
-	wasilogging "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1/logging"
+	"github.com/tetratelabs/wazero/internal/wasip1"
+	wasilogging "github.com/tetratelabs/wazero/internal/wasip1/logging"
 )
 
 type Writer interface {
@@ -107,7 +107,7 @@ func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experim
 	var pSampler logging.ParamSampler
 	var rLoggers []logging.ResultLogger
 	switch fnd.ModuleName() {
-	case wasi_snapshot_preview1.InternalModuleName:
+	case wasip1.InternalModuleName:
 		if !wasilogging.IsInLogScope(fnd, f.scopes) {
 			return nil
 		}

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	wasi "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	wasi "github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/imports/emscripten/emscripten_test.go
+++ b/imports/emscripten/emscripten_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/tetratelabs/wazero"
-	. "github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -34,7 +34,7 @@ func TestGrow(t *testing.T) {
 	var log bytes.Buffer
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{},
+	ctx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{},
 		logging.NewHostLoggingListenerFactory(&log, logging.LogScopeMemory))
 
 	r := wazero.NewRuntime(ctx)
@@ -58,7 +58,7 @@ func TestInvoke(t *testing.T) {
 	var log bytes.Buffer
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(testCtx, FunctionListenerFactoryKey{}, logging.NewLoggingListenerFactory(&log))
+	ctx := context.WithValue(testCtx, experimental.FunctionListenerFactoryKey{}, logging.NewLoggingListenerFactory(&log))
 
 	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx)

--- a/imports/wasi_snapshot_preview1/args.go
+++ b/imports/wasi_snapshot_preview1/args.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -41,7 +41,7 @@ import (
 // See argsSizesGet
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_get
 // See https://en.wikipedia.org/wiki/Null-terminated_string
-var argsGet = newHostFunc(ArgsGetName, argsGetFn, []api.ValueType{i32, i32}, "argv", "argv_buf")
+var argsGet = newHostFunc(wasip1.ArgsGetName, argsGetFn, []api.ValueType{i32, i32}, "argv", "argv_buf")
 
 func argsGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
@@ -78,7 +78,7 @@ func argsGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno
 // See argsGet
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#args_sizes_get
 // See https://en.wikipedia.org/wiki/Null-terminated_string
-var argsSizesGet = newHostFunc(ArgsSizesGetName, argsSizesGetFn, []api.ValueType{i32, i32}, "result.argc", "result.argv_len")
+var argsSizesGet = newHostFunc(wasip1.ArgsSizesGetName, argsSizesGetFn, []api.ValueType{i32, i32}, "result.argc", "result.argv_len")
 
 func argsSizesGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys

--- a/imports/wasi_snapshot_preview1/args_test.go
+++ b/imports/wasi_snapshot_preview1/args_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 func Test_argsGet(t *testing.T) {
@@ -26,7 +26,7 @@ func Test_argsGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory)+int(argvBuf))
 
 	// Invoke argsGet and check the memory side effects.
-	requireErrnoResult(t, ErrnoSuccess, mod, ArgsGetName, uint64(argv), uint64(argvBuf))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.ArgsGetName, uint64(argv), uint64(argvBuf))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.args_get(argv=22,argv_buf=16)
 <== errno=ESUCCESS
@@ -95,7 +95,7 @@ func Test_argsGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, ErrnoFault, mod, ArgsGetName, uint64(tc.argv), uint64(tc.argvBuf))
+			requireErrnoResult(t, wasip1.ErrnoFault, mod, wasip1.ArgsGetName, uint64(tc.argv), uint64(tc.argvBuf))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -118,7 +118,7 @@ func Test_argsSizesGet(t *testing.T) {
 	maskMemory(t, mod, int(resultArgc)+len(expectedMemory))
 
 	// Invoke argsSizesGet and check the memory side effects.
-	requireErrnoResult(t, ErrnoSuccess, mod, ArgsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.ArgsSizesGetName, uint64(resultArgc), uint64(resultArgvLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.args_sizes_get(result.argc=16,result.argv_len=21)
 <== errno=ESUCCESS
@@ -185,7 +185,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, ErrnoFault, mod, ArgsSizesGetName, uint64(tc.argc), uint64(tc.argvLen))
+			requireErrnoResult(t, wasip1.ErrnoFault, mod, wasip1.ArgsSizesGetName, uint64(tc.argc), uint64(tc.argvLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/clock.go
+++ b/imports/wasi_snapshot_preview1/clock.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -37,7 +37,7 @@ import (
 // Note: This is similar to `clock_getres` in POSIX.
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_res_getid-clockid---errno-timestamp
 // See https://linux.die.net/man/3/clock_getres
-var clockResGet = newHostFunc(ClockResGetName, clockResGetFn, []api.ValueType{i32, i32}, "id", "result.resolution")
+var clockResGet = newHostFunc(wasip1.ClockResGetName, clockResGetFn, []api.ValueType{i32, i32}, "id", "result.resolution")
 
 func clockResGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
@@ -45,9 +45,9 @@ func clockResGetFn(_ context.Context, mod api.Module, params []uint64) syscall.E
 
 	var resolution uint64 // ns
 	switch id {
-	case ClockIDRealtime:
+	case wasip1.ClockIDRealtime:
 		resolution = uint64(sysCtx.WalltimeResolution())
-	case ClockIDMonotonic:
+	case wasip1.ClockIDMonotonic:
 		resolution = uint64(sysCtx.NanotimeResolution())
 	default:
 		return syscall.EINVAL
@@ -90,7 +90,7 @@ func clockResGetFn(_ context.Context, mod api.Module, params []uint64) syscall.E
 // Note: This is similar to `clock_gettime` in POSIX.
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-clock_time_getid-clockid-precision-timestamp---errno-timestamp
 // See https://linux.die.net/man/3/clock_gettime
-var clockTimeGet = newHostFunc(ClockTimeGetName, clockTimeGetFn, []api.ValueType{i32, i64, i32}, "id", "precision", "result.timestamp")
+var clockTimeGet = newHostFunc(wasip1.ClockTimeGetName, clockTimeGetFn, []api.ValueType{i32, i64, i32}, "id", "precision", "result.timestamp")
 
 func clockTimeGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
@@ -101,9 +101,9 @@ func clockTimeGetFn(_ context.Context, mod api.Module, params []uint64) syscall.
 
 	var val int64
 	switch id {
-	case ClockIDRealtime:
+	case wasip1.ClockIDRealtime:
 		val = sysCtx.WalltimeNanos()
-	case ClockIDMonotonic:
+	case wasip1.ClockIDMonotonic:
 		val = sysCtx.Nanotime()
 	default:
 		return syscall.EINVAL

--- a/imports/wasi_snapshot_preview1/environ.go
+++ b/imports/wasi_snapshot_preview1/environ.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -41,7 +41,7 @@ import (
 // See environSizesGet
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#environ_get
 // See https://en.wikipedia.org/wiki/Null-terminated_string
-var environGet = newHostFunc(EnvironGetName, environGetFn, []api.ValueType{i32, i32}, "environ", "environ_buf")
+var environGet = newHostFunc(wasip1.EnvironGetName, environGetFn, []api.ValueType{i32, i32}, "environ", "environ_buf")
 
 func environGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys
@@ -81,7 +81,7 @@ func environGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Er
 // See environGet
 // https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#environ_sizes_get
 // and https://en.wikipedia.org/wiki/Null-terminated_string
-var environSizesGet = newHostFunc(EnvironSizesGetName, environSizesGetFn, []api.ValueType{i32, i32}, "result.environc", "result.environv_len")
+var environSizesGet = newHostFunc(wasip1.EnvironSizesGetName, environSizesGetFn, []api.ValueType{i32, i32}, "result.environc", "result.environv_len")
 
 func environSizesGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys

--- a/imports/wasi_snapshot_preview1/environ_test.go
+++ b/imports/wasi_snapshot_preview1/environ_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 func Test_environGet(t *testing.T) {
@@ -28,7 +28,7 @@ func Test_environGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory)+int(resultEnvironBuf))
 
 	// Invoke environGet and check the memory side effects.
-	requireErrnoResult(t, ErrnoSuccess, mod, EnvironGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.EnvironGetName, uint64(resultEnviron), uint64(resultEnvironBuf))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.environ_get(environ=26,environ_buf=16)
 <== errno=ESUCCESS
@@ -98,7 +98,7 @@ func Test_environGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, ErrnoFault, mod, EnvironGetName, uint64(tc.environ), uint64(tc.environBuf))
+			requireErrnoResult(t, wasip1.ErrnoFault, mod, wasip1.EnvironGetName, uint64(tc.environ), uint64(tc.environBuf))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -122,7 +122,7 @@ func Test_environSizesGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory)+int(resultEnvironc))
 
 	// Invoke environSizesGet and check the memory side effects.
-	requireErrnoResult(t, ErrnoSuccess, mod, EnvironSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.EnvironSizesGetName, uint64(resultEnvironc), uint64(resultEnvironvLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.environ_sizes_get(result.environc=16,result.environv_len=21)
 <== errno=ESUCCESS
@@ -190,7 +190,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, ErrnoFault, mod, EnvironSizesGetName, uint64(tc.environc), uint64(tc.environLen))
+			requireErrnoResult(t, wasip1.ErrnoFault, mod, wasip1.EnvironSizesGetName, uint64(tc.environc), uint64(tc.environLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -24,21 +24,21 @@ import (
 	"github.com/tetratelabs/wazero/internal/sysfs"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 func Test_fdAdvise(t *testing.T) {
 	mod, r, _ := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
-	requireErrnoResult(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNormal))
-	requireErrnoResult(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceSequential))
-	requireErrnoResult(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceRandom))
-	requireErrnoResult(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceWillNeed))
-	requireErrnoResult(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceDontNeed))
-	requireErrnoResult(t, ErrnoSuccess, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNoReuse))
-	requireErrnoResult(t, ErrnoInval, mod, FdAdviseName, uint64(3), 0, 0, uint64(FdAdviceNoReuse+1))
-	requireErrnoResult(t, ErrnoBadf, mod, FdAdviseName, uint64(1111111), 0, 0, uint64(FdAdviceNoReuse+1))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceNormal))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceSequential))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceRandom))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceWillNeed))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceDontNeed))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceNoReuse))
+	requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdAdviseName, uint64(3), 0, 0, uint64(wasip1.FdAdviceNoReuse+1))
+	requireErrnoResult(t, wasip1.ErrnoBadf, mod, wasip1.FdAdviseName, uint64(1111111), 0, 0, uint64(wasip1.FdAdviceNoReuse+1))
 }
 
 // Test_fdAllocate only tests it is stubbed for GrainLang per #271
@@ -70,11 +70,11 @@ func Test_fdAllocate(t *testing.T) {
 	}
 
 	t.Run("errors", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoBadf, mod, FdAllocateName, uint64(12345), 0, 0)
+		requireErrnoResult(t, wasip1.ErrnoBadf, mod, wasip1.FdAllocateName, uint64(12345), 0, 0)
 		minusOne := int64(-1)
-		requireErrnoResult(t, ErrnoInval, mod, FdAllocateName, uint64(fd), uint64(minusOne), uint64(minusOne))
-		requireErrnoResult(t, ErrnoInval, mod, FdAllocateName, uint64(fd), 0, uint64(minusOne))
-		requireErrnoResult(t, ErrnoInval, mod, FdAllocateName, uint64(fd), uint64(minusOne), 0)
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdAllocateName, uint64(fd), uint64(minusOne), uint64(minusOne))
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdAllocateName, uint64(fd), 0, uint64(minusOne))
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdAllocateName, uint64(fd), uint64(minusOne), 0)
 	})
 
 	t.Run("do not change size", func(t *testing.T) {
@@ -85,7 +85,7 @@ func Test_fdAllocate(t *testing.T) {
 			{offset: 10, length: 0},
 		} {
 			// This shouldn't change the size.
-			requireErrnoResult(t, ErrnoSuccess, mod, FdAllocateName,
+			requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAllocateName,
 				uint64(fd), tc.offset, tc.length)
 			requireSizeEqual(10)
 		}
@@ -93,7 +93,7 @@ func Test_fdAllocate(t *testing.T) {
 
 	t.Run("increase", func(t *testing.T) {
 		// 10 + 10 > the current size -> increase the size.
-		requireErrnoResult(t, ErrnoSuccess, mod, FdAllocateName,
+		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdAllocateName,
 			uint64(fd), 10, 10)
 		requireSizeEqual(20)
 
@@ -142,7 +142,7 @@ func Test_fdClose(t *testing.T) {
 	require.Zero(t, errno)
 
 	// Close
-	requireErrnoResult(t, ErrnoSuccess, mod, FdCloseName, uint64(fdToClose))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdCloseName, uint64(fdToClose))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_close(fd=4)
 <== errno=ESUCCESS
@@ -158,7 +158,7 @@ func Test_fdClose(t *testing.T) {
 
 	log.Reset()
 	t.Run("ErrnoBadF for an invalid FD", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoBadf, mod, FdCloseName, uint64(42)) // 42 is an arbitrary invalid Fd
+		requireErrnoResult(t, wasip1.ErrnoBadf, mod, wasip1.FdCloseName, uint64(42)) // 42 is an arbitrary invalid Fd
 		require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_close(fd=42)
 <== errno=EBADF
@@ -166,7 +166,7 @@ func Test_fdClose(t *testing.T) {
 	})
 	log.Reset()
 	t.Run("Can close a pre-open", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoSuccess, mod, FdCloseName, uint64(sys.FdPreopen))
+		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdCloseName, uint64(sys.FdPreopen))
 		require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_close(fd=3)
 <== errno=ESUCCESS
@@ -184,13 +184,13 @@ func Test_fdDatasync(t *testing.T) {
 	tests := []struct {
 		name          string
 		fd            uint32
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_datasync(fd=42)
 <== errno=EBADF
@@ -199,7 +199,7 @@ func Test_fdDatasync(t *testing.T) {
 		{
 			name:          "valid FD",
 			fd:            fd,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_datasync(fd=4)
 <== errno=ESUCCESS
@@ -212,7 +212,7 @@ func Test_fdDatasync(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdDatasyncName, uint64(tc.fd))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdDatasyncName, uint64(tc.fd))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -238,7 +238,7 @@ func Test_fdFdstatGet(t *testing.T) {
 		name             string
 		fd, resultFdstat uint32
 		expectedMemory   []byte
-		expectedErrno    Errno
+		expectedErrno    wasip1.Errno
 		expectedLog      string
 	}{
 		{
@@ -328,7 +328,7 @@ func Test_fdFdstatGet(t *testing.T) {
 		{
 			name:          "bad FD",
 			fd:            math.MaxUint32,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=-1)
 <== (stat=,errno=EBADF)
@@ -338,7 +338,7 @@ func Test_fdFdstatGet(t *testing.T) {
 			name:          "resultFdstat exceeds the maximum valid address by 1",
 			fd:            dirFD,
 			resultFdstat:  memorySize - 24 + 1,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=5)
 <== (stat=,errno=EFAULT)
@@ -354,7 +354,7 @@ func Test_fdFdstatGet(t *testing.T) {
 
 			maskMemory(t, mod, len(tc.expectedMemory))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdFdstatGetName, uint64(tc.fd), uint64(tc.resultFdstat))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdFdstatGetName, uint64(tc.fd), uint64(tc.resultFdstat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
@@ -402,7 +402,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 		ok := mod.Memory().Write(0, initialMemory)
 		require.True(t, ok)
 
-		requireErrnoResult(t, ErrnoSuccess, mod, FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
+		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 		require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=1,iovs_len=2)
 <== (nwritten=6,errno=ESUCCESS)
@@ -421,7 +421,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 	requireFileContent("0123456789" + "wazero")
 
 	// Let's remove O_APPEND.
-	requireErrnoResult(t, ErrnoSuccess, mod, FdFdstatSetFlagsName, uint64(fd), uint64(0))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdFdstatSetFlagsName, uint64(fd), uint64(0))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=4,flags=0)
 <== errno=ESUCCESS
@@ -433,7 +433,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 	requireFileContent("wazero6789" + "wazero")
 
 	// Restore the O_APPEND flag.
-	requireErrnoResult(t, ErrnoSuccess, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_APPEND))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdFdstatSetFlagsName, uint64(fd), uint64(wasip1.FD_APPEND))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_fdstat_set_flags(fd=4,flags=1)
 <== errno=ESUCCESS
@@ -445,18 +445,18 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 	requireFileContent("wazero6789" + "wazero" + "wazero")
 
 	t.Run("errors", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_DSYNC))
-		requireErrnoResult(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_NONBLOCK))
-		requireErrnoResult(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_RSYNC))
-		requireErrnoResult(t, ErrnoInval, mod, FdFdstatSetFlagsName, uint64(fd), uint64(FD_SYNC))
-		requireErrnoResult(t, ErrnoBadf, mod, FdFdstatSetFlagsName, uint64(12345), uint64(FD_APPEND))
-		requireErrnoResult(t, ErrnoIsdir, mod, FdFdstatSetFlagsName, uint64(3) /* preopen */, uint64(FD_APPEND))
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdFdstatSetFlagsName, uint64(fd), uint64(wasip1.FD_DSYNC))
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdFdstatSetFlagsName, uint64(fd), uint64(wasip1.FD_NONBLOCK))
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdFdstatSetFlagsName, uint64(fd), uint64(wasip1.FD_RSYNC))
+		requireErrnoResult(t, wasip1.ErrnoInval, mod, wasip1.FdFdstatSetFlagsName, uint64(fd), uint64(wasip1.FD_SYNC))
+		requireErrnoResult(t, wasip1.ErrnoBadf, mod, wasip1.FdFdstatSetFlagsName, uint64(12345), uint64(wasip1.FD_APPEND))
+		requireErrnoResult(t, wasip1.ErrnoIsdir, mod, wasip1.FdFdstatSetFlagsName, uint64(3) /* preopen */, uint64(wasip1.FD_APPEND))
 	})
 }
 
 // Test_fdFdstatSetRights only tests it is stubbed for GrainLang per #271
 func Test_fdFdstatSetRights(t *testing.T) {
-	log := requireErrnoNosys(t, FdFdstatSetRightsName, 0, 0, 0)
+	log := requireErrnoNosys(t, wasip1.FdFdstatSetRightsName, 0, 0, 0)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_fdstat_set_rights(fd=0,fs_rights_base=,fs_rights_inheriting=)
 <== errno=ENOSYS
@@ -483,7 +483,7 @@ func Test_fdFilestatGet(t *testing.T) {
 		name               string
 		fd, resultFilestat uint32
 		expectedMemory     []byte
-		expectedErrno      Errno
+		expectedErrno      wasip1.Errno
 		expectedLog        string
 	}{
 		{
@@ -600,7 +600,7 @@ func Test_fdFilestatGet(t *testing.T) {
 		{
 			name:          "bad FD",
 			fd:            math.MaxUint32,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=-1)
 <== (filestat=,errno=EBADF)
@@ -610,7 +610,7 @@ func Test_fdFilestatGet(t *testing.T) {
 			name:           "resultFilestat exceeds the maximum valid address by 1",
 			fd:             dirFD,
 			resultFilestat: memorySize - 64 + 1,
-			expectedErrno:  ErrnoFault,
+			expectedErrno:  wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_get(fd=5)
 <== (filestat=,errno=EFAULT)
@@ -626,7 +626,7 @@ func Test_fdFilestatGet(t *testing.T) {
 
 			maskMemory(t, mod, len(tc.expectedMemory))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdFilestatGetName, uint64(tc.fd), uint64(tc.resultFilestat))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdFilestatGetName, uint64(tc.fd), uint64(tc.resultFilestat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
@@ -644,13 +644,13 @@ func Test_fdFilestatSetSize(t *testing.T) {
 		size                     uint32
 		content, expectedContent []byte
 		expectedLog              string
-		expectedErrno            Errno
+		expectedErrno            wasip1.Errno
 	}{
 		{
 			name:            "badf",
 			content:         []byte("badf"),
 			expectedContent: []byte("badf"),
-			expectedErrno:   ErrnoBadf,
+			expectedErrno:   wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_size(fd=5,size=0)
 <== errno=EBADF
@@ -661,7 +661,7 @@ func Test_fdFilestatSetSize(t *testing.T) {
 			content:         []byte("123456"),
 			expectedContent: []byte("12345"),
 			size:            5,
-			expectedErrno:   ErrnoSuccess,
+			expectedErrno:   wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_size(fd=4,size=5)
 <== errno=ESUCCESS
@@ -672,7 +672,7 @@ func Test_fdFilestatSetSize(t *testing.T) {
 			content:         []byte("123456"),
 			expectedContent: []byte(""),
 			size:            0,
-			expectedErrno:   ErrnoSuccess,
+			expectedErrno:   wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_size(fd=4,size=0)
 <== errno=ESUCCESS
@@ -683,7 +683,7 @@ func Test_fdFilestatSetSize(t *testing.T) {
 			content:         []byte("123456"),
 			expectedContent: append([]byte("123456"), make([]byte, 100)...),
 			size:            106,
-			expectedErrno:   ErrnoSuccess,
+			expectedErrno:   wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_size(fd=4,size=106)
 <== errno=ESUCCESS
@@ -701,7 +701,7 @@ func Test_fdFilestatSetSize(t *testing.T) {
 			if filepath == "badf" {
 				fd++
 			}
-			requireErrnoResult(t, tc.expectedErrno, mod, FdFilestatSetSizeName, uint64(fd), uint64(tc.size))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdFilestatSetSizeName, uint64(fd), uint64(tc.size))
 
 			actual, err := os.ReadFile(joinPath(tmpDir, filepath))
 			require.NoError(t, err)
@@ -720,11 +720,11 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		mtime, atime  int64
 		flags         uint16
 		expectedLog   string
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 	}{
 		{
 			name:          "badf",
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=-1,atim=0,mtim=0,fst_flags=)
 <== errno=EBADF
@@ -734,7 +734,7 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 			name:          "a=omit,m=omit",
 			mtime:         1234,   // Must be ignored.
 			atime:         123451, // Must be ignored.
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=123451,mtim=1234,fst_flags=)
 <== errno=ESUCCESS
@@ -742,10 +742,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:          "a=now,m=omit",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         1234,   // Must be ignored.
 			atime:         123451, // Must be ignored.
-			flags:         FstflagsAtimNow,
+			flags:         wasip1.FstflagsAtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=123451,mtim=1234,fst_flags=ATIM_NOW)
 <== errno=ESUCCESS
@@ -753,10 +753,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:          "a=omit,m=now",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         1234,   // Must be ignored.
 			atime:         123451, // Must be ignored.
-			flags:         FstflagsMtimNow,
+			flags:         wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=123451,mtim=1234,fst_flags=MTIM_NOW)
 <== errno=ESUCCESS
@@ -764,10 +764,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:          "a=now,m=now",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         1234,   // Must be ignored.
 			atime:         123451, // Must be ignored.
-			flags:         FstflagsAtimNow | FstflagsMtimNow,
+			flags:         wasip1.FstflagsAtimNow | wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=123451,mtim=1234,fst_flags=ATIM_NOW|MTIM_NOW)
 <== errno=ESUCCESS
@@ -775,10 +775,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:          "a=now,m=set",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         55555500,
 			atime:         1234, // Must be ignored.
-			flags:         FstflagsAtimNow | FstflagsMtim,
+			flags:         wasip1.FstflagsAtimNow | wasip1.FstflagsMtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=1234,mtim=55555500,fst_flags=ATIM_NOW|MTIM)
 <== errno=ESUCCESS
@@ -786,10 +786,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:          "a=set,m=now",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         1234, // Must be ignored.
 			atime:         55555500,
-			flags:         FstflagsAtim | FstflagsMtimNow,
+			flags:         wasip1.FstflagsAtim | wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=55555500,mtim=1234,fst_flags=ATIM|MTIM_NOW)
 <== errno=ESUCCESS
@@ -797,10 +797,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:          "a=set,m=omit",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         1234, // Must be ignored.
 			atime:         55555500,
-			flags:         FstflagsAtim,
+			flags:         wasip1.FstflagsAtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=55555500,mtim=1234,fst_flags=ATIM)
 <== errno=ESUCCESS
@@ -809,10 +809,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 
 		{
 			name:          "a=omit,m=set",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         55555500,
 			atime:         1234, // Must be ignored.
-			flags:         FstflagsMtim,
+			flags:         wasip1.FstflagsMtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=1234,mtim=55555500,fst_flags=MTIM)
 <== errno=ESUCCESS
@@ -821,10 +821,10 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 
 		{
 			name:          "a=set,m=set",
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			mtime:         55555500,
 			atime:         6666666600,
-			flags:         FstflagsAtim | FstflagsMtim,
+			flags:         wasip1.FstflagsAtim | wasip1.FstflagsMtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_times(fd=4,atim=6666666600,mtim=55555500,fst_flags=ATIM|MTIM)
 <== errno=ESUCCESS
@@ -854,27 +854,27 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 			require.NoError(t, err)
 			prevAtime, prevMtime := st.Atim, st.Mtim
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdFilestatSetTimesName,
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdFilestatSetTimesName,
 				uint64(paramFd), uint64(tc.atime), uint64(tc.mtime),
 				uint64(tc.flags),
 			)
 
-			if tc.expectedErrno == ErrnoSuccess {
+			if tc.expectedErrno == wasip1.ErrnoSuccess {
 				f, ok := fsc.LookupFile(fd)
 				require.True(t, ok)
 
 				st, err = f.Stat()
 				require.NoError(t, err)
-				if tc.flags&FstflagsAtim != 0 {
+				if tc.flags&wasip1.FstflagsAtim != 0 {
 					require.Equal(t, tc.atime, st.Atim)
-				} else if tc.flags&FstflagsAtimNow != 0 {
+				} else if tc.flags&wasip1.FstflagsAtimNow != 0 {
 					require.True(t, (sys.WalltimeNanos()-st.Atim) < time.Second.Nanoseconds())
 				} else {
 					require.Equal(t, prevAtime, st.Atim)
 				}
-				if tc.flags&FstflagsMtim != 0 {
+				if tc.flags&wasip1.FstflagsMtim != 0 {
 					require.Equal(t, tc.mtime, st.Mtim)
-				} else if tc.flags&FstflagsMtimNow != 0 {
+				} else if tc.flags&wasip1.FstflagsMtimNow != 0 {
 					require.True(t, (sys.WalltimeNanos()-st.Mtim) < time.Second.Nanoseconds())
 				} else {
 					require.Equal(t, prevMtime, st.Mtim)
@@ -953,7 +953,7 @@ func Test_fdPread(t *testing.T) {
 			ok := mod.Memory().Write(0, initialMemory)
 			require.True(t, ok)
 
-			requireErrnoResult(t, ErrnoSuccess, mod, FdPreadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(tc.offset), uint64(resultNread))
+			requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdPreadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(tc.offset), uint64(resultNread))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
@@ -995,7 +995,7 @@ func Test_fdPread_offset(t *testing.T) {
 	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdPreadName, uint64(fd), uint64(iovs), uint64(iovsCount), 2, uint64(resultNread))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdPreadName, uint64(fd), uint64(iovs), uint64(iovsCount), 2, uint64(resultNread))
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
@@ -1012,7 +1012,7 @@ func Test_fdPread_offset(t *testing.T) {
 		'?',
 	)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
 	actual, ok = mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
@@ -1037,14 +1037,14 @@ func Test_fdPread_Errors(t *testing.T) {
 		fd, iovs, iovsCount, resultNread uint32
 		offset                           int64
 		memory                           []byte
-		expectedErrno                    Errno
+		expectedErrno                    wasip1.Errno
 		expectedLog                      string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42,                         // arbitrary invalid fd
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nread validation
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=42,iovs=65532,iovs_len=0,offset=0)
 <== (nread=,errno=EBADF)
@@ -1055,7 +1055,7 @@ func Test_fdPread_Errors(t *testing.T) {
 			fd:            fd,
 			iovs:          1,
 			memory:        []byte{'?'},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65536,iovs_len=0,offset=0)
 <== (nread=,errno=EFAULT)
@@ -1069,7 +1069,7 @@ func Test_fdPread_Errors(t *testing.T) {
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65532,iovs_len=1,offset=0)
 <== (nread=,errno=EFAULT)
@@ -1084,7 +1084,7 @@ func Test_fdPread_Errors(t *testing.T) {
 				0, 0, 0x1, 0, // = iovs[0].offset on the second page
 				1, 0, 0, 0, // = iovs[0].length
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65528,iovs_len=1,offset=0)
 <== (nread=,errno=EFAULT)
@@ -1100,7 +1100,7 @@ func Test_fdPread_Errors(t *testing.T) {
 				0, 0, 0x1, 0, // = iovs[0].length on the second page
 				'?',
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=1,offset=0)
 <== (nread=,errno=EFAULT)
@@ -1117,7 +1117,7 @@ func Test_fdPread_Errors(t *testing.T) {
 				1, 0, 0, 0, // = iovs[0].length
 				'?',
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65527,iovs_len=1,offset=0)
 <== (nread=,errno=EFAULT)
@@ -1136,7 +1136,7 @@ func Test_fdPread_Errors(t *testing.T) {
 				'?', '?', '?', '?',
 			},
 			offset:        int64(-1),
-			expectedErrno: ErrnoIo,
+			expectedErrno: wasip1.ErrnoIo,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pread(fd=4,iovs=65523,iovs_len=1,offset=-1)
 <== (nread=,errno=EIO)
@@ -1154,7 +1154,7 @@ func Test_fdPread_Errors(t *testing.T) {
 			memoryWriteOK := mod.Memory().Write(offset, tc.memory)
 			require.True(t, memoryWriteOK)
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdPreadName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount), uint64(tc.offset), uint64(tc.resultNread+offset))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdPreadName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount), uint64(tc.offset), uint64(tc.resultNread+offset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -1177,7 +1177,7 @@ func Test_fdPrestatGet(t *testing.T) {
 
 	maskMemory(t, mod, len(expectedMemory))
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdPrestatGetName, uint64(sys.FdPreopen), uint64(resultPrestat))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdPrestatGetName, uint64(sys.FdPreopen), uint64(resultPrestat))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_prestat_get(fd=3)
 <== (prestat={pr_name_len=1},errno=ESUCCESS)
@@ -1197,14 +1197,14 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 		name          string
 		fd            uint32
 		resultPrestat uint32
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
 		{
 			name:          "unopened FD",
 			fd:            42, // arbitrary invalid Fd
 			resultPrestat: 0,  // valid offset
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_get(fd=42)
 <== (prestat=,errno=EBADF)
@@ -1214,7 +1214,7 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			name:          "not pre-opened FD",
 			fd:            dirFD,
 			resultPrestat: 0, // valid offset
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_get(fd=4)
 <== (prestat=,errno=EBADF)
@@ -1224,7 +1224,7 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 			name:          "out-of-memory resultPrestat",
 			fd:            sys.FdPreopen,
 			resultPrestat: memorySize,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_get(fd=3)
 <== (prestat=,errno=EFAULT)
@@ -1238,7 +1238,7 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdPrestatGetName, uint64(tc.fd), uint64(tc.resultPrestat))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdPrestatGetName, uint64(tc.fd), uint64(tc.resultPrestat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -1257,7 +1257,7 @@ func Test_fdPrestatDirName(t *testing.T) {
 
 	maskMemory(t, mod, len(expectedMemory))
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdPrestatDirNameName, uint64(sys.FdPreopen), uint64(path), uint64(pathLen))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdPrestatDirNameName, uint64(sys.FdPreopen), uint64(path), uint64(pathLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
 <== (path=,errno=ESUCCESS)
@@ -1283,7 +1283,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 		fd            uint32
 		path          uint32
 		pathLen       uint32
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
 		{
@@ -1291,7 +1291,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          memorySize,
 			pathLen:       pathLen,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
 <== (path=,errno=EFAULT)
@@ -1302,7 +1302,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          memorySize - pathLen + 1,
 			pathLen:       pathLen,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
 <== (path=,errno=EFAULT)
@@ -1313,7 +1313,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          validAddress,
 			pathLen:       pathLen + 1,
-			expectedErrno: ErrnoNametoolong,
+			expectedErrno: wasip1.ErrnoNametoolong,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=3)
 <== (path=,errno=ENAMETOOLONG)
@@ -1324,7 +1324,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			fd:            42, // arbitrary invalid fd
 			path:          validAddress,
 			pathLen:       pathLen,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=42)
 <== (path=,errno=EBADF)
@@ -1335,7 +1335,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 			fd:            dirFD,
 			path:          validAddress,
 			pathLen:       pathLen,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_prestat_dir_name(fd=4)
 <== (path=,errno=EBADF)
@@ -1349,7 +1349,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdPrestatDirNameName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdPrestatDirNameName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -1426,7 +1426,7 @@ func Test_fdPwrite(t *testing.T) {
 			ok := mod.Memory().Write(0, initialMemory)
 			require.True(t, ok)
 
-			requireErrnoResult(t, ErrnoSuccess, mod, FdPwriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(tc.offset), uint64(resultNwritten))
+			requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdPwriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(tc.offset), uint64(resultNwritten))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
@@ -1474,7 +1474,7 @@ func Test_fdPwrite_offset(t *testing.T) {
 	require.True(t, ok)
 
 	// Write the last half first, to offset 3
-	requireErrnoResult(t, ErrnoSuccess, mod, FdPwriteName, uint64(fd), uint64(iovs), uint64(iovsCount), 3, uint64(resultNwritten))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdPwriteName, uint64(fd), uint64(iovs), uint64(iovsCount), 3, uint64(resultNwritten))
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
@@ -1498,7 +1498,7 @@ func Test_fdPwrite_offset(t *testing.T) {
 	ok = mod.Memory().Write(0, writeMemory)
 	require.True(t, ok)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	actual, ok = mod.Memory().Read(0, uint32(len(expectedMemory)))
 	require.True(t, ok)
 	require.Equal(t, expectedMemory, actual)
@@ -1528,14 +1528,14 @@ func Test_fdPwrite_Errors(t *testing.T) {
 		fd, iovs, iovsCount, resultNwritten uint32
 		offset                              int64
 		memory                              []byte
-		expectedErrno                       Errno
+		expectedErrno                       wasip1.Errno
 		expectedLog                         string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42,                         // arbitrary invalid fd
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nwritten validation
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=42,iovs=65532,iovs_len=0,offset=0)
 <== (nwritten=,errno=EBADF)
@@ -1546,7 +1546,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 			fd:            fd,
 			iovs:          1,
 			memory:        []byte{'?'},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=4,iovs=65536,iovs_len=0,offset=0)
 <== (nwritten=,errno=EFAULT)
@@ -1560,7 +1560,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=4,iovs=65532,iovs_len=1,offset=0)
 <== (nwritten=,errno=EFAULT)
@@ -1575,7 +1575,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 				0, 0, 0x1, 0, // = iovs[0].offset on the second page
 				1, 0, 0, 0, // = iovs[0].length
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=4,iovs=65528,iovs_len=1,offset=0)
 <== (nwritten=,errno=EFAULT)
@@ -1591,7 +1591,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 				0, 0, 0x1, 0, // = iovs[0].length on the second page
 				'?',
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=4,iovs=65527,iovs_len=1,offset=0)
 <== (nwritten=,errno=EFAULT)
@@ -1608,7 +1608,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 				1, 0, 0, 0, // = iovs[0].length
 				'?',
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=4,iovs=65527,iovs_len=1,offset=0)
 <== (nwritten=,errno=EFAULT)
@@ -1627,7 +1627,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 				'?', '?', '?', '?',
 			},
 			offset:        int64(-1),
-			expectedErrno: ErrnoIo,
+			expectedErrno: wasip1.ErrnoIo,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_pwrite(fd=4,iovs=65523,iovs_len=1,offset=-1)
 <== (nwritten=,errno=EIO)
@@ -1645,7 +1645,7 @@ func Test_fdPwrite_Errors(t *testing.T) {
 			memoryWriteOK := mod.Memory().Write(offset, tc.memory)
 			require.True(t, memoryWriteOK)
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdPwriteName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount), uint64(tc.offset), uint64(tc.resultNwritten+offset))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdPwriteName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount), uint64(tc.offset), uint64(tc.resultNwritten+offset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -1681,7 +1681,7 @@ func Test_fdRead(t *testing.T) {
 	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReadName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNread))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_read(fd=4,iovs=1,iovs_len=2)
 <== (nread=6,errno=ESUCCESS)
@@ -1700,14 +1700,14 @@ func Test_fdRead_Errors(t *testing.T) {
 		name                             string
 		fd, iovs, iovsCount, resultNread uint32
 		memory                           []byte
-		expectedErrno                    Errno
+		expectedErrno                    wasip1.Errno
 		expectedLog                      string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42,                         // arbitrary invalid fd
 			memory:        []byte{'?', '?', '?', '?'}, // pass result.nread validation
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_read(fd=42,iovs=65532,iovs_len=65532)
 <== (nread=,errno=EBADF)
@@ -1718,7 +1718,7 @@ func Test_fdRead_Errors(t *testing.T) {
 			fd:            fd,
 			iovs:          1,
 			memory:        []byte{'?'},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65536,iovs_len=65535)
 <== (nread=,errno=EFAULT)
@@ -1732,7 +1732,7 @@ func Test_fdRead_Errors(t *testing.T) {
 				'?',        // `iovs` is after this
 				9, 0, 0, 0, // = iovs[0].offset
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65532,iovs_len=65532)
 <== (nread=,errno=EFAULT)
@@ -1747,7 +1747,7 @@ func Test_fdRead_Errors(t *testing.T) {
 				0, 0, 0x1, 0, // = iovs[0].offset on the second page
 				1, 0, 0, 0, // = iovs[0].length
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65528,iovs_len=65528)
 <== (nread=,errno=EFAULT)
@@ -1763,7 +1763,7 @@ func Test_fdRead_Errors(t *testing.T) {
 				0, 0, 0x1, 0, // = iovs[0].length on the second page
 				'?',
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527)
 <== (nread=,errno=EFAULT)
@@ -1780,7 +1780,7 @@ func Test_fdRead_Errors(t *testing.T) {
 				1, 0, 0, 0, // = iovs[0].length
 				'?',
 			},
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_read(fd=4,iovs=65527,iovs_len=65527)
 <== (nread=,errno=EFAULT)
@@ -1798,7 +1798,7 @@ func Test_fdRead_Errors(t *testing.T) {
 			memoryWriteOK := mod.Memory().Write(offset, tc.memory)
 			require.True(t, memoryWriteOK)
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdReadName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount+offset), uint64(tc.resultNread+offset))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdReadName, uint64(tc.fd), uint64(tc.iovs+offset), uint64(tc.iovsCount+offset), uint64(tc.resultNread+offset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -1906,9 +1906,9 @@ func Test_fdReaddir(t *testing.T) {
 
 				return &sys.FileEntry{File: dir}
 			},
-			bufLen:          DirentSize + 1, // size of one entry
+			bufLen:          wasip1.DirentSize + 1, // size of one entry
 			cookie:          0,
-			expectedBufused: DirentSize + 1, // one dot entry
+			expectedBufused: wasip1.DirentSize + 1, // one dot entry
 			expectedMem:     direntDot,
 			expectedReadDir: &sys.ReadDir{
 				CountRead: 2,
@@ -1940,10 +1940,10 @@ func Test_fdReaddir(t *testing.T) {
 
 				return &sys.FileEntry{File: dir}
 			},
-			bufLen:          DirentSize, // length is long enough for first, but not the name.
+			bufLen:          wasip1.DirentSize, // length is long enough for first, but not the name.
 			cookie:          0,
-			expectedBufused: DirentSize,             // == bufLen which is the size of the dirent
-			expectedMem:     direntDot[:DirentSize], // header without name
+			expectedBufused: wasip1.DirentSize,             // == bufLen which is the size of the dirent
+			expectedMem:     direntDot[:wasip1.DirentSize], // header without name
 			expectedReadDir: &sys.ReadDir{
 				CountRead: 3,
 				Dirents:   testDirents[0:3],
@@ -2161,7 +2161,7 @@ func Test_fdReaddir(t *testing.T) {
 
 			resultBufused := uint32(0) // where to write the amount used out of bufLen
 			buf := uint32(8)           // where to start the dirents
-			requireErrnoResult(t, ErrnoSuccess, mod, FdReaddirName,
+			requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReaddirName,
 				uint64(fd), uint64(buf), uint64(tc.bufLen), uint64(tc.cookie), uint64(resultBufused))
 
 			// read back the bufused and compare memory against it
@@ -2196,7 +2196,7 @@ func Test_fdReaddir_Rewind(t *testing.T) {
 	mem := mod.Memory()
 	const resultBufused, buf, bufSize = 0, 8, 200
 	read := func(cookie, bufSize uint64) (bufUsed uint32) {
-		requireErrnoResult(t, ErrnoSuccess, mod, FdReaddirName,
+		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReaddirName,
 			uint64(fd), buf, bufSize, cookie, uint64(resultBufused))
 
 		bufUsed, ok := mem.ReadUint32Le(resultBufused)
@@ -2266,7 +2266,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 		fd, buf, bufLen, resultBufused uint32
 		cookie                         int64
 		readDir                        *sys.ReadDir
-		expectedErrno                  Errno
+		expectedErrno                  wasip1.Errno
 		expectedLog                    string
 	}{
 		{
@@ -2274,7 +2274,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			fd:            dirFD,
 			buf:           memLen,
 			bufLen:        1000,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=65536,buf_len=1000,cookie=0)
 <== (bufused=,errno=EFAULT)
@@ -2282,10 +2282,10 @@ func Test_fdReaddir_Errors(t *testing.T) {
 		},
 		{
 			name: "invalid FD",
-			fd:   42,                    // arbitrary invalid fd
-			buf:  0, bufLen: DirentSize, // enough to read the dirent
+			fd:   42,                           // arbitrary invalid fd
+			buf:  0, bufLen: wasip1.DirentSize, // enough to read the dirent
 			resultBufused: 1000, // arbitrary
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=42,buf=0,buf_len=24,cookie=0)
 <== (bufused=,errno=EBADF)
@@ -2294,9 +2294,9 @@ func Test_fdReaddir_Errors(t *testing.T) {
 		{
 			name: "not a dir",
 			fd:   fileFD,
-			buf:  0, bufLen: DirentSize, // enough to read the dirent
+			buf:  0, bufLen: wasip1.DirentSize, // enough to read the dirent
 			resultBufused: 1000, // arbitrary
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=0,buf_len=24,cookie=0)
 <== (bufused=,errno=EBADF)
@@ -2307,7 +2307,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			fd:            dirFD,
 			buf:           memLen - 1,
 			bufLen:        1000,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=65535,buf_len=1000,cookie=0)
 <== (bufused=,errno=EFAULT)
@@ -2318,7 +2318,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			fd:   dirFD,
 			buf:  0, bufLen: 1,
 			resultBufused: 1000,
-			expectedErrno: ErrnoInval,
+			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=0,buf_len=1,cookie=0)
 <== (bufused=,errno=EINVAL)
@@ -2330,7 +2330,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			buf:  0, bufLen: 1000,
 			cookie:        1,
 			resultBufused: 2000,
-			expectedErrno: ErrnoInval,
+			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=0,buf_len=1000,cookie=1)
 <== (bufused=,errno=EINVAL)
@@ -2343,7 +2343,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			cookie:        -1,
 			readDir:       &sys.ReadDir{CountRead: 1},
 			resultBufused: 2000,
-			expectedErrno: ErrnoInval,
+			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_readdir(fd=5,buf=0,buf_len=1000,cookie=-1)
 <== (bufused=,errno=EINVAL)
@@ -2366,7 +2366,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 				file.ReadDir = nil
 			}
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdReaddirName,
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdReaddirName,
 				uint64(tc.fd), uint64(tc.buf), uint64(tc.bufLen), uint64(tc.cookie), uint64(tc.resultBufused))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
@@ -2379,14 +2379,14 @@ func Test_fdRenumber(t *testing.T) {
 	tests := []struct {
 		name          string
 		from, to      uint32
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
 		{
 			name:          "from=preopen",
 			from:          sys.FdPreopen,
 			to:            dirFD,
-			expectedErrno: ErrnoNotsup,
+			expectedErrno: wasip1.ErrnoNotsup,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_renumber(fd=3,to=5)
 <== errno=ENOTSUP
@@ -2396,7 +2396,7 @@ func Test_fdRenumber(t *testing.T) {
 			name:          "to=preopen",
 			from:          dirFD,
 			to:            sys.FdPreopen,
-			expectedErrno: ErrnoNotsup,
+			expectedErrno: wasip1.ErrnoNotsup,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_renumber(fd=5,to=3)
 <== errno=ENOTSUP
@@ -2406,7 +2406,7 @@ func Test_fdRenumber(t *testing.T) {
 			name:          "file to dir",
 			from:          fileFD,
 			to:            dirFD,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_renumber(fd=4,to=5)
 <== errno=ESUCCESS
@@ -2416,7 +2416,7 @@ func Test_fdRenumber(t *testing.T) {
 			name:          "dir to file",
 			from:          dirFD,
 			to:            fileFD,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_renumber(fd=5,to=4)
 <== errno=ESUCCESS
@@ -2426,7 +2426,7 @@ func Test_fdRenumber(t *testing.T) {
 			name:          "dir to any",
 			from:          dirFD,
 			to:            12345,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_renumber(fd=5,to=12345)
 <== errno=ESUCCESS
@@ -2436,7 +2436,7 @@ func Test_fdRenumber(t *testing.T) {
 			name:          "file to any",
 			from:          fileFD,
 			to:            54,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_renumber(fd=4,to=54)
 <== errno=ESUCCESS
@@ -2462,7 +2462,7 @@ func Test_fdRenumber(t *testing.T) {
 			require.Zero(t, errno)
 			require.Equal(t, uint32(dirFD), dirFDAssigned)
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdRenumberName, uint64(tc.from), uint64(tc.to))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdRenumberName, uint64(tc.from), uint64(tc.to))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -2547,7 +2547,7 @@ func Test_fdSeek(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, int64(1), offset)
 
-			requireErrnoResult(t, ErrnoSuccess, mod, FdSeekName, uint64(fd), uint64(tc.offset), uint64(tc.whence), uint64(resultNewoffset))
+			requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdSeekName, uint64(fd), uint64(tc.offset), uint64(tc.whence), uint64(resultNewoffset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
@@ -2576,13 +2576,13 @@ func Test_fdSeek_Errors(t *testing.T) {
 		fd                      uint32
 		offset                  uint64
 		whence, resultNewoffset uint32
-		expectedErrno           Errno
+		expectedErrno           wasip1.Errno
 		expectedLog             string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=42,offset=0,whence=0,0)
 <== (newoffset=,errno=EBADF)
@@ -2592,7 +2592,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 			name:          "invalid whence",
 			fd:            fileFD,
 			whence:        3, // invalid whence, the largest whence io.SeekEnd(2) + 1
-			expectedErrno: ErrnoInval,
+			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=3,0)
 <== (newoffset=,errno=EINVAL)
@@ -2601,7 +2601,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 		{
 			name:          "dir not file",
 			fd:            dirFD,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=5,offset=0,whence=0,0)
 <== (newoffset=,errno=EBADF)
@@ -2611,7 +2611,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 			name:            "out-of-memory writing resultNewoffset",
 			fd:              fileFD,
 			resultNewoffset: memorySize,
-			expectedErrno:   ErrnoFault,
+			expectedErrno:   wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_seek(fd=4,offset=0,whence=0,)
 <== (newoffset=,errno=EFAULT)
@@ -2624,7 +2624,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdSeekName, uint64(tc.fd), tc.offset, uint64(tc.whence), uint64(tc.resultNewoffset))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdSeekName, uint64(tc.fd), tc.offset, uint64(tc.whence), uint64(tc.resultNewoffset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -2640,13 +2640,13 @@ func Test_fdSync(t *testing.T) {
 	tests := []struct {
 		name          string
 		fd            uint32
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_sync(fd=42)
 <== errno=EBADF
@@ -2655,7 +2655,7 @@ func Test_fdSync(t *testing.T) {
 		{
 			name:          "valid FD",
 			fd:            fd,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_sync(fd=4)
 <== errno=ESUCCESS
@@ -2668,7 +2668,7 @@ func Test_fdSync(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdSyncName, uint64(tc.fd))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdSyncName, uint64(tc.fd))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -2705,7 +2705,7 @@ func Test_fdTell(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), offset)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdTellName, uint64(fd), uint64(resultNewoffset))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdTellName, uint64(fd), uint64(resultNewoffset))
 	require.Equal(t, expectedLog, "\n"+log.String())
 
 	actual, ok := mod.Memory().Read(0, uint32(len(expectedMemory)))
@@ -2727,13 +2727,13 @@ func Test_fdTell_Errors(t *testing.T) {
 		name            string
 		fd              uint32
 		resultNewoffset uint32
-		expectedErrno   Errno
+		expectedErrno   wasip1.Errno
 		expectedLog     string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_tell(fd=42,result.offset=0)
 <== errno=EBADF
@@ -2743,7 +2743,7 @@ func Test_fdTell_Errors(t *testing.T) {
 			name:            "out-of-memory writing resultNewoffset",
 			fd:              fd,
 			resultNewoffset: memorySize,
-			expectedErrno:   ErrnoFault,
+			expectedErrno:   wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_tell(fd=4,result.offset=65536)
 <== errno=EFAULT
@@ -2756,7 +2756,7 @@ func Test_fdTell_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdTellName, uint64(tc.fd), uint64(tc.resultNewoffset))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdTellName, uint64(tc.fd), uint64(tc.resultNewoffset))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -2793,7 +2793,7 @@ func Test_fdWrite(t *testing.T) {
 	ok := mod.Memory().Write(0, initialMemory)
 	require.True(t, ok)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=1,iovs_len=2)
 <== (nwritten=6,errno=ESUCCESS)
@@ -2844,7 +2844,7 @@ func Test_fdWrite_discard(t *testing.T) {
 	require.True(t, ok)
 
 	fd := sys.FdStdout
-	requireErrnoResult(t, ErrnoSuccess, mod, FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdWriteName, uint64(fd), uint64(iovs), uint64(iovsCount), uint64(resultNwritten))
 	// Should not amplify logging
 	require.Zero(t, len(log.Bytes()))
 
@@ -2866,13 +2866,13 @@ func Test_fdWrite_Errors(t *testing.T) {
 	tests := []struct {
 		name                     string
 		fd, iovs, resultNwritten uint32
-		expectedErrno            Errno
+		expectedErrno            wasip1.Errno
 		expectedLog              string
 	}{
 		{
 			name:          "invalid FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=42,iovs=0,iovs_len=1)
 <== (nwritten=,errno=EBADF)
@@ -2881,14 +2881,14 @@ func Test_fdWrite_Errors(t *testing.T) {
 		{
 			name:          "not writable FD",
 			fd:            sys.FdStdin,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog:   "\n", // stdin is not sampled
 		},
 		{
 			name:          "out-of-memory reading iovs[0].offset",
 			fd:            fd,
 			iovs:          memSize - 2,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65534,iovs_len=1)
 <== (nwritten=,errno=EFAULT)
@@ -2898,7 +2898,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			name:          "out-of-memory reading iovs[0].length",
 			fd:            fd,
 			iovs:          memSize - 4, // iovs[0].offset was 4 bytes and iovs[0].length next, but not enough mod.Memory()!
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65532,iovs_len=1)
 <== (nwritten=,errno=EFAULT)
@@ -2908,7 +2908,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			name:          "iovs[0].offset is outside memory",
 			fd:            fd,
 			iovs:          memSize - 5, // iovs[0].offset (where to read "hi") is outside memory.
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65531,iovs_len=1)
 <== (nwritten=,errno=EFAULT)
@@ -2918,7 +2918,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			name:          "length to read exceeds memory by 1",
 			fd:            fd,
 			iovs:          memSize - 9, // iovs[0].offset (where to read "hi") is in memory, but truncated.
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=65527,iovs_len=1)
 <== (nwritten=,errno=EFAULT)
@@ -2928,7 +2928,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 			name:           "resultNwritten offset is outside memory",
 			fd:             fd,
 			resultNwritten: memSize, // read was ok, but there wasn't enough memory to write the result.
-			expectedErrno:  ErrnoFault,
+			expectedErrno:  wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_write(fd=4,iovs=0,iovs_len=1)
 <== (nwritten=,errno=EFAULT)
@@ -2948,7 +2948,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 				'h', 'i', // iovs[0].length bytes
 			))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, FdWriteName, uint64(tc.fd), uint64(tc.iovs), uint64(iovsCount),
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdWriteName, uint64(tc.fd), uint64(tc.iovs), uint64(iovsCount),
 				uint64(tc.resultNwritten))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
@@ -2971,7 +2971,7 @@ func Test_pathCreateDirectory(t *testing.T) {
 	name := 1
 	nameLen := len(pathName)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, PathCreateDirectoryName, uint64(fd), uint64(name), uint64(nameLen))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathCreateDirectoryName, uint64(fd), uint64(name), uint64(nameLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.path_create_directory(fd=3,path=wazero)
 <== errno=ESUCCESS
@@ -3002,13 +3002,13 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 	tests := []struct {
 		name, pathName    string
 		fd, path, pathLen uint32
-		expectedErrno     Errno
+		expectedErrno     wasip1.Errno
 		expectedLog       string
 	}{
 		{
 			name:          "unopened FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=42,path=)
 <== errno=EBADF
@@ -3020,7 +3020,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=4,path=file)
 <== errno=ENOTDIR
@@ -3031,7 +3031,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          mod.Memory().Size(),
 			pathLen:       1,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=3,path=OOM(65536,1))
 <== errno=EFAULT
@@ -3042,7 +3042,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          0,
 			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=3,path=OOM(0,65537))
 <== errno=EFAULT
@@ -3054,7 +3054,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoExist,
+			expectedErrno: wasip1.ErrnoExist,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=3,path=file)
 <== errno=EEXIST
@@ -3066,7 +3066,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 			pathName:      dir,
 			path:          0,
 			pathLen:       uint32(len(dir)),
-			expectedErrno: ErrnoExist,
+			expectedErrno: wasip1.ErrnoExist,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=3,path=dir)
 <== errno=EEXIST
@@ -3081,7 +3081,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 
 			mod.Memory().Write(tc.path, []byte(tc.pathName))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathCreateDirectoryName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathCreateDirectoryName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -3106,7 +3106,7 @@ func Test_pathFilestatGet(t *testing.T) {
 		fd, pathLen, resultFilestat uint32
 		flags                       uint16
 		memory, expectedMemory      []byte
-		expectedErrno               Errno
+		expectedErrno               wasip1.Errno
 		expectedLog                 string
 	}{
 		{
@@ -3178,7 +3178,7 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:          "unopened FD",
 			fd:            math.MaxUint32,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=-1,flags=,path=)
 <== (filestat=,errno=EBADF)
@@ -3190,7 +3190,7 @@ func Test_pathFilestatGet(t *testing.T) {
 			memory:         initialMemoryFile,
 			pathLen:        uint32(len(file)),
 			resultFilestat: 2,
-			expectedErrno:  ErrnoNotdir,
+			expectedErrno:  wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=4,flags=,path=animals.txt)
 <== (filestat=,errno=ENOTDIR)
@@ -3202,7 +3202,7 @@ func Test_pathFilestatGet(t *testing.T) {
 			memory:         initialMemoryNotExists,
 			pathLen:        1,
 			resultFilestat: 2,
-			expectedErrno:  ErrnoNoent,
+			expectedErrno:  wasip1.ErrnoNoent,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=,path=?)
 <== (filestat=,errno=ENOENT)
@@ -3213,7 +3213,7 @@ func Test_pathFilestatGet(t *testing.T) {
 			fd:            sys.FdPreopen,
 			memory:        initialMemoryFile,
 			pathLen:       memorySize,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=,path=OOM(1,65536))
 <== (filestat=,errno=EFAULT)
@@ -3225,7 +3225,7 @@ func Test_pathFilestatGet(t *testing.T) {
 			memory:         initialMemoryFile,
 			pathLen:        uint32(len(file)),
 			resultFilestat: memorySize - 64 + 1,
-			expectedErrno:  ErrnoFault,
+			expectedErrno:  wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=,path=animals.txt)
 <== (filestat=,errno=EFAULT)
@@ -3234,7 +3234,7 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:           "file under root (follow symlinks)",
 			fd:             sys.FdPreopen,
-			flags:          LOOKUP_SYMLINK_FOLLOW,
+			flags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:         initialMemoryFile,
 			pathLen:        uint32(len(file)),
 			resultFilestat: uint32(len(file)) + 1,
@@ -3257,7 +3257,7 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:           "file under dir (follow symlinks)",
 			fd:             sys.FdPreopen, // root
-			flags:          LOOKUP_SYMLINK_FOLLOW,
+			flags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:         initialMemoryFileInDir,
 			pathLen:        uint32(len(fileInDir)),
 			resultFilestat: uint32(len(fileInDir)) + 1,
@@ -3280,7 +3280,7 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:           "dir under root (follow symlinks)",
 			fd:             sys.FdPreopen,
-			flags:          LOOKUP_SYMLINK_FOLLOW,
+			flags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:         initialMemoryDir,
 			pathLen:        uint32(len(dir)),
 			resultFilestat: uint32(len(dir)) + 1,
@@ -3303,8 +3303,8 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:          "unopened FD (follow symlinks)",
 			fd:            math.MaxUint32,
-			flags:         LOOKUP_SYMLINK_FOLLOW,
-			expectedErrno: ErrnoBadf,
+			flags:         wasip1.LOOKUP_SYMLINK_FOLLOW,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=-1,flags=SYMLINK_FOLLOW,path=)
 <== (filestat=,errno=EBADF)
@@ -3313,11 +3313,11 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:           "Fd not a directory (follow symlinks)",
 			fd:             fileFD,
-			flags:          LOOKUP_SYMLINK_FOLLOW,
+			flags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:         initialMemoryFile,
 			pathLen:        uint32(len(file)),
 			resultFilestat: 2,
-			expectedErrno:  ErrnoNotdir,
+			expectedErrno:  wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=4,flags=SYMLINK_FOLLOW,path=animals.txt)
 <== (filestat=,errno=ENOTDIR)
@@ -3326,11 +3326,11 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:           "path under root doesn't exist (follow symlinks)",
 			fd:             sys.FdPreopen,
-			flags:          LOOKUP_SYMLINK_FOLLOW,
+			flags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:         initialMemoryNotExists,
 			pathLen:        1,
 			resultFilestat: 2,
-			expectedErrno:  ErrnoNoent,
+			expectedErrno:  wasip1.ErrnoNoent,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=SYMLINK_FOLLOW,path=?)
 <== (filestat=,errno=ENOENT)
@@ -3339,10 +3339,10 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:          "path is out of memory (follow symlinks)",
 			fd:            sys.FdPreopen,
-			flags:         LOOKUP_SYMLINK_FOLLOW,
+			flags:         wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:        initialMemoryFile,
 			pathLen:       memorySize,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=SYMLINK_FOLLOW,path=OOM(1,65536))
 <== (filestat=,errno=EFAULT)
@@ -3351,11 +3351,11 @@ func Test_pathFilestatGet(t *testing.T) {
 		{
 			name:           "resultFilestat exceeds the maximum valid address by 1 (follow symlinks)",
 			fd:             sys.FdPreopen,
-			flags:          LOOKUP_SYMLINK_FOLLOW,
+			flags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			memory:         initialMemoryFile,
 			pathLen:        uint32(len(file)),
 			resultFilestat: memorySize - 64 + 1,
-			expectedErrno:  ErrnoFault,
+			expectedErrno:  wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_get(fd=3,flags=SYMLINK_FOLLOW,path=animals.txt)
 <== (filestat=,errno=EFAULT)
@@ -3372,7 +3372,7 @@ func Test_pathFilestatGet(t *testing.T) {
 			maskMemory(t, mod, len(tc.expectedMemory))
 			mod.Memory().Write(0, tc.memory)
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathFilestatGetName, uint64(tc.fd), uint64(tc.flags), uint64(1), uint64(tc.pathLen), uint64(tc.resultFilestat))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathFilestatGetName, uint64(tc.fd), uint64(tc.flags), uint64(1), uint64(tc.pathLen), uint64(tc.resultFilestat))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
 			actual, ok := mod.Memory().Read(0, uint32(len(tc.expectedMemory)))
@@ -3402,11 +3402,11 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		mtime, atime  int64
 		fstFlags      uint16
 		expectedLog   string
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 	}{
 		{
 			name:  "a=omit,m=omit",
-			flags: LOOKUP_SYMLINK_FOLLOW,
+			flags: wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime: 123451, // Must be ignored.
 			mtime: 1234,   // Must be ignored.
 			expectedLog: `
@@ -3416,10 +3416,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=now,m=omit",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    123451, // Must be ignored.
 			mtime:    1234,   // Must be ignored.
-			fstFlags: FstflagsAtimNow,
+			fstFlags: wasip1.FstflagsAtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=123451,mtim=1234,fst_flags=ATIM_NOW)
 <== errno=ESUCCESS
@@ -3427,10 +3427,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=omit,m=now",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    123451, // Must be ignored.
 			mtime:    1234,   // Must be ignored.
-			fstFlags: FstflagsMtimNow,
+			fstFlags: wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=123451,mtim=1234,fst_flags=MTIM_NOW)
 <== errno=ESUCCESS
@@ -3438,10 +3438,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=now,m=now",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    123451, // Must be ignored.
 			mtime:    1234,   // Must be ignored.
-			fstFlags: FstflagsAtimNow | FstflagsMtimNow,
+			fstFlags: wasip1.FstflagsAtimNow | wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=123451,mtim=1234,fst_flags=ATIM_NOW|MTIM_NOW)
 <== errno=ESUCCESS
@@ -3449,10 +3449,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=now,m=set",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    1234, // Must be ignored.
 			mtime:    55555500,
-			fstFlags: FstflagsAtimNow | FstflagsMtim,
+			fstFlags: wasip1.FstflagsAtimNow | wasip1.FstflagsMtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=1234,mtim=55555500,fst_flags=ATIM_NOW|MTIM)
 <== errno=ESUCCESS
@@ -3460,10 +3460,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=set,m=now",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    55555500,
 			mtime:    1234, // Must be ignored.
-			fstFlags: FstflagsAtim | FstflagsMtimNow,
+			fstFlags: wasip1.FstflagsAtim | wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=55555500,mtim=1234,fst_flags=ATIM|MTIM_NOW)
 <== errno=ESUCCESS
@@ -3471,10 +3471,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=set,m=omit",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    55555500,
 			mtime:    1234, // Must be ignored.
-			fstFlags: FstflagsAtim,
+			fstFlags: wasip1.FstflagsAtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=55555500,mtim=1234,fst_flags=ATIM)
 <== errno=ESUCCESS
@@ -3482,10 +3482,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=omit,m=set",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    1234, // Must be ignored.
 			mtime:    55555500,
-			fstFlags: FstflagsMtim,
+			fstFlags: wasip1.FstflagsMtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=1234,mtim=55555500,fst_flags=MTIM)
 <== errno=ESUCCESS
@@ -3493,10 +3493,10 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 		{
 			name:     "a=set,m=set",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
 			atime:    6666666600,
 			mtime:    55555500,
-			fstFlags: FstflagsAtim | FstflagsMtim,
+			fstFlags: wasip1.FstflagsAtim | wasip1.FstflagsMtim,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=file,atim=6666666600,mtim=55555500,fst_flags=ATIM|MTIM)
 <== errno=ESUCCESS
@@ -3505,13 +3505,13 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		{
 			name:     "not found",
 			pathName: "nope",
-			flags:    LOOKUP_SYMLINK_FOLLOW,
-			fstFlags: FstflagsAtimNow, // Choose one flag to ensure an update occurs
+			flags:    wasip1.LOOKUP_SYMLINK_FOLLOW,
+			fstFlags: wasip1.FstflagsAtimNow, // Choose one flag to ensure an update occurs
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=SYMLINK_FOLLOW,path=nope,atim=0,mtim=0,fst_flags=ATIM_NOW)
 <== errno=ENOENT
 `,
-			expectedErrno: ErrnoNoent,
+			expectedErrno: wasip1.ErrnoNoent,
 		},
 		{
 			name:     "no_symlink_follow",
@@ -3519,7 +3519,7 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 			flags:    0,
 			atime:    123451, // Must be ignored.
 			mtime:    1234,   // Must be ignored.
-			fstFlags: FstflagsMtimNow,
+			fstFlags: wasip1.FstflagsMtimNow,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_filestat_set_times(fd=3,flags=,path=file-link,atim=123451,mtim=1234,fst_flags=MTIM_NOW)
 <== errno=ESUCCESS
@@ -3534,7 +3534,7 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 			defer log.Reset()
 
 			if tc.flags == 0 && !platform.SupportsSymlinkNoFollow {
-				tc.expectedErrno = ErrnoNosys
+				tc.expectedErrno = wasip1.ErrnoNosys
 				tc.expectedLog = strings.ReplaceAll(tc.expectedLog, "ESUCCESS", "ENOSYS")
 			}
 
@@ -3553,16 +3553,16 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 
 			var oldSt platform.Stat_t
 			var errno syscall.Errno
-			if tc.expectedErrno == ErrnoSuccess {
+			if tc.expectedErrno == wasip1.ErrnoSuccess {
 				oldSt, errno = fsc.RootFS().Stat(pathName)
 				require.Zero(t, errno)
 			}
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathFilestatSetTimesName, uint64(fd), uint64(tc.flags),
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathFilestatSetTimesName, uint64(fd), uint64(tc.flags),
 				uint64(path), uint64(pathLen), uint64(tc.atime), uint64(tc.mtime), uint64(tc.fstFlags))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			if tc.expectedErrno != ErrnoSuccess {
+			if tc.expectedErrno != wasip1.ErrnoSuccess {
 				return
 			}
 
@@ -3570,9 +3570,9 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 			require.Zero(t, errno)
 
 			if platform.CompilerSupported() {
-				if tc.fstFlags&FstflagsAtim != 0 {
+				if tc.fstFlags&wasip1.FstflagsAtim != 0 {
 					require.Equal(t, tc.atime, newSt.Atim)
-				} else if tc.fstFlags&FstflagsAtimNow != 0 {
+				} else if tc.fstFlags&wasip1.FstflagsAtimNow != 0 {
 					now := time.Now().UnixNano()
 					require.True(t, newSt.Atim <= now, "expected atim %d <= now %d", newSt.Atim, now)
 				} else { // omit
@@ -3581,9 +3581,9 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 			}
 
 			// When compiler isn't supported, we can still check mtim.
-			if tc.fstFlags&FstflagsMtim != 0 {
+			if tc.fstFlags&wasip1.FstflagsMtim != 0 {
 				require.Equal(t, tc.mtime, newSt.Mtim)
-			} else if tc.fstFlags&FstflagsMtimNow != 0 {
+			} else if tc.fstFlags&wasip1.FstflagsMtimNow != 0 {
 				now := time.Now().UnixNano()
 				require.True(t, newSt.Mtim <= now, "expected mtim %d <= now %d", newSt.Mtim, now)
 			} else { // omit
@@ -3631,10 +3631,10 @@ func Test_pathLink(t *testing.T) {
 	destinationRealPath := joinPath(newDirPath, destinationName)
 
 	t.Run("success", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoSuccess, mod, PathLinkName,
+		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathLinkName,
 			uint64(oldFd), 0, uint64(file), uint64(len(fileName)),
 			uint64(newFd), uint64(destination), uint64(len(destinationName)))
-		require.Contains(t, log.String(), ErrnoName(ErrnoSuccess))
+		require.Contains(t, log.String(), wasip1.ErrnoName(wasip1.ErrnoSuccess))
 
 		f, err := os.Open(destinationRealPath)
 		require.NoError(t, err)
@@ -3650,29 +3650,29 @@ func Test_pathLink(t *testing.T) {
 
 	t.Run("errors", func(t *testing.T) {
 		for _, tc := range []struct {
-			errno                                      Errno
+			errno                                      wasip1.Errno
 			oldFd /* oldFlags, */, oldPath, oldPathLen uint32
 			newFd, newPath, newPathLen                 uint32
 		}{
-			{errno: ErrnoBadf, oldFd: 1000},
-			{errno: ErrnoBadf, oldFd: oldFd, newFd: 1000},
-			{errno: ErrnoNotdir, oldFd: oldFd, newFd: 1},
-			{errno: ErrnoNotdir, oldFd: 1, newFd: 1},
-			{errno: ErrnoNotdir, oldFd: 1, newFd: newFd},
-			{errno: ErrnoFault, oldFd: oldFd, newFd: newFd, oldPathLen: math.MaxUint32},
-			{errno: ErrnoFault, oldFd: oldFd, newFd: newFd, newPathLen: math.MaxUint32},
+			{errno: wasip1.ErrnoBadf, oldFd: 1000},
+			{errno: wasip1.ErrnoBadf, oldFd: oldFd, newFd: 1000},
+			{errno: wasip1.ErrnoNotdir, oldFd: oldFd, newFd: 1},
+			{errno: wasip1.ErrnoNotdir, oldFd: 1, newFd: 1},
+			{errno: wasip1.ErrnoNotdir, oldFd: 1, newFd: newFd},
+			{errno: wasip1.ErrnoFault, oldFd: oldFd, newFd: newFd, oldPathLen: math.MaxUint32},
+			{errno: wasip1.ErrnoFault, oldFd: oldFd, newFd: newFd, newPathLen: math.MaxUint32},
 			{
-				errno: ErrnoFault, oldFd: oldFd, newFd: newFd,
+				errno: wasip1.ErrnoFault, oldFd: oldFd, newFd: newFd,
 				oldPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100,
 			},
 			{
-				errno: ErrnoFault, oldFd: oldFd, newFd: newFd,
+				errno: wasip1.ErrnoFault, oldFd: oldFd, newFd: newFd,
 				oldPath: 1, oldPathLen: 100, newPath: math.MaxUint32, newPathLen: 100,
 			},
 		} {
-			name := ErrnoName(tc.errno)
+			name := wasip1.ErrnoName(tc.errno)
 			t.Run(name, func(t *testing.T) {
-				requireErrnoResult(t, tc.errno, mod, PathLinkName,
+				requireErrnoResult(t, tc.errno, mod, wasip1.PathLinkName,
 					uint64(tc.oldFd), 0, uint64(tc.oldPath), uint64(tc.oldPathLen),
 					uint64(tc.newFd), uint64(tc.newPath), uint64(tc.newPathLen))
 				require.Contains(t, log.String(), name)
@@ -3715,7 +3715,7 @@ func Test_pathOpen(t *testing.T) {
 		fdflags       uint16
 		rights        uint32
 		expected      func(t *testing.T, fsc *sys.FSContext)
-		expectedErrno Errno
+		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
 		{
@@ -3745,9 +3745,9 @@ func Test_pathOpen(t *testing.T) {
 		{
 			name:          "sysfs.ReadFS FD_APPEND",
 			fs:            readFS,
-			fdflags:       FD_APPEND,
+			fdflags:       wasip1.FD_APPEND,
 			path:          func(t *testing.T) (file string) { return appendName },
-			expectedErrno: ErrnoNosys,
+			expectedErrno: wasip1.ErrnoNosys,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=append,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=APPEND)
 <== (opened_fd=,errno=ENOSYS)
@@ -3757,7 +3757,7 @@ func Test_pathOpen(t *testing.T) {
 			name:    "sysfs.DirFS FD_APPEND",
 			fs:      writeFS,
 			path:    func(t *testing.T) (file string) { return appendName },
-			fdflags: FD_APPEND,
+			fdflags: wasip1.FD_APPEND,
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				contents := []byte("hello")
 				_, err := sys.WriterForFile(fsc, expectedOpenedFd).Write(contents)
@@ -3776,8 +3776,8 @@ func Test_pathOpen(t *testing.T) {
 		{
 			name:          "sysfs.ReadFS O_CREAT",
 			fs:            readFS,
-			oflags:        O_CREAT,
-			expectedErrno: ErrnoNosys,
+			oflags:        wasip1.O_CREAT,
+			expectedErrno: wasip1.ErrnoNosys,
 			path:          func(*testing.T) string { return "creat" },
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=creat,oflags=CREAT,fs_rights_base=,fs_rights_inheriting=,fdflags=)
@@ -3788,7 +3788,7 @@ func Test_pathOpen(t *testing.T) {
 			name:   "sysfs.DirFS O_CREAT",
 			fs:     writeFS,
 			path:   func(t *testing.T) (file string) { return "creat" },
-			oflags: O_CREAT,
+			oflags: wasip1.O_CREAT,
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				// expect to create a new file
 				contents := []byte("hello")
@@ -3808,8 +3808,8 @@ func Test_pathOpen(t *testing.T) {
 		{
 			name:          "sysfs.ReadFS O_CREAT O_TRUNC",
 			fs:            readFS,
-			oflags:        O_CREAT | O_TRUNC,
-			expectedErrno: ErrnoNosys,
+			oflags:        wasip1.O_CREAT | wasip1.O_TRUNC,
+			expectedErrno: wasip1.ErrnoNosys,
 			path:          func(t *testing.T) (file string) { return joinPath(dirName, "O_CREAT-O_TRUNC") },
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=dir/O_CREAT-O_TRUNC,oflags=CREAT|TRUNC,fs_rights_base=,fs_rights_inheriting=,fdflags=)
@@ -3820,7 +3820,7 @@ func Test_pathOpen(t *testing.T) {
 			name:   "sysfs.DirFS O_CREAT O_TRUNC",
 			fs:     writeFS,
 			path:   func(t *testing.T) (file string) { return joinPath(dirName, "O_CREAT-O_TRUNC") },
-			oflags: O_CREAT | O_TRUNC,
+			oflags: wasip1.O_CREAT | wasip1.O_TRUNC,
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				// expect to create a new file
 				contents := []byte("hello")
@@ -3840,7 +3840,7 @@ func Test_pathOpen(t *testing.T) {
 		{
 			name:   "sysfs.ReadFS O_DIRECTORY",
 			fs:     readFS,
-			oflags: O_DIRECTORY,
+			oflags: wasip1.O_DIRECTORY,
 			path:   func(*testing.T) string { return dirName },
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				f, ok := fsc.LookupFile(expectedOpenedFd)
@@ -3858,7 +3858,7 @@ func Test_pathOpen(t *testing.T) {
 			name:   "sysfs.DirFS O_DIRECTORY",
 			fs:     writeFS,
 			path:   func(*testing.T) string { return dirName },
-			oflags: O_DIRECTORY,
+			oflags: wasip1.O_DIRECTORY,
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				f, ok := fsc.LookupFile(expectedOpenedFd)
 				require.True(t, ok)
@@ -3874,8 +3874,8 @@ func Test_pathOpen(t *testing.T) {
 		{
 			name:          "sysfs.ReadFS O_TRUNC",
 			fs:            readFS,
-			oflags:        O_TRUNC,
-			expectedErrno: ErrnoNosys,
+			oflags:        wasip1.O_TRUNC,
+			expectedErrno: wasip1.ErrnoNosys,
 			path:          func(*testing.T) string { return "trunc" },
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=trunc,oflags=TRUNC,fs_rights_base=,fs_rights_inheriting=,fdflags=)
@@ -3886,7 +3886,7 @@ func Test_pathOpen(t *testing.T) {
 			name:   "sysfs.DirFS O_TRUNC",
 			fs:     writeFS,
 			path:   func(t *testing.T) (file string) { return "trunc" },
-			oflags: O_TRUNC,
+			oflags: wasip1.O_TRUNC,
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				contents := []byte("hello")
 				_, err := sys.WriterForFile(fsc, expectedOpenedFd).Write(contents)
@@ -3907,7 +3907,7 @@ func Test_pathOpen(t *testing.T) {
 			fs:     writeFS,
 			path:   func(*testing.T) string { return fileName },
 			oflags: 0,
-			rights: RIGHT_FD_WRITE,
+			rights: wasip1.RIGHT_FD_WRITE,
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				requireContents(t, fsc, expectedOpenedFd, fileName, fileContents)
 			},
@@ -3940,11 +3940,11 @@ func Test_pathOpen(t *testing.T) {
 			// inherited rights aren't used
 			fsRightsInheriting := uint64(0)
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathOpenName, uint64(fd), uint64(dirflags), uint64(path),
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathOpenName, uint64(fd), uint64(dirflags), uint64(path),
 				uint64(pathLen), uint64(tc.oflags), uint64(tc.rights), fsRightsInheriting, uint64(tc.fdflags), uint64(resultOpenedFd))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 
-			if tc.expectedErrno == ErrnoSuccess {
+			if tc.expectedErrno == wasip1.ErrnoSuccess {
 				openedFd, ok := mod.Memory().ReadUint32Le(pathLen)
 				require.True(t, ok)
 				require.Equal(t, expectedOpenedFd, openedFd)
@@ -4018,13 +4018,13 @@ func Test_pathOpen_Errors(t *testing.T) {
 	tests := []struct {
 		name, pathName                            string
 		fd, path, pathLen, oflags, resultOpenedFd uint32
-		expectedErrno                             Errno
+		expectedErrno                             wasip1.Errno
 		expectedLog                               string
 	}{
 		{
 			name:          "unopened FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=42,dirflags=,path=,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EBADF)
@@ -4036,7 +4036,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=4,dirflags=,path=file,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=ENOTDIR)
@@ -4047,7 +4047,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          mod.Memory().Size(),
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=OOM(65536,4),oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EFAULT)
@@ -4058,7 +4058,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          0,
 			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=OOM(0,65537),oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EFAULT)
@@ -4070,7 +4070,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:      dir,
 			path:          0,
 			pathLen:       uint32(len(dir)) - 1,
-			expectedErrno: ErrnoNoent,
+			expectedErrno: wasip1.ErrnoNoent,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=di,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=ENOENT)
@@ -4082,7 +4082,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:      nested + "/",
 			path:          0,
 			pathLen:       uint32(len(nested)) + 1,
-			expectedErrno: ErrnoSuccess,
+			expectedErrno: wasip1.ErrnoSuccess,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=dir/nested/,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=5,errno=ESUCCESS)
@@ -4094,7 +4094,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:      "../" + file,
 			path:          0,
 			pathLen:       uint32(len(file)) + 3,
-			expectedErrno: ErrnoPerm,
+			expectedErrno: wasip1.ErrnoPerm,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=../file,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EPERM)
@@ -4106,7 +4106,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:      "/" + file,
 			path:          0,
 			pathLen:       uint32(len(file)) + 1,
-			expectedErrno: ErrnoPerm,
+			expectedErrno: wasip1.ErrnoPerm,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=/file,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EPERM)
@@ -4118,7 +4118,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:      nestedFile + "/",
 			path:          0,
 			pathLen:       uint32(len(nestedFile)) + 1,
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=dir/nested/file/,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=ENOTDIR)
@@ -4131,7 +4131,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			path:           0,
 			pathLen:        uint32(len(dir)),
 			resultOpenedFd: mod.Memory().Size(), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
-			expectedErrno:  ErrnoFault,
+			expectedErrno:  wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=dir,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EFAULT)
@@ -4139,12 +4139,12 @@ func Test_pathOpen_Errors(t *testing.T) {
 		},
 		{
 			name:          "O_DIRECTORY, but not a directory",
-			oflags:        uint32(O_DIRECTORY),
+			oflags:        uint32(wasip1.O_DIRECTORY),
 			fd:            sys.FdPreopen,
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=file,oflags=DIRECTORY,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=ENOTDIR)
@@ -4152,12 +4152,12 @@ func Test_pathOpen_Errors(t *testing.T) {
 		},
 		{
 			name:          "oflags=directory and create invalid",
-			oflags:        uint32(O_DIRECTORY | O_CREAT),
+			oflags:        uint32(wasip1.O_DIRECTORY | wasip1.O_CREAT),
 			fd:            sys.FdPreopen,
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoInval,
+			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=file,oflags=CREAT|DIRECTORY,fs_rights_base=,fs_rights_inheriting=,fdflags=)
 <== (opened_fd=,errno=EINVAL)
@@ -4172,7 +4172,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 
 			mod.Memory().Write(tc.path, []byte(tc.pathName))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathOpenName, uint64(tc.fd), uint64(0), uint64(tc.path),
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathOpenName, uint64(tc.fd), uint64(0), uint64(tc.path),
 				uint64(tc.pathLen), uint64(tc.oflags), 0, 0, 0, uint64(tc.resultOpenedFd))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
@@ -4237,10 +4237,10 @@ func Test_pathReadlink(t *testing.T) {
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				const buf, bufLen, resultBufused = 0x100, 0xff, 0x200
-				requireErrnoResult(t, ErrnoSuccess, mod, PathReadlinkName,
+				requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathReadlinkName,
 					uint64(dirFD), uint64(tc.path), uint64(tc.pathLen),
 					buf, bufLen, resultBufused)
-				require.Contains(t, log.String(), ErrnoName(ErrnoSuccess))
+				require.Contains(t, log.String(), wasip1.ErrnoName(wasip1.ErrnoSuccess))
 
 				size, ok := mem.ReadUint32Le(resultBufused)
 				require.True(t, ok)
@@ -4255,14 +4255,14 @@ func Test_pathReadlink(t *testing.T) {
 		for _, tc := range []struct {
 			name                                          string
 			fd, path, pathLen, buf, bufLen, resultBufused uint32
-			expectedErrno                                 Errno
+			expectedErrno                                 wasip1.Errno
 		}{
-			{expectedErrno: ErrnoInval},
-			{expectedErrno: ErrnoInval, pathLen: 100},
-			{expectedErrno: ErrnoInval, bufLen: 100},
+			{expectedErrno: wasip1.ErrnoInval},
+			{expectedErrno: wasip1.ErrnoInval, pathLen: 100},
+			{expectedErrno: wasip1.ErrnoInval, bufLen: 100},
 			{
 				name:          "bufLen too short",
-				expectedErrno: ErrnoFault,
+				expectedErrno: wasip1.ErrnoFault,
 				fd:            dirFD,
 				bufLen:        10,
 				path:          destinationPath,
@@ -4271,16 +4271,16 @@ func Test_pathReadlink(t *testing.T) {
 			},
 			{
 				name:          "path past memory",
-				expectedErrno: ErrnoFault,
+				expectedErrno: wasip1.ErrnoFault,
 				bufLen:        100,
 				pathLen:       100,
 				buf:           50,
 				path:          math.MaxUint32,
 			},
-			{expectedErrno: ErrnoNotdir, bufLen: 100, pathLen: 100, buf: 50, path: 50, fd: 1},
-			{expectedErrno: ErrnoBadf, bufLen: 100, pathLen: 100, buf: 50, path: 50, fd: 1000},
+			{expectedErrno: wasip1.ErrnoNotdir, bufLen: 100, pathLen: 100, buf: 50, path: 50, fd: 1},
+			{expectedErrno: wasip1.ErrnoBadf, bufLen: 100, pathLen: 100, buf: 50, path: 50, fd: 1000},
 			{
-				expectedErrno: ErrnoNoent,
+				expectedErrno: wasip1.ErrnoNoent,
 				bufLen:        100, buf: 50,
 				path: destinationPath, pathLen: uint32(len(destinationPathName)) - 1,
 				fd: dirFD,
@@ -4288,13 +4288,13 @@ func Test_pathReadlink(t *testing.T) {
 		} {
 			name := tc.name
 			if name == "" {
-				name = ErrnoName(tc.expectedErrno)
+				name = wasip1.ErrnoName(tc.expectedErrno)
 			}
 			t.Run(name, func(t *testing.T) {
-				requireErrnoResult(t, tc.expectedErrno, mod, PathReadlinkName,
+				requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathReadlinkName,
 					uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen), uint64(tc.buf),
 					uint64(tc.bufLen), uint64(tc.resultBufused))
-				require.Contains(t, log.String(), ErrnoName(tc.expectedErrno))
+				require.Contains(t, log.String(), wasip1.ErrnoName(tc.expectedErrno))
 			})
 		}
 	})
@@ -4320,7 +4320,7 @@ func Test_pathRemoveDirectory(t *testing.T) {
 	name := 1
 	nameLen := len(pathName)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, PathRemoveDirectoryName, uint64(fd), uint64(name), uint64(nameLen))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathRemoveDirectoryName, uint64(fd), uint64(name), uint64(nameLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=wazero)
 <== errno=ESUCCESS
@@ -4354,13 +4354,13 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 	tests := []struct {
 		name, pathName    string
 		fd, path, pathLen uint32
-		expectedErrno     Errno
+		expectedErrno     wasip1.Errno
 		expectedLog       string
 	}{
 		{
 			name:          "unopened FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=42,path=)
 <== errno=EBADF
@@ -4372,7 +4372,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=4,path=file)
 <== errno=ENOTDIR
@@ -4383,7 +4383,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          mod.Memory().Size(),
 			pathLen:       1,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=OOM(65536,1))
 <== errno=EFAULT
@@ -4394,7 +4394,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          0,
 			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=OOM(0,65537))
 <== errno=EFAULT
@@ -4406,7 +4406,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file) - 1),
-			expectedErrno: ErrnoNoent,
+			expectedErrno: wasip1.ErrnoNoent,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=fil)
 <== errno=ENOENT
@@ -4418,11 +4418,11 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file)),
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: fmt.Sprintf(`
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=file)
 <== errno=%s
-`, ErrnoName(ErrnoNotdir)),
+`, wasip1.ErrnoName(wasip1.ErrnoNotdir)),
 		},
 		{
 			name:          "dir not empty",
@@ -4430,7 +4430,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			pathName:      dirNotEmpty,
 			path:          0,
 			pathLen:       uint32(len(dirNotEmpty)),
-			expectedErrno: ErrnoNotempty,
+			expectedErrno: wasip1.ErrnoNotempty,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=notempty)
 <== errno=ENOTEMPTY
@@ -4445,7 +4445,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 
 			mod.Memory().Write(tc.path, []byte(tc.pathName))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathRemoveDirectoryName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathRemoveDirectoryName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -4480,9 +4480,9 @@ func Test_pathSymlink_errors(t *testing.T) {
 	require.True(t, ok)
 
 	t.Run("success", func(t *testing.T) {
-		requireErrnoResult(t, ErrnoSuccess, mod, PathSymlinkName,
+		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathSymlinkName,
 			uint64(file), uint64(len(fileName)), uint64(fd), uint64(link), uint64(len(linkName)))
-		require.Contains(t, log.String(), ErrnoName(ErrnoSuccess))
+		require.Contains(t, log.String(), wasip1.ErrnoName(wasip1.ErrnoSuccess))
 		st, err := os.Lstat(joinPath(dirPath, linkName))
 		require.NoError(t, err)
 		require.Equal(t, st.Mode()&os.ModeSymlink, os.ModeSymlink)
@@ -4490,33 +4490,33 @@ func Test_pathSymlink_errors(t *testing.T) {
 
 	t.Run("errors", func(t *testing.T) {
 		for _, tc := range []struct {
-			errno                                        Errno
+			errno                                        wasip1.Errno
 			oldPath, oldPathLen, fd, newPath, newPathLen uint32
 		}{
-			{errno: ErrnoBadf, fd: 1000},
-			{errno: ErrnoNotdir, fd: 2},
+			{errno: wasip1.ErrnoBadf, fd: 1000},
+			{errno: wasip1.ErrnoNotdir, fd: 2},
 			// Length zero buffer is not valid.
-			{errno: ErrnoInval, fd: fd},
-			{errno: ErrnoInval, oldPathLen: 100, fd: fd},
-			{errno: ErrnoInval, newPathLen: 100, fd: fd},
+			{errno: wasip1.ErrnoInval, fd: fd},
+			{errno: wasip1.ErrnoInval, oldPathLen: 100, fd: fd},
+			{errno: wasip1.ErrnoInval, newPathLen: 100, fd: fd},
 			// Invalid pointer to the names.
-			{errno: ErrnoFault, oldPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100, fd: fd},
-			{errno: ErrnoFault, newPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100, fd: fd},
-			{errno: ErrnoFault, oldPath: math.MaxUint32, newPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100, fd: fd},
+			{errno: wasip1.ErrnoFault, oldPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100, fd: fd},
+			{errno: wasip1.ErrnoFault, newPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100, fd: fd},
+			{errno: wasip1.ErrnoFault, oldPath: math.MaxUint32, newPath: math.MaxUint32, oldPathLen: 100, newPathLen: 100, fd: fd},
 			// Non-existing path as source.
 			{
-				errno: ErrnoInval, oldPath: notFoundFile, oldPathLen: uint32(len(notFoundFileName)),
+				errno: wasip1.ErrnoInval, oldPath: notFoundFile, oldPathLen: uint32(len(notFoundFileName)),
 				newPath: 0, newPathLen: 5, fd: fd,
 			},
 			// Linking to existing file.
 			{
-				errno: ErrnoExist, oldPath: file, oldPathLen: uint32(len(fileName)),
+				errno: wasip1.ErrnoExist, oldPath: file, oldPathLen: uint32(len(fileName)),
 				newPath: file, newPathLen: uint32(len(fileName)), fd: fd,
 			},
 		} {
-			name := ErrnoName(tc.errno)
+			name := wasip1.ErrnoName(tc.errno)
 			t.Run(name, func(t *testing.T) {
-				requireErrnoResult(t, tc.errno, mod, PathSymlinkName,
+				requireErrnoResult(t, tc.errno, mod, wasip1.PathSymlinkName,
 					uint64(tc.oldPath), uint64(tc.oldPathLen), uint64(tc.fd), uint64(tc.newPath), uint64(tc.newPathLen))
 				require.Contains(t, log.String(), name)
 			})
@@ -4551,7 +4551,7 @@ func Test_pathRename(t *testing.T) {
 	ok = mod.Memory().Write(newPath, []byte(newPathName))
 	require.True(t, ok)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, PathRenameName,
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathRenameName,
 		uint64(oldfd), uint64(oldPath), uint64(oldPathLen),
 		uint64(newfd), uint64(newPath), uint64(newPathLen))
 	require.Equal(t, `
@@ -4596,14 +4596,14 @@ func Test_pathRename_Errors(t *testing.T) {
 		name, oldPathName, newPathName string
 		oldFd, oldPath, oldPathLen     uint32
 		newFd, newPath, newPathLen     uint32
-		expectedErrno                  Errno
+		expectedErrno                  wasip1.Errno
 		expectedLog                    string
 	}{
 		{
 			name:          "unopened old FD",
 			oldFd:         42, // arbitrary invalid fd
 			newFd:         sys.FdPreopen,
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=42,old_path=,new_fd=3,new_path=)
 <== errno=EBADF
@@ -4613,7 +4613,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			name:          "old FD not a directory",
 			oldFd:         fileFD,
 			newFd:         sys.FdPreopen,
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=4,old_path=,new_fd=3,new_path=)
 <== errno=ENOTDIR
@@ -4623,7 +4623,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			name:          "unopened new FD",
 			oldFd:         sys.FdPreopen,
 			newFd:         42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=,new_fd=42,new_path=)
 <== errno=EBADF
@@ -4633,7 +4633,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			name:          "new FD not a directory",
 			oldFd:         sys.FdPreopen,
 			newFd:         fileFD,
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=,new_fd=4,new_path=)
 <== errno=ENOTDIR
@@ -4645,7 +4645,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			newFd:         sys.FdPreopen,
 			oldPath:       mod.Memory().Size(),
 			oldPathLen:    1,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=OOM(65536,1),new_fd=3,new_path=)
 <== errno=EFAULT
@@ -4660,7 +4660,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			oldPathLen:    1,
 			newPath:       mod.Memory().Size(),
 			newPathLen:    1,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=a,new_fd=3,new_path=OOM(65536,1))
 <== errno=EFAULT
@@ -4672,7 +4672,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			newFd:         sys.FdPreopen,
 			oldPath:       0,
 			oldPathLen:    mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=OOM(0,65537),new_fd=3,new_path=)
 <== errno=EFAULT
@@ -4686,7 +4686,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			oldPathLen:    uint32(len(file)),
 			newPath:       0,
 			newPathLen:    mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=file,new_fd=3,new_path=OOM(0,65537))
 <== errno=EFAULT
@@ -4701,7 +4701,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			newPath:       16,
 			newPathName:   file,
 			newPathLen:    uint32(len(file)),
-			expectedErrno: ErrnoNoent,
+			expectedErrno: wasip1.ErrnoNoent,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=fil,new_fd=3,new_path=file)
 <== errno=ENOENT
@@ -4716,7 +4716,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			newPath:       16,
 			newPathName:   dir,
 			newPathLen:    uint32(len(dir)),
-			expectedErrno: ErrnoIsdir,
+			expectedErrno: wasip1.ErrnoIsdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=file,new_fd=3,new_path=notempty/dir)
 <== errno=EISDIR
@@ -4732,7 +4732,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			mod.Memory().Write(tc.oldPath, []byte(tc.oldPathName))
 			mod.Memory().Write(tc.newPath, []byte(tc.newPathName))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathRenameName,
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathRenameName,
 				uint64(tc.oldFd), uint64(tc.oldPath), uint64(tc.oldPathLen),
 				uint64(tc.newFd), uint64(tc.newPath), uint64(tc.newPathLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
@@ -4760,7 +4760,7 @@ func Test_pathUnlinkFile(t *testing.T) {
 	name := 1
 	nameLen := len(pathName)
 
-	requireErrnoResult(t, ErrnoSuccess, mod, PathUnlinkFileName, uint64(fd), uint64(name), uint64(nameLen))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathUnlinkFileName, uint64(fd), uint64(name), uint64(nameLen))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=3,path=wazero)
 <== errno=ESUCCESS
@@ -4789,13 +4789,13 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 	tests := []struct {
 		name, pathName    string
 		fd, path, pathLen uint32
-		expectedErrno     Errno
+		expectedErrno     wasip1.Errno
 		expectedLog       string
 	}{
 		{
 			name:          "unopened FD",
 			fd:            42, // arbitrary invalid fd
-			expectedErrno: ErrnoBadf,
+			expectedErrno: wasip1.ErrnoBadf,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=42,path=)
 <== errno=EBADF
@@ -4804,7 +4804,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 		{
 			name:          "Fd not a directory",
 			fd:            fileFD,
-			expectedErrno: ErrnoNotdir,
+			expectedErrno: wasip1.ErrnoNotdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=4,path=)
 <== errno=ENOTDIR
@@ -4815,7 +4815,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          mod.Memory().Size(),
 			pathLen:       1,
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=3,path=OOM(65536,1))
 <== errno=EFAULT
@@ -4826,7 +4826,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 			fd:            sys.FdPreopen,
 			path:          0,
 			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
-			expectedErrno: ErrnoFault,
+			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=3,path=OOM(0,65537))
 <== errno=EFAULT
@@ -4838,7 +4838,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 			pathName:      file,
 			path:          0,
 			pathLen:       uint32(len(file) - 1),
-			expectedErrno: ErrnoNoent,
+			expectedErrno: wasip1.ErrnoNoent,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=3,path=fil)
 <== errno=ENOENT
@@ -4850,7 +4850,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 			pathName:      dir,
 			path:          0,
 			pathLen:       uint32(len(dir)),
-			expectedErrno: ErrnoIsdir,
+			expectedErrno: wasip1.ErrnoIsdir,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=3,path=dir)
 <== errno=EISDIR
@@ -4865,7 +4865,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 
 			mod.Memory().Write(tc.path, []byte(tc.pathName))
 
-			requireErrnoResult(t, tc.expectedErrno, mod, PathUnlinkFileName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
+			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.PathUnlinkFileName, uint64(tc.fd), uint64(tc.path), uint64(tc.pathLen))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -4920,7 +4920,7 @@ func Test_fdReaddir_dotEntriesHaveRealInodes(t *testing.T) {
 
 	readDirTarget := "dir"
 	mem.Write(0, []byte(readDirTarget))
-	requireErrnoResult(t, ErrnoSuccess, mod, PathCreateDirectoryName,
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathCreateDirectoryName,
 		uint64(sys.FdPreopen), uint64(0), uint64(len(readDirTarget)))
 
 	// Open the directory, before writing files!
@@ -4948,7 +4948,7 @@ func Test_fdReaddir_dotEntriesHaveRealInodes(t *testing.T) {
 	// Try to list them!
 	resultBufused := uint32(0) // where to write the amount used out of bufLen
 	buf := uint32(8)           // where to start the dirents
-	requireErrnoResult(t, ErrnoSuccess, mod, FdReaddirName,
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReaddirName,
 		uint64(fd), uint64(buf), uint64(0x2000), 0, uint64(resultBufused))
 
 	used, _ := mem.ReadUint32Le(resultBufused)
@@ -4979,7 +4979,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	dirName := "dir"
 	dirPath := joinPath(tmpDir, dirName)
 	mem.Write(0, []byte(dirName))
-	requireErrnoResult(t, ErrnoSuccess, mod, PathCreateDirectoryName,
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.PathCreateDirectoryName,
 		uint64(sys.FdPreopen), uint64(0), uint64(len(dirName)))
 
 	// Open the directory, before writing files!
@@ -5021,7 +5021,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	// Try to list them!
 	resultBufused := uint32(0) // where to write the amount used out of bufLen
 	buf := uint32(8)           // where to start the dirents
-	requireErrnoResult(t, ErrnoSuccess, mod, FdReaddirName,
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReaddirName,
 		uint64(dirFD), uint64(buf), uint64(0x2000), 0, uint64(resultBufused))
 
 	used, _ := mem.ReadUint32Le(resultBufused)

--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 func Test_fdRead_shouldContinueRead(t *testing.T) {
@@ -380,42 +380,42 @@ func Test_openFlags(t *testing.T) {
 		},
 		{
 			name:              "oflags=O_CREAT",
-			oflags:            O_CREAT,
+			oflags:            wasip1.O_CREAT,
 			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDWR | syscall.O_CREAT,
 		},
 		{
 			name:              "oflags=O_DIRECTORY",
-			oflags:            O_DIRECTORY,
+			oflags:            wasip1.O_DIRECTORY,
 			expectedOpenFlags: platform.O_NOFOLLOW | platform.O_DIRECTORY,
 		},
 		{
 			name:              "oflags=O_EXCL",
-			oflags:            O_EXCL,
+			oflags:            wasip1.O_EXCL,
 			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDONLY | syscall.O_EXCL,
 		},
 		{
 			name:              "oflags=O_TRUNC",
-			oflags:            O_TRUNC,
+			oflags:            wasip1.O_TRUNC,
 			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDWR | syscall.O_TRUNC,
 		},
 		{
 			name:              "fdflags=FD_APPEND",
-			fdflags:           FD_APPEND,
+			fdflags:           wasip1.FD_APPEND,
 			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDWR | syscall.O_APPEND,
 		},
 		{
 			name:              "oflags=O_TRUNC|O_CREAT",
-			oflags:            O_TRUNC | O_CREAT,
+			oflags:            wasip1.O_TRUNC | wasip1.O_CREAT,
 			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDWR | syscall.O_TRUNC | syscall.O_CREAT,
 		},
 		{
 			name:              "dirflags=LOOKUP_SYMLINK_FOLLOW",
-			dirflags:          LOOKUP_SYMLINK_FOLLOW,
+			dirflags:          wasip1.LOOKUP_SYMLINK_FOLLOW,
 			expectedOpenFlags: syscall.O_RDONLY,
 		},
 		{
 			name:              "rights=FD_WRITE",
-			rights:            RIGHT_FD_WRITE,
+			rights:            wasip1.RIGHT_FD_WRITE,
 			expectedOpenFlags: platform.O_NOFOLLOW | syscall.O_RDWR,
 		},
 	}
@@ -437,5 +437,5 @@ func Test_getWasiFiletype_DevNull(t *testing.T) {
 	ft := getWasiFiletype(st.Mode())
 
 	// Should be a character device, and not contain permissions
-	require.Equal(t, FILETYPE_CHARACTER_DEVICE, ft)
+	require.Equal(t, wasip1.FILETYPE_CHARACTER_DEVICE, ft)
 }

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
 )
@@ -19,8 +19,8 @@ import (
 //
 // See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 var procExit = &wasm.HostFunc{
-	ExportNames: []string{ProcExitName},
-	Name:        ProcExitName,
+	ExportNames: []string{wasip1.ProcExitName},
+	Name:        wasip1.ProcExitName,
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"rval"},
 	Code: wasm.Code{
@@ -43,4 +43,4 @@ func procExitFn(ctx context.Context, mod api.Module, params []uint64) {
 // procRaise is stubbed and will never be supported, as it was removed.
 //
 // See https://github.com/WebAssembly/WASI/pull/136
-var procRaise = stubFunction(ProcRaiseName, []api.ValueType{i32}, "sig")
+var procRaise = stubFunction(wasip1.ProcRaiseName, []api.ValueType{i32}, "sig")

--- a/imports/wasi_snapshot_preview1/proc_test.go
+++ b/imports/wasi_snapshot_preview1/proc_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -41,7 +41,7 @@ func Test_procExit(t *testing.T) {
 			defer log.Reset()
 
 			// Since procExit panics, any opcodes afterwards cannot be reached.
-			_, err := mod.ExportedFunction(ProcExitName).Call(testCtx, uint64(tc.exitCode))
+			_, err := mod.ExportedFunction(wasip1.ProcExitName).Call(testCtx, uint64(tc.exitCode))
 			require.Error(t, err)
 			sysErr, ok := err.(*sys.ExitError)
 			require.True(t, ok, err)
@@ -53,7 +53,7 @@ func Test_procExit(t *testing.T) {
 
 // Test_procRaise only tests it is stubbed for GrainLang per #271
 func Test_procRaise(t *testing.T) {
-	log := requireErrnoNosys(t, ProcRaiseName, 0)
+	log := requireErrnoNosys(t, wasip1.ProcRaiseName, 0)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.proc_raise(sig=0)
 <== errno=ENOSYS

--- a/imports/wasi_snapshot_preview1/random.go
+++ b/imports/wasi_snapshot_preview1/random.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -34,7 +34,7 @@ import (
 //	    buf --^
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-random_getbuf-pointeru8-bufLen-size---errno
-var randomGet = newHostFunc(RandomGetName, randomGetFn, []api.ValueType{i32, i32}, "buf", "buf_len")
+var randomGet = newHostFunc(wasip1.RandomGetName, randomGetFn, []api.ValueType{i32, i32}, "buf", "buf_len")
 
 func randomGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys

--- a/imports/wasi_snapshot_preview1/random_test.go
+++ b/imports/wasi_snapshot_preview1/random_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 func Test_randomGet(t *testing.T) {
@@ -28,7 +28,7 @@ func Test_randomGet(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory))
 
 	// Invoke randomGet and check the memory side effects!
-	requireErrnoResult(t, ErrnoSuccess, mod, RandomGetName, uint64(offset), uint64(length))
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.RandomGetName, uint64(offset), uint64(length))
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.random_get(buf=1,buf_len=5)
 <== errno=ESUCCESS
@@ -76,7 +76,7 @@ func Test_randomGet_Errors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
 
-			requireErrnoResult(t, ErrnoFault, mod, RandomGetName, uint64(tc.offset), uint64(tc.length))
+			requireErrnoResult(t, wasip1.ErrnoFault, mod, wasip1.RandomGetName, uint64(tc.offset), uint64(tc.length))
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}
@@ -113,7 +113,7 @@ func Test_randomGet_SourceError(t *testing.T) {
 				WithRandSource(tc.randSource))
 			defer r.Close(testCtx)
 
-			requireErrnoResult(t, ErrnoIo, mod, RandomGetName, uint64(1), uint64(5)) // arbitrary offset and length
+			requireErrnoResult(t, wasip1.ErrnoIo, mod, wasip1.RandomGetName, uint64(1), uint64(5)) // arbitrary offset and length
 			require.Equal(t, tc.expectedLog, "\n"+log.String())
 		})
 	}

--- a/imports/wasi_snapshot_preview1/sched.go
+++ b/imports/wasi_snapshot_preview1/sched.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -13,7 +13,7 @@ import (
 // yields execution of the calling thread.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sched_yield---errno
-var schedYield = newHostFunc(SchedYieldName, schedYieldFn, nil)
+var schedYield = newHostFunc(wasip1.SchedYieldName, schedYieldFn, nil)
 
 func schedYieldFn(_ context.Context, mod api.Module, _ []uint64) syscall.Errno {
 	sysCtx := mod.(*wasm.CallContext).Sys

--- a/imports/wasi_snapshot_preview1/sched_test.go
+++ b/imports/wasi_snapshot_preview1/sched_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 func Test_schedYield(t *testing.T) {
@@ -15,7 +15,7 @@ func Test_schedYield(t *testing.T) {
 			yielded = true
 		}))
 	defer r.Close(testCtx)
-	requireErrnoResult(t, ErrnoSuccess, mod, SchedYieldName)
+	requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.SchedYieldName)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.sched_yield()
 <== errno=ESUCCESS

--- a/imports/wasi_snapshot_preview1/sock.go
+++ b/imports/wasi_snapshot_preview1/sock.go
@@ -1,7 +1,7 @@
 package wasi_snapshot_preview1
 
 import (
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -11,7 +11,7 @@ import (
 // See: https://github.com/WebAssembly/WASI/blob/0ba0c5e2e37625ca5a6d3e4255a998dfaa3efc52/phases/snapshot/docs.md#sock_accept
 // and https://github.com/WebAssembly/WASI/pull/458
 var sockAccept = stubFunction(
-	SockAcceptName,
+	wasip1.SockAcceptName,
 	[]wasm.ValueType{i32, i32, i32},
 	"fd", "flags", "result.fd",
 )
@@ -21,7 +21,7 @@ var sockAccept = stubFunction(
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_recvfd-fd-ri_data-iovec_array-ri_flags-riflags---errno-size-roflags
 var sockRecv = stubFunction(
-	SockRecvName,
+	wasip1.SockRecvName,
 	[]wasm.ValueType{i32, i32, i32, i32, i32, i32},
 	"fd", "ri_data", "ri_data_count", "ri_flags", "result.ro_datalen", "result.ro_flags",
 )
@@ -31,7 +31,7 @@ var sockRecv = stubFunction(
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_sendfd-fd-si_data-ciovec_array-si_flags-siflags---errno-size
 var sockSend = stubFunction(
-	SockSendName,
+	wasip1.SockSendName,
 	[]wasm.ValueType{i32, i32, i32, i32, i32},
 	"fd", "si_data", "si_data_count", "si_flags", "result.so_datalen",
 )
@@ -40,4 +40,4 @@ var sockSend = stubFunction(
 // down socket send and receive channels.
 //
 // See: https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-sock_shutdownfd-fd-how-sdflags---errno
-var sockShutdown = stubFunction(SockShutdownName, []wasm.ValueType{i32, i32}, "fd", "how")
+var sockShutdown = stubFunction(wasip1.SockShutdownName, []wasm.ValueType{i32, i32}, "fd", "how")

--- a/imports/wasi_snapshot_preview1/sock_test.go
+++ b/imports/wasi_snapshot_preview1/sock_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 // Test_sockAccept only tests it is stubbed for GrainLang per #271
 func Test_sockAccept(t *testing.T) {
-	log := requireErrnoNosys(t, SockAcceptName, 0, 0, 0)
+	log := requireErrnoNosys(t, wasip1.SockAcceptName, 0, 0, 0)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.sock_accept(fd=0,flags=0,result.fd=0)
 <== errno=ENOSYS
@@ -18,7 +18,7 @@ func Test_sockAccept(t *testing.T) {
 
 // Test_sockRecv only tests it is stubbed for GrainLang per #271
 func Test_sockRecv(t *testing.T) {
-	log := requireErrnoNosys(t, SockRecvName, 0, 0, 0, 0, 0, 0)
+	log := requireErrnoNosys(t, wasip1.SockRecvName, 0, 0, 0, 0, 0, 0)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.sock_recv(fd=0,ri_data=0,ri_data_count=0,ri_flags=0,result.ro_datalen=0,result.ro_flags=0)
 <== errno=ENOSYS
@@ -27,7 +27,7 @@ func Test_sockRecv(t *testing.T) {
 
 // Test_sockSend only tests it is stubbed for GrainLang per #271
 func Test_sockSend(t *testing.T) {
-	log := requireErrnoNosys(t, SockSendName, 0, 0, 0, 0, 0)
+	log := requireErrnoNosys(t, wasip1.SockSendName, 0, 0, 0, 0, 0)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.sock_send(fd=0,si_data=0,si_data_count=0,si_flags=0,result.so_datalen=0)
 <== errno=ENOSYS
@@ -36,7 +36,7 @@ func Test_sockSend(t *testing.T) {
 
 // Test_sockShutdown only tests it is stubbed for GrainLang per #271
 func Test_sockShutdown(t *testing.T) {
-	log := requireErrnoNosys(t, SockShutdownName, 0, 0)
+	log := requireErrnoNosys(t, wasip1.SockShutdownName, 0, 0)
 	require.Equal(t, `
 ==> wasi_snapshot_preview1.sock_shutdown(fd=0,how=0)
 <== errno=ENOSYS

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -23,14 +23,14 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
 // ModuleName is the module name WASI functions are exported into.
 //
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md
-const ModuleName = InternalModuleName
+const ModuleName = wasip1.InternalModuleName
 
 const i32, i64 = wasm.ValueTypeI32, wasm.ValueTypeI64
 
@@ -282,7 +282,7 @@ func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
 	// Write the result back onto the stack
 	errno := f(ctx, mod, stack)
 	if errno != 0 {
-		stack[0] = uint64(ToErrno(errno))
+		stack[0] = uint64(wasip1.ToErrno(errno))
 	} else { // special case ass ErrnoSuccess is zero
 		stack[0] = 0
 	}
@@ -298,7 +298,7 @@ func stubFunction(name string, paramTypes []wasm.ValueType, paramNames ...string
 		ResultTypes: []api.ValueType{i32},
 		ResultNames: []string{"errno"},
 		Code: wasm.Code{
-			GoFunc: api.GoModuleFunc(func(_ context.Context, _ api.Module, stack []uint64) { stack[0] = uint64(ErrnoNosys) }),
+			GoFunc: api.GoModuleFunc(func(_ context.Context, _ api.Module, stack []uint64) { stack[0] = uint64(wasip1.ErrnoNosys) }),
 		},
 	}
 }

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -32,10 +32,10 @@ func Benchmark_ArgsEnviron(b *testing.B) {
 	}
 
 	for _, n := range []string{
-		ArgsGetName,
-		ArgsSizesGetName,
-		EnvironGetName,
-		EnvironSizesGetName,
+		wasip1.ArgsGetName,
+		wasip1.ArgsSizesGetName,
+		wasip1.EnvironGetName,
+		wasip1.EnvironSizesGetName,
 	} {
 		n := n
 		fn := mod.ExportedFunction(n)
@@ -71,7 +71,7 @@ func Benchmark_fdRead(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	fn := mod.ExportedFunction(FdReadName)
+	fn := mod.ExportedFunction(wasip1.FdReadName)
 
 	mod.Memory().Write(0, []byte{
 		32, 0, 0, 0, // = iovs[0].offset
@@ -188,7 +188,7 @@ func Benchmark_fdReaddir(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			fn := mod.ExportedFunction(FdReaddirName)
+			fn := mod.ExportedFunction(wasip1.FdReaddirName)
 
 			// Open the root directory as a file-descriptor.
 			fsc := mod.(*wasm.CallContext).Sys.FS()
@@ -325,7 +325,7 @@ func Benchmark_pathFilestat(b *testing.B) {
 				defer fsc.CloseFile(fd) //nolint
 			}
 
-			fn := mod.ExportedFunction(PathFilestatGetName)
+			fn := mod.ExportedFunction(wasip1.PathFilestatGetName)
 
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -356,8 +356,8 @@ func Benchmark_pathFilestat(b *testing.B) {
 }
 
 func requireESuccess(b *testing.B, results []uint64) {
-	if errno := Errno(results[0]); errno != 0 {
-		b.Fatal(ErrnoName(errno))
+	if errno := wasip1.Errno(results[0]); errno != 0 {
+		b.Fatal(wasip1.ErrnoName(errno))
 	}
 }
 
@@ -378,7 +378,7 @@ func Benchmark_fdWrite(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	fn := mod.ExportedFunction(FdWriteName)
+	fn := mod.ExportedFunction(wasip1.FdWriteName)
 
 	iovs := uint32(1) // arbitrary offset
 	mod.Memory().Write(0, []byte{

--- a/internal/wasip1/args.go
+++ b/internal/wasip1/args.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const (
 	ArgsGetName      = "args_get"

--- a/internal/wasip1/clock.go
+++ b/internal/wasip1/clock.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const (
 	ClockResGetName  = "clock_res_get"

--- a/internal/wasip1/environ.go
+++ b/internal/wasip1/environ.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const (
 	EnvironGetName      = "environ_get"

--- a/internal/wasip1/errno.go
+++ b/internal/wasip1/errno.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 import (
 	"fmt"

--- a/internal/wasip1/errno_test.go
+++ b/internal/wasip1/errno_test.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 import (
 	"syscall"

--- a/internal/wasip1/fs.go
+++ b/internal/wasip1/fs.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 import (
 	"fmt"

--- a/internal/wasip1/logging/logging.go
+++ b/internal/wasip1/logging/logging.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/logging"
 	"github.com/tetratelabs/wazero/internal/sys"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	. "github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 var le = binary.LittleEndian

--- a/internal/wasip1/logging/logging_test.go
+++ b/internal/wasip1/logging/logging_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/logging"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	. "github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 

--- a/internal/wasip1/poll.go
+++ b/internal/wasip1/poll.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 // https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-eventtype-enumu8
 const (

--- a/internal/wasip1/proc.go
+++ b/internal/wasip1/proc.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const (
 	ProcExitName  = "proc_exit"

--- a/internal/wasip1/random.go
+++ b/internal/wasip1/random.go
@@ -1,3 +1,3 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const RandomGetName = "random_get"

--- a/internal/wasip1/rights.go
+++ b/internal/wasip1/rights.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 // See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#-rights-flagsu64
 const (

--- a/internal/wasip1/sched.go
+++ b/internal/wasip1/sched.go
@@ -1,3 +1,3 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const SchedYieldName = "sched_yield"

--- a/internal/wasip1/sock.go
+++ b/internal/wasip1/sock.go
@@ -1,4 +1,4 @@
-package wasi_snapshot_preview1
+package wasip1
 
 const (
 	SockAcceptName   = "sock_accept"

--- a/internal/wasip1/wasi.go
+++ b/internal/wasip1/wasi.go
@@ -1,6 +1,6 @@
 // Package wasi_snapshot_preview1 is a helper to remove package cycles re-using
 // constants.
-package wasi_snapshot_preview1
+package wasip1
 
 import (
 	"strings"

--- a/internal/wasm/host_test.go
+++ b/internal/wasm/host_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/testing/require"
-	. "github.com/tetratelabs/wazero/internal/wasi_snapshot_preview1"
+	. "github.com/tetratelabs/wazero/internal/wasip1"
 )
 
 func argsSizesGet(ctx context.Context, mod api.Module, resultArgc, resultArgvBufSize uint32) uint32 {


### PR DESCRIPTION
This removes the generally frowned upon practice of dot imports by shortening the name of internal/wasi_snapshot_preview1 to internal/wasip1. This leaves the external one alone as it would break users to change it.