### PR TITLE
Refactors NewModuleEngine and NewCallEngine

### DIFF
--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -498,11 +498,11 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 func TestInterpreter_Compile(t *testing.T) {
 	t.Run("uncompiled", func(t *testing.T) {
 		e := et.NewEngine(api.CoreFeaturesV1).(*engine)
-		_, err := e.NewModuleEngine("foo",
+		_, err := e.NewModuleEngine(
 			&wasm.Module{},
 			nil, // functions
 		)
-		require.EqualError(t, err, "source module for foo must be compiled before instantiation")
+		require.EqualError(t, err, "source module must be compiled before instantiation")
 	})
 	t.Run("fail", func(t *testing.T) {
 		e := et.NewEngine(api.CoreFeaturesV1).(*engine)

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"encoding/binary"
-	"fmt"
 	"math"
 	"testing"
 
@@ -115,13 +114,7 @@ func TestBenchmarkFunctionCall(t *testing.T) {
 
 func getCallEngine(m *wasm.ModuleInstance, name string) (ce wasm.CallEngine, err error) {
 	exp := m.Exports[name]
-	f := &m.Functions[exp.Index]
-	if f == nil {
-		err = fmt.Errorf("%s not found", name)
-		return
-	}
-
-	ce, err = m.Engine.NewCallEngine(m, f)
+	ce, err = m.Engine.NewCallEngine(exp.Index)
 	return
 }
 
@@ -182,7 +175,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 	err := eng.CompileModule(testCtx, hostModule, nil, false)
 	requireNoError(err)
 
-	hostME, err := eng.NewModuleEngine(host.ModuleName, hostModule, host.Functions)
+	hostME, err := eng.NewModuleEngine(hostModule, host.Functions)
 	requireNoError(err)
 	linkModuleToEngine(host, hostME)
 
@@ -224,7 +217,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 	importing.BuildFunctions(importingModule)
 	importing.Exports = importingModule.Exports
 
-	importingMe, err := eng.NewModuleEngine(importing.ModuleName, importingModule, importing.Functions)
+	importingMe, err := eng.NewModuleEngine(importingModule, importing.Functions)
 	requireNoError(err)
 	linkModuleToEngine(importing, importingMe)
 

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -25,22 +25,18 @@ type Engine interface {
 
 	// NewModuleEngine compiles down the function instances in a module, and returns ModuleEngine for the module.
 	//
-	// * name is the name the module was instantiated with used for error handling.
 	// * module is the source module from which moduleFunctions are instantiated. This is used for caching.
 	// * functions: the list of FunctionInstance which exists in this module, including the imported ones.
 	//
 	// Note: Input parameters must be pre-validated with wasm.Module Validate, to ensure no fields are invalid
 	// due to reasons such as out-of-bounds.
-	NewModuleEngine(name string, module *Module, functions []FunctionInstance) (ModuleEngine, error)
+	NewModuleEngine(module *Module, functions []FunctionInstance) (ModuleEngine, error)
 }
 
 // ModuleEngine implements function calls for a given module.
 type ModuleEngine interface {
-	// Name returns the name of the module this engine was compiled for.
-	Name() string
-
 	// NewCallEngine returns a CallEngine for the given FunctionInstance.
-	NewCallEngine(m *ModuleInstance, f *FunctionInstance) (CallEngine, error)
+	NewCallEngine(index Index) (CallEngine, error)
 
 	// LookupFunction returns the index of the function in the function table.
 	LookupFunction(t *TableInstance, typeId FunctionTypeID, tableOffset Index) (Index, error)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -106,7 +106,9 @@ type (
 		// CodeCloser is non-nil when the code should be closed after this module.
 		CodeCloser api.Closer
 
-		s           *Store
+		// s is the Store on which this module is instantiated.
+		s *Store
+		// definitions is derived from *Module, and is constructed during compilation phrase.
 		definitions []FunctionDefinition
 	}
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -796,7 +796,7 @@ func (e *mockEngine) DeleteCompiledModule(module *wasm.Module) {
 }
 
 // NewModuleEngine implements the same method as documented on wasm.Engine.
-func (e *mockEngine) NewModuleEngine(_ string, _ *wasm.Module, _ []wasm.FunctionInstance) (wasm.ModuleEngine, error) {
+func (e *mockEngine) NewModuleEngine(_ *wasm.Module, _ []wasm.FunctionInstance) (wasm.ModuleEngine, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This drops the unnecessary parameters from `NewModuleEngine` and `NewCallEngine` 
interface methods.