### PR TITLE
interpreter: use slice of values on functions, not ptrs

### DIFF
--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -542,7 +542,7 @@ func TestInterpreter_Compile(t *testing.T) {
 
 func TestEngine_CachedcodesPerModule(t *testing.T) {
 	e := et.NewEngine(api.CoreFeaturesV1).(*engine)
-	exp := []*code{
+	exp := []code{
 		{body: []wazeroir.UnionOperation{}},
 		{body: []wazeroir.UnionOperation{}},
 	}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                   │   old.txt   │              new.txt              │
                                   │   sec/op    │   sec/op     vs base              │
Compilation_sqlite3/compiler-10      194.7m ± 0%   195.0m ± 0%       ~ (p=0.165 n=7)
Compilation_sqlite3/interpreter-10   62.54m ± 1%   61.90m ± 1%  -1.03% (p=0.001 n=7)
geomean                              110.3m        109.9m       -0.44%

                                   │   old.txt    │              new.txt               │
                                   │     B/op     │     B/op      vs base              │
Compilation_sqlite3/compiler-10      51.90Mi ± 0%   51.90Mi ± 0%       ~ (p=0.259 n=7)
Compilation_sqlite3/interpreter-10   51.76Mi ± 0%   51.75Mi ± 0%  -0.02% (p=0.001 n=7)
geomean                              51.83Mi        51.82Mi       -0.01%

                                   │   old.txt   │              new.txt              │
                                   │  allocs/op  │  allocs/op   vs base              │
Compilation_sqlite3/compiler-10      32.19k ± 0%   32.19k ± 0%       ~ (p=0.056 n=7)
Compilation_sqlite3/interpreter-10   15.41k ± 0%   13.89k ± 0%  -9.84% (p=0.001 n=7)
geomean                              22.27k        21.15k       -5.04%

```