### PR TITLE
asm: reuse StaticConstPool

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -228,7 +228,7 @@ type AssemblerImpl struct {
 
 	readInstructionAddressNodes []*nodeImpl
 
-	pool *asm.StaticConstPool
+	pool asm.StaticConstPool
 }
 
 func NewAssembler() *AssemblerImpl {

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -271,10 +271,12 @@ func (n *nodePool) allocNode() (ret *nodeImpl) {
 
 // Reset implements asm.AssemblerBase.
 func (a *AssemblerImpl) Reset() {
+	pool := a.pool
+	pool.Reset()
 	*a = AssemblerImpl{
 		buf:                         a.buf,
 		nodePool:                    a.nodePool,
-		pool:                        asm.NewStaticConstPool(),
+		pool:                        pool,
 		enablePadding:               a.enablePadding,
 		readInstructionAddressNodes: a.readInstructionAddressNodes[:0],
 		BaseAssemblerImpl: asm.BaseAssemblerImpl{

--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -44,7 +44,7 @@ func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
 			a.buf.Write(c.Raw)
 		}
 
-		a.pool = asm.NewStaticConstPool() // reset
+		a.pool.Reset()
 	}
 }
 

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -219,7 +219,7 @@ type AssemblerImpl struct {
 	buf               *bytes.Buffer
 	temporaryRegister asm.Register
 	nodeCount         int
-	pool              *asm.StaticConstPool
+	pool              asm.StaticConstPool
 	// MaxDisplacementForConstantPool is fixed to defaultMaxDisplacementForConstPool
 	// but have it as a field here for testability.
 	MaxDisplacementForConstantPool         int

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -267,8 +267,10 @@ func NewAssembler(temporaryRegister asm.Register) *AssemblerImpl {
 // Reset implements asm.AssemblerBase.
 func (a *AssemblerImpl) Reset() {
 	buf, np, tmp := a.buf, a.nodePool, a.temporaryRegister
+	pool := a.pool
+	pool.Reset()
 	*a = AssemblerImpl{
-		buf: buf, nodePool: np, pool: asm.NewStaticConstPool(),
+		buf: buf, nodePool: np, pool: pool,
 		temporaryRegister:   tmp,
 		adrInstructionNodes: a.adrInstructionNodes[:0],
 		relativeJumpNodes:   a.relativeJumpNodes[:0],
@@ -393,7 +395,7 @@ func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
 		}
 
 		// After the flush, reset the constant pool.
-		a.pool = asm.NewStaticConstPool()
+		a.pool.Reset()
 	}
 }
 

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -90,9 +90,19 @@ type StaticConstPool struct {
 	PoolSizeInBytes int
 }
 
-// NewStaticConstPool returns the pointer to a new StaticConstPool.
-func NewStaticConstPool() *StaticConstPool {
-	return &StaticConstPool{addedConsts: map[*StaticConst]struct{}{}}
+func NewStaticConstPool() StaticConstPool {
+	return StaticConstPool{addedConsts: map[*StaticConst]struct{}{}}
+}
+
+// Reset resets the *StaticConstPool for reuse.
+func (p *StaticConstPool) Reset() {
+	for _, c := range p.Consts {
+		delete(p.addedConsts, c)
+	}
+	// Reuse the slice to avoid re-allocations.
+	p.Consts = p.Consts[:0]
+	p.PoolSizeInBytes = 0
+	p.FirstUseOffsetInBinary = nil
 }
 
 // AddConst adds a *StaticConst into the pool if it's not already added.


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      135.5µ ± 2%   133.0µ ± 2%  -1.81% (p=0.004 n=7)
Compilation/without_extern_cache-10   2.486m ± 1%   2.445m ± 1%  -1.68% (p=0.004 n=7)
geomean                               580.4µ        570.2µ       -1.74%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.38Ki ± 0%   53.36Ki ± 0%  -0.03% (p=0.023 n=7)
Compilation/without_extern_cache-10   1.073Mi ± 0%   1.069Mi ± 0%  -0.41% (p=0.001 n=7)
geomean                               242.2Ki        241.6Ki       -0.22%

                                    │   old.txt   │              new.txt              │
                                    │  allocs/op  │  allocs/op   vs base              │
Compilation/with_extern_cache-10       979.0 ± 0%    979.0 ± 0%       ~ (p=0.192 n=7)
Compilation/without_extern_cache-10   11.33k ± 0%   11.23k ± 0%  -0.86% (p=0.001 n=7)
geomean                               3.330k        3.316k       -0.43%


```