### PR TITLE
Defer resource closure on context cancelation to m.FailIfClosed

### DIFF
--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4958,7 +4958,7 @@ func (c *amd64Compiler) compileModuleContextInitialization() error {
 		amd64ReservedRegisterForCallEngine, callEngineModuleContextModuleInstanceOffset, amd64CallingConventionDestinationFunctionModuleInstanceAddressRegister)
 	jmpIfModuleNotChange := c.assembler.CompileJump(amd64.JEQ)
 
-	// If engine.CallContext.ModuleInstanceAddress is not equal the value on amd64CallingConventionDestinationFunctionModuleInstanceAddressRegister,
+	// If engine.ModuleContext.ModuleInstance is not equal the value on amd64CallingConventionDestinationFunctionModuleInstanceAddressRegister,
 	// we have to put the new value there.
 	c.assembler.CompileRegisterToMemory(amd64.MOVQ, amd64CallingConventionDestinationFunctionModuleInstanceAddressRegister,
 		amd64ReservedRegisterForCallEngine, callEngineModuleContextModuleInstanceOffset)

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -124,7 +124,7 @@ type exitCodeFlag = uint64
 
 const (
 	// exitCodeFlagResourceClosed indicates that the module was closed and resources were already closed.
-	exitCodeFlagResourceClosed = iota + 1
+	exitCodeFlagResourceClosed = 1 << iota
 	// exitCodeFlagResourceNotClosed indicates that the module was closed while resources are not closed yet.
 	exitCodeFlagResourceNotClosed
 )

