### PR TITLE
compiler: avoid allocation in SetJumpTargetOnNext

### DIFF
--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -135,7 +135,7 @@ type AssemblerBase interface {
 
 	// SetJumpTargetOnNext instructs the assembler that the next node must be
 	// assigned to the given node's jump destination.
-	SetJumpTargetOnNext(nodes ...Node)
+	SetJumpTargetOnNext(node Node)
 
 	// BuildJumpTable calculates the offsets between the first instruction `initialInstructions[0]`
 	// and others (e.g. initialInstructions[3]), and wrote the calculated offsets into pre-allocated

--- a/internal/asm/impl.go
+++ b/internal/asm/impl.go
@@ -26,8 +26,8 @@ type JumpTableEntry struct {
 }
 
 // SetJumpTargetOnNext implements AssemblerBase.SetJumpTargetOnNext
-func (a *BaseAssemblerImpl) SetJumpTargetOnNext(nodes ...Node) {
-	a.SetBranchTargetOnNextNodes = append(a.SetBranchTargetOnNextNodes, nodes...)
+func (a *BaseAssemblerImpl) SetJumpTargetOnNext(node Node) {
+	a.SetBranchTargetOnNextNodes = append(a.SetBranchTargetOnNextNodes, node)
 }
 
 // BuildJumpTable implements AssemblerBase.BuildJumpTable

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -1534,7 +1534,8 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		c.compileExitFromNativeCode(nativeCallStatusIntegerOverflow)
 
 		// Set the normal case's jump target.
-		c.assembler.SetJumpTargetOnNext(nonMinusOneDivisorJmp, jmpOK)
+		c.assembler.SetJumpTargetOnNext(nonMinusOneDivisorJmp)
+		c.assembler.SetJumpTargetOnNext(jmpOK)
 	}
 
 	// Now ready to emit the div instruction.
@@ -1946,7 +1947,8 @@ func (c *amd64Compiler) compileMinOrMax(is32Bit, isMin bool, minOrMaxInstruction
 	c.assembler.CompileRegisterToRegister(minOrMaxInstruction, x2.register, x1.register)
 
 	// Set the jump target of 1) and 2) cases to the next instruction after 3) case.
-	c.assembler.SetJumpTargetOnNext(nanExitJmp, sameExitJmp)
+	c.assembler.SetJumpTargetOnNext(nanExitJmp)
+	c.assembler.SetJumpTargetOnNext(sameExitJmp)
 
 	// Record that we consumed the x2 and placed the minOrMax result in the x1's register.
 	c.locationStack.markRegisterUnused(x2.register)
@@ -2195,9 +2197,11 @@ func (c *amd64Compiler) emitUnsignedI32TruncFromFloat(isFloat32Bit, nonTrapping 
 	}
 
 	// We jump to the next instructions for valid cases.
-	c.assembler.SetJumpTargetOnNext(okJmpForLessThanMaxInt32PlusOne, okJmpForAboveOrEqualMaxInt32PlusOne)
+	c.assembler.SetJumpTargetOnNext(okJmpForLessThanMaxInt32PlusOne)
+	c.assembler.SetJumpTargetOnNext(okJmpForAboveOrEqualMaxInt32PlusOne)
 	if nonTrapping {
-		c.assembler.SetJumpTargetOnNext(nonTrappingMinusJump, nonTrappingNaNJump)
+		c.assembler.SetJumpTargetOnNext(nonTrappingMinusJump)
+		c.assembler.SetJumpTargetOnNext(nonTrappingNaNJump)
 	}
 
 	// We consumed the source's register and placed the conversion result
@@ -2326,9 +2330,11 @@ func (c *amd64Compiler) emitUnsignedI64TruncFromFloat(isFloat32Bit, nonTrapping 
 	}
 
 	// We jump to the next instructions for valid cases.
-	c.assembler.SetJumpTargetOnNext(okJmpForLessThanMaxInt64PlusOne, okJmpForAboveOrEqualMaxInt64PlusOne)
+	c.assembler.SetJumpTargetOnNext(okJmpForLessThanMaxInt64PlusOne)
+	c.assembler.SetJumpTargetOnNext(okJmpForAboveOrEqualMaxInt64PlusOne)
 	if nonTrapping {
-		c.assembler.SetJumpTargetOnNext(nonTrappingMinusJump, nonTrappingNaNJump)
+		c.assembler.SetJumpTargetOnNext(nonTrappingMinusJump)
+		c.assembler.SetJumpTargetOnNext(nonTrappingNaNJump)
 	}
 
 	// We consumed the source's register and placed the conversion result
@@ -2433,7 +2439,8 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 		c.compileExitFromNativeCode(nativeCallStatusIntegerOverflow)
 
 		// We jump to the next instructions for valid cases.
-		c.assembler.SetJumpTargetOnNext(okJmp, jmpIfMinimumSignedInt)
+		c.assembler.SetJumpTargetOnNext(okJmp)
+		c.assembler.SetJumpTargetOnNext(jmpIfMinimumSignedInt)
 	} else {
 		// Jump if the value does not exceed the lower bound.
 		var jmpIfNotExceedsLowerBound asm.Node
@@ -2470,7 +2477,10 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 			return err
 		}
 
-		c.assembler.SetJumpTargetOnNext(okJmp, nontrappingNanJump, nonTrappingSaturatedMinimumJump, jmpIfMinimumSignedInt)
+		c.assembler.SetJumpTargetOnNext(okJmp)
+		c.assembler.SetJumpTargetOnNext(nontrappingNanJump)
+		c.assembler.SetJumpTargetOnNext(nonTrappingSaturatedMinimumJump)
+		c.assembler.SetJumpTargetOnNext(jmpIfMinimumSignedInt)
 	}
 
 	// We consumed the source's register and placed the conversion result
