### PR TITLE
ensures we don't open a file to close it

### DIFF
--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -142,15 +142,11 @@ func (r *lazyDir) Read(p []byte) (n int, err error) {
 
 // Close implements fs.File
 func (r *lazyDir) Close() error {
-	f, errno := r.file()
-	switch errno {
-	case 0:
-		return f.Close()
-	case syscall.ENOENT:
-		return nil
-	default:
-		return errno
+	f := r.f
+	if f == nil {
+		return nil // never opened
 	}
+	return f.Close()
 }
 
 // FileEntry maps a path to an open file in a file system.


### PR DESCRIPTION
I noticed browsing our code that lazyDir accidentally opens a directory just to close it.