### PR TITLE
Deletes wasm.CallCtx

### DIFF
--- a/imports/assemblyscript/assemblyscript.go
+++ b/imports/assemblyscript/assemblyscript.go
@@ -149,7 +149,7 @@ var abortMessageDisabled = abortMessageEnabled.WithGoModuleFunc(abort)
 
 // abortWithMessage implements AbortName
 func abortWithMessage(ctx context.Context, mod api.Module, stack []uint64) {
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	mem := mod.Memory()
 
 	message := uint32(stack[0])
@@ -191,7 +191,7 @@ var traceStdout = &wasm.HostFunc{
 	ParamNames:  []string{"message", "nArgs", "arg0", "arg1", "arg2", "arg3", "arg4"},
 	Code: wasm.Code{
 		GoFunc: api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
-			fsc := mod.(*wasm.CallContext).Sys.FS()
+			fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 			traceTo(mod, stack, internalsys.WriterForFile(fsc, internalsys.FdStdout))
 		}),
 	},
@@ -199,7 +199,7 @@ var traceStdout = &wasm.HostFunc{
 
 // traceStderr implements trace to the configured Stderr.
 var traceStderr = traceStdout.WithGoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	traceTo(mod, stack, internalsys.WriterForFile(fsc, internalsys.FdStderr))
 })
 
@@ -276,7 +276,7 @@ var seed = &wasm.HostFunc{
 	ResultNames: []string{"rand"},
 	Code: wasm.Code{
 		GoFunc: api.GoModuleFunc(func(ctx context.Context, mod api.Module, stack []uint64) {
-			r := mod.(*wasm.CallContext).Sys.RandSource()
+			r := mod.(*wasm.ModuleInstance).Sys.RandSource()
 			buf := make([]byte, 8)
 			_, err := io.ReadFull(r, buf)
 			if err != nil {

--- a/imports/emscripten/emscripten.go
+++ b/imports/emscripten/emscripten.go
@@ -143,7 +143,7 @@ var invokeI = &wasm.HostFunc{
 }
 
 func invokeIFn(ctx context.Context, mod api.Module, stack []uint64) {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_v_i32, wasm.Index(stack[0]), nil)
+	ret, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_v_i32, wasm.Index(stack[0]), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -160,7 +160,7 @@ var invokeIi = &wasm.HostFunc{
 }
 
 func invokeIiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32_i32, wasm.Index(stack[0]), stack[1:])
+	ret, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32_i32, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -177,7 +177,7 @@ var invokeIii = &wasm.HostFunc{
 }
 
 func invokeIiiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32i32_i32, wasm.Index(stack[0]), stack[1:])
+	ret, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32i32_i32, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -194,7 +194,7 @@ var invokeIiii = &wasm.HostFunc{
 }
 
 func invokeIiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32i32i32_i32, wasm.Index(stack[0]), stack[1:])
+	ret, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32i32i32_i32, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -211,7 +211,7 @@ var invokeIiiii = &wasm.HostFunc{
 }
 
 func invokeIiiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	ret, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32i32i32i32_i32, wasm.Index(stack[0]), stack[1:])
+	ret, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32i32i32i32_i32, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -228,7 +228,7 @@ var invokeV = &wasm.HostFunc{
 }
 
 func invokeVFn(ctx context.Context, mod api.Module, stack []uint64) {
-	_, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_v_v, wasm.Index(stack[0]), nil)
+	_, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_v_v, wasm.Index(stack[0]), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -244,7 +244,7 @@ var invokeVi = &wasm.HostFunc{
 }
 
 func invokeViFn(ctx context.Context, mod api.Module, stack []uint64) {
-	_, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32_v, wasm.Index(stack[0]), stack[1:])
+	_, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32_v, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -260,7 +260,7 @@ var invokeVii = &wasm.HostFunc{
 }
 
 func invokeViiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	_, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32i32_v, wasm.Index(stack[0]), stack[1:])
+	_, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32i32_v, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -276,7 +276,7 @@ var invokeViii = &wasm.HostFunc{
 }
 
 func invokeViiiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	_, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32i32i32_v, wasm.Index(stack[0]), stack[1:])
+	_, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32i32i32_v, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -292,7 +292,7 @@ var invokeViiii = &wasm.HostFunc{
 }
 
 func invokeViiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
-	_, err := callDynamic(ctx, mod.(*wasm.CallContext), wasm.PreAllocatedTypeID_i32i32i32i32_v, wasm.Index(stack[0]), stack[1:])
+	_, err := callDynamic(ctx, mod.(*wasm.ModuleInstance), wasm.PreAllocatedTypeID_i32i32i32i32_v, wasm.Index(stack[0]), stack[1:])
 	if err != nil {
 		panic(err)
 	}
@@ -304,17 +304,15 @@ func invokeViiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 // # Parameters
 //
 //   - ctx: the propagated go context.
-//   - callCtx: the incoming context of the `invoke_` function.
+//   - m: the incoming module instance of the `invoke_` function.
 //   - typeID: used to type check on indirect calls.
 //   - tableOffset: position in the module's only table
 //   - params: parameters to the funcref
