### PR TITLE
compiler: removes takeFreeRegisters fn

### DIFF
--- a/internal/engine/compiler/compiler_value_location.go
+++ b/internal/engine/compiler/compiler_value_location.go
@@ -299,29 +299,6 @@ func (v *runtimeValueLocationStack) takeFreeRegister(tp registerType) (reg asm.R
 	return 0, false
 }
 
-func (v *runtimeValueLocationStack) takeFreeRegisters(tp registerType, num int) (regs []asm.Register, found bool) {
-	var targetRegs []asm.Register
-	switch tp {
-	case registerTypeVector:
-		targetRegs = v.unreservedVectorRegisters
-	case registerTypeGeneralPurpose:
-		targetRegs = v.unreservedGeneralPurposeRegisters
-	}
-
-	regs = make([]asm.Register, 0, num)
-	for _, candidate := range targetRegs {
-		if _, ok := v.usedRegisters[candidate]; ok {
-			continue
-		}
-		regs = append(regs, candidate)
-		if len(regs) == num {
-			found = true
-			break
-		}
-	}
-	return
-}
-
 // Search through the stack, and steal the register from the last used
 // variable on the stack.
 func (v *runtimeValueLocationStack) takeStealTargetFromUsedRegister(tp registerType) (*runtimeValueLocation, bool) {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │             new2.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      102.6µ ± 3%   102.1µ ± 0%       ~ (p=0.259 n=7)
Compilation/without_extern_cache-10   2.089m ± 1%   2.087m ± 1%       ~ (p=0.620 n=7)
geomean                               462.9µ        461.6µ       -0.27%

                                    │   old.txt    │              new2.txt              │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.36Ki ± 0%   53.35Ki ± 0%       ~ (p=0.078 n=7)
Compilation/without_extern_cache-10   1.211Mi ± 0%   1.210Mi ± 0%  -0.03% (p=0.001 n=7)
geomean                               257.2Ki        257.1Ki       -0.02%

                                    │   old.txt   │              new2.txt               │
                                    │  allocs/op  │  allocs/op   vs base                │
Compilation/with_extern_cache-10       979.0 ± 0%    979.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation/without_extern_cache-10   12.18k ± 0%   11.98k ± 0%  -1.59% (p=0.001 n=7)
geomean                               3.453k        3.425k       -0.80%
¹ all samples are equal

```