### PR TITLE
asm/amd64: avoids allocation in getting memory location

### DIFF
--- a/internal/asm/amd64/impl_memorylocation_test.go
+++ b/internal/asm/amd64/impl_memorylocation_test.go
@@ -40,7 +40,7 @@ func TestNodeImpl_GetMemoryLocation_errors(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		_, _, _, _, err := tt.n.GetMemoryLocation()
+		_, _, _, _, _, err := tt.n.GetMemoryLocation()
 		require.EqualError(t, err, tt.expErr, tt.expErr)
 	}
 }
@@ -61,11 +61,12 @@ func TestNodeImpl_GetMemoryLocation_without_base(t *testing.T) {
 			types:  operandTypesMemoryToRegister,
 			srcReg: asm.NilRegister, srcConst: tc.offset,
 		}
-		rexPrefix, modRM, sbi, displacementWidth, err := n.GetMemoryLocation()
+		rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.GetMemoryLocation()
 		require.NoError(t, err)
 		require.Equal(t, RexPrefixNone, rexPrefix)
 		require.Equal(t, tc.modRM, modRM)
-		require.Equal(t, tc.sbi, *sbi)
+		require.True(t, sbiExist)
+		require.Equal(t, tc.sbi, sbi)
 		require.Equal(t, byte(32), displacementWidth)
 	}
 }
@@ -1687,15 +1688,13 @@ func TestNodeImpl_GetMemoryLocation_with_base(t *testing.T) {
 			types:  operandTypesMemoryToRegister,
 			srcReg: tc.baseReg, srcConst: tc.offset, srcMemIndex: tc.indexReg, srcMemScale: tc.scale,
 		}
-		rexPrefix, modRM, sbi, displacementWidth, err := n.GetMemoryLocation()
+		rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.GetMemoryLocation()
 		require.NoError(t, err, tc.name)
 		require.Equal(t, tc.expRex, rexPrefix, tc.name)
 		require.Equal(t, tc.expModRM, modRM, tc.name)
+		require.Equal(t, tc.needSBI, sbiExist)
 		if tc.needSBI {
-			require.NotNil(t, sbi, tc.name)
-			require.Equal(t, tc.expSBI, *sbi, tc.name)
-		} else {
-			require.Nil(t, sbi, tc.name)
+			require.Equal(t, tc.expSBI, sbi, tc.name)
 		}
 		require.Equal(t, tc.displacementWidth, displacementWidth, tc.name)
 	}


### PR DESCRIPTION
```
$ benchstat old.txt new.txt
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: VirtualApple @ 2.50GHz
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      263.7µ ± 3%   251.5µ ± 3%  -4.63% (p=0.001 n=7)
Compilation/without_extern_cache-10   4.234m ± 0%   4.225m ± 1%       ~ (p=0.165 n=7)
geomean                               1.057m        1.031m       -2.45%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.56Ki ± 0%   53.56Ki ± 0%       ~ (p=0.872 n=7)
Compilation/without_extern_cache-10   1.198Mi ± 0%   1.195Mi ± 0%  -0.26% (p=0.001 n=7)
geomean                               256.3Ki        256.0Ki       -0.13%

                                    │   old.txt   │              new.txt               │
                                    │  allocs/op  │  allocs/op   vs base               │
Compilation/with_extern_cache-10       982.0 ± 0%    981.0 ± 0%        ~ (p=0.070 n=7)
Compilation/without_extern_cache-10   15.00k ± 0%   12.33k ± 0%  -17.81% (p=0.001 n=7)
geomean                               3.838k        3.477k        -9.39%

```