### PR TITLE
compiler: stop using map for label infos

### DIFF
--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -819,10 +819,12 @@ type Label struct {
 // LabelID is the unique identifiers for blocks in a single function.
 type LabelID uint64
 
+// Kind returns the LabelKind encoded in this LabelID.
 func (l LabelID) Kind() LabelKind {
 	return LabelKind(uint32(l))
 }
 
+// FrameID returns the frame id encoded in this LabelID.
 func (l LabelID) FrameID() int {
 	return int(uint32(l >> 32))
 }

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -819,6 +819,14 @@ type Label struct {
 // LabelID is the unique identifiers for blocks in a single function.
 type LabelID uint64
 
+func (l LabelID) Kind() LabelKind {
+	return LabelKind(uint32(l))
+}
+
+func (l LabelID) FrameID() int {
+	return int(uint32(l >> 32))
+}
+
 // ID returns the LabelID for this Label.
 func (l Label) ID() (id LabelID) {
 	id = LabelID(l.Kind) | LabelID(l.FrameID)<<32
@@ -863,6 +871,7 @@ const (
 	// we have the continuation block (of if-block) corresponding to "return" opcode.
 	LabelKindContinuation
 	LabelKindReturn
+	LabelKindNum
 )
 
 func (l Label) asBranchTargetDrop() BranchTargetDrop {

--- a/internal/wazeroir/operations_test.go
+++ b/internal/wazeroir/operations_test.go
@@ -65,3 +65,12 @@ func TestUnionOperation_String(t *testing.T) {
 		require.NotEqual(t, "", op.String())
 	}
 }
+
+func TestLabelID(t *testing.T) {
+	for k := LabelKind(0); k < LabelKindNum; k++ {
+		l := Label{Kind: k, FrameID: 12345}
+		id := l.ID()
+		require.Equal(t, k, id.Kind())
+		require.Equal(t, int(l.FrameID), id.FrameID())
+	}
+}


### PR DESCRIPTION
_arm64_
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      133.9µ ± 1%   134.4µ ± 1%       ~ (p=0.456 n=7)
Compilation/without_extern_cache-10   2.125m ± 1%   2.058m ± 1%  -3.14% (p=0.001 n=7)
geomean                               533.3µ        526.0µ       -1.37%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      53.39Ki ± 0%   53.38Ki ± 0%       ~ (p=0.779 n=7)
Compilation/without_extern_cache-10   1.115Mi ± 0%   1.082Mi ± 0%  -2.99% (p=0.001 n=7)
geomean                               246.9Ki        243.2Ki       -1.52%

                                    │   old.txt   │               new.txt               │
                                    │  allocs/op  │  allocs/op   vs base                │
Compilation/with_extern_cache-10       979.0 ± 0%    979.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation/without_extern_cache-10   8.440k ± 0%   7.956k ± 0%  -5.73% (p=0.001 n=7)
geomean                               2.875k        2.791k       -2.91%
¹ all samples are equal
```


_amd64_
```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: VirtualApple @ 2.50GHz
                                    │ old_amd64.txt │           new_amd64.txt           │
                                    │    sec/op     │   sec/op     vs base              │
Compilation/with_extern_cache-10        328.8µ ± 1%   332.2µ ± 2%       ~ (p=0.097 n=7)
Compilation/without_extern_cache-10     4.679m ± 0%   4.550m ± 1%  -2.76% (p=0.001 n=7)
geomean                                 1.240m        1.229m       -0.89%

                                    │ old_amd64.txt │           new_amd64.txt            │
                                    │     B/op      │     B/op      vs base              │
Compilation/with_extern_cache-10       53.63Ki ± 0%   53.64Ki ± 0%       ~ (p=0.607 n=7)
Compilation/without_extern_cache-10    1.124Mi ± 0%   1.090Mi ± 0%  -3.00% (p=0.001 n=7)
geomean                                248.5Ki        244.7Ki       -1.51%

                                    │ old_amd64.txt │            new_amd64.txt            │
                                    │   allocs/op   │  allocs/op   vs base                │
Compilation/with_extern_cache-10         981.0 ± 0%    981.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation/without_extern_cache-10     9.391k ± 0%   8.906k ± 0%  -5.16% (p=0.001 n=7)
geomean                                 3.035k        2.956k       -2.62%

```