### PR TITLE
asm: reuses the slice on SetBranchTargetOnNextNodes

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -310,7 +310,8 @@ func (a *AssemblerImpl) addNode(node *nodeImpl) {
 		origin := o.(*nodeImpl)
 		origin.jumpTarget = node
 	}
-	a.SetBranchTargetOnNextNodes = nil
+	// Reuse the underlying slice to avoid re-allocations.
+	a.SetBranchTargetOnNextNodes = a.SetBranchTargetOnNextNodes[:0]
 }
 
 // EncodeNode encodes the given node into writer.

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -308,7 +308,8 @@ func (a *AssemblerImpl) addNode(node *nodeImpl) {
 		origin := o.(*nodeImpl)
 		origin.jumpTarget = node
 	}
-	a.SetBranchTargetOnNextNodes = nil
+	// Reuse the underlying slice to avoid re-allocations.
+	a.SetBranchTargetOnNextNodes = a.SetBranchTargetOnNextNodes[:0]
 }
 
 // Assemble implements asm.AssemblerBase


### PR DESCRIPTION
small change, huge win

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      139.5µ ± 8%   138.4µ ± 8%       ~ (p=0.620 n=7)
Compilation/without_extern_cache-10   2.608m ± 1%   2.465m ± 2%  -5.48% (p=0.001 n=7)
geomean                               603.1µ        584.2µ       -3.13%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.38Ki ± 0%   53.39Ki ± 0%       ~ (p=0.512 n=7)
Compilation/without_extern_cache-10   1.073Mi ± 0%   1.058Mi ± 0%  -1.43% (p=0.001 n=7)
geomean                               242.2Ki        240.5Ki       -0.71%

                                    │   old.txt   │              new.txt              │
                                    │  allocs/op  │  allocs/op   vs base              │
Compilation/with_extern_cache-10       979.0 ± 0%    979.0 ± 0%       ~ (p=0.559 n=7)
Compilation/without_extern_cache-10   11.33k ± 0%   10.36k ± 0%  -8.56% (p=0.001 n=7)
geomean                               3.330k        3.185k       -4.38%

```