### PR TITLE
Shrink the store's nameToModule map

### DIFF
--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -12,9 +12,10 @@ import (
 	"github.com/tetratelabs/wazero/sys"
 )
 
-// initialNameToModuleListSize is the initial capacity of the nameToModule map.
-// The capacity will never be smaller than this.
-const initialNameToModuleListSize = 100
+// nameToModuleShrinkThreshold is the size the nameToModule map can grow to
+// before it starts to be monitored for shrinking.
+// The capacity will never be smaller than this once the threshold is met.
+const nameToModuleShrinkThreshold = 100
 
 type (
 	// Store is the runtime representation of "instantiated" Wasm module and objects.
@@ -266,8 +267,8 @@ func NewStore(enabledFeatures api.CoreFeatures, engine Engine) *Store {
 		typeIDs[k] = v
 	}
 	return &Store{
-		nameToModule:     make(map[string]*ModuleInstance, initialNameToModuleListSize),
-		nameToModuleCap:  initialNameToModuleListSize,
+		nameToModule:     map[string]*ModuleInstance{},
+		nameToModuleCap:  nameToModuleShrinkThreshold,
 		EnabledFeatures:  enabledFeatures,
 		Engine:           engine,
 		typeIDs:          typeIDs,

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -267,6 +267,7 @@ func NewStore(enabledFeatures api.CoreFeatures, engine Engine) *Store {
 	}
 	return &Store{
 		nameToModule:     make(map[string]*ModuleInstance, initialNameToModuleListSize),
+		nameToModuleCap:  initialNameToModuleListSize,
 		EnabledFeatures:  enabledFeatures,
 		Engine:           engine,
 		typeIDs:          typeIDs,

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -30,14 +30,12 @@ func (s *Store) deleteModule(m *ModuleInstance) error {
 	if m.ModuleName != "" {
 		delete(s.nameToModule, m.ModuleName)
 
-		// shrink the map if it's allocated more than twice the size of the list
-		nameToModuleLen := len(s.nameToModule)
-		if s.nameToModuleCap > nameToModuleShrinkThreshold && s.nameToModuleCap >= nameToModuleLen*2 {
-			newCap := nameToModuleShrinkThreshold
-			if newCap < nameToModuleLen {
-				newCap = nameToModuleLen
-			}
-
+		// Shrink the map if it's allocated more than twice the size of the list
+		newCap := len(s.nameToModule)
+		if newCap < nameToModuleShrinkThreshold {
+			newCap = nameToModuleShrinkThreshold
+		}
+		if newCap*2 <= s.nameToModuleCap {
 			nameToModule := make(map[string]*ModuleInstance, newCap)
 			for k, v := range s.nameToModule {
 				nameToModule[k] = v

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -32,8 +32,8 @@ func (s *Store) deleteModule(m *ModuleInstance) error {
 
 		// shrink the map if it's allocated more than twice the size of the list
 		nameToModuleLen := len(s.nameToModule)
-		if s.nameToModuleCap > initialNameToModuleListSize && s.nameToModuleCap >= nameToModuleLen*2 {
-			newCap := initialNameToModuleListSize
+		if s.nameToModuleCap > nameToModuleShrinkThreshold && s.nameToModuleCap >= nameToModuleLen*2 {
+			newCap := nameToModuleShrinkThreshold
 			if newCap < nameToModuleLen {
 				newCap = nameToModuleLen
 			}

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -15,6 +16,7 @@ func TestStore_registerModule(t *testing.T) {
 		require.NoError(t, s.registerModule(m1))
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
+		require.Equal(t, 1, s.nameToModuleCap)
 	})
 
 	t.Run("adds second module", func(t *testing.T) {
@@ -22,6 +24,7 @@ func TestStore_registerModule(t *testing.T) {
 		require.NoError(t, s.registerModule(m2))
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}, s.nameToModule)
 		require.Equal(t, m2, s.moduleList)
+		require.Equal(t, 2, s.nameToModuleCap)
 	})
 
 	t.Run("error on duplicated non anonymous", func(t *testing.T) {
@@ -44,6 +47,7 @@ func TestStore_deleteModule(t *testing.T) {
 		// Leaves the other module alone.
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
+		require.Equal(t, 0, s.nameToModuleCap)
 	})
 
 	t.Run("ok if missing", func(t *testing.T) {
@@ -55,6 +59,7 @@ func TestStore_deleteModule(t *testing.T) {
 
 		require.Zero(t, len(s.nameToModule))
 		require.Nil(t, s.moduleList)
+		require.Equal(t, 0, s.nameToModuleCap)
 	})
 
 	t.Run("delete middle", func(t *testing.T) {
@@ -112,6 +117,53 @@ func TestStore_AliasModule(t *testing.T) {
 		require.Equal(t, map[string]*ModuleInstance{"m1": m1, "m2": m1}, s.nameToModule)
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
+		require.Equal(t, 2, s.nameToModuleCap)
+	})
+}
+
+func TestStore_nameToModuleCap(t *testing.T) {
+	t.Run("nameToModuleCap grows beyond initial cap", func(t *testing.T) {
+		s := newStore()
+		for i := 0; i < 300; i++ {
+			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i)}))
+		}
+
+		require.Equal(t, 300, s.nameToModuleCap)
+	})
+
+	t.Run("nameToModuleCap shrinks by half the cap", func(t *testing.T) {
+		s := newStore()
+		for i := 0; i < 400; i++ {
+			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i)}))
+		}
+
+		for i := 0; i < 250; i++ {
+			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i)]))
+		}
+
+		require.Equal(t, 200, s.nameToModuleCap)
+	})
+
+	t.Run("nameToModuleCap does not shrink below initial size", func(t *testing.T) {
+		s := newStore()
+		for i := 0; i < 400; i++ {
+			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i)}))
+		}
+
+		for i := 0; i < 350; i++ {
+			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i)]))
+		}
+
+		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+	})
+
+	t.Run("nameToModuleCap does not grow when if nameToModule does not grow", func(t *testing.T) {
+		s := newStore()
+		for i := 0; i < 400; i++ {
+			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i)}))
+			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i)]))
+			require.Equal(t, 1, s.nameToModuleCap)
+		}
 	})
 }
 

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -16,7 +16,7 @@ func TestStore_registerModule(t *testing.T) {
 		require.NoError(t, s.registerModule(m1))
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
-		require.Equal(t, 1, s.nameToModuleCap)
+		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
 	})
 
 	t.Run("adds second module", func(t *testing.T) {
@@ -24,7 +24,7 @@ func TestStore_registerModule(t *testing.T) {
 		require.NoError(t, s.registerModule(m2))
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}, s.nameToModule)
 		require.Equal(t, m2, s.moduleList)
-		require.Equal(t, 2, s.nameToModuleCap)
+		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
 	})
 
 	t.Run("error on duplicated non anonymous", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestStore_deleteModule(t *testing.T) {
 		// Leaves the other module alone.
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
-		require.Equal(t, 0, s.nameToModuleCap)
+		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
 	})
 
 	t.Run("ok if missing", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestStore_deleteModule(t *testing.T) {
 
 		require.Zero(t, len(s.nameToModule))
 		require.Nil(t, s.moduleList)
-		require.Equal(t, 0, s.nameToModuleCap)
+		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
 	})
 
 	t.Run("delete middle", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestStore_AliasModule(t *testing.T) {
 		require.Equal(t, map[string]*ModuleInstance{"m1": m1, "m2": m1}, s.nameToModule)
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
-		require.Equal(t, 2, s.nameToModuleCap)
+		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
 	})
 }
 
