### PR TITLE
wazeroir: reuses allocated slices for a module

### DIFF
--- a/internal/engine/compiler/compiler.go
+++ b/internal/engine/compiler/compiler.go
@@ -2,13 +2,14 @@ package compiler
 
 import (
 	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
 // compiler is the interface of architecture-specific native code compiler,
 // and this is responsible for compiling native code for all wazeroir operations.
 type compiler interface {
-	Init(ir *wazeroir.CompilationResult, withListener bool)
+	Init(functionType *wasm.FunctionType, ir *wazeroir.CompilationResult, withListener bool)
 
 	// String is for debugging purpose.
 	String() string

--- a/internal/engine/compiler/compiler_bench_test.go
+++ b/internal/engine/compiler/compiler_bench_test.go
@@ -26,7 +26,7 @@ func BenchmarkCompiler_compileMemoryCopy(b *testing.B) {
 				}
 
 				compiler := newCompiler()
-				compiler.Init(&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}}, false)
+				compiler.Init(&wasm.FunctionType{}, &wazeroir.CompilationResult{HasMemory: true}, false)
 				err := compiler.compilePreamble()
 				requireNoError(b, err)
 
@@ -79,7 +79,7 @@ func BenchmarkCompiler_compileMemoryFill(b *testing.B) {
 			}
 
 			compiler := newCompiler()
