### PR TITLE
Reuses bytes.Reader in func validation

### DIFF
--- a/internal/wasm/func_validation_test.go
+++ b/internal/wasm/func_validation_test.go
@@ -35,11 +35,13 @@ func TestModule_ValidateFunction_validateFunctionWithMaxStackValues(t *testing.T
 	}
 
 	t.Run("not exceed", func(t *testing.T) {
-		err := m.validateFunctionWithMaxStackValues(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, max+1, nil)
+		err := m.validateFunctionWithMaxStackValues(&stacks{}, api.CoreFeaturesV1,
+			0, []Index{0}, nil, nil, nil, max+1, nil, bytes.NewReader(nil))
 		require.NoError(t, err)
 	})
 	t.Run("exceed", func(t *testing.T) {
-		err := m.validateFunctionWithMaxStackValues(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, max, nil)
+		err := m.validateFunctionWithMaxStackValues(&stacks{}, api.CoreFeaturesV1,
+			0, []Index{0}, nil, nil, nil, max, nil, bytes.NewReader(nil))
 		require.Error(t, err)
 		expMsg := fmt.Sprintf("function may have %d stack values, which exceeds limit %d", valuesNum, max)
 		require.Equal(t, expMsg, err.Error())
@@ -82,7 +84,9 @@ func TestModule_ValidateFunction_SignExtensionOps(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: []byte{tc.input}}},
 				}
-				err := m.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeaturesV1,
+					0, []Index{0}, nil, nil, nil, nil,
+					bytes.NewReader(nil))
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
@@ -99,7 +103,9 @@ func TestModule_ValidateFunction_SignExtensionOps(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: body}},
 				}
-				err := m.validateFunction(&stacks{}, api.CoreFeatureSignExtensionOps, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeatureSignExtensionOps,
+					0, []Index{0}, nil, nil, nil,
+					nil, bytes.NewReader(nil))
 				require.NoError(t, err)
 			})
 		})
@@ -154,7 +160,8 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: []byte{OpcodeMiscPrefix, tc.input}}},
 				}
-				err := m.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeaturesV1,
+					0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
@@ -172,7 +179,8 @@ func TestModule_ValidateFunction_NonTrappingFloatToIntConversion(t *testing.T) {
 					FunctionSection: []Index{0},
 					CodeSection:     []Code{{Body: body}},
 				}
-				err := m.validateFunction(&stacks{}, api.CoreFeatureNonTrappingFloatToIntConversion, 0, []Index{0}, nil, nil, nil, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeatureNonTrappingFloatToIntConversion,
+					0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 				require.NoError(t, err)
 			})
 		})
@@ -249,11 +257,13 @@ func TestModule_ValidateFunction_MultiValue(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("disabled", func(t *testing.T) {
-				err := tc.module.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, nil, nil, nil)
+				err := tc.module.validateFunction(&stacks{}, api.CoreFeaturesV1,
+					0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 				require.EqualError(t, err, tc.expectedErrOnDisable)
 			})
 			t.Run("enabled", func(t *testing.T) {
-				err := tc.module.validateFunction(&stacks{}, api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
+				err := tc.module.validateFunction(&stacks{}, api.CoreFeatureMultiValue,
+					0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 				require.NoError(t, err)
 			})
 		})
@@ -290,7 +300,8 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 					ElementSection:   []ElementSegment{{}},
 					DataCountSection: &c,
 				}
-				err := m.validateFunction(&stacks{}, api.CoreFeatureBulkMemoryOperations, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
+				err := m.validateFunction(&stacks{}, api.CoreFeatureBulkMemoryOperations,
+					0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil, bytes.NewReader(nil))
 				require.NoError(t, err)
 			})
 		}
@@ -654,7 +665,7 @@ func TestModule_ValidateFunction_BulkMemoryOperations(t *testing.T) {
 					c := uint32(0)
 					m.DataCountSection = &c
 				}
-				err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, tc.memory, tc.tables, nil)
+				err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, tc.memory, tc.tables, nil, bytes.NewReader(nil))
 				require.EqualError(t, err, tc.expectedErr)
 			})
 		}
@@ -2182,7 +2193,8 @@ func TestModule_ValidateFunction_MultiValue_TypeMismatch(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.module.validateFunction(&stacks{}, api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
+			err := tc.module.validateFunction(&stacks{}, api.CoreFeatureMultiValue,
+				0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -2199,7 +2211,8 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 				OpcodeEnd,
 			}}},
 		}
-		err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeFuncref}}, nil)
+		err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes,
+			0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeFuncref}}, nil, bytes.NewReader(nil))
 		require.NoError(t, err)
 	})
 	t.Run("non zero table index", func(t *testing.T) {
@@ -2213,11 +2226,13 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 			}}},
 		}
 		t.Run("disabled", func(t *testing.T) {
-			err := m.validateFunction(&stacks{}, api.CoreFeaturesV1, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeaturesV1,
+				0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil, bytes.NewReader(nil))
 			require.EqualError(t, err, "table index must be zero but was 100: feature \"reference-types\" is disabled")
 		})
 		t.Run("enabled but out of range", func(t *testing.T) {
-			err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes,
+				0, []Index{0}, nil, &Memory{}, []Table{{}, {}}, nil, bytes.NewReader(nil))
 			require.EqualError(t, err, "unknown table index: 100")
 		})
 	})
@@ -2231,7 +2246,8 @@ func TestModule_funcValidation_CallIndirect(t *testing.T) {
 				OpcodeEnd,
 			}}},
 		}
-		err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes, 0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeExternref}}, nil)
+		err := m.validateFunction(&stacks{}, api.CoreFeatureReferenceTypes,
+			0, []Index{0}, nil, &Memory{}, []Table{{Type: RefTypeExternref}}, nil, bytes.NewReader(nil))
 		require.EqualError(t, err, "table is not funcref type but was externref for call_indirect")
 	})
 }