@@ -2570,7 +2580,8 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 		c.compileExitFromNativeCode(nativeCallStatusIntegerOverflow)
 
 		// We jump to the next instructions for valid cases.
-		c.assembler.SetJumpTargetOnNext(okJmp, jmpIfMinimumSignedInt)
+		c.assembler.SetJumpTargetOnNext(okJmp)
+		c.assembler.SetJumpTargetOnNext(jmpIfMinimumSignedInt)
 	} else {
 		// Jump if the value is not -Inf.
 		jmpIfNotExceedsLowerBound := c.assembler.CompileJump(amd64.JCC)
@@ -2603,7 +2614,10 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 			return err
 		}
 
-		c.assembler.SetJumpTargetOnNext(okJmp, jmpIfMinimumSignedInt, nonTrappingSaturatedMinimumJump, nontrappingNanJump)
+		c.assembler.SetJumpTargetOnNext(okJmp)
+		c.assembler.SetJumpTargetOnNext(jmpIfMinimumSignedInt)
+		c.assembler.SetJumpTargetOnNext(nonTrappingSaturatedMinimumJump)
+		c.assembler.SetJumpTargetOnNext(nontrappingNanJump)
 	}
 
 	// We consumed the source's register and placed the conversion result
@@ -3828,12 +3842,14 @@ func (c *amd64Compiler) compileMemoryCopy() error {
 	endJump := c.assembler.CompileJump(amd64.JMP)
 
 	// Copy forwards.
-	c.assembler.SetJumpTargetOnNext(destLowerThanSourceJump, sourceBoundLowerThanDestJump)
+	c.assembler.SetJumpTargetOnNext(destLowerThanSourceJump)
+	c.assembler.SetJumpTargetOnNext(sourceBoundLowerThanDestJump)
 	c.compileMemoryCopyLoopImpl(destinationOffset, sourceOffset, copySize, tmp, false)
 
 	c.locationStack.markRegisterUnused(copySize.register, sourceOffset.register,
 		destinationOffset.register, tmp)
-	c.assembler.SetJumpTargetOnNext(skipJump, endJump)
+	c.assembler.SetJumpTargetOnNext(skipJump)
+	c.assembler.SetJumpTargetOnNext(endJump)
 
 	return nil
 }
