### PR TITLE
Reuses allocated slices in func validation 

### DIFF
--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -35,11 +35,11 @@ func TestModule_ValidateFunction_validateFunctionWithMaxStackValues(t *testing.T
 	}
 
 	t.Run("not exceed", func(t *testing.T) {
-		err := m.validateFunctionWithMaxStackValues(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, max+1, nil)
+		err := m.validateFunctionWithMaxStackValues(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, max+1, nil)
 		require.NoError(t, err)
 	})
 	t.Run("exceed", func(t *testing.T) {
-		err := m.validateFunctionWithMaxStackValues(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, max, nil)
+		err := m.validateFunctionWithMaxStackValues(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, max, nil)
 		require.Error(t, err)
 		expMsg := fmt.Sprintf("function may have %d stack values, which exceeds limit %d", valuesNum, max)
 		require.Equal(t, expMsg, err.Error())
@@ -82,7 +82,7 @@ func TestModule_ValidateFunction_SignExtensionOps(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: []byte{tc.input}}},
 				}
-				err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestModule_ValidateFunction_SignExtensionOps(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: body}},
 				}
-				err := m.validateFunction(api.CoreFeatureSignExtensionOps, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeatureSignExtensionOps, 0, []Index{0}, nil, nil, nil, nil)
 				require.NoError(t, err)
 			})
 		})
@@ -154,7 +154,7 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: []byte{OpcodeMiscPrefix, tc.input}}},
 				}
-				err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
@@ -172,14 +172,14 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: body}},
 				}
-				err := m.validateFunction(api.CoreFeatureNonTrappingFloatToIntConversion, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeatureNonTrappingFloatToIntConversion, 0, []Index{0}, nil, nil, nil, nil)
 				require.NoError(t, err)
 			})
 		})
 	}
 }
 
-// TestModule_ValidateFunction_MultiValue only tests what can't yet be detected during compilation. These examples are
+// TestModule_validateFunction(&valueTypeStack{},_MultiValue only tests what can't yet be detected during compilation. These examples are
 // from test/core/if.wast from the commit that added "multi-value" support.
 //
 // See https://github.com/WebAssembly/spec/commit/484180ba3d9d7638ba1cb400b699ffede796927c
@@ -249,11 +249,11 @@ func TestModule_ValidateFunction_MultiValue(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("disabled", func(t *testing.T) {
-				err := tc.module.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
+				err := tc.module.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
-				err := tc.module.validateFunction(api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
+				err := tc.module.validateFunction(&stacks{}, api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
 				require.NoError(t, err)
 			})
 		})
@@ -290,7 +290,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 					ElementSection:   []ElementSegment{{}},
 					DataCountSection: &c,
 				}
-				err := m.validateFunction(api.CoreFeatureBulkMemoryOperations, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeatureBulkMemoryOperations, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
 				require.NoError(t, err)
 			})
 		}
@@ -654,7 +654,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 					c := uint32(0)
 					m.DataCountSection = &c
 				}
-				err := m.validateFunction(tc.flag, 0, []Index{0}, nil, tc.memory, tc.tables, nil)
+				err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, tc.memory, tc.tables, nil)
 				require.EqualError(t, err, tc.expectedErr)
 			})
 		}
@@ -679,7 +679,7 @@ var (
 	v_i64i64                      = FunctionType{Results: []ValueType{i64, i64}}
 )
 
-// TestModule_ValidateFunction_TypeMismatchSpecTests are "type mismatch" tests when "multi-value" was merged.
+// TestModule_validateFunction(&valueTypeStack{},_TypeMismatchSpecTests are "type mismatch" tests when "multi-value" was merged.
 //
 // See https://github.com/WebAssembly/spec/commit/484180ba3d9d7638ba1cb400b699ffede796927c
 func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
@@ -2182,7 +2182,7 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.module.validateFunction(api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
+			err := tc.module.validateFunction(&stacks{}, api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -2199,7 +2199,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 				OpcodeEnd,
 			}}},
 		}
-		err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeFuncref}}, nil)
+		err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeFuncref}}, nil)
 		require.NoError(t, err)
 	})
 	t.Run("non zero table index", func(t *testing.T) {
@@ -2213,11 +2213,11 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 			}}},
 		}
 		t.Run("disabled", func(t *testing.T) {
-			err := m.validateFunction(api.CoreFeaturesV1, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
 			require.EqualError(t, err, "table index must be zero but was 100: feature \"reference-types\" is disabled")
 		})
 		t.Run("enabled but out of range", func(t *testing.T) {
-			err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
 			require.EqualError(t, err, "unknown table index: 100")
 		})
 	})
@@ -2231,7 +2231,7 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 				OpcodeEnd,
 			}}},
 		}
-		err := m.validateFunction(api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeExternref}}, nil)
+		err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeExternref}}, nil)
 		require.EqualError(t, err, "table is not funcref type but was externref for call_indirect")
 	})
 }
