### PR TITLE
wasm: move ModuleInstance.Closed to the top

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -348,13 +348,13 @@ const (
 	functionSize                     = 56
 
 	// Offsets for wasm.ModuleInstance.
-	moduleInstanceGlobalsOffset          = 24
-	moduleInstanceMemoryOffset           = 48
-	moduleInstanceTablesOffset           = 56
-	moduleInstanceEngineOffset           = 80
-	moduleInstanceTypeIDsOffset          = 96
-	moduleInstanceDataInstancesOffset    = 120
-	moduleInstanceElementInstancesOffset = 144
+	moduleInstanceGlobalsOffset          = 32
+	moduleInstanceMemoryOffset           = 56
+	moduleInstanceTablesOffset           = 64
+	moduleInstanceEngineOffset           = 88
+	moduleInstanceTypeIDsOffset          = 104
+	moduleInstanceDataInstancesOffset    = 128
+	moduleInstanceElementInstancesOffset = 152
 
 	// Offsets for wasm.TableInstance.
 	tableInstanceTableOffset    = 0


### PR DESCRIPTION
ModuleInstance.Closed is an atomic variable meant to be loaded and swapped with sync/atomic. Closed, being a 64 bit integer, requires 64 bit alignment. The simplest way we can get alignment is to place these atomic fields at the top of their struct.

Closed can be moved to a more logical place once support for Go 1.18 is dropped and its type changed to atomic.Uint64.