### PR TITLE
bench: do not call _start in concurrent instantiation

### DIFF
--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -100,7 +100,9 @@ func runInitializationBench(b *testing.B, r wazero.Runtime) {
 	defer compiled.Close(testCtx)
 	// Configure with real sources to avoid performance hit initializing fake ones. These sources are not used
 	// in the benchmark.
-	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader).WithStartFunctions()
+	config := wazero.NewModuleConfig().WithSysNanotime().WithSysWalltime().WithRandSource(rand.Reader).
+		// To measure the pure instantiation time without including calling _start.
+		WithStartFunctions()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mod, err := r.InstantiateModule(testCtx, compiled, config)
@@ -120,6 +122,8 @@ func runInitializationConcurrentBench(b *testing.B, r wazero.Runtime) {
 		WithSysNanotime().
 		WithSysWalltime().
 		WithRandSource(rand.Reader).
+		// To measure the pure instantiation time without including calling _start.
+		WithStartFunctions("").
 		WithName("")
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -123,7 +123,7 @@ func runInitializationConcurrentBench(b *testing.B, r wazero.Runtime) {
 		WithSysWalltime().
 		WithRandSource(rand.Reader).
 		// To measure the pure instantiation time without including calling _start.
-		WithStartFunctions("").
+		WithStartFunctions().
 		WithName("")
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {


### PR DESCRIPTION
In the sequential instantiation bench, we've already disabled calling _start.
This makes the same change to the concurrent installation bench so that
we can measure the pure concurrent instantiation time.