@@ -2326,7 +2342,8 @@ func TestModule_funcValidation_RefTypes(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, nil, tc.declaredFunctionIndexes)
+			err := m.validateFunction(&stacks{}, tc.flag,
+				0, []Index{0}, nil, nil, nil, tc.declaredFunctionIndexes, bytes.NewReader(nil))
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -2494,7 +2511,8 @@ func TestModule_funcValidation_TableGrowSizeFill(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, tables, nil)
+			err := m.validateFunction(&stacks{}, tc.flag,
+				0, []Index{0}, nil, nil, tables, nil, bytes.NewReader(nil))
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -2606,7 +2624,8 @@ func TestModule_funcValidation_TableGetSet(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, tables, nil)
+			err := m.validateFunction(&stacks{}, tc.flag,
+				0, []Index{0}, nil, nil, tables, nil, bytes.NewReader(nil))
 			if tc.expectedErr != "" {
 				require.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -2663,7 +2682,8 @@ func TestModule_funcValidation_Select_error(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, nil, nil, nil)
+			err := m.validateFunction(&stacks{}, tc.flag,
+				0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -3148,7 +3168,8 @@ func TestModule_funcValidation_SIMD(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, api.CoreFeatureSIMD, 0, []Index{0}, nil, &Memory{}, nil, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeatureSIMD,
+				0, []Index{0}, nil, &Memory{}, nil, nil, bytes.NewReader(nil))
 			require.NoError(t, err)
 		})
 	}
@@ -3293,7 +3314,8 @@ func TestModule_funcValidation_SIMD_error(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, tc.flag, 0, []Index{0}, nil, &Memory{}, nil, nil)
+			err := m.validateFunction(&stacks{}, tc.flag,
+				0, []Index{0}, nil, &Memory{}, nil, nil, bytes.NewReader(nil))
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
@@ -3410,7 +3432,8 @@ func TestFuncValidation_UnreachableBrTable_NotModifyTypes(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.m.validateFunction(&stacks{}, api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
+			err := tc.m.validateFunction(&stacks{}, api.CoreFeaturesV2,
+				0, nil, nil, nil, nil, nil, bytes.NewReader(nil))
 			require.NoError(t, err)
 
 			// Ensures that funcType has remained intact.
@@ -3534,7 +3557,8 @@ func TestModule_funcValidation_loopWithParams(t *testing.T) {
 				FunctionSection: []Index{0},
 				CodeSection:     []Code{{Body: tc.body}},
 			}
-			err := m.validateFunction(&stacks{}, api.CoreFeatureMultiValue, 0, []Index{0}, nil, nil, nil, nil)
+			err := m.validateFunction(&stacks{}, api.CoreFeatureMultiValue,
+				0, []Index{0}, nil, nil, nil, nil, bytes.NewReader(nil))
 			if tc.expErr != "" {
 				require.EqualError(t, err, tc.expErr)
 			} else {
@@ -3551,7 +3575,8 @@ func TestFunctionValidation_redundantEnd(t *testing.T) {
 		FunctionSection: []Index{0},
 		CodeSection:     []Code{{Body: []byte{OpcodeEnd, OpcodeEnd}}},
 	}
-	err := m.validateFunction(&stacks{}, api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
+	err := m.validateFunction(&stacks{}, api.CoreFeaturesV2,
+		0, nil, nil, nil, nil, nil, bytes.NewReader(nil))
 	require.EqualError(t, err, "redundant End instruction at 0x1")
 }
 
@@ -3562,6 +3587,7 @@ func TestFunctionValidation_redundantElse(t *testing.T) {
 		FunctionSection: []Index{0},
 		CodeSection:     []Code{{Body: []byte{OpcodeEnd, OpcodeElse}}},
 	}
-	err := m.validateFunction(&stacks{}, api.CoreFeaturesV2, 0, nil, nil, nil, nil, nil)
+	err := m.validateFunction(&stacks{}, api.CoreFeaturesV2,
+		0, nil, nil, nil, nil, nil, bytes.NewReader(nil))
 	require.EqualError(t, err, "redundant Else instruction at 0x1")
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -465,7 +465,7 @@ func TestModule_validateFunctions(t *testing.T) {
 		m := Module{}
 		err := m.validateFunctions(api.CoreFeaturesV1, []uint32{1, 2, 3, 4}, nil, nil, nil, 3)
 		require.Error(t, err)
-		require.EqualError(t, err, "too many functions in a module")
+		require.EqualError(t, err, "too many functions (4) in a module")
 	})
 	t.Run("function, but no code", func(t *testing.T) {
 		m := Module{


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache-10      120.8µ ± 8%   118.0µ ± 3%  -2.31% (p=0.011 n=7)
Compilation/without_extern_cache-10   2.295m ± 1%   2.277m ± 0%  -0.77% (p=0.001 n=7)
geomean                               526.5µ        518.4µ       -1.54%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache-10      40.81Ki ± 0%   38.92Ki ± 0%  -4.63% (p=0.001 n=7)
Compilation/without_extern_cache-10   1.218Mi ± 0%   1.216Mi ± 0%  -0.15% (p=0.001 n=7)
geomean                               225.6Ki        220.2Ki       -2.41%

                                    │   old.txt   │              new.txt              │
                                    │  allocs/op  │  allocs/op   vs base              │
Compilation/with_extern_cache-10       632.0 ± 0%    592.0 ± 0%  -6.33% (p=0.001 n=7)
Compilation/without_extern_cache-10   7.618k ± 0%   7.578k ± 0%  -0.53% (p=0.001 n=7)
geomean                               2.194k        2.118k       -3.47%

```