@@ -4078,12 +4094,14 @@ func (c *amd64Compiler) compileTableCopy(o wazeroir.OperationTableCopy) error {
 	endJump := c.assembler.CompileJump(amd64.JMP)
 
 	// Copy forwards.
-	c.assembler.SetJumpTargetOnNext(destLowerThanSourceJump, sourceBoundLowerThanDestJump)
+	c.assembler.SetJumpTargetOnNext(destLowerThanSourceJump)
+	c.assembler.SetJumpTargetOnNext(sourceBoundLowerThanDestJump)
 	c.compileTableCopyLoopImpl(o, destinationOffset, sourceOffset, copySize, tmp, false)
 
 	c.locationStack.markRegisterUnused(copySize.register, sourceOffset.register,
 		destinationOffset.register, tmp)
-	c.assembler.SetJumpTargetOnNext(skipJump, endJump)
+	c.assembler.SetJumpTargetOnNext(skipJump)
+	c.assembler.SetJumpTargetOnNext(endJump)
 	return nil
 }
 

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -1711,7 +1711,8 @@ func (c *arm64Compiler) compileIntegerDivPrecheck(is32Bit, isSigned bool, divide
 		// Otherwise, we raise overflow error.
 		c.compileExitFromNativeCode(nativeCallStatusIntegerOverflow)
 
-		c.assembler.SetJumpTargetOnNext(brIfDivisorNonMinusOne, brIfDividendNotMinInt)
+		c.assembler.SetJumpTargetOnNext(brIfDivisorNonMinusOne)
+		c.assembler.SetJumpTargetOnNext(brIfDividendNotMinInt)
 	}
 	return nil
 }
@@ -3457,7 +3458,8 @@ func (c *arm64Compiler) compileCopyImpl(isTable bool, srcTableIndex, dstTableInd
 			c.assembler.CompileConstToRegister(arm64.ADDS, movSize, copySize.register)
 			c.assembler.CompileJump(arm64.BCONDMI).AssignJumpTarget(beginCopyLoop)
 		}
-		c.assembler.SetJumpTargetOnNext(skipCopyJump, endJump)
+		c.assembler.SetJumpTargetOnNext(skipCopyJump)
+		c.assembler.SetJumpTargetOnNext(endJump)
 	}
 
 	// Mark all of the operand registers.


### PR DESCRIPTION
_arm64_

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      132.6µ ± 1%   133.0µ ± 0%       ~ (p=0.165 n=7)
Compilation/without_extern_cache-10   2.225m ± 0%   2.188m ± 1%  -1.68% (p=0.001 n=7)
geomean                               543.2µ        539.4µ       -0.71%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.40Ki ± 0%   53.40Ki ± 0%       ~ (p=0.511 n=7)
Compilation/without_extern_cache-10   1.159Mi ± 0%   1.144Mi ± 0%  -1.28% (p=0.001 n=7)
geomean                               251.8Ki        250.1Ki       -0.64%

                                    │   old.txt    │               new.txt               │
                                    │  allocs/op   │  allocs/op   vs base                │
Compilation/with_extern_cache-10        979.0 ± 0%    979.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation/without_extern_cache-10   10.384k ± 0%   9.414k ± 0%  -9.34% (p=0.001 n=7)
geomean                                3.188k        3.036k       -4.79%

```

_amd64_ (with_extern_cache must be noisy)

```
benchstat old_amd64.txt new_amd64.txt
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: VirtualApple @ 2.50GHz
                                    │ old_amd64.txt │           new_amd64.txt           │
                                    │    sec/op     │   sec/op     vs base              │
Compilation/with_extern_cache-10        327.0µ ± 2%   333.6µ ± 2%  +2.02% (p=0.004 n=7)
Compilation/without_extern_cache-10     4.792m ± 1%   4.781m ± 1%       ~ (p=0.456 n=7)
geomean                                 1.252m        1.263m       +0.90%

                                    │ old_amd64.txt │           new_amd64.txt            │
                                    │     B/op      │     B/op      vs base              │
Compilation/with_extern_cache-10       53.64Ki ± 0%   53.64Ki ± 0%       ~ (p=0.557 n=7)
Compilation/without_extern_cache-10    1.168Mi ± 0%   1.153Mi ± 0%  -1.29% (p=0.001 n=7)
geomean                                253.3Ki        251.6Ki       -0.65%

                                    │ old_amd64.txt │           new_amd64.txt           │
                                    │   allocs/op   │  allocs/op   vs base              │
Compilation/with_extern_cache-10         981.0 ± 0%    981.0 ± 0%       ~ (p=0.462 n=7)
Compilation/without_extern_cache-10     11.33k ± 0%   10.36k ± 0%  -8.55% (p=0.001 n=7)
geomean                                 3.334k        3.189k       -4.37%

```