### PR TITLE
sysfs: stubs in approach to defining a new file type

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -64,8 +64,8 @@ func Test_fdAllocate(t *testing.T) {
 	require.True(t, ok)
 
 	requireSizeEqual := func(exp int64) {
-		st, err := f.Stat()
-		require.NoError(t, err)
+		st, errno := f.Stat()
+		require.Zero(t, errno)
 		require.Equal(t, exp, st.Size)
 	}
 
@@ -852,8 +852,8 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 			f, ok := fsc.LookupFile(fd)
 			require.True(t, ok)
 
-			st, err := f.Stat()
-			require.NoError(t, err)
+			st, errno := f.Stat()
+			require.Zero(t, errno)
 			prevAtime, prevMtime := st.Atim, st.Mtim
 
 			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdFilestatSetTimesName,
@@ -865,8 +865,8 @@ func Test_fdFilestatSetTimes(t *testing.T) {
 				f, ok := fsc.LookupFile(fd)
 				require.True(t, ok)
 
-				st, err = f.Stat()
-				require.NoError(t, err)
+				st, errno = f.Stat()
+				require.Zero(t, errno)
 				if tc.flags&wasip1.FstflagsAtim != 0 {
 					require.Equal(t, tc.atime, st.Atim)
 				} else if tc.flags&wasip1.FstflagsAtimNow != 0 {
@@ -1908,8 +1908,8 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "empty dir",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("emptydir")
-				require.NoError(t, err)
+				dir, errno := preopen.OpenFile("emptydir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
 
 				return &sys.FileEntry{File: dir}
 			},
@@ -1925,8 +1925,8 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "full read",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
 
 				return &sys.FileEntry{File: dir}
 			},
@@ -1942,8 +1942,8 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "can't read name",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
 
 				return &sys.FileEntry{File: dir}
 			},
@@ -1959,8 +1959,8 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read exactly first",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
 
 				return &sys.FileEntry{File: dir}
 			},
