### PR TITLE
Allow perf to resolve guest symbols with perf maps

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -57,7 +57,7 @@ type cache struct {
 }
 
 func (c *cache) initEngine(ek engineKind, ne newEngine, ctx context.Context, features api.CoreFeatures) wasm.Engine {
-	c.initOnces[ek].Do(func() { c.engs[ek] = ne(ctx, features, c.fileCache) })
+	c.initOnces[ek].Do(func() { c.engs[ek] = ne(ctx, features, c.fileCache, false) })
 	return c.engs[ek]
 }
 

--- a/cache.go
+++ b/cache.go
@@ -57,7 +57,12 @@ type cache struct {
 }
 
 func (c *cache) initEngine(ek engineKind, ne newEngine, ctx context.Context, features api.CoreFeatures) wasm.Engine {
-	c.initOnces[ek].Do(func() { c.engs[ek] = ne(ctx, features, c.fileCache, false) })
+	c.initOnces[ek].Do(func() {
+		c.engs[ek] = ne(ctx, wasm.EngineConfig{
+			EnabledFeatures: features,
+			FileCache:       c.fileCache,
+		})
+	})
 	return c.engs[ek]
 }
 

--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -149,6 +149,10 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 		"a comma-separated list of host function scopes to log to stderr. "+
 			"This may be specified multiple times. Supported values: all,clock,filesystem,memory,proc,poll,random")
 
+	var enabledPerfmap bool
+	flags.BoolVar(&enabledPerfmap, "enable-perfmap", false,
+		"when used, Wazero will produce perfmap files to provide debug symbols to external profilers.")
+
 	cacheDir := cacheDirFlag(flags)
 
 	_ = flags.Parse(args)
@@ -202,6 +206,7 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer, exit func(cod
 		rtc = wazero.NewRuntimeConfigInterpreter()
 	} else {
 		rtc = wazero.NewRuntimeConfig()
+		rtc = rtc.WithPerfmap(enabledPerfmap)
 	}
 
 	ctx := maybeHostLogging(context.Background(), logging.LogScopes(hostlogging), stdErr)

--- a/config.go
+++ b/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/engine/compiler"
 	"github.com/tetratelabs/wazero/internal/engine/interpreter"
-	"github.com/tetratelabs/wazero/internal/filecache"
 	"github.com/tetratelabs/wazero/internal/platform"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/sysfs"
@@ -174,7 +173,7 @@ func NewRuntimeConfig() RuntimeConfig {
 	return newRuntimeConfig()
 }
 