-func callDynamic(ctx context.Context, callCtx *wasm.CallContext, typeID wasm.FunctionTypeID, tableOffset wasm.Index, params []uint64) (results []uint64, err error) {
-	m := callCtx.Module()
-
+func callDynamic(ctx context.Context, m *wasm.ModuleInstance, typeID wasm.FunctionTypeID, tableOffset wasm.Index, params []uint64) (results []uint64, err error) {
 	t := m.Tables[0] // Emscripten doesn't use multiple tables
 	idx, err := m.Engine.LookupFunction(t, typeID, tableOffset)
 	if err != nil {
 		return nil, err
 	}
-	return callCtx.Function(idx).Call(ctx, params...)
+	return m.Function(idx).Call(ctx, params...)
 }

--- a/imports/wasi_snapshot_preview1/args.go
+++ b/imports/wasi_snapshot_preview1/args.go
@@ -44,7 +44,7 @@ import (
 var argsGet = newHostFunc(wasip1.ArgsGetName, argsGetFn, []api.ValueType{i32, i32}, "argv", "argv_buf")
 
 func argsGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	argv, argvBuf := uint32(params[0]), uint32(params[1])
 	return writeOffsetsAndNullTerminatedValues(mod.Memory(), sysCtx.Args(), argv, argvBuf, sysCtx.ArgsSize())
 }
@@ -81,7 +81,7 @@ func argsGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno
 var argsSizesGet = newHostFunc(wasip1.ArgsSizesGetName, argsSizesGetFn, []api.ValueType{i32, i32}, "result.argc", "result.argv_len")
 
 func argsSizesGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	mem := mod.Memory()
 	resultArgc, resultArgvLen := uint32(params[0]), uint32(params[1])
 

--- a/imports/wasi_snapshot_preview1/clock.go
+++ b/imports/wasi_snapshot_preview1/clock.go
@@ -40,7 +40,7 @@ import (
 var clockResGet = newHostFunc(wasip1.ClockResGetName, clockResGetFn, []api.ValueType{i32, i32}, "id", "result.resolution")
 
 func clockResGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	id, resultResolution := uint32(params[0]), uint32(params[1])
 
 	var resolution uint64 // ns
@@ -93,7 +93,7 @@ func clockResGetFn(_ context.Context, mod api.Module, params []uint64) syscall.E
 var clockTimeGet = newHostFunc(wasip1.ClockTimeGetName, clockTimeGetFn, []api.ValueType{i32, i64, i32}, "id", "precision", "result.timestamp")
 
 func clockTimeGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	id := uint32(params[0])
 	// TODO: precision is currently ignored.
 	// precision = params[1]

--- a/imports/wasi_snapshot_preview1/environ.go
+++ b/imports/wasi_snapshot_preview1/environ.go
@@ -44,7 +44,7 @@ import (
 var environGet = newHostFunc(wasip1.EnvironGetName, environGetFn, []api.ValueType{i32, i32}, "environ", "environ_buf")
 
 func environGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	environ, environBuf := uint32(params[0]), uint32(params[1])
 
 	return writeOffsetsAndNullTerminatedValues(mod.Memory(), sysCtx.Environ(), environ, environBuf, sysCtx.EnvironSize())
@@ -84,7 +84,7 @@ func environGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Er
 var environSizesGet = newHostFunc(wasip1.EnvironSizesGetName, environSizesGetFn, []api.ValueType{i32, i32}, "result.environc", "result.environv_len")
 
 func environSizesGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	mem := mod.Memory()
 	resultEnvironc, resultEnvironvLen := uint32(params[0]), uint32(params[1])
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -53,7 +53,7 @@ func Test_fdAllocate(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFSConfig(
 		wazero.NewFSConfig().WithDirMount(tmpDir, "/"),
 	))
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 	defer r.Close(testCtx)
 
@@ -132,7 +132,7 @@ func Test_fdClose(t *testing.T) {
 	defer r.Close(testCtx)
 
 	// open both paths without using WASI
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fdToClose, errno := fsc.OpenFile(preopen, path1, os.O_RDONLY, 0)
@@ -225,7 +225,7 @@ func Test_fdFdstatGet(t *testing.T) {
 	memorySize := mod.Memory().Size()
 
 	// open both paths without using WASI
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fileFD, errno := fsc.OpenFile(preopen, file, os.O_RDONLY, 0)
@@ -374,7 +374,7 @@ func Test_fdFdstatSetFlags(t *testing.T) {
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFSConfig(wazero.NewFSConfig().
 		WithDirMount(tmpDir, "/")))
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 	defer r.Close(testCtx)
 
@@ -470,7 +470,7 @@ func Test_fdFilestatGet(t *testing.T) {
 	memorySize := mod.Memory().Size()
 
 	// open both paths without using WASI
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fileFD, errno := fsc.OpenFile(preopen, file, os.O_RDONLY, 0)
@@ -839,7 +839,7 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 			mod, fd, log, r := requireOpenFile(t, tmpDir, filepath, []byte("anything"), false)
 			defer r.Close(testCtx)
 
-			sys := mod.(*wasm.CallContext).Sys
+			sys := mod.(*wasm.ModuleInstance).Sys
 			fsc := sys.FS()
 
 			paramFd := fd
@@ -1882,7 +1882,7 @@ func Test_fdReaddir(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fd, errno := fsc.OpenFile(preopen, "dir", os.O_RDONLY, 0)
@@ -2188,7 +2188,7 @@ func Test_fdReaddir_Rewind(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 
 	fd, errno := fsc.OpenFile(fsc.RootFS(), "dir", os.O_RDONLY, 0)
 	require.Zero(t, errno)
@@ -2251,7 +2251,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 	defer r.Close(testCtx)
 	memLen := mod.Memory().Size()
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fileFD, errno := fsc.OpenFile(preopen, "animals.txt", os.O_RDONLY, 0)
@@ -2450,7 +2450,7 @@ func Test_fdRenumber(t *testing.T) {
 			mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 			defer r.Close(testCtx)
 
-			fsc := mod.(*wasm.CallContext).Sys.FS()
+			fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 			preopen := fsc.RootFS()
 
 			// Sanity check of the file descriptor assignment.
@@ -2537,7 +2537,7 @@ func Test_fdSeek(t *testing.T) {
 			maskMemory(t, mod, len(tc.expectedMemory))
 
 			// Since we initialized this file, we know it is a seeker (because it is a MapFile)
-			fsc := mod.(*wasm.CallContext).Sys.FS()
+			fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 			f, ok := fsc.LookupFile(fd)
 			require.True(t, ok)
 			seeker := f.File.(io.Seeker)
@@ -2565,7 +2565,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 	mod, fileFD, log, r := requireOpenFile(t, t.TempDir(), "test_path", []byte("wazero"), false)
 	defer r.Close(testCtx)
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	require.Zero(t, fsc.RootFS().Mkdir("dir", 0o0700))
 	dirFD := requireOpenFD(t, mod, "dir")
 
@@ -2695,7 +2695,7 @@ func Test_fdTell(t *testing.T) {
 	maskMemory(t, mod, len(expectedMemory))
 
 	// Since we initialized this file, we know it is a seeker (because it is a MapFile)
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	f, ok := fsc.LookupFile(fd)
 	require.True(t, ok)
 	seeker := f.File.(io.Seeker)
@@ -3548,7 +3548,7 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 			path := 0
 			pathLen := uint32(len(pathName))
 
-			sys := mod.(*wasm.CallContext).Sys
+			sys := mod.(*wasm.ModuleInstance).Sys
 			fsc := sys.FS()
 
 			var oldSt platform.Stat_t
@@ -3604,7 +3604,7 @@ func Test_pathLink(t *testing.T) {
 	newDirName := "my-new-dir/sub"
 	newDirPath := joinPath(tmpDir, newDirName)
 	require.NoError(t, os.MkdirAll(joinPath(tmpDir, newDirName), 0o700))
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	newFd, errno := fsc.OpenFile(fsc.RootFS(), newDirName, 0o600, 0)
 	require.Zero(t, errno)
 
@@ -3949,14 +3949,14 @@ func Test_pathOpen(t *testing.T) {
 				require.True(t, ok)
 				require.Equal(t, expectedOpenedFd, openedFd)
 
-				tc.expected(t, mod.(*wasm.CallContext).Sys.FS())
+				tc.expected(t, mod.(*wasm.ModuleInstance).Sys.FS())
 			}
 		})
 	}
 }
 
 func requireOpenFD(t *testing.T, mod api.Module, path string) uint32 {
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fd, errno := fsc.OpenFile(preopen, path, os.O_RDONLY, 0)
@@ -4892,7 +4892,7 @@ func requireOpenFile(t *testing.T, tmpDir string, pathName string, data []byte, 
 	}
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFSConfig(fsConfig))
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	fd, errno := fsc.OpenFile(preopen, pathName, oflags, 0)
@@ -4915,7 +4915,7 @@ func Test_fdReaddir_dotEntriesHaveRealInodes(t *testing.T) {
 
 	mem := mod.Memory()
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	readDirTarget := "dir"
@@ -4973,7 +4973,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 
 	mem := mod.Memory()
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
 
 	dirName := "dir"

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -127,7 +127,7 @@ func processClockEvent(_ context.Context, mod api.Module, inBuf []byte) syscall.
 	// unaffected. Since this function only supports relative timeout, we can
 	// skip name ID validation and use a single sleep function.
 
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	sysCtx.Nanosleep(int64(timeout))
 	return 0
 }
@@ -136,7 +136,7 @@ func processClockEvent(_ context.Context, mod api.Module, inBuf []byte) syscall.
 // subscriptions are not yet supported.
 func processFDEvent(mod api.Module, eventType byte, inBuf []byte) syscall.Errno {
 	fd := le.Uint32(inBuf)
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 
 	// Choose the best error, which falls back to unsupported, until we support
 	// files.

--- a/imports/wasi_snapshot_preview1/random.go
+++ b/imports/wasi_snapshot_preview1/random.go
@@ -37,7 +37,7 @@ import (
 var randomGet = newHostFunc(wasip1.RandomGetName, randomGetFn, []api.ValueType{i32, i32}, "buf", "buf_len")
 
 func randomGetFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	randSource := sysCtx.RandSource()
 	buf, bufLen := uint32(params[0]), uint32(params[1])
 

--- a/imports/wasi_snapshot_preview1/sched.go
+++ b/imports/wasi_snapshot_preview1/sched.go
@@ -16,7 +16,7 @@ import (
 var schedYield = newHostFunc(wasip1.SchedYieldName, schedYieldFn, nil)
 
 func schedYieldFn(_ context.Context, mod api.Module, _ []uint64) syscall.Errno {
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	sysCtx.Osyield()
 	return 0
 }

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -191,7 +191,7 @@ func Benchmark_fdReaddir(b *testing.B) {
 			fn := mod.ExportedFunction(wasip1.FdReaddirName)
 
 			// Open the root directory as a file-descriptor.
-			fsc := mod.(*wasm.CallContext).Sys.FS()
+			fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 			fd, errno := fsc.OpenFile(fsc.RootFS(), ".", os.O_RDONLY, 0)
 			if errno != 0 {
 				b.Fatal(errno)
@@ -317,7 +317,7 @@ func Benchmark_pathFilestat(b *testing.B) {
 			// under a pre-determined directory: zig
 			fd := sys.FdPreopen
 			if bc.fd != sys.FdPreopen {
-				fsc := mod.(*wasm.CallContext).Sys.FS()
+				fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 				fd, errno := fsc.OpenFile(fsc.RootFS(), "zig", os.O_RDONLY, 0)
 				if errno != 0 {
 					b.Fatal(errno)

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -19,8 +19,8 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "no nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Globals: []*wasm.GlobalInstance{{Val: 100}},
-				Memory:  &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				Globals:        []*wasm.GlobalInstance{{Val: 100}},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Tables: []*wasm.TableInstance{
 					{References: make([]wasm.Reference, 20)},
 					{References: make([]wasm.Reference, 10)},
@@ -34,7 +34,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			name: "element instances nil",
 			moduleInstance: &wasm.ModuleInstance{
 				Globals:          []*wasm.GlobalInstance{{Val: 100}},
-				Memory:           &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				MemoryInstance:   &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Tables:           []*wasm.TableInstance{{References: make([]wasm.Reference, 20)}},
 				TypeIDs:          make([]wasm.FunctionTypeID, 10),
 				DataInstances:    make([][]byte, 10),
@@ -45,7 +45,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			name: "data instances nil",
 			moduleInstance: &wasm.ModuleInstance{
 				Globals:          []*wasm.GlobalInstance{{Val: 100}},
-				Memory:           &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				MemoryInstance:   &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Tables:           []*wasm.TableInstance{{References: make([]wasm.Reference, 20)}},
 				TypeIDs:          make([]wasm.FunctionTypeID, 10),
 				DataInstances:    nil,
@@ -55,7 +55,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "globals nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:           &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				MemoryInstance:   &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Tables:           []*wasm.TableInstance{{References: make([]wasm.Reference, 20)}},
 				TypeIDs:          make([]wasm.FunctionTypeID, 10),
 				DataInstances:    make([][]byte, 10),
@@ -75,7 +75,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "table nil",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory:           &wasm.MemoryInstance{Buffer: make([]byte, 10)},
+				MemoryInstance:   &wasm.MemoryInstance{Buffer: make([]byte, 10)},
 				Tables:           []*wasm.TableInstance{{References: nil}},
 				TypeIDs:          make([]wasm.FunctionTypeID, 10),
 				DataInstances:    make([][]byte, 10),
@@ -94,7 +94,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 		{
 			name: "memory zero length",
 			moduleInstance: &wasm.ModuleInstance{
-				Memory: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
+				MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, 0)},
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			ce := env.callEngine()
 
 			ir := &wazeroir.CompilationResult{
-				HasMemory:           tc.moduleInstance.Memory != nil,
+				HasMemory:           tc.moduleInstance.MemoryInstance != nil,
 				HasTable:            len(tc.moduleInstance.Tables) > 0,
 				HasDataInstances:    len(tc.moduleInstance.DataInstances) > 0,
 				HasElementInstances: len(tc.moduleInstance.ElementInstances) > 0,
@@ -142,11 +142,11 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Globals))
 			require.Equal(t, bufSliceHeader.Data, ce.moduleContext.globalElement0Address)
 
-			if tc.moduleInstance.Memory != nil {
-				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.Memory.Buffer))
+			if tc.moduleInstance.MemoryInstance != nil {
+				bufSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&tc.moduleInstance.MemoryInstance.Buffer))
 				require.Equal(t, uint64(bufSliceHeader.Len), ce.moduleContext.memorySliceLen)
 				require.Equal(t, bufSliceHeader.Data, ce.moduleContext.memoryElement0Address)
-				require.Equal(t, tc.moduleInstance.Memory, ce.moduleContext.memoryInstance)
+				require.Equal(t, tc.moduleInstance.MemoryInstance, ce.moduleContext.memoryInstance)
 			}
 
 			if len(tc.moduleInstance.Tables) > 0 {

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -74,7 +74,7 @@ func init() {
 	// Offsets for wasm.ModuleInstance.
 	var moduleInstance wasm.ModuleInstance
 	requireEqual(int(unsafe.Offsetof(moduleInstance.Globals)), moduleInstanceGlobalsOffset, "moduleInstanceGlobalsOffset")
-	requireEqual(int(unsafe.Offsetof(moduleInstance.Memory)), moduleInstanceMemoryOffset, "moduleInstanceMemoryOffset")
+	requireEqual(int(unsafe.Offsetof(moduleInstance.MemoryInstance)), moduleInstanceMemoryOffset, "moduleInstanceMemoryOffset")
 	requireEqual(int(unsafe.Offsetof(moduleInstance.Tables)), moduleInstanceTablesOffset, "moduleInstanceTablesOffset")
 	requireEqual(int(unsafe.Offsetof(moduleInstance.Engine)), moduleInstanceEngineOffset, "moduleInstanceEngineOffset")
 	requireEqual(int(unsafe.Offsetof(moduleInstance.TypeIDs)), moduleInstanceTypeIDsOffset, "moduleInstanceTypeIDsOffset")
@@ -147,7 +147,7 @@ func (j *compilerEnv) stackTopAsV128() (lo uint64, hi uint64) {
 }
 
 func (j *compilerEnv) memory() []byte {
-	return j.moduleInstance.Memory.Buffer
+	return j.moduleInstance.MemoryInstance.Buffer
 }
 
 func (j *compilerEnv) stack() []uint64 {
@@ -267,10 +267,10 @@ func newCompilerEnvironment() *compilerEnv {
 	return &compilerEnv{
 		me: me,
 		moduleInstance: &wasm.ModuleInstance{
-			Memory:  &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
-			Tables:  []*wasm.TableInstance{},
-			Globals: []*wasm.GlobalInstance{},
-			Engine:  me,
+			MemoryInstance: &wasm.MemoryInstance{Buffer: make([]byte, wasm.MemoryPageSize*defaultMemoryPageNumInTest)},
+			Tables:         []*wasm.TableInstance{},
+			Globals:        []*wasm.GlobalInstance{},
+			Engine:         me,
 		},
 		ce: me.newCallEngine(initialStackSize, nil),
 	}

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -606,7 +606,7 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 		stackContext: stackContext{stackBasePointerInBytes: 16},
 		contextStack: &contextStack{self: prevContext},
 	}
-	ce.builtinFunctionFunctionListenerBefore(ce.ctx, &wasm.CallContext{}, f)
+	ce.builtinFunctionFunctionListenerBefore(ce.ctx, &wasm.ModuleInstance{}, f)
 
 	// Contexts must be stacked.
 	require.Equal(t, currentContext, ce.contextStack.self)
@@ -635,7 +635,7 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 		stackContext: stackContext{stackBasePointerInBytes: 40},
 		contextStack: &contextStack{self: prevContext},
 	}
-	ce.builtinFunctionFunctionListenerAfter(ce.ctx, &wasm.CallContext{}, f)
+	ce.builtinFunctionFunctionListenerAfter(ce.ctx, &wasm.ModuleInstance{}, f)
 
 	// Contexts must be popped.
 	require.Nil(t, ce.contextStack)

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -367,7 +367,7 @@ func TestInterpreter_NonTrappingFloatToIntConversion(t *testing.T) {
 						source: &wasm.FunctionInstance{Module: &wasm.ModuleInstance{Engine: &moduleEngine{}}},
 						parent: &code{body: body},
 					}
-					ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
+					ce.callNativeFunc(testCtx, &wasm.ModuleInstance{}, f)
 
 					if len(tc.expected32bit) > 0 {
 						require.Equal(t, tc.expected32bit[i], int32(uint32(ce.popValue())))
@@ -434,7 +434,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
 					}},
 				}
-				ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
+				ce.callNativeFunc(testCtx, &wasm.ModuleInstance{}, f)
 				require.Equal(t, tc.expected, int32(uint32(ce.popValue())))
 			})
 		}
@@ -488,7 +488,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 						{kind: wazeroir.OperationKindBr, us: []uint64{math.MaxUint64}},
 					}},
 				}
-				ce.callNativeFunc(testCtx, &wasm.CallContext{}, f)
+				ce.callNativeFunc(testCtx, &wasm.ModuleInstance{}, f)
 				require.Equal(t, tc.expected, int64(ce.popValue()))
 			})
 		}

--- a/internal/gojs/argsenv.go
+++ b/internal/gojs/argsenv.go
@@ -22,7 +22,7 @@ var le = binary.LittleEndian
 // they can be read by main, Go compiles as the function export "run".
 func WriteArgsAndEnviron(mod api.Module) (argc, argv uint32, err error) {
 	mem := mod.Memory()
-	sysCtx := mod.(*wasm.CallContext).Sys
+	sysCtx := mod.(*wasm.ModuleInstance).Sys
 	args := sysCtx.Args()
 	environ := sysCtx.Environ()
 

--- a/internal/gojs/crypto.go
+++ b/internal/gojs/crypto.go
@@ -23,7 +23,7 @@ var jsCrypto = newJsVal(goos.RefJsCrypto, custom.NameCrypto).
 type cryptoGetRandomValues struct{}
 
 func (cryptoGetRandomValues) invoke(_ context.Context, mod api.Module, args ...interface{}) (interface{}, error) {
-	randSource := mod.(*wasm.CallContext).Sys.RandSource()
+	randSource := mod.(*wasm.ModuleInstance).Sys.RandSource()
 
 	r := args[0].(*goos.ByteArray)
 	n, err := randSource.Read(r.Unwrap())

--- a/internal/gojs/goarch/wasm.go
+++ b/internal/gojs/goarch/wasm.go
@@ -152,7 +152,7 @@ func (s *stack) SetResultUint32(i int, v uint32) {
 func GetSP(mod api.Module) uint32 {
 	// Cheat by reading global[0] directly instead of through a function proxy.
 	// https://github.com/golang/go/blob/go1.20/src/runtime/rt0_js_wasm.s#L87-L90
-	return uint32(mod.(*wasm.CallContext).GlobalVal(0))
+	return uint32(mod.(*wasm.ModuleInstance).GlobalVal(0))
 }
 
 func NewFunc(name string, goFunc Func) *wasm.HostFunc {

--- a/internal/gojs/runtime.go
+++ b/internal/gojs/runtime.go
@@ -41,7 +41,7 @@ func wasmWrite(_ context.Context, mod api.Module, stack goarch.Stack) {
 	fd := stack.ParamUint32(0)
 	p := stack.ParamBytes(mod.Memory(), 1 /*, 2 */)
 
-	fsc := mod.(*wasm.CallContext).Sys.FS()
+	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	if writer := internalsys.WriterForFile(fsc, fd); writer == nil {
 		panic(fmt.Errorf("fd %d invalid", fd))
 	} else if _, err := writer.Write(p); err != nil {
@@ -67,7 +67,7 @@ func resetMemoryDataView(context.Context, api.Module, goarch.Stack) {
 var Nanotime1 = goarch.NewFunc(custom.NameRuntimeNanotime1, nanotime1)
 
 func nanotime1(_ context.Context, mod api.Module, stack goarch.Stack) {
-	nsec := mod.(*wasm.CallContext).Sys.Nanotime()
+	nsec := mod.(*wasm.ModuleInstance).Sys.Nanotime()
 
 	stack.SetResultI64(0, nsec)
 }
@@ -78,7 +78,7 @@ func nanotime1(_ context.Context, mod api.Module, stack goarch.Stack) {
 var Walltime = goarch.NewFunc(custom.NameRuntimeWalltime, walltime)
 
 func walltime(_ context.Context, mod api.Module, stack goarch.Stack) {
-	sec, nsec := mod.(*wasm.CallContext).Sys.Walltime()
+	sec, nsec := mod.(*wasm.ModuleInstance).Sys.Walltime()
 
 	stack.SetResultI64(0, sec)
 	stack.SetResultI32(1, nsec)
@@ -144,7 +144,7 @@ var GetRandomData = goarch.NewFunc(custom.NameRuntimeGetRandomData, getRandomDat
 func getRandomData(_ context.Context, mod api.Module, stack goarch.Stack) {
 	r := stack.ParamBytes(mod.Memory(), 0 /*, 1 */)
 
-	randSource := mod.(*wasm.CallContext).Sys.RandSource()
+	randSource := mod.(*wasm.ModuleInstance).Sys.RandSource()
 
 	bufLen := len(r)
 	if n, err := randSource.Read(r); err != nil {

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -40,7 +40,7 @@ type ModuleEngine interface {
 	Name() string
 
 	// NewCallEngine returns a CallEngine for the given FunctionInstance.
-	NewCallEngine(callCtx *CallContext, f *FunctionInstance) (CallEngine, error)
+	NewCallEngine(m *ModuleInstance, f *FunctionInstance) (CallEngine, error)
 
 	// LookupFunction returns the index of the function in the function table.
 	LookupFunction(t *TableInstance, typeId FunctionTypeID, tableOffset Index) (Index, error)
@@ -54,5 +54,5 @@ type ModuleEngine interface {
 // internally, and shouldn't be used concurrently.
 type CallEngine interface {
 	// Call invokes a function instance f with given parameters.
-	Call(ctx context.Context, m *CallContext, params []uint64) (results []uint64, err error)
+	Call(ctx context.Context, m *ModuleInstance, params []uint64) (results []uint64, err error)
 }

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -175,7 +175,7 @@ func TestPopValues(t *testing.T) {
 
 func Test_callGoFunc(t *testing.T) {
 	tPtr := uintptr(unsafe.Pointer(t))
-	callCtx := &CallContext{}
+	inst := &ModuleInstance{}
 
 	tests := []struct {
 		name                         string
@@ -196,7 +196,7 @@ func Test_callGoFunc(t *testing.T) {
 			name: "(ctx, mod) -> ()",
 			input: func(ctx context.Context, m api.Module) {
 				require.Equal(t, testCtx, ctx)
-				require.Equal(t, callCtx, m)
+				require.Equal(t, inst, m)
 			},
 		},
 		{
@@ -242,7 +242,7 @@ func Test_callGoFunc(t *testing.T) {
 			name: "all supported params and i32 result - (ctx, mod)",
 			input: func(ctx context.Context, m api.Module, v uintptr, w uint32, x uint64, y float32, z float64) uint32 {
 				require.Equal(t, testCtx, ctx)
-				require.Equal(t, callCtx, m)
+				require.Equal(t, inst, m)
 				require.Equal(t, tPtr, v)
 				require.Equal(t, uint32(math.MaxUint32), w)
 				require.Equal(t, uint64(math.MaxUint64), x)
@@ -279,7 +279,7 @@ func Test_callGoFunc(t *testing.T) {
 			case api.GoFunction:
 				code.GoFunc.(api.GoFunction).Call(testCtx, stack)
 			case api.GoModuleFunction:
-				code.GoFunc.(api.GoModuleFunction).Call(testCtx, callCtx, stack)
+				code.GoFunc.(api.GoModuleFunction).Call(testCtx, inst, stack)
 			default:
 				t.Fatal("unexpected type.")
 			}

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -637,8 +637,8 @@ func paramNames(localNames IndirectNameMap, funcIdx uint32, paramLen int) []stri
 func (m *ModuleInstance) buildMemory(module *Module) {
 	memSec := module.MemorySection
 	if memSec != nil {
-		m.Memory = NewMemoryInstance(memSec)
-		m.Memory.definition = &module.MemoryDefinitionSection[0]
+		m.MemoryInstance = NewMemoryInstance(memSec)
+		m.MemoryInstance.definition = &module.MemoryDefinitionSection[0]
 	}
 }
 

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -852,7 +852,7 @@ func TestModule_buildFunctions(t *testing.T) {
 
 	// Note: This only returns module-defined functions, not imported ones. That's why the index starts with 1, not 0.
 	instance := &ModuleInstance{
-		Name: "counter", TypeIDs: []FunctionTypeID{0},
+		ModuleName: "counter", TypeIDs: []FunctionTypeID{0},
 		Functions: make([]FunctionInstance, len(m.ImportSection)+len(m.FunctionSection)),
 	}
 	instance.BuildFunctions(m)
@@ -865,7 +865,7 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		m := ModuleInstance{}
 		m.buildMemory(&Module{})
-		require.Nil(t, m.Memory)
+		require.Nil(t, m.MemoryInstance)
 	})
 	t.Run("non-nil", func(t *testing.T) {
 		min := uint32(1)
@@ -876,7 +876,7 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 			MemorySection:           &Memory{Min: min, Cap: min, Max: max},
 			MemoryDefinitionSection: []MemoryDefinition{mDef},
 		})
-		mem := m.Memory
+		mem := m.MemoryInstance
 		require.Equal(t, min, mem.Min)
 		require.Equal(t, max, mem.Max)
 		require.Equal(t, &mDef, mem.definition)

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -18,9 +18,9 @@ func (s *Store) setModule(m *ModuleInstance) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
-	node, ok := s.nameToNode[m.Name]
+	node, ok := s.nameToNode[m.ModuleName]
 	if !ok {
-		return fmt.Errorf("module[%s] name has not been required", m.Name)
+		return fmt.Errorf("module[%s] name has not been required", m.ModuleName)
 	}
 
 	node.module = m
@@ -143,5 +143,5 @@ func (s *Store) Module(moduleName string) api.Module {
 	if err != nil {
 		return nil
 	}
-	return m.CallCtx
+	return m
 }

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -9,16 +9,16 @@ import (
 
 func TestStore_setModule(t *testing.T) {
 	s := newStore()
-	m1 := &ModuleInstance{Name: "m1"}
+	m1 := &ModuleInstance{ModuleName: "m1"}
 
 	t.Run("errors if not required", func(t *testing.T) {
 		require.Error(t, s.setModule(m1))
 	})
 
 	t.Run("adds module", func(t *testing.T) {
-		s.nameToNode[m1.Name] = &moduleListNode{name: m1.Name}
+		s.nameToNode[m1.ModuleName] = &moduleListNode{name: m1.ModuleName}
 		require.NoError(t, s.setModule(m1))
-		require.Equal(t, map[string]*moduleListNode{m1.Name: {name: m1.Name, module: m1}}, s.nameToNode)
+		require.Equal(t, map[string]*moduleListNode{m1.ModuleName: {name: m1.ModuleName, module: m1}}, s.nameToNode)
 
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
@@ -26,17 +26,17 @@ func TestStore_setModule(t *testing.T) {
 
 	t.Run("redundant ok", func(t *testing.T) {
 		require.NoError(t, s.setModule(m1))
-		require.Equal(t, map[string]*moduleListNode{m1.Name: {name: m1.Name, module: m1}}, s.nameToNode)
+		require.Equal(t, map[string]*moduleListNode{m1.ModuleName: {name: m1.ModuleName, module: m1}}, s.nameToNode)
 
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
 	})
 
 	t.Run("adds second module", func(t *testing.T) {
-		m2 := &ModuleInstance{Name: "m2"}
-		s.nameToNode[m2.Name] = &moduleListNode{name: m2.Name}
+		m2 := &ModuleInstance{ModuleName: "m2"}
+		s.nameToNode[m2.ModuleName] = &moduleListNode{name: m2.ModuleName}
 		require.NoError(t, s.setModule(m2))
-		require.Equal(t, map[string]*moduleListNode{m1.Name: {name: m1.Name, module: m1}, m2.Name: {name: m2.Name, module: m2}}, s.nameToNode)
+		require.Equal(t, map[string]*moduleListNode{m1.ModuleName: {name: m1.ModuleName, module: m1}, m2.ModuleName: {name: m2.ModuleName, module: m2}}, s.nameToNode)
 
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
@@ -55,8 +55,8 @@ func TestStore_deleteModule(t *testing.T) {
 		require.NoError(t, s.deleteModule(m2.moduleListNode))
 
 		// Leaves the other module alone
-		m1Node := &moduleListNode{name: m1.Name, module: m1}
-		require.Equal(t, map[string]*moduleListNode{m1.Name: m1Node}, s.nameToNode)
+		m1Node := &moduleListNode{name: m1.ModuleName, module: m1}
+		require.Equal(t, map[string]*moduleListNode{m1.ModuleName: m1Node}, s.nameToNode)
 		require.Equal(t, m1Node, s.moduleList)
 	})
 
@@ -76,7 +76,7 @@ func TestStore_module(t *testing.T) {
 	s, m1, _ := newTestStore()
 
 	t.Run("ok", func(t *testing.T) {
-		got, err := s.module(m1.Name)
+		got, err := s.module(m1.ModuleName)
 		require.NoError(t, err)
 		require.Equal(t, m1, got)
 	})
@@ -96,7 +96,7 @@ func TestStore_module(t *testing.T) {
 
 	t.Run("store closed", func(t *testing.T) {
 		require.NoError(t, s.CloseWithExitCode(context.Background(), 0))
-		got, err := s.module(m1.Name)
+		got, err := s.module(m1.ModuleName)
 		require.Error(t, err)
 		require.Nil(t, got)
 	})
@@ -106,9 +106,9 @@ func TestStore_requireModules(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		s, m1, _ := newTestStore()
 
-		modules, err := s.requireModules(map[string]struct{}{m1.Name: {}})
+		modules, err := s.requireModules(map[string]struct{}{m1.ModuleName: {}})
 		require.NoError(t, err)
-		require.Equal(t, map[string]*ModuleInstance{m1.Name: m1}, modules)
+		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, modules)
 	})
 	t.Run("module not instantiated", func(t *testing.T) {
 		s, _, _ := newTestStore()
@@ -156,8 +156,8 @@ func TestStore_requireModuleName(t *testing.T) {
 func TestStore_AliasModule(t *testing.T) {
 	s := newStore()
 
-	m1 := &ModuleInstance{Name: "m1"}
-	s.nameToNode[m1.Name] = &moduleListNode{name: m1.Name, module: m1}
+	m1 := &ModuleInstance{ModuleName: "m1"}
+	s.nameToNode[m1.ModuleName] = &moduleListNode{name: m1.ModuleName, module: m1}
 
 	t.Run("alias module", func(t *testing.T) {
 		require.NoError(t, s.AliasModule("m1", "m2"))
@@ -172,7 +172,7 @@ func TestStore_Module(t *testing.T) {
 	s, m1, _ := newTestStore()
 
 	t.Run("ok", func(t *testing.T) {
-		require.Equal(t, m1.CallCtx, s.Module(m1.Name))
+		require.Equal(t, m1, s.Module(m1.ModuleName))
 	})
 
 	t.Run("unknown", func(t *testing.T) {
@@ -183,16 +183,13 @@ func TestStore_Module(t *testing.T) {
 // newTestStore sets up a new Store without adding test coverage its functions.
 func newTestStore() (*Store, *ModuleInstance, *ModuleInstance) {
 	s := newStore()
-	m1 := &ModuleInstance{Name: "m1"}
-	m1.CallCtx = NewCallContext(s, m1, nil)
+	m1 := &ModuleInstance{ModuleName: "m1"}
+	m2 := &ModuleInstance{ModuleName: "m2"}
 
-	m2 := &ModuleInstance{Name: "m2"}
-	m2.CallCtx = NewCallContext(s, m2, nil)
-
-	node1 := &moduleListNode{name: m1.Name, module: m1}
-	node2 := &moduleListNode{name: m2.Name, module: m2, next: node1}
+	node1 := &moduleListNode{name: m1.ModuleName, module: m1}
+	node2 := &moduleListNode{name: m2.ModuleName, module: m2, next: node1}
 	node1.prev = node2
-	s.nameToNode = map[string]*moduleListNode{m1.Name: node1, m2.Name: node2}
+	s.nameToNode = map[string]*moduleListNode{m1.ModuleName: node1, m2.ModuleName: node2}
 	s.moduleList = node2
 
 	m1.moduleListNode = node1

--- a/internal/wasm/table_test.go
+++ b/internal/wasm/table_test.go
@@ -24,9 +24,9 @@ func Test_resolveImports_table(t *testing.T) {
 		tableInst := &TableInstance{Max: &max}
 		importedModules := map[string]*ModuleInstance{
 			moduleName: {
-				Tables:  []*TableInstance{tableInst},
-				Exports: map[string]*Export{name: {Type: ExternTypeTable, Index: 0}},
-				Name:    moduleName,
+				Tables:     []*TableInstance{tableInst},
+				Exports:    map[string]*Export{name: {Type: ExternTypeTable, Index: 0}},
+				ModuleName: moduleName,
 			},
 		}
 		m := &ModuleInstance{Tables: make([]*TableInstance, 1)}
@@ -38,9 +38,9 @@ func Test_resolveImports_table(t *testing.T) {
 		importTableType := Table{Min: 2}
 		importedModules := map[string]*ModuleInstance{
 			moduleName: {
-				Tables:  []*TableInstance{{Min: importTableType.Min - 1}},
-				Exports: map[string]*Export{name: {Type: ExternTypeTable}},
-				Name:    moduleName,
+				Tables:     []*TableInstance{{Min: importTableType.Min - 1}},
+				Exports:    map[string]*Export{name: {Type: ExternTypeTable}},
+				ModuleName: moduleName,
 			},
 		}
 		m := &ModuleInstance{Tables: make([]*TableInstance, 1)}
@@ -52,9 +52,9 @@ func Test_resolveImports_table(t *testing.T) {
 		importTableType := Table{Max: &max}
 		importedModules := map[string]*ModuleInstance{
 			moduleName: {
-				Tables:  []*TableInstance{{Min: importTableType.Min - 1}},
-				Exports: map[string]*Export{name: {Type: ExternTypeTable}},
-				Name:    moduleName,
+				Tables:     []*TableInstance{{Min: importTableType.Min - 1}},
+				Exports:    map[string]*Export{name: {Type: ExternTypeTable}},
+				ModuleName: moduleName,
 			},
 		}
 		m := &ModuleInstance{Tables: make([]*TableInstance, 1)}
@@ -64,9 +64,9 @@ func Test_resolveImports_table(t *testing.T) {
 	t.Run("type mismatch", func(t *testing.T) {
 		importedModules := map[string]*ModuleInstance{
 			moduleName: {
-				Tables:  []*TableInstance{{Type: RefTypeFuncref}},
-				Exports: map[string]*Export{name: {Type: ExternTypeTable}},
-				Name:    moduleName,
+				Tables:     []*TableInstance{{Type: RefTypeFuncref}},
+				Exports:    map[string]*Export{name: {Type: ExternTypeTable}},
+				ModuleName: moduleName,
 			},
 		}
 		m := &ModuleInstance{Tables: make([]*TableInstance, 1)}

--- a/runtime.go
+++ b/runtime.go
@@ -313,7 +313,7 @@ func (r *runtime) InstantiateModule(
 
 	// Attach the code closer so that anything afterwards closes the compiled code when closing the module.
 	if code.closeWithModule {
-		mod.(*wasm.CallContext).CodeCloser = code
+		mod.(*wasm.ModuleInstance).CodeCloser = code
 	}
 
 	// Now, invoke any start functions, failing at first error.


### PR DESCRIPTION
`wasm.CallCtx` was introduced in the past bound to "function call" as the doc says, 
but it is no longer the case. In fact, it is just a thin wrapper over `*wasm.ModuleInstance`,
and unnecessary and confusing internal data structure now.
This removes the type and implements api.Module directly over `*wasm.ModuleInstance`.
As a result, we can clean up the internal and reduce the allocation.
```
goos: linux
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: AMD Ryzen 9 3950X 16-Core Processor
                                       │   old.txt   │              new.txt               │
                                       │   sec/op    │   sec/op     vs base               │
Initialization/interpreter-32            33.25µ ± 1%   32.75µ ± 0%  -1.52% (p=0.000 n=30)
Initialization/interpreter-multiple-32   14.16µ ± 0%   14.25µ ± 1%  +0.64% (p=0.020 n=30)
Initialization/compiler-32               38.60µ ± 1%   37.93µ ± 0%  -1.73% (p=0.000 n=30)
Initialization/compiler-multiple-32      13.65µ ± 1%   13.65µ ± 1%       ~ (p=0.117 n=30)
Compilation/with_extern_cache-32         292.4µ ± 1%   289.8µ ± 1%       ~ (p=0.100 n=30)
Compilation/without_extern_cache-32      10.61m ± 1%   10.46m ± 1%  -1.33% (p=0.000 n=30)
geomean                                  95.72µ        94.95µ       -0.80%

                                       │   old.txt    │               new.txt               │
                                       │     B/op     │     B/op      vs base               │
Initialization/interpreter-32            132.4Ki ± 0%   132.4Ki ± 0%  -0.02% (p=0.000 n=30)
Initialization/interpreter-multiple-32   132.9Ki ± 0%   132.8Ki ± 0%  -0.02% (p=0.000 n=30)
Initialization/compiler-32               133.1Ki ± 0%   133.1Ki ± 0%  -0.02% (p=0.000 n=30)
Initialization/compiler-multiple-32      137.4Ki ± 0%   137.4Ki ± 0%  -0.02% (p=0.000 n=30)
Compilation/with_extern_cache-32         53.76Ki ± 0%   53.78Ki ± 0%  +0.05% (p=0.000 n=30)
Compilation/without_extern_cache-32      1.907Mi ± 0%   1.907Mi ± 0%  -0.03% (p=0.000 n=30)
geomean                                  179.8Ki        179.8Ki       -0.01%

                                       │   old.txt   │              new.txt               │
                                       │  allocs/op  │  allocs/op   vs base               │
Initialization/interpreter-32             29.00 ± 0%    28.00 ± 0%  -3.45% (p=0.000 n=30)
Initialization/interpreter-multiple-32    42.00 ± 0%    41.00 ± 0%  -2.38% (p=0.000 n=30)
Initialization/compiler-32                29.00 ± 0%    28.00 ± 0%  -3.45% (p=0.000 n=30)
Initialization/compiler-multiple-32       32.00 ± 0%    31.00 ± 0%  -3.12% (p=0.000 n=30)
Compilation/with_extern_cache-32          986.0 ± 0%    986.0 ± 0%       ~ (p=0.313 n=30)
Compilation/without_extern_cache-32      32.62k ± 0%   32.62k ± 0%   0.00% (p=0.017 n=30)
geomean                                   182.0         178.2       -2.08%

```