### PR TITLE
asm/amd64: avoids map allocation per node

### DIFF
--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -48,7 +48,7 @@ func TestNodePool_allocNode(t *testing.T) {
 	// Ensure allocation clears the existing content.
 	n := np.allocNode()
 	require.Equal(t, ptr, n)
-	require.Equal(t, &nodeImpl{jumpOrigins: map[*nodeImpl]struct{}{}}, n)
+	require.Equal(t, &nodeImpl{jumpOrigins: nil}, n)
 }
 
 func TestAssemblerImpl_Reset(t *testing.T) {


### PR DESCRIPTION
small change, but an extraordinarily huge win...
```
$ benchstat old.txt new.txt
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: VirtualApple @ 2.50GHz
                                    │   old.txt   │              new.txt               │
                                    │   sec/op    │   sec/op     vs base               │
Compilation/with_extern_cache-10      329.9µ ± 1%   333.5µ ± 2%        ~ (p=0.383 n=7)
Compilation/without_extern_cache-10   6.404m ± 1%   5.430m ± 3%  -15.21% (p=0.001 n=7)
geomean                               1.453m        1.346m        -7.41%

                                    │   old.txt    │               new.txt               │
                                    │     B/op     │     B/op      vs base               │
Compilation/with_extern_cache-10      53.90Ki ± 0%   53.66Ki ± 0%   -0.43% (p=0.001 n=7)
Compilation/without_extern_cache-10   1.862Mi ± 0%   1.159Mi ± 0%  -37.76% (p=0.001 n=7)
geomean                               320.6Ki        252.4Ki       -21.28%

                                    │   old.txt   │              new.txt               │
                                    │  allocs/op  │  allocs/op   vs base               │
Compilation/with_extern_cache-10       988.0 ± 0%    983.0 ± 0%   -0.51% (p=0.001 n=7)
Compilation/without_extern_cache-10   31.13k ± 0%   15.81k ± 0%  -49.21% (p=0.001 n=7)
geomean                               5.546k        3.942k       -28.92%
```