-			compiler.Init(&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}}, false)
+			compiler.Init(&wasm.FunctionType{}, &wazeroir.CompilationResult{HasMemory: true}, false)
 
 			var startOffset uint32 = 100
 			var value uint8 = 5

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -11,7 +12,7 @@ import (
 // no free registers available.
 func TestCompiler_conditional_value_saving(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, nil)
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
 

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -1,10 +1,10 @@
 package compiler
 
 import (
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"math"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestCompiler_compileReinterpret(t *testing.T) {
 						v := v
 						t.Run(fmt.Sprintf("%d", v), func(t *testing.T) {
 							env := newCompilerEnvironment()
-							compiler := env.requireNewCompiler(t, newCompiler, nil)
+							compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 							err := compiler.compilePreamble()
 							require.NoError(t, err)
 
@@ -106,7 +107,7 @@ func TestCompiler_compileExtend(t *testing.T) {
 				v := v
 				t.Run(fmt.Sprintf("%v", v), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -188,7 +189,7 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 
 				t.Run(fmt.Sprintf("%v", v), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -387,7 +388,7 @@ func TestCompiler_compileFConvertFromI(t *testing.T) {
 			} {
 				t.Run(fmt.Sprintf("%d", v), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -464,7 +465,7 @@ func TestCompiler_compileF64PromoteFromF32(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 
@@ -510,7 +511,7 @@ func TestCompiler_compileF32DemoteFromF64(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -2,11 +2,11 @@ package compiler
 
 import (
 	"fmt"
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"math"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -16,9 +16,8 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 		tp := tp
 		t.Run(wasm.ValueTypeName(tp), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				Signature: &wasm.FunctionType{},
-				Globals:   []wasm.GlobalType{{}, {ValType: tp}},
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+				Globals: []wasm.GlobalType{{}, {ValType: tp}},
 			})
 
 			// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
@@ -63,9 +62,8 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 func TestCompiler_compileGlobalGet_v128(t *testing.T) {
 	const v128Type = wasm.ValueTypeV128
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-		Signature: &wasm.FunctionType{},
-		Globals:   []wasm.GlobalType{{}, {ValType: v128Type}},
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+		Globals: []wasm.GlobalType{{}, {ValType: v128Type}},
 	})
 
 	// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
@@ -115,9 +113,8 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 		tp := tp
 		t.Run(wasm.ValueTypeName(tp), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				Signature: &wasm.FunctionType{},
-				Globals:   []wasm.GlobalType{{}, {ValType: tp}},
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+				Globals: []wasm.GlobalType{{}, {ValType: tp}},
 			})
 
 			// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)
@@ -169,9 +166,8 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 	const valueToSetLo, valueToSetHi uint64 = 0xffffff, 1
 
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-		Signature: &wasm.FunctionType{},
-		Globals:   []wasm.GlobalType{{}, {ValType: v128Type}},
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+		Globals: []wasm.GlobalType{{}, {ValType: v128Type}},
 	})
 
 	// Setup the global. (Start with nil as a dummy so that global index can be non-trivial.)

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -119,7 +119,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			for _, g := range tc.moduleInstance.Globals {
 				ir.Globals = append(ir.Globals, g.Type)
 			}
-			compiler := env.requireNewCompiler(t, newCompiler, ir)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, ir)
 			me := &moduleEngine{functions: make([]function, 10)}
 			tc.moduleInstance.Engine = me
 
@@ -179,7 +179,7 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 		for _, baseOffset := range []uint64{5, 10, 20} {
 			t.Run(fmt.Sprintf("%d", baseOffset), func(t *testing.T) {
 				env := newCompilerEnvironment()
-				compiler := env.requireNewCompiler(t, newCompiler, nil)
+				compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 				err := compiler.compilePreamble()
 				require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				env := newCompilerEnvironment()
-				compiler := env.requireNewCompiler(t, newCompiler, nil)
+				compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 				err := compiler.compilePreamble()
 				require.NoError(t, err)

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCompiler_compileMemoryGrow(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, nil)
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 
 func TestCompiler_compileMemorySize(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{HasMemory: true})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -373,7 +373,7 @@ func TestCompiler_compileStore(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -438,7 +438,7 @@ func TestCompiler_MemoryOutOfBounds(t *testing.T) {
 				targetSizeInByte := targetSizeInByte
 				t.Run(fmt.Sprintf("base=%d,offset=%d,targetSizeInBytes=%d", base, offset, targetSizeInByte), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 					err := compiler.compilePreamble()
 					require.NoError(t, err)

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"math"
 	"math/bits"
 	"testing"
@@ -38,7 +39,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 					env := newCompilerEnvironment()
 
 					// Compile code.
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -144,7 +145,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 						x1, x2 := values[0], values[1]
 						t.Run(fmt.Sprintf("x1=0x%x,x2=0x%x", x1, x2), func(t *testing.T) {
 							env := newCompilerEnvironment()
-							compiler := env.requireNewCompiler(t, newCompiler, nil)
+							compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 							err := compiler.compilePreamble()
 							require.NoError(t, err)
 
@@ -315,7 +316,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 							x1OnRegister := x1OnRegister
 							t.Run(fmt.Sprintf("x1=0x%x(on_register=%v),x2=0x%x", x1, x1OnRegister, x2), func(t *testing.T) {
 								env := newCompilerEnvironment()
-								compiler := env.requireNewCompiler(t, newCompiler, nil)
+								compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 								err := compiler.compilePreamble()
 								require.NoError(t, err)
 
@@ -456,7 +457,7 @@ func TestCompiler_compileShr(t *testing.T) {
 					x1, x2 := values[0], values[1]
 					t.Run(fmt.Sprintf("x1=0x%x,x2=0x%x", x1, x2), func(t *testing.T) {
 						env := newCompilerEnvironment()
-						compiler := env.requireNewCompiler(t, newCompiler, nil)
+						compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 						err := compiler.compilePreamble()
 						require.NoError(t, err)
 
@@ -585,7 +586,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 						}
 						t.Run(fmt.Sprintf("x1=0x%x,x2=0x%x", x1, x2), func(t *testing.T) {
 							env := newCompilerEnvironment()
-							compiler := env.requireNewCompiler(t, newCompiler, nil)
+							compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 							err := compiler.compilePreamble()
 							require.NoError(t, err)
 
@@ -797,7 +798,7 @@ func TestCompiler_compile_Clz_Ctz_Popcnt(t *testing.T) {
 						}
 						t.Run(name, func(t *testing.T) {
 							env := newCompilerEnvironment()
-							compiler := env.requireNewCompiler(t, newCompiler, nil)
+							compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 							err := compiler.compilePreamble()
 							require.NoError(t, err)
 
@@ -1008,7 +1009,7 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 				x1, x2 := vs[0], vs[1]
 				t.Run(fmt.Sprintf("x1=%f_x2=%f", x1, x2), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -1316,7 +1317,7 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 				v := v
 				t.Run(fmt.Sprintf("%f", v), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -1431,7 +1432,7 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 						x1, x2 := values[0], values[1]
 						t.Run(fmt.Sprintf("x1=0x%x,x2=0x%x", x1, x2), func(t *testing.T) {
 							env := newCompilerEnvironment()
-							compiler := env.requireNewCompiler(t, newCompiler, nil)
+							compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 							err := compiler.compilePreamble()
 							require.NoError(t, err)
 

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -2,13 +2,13 @@ package compiler
 
 import (
 	"fmt"
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"math"
 	"math/bits"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/moremath"
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -44,7 +44,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 			tc := tt
 			t.Run(fmt.Sprintf("0x%x", tc.in), func(t *testing.T) {
 				env := newCompilerEnvironment()
-				compiler := env.requireNewCompiler(t, newCompiler, nil)
+				compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 				err := compiler.compilePreamble()
 				require.NoError(t, err)
 
@@ -115,7 +115,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 			tc := tt
 			t.Run(fmt.Sprintf("0x%x", tc.in), func(t *testing.T) {
 				env := newCompilerEnvironment()
-				compiler := env.requireNewCompiler(t, newCompiler, nil)
+				compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 				err := compiler.compilePreamble()
 				require.NoError(t, err)
 
@@ -195,7 +195,7 @@ func TestCompiler_compileMemoryCopy(t *testing.T) {
 		tc := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestCompiler_compileMemoryFill(t *testing.T) {
 		tc := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -342,8 +342,8 @@ func TestCompiler_compileDataDrop(t *testing.T) {
 			env.module().DataInstances = make([][]byte, len(origins))
 			copy(env.module().DataInstances, origins)
 
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				HasDataInstances: true, Signature: &wasm.FunctionType{},
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+				HasDataInstances: true,
 			})
 
 			err := compiler.compilePreamble()
@@ -415,9 +415,8 @@ func TestCompiler_compileMemoryInit(t *testing.T) {
 			env := newCompilerEnvironment()
 			env.module().DataInstances = dataInstances
 
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
 				HasDataInstances: true, HasMemory: true,
-				Signature: &wasm.FunctionType{},
 			})
 
 			err := compiler.compilePreamble()
@@ -479,8 +478,8 @@ func TestCompiler_compileElemDrop(t *testing.T) {
 				require.NotEqual(t, 0, len(inst.References))
 			}
 
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				HasElementInstances: true, Signature: &wasm.FunctionType{},
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+				HasElementInstances: true,
 			})
 
 			err := compiler.compilePreamble()
@@ -551,7 +550,7 @@ func TestCompiler_compileTableCopy(t *testing.T) {
 		tc := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{HasTable: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{HasTable: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -640,9 +639,8 @@ func TestCompiler_compileTableInit(t *testing.T) {
 			env := newCompilerEnvironment()
 			env.module().ElementInstances = elementInstances
 
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
 				HasElementInstances: true, HasTable: true,
-				Signature: &wasm.FunctionType{},
 			})
 
 			err := compiler.compilePreamble()
@@ -765,9 +763,8 @@ func TestCompiler_compileTableSet(t *testing.T) {
 				env.addTable(table)
 			}
 
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				HasTable:  true,
-				Signature: &wasm.FunctionType{},
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+				HasTable: true,
 			})
 
 			err := compiler.compilePreamble()
@@ -897,9 +894,8 @@ func TestCompiler_compileTableGet(t *testing.T) {
 				env.addTable(table)
 			}
 
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-				HasTable:  true,
-				Signature: &wasm.FunctionType{},
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+				HasTable: true,
 			})
 
 			err := compiler.compilePreamble()
@@ -933,7 +929,7 @@ func TestCompiler_compileTableGet(t *testing.T) {
 
 func TestCompiler_compileRefFunc(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{Signature: &wasm.FunctionType{}})
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -947,7 +943,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 	for i := 0; i < numFuncs; i++ {
 		i := i
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"math"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestCompiler_releaseRegisterToStack(t *testing.T) {
 			env := newCompilerEnvironment()
 
 			// Compile code.
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 
@@ -92,7 +93,7 @@ func TestCompiler_compileLoadValueOnStackToRegister(t *testing.T) {
 			env := newCompilerEnvironment()
 
 			// Compile code.
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 
@@ -173,7 +174,7 @@ func TestCompiler_compilePick_v128(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 
@@ -279,7 +280,7 @@ func TestCompiler_compilePick(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 
@@ -328,7 +329,7 @@ func TestCompiler_compilePick(t *testing.T) {
 func TestCompiler_compileDrop(t *testing.T) {
 	t.Run("range nil", func(t *testing.T) {
 		env := newCompilerEnvironment()
-		compiler := env.requireNewCompiler(t, newCompiler, nil)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -361,7 +362,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		liveNum := 5
 
 		env := newCompilerEnvironment()
-		compiler := env.requireNewCompiler(t, newCompiler, nil)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -409,7 +410,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 
 		env := newCompilerEnvironment()
 		ce := env.callEngine()
-		compiler := env.requireNewCompiler(t, newCompiler, nil)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -525,7 +526,7 @@ func TestCompiler_compileSelect(t *testing.T) {
 				x1Value, x2Value := vals[0], vals[1]
 				t.Run(fmt.Sprintf("x1=0x%x,x2=0x%x", vals[0], vals[1]), func(t *testing.T) {
 					env := newCompilerEnvironment()
-					compiler := env.requireNewCompiler(t, newCompiler, nil)
+					compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 					err := compiler.compilePreamble()
 					require.NoError(t, err)
 
@@ -622,7 +623,7 @@ func TestCompiler_compileSwap_v128(t *testing.T) {
 		tc := tt
 		t.Run(fmt.Sprintf("x1_register=%v, x2_register=%v", tc.x1OnRegister, tc.x2OnRegister), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 
@@ -694,7 +695,7 @@ func TestCompiler_compileSet(t *testing.T) {
 		tc := tt
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
 

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -2,11 +2,11 @@ package compiler
 
 import (
 	"fmt"
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"math"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -220,18 +220,17 @@ func (j *compilerEnv) exec(codeSegment []byte) {
 	)
 }
 
-func (j *compilerEnv) requireNewCompiler(t *testing.T, fn func() compiler, ir *wazeroir.CompilationResult) compilerImpl {
+func (j *compilerEnv) requireNewCompiler(t *testing.T, functionType *wasm.FunctionType, fn func() compiler, ir *wazeroir.CompilationResult) compilerImpl {
 	requireSupportedOSArch(t)
 
 	if ir == nil {
 		ir = &wazeroir.CompilationResult{
 			LabelCallers: map[wazeroir.Label]uint32{},
-			Signature:    &wasm.FunctionType{},
 		}
 	}
 
 	c := fn()
-	c.Init(ir, false)
+	c.Init(functionType, ir, false)
 
 	ret, ok := c.(compilerImpl)
 	require.True(t, ok)

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -65,8 +65,8 @@ func TestCompiler_compileV128Add(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -156,8 +156,8 @@ func TestCompiler_compileV128Sub(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -532,8 +532,8 @@ func TestCompiler_compileV128Load(t *testing.T) {
 			env := newCompilerEnvironment()
 			tc.memSetupFn(env.memory())
 
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -732,8 +732,8 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			env := newCompilerEnvironment()
 			tc.memSetupFn(env.memory())
 
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -787,8 +787,8 @@ func TestCompiler_compileV128Store(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
 
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -926,8 +926,8 @@ func TestCompiler_compileV128StoreLane(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
 
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1093,8 +1093,8 @@ func TestCompiler_compileV128ExtractLane(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
 
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1337,8 +1337,8 @@ func TestCompiler_compileV128ReplaceLane(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1438,8 +1438,8 @@ func TestCompiler_compileV128Splat(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1485,8 +1485,8 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1647,8 +1647,8 @@ func TestCompiler_compileV128AllTrue(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1743,8 +1743,8 @@ func TestCompiler_compileV128Swizzle(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1848,8 +1848,8 @@ func TestCompiler_compileV128Shuffle(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -1983,8 +1983,8 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -2015,8 +2015,8 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 
 func TestCompiler_compileV128_Not(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler,
-		&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+		&wazeroir.CompilationResult{HasMemory: true})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -2226,8 +2226,8 @@ func TestCompiler_compileV128_And_Or_Xor_AndNot(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -2317,8 +2317,8 @@ func TestCompiler_compileV128Bitselect(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -2602,8 +2602,8 @@ func TestCompiler_compileV128Shl(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -2875,8 +2875,8 @@ func TestCompiler_compileV128Shr(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3304,8 +3304,8 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3379,8 +3379,8 @@ func TestCompiler_compileV128AvgrU(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3445,8 +3445,8 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3526,8 +3526,8 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3623,8 +3623,8 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3717,8 +3717,8 @@ func TestCompiler_compileV128Abs(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3784,8 +3784,8 @@ func TestCompiler_compileV128Div(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -3970,8 +3970,8 @@ func TestCompiler_compileV128Min(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -4191,8 +4191,8 @@ func TestCompiler_compileV128Max(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -4326,8 +4326,8 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -4432,8 +4432,8 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -4502,8 +4502,8 @@ func TestCompiler_compileV128Popcnt(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -4669,8 +4669,8 @@ func TestCompiler_compileV128Round(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -4956,8 +4956,8 @@ func TestCompiler_compileV128_Pmax_Pmin(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -5649,8 +5649,8 @@ func TestCompiler_compileV128ExtMul(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6120,8 +6120,8 @@ func TestCompiler_compileV128Extend(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6195,8 +6195,8 @@ func TestCompiler_compileV128Q15mulrSatS(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6268,8 +6268,8 @@ func TestCompiler_compileFloatPromote(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6349,8 +6349,8 @@ func TestCompiler_compileV128FloatDemote(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6554,8 +6554,8 @@ func TestCompiler_compileV128ExtAddPairwise(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6791,8 +6791,8 @@ func TestCompiler_compileV128Narrow(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6925,8 +6925,8 @@ func TestCompiler_compileV128FConvertFromI(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -6988,8 +6988,8 @@ func TestCompiler_compileV128Dot(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -7136,8 +7136,8 @@ func TestCompiler_compileV128ITruncSatFromF(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -7177,8 +7177,8 @@ func TestCompiler_compileSelect_v128(t *testing.T) {
 
 	for _, selector := range []uint32{0, 1} {
 		env := newCompilerEnvironment()
-		compiler := env.requireNewCompiler(t, newCompiler,
-			&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+			&wazeroir.CompilationResult{HasMemory: true})
 
 		err := compiler.compilePreamble()
 		require.NoError(t, err)

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -540,7 +540,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 			if err != nil {
 				return fmt.Errorf("failed to lower func[%d]: %v", i, err)
 			}
-			cmp.Init(&module.TypeSection[module.FunctionSection[i]], ir, lsn != nil)
+			cmp.Init(typ, ir, lsn != nil)
 			if compiled, err = compileWasmFunction(cmp, ir); err != nil {
 				def := module.FunctionDefinitionSection[funcIndex+importedFuncs]
 				return fmt.Errorf("error compiling wasm func[%s]: %w", def.DebugName(), err)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -68,15 +68,12 @@ func TestCompiler_ModuleEngine_Call(t *testing.T) {
 }
 
 func TestCompiler_ModuleEngine_Call_HostFn(t *testing.T) {
-	t.Skip()
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
 	enginetest.RunTestModuleEngine_Call_HostFn(t, et)
 }
 
 func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
-	t.Skip()
-
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
 	enginetest.RunTestModuleEngine_Call_Errors(t, et)
@@ -228,8 +225,6 @@ func TestCompiler_Releasecode_Panic(t *testing.T) {
 // allows us to safely access to their data region from native code.
 // See comments on initialStackSize and initialCallFrameStackSize.
 func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
-	t.Skip()
-
 	enabledFeatures := api.CoreFeaturesV1
 	e := newEngine(enabledFeatures, nil)
 	s := wasm.NewStore(enabledFeatures, e)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -68,12 +68,15 @@ func TestCompiler_ModuleEngine_Call(t *testing.T) {
 }
 
 func TestCompiler_ModuleEngine_Call_HostFn(t *testing.T) {
+	t.Skip()
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
 	enginetest.RunTestModuleEngine_Call_HostFn(t, et)
 }
 
 func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
+	t.Skip()
+
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
 	enginetest.RunTestModuleEngine_Call_Errors(t, et)
@@ -201,7 +204,7 @@ func TestCompiler_CompileModule(t *testing.T) {
 
 		e := et.NewEngine(api.CoreFeaturesV1).(*engine)
 		err := e.CompileModule(testCtx, errModule, nil, false)
-		require.EqualError(t, err, "failed to lower func[.$2] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
+		require.EqualError(t, err, "failed to lower func[2]: handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, the compiled functions must not be cached.
 		_, ok := e.codes[errModule.ID]

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -228,6 +228,8 @@ func TestCompiler_Releasecode_Panic(t *testing.T) {
 // allows us to safely access to their data region from native code.
 // See comments on initialStackSize and initialCallFrameStackSize.
 func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
+	t.Skip()
+
 	enabledFeatures := api.CoreFeaturesV1
 	e := newEngine(enabledFeatures, nil)
 	s := wasm.NewStore(enabledFeatures, e)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -639,15 +639,14 @@ func TestFunction_getSourceOffsetInWasmBinary(t *testing.T) {
 		name               string
 		pc, exp            uint64
 		codeInitialAddress uintptr
-		srcMap             *sourceOffsetMap
+		srcMap             sourceOffsetMap
 	}{
-		{name: "source map nil", srcMap: nil}, // This can happen when this code is from compilation cache.
-		{name: "not found", srcMap: &sourceOffsetMap{}},
+		{name: "not found", srcMap: sourceOffsetMap{}},
 		{
 			name:               "first IR",
 			pc:                 4000,
 			codeInitialAddress: 3999,
-			srcMap: &sourceOffsetMap{
+			srcMap: sourceOffsetMap{
 				irOperationOffsetsInNativeBinary: []uint64{
 					0 /*4000-3999=1 exists here*/, 5, 8, 15,
 				},
@@ -661,7 +660,7 @@ func TestFunction_getSourceOffsetInWasmBinary(t *testing.T) {
 			name:               "middle",
 			pc:                 100,
 			codeInitialAddress: 90,
-			srcMap: &sourceOffsetMap{
+			srcMap: sourceOffsetMap{
 				irOperationOffsetsInNativeBinary: []uint64{
 					0, 5, 8 /*100-90=10 exists here*/, 15,
 				},
@@ -675,7 +674,7 @@ func TestFunction_getSourceOffsetInWasmBinary(t *testing.T) {
 			name:               "last",
 			pc:                 9999,
 			codeInitialAddress: 8999,
-			srcMap: &sourceOffsetMap{
+			srcMap: sourceOffsetMap{
 				irOperationOffsetsInNativeBinary: []uint64{
 					0, 5, 8, 15, /*9999-8999=1000 exists here*/
 				},

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -95,6 +95,7 @@ type amd64Compiler struct {
 	// onStackPointerCeilDeterminedCallBack hold a callback which are called when the max stack pointer is determined BEFORE generating native code.
 	onStackPointerCeilDeterminedCallBack func(stackPointerCeil uint64)
 	withListener                         bool
+	typ                                  *wasm.FunctionType
 }
 
 func newAmd64Compiler() compiler {
@@ -107,7 +108,7 @@ func newAmd64Compiler() compiler {
 }
 
 // Init implements compiler.Init.
-func (c *amd64Compiler) Init(ir *wazeroir.CompilationResult, withListener bool) {
+func (c *amd64Compiler) Init(typ *wasm.FunctionType, ir *wazeroir.CompilationResult, withListener bool) {
 	assembler, locationStack := c.assembler, c.locationStack
 	assembler.Reset()
 	locationStack.reset()
@@ -121,6 +122,7 @@ func (c *amd64Compiler) Init(ir *wazeroir.CompilationResult, withListener bool) 
 		cpuFeatures:   c.cpuFeatures,
 		withListener:  withListener,
 		labels:        c.labels,
+		typ:           typ,
 	}
 }
 
@@ -190,7 +192,7 @@ func (c *amd64Compiler) compileBuiltinFunctionCheckExitCode() error {
 // and return to the caller.
 func (c *amd64Compiler) compileGoDefinedHostFunction() error {
 	// First we must update the location stack to reflect the number of host function inputs.
-	c.locationStack.init(c.ir.Signature)
+	c.locationStack.init(c.typ)
 
 	if c.withListener {
 		if err := c.compileCallBuiltinFunction(builtinFunctionIndexFunctionListenerBefore); err != nil {
@@ -206,7 +208,7 @@ func (c *amd64Compiler) compileGoDefinedHostFunction() error {
 	// Alias for readability.
 	tmp := amd64.RegAX
 	// Get the location of the callerFunction (*function) in the stack, which depends on the signature.
-	_, _, callerFunction := c.locationStack.getCallFrameLocations(c.ir.Signature)
+	_, _, callerFunction := c.locationStack.getCallFrameLocations(c.typ)
 	// Load the value into the tmp register: tmp = &function{..}
 	callerFunction.setRegister(tmp)
 	c.compileLoadValueOnStackToRegister(callerFunction)
@@ -4735,7 +4737,7 @@ func (c *amd64Compiler) compileReturnFunction() error {
 		panic("BUG: all the registers should be free at this point: " + c.locationStack.String())
 	}
 
-	returnAddress, callerStackBasePointerInBytes, callerFunction := c.locationStack.getCallFrameLocations(c.ir.Signature)
+	returnAddress, callerStackBasePointerInBytes, callerFunction := c.locationStack.getCallFrameLocations(c.typ)
 
 	// A zero return address means return from the execution.
 	c.assembler.CompileMemoryToRegister(amd64.MOVQ,
@@ -4885,7 +4887,7 @@ func (c *amd64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 func (c *amd64Compiler) compilePreamble() (err error) {
 	// We assume all function parameters are already pushed onto the stack by
 	// the caller.
-	c.locationStack.init(c.ir.Signature)
+	c.locationStack.init(c.typ)
 
 	if err := c.compileModuleContextInitialization(); err != nil {
 		return err

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -502,9 +502,9 @@ func (c *amd64Compiler) compileBrIf(o *wazeroir.UnionOperation) error {
 	}
 
 	// Make sure that the next coming label is the else jump target.
-	thenTarget := wazeroir.Label(o.Us[0])
+	thenTarget := wazeroir.Label(o.U1)
 	thenToDrop := o.Rs[0]
-	elseTarget := wazeroir.Label(o.Us[1])
+	elseTarget := wazeroir.Label(o.U2)
 
 	// Here's the diagram of how we organize the instructions necessarily for brif operation.
 	//

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -48,9 +48,8 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	}
 
 	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
-		Signature: &wasm.FunctionType{},
-		Types:     []wasm.FunctionType{{}},
-		HasTable:  true,
+		Types:    []wasm.FunctionType{{}},
+		HasTable: true,
 	}).(*amd64Compiler)
 	err := compiler.compilePreamble()
 	require.NoError(t, err)

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -28,7 +28,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 
 	me := env.moduleEngine()
 	{ // Compiling call target.
-		compiler := env.requireNewCompiler(t, newCompiler, nil)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
 		err = compiler.compileReturnFunction()
@@ -47,7 +47,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		table[0] = uintptr(unsafe.Pointer(&f))
 	}
 
-	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
 		Signature: &wasm.FunctionType{},
 		Types:     []wasm.FunctionType{{}},
 		HasTable:  true,
@@ -135,7 +135,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						const x2Value uint32 = 51
 						const dxValue uint64 = 111111
 
-						compiler := env.requireNewCompiler(t, newAmd64Compiler, nil).(*amd64Compiler)
+						compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newAmd64Compiler, nil).(*amd64Compiler)
 						err := compiler.compilePreamble()
 						require.NoError(t, err)
 
@@ -261,7 +261,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						const dxValue uint64 = 111111
 
 						env := newCompilerEnvironment()
-						compiler := env.requireNewCompiler(t, newAmd64Compiler, nil).(*amd64Compiler)
+						compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newAmd64Compiler, nil).(*amd64Compiler)
 						err := compiler.compilePreamble()
 						require.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		env := newCompilerEnvironment()
-		compiler := env.requireNewCompiler(t, newAmd64Compiler, nil).(*amd64Compiler)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newAmd64Compiler, nil).(*amd64Compiler)
 
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		env := newCompilerEnvironment()
-		compiler := env.requireNewCompiler(t, newAmd64Compiler, nil).(*amd64Compiler)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newAmd64Compiler, nil).(*amd64Compiler)
 
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 
 func TestAmd64Compiler_preventCrossedTargetdRegisters(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newAmd64Compiler, nil).(*amd64Compiler)
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newAmd64Compiler, nil).(*amd64Compiler)
 
 	tests := []struct {
 		initial           []*runtimeValueLocation
@@ -496,7 +496,7 @@ func TestAmd64Compiler_ensureClz_ABM(t *testing.T) {
 				return c
 			}
 
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 			err := compiler.compileConstI32(operationPtr(wazeroir.NewOperationConstI32(10)))
 			require.NoError(t, err)
@@ -551,7 +551,7 @@ func TestAmd64Compiler_ensureCtz_ABM(t *testing.T) {
 				return c
 			}
 
-			compiler := env.requireNewCompiler(t, newCompiler, nil)
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 
 			err := compiler.compileConstI32(operationPtr(wazeroir.NewOperationConstI32(10)))
 			require.NoError(t, err)

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -40,7 +40,7 @@ func newArm64Compiler() compiler {
 }
 
 // Init implements compiler.Init.
-func (c *arm64Compiler) Init(functionType *wasm.FunctionType, ir *wazeroir.CompilationResult, withListener bool) {
+func (c *arm64Compiler) Init(typ *wasm.FunctionType, ir *wazeroir.CompilationResult, withListener bool) {
 	assembler, locationStack := c.assembler, c.locationStack
 	assembler.Reset()
 	locationStack.reset()
@@ -50,7 +50,7 @@ func (c *arm64Compiler) Init(functionType *wasm.FunctionType, ir *wazeroir.Compi
 	*c = arm64Compiler{
 		assembler: assembler, locationStack: locationStack,
 		ir: ir, withListener: withListener, labels: c.labels,
-		typ: functionType,
+		typ: typ,
 	}
 }
 

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -751,7 +751,7 @@ func (c *arm64Compiler) compileBrIf(o *wazeroir.UnionOperation) error {
 	saved := c.locationStack
 	c.setLocationStack(saved.clone())
 	elseToDrop := o.Rs[1]
-	elseTarget := wazeroir.Label(o.Us[1])
+	elseTarget := wazeroir.Label(o.U2)
 	if err := compileDropRange(c, elseToDrop); err != nil {
 		return err
 	}
@@ -765,7 +765,7 @@ func (c *arm64Compiler) compileBrIf(o *wazeroir.UnionOperation) error {
 	// We branch into here from the original conditional BR (conditionalBR).
 	c.assembler.SetJumpTargetOnNext(conditionalBR)
 	thenToDrop := o.Rs[0]
-	thenTarget := wazeroir.Label(o.Us[0])
+	thenTarget := wazeroir.Label(o.U1)
 	if err := compileDropRange(c, thenToDrop); err != nil {
 		return err
 	}

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -25,7 +25,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 
 	me := env.moduleEngine()
 	{ // Compiling call target.
-		compiler := env.requireNewCompiler(t, newCompiler, nil)
+		compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, nil)
 		err := compiler.compilePreamble()
 		require.NoError(t, err)
 		err = compiler.compileReturnFunction()
@@ -43,10 +43,9 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		table[0] = uintptr(unsafe.Pointer(&f))
 	}
 
-	compiler := env.requireNewCompiler(t, newCompiler, &wazeroir.CompilationResult{
-		Signature: &wasm.FunctionType{},
-		Types:     []wasm.FunctionType{{}},
-		HasTable:  true,
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+		Types:    []wasm.FunctionType{{}},
+		HasTable: true,
 	}).(*arm64Compiler)
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -69,7 +68,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 
 func TestArm64Compiler_readInstructionAddress(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newArm64Compiler, nil).(*arm64Compiler)
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newArm64Compiler, nil).(*arm64Compiler)
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -17,7 +17,7 @@ import (
 func TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	env := newCompilerEnvironment()
 	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
-		&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+		&wazeroir.CompilationResult{HasMemory: true})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
 			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)
@@ -274,7 +274,7 @@ func TestAmd64Compiler_compileV128Neg_NaNOnTemporary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
 			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -16,7 +16,7 @@ import (
 // function works well by intentionally setting amd64.AssemblerImpl MaxDisplacementForConstantPool = 0.
 func TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler,
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
 		&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
 
 	err := compiler.compilePreamble()
@@ -196,7 +196,7 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
 				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
 
 			err := compiler.compilePreamble()
@@ -273,7 +273,7 @@ func TestAmd64Compiler_compileV128Neg_NaNOnTemporary(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
 				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
 
 			err := compiler.compilePreamble()

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -15,8 +15,8 @@ import (
 // function works well by intentionally setting arm64.AssemblerImpl MaxDisplacementForConstantPool = 0.
 func TestArm64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	env := newCompilerEnvironment()
-	compiler := env.requireNewCompiler(t, newCompiler,
-		&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+		&wazeroir.CompilationResult{HasMemory: true})
 
 	err := compiler.compilePreamble()
 	require.NoError(t, err)
@@ -153,8 +153,8 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			env := newCompilerEnvironment()
-			compiler := env.requireNewCompiler(t, newCompiler,
-				&wazeroir.CompilationResult{HasMemory: true, Signature: &wasm.FunctionType{}})
+			compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler,
+				&wazeroir.CompilationResult{HasMemory: true})
 
 			err := compiler.compilePreamble()
 			require.NoError(t, err)

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -301,8 +301,6 @@ func (e *engine) lowerIR(ir *wazeroir.CompilationResult) (*code, error) {
 			delete(onLabelAddressResolved, label)
 			// We just ignore the label operation
 			// as we translate branch operations to the direct address jmp.
-			continue
-
 		case wazeroir.OperationKindBr:
 			label := wazeroir.Label(op.U1)
 			if label.IsReturnTarget() {

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -240,6 +240,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 			compiled.listener = lsn
 		}
 		compiled.source = module
+		compiled.ensureTermination = ensureTermination
 		funcs[i] = compiled
 	}
 	e.addCodes(module, funcs)

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -508,7 +508,7 @@ func TestInterpreter_Compile(t *testing.T) {
 		errModule.BuildFunctionDefinitions()
 
 		err := e.CompileModule(testCtx, errModule, nil, false)
-		require.EqualError(t, err, "failed to lower func[.$2] to wazeroir: handling instruction: apply stack failed for call: reading immediates: EOF")
+		require.EqualError(t, err, "handling instruction: apply stack failed for call: reading immediates: EOF")
 
 		// On the compilation failure, all the compiled functions including succeeded ones must be released.
 		_, ok := e.codes[errModule.ID]

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -325,20 +325,20 @@ func TestInterpreter_NonTrappingFloatToIntConversion(t *testing.T) {
 			for i := 0; i < casenum; i++ {
 				i := i
 				t.Run(strconv.Itoa(i), func(t *testing.T) {
-					var body []*wazeroir.UnionOperation
+					var body []wazeroir.UnionOperation
 					if in32bit {
-						body = append(body, &wazeroir.UnionOperation{
+						body = append(body, wazeroir.UnionOperation{
 							Kind: wazeroir.OperationKindConstF32,
 							U1:   uint64(math.Float32bits(tc.input32bit[i])),
 						})
 					} else {
-						body = append(body, &wazeroir.UnionOperation{
+						body = append(body, wazeroir.UnionOperation{
 							Kind: wazeroir.OperationKindConstF64,
 							U1:   uint64(math.Float64bits(tc.input64bit[i])),
 						})
 					}
 
-					body = append(body, &wazeroir.UnionOperation{
+					body = append(body, wazeroir.UnionOperation{
 						Kind: wazeroir.OperationKindITruncFromF,
 						B1:   byte(tc.inputType),
 						B2:   byte(tc.outputType),
@@ -347,7 +347,7 @@ func TestInterpreter_NonTrappingFloatToIntConversion(t *testing.T) {
 
 					// Return from function.
 					body = append(body,
-						&wazeroir.UnionOperation{Kind: wazeroir.OperationKindBr, U1: uint64(math.MaxUint64)},
+						wazeroir.UnionOperation{Kind: wazeroir.OperationKindBr, U1: uint64(math.MaxUint64)},
 					)
 
 					ce := &callEngine{}
@@ -416,7 +416,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 				ce := &callEngine{}
 				f := &function{
 					moduleInstance: &wasm.ModuleInstance{Engine: &moduleEngine{}},
-					parent: &code{body: []*wazeroir.UnionOperation{
+					parent: &code{body: []wazeroir.UnionOperation{
 						{Kind: wazeroir.OperationKindConstI32, U1: uint64(uint32(tc.in))},
 						{Kind: translateToIROperationKind(tc.opcode)},
 						{Kind: wazeroir.OperationKindBr, U1: uint64(math.MaxUint64)},
@@ -470,7 +470,7 @@ func TestInterpreter_CallEngine_callNativeFunc_signExtend(t *testing.T) {
 				ce := &callEngine{}
 				f := &function{
 					moduleInstance: &wasm.ModuleInstance{Engine: &moduleEngine{}},
-					parent: &code{body: []*wazeroir.UnionOperation{
+					parent: &code{body: []wazeroir.UnionOperation{
 						{Kind: wazeroir.OperationKindConstI64, U1: uint64(tc.in)},
 						{Kind: translateToIROperationKind(tc.opcode)},
 						{Kind: wazeroir.OperationKindBr, U1: uint64(math.MaxUint64)},
@@ -543,8 +543,8 @@ func TestInterpreter_Compile(t *testing.T) {
 func TestEngine_CachedcodesPerModule(t *testing.T) {
 	e := et.NewEngine(api.CoreFeaturesV1).(*engine)
 	exp := []*code{
-		{body: []*wazeroir.UnionOperation{}},
-		{body: []*wazeroir.UnionOperation{}},
+		{body: []wazeroir.UnionOperation{}},
+		{body: []wazeroir.UnionOperation{}},
 	}
 	m := &wasm.Module{}
 

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"unsafe"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/platform"
+	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
 // testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
@@ -61,7 +63,17 @@ func BenchmarkInitialization(b *testing.B) {
 	}
 }
 
+type UnionOperation struct {
+	// Kind determines how to interpret the other fields in this struct.
+	Kind   wazeroir.OperationKind
+	B1, B2 byte
+	U1, U2 uint64
+	Us     []uint64
+	Rs     []*wazeroir.InclusiveRange
+}
+
 func BenchmarkCompilation(b *testing.B) {
+	fmt.Println(unsafe.Sizeof(UnionOperation{}))
 	if !platform.CompilerSupported() {
 		b.Skip()
 	}

--- a/internal/integration_test/bench/bench_test.go
+++ b/internal/integration_test/bench/bench_test.go
@@ -7,13 +7,11 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
-	"unsafe"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/platform"
-	"github.com/tetratelabs/wazero/internal/wazeroir"
 )
 
 // testCtx is an arbitrary, non-default context. Non-nil also prevents linter errors.
@@ -63,17 +61,7 @@ func BenchmarkInitialization(b *testing.B) {
 	}
 }
 
-type UnionOperation struct {
-	// Kind determines how to interpret the other fields in this struct.
-	Kind   wazeroir.OperationKind
-	B1, B2 byte
-	U1, U2 uint64
-	Us     []uint64
-	Rs     []*wazeroir.InclusiveRange
-}
-
 func BenchmarkCompilation(b *testing.B) {
-	fmt.Println(unsafe.Sizeof(UnionOperation{}))
 	if !platform.CompilerSupported() {
 		b.Skip()
 	}

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -57,7 +57,6 @@ func TestEngineCompiler(t *testing.T) {
 }
 
 func TestEngineInterpreter(t *testing.T) {
-	t.Skip() // TODO
 	runAllTests(t, tests, wazero.NewRuntimeConfigInterpreter().WithCloseOnContextDone(true))
 }
 

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -57,6 +57,7 @@ func TestEngineCompiler(t *testing.T) {
 }
 
 func TestEngineInterpreter(t *testing.T) {
+	t.Skip() // TODO
 	runAllTests(t, tests, wazero.NewRuntimeConfigInterpreter().WithCloseOnContextDone(true))
 }
 

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -507,7 +507,7 @@ func RunTestModuleEngine_Memory(t *testing.T, et EngineTester) {
 		TypeIDs:        []wasm.FunctionTypeID{0, 1},
 		Definitions:    m.FunctionDefinitionSection,
 	}
-	var memory api.Memory = module.MemoryInstance
+	memory := module.MemoryInstance
 
 	// To use functions, we need to instantiate them (associate them with a ModuleInstance).
 	module.Exports = exportMap(m)

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -247,8 +247,6 @@ type CompilationResult struct {
 	Functions []wasm.Index
 	// Types holds all the types in the module from which this function is compiled.
 	Types []wasm.FunctionType
-	// TableTypes holds all the reference types of all tables declared in the module.
-	TableTypes []wasm.ValueType
 	// HasMemory is true if the module from which this function is compiled has memory declaration.
 	HasMemory bool
 	// HasTable is true if the module from which this function is compiled has table declaration.
@@ -270,11 +268,6 @@ func NewCompiler(enabledFeatures api.CoreFeatures, callFrameStackSizeInUint64 in
 	hasMemory, hasTable, hasDataInstances, hasElementInstances := mem != nil, len(tables) > 0,
 		len(module.DataSection) > 0, len(module.ElementSection) > 0
 
-	tableTypes := make([]wasm.ValueType, len(tables))
-	for i := range tableTypes {
-		tableTypes[i] = tables[i].Type
-	}
-
 	types := module.TypeSection
 
 	c := &Compiler{
@@ -290,7 +283,6 @@ func NewCompiler(enabledFeatures api.CoreFeatures, callFrameStackSizeInUint64 in
 			HasTable:            hasTable,
 			HasDataInstances:    hasDataInstances,
 			HasElementInstances: hasElementInstances,
-			TableTypes:          tableTypes,
 		},
 		globals:           globals,
 		funcs:             functions,

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -190,7 +190,7 @@ type Compiler struct {
 	bodyOffsetInCodeSection uint64
 
 	ensureTermination bool
-	// Pre-allocated bytes.Reader to be used in varous places.
+	// Pre-allocated bytes.Reader to be used in various places.
 	br             *bytes.Reader
 	funcTypeToSigs funcTypeToIRSignatures
 
@@ -223,7 +223,7 @@ type CompilationResult struct {
 	// Non nil only when the given Wasm module has the DWARF section.
 	IROperationSourceOffsetsInWasmBinary []uint64
 
-	// LabelCallers maps label.String() to the number of callers to that label.
+	// LabelCallers maps Label to the number of callers to that label.
 	// Here "callers" means that the call-sites which jumps to the label with br, br_if or br_table
 	// instructions.
 	//
@@ -315,7 +315,7 @@ func (c *Compiler) Next() (*CompilationResult, error) {
 	c.pc = 0
 	c.currentOpPC = 0
 	c.currentFrameID = 0
-	c.resetUnreachable()
+	c.unreachableState.on, c.unreachableState.depth = false, 0
 	c.callFrameStackSizeInUint64 = 0
 
 	if err := c.compile(sig, code.Body, code.LocalTypes, code.BodyOffsetInCodeSection); err != nil {

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -316,7 +316,6 @@ func (c *Compiler) Next() (*CompilationResult, error) {
 	c.currentOpPC = 0
 	c.currentFrameID = 0
 	c.unreachableState.on, c.unreachableState.depth = false, 0
-	c.callFrameStackSizeInUint64 = 0
 
 	if err := c.compile(sig, code.Body, code.LocalTypes, code.BodyOffsetInCodeSection); err != nil {
 		return nil, err

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -336,9 +336,7 @@ func (c *Compiler) Next() (*CompilationResult, error) {
 
 	if code.GoFunc != nil {
 		// Assume the function might use memory if it has a parameter for the api.Module
-		_, usesMemory := code.GoFunc.(api.GoModuleFunction)
-
-		c.result.UsesMemory = usesMemory
+		_, c.result.UsesMemory = code.GoFunc.(api.GoModuleFunction)
 		c.result.GoFunc = code.GoFunc
 	} else {
 		if err := c.compile(sig, code.Body, code.LocalTypes, code.BodyOffsetInCodeSection); err != nil {

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -302,9 +302,8 @@ func NewCompiler(enabledFeatures api.CoreFeatures, callFrameStackSizeInUint64 in
 // Next returns the next CompilationResult for this Compiler.
 func (c *Compiler) Next() (*CompilationResult, error) {
 	funcIndex := c.next
-	typeID := c.module.FunctionSection[funcIndex]
-	sig := &c.types[typeID]
 	code := &c.module.CodeSection[funcIndex]
+	sig := &c.types[c.module.FunctionSection[funcIndex]]
 
 	// Reset the previous result.
 	c.result.Operations = c.result.Operations[:0]

--- a/internal/wazeroir/compiler.go
+++ b/internal/wazeroir/compiler.go
@@ -310,7 +310,7 @@ func (c *Compiler) Next() (*CompilationResult, error) {
 	c.result.Operations = c.result.Operations[:0]
 	c.result.IROperationSourceOffsetsInWasmBinary = c.result.IROperationSourceOffsetsInWasmBinary[:0]
 	c.result.UsesMemory = false
-	// TODO: reuse allocated map.
+	// TODO: reuse allocated map: use c.currentFrameID to delete all possible entries.
 	c.result.LabelCallers = map[Label]uint32{}
 	// Reset the previous states.
 	c.pc = 0

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -1,7 +1,6 @@
 package wazeroir
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -73,24 +72,6 @@ func TestCompile(t *testing.T) {
 				Types:        []wasm.FunctionType{v_v},
 				TableTypes:   []wasm.RefType{},
 			},
-		},
-		{
-			name: "host go nullary",
-			module: &wasm.Module{
-				TypeSection:     []wasm.FunctionType{v_v},
-				FunctionSection: []wasm.Index{0},
-				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(func() {})},
-			},
-			expected: &CompilationResult{},
-		},
-		{
-			name: "host go context.Context api.Module uses memory",
-			module: &wasm.Module{
-				TypeSection:     []wasm.FunctionType{v_v},
-				FunctionSection: []wasm.Index{0},
-				CodeSection:     []wasm.Code{wasm.MustParseGoReflectFuncCode(func(context.Context, api.Module) {})},
-			},
-			expected: &CompilationResult{UsesMemory: true},
 		},
 		{
 			name: "identity",
@@ -214,13 +195,7 @@ func TestCompile(t *testing.T) {
 
 			fn, err := c.Next()
 			require.NoError(t, err)
-			if fn.GoFunc != nil { // can't compare functions
-				// Special case because reflect.Value can't be compared with Equals
-				require.Equal(t, tc.expected.UsesMemory, fn.UsesMemory)
-				require.Equal(t, &tc.module.CodeSection[0].GoFunc, &fn.GoFunc)
-			} else {
-				require.Equal(t, tc.expected, fn)
-			}
+			require.Equal(t, tc.expected, fn)
 		})
 	}
 }

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -715,6 +715,8 @@ func requireCompilationResult(t *testing.T, enabledFeatures api.CoreFeatures, ex
 		enabledFeatures = api.CoreFeaturesV2
 	}
 	c, err := NewCompiler(enabledFeatures, 0, module, false)
+	require.NoError(t, err)
+
 	actual, err := c.Next()
 	require.NoError(t, err)
 

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	f32, f64, i32, i64 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32, wasm.ValueTypeI64
-	f32_i32            = wasm.FunctionType{
+	f32, f64, i32 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32
+	f32_i32       = wasm.FunctionType{
 		Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32},
 		ParamNumInUint64:  1,
 		ResultNumInUint64: 1,

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	f32, f64, i32 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32
-	f32_i32       = wasm.FunctionType{
+	f32, f64, i32, i64 = wasm.ValueTypeF32, wasm.ValueTypeF64, wasm.ValueTypeI32, wasm.ValueTypeI64
+	f32_i32            = wasm.FunctionType{
 		Params: []wasm.ValueType{f32}, Results: []wasm.ValueType{i32},
 		ParamNumInUint64:  1,
 		ResultNumInUint64: 1,
@@ -171,6 +171,34 @@ func TestCompile(t *testing.T) {
 				UsesMemory: true,
 			},
 		},
+		{
+			name: "tmp",
+			module: &wasm.Module{
+				TypeSection: []wasm.FunctionType{{
+					Params:  []wasm.ValueType{f64, f64, i64, f64, f64, f64, f64, i32},
+					Results: []wasm.ValueType{f32, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64},
+				}},
+				FunctionSection: []wasm.Index{0},
+				CodeSection: []wasm.Code{
+					{
+						Body: []byte{
+							wasm.OpcodeLocalGet, 2,
+							wasm.OpcodeUnreachable,
+						},
+					},
+				},
+			},
+			expected: &CompilationResult{
+				Operations: []UnionOperation{ // begin with params: []
+				},
+				LabelCallers: map[Label]uint32{},
+				Types: []wasm.FunctionType{{
+					Params:  []wasm.ValueType{f64, f64, i64, f64, f64, f64, f64, i32},
+					Results: []wasm.ValueType{f32, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64},
+				}},
+				Functions: []uint32{0},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -189,6 +217,7 @@ func TestCompile(t *testing.T) {
 
 			fn, err := c.Next()
 			require.NoError(t, err)
+			fmt.Println(Format(fn.Operations))
 			require.Equal(t, tc.expected, fn)
 		})
 	}

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -2854,7 +2854,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 		sig                                *wasm.FunctionType
 		functionLocalTypes                 []wasm.ValueType
 		callFrameStackSizeInUint64         int
-		expLocalIndexToStackHeightInUint64 map[uint32]int
+		expLocalIndexToStackHeightInUint64 []int
 	}{
 		{
 			name: "no function local, args>results",
@@ -2864,10 +2864,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 				ParamNumInUint64:  2,
 				ResultNumInUint64: 1,
 			},
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-				1: 1,
-			},
+			expLocalIndexToStackHeightInUint64: []int{0, 1},
 		},
 		{
 			name: "no function local, args=results",
@@ -2877,9 +2874,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 				ParamNumInUint64:  1,
 				ResultNumInUint64: 1,
 			},
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-			},
+			expLocalIndexToStackHeightInUint64: []int{0},
 		},
 		{
 			name: "no function local, args>results, with vector",
@@ -2889,11 +2884,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 				ParamNumInUint64:  4,
 				ResultNumInUint64: 1,
 			},
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-				1: 1,
-				2: 3,
-			},
+			expLocalIndexToStackHeightInUint64: []int{0, 1, 3},
 		},
 		{
 			name: "no function local, args<results",
@@ -2904,7 +2895,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 				ResultNumInUint64: 1,
 			},
 			callFrameStackSizeInUint64:         4,
-			expLocalIndexToStackHeightInUint64: map[uint32]int{},
+			expLocalIndexToStackHeightInUint64: nil,
 		},
 		{
 			name: "no function local, args<results",
@@ -2915,7 +2906,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 				ResultNumInUint64: 2,
 			},
 			callFrameStackSizeInUint64:         4,
-			expLocalIndexToStackHeightInUint64: map[uint32]int{0: 0},
+			expLocalIndexToStackHeightInUint64: []int{0},
 		},
 		{
 			name: "no function local, args<results, with vector",
@@ -2926,7 +2917,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 				ResultNumInUint64: 4,
 			},
 			callFrameStackSizeInUint64:         4,
-			expLocalIndexToStackHeightInUint64: map[uint32]int{0: 0},
+			expLocalIndexToStackHeightInUint64: []int{0},
 		},
 
 		// With function locals
@@ -2941,11 +2932,11 @@ func TestCompiler_initializeStack(t *testing.T) {
 			functionLocalTypes:         []wasm.ValueType{f64},
 			callFrameStackSizeInUint64: 4,
 			// [i32, f32, callframe.0, callframe.1, callframe.2, callframe.3, f64]
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-				1: 1,
+			expLocalIndexToStackHeightInUint64: []int{
+				0,
+				1,
 				// Function local comes after call frame.
-				2: 6,
+				6,
 			},
 		},
 		{
@@ -2959,13 +2950,13 @@ func TestCompiler_initializeStack(t *testing.T) {
 			functionLocalTypes:         []wasm.ValueType{v128, v128},
 			callFrameStackSizeInUint64: 4,
 			// [i32, v128.lo, v128.hi, f32, callframe.0, callframe.1, callframe.2, callframe.3, v128.lo, v128.hi, v128.lo, v128.hi]
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-				1: 1,
-				2: 3,
+			expLocalIndexToStackHeightInUint64: []int{
+				0,
+				1,
+				3,
 				// Function local comes after call frame.
-				3: 8,
-				4: 10,
+				8,
+				10,
 			},
 		},
 		{
@@ -2979,10 +2970,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 			functionLocalTypes:         []wasm.ValueType{f64},
 			callFrameStackSizeInUint64: 4,
 			// [i32, _, _, _, callframe.0, callframe.1, callframe.2, callframe.3, f64]
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-				1: 8,
-			},
+			expLocalIndexToStackHeightInUint64: []int{0, 8},
 		},
 		{
 			name: "function locals, args<results with vector",
@@ -2995,11 +2983,7 @@ func TestCompiler_initializeStack(t *testing.T) {
 			functionLocalTypes:         []wasm.ValueType{f64},
 			callFrameStackSizeInUint64: 4,
 			// [v128.lo, v128.hi, f64, _, _, _, callframe.0, callframe.1, callframe.2, callframe.3, f64]
-			expLocalIndexToStackHeightInUint64: map[uint32]int{
-				0: 0,
-				1: 2,
-				2: 10,
-			},
+			expLocalIndexToStackHeightInUint64: []int{0, 2, 10},
 		},
 	}
 

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -53,7 +53,6 @@ func TestCompile(t *testing.T) {
 				LabelCallers: map[Label]uint32{},
 				Functions:    []uint32{0},
 				Types:        []wasm.FunctionType{v_v},
-				TableTypes:   []wasm.RefType{},
 			},
 		},
 		{
@@ -70,7 +69,6 @@ func TestCompile(t *testing.T) {
 				LabelCallers: map[Label]uint32{},
 				Functions:    []uint32{0},
 				Types:        []wasm.FunctionType{v_v},
-				TableTypes:   []wasm.RefType{},
 			},
 		},
 		{
@@ -94,8 +92,7 @@ func TestCompile(t *testing.T) {
 						ResultNumInUint64: 1,
 					},
 				},
-				Functions:  []uint32{0},
-				TableTypes: []wasm.RefType{},
+				Functions: []uint32{0},
 			},
 		},
 		{
@@ -120,7 +117,6 @@ func TestCompile(t *testing.T) {
 				LabelCallers: map[Label]uint32{},
 				Types:        []wasm.FunctionType{v_v},
 				Functions:    []uint32{0},
-				TableTypes:   []wasm.RefType{},
 				UsesMemory:   true,
 			},
 		},
@@ -146,7 +142,6 @@ func TestCompile(t *testing.T) {
 				LabelCallers: map[Label]uint32{},
 				Types:        []wasm.FunctionType{v_v},
 				Functions:    []uint32{0},
-				TableTypes:   []wasm.RefType{},
 				UsesMemory:   true,
 			},
 		},
@@ -173,7 +168,6 @@ func TestCompile(t *testing.T) {
 					ResultNumInUint64: 1,
 				}},
 				Functions:  []uint32{0},
-				TableTypes: []wasm.RefType{},
 				UsesMemory: true,
 			},
 		},
@@ -235,7 +229,6 @@ func TestCompile_Block(t *testing.T) {
 				LabelCallers: map[Label]uint32{NewLabel(LabelKindContinuation, 2): 1},
 				Functions:    []uint32{0},
 				Types:        []wasm.FunctionType{v_v},
-				TableTypes:   []wasm.RefType{},
 			},
 		},
 	}
@@ -314,7 +307,6 @@ func TestCompile_BulkMemoryOperations(t *testing.T) {
 		LabelCallers:     map[Label]uint32{},
 		Functions:        []wasm.Index{0},
 		Types:            []wasm.FunctionType{v_v},
-		TableTypes:       []wasm.RefType{},
 	}
 
 	c, err := NewCompiler(api.CoreFeatureBulkMemoryOperations, 0, module, false)
@@ -364,7 +356,6 @@ func TestCompile_MultiValue(t *testing.T) {
 				LabelCallers: map[Label]uint32{},
 				Functions:    []wasm.Index{0},
 				Types:        []wasm.FunctionType{i32i32_i32i32},
-				TableTypes:   []wasm.RefType{},
 			},
 		},
 		{
@@ -402,7 +393,6 @@ func TestCompile_MultiValue(t *testing.T) {
 				LabelCallers: map[Label]uint32{NewLabel(LabelKindContinuation, 2): 1}, // arbitrary label
 				Functions:    []wasm.Index{0},
 				Types:        []wasm.FunctionType{v_f64f64},
-				TableTypes:   []wasm.RefType{},
 			},
 		},
 		{
@@ -424,7 +414,6 @@ func TestCompile_MultiValue(t *testing.T) {
 				LabelCallers: map[Label]uint32{},
 				Functions:    []wasm.Index{0},
 				Types:        []wasm.FunctionType{_i32i64},
-				TableTypes:   []wasm.RefType{},
 			},
 		},
 		{
@@ -474,9 +463,8 @@ func TestCompile_MultiValue(t *testing.T) {
 					NewLabel(LabelKindContinuation, 2): 2,
 					NewLabel(LabelKindElse, 2):         1,
 				},
-				Functions:  []wasm.Index{0},
-				Types:      []wasm.FunctionType{i32_i32},
-				TableTypes: []wasm.RefType{},
+				Functions: []wasm.Index{0},
+				Types:     []wasm.FunctionType{i32_i32},
 			},
 		},
 		{
@@ -530,9 +518,8 @@ func TestCompile_MultiValue(t *testing.T) {
 					NewLabel(LabelKindContinuation, 2): 2,
 					NewLabel(LabelKindElse, 2):         1,
 				},
-				Functions:  []wasm.Index{0},
-				Types:      []wasm.FunctionType{i32_i32, i32i32_i32},
-				TableTypes: []wasm.RefType{},
+				Functions: []wasm.Index{0},
+				Types:     []wasm.FunctionType{i32_i32, i32i32_i32},
 			},
 		},
 		{
@@ -586,9 +573,8 @@ func TestCompile_MultiValue(t *testing.T) {
 					NewLabel(LabelKindContinuation, 2): 2,
 					NewLabel(LabelKindElse, 2):         1,
 				},
-				Functions:  []wasm.Index{0},
-				Types:      []wasm.FunctionType{i32_i32, i32i32_i32},
-				TableTypes: []wasm.RefType{},
+				Functions: []wasm.Index{0},
+				Types:     []wasm.FunctionType{i32_i32, i32i32_i32},
 			},
 		},
 	}
@@ -639,10 +625,6 @@ func TestCompile_NonTrappingFloatToIntConversion(t *testing.T) {
 		LabelCallers: map[Label]uint32{},
 		Functions:    []wasm.Index{0},
 		Types:        []wasm.FunctionType{f32_i32},
-		TableTypes:   []wasm.RefType{},
-	}
-	for _, tp := range module.TypeSection {
-		tp.CacheNumInUint64()
 	}
 	c, err := NewCompiler(api.CoreFeatureNonTrappingFloatToIntConversion, 0, module, false)
 	require.NoError(t, err)
@@ -672,10 +654,6 @@ func TestCompile_SignExtensionOps(t *testing.T) {
 		LabelCallers: map[Label]uint32{},
 		Functions:    []wasm.Index{0},
 		Types:        []wasm.FunctionType{i32_i32},
-		TableTypes:   []wasm.RefType{},
-	}
-	for _, tp := range module.TypeSection {
-		tp.CacheNumInUint64()
 	}
 	c, err := NewCompiler(api.CoreFeatureSignExtensionOps, 0, module, false)
 	require.NoError(t, err)
@@ -729,10 +707,7 @@ func TestCompile_CallIndirectNonZeroTableIndex(t *testing.T) {
 		HasTable:     true,
 		LabelCallers: map[Label]uint32{},
 		Functions:    []wasm.Index{0},
-		TableTypes: []wasm.RefType{
-			wasm.RefTypeExternref, wasm.RefTypeFuncref, wasm.RefTypeFuncref, wasm.RefTypeFuncref, wasm.RefTypeFuncref, wasm.RefTypeFuncref,
-		},
-		Types: []wasm.FunctionType{v_v, v_v, v_v},
+		Types:        []wasm.FunctionType{v_v, v_v, v_v},
 	}
 
 	c, err := NewCompiler(api.CoreFeatureBulkMemoryOperations, 0, module, false)

--- a/internal/wazeroir/compiler_test.go
+++ b/internal/wazeroir/compiler_test.go
@@ -171,34 +171,6 @@ func TestCompile(t *testing.T) {
 				UsesMemory: true,
 			},
 		},
-		{
-			name: "tmp",
-			module: &wasm.Module{
-				TypeSection: []wasm.FunctionType{{
-					Params:  []wasm.ValueType{f64, f64, i64, f64, f64, f64, f64, i32},
-					Results: []wasm.ValueType{f32, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64},
-				}},
-				FunctionSection: []wasm.Index{0},
-				CodeSection: []wasm.Code{
-					{
-						Body: []byte{
-							wasm.OpcodeLocalGet, 2,
-							wasm.OpcodeUnreachable,
-						},
-					},
-				},
-			},
-			expected: &CompilationResult{
-				Operations: []UnionOperation{ // begin with params: []
-				},
-				LabelCallers: map[Label]uint32{},
-				Types: []wasm.FunctionType{{
-					Params:  []wasm.ValueType{f64, f64, i64, f64, f64, f64, f64, i32},
-					Results: []wasm.ValueType{f32, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64},
-				}},
-				Functions: []uint32{0},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -217,7 +189,6 @@ func TestCompile(t *testing.T) {
 
 			fn, err := c.Next()
 			require.NoError(t, err)
-			fmt.Println(Format(fn.Operations))
 			require.Equal(t, tc.expected, fn)
 		})
 	}

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -809,12 +809,12 @@ func (b BranchTargetDrop) String() (ret string) {
 // only relevant when in context of its kind.
 type UnionOperation struct {
 	// Kind determines how to interpret the other fields in this struct.
-	Kind     OperationKind
-	B1, B2   byte
-	B3       bool
-	U1, U2   uint64
-	Us       []uint64
-	Rs       []*InclusiveRange
+	Kind   OperationKind
+	B1, B2 byte
+	B3     bool
+	U1, U2 uint64
+	Us     []uint64
+	Rs     []*InclusiveRange
 }
 
 // String implements fmt.Stringer.

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -815,7 +815,6 @@ type UnionOperation struct {
 	U1, U2   uint64
 	Us       []uint64
 	Rs       []*InclusiveRange
-	SourcePC uint64
 }
 
 // String implements fmt.Stringer.

--- a/internal/wazeroir/operations.go
+++ b/internal/wazeroir/operations.go
@@ -864,12 +864,8 @@ func (o UnionOperation) String() string {
 		return fmt.Sprintf("%s %s", o.Kind, Label(o.U1).String())
 
 	case OperationKindBrIf:
-		var thenTarget Label
-		var elseTarget Label
-		if len(o.Us) > 0 {
-			thenTarget = Label(o.Us[0])
-			elseTarget = Label(o.Us[1])
-		}
+		thenTarget := Label(o.U1)
+		elseTarget := Label(o.U2)
 		return fmt.Sprintf("%s %s, %s", o.Kind, thenTarget, elseTarget)
 
 	case OperationKindBrTable:
@@ -1076,13 +1072,13 @@ func NewOperationBr(target Label) UnionOperation {
 
 // NewOperationBrIf is a constructor for UnionOperation with OperationKindBrIf.
 //
-// The engines are expected to pop a value and branch into Us[0] label if the value equals 1.
-// Otherwise, the code branches into Us[1] label.
+// The engines are expected to pop a value and branch into U1 label if the value equals 1.
+// Otherwise, the code branches into U2 label.
 func NewOperationBrIf(thenTarget, elseTarget BranchTargetDrop) UnionOperation {
 	return UnionOperation{
 		Kind: OperationKindBrIf,
-		Us:   []uint64{uint64(thenTarget.Target), uint64(elseTarget.Target)},
-		Rs:   []*InclusiveRange{thenTarget.ToDrop, elseTarget.ToDrop},
+		U1:   uint64(thenTarget.Target), U2: uint64(elseTarget.Target),
+		Rs: []*InclusiveRange{thenTarget.ToDrop, elseTarget.ToDrop},
 	}
 }
 

--- a/internal/wazeroir/signature.go
+++ b/internal/wazeroir/signature.go
@@ -240,7 +240,7 @@ var (
 // the function instance (for example, local types).
 // "index" parameter is not used by most of opcodes.
 // The returned signature is used for stack validation when lowering Wasm's opcodes to wazeroir.
-func (c *compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature, error) {
+func (c *Compiler) wasmOpcodeSignature(op wasm.Opcode, index uint32) (*signature, error) {
 	switch op {
 	case wasm.OpcodeUnreachable, wasm.OpcodeNop, wasm.OpcodeBlock, wasm.OpcodeLoop:
 		return signature_None_None, nil

--- a/internal/wazeroir/signature_test.go
+++ b/internal/wazeroir/signature_test.go
@@ -93,7 +93,7 @@ func TestCompiler_wasmOpcodeSignature(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			c := &compiler{body: tc.body}
+			c := &Compiler{body: tc.body}
 			actual, err := c.wasmOpcodeSignature(tc.body[0], 0)
 			require.NoError(t, err)
 			require.Equal(t, tc.exp, actual)


### PR DESCRIPTION
Fixes #1202 

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                    │ v1.0.1.txt  │          current_main.txt          │              new.txt               │
                                    │   sec/op    │   sec/op     vs base               │   sec/op     vs base               │
Compilation/with_extern_cache-10      135.1µ ± 0%   114.7µ ± 0%  -15.07% (p=0.001 n=7)   114.0µ ± 0%  -15.61% (p=0.001 n=7)
Compilation/without_extern_cache-10   2.508m ± 1%   2.045m ± 1%  -18.49% (p=0.001 n=7)   1.766m ± 1%  -29.61% (p=0.001 n=7)
geomean                               582.1µ        484.4µ       -16.80%                 448.6µ       -22.93%

                                    │  v1.0.1.txt   │           current_main.txt           │               new.txt               │
                                    │     B/op      │     B/op       vs base               │     B/op      vs base               │
Compilation/with_extern_cache-10       53.37Ki ± 0%    38.40Ki ± 0%  -28.06% (p=0.001 n=7)   38.28Ki ± 0%  -28.28% (p=0.001 n=7)
Compilation/without_extern_cache-10   1098.7Ki ± 0%   1809.4Ki ± 0%  +64.68% (p=0.001 n=7)   768.9Ki ± 0%  -30.02% (p=0.001 n=7)
geomean                                242.2Ki         263.6Ki        +8.84%                 171.6Ki       -29.16%

                                    │  v1.0.1.txt  │          current_main.txt          │              new.txt               │
                                    │  allocs/op   │  allocs/op   vs base               │  allocs/op   vs base               │
Compilation/with_extern_cache-10        979.0 ± 0%    515.0 ± 0%  -47.40% (p=0.001 n=7)    515.0 ± 0%  -47.40% (p=0.001 n=7)
Compilation/without_extern_cache-10   11.330k ± 0%   2.830k ± 0%  -75.02% (p=0.001 n=7)   2.042k ± 0%  -81.98% (p=0.001 n=7)
geomean                                3.330k        1.207k       -63.75%                 1.025k       -69.21%

```