@@ -2326,7 +2326,7 @@ func TestModule_funcValidation_RefTypes(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, nil, tc.declaredFunctionIndexes)
+			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, nil, tc.declaredFunctionIndexes)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -2494,7 +2494,7 @@ func TestModule_funcValidation_TableGrowSizeFill(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, tables, nil)
+			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, tables, nil)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -2606,7 +2606,7 @@ func TestModule_funcValidation_TableGetSet(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, tables, nil)
+			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, tables, nil)
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -2663,7 +2663,7 @@ func TestModule_funcValidation_Select_error(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, nil, nil, nil)
+			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, nil, nil)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -3148,7 +3148,7 @@ func TestModule_funcValidation_SIMD(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(api.CoreFeatureSIMD, 0, []Index{0}, nil, &Memory{}, nil, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeatureSIMD, 0, []Index{0}, nil, &Memory{}, nil, nil)
 			require.NoError(t, err)
 		})
 	}
@@ -3293,7 +3293,7 @@ func TestModule_funcValidation_SIMD_error(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(tc.flag, 0, []Index{0}, nil, &Memory{}, nil, nil)
+			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, &Memory{}, nil, nil)
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -3410,7 +3410,7 @@ func TestFuncValidation_UnreachableBrTable_NotModifyTypes(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.m.validateFunction(api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
+			err := tc.m.validateFunction(&stacks{}, api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
 			require.NoError(t, err)
 
 			// Ensures that funcType has remained intact.
@@ -3534,7 +3534,7 @@ func TestModule_funcValidation_loopWithParams(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
 			} else {
@@ -3551,7 +3551,7 @@ func TestFunctionValidation_redundantEnd(t *testing.T) {
 		FunctionSection: []Index{0},
 		CodeSection:     []Code{{Body: []byte{OpcodeEnd, OpcodeEnd}}},
 	}
-	err := m.validateFunction(api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
+	err := m.validateFunction(&stacks{}, api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
 	require.EqualError(t, err, "redundant End instruction at 0x1")
 }
 
@@ -3562,6 +3562,6 @@ func TestFunctionValidation_redundantElse(t *testing.T) {
 		FunctionSection: []Index{0},
 		CodeSection:     []Code{{Body: []byte{OpcodeEnd, OpcodeElse}}},
 	}
-	err := m.validateFunction(api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
+	err := m.validateFunction(&stacks{}, api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
 	require.EqualError(t, err, "redundant Else instruction at 0x1")
 }

--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -179,7 +179,7 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 	}
 }
 
-// TestModule_validateFunction(&valueTypeStack{},_MultiValue only tests what can't yet be detected during compilation. These examples are
+// TestModule_ValidateFunction_MultiValue only tests what can't yet be detected during compilation. These examples are
 // from test/core/if.wast from the commit that added "multi-value" support.
 //
 // See https://github.com/WebAssembly/spec/commit/484180ba3d9d7638ba1cb400b699ffede796927c
@@ -679,7 +679,7 @@ var (
 	v_i64i64                      = FunctionType{Results: []ValueType{i64, i64}}
 )
 
-// TestModule_validateFunction(&valueTypeStack{},_TypeMismatchSpecTests are "type mismatch" tests when "multi-value" was merged.
+// TestModule_ValidateFunction_MultiValue_TypeMismatch are "type mismatch" tests when "multi-value" was merged.
 //
 // See https://github.com/WebAssembly/spec/commit/484180ba3d9d7638ba1cb400b699ffede796927c
 func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -326,6 +326,7 @@ func (m *Module) validateFunctions(enabledFeatures api.CoreFeatures, functions [
 		return err
 	}
 
+	vs := &stacks{}
 	for idx, typeIndex := range m.FunctionSection {
 		if typeIndex >= typeCount {
 			return fmt.Errorf("invalid %s: type section index %d out of range", m.funcDesc(SectionIDFunction, Index(idx)), typeIndex)
@@ -334,7 +335,7 @@ func (m *Module) validateFunctions(enabledFeatures api.CoreFeatures, functions [
 		if c.GoFunc != nil {
 			continue
 		}
-		if err = m.validateFunction(enabledFeatures, Index(idx), functions, globals, memory, tables, declaredFuncIndexes); err != nil {
+		if err = m.validateFunction(vs, enabledFeatures, Index(idx), functions, globals, memory, tables, declaredFuncIndexes); err != nil {
 			return fmt.Errorf("invalid %s: %w", m.funcDesc(SectionIDFunction, Index(idx)), err)
 		}
 	}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt               │
                                    │   sec/op    │   sec/op     vs base               │
Compilation/with_extern_cache-10      134.4µ ± 1%   120.5µ ± 1%  -10.36% (p=0.001 n=7)
Compilation/without_extern_cache-10   2.058m ± 1%   2.027m ± 1%   -1.50% (p=0.001 n=7)
geomean                               526.0µ        494.3µ        -6.04%

                                    │   old.txt    │               new.txt               │
                                    │     B/op     │     B/op      vs base               │
Compilation/with_extern_cache-10      53.38Ki ± 0%   40.80Ki ± 0%  -23.57% (p=0.001 n=7)
Compilation/without_extern_cache-10   1.082Mi ± 0%   1.070Mi ± 0%   -1.13% (p=0.001 n=7)
geomean                               243.2Ki        211.4Ki       -13.07%

                                    │   old.txt   │              new.txt               │
                                    │  allocs/op  │  allocs/op   vs base               │
Compilation/with_extern_cache-10       979.0 ± 0%    632.0 ± 0%  -35.44% (p=0.001 n=7)
Compilation/without_extern_cache-10   7.956k ± 0%   7.609k ± 0%   -4.36% (p=0.001 n=7)
geomean                               2.791k        2.193k       -21.43%
```