### PR TITLE
compiler: avoids allocation in label resolution

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -272,6 +272,19 @@ func (n *nodePool) allocNode() (ret *nodeImpl) {
 	return
 }
 
+// AllocateNOP implements asm.AssemblerBase.
+func (a *AssemblerImpl) AllocateNOP() asm.Node {
+	n := a.nodePool.allocNode()
+	n.instruction = NOP
+	n.types = operandTypesNoneToNone
+	return n
+}
+
+// Add implements asm.AssemblerBase.
+func (a *AssemblerImpl) Add(n asm.Node) {
+	a.addNode(n.(*nodeImpl))
+}
+
 // Reset implements asm.AssemblerBase.
 func (a *AssemblerImpl) Reset() {
 	pool := a.pool

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -264,6 +264,19 @@ func NewAssembler(temporaryRegister asm.Register) *AssemblerImpl {
 	}
 }
 
+// AllocateNOP implements asm.AssemblerBase.
+func (a *AssemblerImpl) AllocateNOP() asm.Node {
+	n := a.nodePool.allocNode()
+	n.instruction = NOP
+	n.types = operandTypesNoneToNone
+	return n
+}
+
+// Add implements asm.AssemblerBase.
+func (a *AssemblerImpl) Add(n asm.Node) {
+	a.addNode(n.(*nodeImpl))
+}
+
 // Reset implements asm.AssemblerBase.
 func (a *AssemblerImpl) Reset() {
 	buf, np, tmp := a.buf, a.nodePool, a.temporaryRegister

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -142,6 +142,12 @@ type AssemblerBase interface {
 	// `table` StaticConst in little endian.
 	BuildJumpTable(table *StaticConst, initialInstructions []Node)
 
+	// AllocateNOP allocates Node for NOP instruction.
+	AllocateNOP() Node
+
+	// Add appends the given `Node` in the assembled linked list.
+	Add(Node)
+
 	// CompileStandAlone adds an instruction to take no arguments.
 	CompileStandAlone(instruction Instruction) Node
 


### PR DESCRIPTION
_arm64_
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      133.8µ ± 1%   134.4µ ± 1%       ~ (p=0.383 n=7)
Compilation/without_extern_cache-10   2.181m ± 0%   2.124m ± 1%  -2.63% (p=0.001 n=7)
geomean                               540.2µ        534.3µ       -1.09%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.41Ki ± 0%   53.41Ki ± 0%       ~ (p=0.778 n=7)
Compilation/without_extern_cache-10   1.144Mi ± 0%   1.115Mi ± 0%  -2.53% (p=0.001 n=7)
geomean                               250.2Ki        247.0Ki       -1.27%

                                    │   old.txt   │               new.txt                │
                                    │  allocs/op  │  allocs/op   vs base                 │
Compilation/with_extern_cache-10       979.0 ± 0%    979.0 ± 0%        ~ (p=1.000 n=7) ¹
Compilation/without_extern_cache-10   9.413k ± 0%   8.440k ± 0%  -10.34% (p=0.001 n=7)
geomean                               3.036k        2.875k        -5.31%
¹ all samples are equal

```

_amd64_
```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: VirtualApple @ 2.50GHz
                                    │ old_amd64.txt │           new_amd64.txt           │
                                    │    sec/op     │   sec/op     vs base              │
Compilation/with_extern_cache-10        334.4µ ± 1%   331.5µ ± 1%  -0.86% (p=0.017 n=7)
Compilation/without_extern_cache-10     4.806m ± 0%   4.677m ± 1%  -2.67% (p=0.001 n=7)
geomean                                 1.268m        1.245m       -1.77%

                                    │ old_amd64.txt │           new_amd64.txt            │
                                    │     B/op      │     B/op      vs base              │
Compilation/with_extern_cache-10       53.66Ki ± 0%   53.65Ki ± 0%       ~ (p=0.128 n=7)
Compilation/without_extern_cache-10    1.153Mi ± 0%   1.124Mi ± 0%  -2.52% (p=0.001 n=7)
geomean                                251.7Ki        248.5Ki       -1.28%

                                    │ old_amd64.txt │            new_amd64.txt            │
                                    │   allocs/op   │  allocs/op   vs base                │
Compilation/with_extern_cache-10         981.0 ± 0%    981.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation/without_extern_cache-10    10.364k ± 0%   9.391k ± 0%  -9.39% (p=0.001 n=7)
geomean                                 3.189k        3.035k       -4.81%

```