@@ -1976,9 +1976,9 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read exactly second",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				dirent, errno := platform.Readdir(dir, 1)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				dirent, errno := platform.Readdir(dir.File(), 1)
 				require.Zero(t, errno)
 
 				return &sys.FileEntry{
@@ -2001,9 +2001,9 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read second and a little more",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				dirent, errno := platform.Readdir(dir, 1)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				dirent, errno := platform.Readdir(dir.File(), 1)
 				require.Zero(t, errno)
 
 				return &sys.FileEntry{
@@ -2027,9 +2027,9 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read second and header of third",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				dirent, errno := platform.Readdir(dir, 1)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				dirent, errno := platform.Readdir(dir.File(), 1)
 				require.Zero(t, errno)
 
 				return &sys.FileEntry{
@@ -2052,9 +2052,9 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read second and third",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				dirent, errno := platform.Readdir(dir, 1)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				dirent, errno := platform.Readdir(dir.File(), 1)
 				require.Zero(t, errno)
 
 				return &sys.FileEntry{
@@ -2077,9 +2077,9 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read exactly third",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				two, errno := platform.Readdir(dir, 2)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				two, errno := platform.Readdir(dir.File(), 2)
 				require.Zero(t, errno)
 
 				return &sys.FileEntry{
@@ -2102,9 +2102,9 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read third and beyond",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				two, errno := platform.Readdir(dir, 2)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				two, errno := platform.Readdir(dir.File(), 2)
 				require.Zero(t, errno)
 
 				return &sys.FileEntry{
@@ -2127,10 +2127,10 @@ func Test_fdReaddir(t *testing.T) {
 		{
 			name: "read exhausted directory",
 			dir: func() *sys.FileEntry {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
-				_, errno = platform.Readdir(dir, 3)
-				require.NoError(t, err)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
+				_, errno = platform.Readdir(dir.File(), 3)
+				require.Zero(t, errno)
 
 				return &sys.FileEntry{
 					File: dir,
@@ -2366,8 +2366,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 
 			// Reset the directory so that tests don't taint each other.
 			if file, ok := fsc.LookupFile(tc.fd); ok && tc.fd == dirFD {
-				dir, err := fstest.FS.Open("dir")
-				require.NoError(t, err)
+				dir, errno := preopen.OpenFile("dir", os.O_RDONLY, 0)
+				require.Zero(t, errno)
 				defer dir.Close()
 
 				file.File = dir
@@ -2568,7 +2568,7 @@ func Test_fdSeek(t *testing.T) {
 			fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 			f, ok := fsc.LookupFile(fd)
 			require.True(t, ok)
-			seeker := f.File.(io.Seeker)
+			seeker := f.File.File().(io.Seeker)
 
 			// set the initial offset of the file to 1
 			offset, err := seeker.Seek(1, io.SeekStart)
@@ -2726,7 +2726,7 @@ func Test_fdTell(t *testing.T) {
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	f, ok := fsc.LookupFile(fd)
 	require.True(t, ok)
-	seeker := f.File.(io.Seeker)
+	seeker := f.File.File().(io.Seeker)
 
 	// set the initial offset of the file to 1
 	offset, err := seeker.Seek(1, io.SeekStart)
@@ -3667,13 +3667,13 @@ func Test_pathLink(t *testing.T) {
 			uint64(newFd), uint64(destination), uint64(len(destinationName)))
 		require.Contains(t, log.String(), wasip1.ErrnoName(wasip1.ErrnoSuccess))
 
-		f, err := os.Open(destinationRealPath)
-		require.NoError(t, err)
+		f, errno := platform.OpenFile(destinationRealPath, os.O_RDONLY, 0)
+		require.Zero(t, errno)
 		defer func() {
-			require.NoError(t, f.Close())
+			require.Zero(t, f.Close())
 		}()
 
-		st, errno := platform.StatFile(f)
+		st, errno := f.Stat()
 		require.Zero(t, errno)
 		require.False(t, st.Mode&os.ModeSymlink == os.ModeSymlink)
 		require.Equal(t, uint64(2), st.Nlink)
@@ -3878,8 +3878,8 @@ func Test_pathOpen(t *testing.T) {
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				f, ok := fsc.LookupFile(expectedOpenedFd)
 				require.True(t, ok)
-				_, ft, err := f.CachedStat()
-				require.NoError(t, err)
+				_, ft, errno := f.CachedStat()
+				require.Zero(t, errno)
 				require.Equal(t, fs.ModeDir, ft)
 			},
 			expectedLog: `
@@ -3895,8 +3895,8 @@ func Test_pathOpen(t *testing.T) {
 			expected: func(t *testing.T, fsc *sys.FSContext) {
 				f, ok := fsc.LookupFile(expectedOpenedFd)
 				require.True(t, ok)
-				_, ft, err := f.CachedStat()
-				require.NoError(t, err)
+				_, ft, errno := f.CachedStat()
+				require.Zero(t, errno)
 				require.Equal(t, fs.ModeDir, ft)
 			},
 			expectedLog: `
@@ -4004,7 +4004,7 @@ func requireContents(t *testing.T, fsc *sys.FSContext, expectedOpenedFd int32, f
 	require.Equal(t, fileName, f.Name)
 
 	// verify the contents are readable
-	b, err := io.ReadAll(f.File)
+	b, err := io.ReadAll(f.File.File())
 	require.NoError(t, err)
 	require.Equal(t, fileContents, b)
 }
@@ -5028,8 +5028,8 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	require.Zero(t, errno)
 
 	// Then write a file to the directory.
-	f, err := os.Create(joinPath(dirPath, "file"))
-	require.NoError(t, err)
+	f, errno := platform.OpenFile(joinPath(dirPath, "file"), os.O_CREATE, 0)
+	require.Zero(t, errno)
 	defer f.Close()
 
 	// get the real inode of the current directory
@@ -5051,7 +5051,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	dirents = append(dirents, '.', '.')               // name
 
 	// get the real inode of the file
-	st, errno = platform.StatFile(f)
+	st, errno = f.Stat()
 	require.Zero(t, errno)
 	dirents = append(dirents, 3, 0, 0, 0, 0, 0, 0, 0) // d_next = 3
 	dirents = append(dirents, u64.LeBytes(st.Ino)...) // d_ino

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -253,7 +253,7 @@ func writeEvent(outBuf []byte, evt *event) {
 func getStdioFileReader(mod api.Module) *internalsys.StdioFileReader {
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	if file, ok := fsc.LookupFile(internalsys.FdStdin); ok {
-		if reader, typeOk := file.File.(*internalsys.StdioFileReader); typeOk {
+		if reader, typeOk := file.File.File().(*internalsys.StdioFileReader); typeOk {
 			return reader
 		}
 	}

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -213,8 +213,8 @@ func Benchmark_fdReaddir(b *testing.B) {
 				bufLen := 8096     // allow up to 8KB buffer usage
 
 				// Recreate the file under the file-descriptor
-				if err = f.File.Close(); err != nil {
-					b.Fatal(err)
+				if errno = f.File.Close(); errno != 0 {
+					b.Fatal(errno)
 				}
 				if f.File, errno = fsc.RootFS().OpenFile(".", os.O_RDONLY, 0); errno != 0 {
 					b.Fatal(errno)

--- a/internal/platform/chown_unix_test.go
+++ b/internal/platform/chown_unix_test.go
@@ -21,7 +21,7 @@ func TestChown(t *testing.T) {
 	dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	dirStat, err := dirF.Stat()
+	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
 	dirSys := dirStat.Sys().(*syscall.Stat_t)
 
@@ -50,7 +50,7 @@ func TestChown(t *testing.T) {
 			checkUidGid(t, dir, dirSys.Uid, uint32(g))
 
 			// Revert back with os.File.Chown
-			require.NoError(t, dirF.(*os.File).Chown(-1, gid))
+			require.NoError(t, dirF.File().(*os.File).Chown(-1, gid))
 			checkUidGid(t, dir, dirSys.Uid, uint32(gid))
 		})
 	}
@@ -69,7 +69,7 @@ func TestChownFile(t *testing.T) {
 	dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	dirStat, err := dirF.Stat()
+	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
 
 	dirSys := dirStat.Sys().(*syscall.Stat_t)
@@ -81,12 +81,12 @@ func TestChownFile(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("-1 parameters means leave alone", func(t *testing.T) {
-		require.Zero(t, ChownFile(dirF, -1, -1))
+		require.Zero(t, ChownFile(dirF.File(), -1, -1))
 		checkUidGid(t, dir, dirSys.Uid, dirSys.Gid)
 	})
 
 	t.Run("change gid, but not uid", func(t *testing.T) {
-		require.Zero(t, ChownFile(dirF, -1, gid))
+		require.Zero(t, ChownFile(dirF.File(), -1, gid))
 		checkUidGid(t, dir, dirSys.Uid, uint32(gid))
 	})
 
@@ -95,18 +95,18 @@ func TestChownFile(t *testing.T) {
 		g := g
 		t.Run(fmt.Sprintf("change to gid %d", g), func(t *testing.T) {
 			// Test using our ChownFile
-			require.Zero(t, ChownFile(dirF, -1, g))
+			require.Zero(t, ChownFile(dirF.File(), -1, g))
 			checkUidGid(t, dir, dirSys.Uid, uint32(g))
 
 			// Revert back with os.File.Chown
-			require.NoError(t, dirF.(*os.File).Chown(-1, gid))
+			require.NoError(t, dirF.File().(*os.File).Chown(-1, gid))
 			checkUidGid(t, dir, dirSys.Uid, uint32(gid))
 		})
 	}
 
 	t.Run("closed", func(t *testing.T) {
-		require.NoError(t, dirF.Close())
-		require.EqualErrno(t, syscall.EBADF, ChownFile(dirF, -1, gid))
+		require.Zero(t, dirF.Close())
+		require.EqualErrno(t, syscall.EBADF, ChownFile(dirF.File(), -1, gid))
 	})
 }
 
@@ -119,7 +119,7 @@ func TestLchown(t *testing.T) {
 	dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	dirStat, err := dirF.Stat()
+	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
 
 	dirSys := dirStat.Sys().(*syscall.Stat_t)
@@ -130,7 +130,7 @@ func TestLchown(t *testing.T) {
 	linkF, errno := OpenFile(link, syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	linkStat, err := linkF.Stat()
+	linkStat, err := linkF.File().Stat()
 	require.NoError(t, err)
 
 	linkSys := linkStat.Sys().(*syscall.Stat_t)

--- a/internal/platform/file.go
+++ b/internal/platform/file.go
@@ -3,7 +3,82 @@ package platform
 import (
 	"io"
 	"io/fs"
+	"syscall"
 )
+
+// File is a writeable fs.File bridge backed by syscall functions needed for ABI
+// including WASI and runtime.GOOS=js.
+//
+// Implementations should embed UnimplementedFile for forward compatability. Any
+// unsupported method or parameter should return syscall.ENOSYS.
+//
+// # Errors
+//
+// All methods that can return an error return a syscall.Errno, which is zero
+// on success.
+//
+// Restricting to syscall.Errno matches current WebAssembly host functions,
+// which are constrained to well-known error codes. For example, `GOOS=js` maps
+// hard coded values and panics otherwise. More commonly, WASI maps syscall
+// errors to u32 numeric values.
+//
+// # Notes
+//
+// A writable filesystem abstraction is not yet implemented as of Go 1.20. See
+// https://github.com/golang/go/issues/45757
+type File interface {
+	// Stat is similar to syscall.Fstat.
+	//
+	// # Errors
+	//
+	// The following errors are expected:
+	//   - syscall.EBADF if the file or directory was closed.
+	//
+	// # Notes
+	//
+	//   - An fs.FileInfo backed implementation sets atim, mtim and ctim to the
+	//     same value.
+	//   - Windows allows you to stat a closed directory.
+	Stat() (Stat_t, syscall.Errno)
+
+	// Close closes the underlying file.
+	Close() syscall.Errno
+
+	// File is temporary until we port other methods.
+	File() fs.File
+}
+
+// UnimplementedFile is a File that returns syscall.ENOSYS for all functions,
+// This should be embedded to have forward compatible implementations.
+type UnimplementedFile struct{}
+
+// Stat implements File.Stat
+func (UnimplementedFile) Stat() (Stat_t, syscall.Errno) {
+	return Stat_t{}, syscall.ENOSYS
+}
+
+type DefaultFile struct {
+	F fs.File
+}
+
+// Stat implements File.Stat
+func (f *DefaultFile) Stat() (Stat_t, syscall.Errno) {
+	st, errno := statFile(f.F)
+	if errno == syscall.EIO {
+		errno = syscall.EBADF
+	}
+	return st, errno
+}
+
+// Close implements File.Close
+func (f *DefaultFile) Close() syscall.Errno {
+	return UnwrapOSError(f.F.Close())
+}
+
+// File implements File.File
+func (f *DefaultFile) File() fs.File {
+	return f.F
+}
 
 // ReadFile declares all read interfaces defined on os.File used by wazero.
 type ReadFile interface {
@@ -15,8 +90,8 @@ type ReadFile interface {
 	io.Seeker   // fallback for ReaderAt for embed:fs
 }
 
-// File declares all interfaces defined on os.File used by wazero.
-type File interface {
+// WriteFile declares all interfaces defined on os.File used by wazero.
+type WriteFile interface {
 	ReadFile
 	io.Writer
 	io.WriterAt // for pwrite

--- a/internal/platform/futimens_test.go
+++ b/internal/platform/futimens_test.go
@@ -156,7 +156,7 @@ func testFutimens(t *testing.T, usePath bool) {
 						require.EqualErrno(t, syscall.ENOSYS, err)
 						return
 					}
-					require.Zero(t, err)
+					require.Zero(t, errno)
 				} else {
 					flag := syscall.O_RDWR
 					if path == dir {
@@ -170,8 +170,8 @@ func testFutimens(t *testing.T, usePath bool) {
 					f, errno := OpenFile(path, flag, 0)
 					require.Zero(t, errno)
 
-					errno = UtimensFile(f, tc.times)
-					require.NoError(t, f.Close())
+					errno = UtimensFile(f.File(), tc.times)
+					require.Zero(t, f.Close())
 					require.Zero(t, errno)
 				}
 
@@ -224,9 +224,9 @@ func TestUtimensFile(t *testing.T) {
 
 		fileF, errno := OpenFile(file, syscall.O_RDWR, 0)
 		require.Zero(t, errno)
-		require.NoError(t, fileF.Close())
+		require.Zero(t, fileF.Close())
 
-		errno = UtimensFile(fileF, nil)
+		errno = UtimensFile(fileF.File(), nil)
 		require.EqualErrno(t, syscall.EBADF, errno)
 	})
 
@@ -237,9 +237,9 @@ func TestUtimensFile(t *testing.T) {
 
 		dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
 		require.Zero(t, errno)
-		require.NoError(t, dirF.Close())
+		require.Zero(t, dirF.Close())
 
-		err = UtimensFile(dirF, nil)
+		err = UtimensFile(dirF.File(), nil)
 		require.EqualErrno(t, syscall.EBADF, err)
 	})
 }

--- a/internal/platform/open_file.go
+++ b/internal/platform/open_file.go
@@ -19,5 +19,5 @@ const (
 // syscall.Errno is success.
 func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
 	f, err := os.OpenFile(path, flag, perm)
-	return f, UnwrapOSError(err)
+	return &DefaultFile{F: f}, UnwrapOSError(err)
 }

--- a/internal/platform/open_file_js.go
+++ b/internal/platform/open_file_js.go
@@ -15,5 +15,5 @@ const (
 func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
 	flag &= ^(O_DIRECTORY | O_NOFOLLOW) // erase placeholders
 	f, err := os.OpenFile(path, flag, perm)
-	return f, UnwrapOSError(err)
+	return &DefaultFile{F: f}, UnwrapOSError(err)
 }

--- a/internal/platform/open_file_sun.go
+++ b/internal/platform/open_file_sun.go
@@ -16,5 +16,5 @@ const (
 
 func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
 	f, err := os.OpenFile(path, flag, perm)
-	return f, UnwrapOSError(err)
+	return &DefaultFile{F: f}, UnwrapOSError(err)
 }

--- a/internal/platform/open_file_test.go
+++ b/internal/platform/open_file_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"io"
 	"os"
 	path "path/filepath"
 	"runtime"
@@ -20,7 +21,7 @@ func TestOpenFile(t *testing.T) {
 
 		f, errno := OpenFile(path+"/", os.O_RDONLY, 0)
 		require.Zero(t, errno)
-		require.NoError(t, f.Close())
+		require.Zero(t, f.Close())
 	})
 
 	// from os.TestDirFSPathsValid
@@ -28,7 +29,7 @@ func TestOpenFile(t *testing.T) {
 		t.Run("strange name", func(t *testing.T) {
 			f, errno := OpenFile(path.Join(tmpDir, `e:xperi\ment.txt`), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 			require.Zero(t, errno)
-			require.NoError(t, f.Close())
+			require.Zero(t, f.Close())
 		})
 	}
 }
@@ -59,7 +60,7 @@ func TestOpenFile_Errors(t *testing.T) {
 		filepath := path.Join(tmpDir, "file.txt")
 		f, errno := OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 		require.Zero(t, errno)
-		defer require.NoError(t, f.Close())
+		defer require.Zero(t, f.Close())
 
 		_, errno = OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
 		require.EqualErrno(t, syscall.EEXIST, errno)
@@ -70,10 +71,10 @@ func TestOpenFile_Errors(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, nil, 0o600))
 
 		f, errno := OpenFile(path, os.O_RDONLY, 0)
-		defer require.NoError(t, f.Close())
+		defer require.Zero(t, f.Close())
 		require.Zero(t, errno)
 
-		_, err := f.Write([]byte{1, 2, 3, 4})
+		_, err := f.File().(io.Writer).Write([]byte{1, 2, 3, 4})
 		require.EqualErrno(t, syscall.EBADF, UnwrapOSError(err))
 	})
 
@@ -82,10 +83,10 @@ func TestOpenFile_Errors(t *testing.T) {
 		require.NoError(t, os.Mkdir(path, 0o755))
 
 		f, errno := OpenFile(path, os.O_RDONLY, 0)
-		defer require.NoError(t, f.Close())
+		defer require.Zero(t, f.Close())
 		require.Zero(t, errno)
 
-		_, err := f.Write([]byte{1, 2, 3, 4})
+		_, err := f.File().(io.Writer).Write([]byte{1, 2, 3, 4})
 		require.EqualErrno(t, syscall.EBADF, UnwrapOSError(err))
 	})
 

--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -32,7 +32,8 @@ func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
 	if f, errno := openFile(path, flag, perm); errno != 0 {
 		return nil, errno
 	} else {
-		return &windowsWrappedFile{File: f, path: path, flag: flag, perm: perm}, 0
+		f := &windowsWrappedFile{WriteFile: f, path: path, flag: flag, perm: perm}
+		return &DefaultFile{F: f}, 0
 	}
 }
 

--- a/internal/platform/stat.go
+++ b/internal/platform/stat.go
@@ -68,17 +68,6 @@ func Stat(path string) (Stat_t, syscall.Errno) {
 	return stat(path) // extracted to override more expensively in windows
 }
 
-// StatFile is like syscall.Fstat, but for fs.File instead of a file
-// descriptor. This returns syscall.EBADF if the file or directory was closed.
-// Note: windows allows you to stat a closed directory.
-func StatFile(f fs.File) (Stat_t, syscall.Errno) {
-	st, errno := statFile(f)
-	if errno == syscall.EIO {
-		errno = syscall.EBADF
-	}
-	return st, errno
-}
-
 func defaultStatFile(f fs.File) (Stat_t, syscall.Errno) {
 	if t, err := f.Stat(); err != nil {
 		return Stat_t{}, UnwrapOSError(err)

--- a/internal/platform/stat_test.go
+++ b/internal/platform/stat_test.go
@@ -165,7 +165,7 @@ func TestStatFile(t *testing.T) {
 	defer tmpDirF.Close()
 
 	t.Run("dir", func(t *testing.T) {
-		st, errno = StatFile(tmpDirF)
+		st, errno = tmpDirF.Stat()
 		require.Zero(t, errno)
 
 		require.True(t, st.Mode.IsDir())
@@ -176,8 +176,8 @@ func TestStatFile(t *testing.T) {
 	// not by file descriptor.
 	if runtime.GOOS != "windows" {
 		t.Run("closed dir", func(t *testing.T) {
-			require.NoError(t, tmpDirF.Close())
-			st, errno = StatFile(tmpDirF)
+			require.Zero(t, tmpDirF.Close())
+			st, errno = tmpDirF.Stat()
 			require.EqualErrno(t, syscall.EBADF, errno)
 		})
 	}
@@ -189,7 +189,7 @@ func TestStatFile(t *testing.T) {
 	defer fileF.Close()
 
 	t.Run("file", func(t *testing.T) {
-		st, errno = StatFile(fileF)
+		st, errno = fileF.Stat()
 		require.Zero(t, errno)
 
 		require.False(t, st.Mode.IsDir())
@@ -197,8 +197,8 @@ func TestStatFile(t *testing.T) {
 	})
 
 	t.Run("closed file", func(t *testing.T) {
-		require.NoError(t, fileF.Close())
-		_, errno = StatFile(fileF)
+		require.Zero(t, fileF.Close())
+		_, errno = fileF.Stat()
 		require.EqualErrno(t, syscall.EBADF, errno)
 	})
 
@@ -209,7 +209,7 @@ func TestStatFile(t *testing.T) {
 	defer subdirF.Close()
 
 	t.Run("subdir", func(t *testing.T) {
-		st, errno = StatFile(subdirF)
+		st, errno = subdirF.Stat()
 		require.Zero(t, errno)
 
 		require.True(t, st.Mode.IsDir())
@@ -218,8 +218,8 @@ func TestStatFile(t *testing.T) {
 
 	if runtime.GOOS != "windows" { // windows allows you to stat a closed dir
 		t.Run("closed subdir", func(t *testing.T) {
-			require.NoError(t, subdirF.Close())
-			st, errno = StatFile(subdirF)
+			require.Zero(t, subdirF.Close())
+			st, errno = subdirF.Stat()
 			require.EqualErrno(t, syscall.EBADF, errno)
 		})
 	}
@@ -264,11 +264,11 @@ func Test_StatFile_times(t *testing.T) {
 			err := os.Chtimes(file, time.UnixMicro(tc.atimeNsec/1e3), time.UnixMicro(tc.mtimeNsec/1e3))
 			require.NoError(t, err)
 
-			f, err := os.Open(file)
-			require.NoError(t, err)
+			f, errno := OpenFile(file, syscall.O_RDONLY, 0)
+			require.Zero(t, errno)
 			defer f.Close()
 
-			st, errno := StatFile(f)
+			st, errno := f.Stat()
 			require.Zero(t, errno)
 
 			require.Equal(t, st.Atim, tc.atimeNsec)
@@ -279,41 +279,41 @@ func Test_StatFile_times(t *testing.T) {
 
 func TestStatFile_dev_inode(t *testing.T) {
 	tmpDir := t.TempDir()
-	d, err := os.Open(tmpDir)
-	require.NoError(t, err)
+	d, errno := OpenFile(tmpDir, os.O_RDONLY, 0)
+	require.Zero(t, errno)
 	defer d.Close()
 
 	path1 := path.Join(tmpDir, "1")
-	f1, err := os.Create(path1)
-	require.NoError(t, err)
+	f1, errno := OpenFile(path1, os.O_CREATE, 0o666)
+	require.Zero(t, errno)
 	defer f1.Close()
 
 	path2 := path.Join(tmpDir, "2")
-	f2, err := os.Create(path2)
-	require.NoError(t, err)
+	f2, errno := OpenFile(path2, os.O_CREATE, 0o666)
+	require.Zero(t, errno)
 	defer f2.Close()
 
 	pathLink2 := path.Join(tmpDir, "link2")
-	err = os.Symlink(path2, pathLink2)
+	err := os.Symlink(path2, pathLink2)
 	require.NoError(t, err)
-	l2, err := os.Open(pathLink2)
-	require.NoError(t, err)
+	l2, errno := OpenFile(pathLink2, os.O_RDONLY, 0)
+	require.Zero(t, errno)
 	defer l2.Close()
 
 	// First, stat the directory
-	st1, errno := StatFile(d)
+	st1, errno := d.Stat()
 	require.Zero(t, errno)
 
 	requireDirectoryDevIno(t, st1)
 
 	// Now, stat the files in it
-	st1, errno = StatFile(f1)
+	st1, errno = f1.Stat()
 	require.Zero(t, errno)
 
-	st2, errno := StatFile(f2)
+	st2, errno := f2.Stat()
 	require.Zero(t, errno)
 
-	st3, errno := StatFile(l2)
+	st3, errno := l2.Stat()
 	require.Zero(t, errno)
 
 	// The files should be on the same device, but different inodes
@@ -322,23 +322,23 @@ func TestStatFile_dev_inode(t *testing.T) {
 	require.Equal(t, st2, st3) // stat on a link is for its target
 
 	// Redoing stat should result in the same inodes
-	st1Again, errno := StatFile(f1)
+	st1Again, errno := f1.Stat()
 	require.Zero(t, errno)
 	require.Equal(t, st1.Dev, st1Again.Dev)
 
 	// On Windows, we cannot rename while opening.
 	// So we manually close here before renaming.
-	require.NoError(t, f1.Close())
-	require.NoError(t, f2.Close())
-	require.NoError(t, l2.Close())
+	require.Zero(t, f1.Close())
+	require.Zero(t, f2.Close())
+	require.Zero(t, l2.Close())
 
 	// Renaming a file shouldn't change its inodes.
 	require.Zero(t, Rename(path1, path2))
-	f1, err = os.Open(path2)
-	require.NoError(t, err)
+	f1, errno = OpenFile(path2, os.O_RDONLY, 0)
+	require.Zero(t, errno)
 	defer f1.Close()
 
-	st1Again, errno = StatFile(f1)
+	st1Again, errno = f1.Stat()
 	require.Zero(t, errno)
 	require.Equal(t, st1.Dev, st1Again.Dev)
 	require.Equal(t, st1.Ino, st1Again.Ino)

--- a/internal/platform/wrap_windows.go
+++ b/internal/platform/wrap_windows.go
@@ -120,7 +120,7 @@ func (w *windowsWrappedFile) requireFile(op string, readOnly, isDir bool) error 
 // getFileType caches the file type as this cannot change on an open file.
 func (w *windowsWrappedFile) getFileType() (fs.FileMode, error) {
 	if w.fileType == nil {
-		st, errno := StatFile(w.WriteFile)
+		st, errno := statFile(w.WriteFile)
 		if errno != 0 {
 			return 0, nil
 		}

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -98,8 +98,8 @@ func TestFileEntry_cachedStat(t *testing.T) {
 
 			f, ok := fsc.LookupFile(FdPreopen)
 			require.True(t, ok)
-			ino, ft, err := f.CachedStat()
-			require.NoError(t, err)
+			ino, ft, errno := f.CachedStat()
+			require.Zero(t, errno)
 			require.Equal(t, fs.ModeDir, ft)
 			if !canReadDirInode() {
 				tc.expectedIno = 0

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -45,10 +45,10 @@ func (a *adapter) Open(name string) (fs.File, error) {
 }
 
 // OpenFile implements FS.OpenFile
-func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
+func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	path = cleanPath(path)
 	f, err := a.fs.Open(path)
-	return f, platform.UnwrapOSError(err)
+	return &platform.DefaultFile{F: f}, platform.UnwrapOSError(err)
 }
 
 // Stat implements FS.Stat
@@ -59,7 +59,7 @@ func (a *adapter) Stat(path string) (platform.Stat_t, syscall.Errno) {
 		return platform.Stat_t{}, platform.UnwrapOSError(err)
 	}
 	defer f.Close()
-	return platform.StatFile(f)
+	return (&platform.DefaultFile{F: f}).Stat()
 }
 
 // Lstat implements FS.Lstat
@@ -107,6 +107,6 @@ func fsOpen(f FS, name string) (fs.File, error) {
 	if f, err := f.OpenFile(name, os.O_RDONLY, 0); err != 0 {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 	} else {
-		return f, nil
+		return f.File(), nil
 	}
 }

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -41,7 +41,7 @@ func (d *dirFS) Open(name string) (fs.File, error) {
 }
 
 // OpenFile implements FS.OpenFile
-func (d *dirFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
+func (d *dirFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	return platform.OpenFile(d.join(path), flag, perm)
 }
 

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -21,7 +21,7 @@ func TestNewDirFS(t *testing.T) {
 	// Guest can look up /
 	f, errno := testFS.OpenFile("/", os.O_RDONLY, 0)
 	require.Zero(t, errno)
-	require.NoError(t, f.Close())
+	require.Zero(t, f.Close())
 
 	t.Run("host path not found", func(t *testing.T) {
 		testFS := NewDirFS("a")
@@ -34,7 +34,7 @@ func TestNewDirFS(t *testing.T) {
 		testFS := NewDirFS(arg0)
 		d, errno := testFS.OpenFile(".", os.O_RDONLY, 0)
 		require.Zero(t, errno)
-		_, err := d.(fs.ReadDirFile).ReadDir(-1)
+		_, err := d.File().(fs.ReadDirFile).ReadDir(-1)
 		require.EqualErrno(t, syscall.ENOTDIR, platform.UnwrapOSError(err))
 	})
 }
@@ -434,7 +434,7 @@ func TestDirFS_Rmdir(t *testing.T) {
 		f, errno := testFS.OpenFile(name, platform.O_DIRECTORY, 0o700)
 		require.Zero(t, errno)
 		defer func() {
-			require.NoError(t, f.Close())
+			require.Zero(t, f.Close())
 		}()
 
 		require.Zero(t, testFS.Rmdir(name))
@@ -497,8 +497,8 @@ func TestDirFS_Unlink(t *testing.T) {
 		require.Zero(t, testFS.Symlink("subdir", symlinkName))
 
 		// Unlinking the symlink should suceed.
-		err := testFS.Unlink(symlinkName)
-		require.Zero(t, err)
+		errno := testFS.Unlink(symlinkName)
+		require.Zero(t, errno)
 	})
 
 	t.Run("file exists", func(t *testing.T) {
@@ -838,7 +838,7 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	dir, ok := dirFile.(fs.ReadDirFile)
+	dir, ok := dirFile.File().(fs.ReadDirFile)
 	require.True(t, ok)
 
 	entries, err := dir.ReadDir(-1)

--- a/internal/sysfs/dirfs_unix_test.go
+++ b/internal/sysfs/dirfs_unix_test.go
@@ -21,7 +21,7 @@ func TestDirFS_Chown(t *testing.T) {
 	dirF, errno := testFS.OpenFile("dir", syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	dirStat, err := dirF.Stat()
+	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
 
 	dirSys := dirStat.Sys().(*syscall.Stat_t)
@@ -51,7 +51,7 @@ func TestDirFS_Chown(t *testing.T) {
 			checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, uint32(g))
 
 			// Revert back with platform.ChownFile
-			require.Zero(t, platform.ChownFile(dirF, -1, gid))
+			require.Zero(t, platform.ChownFile(dirF.File(), -1, gid))
 			checkUidGid(t, path.Join(tmpDir, "dir"), dirSys.Uid, uint32(gid))
 		})
 	}
@@ -69,7 +69,7 @@ func TestDirFS_Lchown(t *testing.T) {
 	dirF, errno := testFS.OpenFile("dir", syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	dirStat, err := dirF.Stat()
+	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
 
 	dirSys := dirStat.Sys().(*syscall.Stat_t)
@@ -78,7 +78,7 @@ func TestDirFS_Lchown(t *testing.T) {
 	linkF, errno := testFS.OpenFile("link", syscall.O_RDONLY, 0)
 	require.Zero(t, errno)
 
-	linkStat, err := linkF.Stat()
+	linkStat, err := linkF.File().Stat()
 	require.NoError(t, err)
 
 	linkSys := linkStat.Sys().(*syscall.Stat_t)

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -37,7 +37,7 @@ func (r *readFS) Open(name string) (fs.File, error) {
 }
 
 // OpenFile implements FS.OpenFile
-func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
+func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	// TODO: Once the real implementation is complete, move the below to
 	// /RATIONALE.md. Doing this while the type is unstable creates
 	// documentation drift as we expect a lot of reshaping meanwhile.
@@ -67,7 +67,7 @@ func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, sys
 	if errno != 0 {
 		return nil, errno
 	}
-	return maskForReads(f), 0
+	return &platform.DefaultFile{F: maskForReads(f.File())}, 0
 }
 
 // maskForReads masks the file with read-only interfaces used by wazero.

--- a/internal/sysfs/rootfs_test.go
+++ b/internal/sysfs/rootfs_test.go
@@ -50,13 +50,13 @@ func TestNewRootFS(t *testing.T) {
 		// Guest can look up /tmp
 		f, errno := rootFS.OpenFile("/tmp", os.O_RDONLY, 0)
 		require.Zero(t, errno)
-		require.NoError(t, f.Close())
+		require.Zero(t, f.Close())
 
 		// Guest can look up / and see "/tmp" in it
 		f, errno = rootFS.OpenFile("/", os.O_RDONLY, 0)
 		require.Zero(t, errno)
 
-		dirents, err := f.(fs.ReadDirFile).ReadDir(-1)
+		dirents, err := f.File().(fs.ReadDirFile).ReadDir(-1)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(dirents))
 		require.Equal(t, "tmp", dirents[0].Name())
@@ -100,7 +100,7 @@ func TestNewRootFS(t *testing.T) {
 			require.Zero(t, errno)
 			defer f.Close()
 
-			b, err := io.ReadAll(f)
+			b, err := io.ReadAll(f.File())
 			require.NoError(t, err)
 			require.Equal(t, []byte{2}, b)
 		})
@@ -111,7 +111,7 @@ func TestNewRootFS(t *testing.T) {
 			require.Zero(t, errno)
 			defer f.Close()
 
-			require.Equal(t, []string{"a", "tmp"}, readDirNames(t, f))
+			require.Equal(t, []string{"a", "tmp"}, readDirNames(t, f.File()))
 		})
 	})
 }
@@ -283,7 +283,7 @@ func TestRootFS_examples(t *testing.T) {
 			for _, p := range tc.expected {
 				f, errno := root.OpenFile(p, os.O_RDONLY, 0)
 				require.Zero(t, errno, p)
-				require.NoError(t, f.Close(), p)
+				require.Zero(t, f.Close(), p)
 			}
 
 			for _, p := range tc.unexpected {

--- a/internal/sysfs/sysfs.go
+++ b/internal/sysfs/sysfs.go
@@ -71,7 +71,7 @@ type FS interface {
 	//   - flag are the same as OpenFile, for example, os.O_CREATE.
 	//   - Implications of permissions when os.O_CREATE are described in Chmod
 	//     notes.
-	OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno)
+	OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno)
 	// ^^ TODO: Consider syscall.Open, though this implies defining and
 	// coercing flags and perms similar to what is done in os.OpenFile.
 

--- a/internal/sysfs/unimplemented.go
+++ b/internal/sysfs/unimplemented.go
@@ -22,7 +22,7 @@ func (UnimplementedFS) Open(name string) (fs.File, error) {
 }
 
 // OpenFile implements FS.OpenFile
-func (UnimplementedFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
+func (UnimplementedFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	return nil, syscall.ENOSYS
 }
 

--- a/internal/wasm/module_instance_test.go
+++ b/internal/wasm/module_instance_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -154,7 +155,8 @@ func TestModuleInstance_Close(t *testing.T) {
 		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx, nil)
 		require.NoError(t, err)
 
-		require.EqualError(t, m.Close(testCtx), "error closing")
+		// In sysfs.FS, non syscall errors map to syscall.EIO.
+		require.EqualErrno(t, syscall.EIO, m.Close(testCtx))
 
 		// Verify our intended side-effect
 		_, ok := fsCtx.LookupFile(3)
@@ -252,7 +254,8 @@ func TestModuleInstance_CallDynamic(t *testing.T) {
 		m, err := s.Instantiate(testCtx, &Module{}, t.Name(), sysCtx, nil)
 		require.NoError(t, err)
 
-		require.EqualError(t, m.Close(testCtx), "error closing")
+		// In sysfs.FS, non syscall errors map to syscall.EIO.
+		require.EqualErrno(t, syscall.EIO, m.Close(testCtx))
 
 		// Verify our intended side-effect
 		_, ok := fsCtx.LookupFile(3)


### PR DESCRIPTION
After the last couple months of thinking, I eventually got to the idea that defining a new file type has two problems:

* What sort of type do we define?
* How in the world do we migrate to a new type?

What this PR does is spike an approach to the latter without solidifying the former. My thinking is that the best way is to incrementally migrate functions one-by-one to a new type. Meanwhile, temporarily expose a `.File()` function to access the `fs.File` we want to rid eventually. This makes it easy to identify what's left as you just look for any calls to `.File()`.

If this approach helps, lemme know and I can polish for merge. I mainly had this branch locally so want to decide to delete it or not!