### PR TITLE
api: adds CallTo to avoid allocations

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -329,6 +329,13 @@ type Function interface {
 	// WithCloseOnContextDone on wazero.RuntimeConfig for detail. See examples in context_done_example_test.go for
 	// the end-to-end demonstrations of how these terminations can be performed.
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
+
+	// CallTo invokes the function with the given parameters and writes the
+	// results to the given slice. The slice must be large enough to hold all
+	// results.
+	//
+	// See Call for more details.
+	CallTo(ctx context.Context, out []uint64, params ...uint64) error
 }
 
 // GoModuleFunction is a Function implemented in Go instead of a wasm binary.

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -663,6 +663,19 @@ func (ce *callEngine) Call(ctx context.Context, params ...uint64) (results []uin
 	return ce.call(ctx, ce.compiled, params)
 }
 
+// CallTo implements the same method as documented on api.Function.
+func (ce *callEngine) CallTo(ctx context.Context, out []uint64, params ...uint64) (err error) {
+	ret, err := ce.call(ctx, ce.compiled, params)
+	if err != nil {
+		return err
+	}
+	if len(out) < len(ret) {
+		return fmt.Errorf("expected %d results, but got %d", len(out), len(ret))
+	}
+	copy(out, ret)
+	return nil
+}
+
 func (ce *callEngine) call(ctx context.Context, tf *function, params []uint64) (results []uint64, err error) {
 	m := ce.compiled.moduleInstance
 	if ce.compiled.parent.ensureTermination {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -480,6 +480,15 @@ func (ce *mockCallEngine) Call(_ context.Context, _ ...uint64) (results []uint64
 	return
 }
 
+// CallTo implements the same method as documented on api.Function.
+func (ce *mockCallEngine) CallTo(_ context.Context, out []uint64, _ ...uint64) (err error) {
+	if ce.callFailIndex >= 0 && ce.index == Index(ce.callFailIndex) {
+		err = errors.New("call failed")
+		return
+	}
+	return
+}
+
 func TestStore_getFunctionTypeID(t *testing.T) {
 	t.Run("too many functions", func(t *testing.T) {
 		s := newStore()


### PR DESCRIPTION
Before that change each function call creates a new slice, which copies the result from wasm function. That causes a allocation on each call, since golang-compiler are not able to optimize such case.

That patch introduce a new function, CallTo, which makes possible to re-use an already existent slice. In some cases that makes possible to call multiple functions without any allocation.

Currently, such optimization only affects compiler/engine.go, and was not fully ported to interpreter/interpreter.go.