--- a/internal/wasm/module_instance_test.go
+++ b/internal/wasm/module_instance_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func TestCallContext_String(t *testing.T) {
+func TestModuleInstance_String(t *testing.T) {
 	s := newStore()
 
 	tests := []struct {
@@ -57,7 +57,7 @@ func TestCallContext_String(t *testing.T) {
 	}
 }
 
-func TestCallContext_Close(t *testing.T) {
+func TestModuleInstance_Close(t *testing.T) {
 	s := newStore()
 
 	tests := []struct {
@@ -67,15 +67,15 @@ func TestCallContext_Close(t *testing.T) {
 	}{
 		{
 			name: "Close()",
-			closer: func(ctx context.Context, callContext *ModuleInstance) error {
-				return callContext.Close(ctx)
+			closer: func(ctx context.Context, m *ModuleInstance) error {
+				return m.Close(ctx)
 			},
 			expectedClosed: uint64(1),
 		},
 		{
 			name: "CloseWithExitCode(255)",
-			closer: func(ctx context.Context, callContext *ModuleInstance) error {
-				return callContext.CloseWithExitCode(ctx, 255)
+			closer: func(ctx context.Context, m *ModuleInstance) error {
+				return m.CloseWithExitCode(ctx, 255)
 			},
 			expectedClosed: uint64(255)<<32 + 1,
 		},
@@ -161,7 +161,7 @@ func TestCallContext_Close(t *testing.T) {
 	})
 }
 
-func TestCallContext_CallDynamic(t *testing.T) {
+func TestModuleInstance_CallDynamic(t *testing.T) {
 	s := newStore()
 
 	tests := []struct {
@@ -171,15 +171,15 @@ func TestCallContext_CallDynamic(t *testing.T) {
 	}{
 		{
 			name: "Close()",
-			closer: func(ctx context.Context, callContext *ModuleInstance) error {
-				return callContext.Close(ctx)
+			closer: func(ctx context.Context, m *ModuleInstance) error {
+				return m.Close(ctx)
 			},
 			expectedClosed: uint64(1),
 		},
 		{
 			name: "CloseWithExitCode(255)",
-			closer: func(ctx context.Context, callContext *ModuleInstance) error {
-				return callContext.CloseWithExitCode(ctx, 255)
+			closer: func(ctx context.Context, m *ModuleInstance) error {
+				return m.CloseWithExitCode(ctx, 255)
 			},
 			expectedClosed: uint64(255)<<32 + 1,
 		},
@@ -259,7 +259,7 @@ func TestCallContext_CallDynamic(t *testing.T) {
 	})
 }
 
-func TestCallContext_CloseModuleOnCanceledOrTimeout(t *testing.T) {
+func TestModuleInstance_CloseModuleOnCanceledOrTimeout(t *testing.T) {
 	s := newStore()
 	t.Run("timeout", func(t *testing.T) {
 		cc := &ModuleInstance{Closed: 0, ModuleName: "test", s: s, Sys: internalsys.DefaultContext(nil)}
@@ -271,7 +271,7 @@ func TestCallContext_CloseModuleOnCanceledOrTimeout(t *testing.T) {
 		defer done()
 
 		// Resource shouldn't be released at this point.
-		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagResourceNotClosed)
+		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagMask)
 		require.NotNil(t, cc.Sys)
 
 		err := cc.FailIfClosed()
@@ -293,7 +293,7 @@ func TestCallContext_CloseModuleOnCanceledOrTimeout(t *testing.T) {
 		time.Sleep(time.Second)
 
 		// Resource shouldn't be released at this point.
-		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagResourceNotClosed)
+		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagMask)
 		require.NotNil(t, cc.Sys)
 
 		err := cc.FailIfClosed()
@@ -316,7 +316,7 @@ func TestCallContext_CloseModuleOnCanceledOrTimeout(t *testing.T) {
 		defer done()
 
 		// Resource shouldn't be released at this point.
-		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagResourceNotClosed)
+		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagMask)
 		require.NotNil(t, cc.Sys)
 
 		err := cc.FailIfClosed()
@@ -341,7 +341,7 @@ func TestCallContext_CloseModuleOnCanceledOrTimeout(t *testing.T) {
 		time.Sleep(time.Second)
 
 		// Resource shouldn't be released at this point.
-		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagResourceNotClosed)
+		require.Equal(t, exitCodeFlag(exitCodeFlagResourceNotClosed), cc.Closed&exitCodeFlagMask)
 		require.NotNil(t, cc.Sys)
 
 		err := cc.FailIfClosed()
@@ -380,7 +380,7 @@ func TestCallContext_CloseModuleOnCanceledOrTimeout(t *testing.T) {
 	})
 }
 
-func TestCallContext_CloseWithCtxErr(t *testing.T) {
+func TestModuleInstance_CloseWithCtxErr(t *testing.T) {
 	s := newStore()
 
 	t.Run("context canceled", func(t *testing.T) {
@@ -425,7 +425,7 @@ func (m *mockCloser) Close(context.Context) error {
 	return nil
 }
 
-func TestCallContext_ensureResourcesClosed(t *testing.T) {
+func TestModuleInstance_ensureResourcesClosed(t *testing.T) {
 	closer := &mockCloser{}
 
 	for _, tc := range []struct {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -99,7 +99,7 @@ type (
 		//
 		// # Notes
 		//
-		//   - This is a part of CallContext so that scope and Close is coherent.
+		//   - This is a part of ModuleInstance so that scope and Close is coherent.
 		//   - This is not exposed outside this repository (as a host function
 		//	  parameter) because we haven't thought through capabilities based
 		//	  security implications.
@@ -271,7 +271,7 @@ func NewStore(enabledFeatures api.CoreFeatures, engine Engine) *Store {
 //
 // * ctx: the default context used for function calls.
 // * name: the name of the module.
-// * sys: the system context, which will be closed (SysContext.Close) on CallContext.Close.
+// * sys: the system context, which will be closed (SysContext.Close) on ModuleInstance.Close.
 //
 // Note: Module.Validate must be called prior to instantiation.
 func (s *Store) Instantiate(

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -113,7 +113,7 @@ func TestStore_Instantiate(t *testing.T) {
 	require.NoError(t, err)
 	defer mod.Close(testCtx)
 
-	t.Run("CallContext defaults", func(t *testing.T) {
+	t.Run("ModuleInstance defaults", func(t *testing.T) {
 		require.Equal(t, s.nameToNode["bar"].module, mod)
 		require.Equal(t, s.nameToNode["bar"].module.MemoryInstance, mod.MemoryInstance)
 		require.Equal(t, s, mod.s)


### PR DESCRIPTION
Fixes #1314. Previously, when context cancelation is enabled, the resource is 
also closed in the `closeModuleOnCanceledOrTimeout` function which is 
asynchronously called concurrently to the Wasm function call. On the other hand,
host functions, especially wasi functions, do not check if the module is closed or not
therefore, if we reached the context cancelation while executing wasi functions, we
had race conditions.

This makes change to `closeModuleOnCanceledOrTimeout` so that it won't close resources,
and defer closing them to in `FailIfClosed` which is called synchronously during `api.Function.Call`.