@@ -159,10 +159,13 @@ func TestStore_nameToModuleCap(t *testing.T) {
 
 	t.Run("nameToModuleCap does not grow when if nameToModule does not grow", func(t *testing.T) {
 		s := newStore()
-		for i := 0; i < 400; i++ {
+		for i := 0; i < 99; i++ {
 			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i)}))
-			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i)]))
-			require.Equal(t, 1, s.nameToModuleCap)
+		}
+		for i := 0; i < 400; i++ {
+			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i+99)}))
+			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i+99)]))
+			require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
 		}
 	})
 }

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -16,7 +16,7 @@ func TestStore_registerModule(t *testing.T) {
 		require.NoError(t, s.registerModule(m1))
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
-		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 	})
 
 	t.Run("adds second module", func(t *testing.T) {
@@ -24,7 +24,7 @@ func TestStore_registerModule(t *testing.T) {
 		require.NoError(t, s.registerModule(m2))
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}, s.nameToModule)
 		require.Equal(t, m2, s.moduleList)
-		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 	})
 
 	t.Run("error on duplicated non anonymous", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestStore_deleteModule(t *testing.T) {
 		// Leaves the other module alone.
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
-		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 	})
 
 	t.Run("ok if missing", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestStore_deleteModule(t *testing.T) {
 
 		require.Zero(t, len(s.nameToModule))
 		require.Nil(t, s.moduleList)
-		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 	})
 
 	t.Run("delete middle", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestStore_AliasModule(t *testing.T) {
 		require.Equal(t, map[string]*ModuleInstance{"m1": m1, "m2": m1}, s.nameToModule)
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
-		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 	})
 }
 
@@ -154,7 +154,7 @@ func TestStore_nameToModuleCap(t *testing.T) {
 			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i)]))
 		}
 
-		require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 	})
 
 	t.Run("nameToModuleCap does not grow when if nameToModule does not grow", func(t *testing.T) {
@@ -165,7 +165,7 @@ func TestStore_nameToModuleCap(t *testing.T) {
 		for i := 0; i < 400; i++ {
 			require.NoError(t, s.registerModule(&ModuleInstance{ModuleName: fmt.Sprintf("m%d", i+99)}))
 			require.NoError(t, s.deleteModule(s.nameToModule[fmt.Sprintf("m%d", i+99)]))
-			require.Equal(t, initialNameToModuleListSize, s.nameToModuleCap)
+			require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
 		}
 	})
 }


### PR DESCRIPTION
Putting this out there. Go does not shrink maps when elements are deleted so a long lived map with lots of elements added and deleted can consume a lot of memory.

This change would track the largest size the nameToNode map has grown to and if that size is more than twice the size it needs to be it gets replaced with a new map. Since we wouldn't want to be constantly resizing small maps I've set a floor and set the initial capacity of the map to that floor. I some what arbitrarily chose 10,000 as the floor.

The scenario this helps with is if a long running application has bursty periods of time when it instantiates a lot of named modules but most of the time has a very low volume of named modules.

I think it might be nice to make an option to disable or adjust the floor for applications running in memory constrained environments who know they will never need to instantiate a lot of named modules.

If there is interest in merging this I'll update the tests and add that option.