-type newEngine func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine
+type newEngine func(context.Context, wasm.EngineConfig) wasm.Engine
 
 type runtimeConfig struct {
 	enabledFeatures       api.CoreFeatures

--- a/config.go
+++ b/config.go
@@ -161,6 +161,11 @@ type RuntimeConfig interface {
 	// When the invocations of api.Function are closed due to this, sys.ExitError is raised to the callers and
 	// the api.Module from which the functions are derived is made closed.
 	WithCloseOnContextDone(bool) RuntimeConfig
+
+	// WtihPerfmap enables perfmap files generation at compile time. Defaults to false.
+	//
+	// Perfmap files are used as source for debug symbols by external profiler such as `perf`.
+	WithPerfmap(bool) RuntimeConfig
 }
 
 // NewRuntimeConfig returns a RuntimeConfig using the compiler if it is supported in this environment,
@@ -169,7 +174,7 @@ func NewRuntimeConfig() RuntimeConfig {
 	return newRuntimeConfig()
 }
 
-type newEngine func(context.Context, api.CoreFeatures, filecache.Cache) wasm.Engine
+type newEngine func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine
 
 type runtimeConfig struct {
 	enabledFeatures       api.CoreFeatures
@@ -177,6 +182,7 @@ type runtimeConfig struct {
 	memoryCapacityFromMax bool
 	engineKind            engineKind
 	dwarfDisabled         bool // negative as defaults to enabled
+	perfmapEnabled        bool
 	newEngine             newEngine
 	cache                 CompilationCache
 	storeCustomSections   bool
@@ -277,6 +283,13 @@ func (c *runtimeConfig) WithMemoryCapacityFromMax(memoryCapacityFromMax bool) Ru
 func (c *runtimeConfig) WithDebugInfoEnabled(dwarfEnabled bool) RuntimeConfig {
 	ret := c.clone()
 	ret.dwarfDisabled = !dwarfEnabled
+	return ret
+}
+
+// WithEnablePerfmap implements RuntimeConfig.WithEnablePerfmap
+func (c *runtimeConfig) WithPerfmap(enable bool) RuntimeConfig {
+	ret := c.clone()
+	ret.perfmapEnabled = enable
 	return ret
 }
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -843,18 +843,18 @@ func (f *function) getSourceOffsetInWasmBinary(pc uint64) uint64 {
 	}
 }
 
-func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, fileCache filecache.Cache, enabledPerfmap bool) wasm.Engine {
-	return newEngine(enabledFeatures, fileCache, enabledPerfmap)
+func NewEngine(_ context.Context, config wasm.EngineConfig) wasm.Engine {
+	return newEngine(config)
 }
 
-func newEngine(enabledFeatures api.CoreFeatures, fileCache filecache.Cache, enabledPerfmap bool) *engine {
+func newEngine(config wasm.EngineConfig) *engine {
 	return &engine{
-		enabledFeatures: enabledFeatures,
+		enabledFeatures: config.EnabledFeatures,
 		codes:           map[wasm.ModuleID][]*code{},
 		setFinalizer:    runtime.SetFinalizer,
-		fileCache:       fileCache,
+		fileCache:       config.FileCache,
 		wazeroVersion:   version.GetWazeroVersion(),
-		enabledPerfmap:  enabledPerfmap,
+		enabledPerfmap:  config.EnabledPerfmap,
 	}
 }
 

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -38,7 +38,7 @@ func (e engineTester) ListenerFactory() experimental.FunctionListenerFactory {
 
 // NewEngine implements the same method as documented on enginetest.EngineTester.
 func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
-	return newEngine(enabledFeatures, nil, false)
+	return newEngine(wasm.EngineConfig{EnabledFeatures: enabledFeatures})
 }
 
 func TestCompiler_Engine_NewModuleEngine(t *testing.T) {
@@ -226,7 +226,7 @@ func TestCompiler_Releasecode_Panic(t *testing.T) {
 // See comments on initialStackSize and initialCallFrameStackSize.
 func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 	enabledFeatures := api.CoreFeaturesV1
-	e := newEngine(enabledFeatures, nil, false)
+	e := newEngine(wasm.EngineConfig{EnabledFeatures: enabledFeatures})
 	s := wasm.NewStore(enabledFeatures, e)
 
 	const hostModuleName = "env"

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -38,7 +38,7 @@ func (e engineTester) ListenerFactory() experimental.FunctionListenerFactory {
 
 // NewEngine implements the same method as documented on enginetest.EngineTester.
 func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
-	return newEngine(enabledFeatures, nil)
+	return newEngine(enabledFeatures, nil, false)
 }
 
 func TestCompiler_Engine_NewModuleEngine(t *testing.T) {
@@ -226,7 +226,7 @@ func TestCompiler_Releasecode_Panic(t *testing.T) {
 // See comments on initialStackSize and initialCallFrameStackSize.
 func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 	enabledFeatures := api.CoreFeaturesV1
-	e := newEngine(enabledFeatures, nil)
+	e := newEngine(enabledFeatures, nil, false)
 	s := wasm.NewStore(enabledFeatures, e)
 
 	const hostModuleName = "env"

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -35,7 +35,7 @@ type engine struct {
 	labelAddressResolutionCache [wazeroir.LabelKindNum][]uint64
 }
 
-func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, _ filecache.Cache) wasm.Engine {
+func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, _ filecache.Cache, _ bool) wasm.Engine {
 	return &engine{
 		enabledFeatures: enabledFeatures,
 		codes:           map[wasm.ModuleID][]*code{},

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
-	"github.com/tetratelabs/wazero/internal/filecache"
 	"github.com/tetratelabs/wazero/internal/moremath"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
@@ -35,9 +34,9 @@ type engine struct {
 	labelAddressResolutionCache [wazeroir.LabelKindNum][]uint64
 }
 
-func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, _ filecache.Cache, _ bool) wasm.Engine {
+func NewEngine(_ context.Context, config wasm.EngineConfig) wasm.Engine {
 	return &engine{
-		enabledFeatures: enabledFeatures,
+		enabledFeatures: config.EnabledFeatures,
 		codes:           map[wasm.ModuleID][]*code{},
 	}
 }

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -80,7 +80,7 @@ func (e engineTester) ListenerFactory() experimental.FunctionListenerFactory {
 
 // NewEngine implements enginetest.EngineTester NewEngine.
 func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
-	return NewEngine(context.Background(), enabledFeatures, nil, false)
+	return NewEngine(context.Background(), wasm.EngineConfig{EnabledFeatures: enabledFeatures})
 }
 
 func TestInterpreter_MemoryGrowInRecursiveCall(t *testing.T) {

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -80,7 +80,7 @@ func (e engineTester) ListenerFactory() experimental.FunctionListenerFactory {
 
 // NewEngine implements enginetest.EngineTester NewEngine.
 func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
-	return NewEngine(context.Background(), enabledFeatures, nil)
+	return NewEngine(context.Background(), enabledFeatures, nil, false)
 }
 
 func TestInterpreter_MemoryGrowInRecursiveCall(t *testing.T) {

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -113,7 +113,7 @@ func getCallEngine(m *wasm.ModuleInstance, name string) (ce api.Function) {
 }
 
 func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
-	eng := compiler.NewEngine(context.Background(), api.CoreFeaturesV2, nil, false)
+	eng := compiler.NewEngine(context.Background(), wasm.EngineConfig{EnabledFeatures: api.CoreFeaturesV2})
 
 	ft := wasm.FunctionType{
 		Params:           []wasm.ValueType{wasm.ValueTypeI32},

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -113,7 +113,7 @@ func getCallEngine(m *wasm.ModuleInstance, name string) (ce api.Function) {
 }
 
 func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
-	eng := compiler.NewEngine(context.Background(), api.CoreFeaturesV2, nil)
+	eng := compiler.NewEngine(context.Background(), api.CoreFeaturesV2, nil, false)
 
 	ft := wasm.FunctionType{
 		Params:           []wasm.ValueType{wasm.ValueTypeI32},

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -353,7 +353,7 @@ func maybeSetMemoryCap(mod *wasm.Module) {
 
 // Run runs all the test inside the testDataFS file system where all the cases are described
 // via JSON files created from wast2json.
-func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Cache, newEngine func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine, enabledFeatures api.CoreFeatures) {
+func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Cache, newEngine func(context.Context, wasm.EngineConfig) wasm.Engine, enabledFeatures api.CoreFeatures) {
 	files, err := testDataFS.ReadDir("testdata")
 	require.NoError(t, err)
 
@@ -379,7 +379,7 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Ca
 		wastName := basename(base.SourceFile)
 
 		t.Run(wastName, func(t *testing.T) {
-			s := wasm.NewStore(enabledFeatures, newEngine(ctx, enabledFeatures, fc, false))
+			s := wasm.NewStore(enabledFeatures, newEngine(ctx, wasm.EngineConfig{FileCache: fc, EnabledFeatures: enabledFeatures}))
 			addSpectestModule(t, ctx, s, enabledFeatures)
 
 			var lastInstantiatedModuleName string

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -353,7 +353,7 @@ func maybeSetMemoryCap(mod *wasm.Module) {
 
 // Run runs all the test inside the testDataFS file system where all the cases are described
 // via JSON files created from wast2json.
-func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Cache, newEngine func(context.Context, api.CoreFeatures, filecache.Cache) wasm.Engine, enabledFeatures api.CoreFeatures) {
+func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Cache, newEngine func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine, enabledFeatures api.CoreFeatures) {
 	files, err := testDataFS.ReadDir("testdata")
 	require.NoError(t, err)
 
@@ -379,7 +379,7 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Ca
 		wastName := basename(base.SourceFile)
 
 		t.Run(wastName, func(t *testing.T) {
-			s := wasm.NewStore(enabledFeatures, newEngine(ctx, enabledFeatures, fc))
+			s := wasm.NewStore(enabledFeatures, newEngine(ctx, enabledFeatures, fc, false))
 			addSpectestModule(t, ctx, s, enabledFeatures)
 
 			var lastInstantiatedModuleName string

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/internal/filecache"
 )
 
 // Engine is a Store-scoped mechanism to compile functions declared or imported by a module.
@@ -51,4 +52,14 @@ type ModuleEngine interface {
 	// FunctionInstanceReference returns Reference for the given Index for a FunctionInstance. The returned values are used by
 	// the initialization via ElementSegment.
 	FunctionInstanceReference(funcIndex Index) Reference
+}
+
+// EngineConfig caries extra configuration for an Engine.
+type EngineConfig struct {
+	// EnabledPerfmap enable the generation of perfmap files used for profiling.
+	EnabledPerfmap bool
+
+	EnabledFeatures api.CoreFeatures
+
+	FileCache filecache.Cache
 }

--- a/internal/wasmdebug/perfmap.go
+++ b/internal/wasmdebug/perfmap.go
@@ -1,0 +1,67 @@
+package wasmdebug
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Perfmap holds perfmap entries to be flushed into a perfmap file.
+type Perfmap struct {
+	entries []entry
+	fh      *os.File
+}
+
+type entry struct {
+	addr *uint64
+	size uint64
+	name string
+}
+
+func NewPerfmap() *Perfmap {
+	return &Perfmap{}
+}
+
+// AddEntry adds a new entry to the perfmap. Each entry contains the address,
+// the size and the name of the function.
+func (f *Perfmap) AddEntry(addr *uint64, size uint64, name string) {
+	e := entry{addr, size, name}
+	if f.entries == nil {
+		f.entries = []entry{e}
+		return
+	}
+	f.entries = append(f.entries, e)
+}
+
+func (f *Perfmap) Flush() error {
+	defer func() {
+		_ = f.fh.Sync()
+		_ = f.fh.Close()
+	}()
+
+	var err error
+	f.fh, err = f.file()
+	if err != nil {
+		return err
+	}
+
+	for _, e := range f.entries {
+		f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
+			e.addr,
+			strconv.FormatUint(e.size, 16),
+			e.name,
+		))
+	}
+	return nil
+}
+
+func (f *Perfmap) file() (*os.File, error) {
+	pid := os.Getpid()
+	filename := "/tmp/perf-" + strconv.Itoa(pid) + ".map"
+
+	fh, err := os.OpenFile(filename, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return fh, nil
+}

--- a/runtime.go
+++ b/runtime.go
@@ -148,7 +148,7 @@ func NewRuntimeWithConfig(ctx context.Context, rConfig RuntimeConfig) Runtime {
 		engine = cacheImpl.initEngine(config.engineKind, config.newEngine, ctx, config.enabledFeatures)
 	} else {
 		// Otherwise, we create a new engine.
-		engine = config.newEngine(ctx, config.enabledFeatures, nil, config.perfmapEnabled)
+		engine = config.newEngine(ctx, wasm.EngineConfig{EnabledFeatures: config.enabledFeatures, EnabledPerfmap: config.perfmapEnabled})
 	}
 	store := wasm.NewStore(config.enabledFeatures, engine)
 	zero := uint64(0)

--- a/runtime.go
+++ b/runtime.go
@@ -148,7 +148,7 @@ func NewRuntimeWithConfig(ctx context.Context, rConfig RuntimeConfig) Runtime {
 		engine = cacheImpl.initEngine(config.engineKind, config.newEngine, ctx, config.enabledFeatures)
 	} else {
 		// Otherwise, we create a new engine.
-		engine = config.newEngine(ctx, config.enabledFeatures, nil)
+		engine = config.newEngine(ctx, config.enabledFeatures, nil, config.perfmapEnabled)
 	}
 	store := wasm.NewStore(config.enabledFeatures, engine)
 	zero := uint64(0)

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
-	"github.com/tetratelabs/wazero/internal/filecache"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/binaryencoding"
@@ -701,7 +700,7 @@ func TestRuntime_Close_ClosesCompiledModules(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			engine := &mockEngine{name: "mock", cachedModules: map[*wasm.Module]struct{}{}}
 			conf := *engineLessConfig
-			conf.newEngine = func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine { return engine }
+			conf.newEngine = func(context.Context, wasm.EngineConfig) wasm.Engine { return engine }
 			if tc.withCompilationCache {
 				conf.cache = NewCompilationCache()
 			}
@@ -753,7 +752,7 @@ func TestRuntime_Closed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			engine := &mockEngine{name: "mock", cachedModules: map[*wasm.Module]struct{}{}}
 			conf := *engineLessConfig
-			conf.newEngine = func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine { return engine }
+			conf.newEngine = func(context.Context, wasm.EngineConfig) wasm.Engine { return engine }
 			r := NewRuntimeWithConfig(testCtx, &conf)
 			defer r.Close(testCtx)
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -701,7 +701,7 @@ func TestRuntime_Close_ClosesCompiledModules(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			engine := &mockEngine{name: "mock", cachedModules: map[*wasm.Module]struct{}{}}
 			conf := *engineLessConfig
-			conf.newEngine = func(context.Context, api.CoreFeatures, filecache.Cache) wasm.Engine { return engine }
+			conf.newEngine = func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine { return engine }
 			if tc.withCompilationCache {
 				conf.cache = NewCompilationCache()
 			}
@@ -753,7 +753,7 @@ func TestRuntime_Closed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			engine := &mockEngine{name: "mock", cachedModules: map[*wasm.Module]struct{}{}}
 			conf := *engineLessConfig
-			conf.newEngine = func(context.Context, api.CoreFeatures, filecache.Cache) wasm.Engine { return engine }
+			conf.newEngine = func(context.Context, api.CoreFeatures, filecache.Cache, bool) wasm.Engine { return engine }
 			r := NewRuntimeWithConfig(testCtx, &conf)
 			defer r.Close(testCtx)
 


### PR DESCRIPTION
Related to #1350, this change adds the ability for Wazero to create perfmap files during the module compilation.
The "demangling" of the function names is let as the client tool discretion. `perf` and other `go tool pprof` already support demangle of c++ and rust function names.

I'm not certain about the way I'm propagating the enable flag for the perfmap feature. Happy to adapt to anyway we like.