### PR TITLE
wasm: removes name node to simplify instantiation path

### DIFF
--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -102,7 +102,7 @@ func (m *ModuleInstance) CloseWithExitCode(ctx context.Context, exitCode uint32)
 	if !m.setExitCode(exitCode, exitCodeFlagResourceClosed) {
 		return nil // not an error to have already closed
 	}
-	_ = m.s.deleteModule(m.moduleListNode)
+	_ = m.s.deleteModule(m)
 	return m.ensureResourcesClosed(ctx)
 }
 
@@ -110,7 +110,7 @@ func (m *ModuleInstance) closeWithExitCodeWithoutClosingResource(exitCode uint32
 	if !m.setExitCode(exitCode, exitCodeFlagResourceNotClosed) {
 		return nil // not an error to have already closed
 	}
-	_ = m.s.deleteModule(m.moduleListNode)
+	_ = m.s.deleteModule(m)
 	return nil
 }
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -107,7 +107,8 @@ type (
 		CodeCloser api.Closer
 
 		// s is the Store on which this module is instantiated.
-		s          *Store
+		s *Store
+		// prev and next hold the nodes in the linked list of ModuleInstance held by Store.
 		prev, next *ModuleInstance
 		// Definitions is derived from *Module, and is constructed during compilation phrase.
 		Definitions []FunctionDefinition

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -296,7 +296,9 @@ func (s *Store) Instantiate(
 	// Instantiate the module and add it to the store so that other modules can import it.
 	m, err := s.instantiate(ctx, module, name, sys, importedModules, typeIDs)
 	if err != nil {
-		_ = s.deleteModule(m)
+		if m != nil {
+			_ = s.deleteModule(m)
+		}
 		return nil, err
 	}
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -28,9 +28,9 @@ type (
 		// moduleList ensures modules are closed in reverse initialization order.
 		moduleList *ModuleInstance // guarded by mux
 
-		// nameToNode holds the instantiated Wasm modules by module name from Instantiate.
+		// nameToModule holds the instantiated Wasm modules by module name from Instantiate.
 		// It ensures no race conditions instantiating two modules of the same name.
-		nameToNode map[string]*ModuleInstance // guarded by mux
+		nameToModule map[string]*ModuleInstance // guarded by mux
 
 		// EnabledFeatures are read-only to allow optimizations.
 		EnabledFeatures api.CoreFeatures
@@ -258,7 +258,7 @@ func NewStore(enabledFeatures api.CoreFeatures, engine Engine) *Store {
 		typeIDs[k] = v
 	}
 	return &Store{
-		nameToNode:       map[string]*ModuleInstance{},
+		nameToModule:     map[string]*ModuleInstance{},
 		EnabledFeatures:  enabledFeatures,
 		Engine:           engine,
 		typeIDs:          typeIDs,
@@ -629,7 +629,7 @@ func (s *Store) CloseWithExitCode(ctx context.Context, exitCode uint32) (err err
 		}
 	}
 	s.moduleList = nil
-	s.nameToNode = nil
+	s.nameToModule = nil
 	s.typeIDs = nil
 	return
 }

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -301,7 +301,10 @@ func (s *Store) Instantiate(
 	}
 
 	// Now that the instantiation is complete without error, add it.
-	s.registerModule(m)
+	if err := s.registerModule(m); err != nil {
+		_ = m.Close(ctx)
+		return nil, err
+	}
 	return m, nil
 }
 

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -297,14 +297,11 @@ func (s *Store) Instantiate(
 	// Instantiate the module and add it to the store so that other modules can import it.
 	m, err := s.instantiate(ctx, module, name, sys, importedModules, typeIDs)
 	if err != nil {
-		if m != nil {
-			_ = s.deleteModule(m)
-		}
 		return nil, err
 	}
 
 	// Now that the instantiation is complete without error, add it.
-	if err := s.registerModule(m); err != nil {
+	if err = s.registerModule(m); err != nil {
 		_ = m.Close(ctx)
 		return nil, err
 	}

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -26,11 +26,11 @@ type (
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#store%E2%91%A0
 	Store struct {
 		// moduleList ensures modules are closed in reverse initialization order.
-		moduleList *moduleListNode // guarded by mux
+		moduleList *ModuleInstance // guarded by mux
 
 		// nameToNode holds the instantiated Wasm modules by module name from Instantiate.
 		// It ensures no race conditions instantiating two modules of the same name.
-		nameToNode map[string]*moduleListNode // guarded by mux
+		nameToNode map[string]*ModuleInstance // guarded by mux
 
 		// EnabledFeatures are read-only to allow optimizations.
 		EnabledFeatures api.CoreFeatures
@@ -92,8 +92,6 @@ type (
 		// or external objects (unimplemented).
 		ElementInstances []ElementInstance
 
-		moduleListNode *moduleListNode
-
 		// Sys is exposed for use in special imports such as WASI, assemblyscript
 		// and gojs.
 		//
@@ -109,7 +107,8 @@ type (
 		CodeCloser api.Closer
 
 		// s is the Store on which this module is instantiated.
-		s *Store
+		s          *Store
+		prev, next *ModuleInstance
 		// Definitions is derived from *Module, and is constructed during compilation phrase.
 		Definitions []FunctionDefinition
 	}
@@ -258,7 +257,7 @@ func NewStore(enabledFeatures api.CoreFeatures, engine Engine) *Store {
 		typeIDs[k] = v
 	}
 	return &Store{
-		nameToNode:       map[string]*moduleListNode{},
+		nameToNode:       map[string]*ModuleInstance{},
 		EnabledFeatures:  enabledFeatures,
 		Engine:           engine,
 		typeIDs:          typeIDs,
@@ -294,34 +293,15 @@ func (s *Store) Instantiate(
 		return nil, err
 	}
 
-	var listNode *moduleListNode
-	if name == "" {
-		listNode = s.registerAnonymous()
-	} else {
-		// Write-Lock the store and claim the name of the current module.
-		listNode, err = s.requireModuleName(name)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// Instantiate the module and add it to the store so that other modules can import it.
 	m, err := s.instantiate(ctx, module, name, sys, importedModules, typeIDs)
 	if err != nil {
-		_ = s.deleteModule(listNode)
+		_ = s.deleteModule(m)
 		return nil, err
 	}
 
-	m.moduleListNode = listNode
-
-	if name != "" {
-		// Now that the instantiation is complete without error, add it.
-		// This makes the module visible for import, and ensures it is closed when the store is.
-		if err := s.setModule(m); err != nil {
-			m.Close(ctx)
-			return nil, err
-		}
-	}
+	// Now that the instantiation is complete without error, add it.
+	s.registerModule(m)
 	return m, nil
 }
 
@@ -638,13 +618,11 @@ func (s *Store) CloseWithExitCode(ctx context.Context, exitCode uint32) (err err
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	// Close modules in reverse initialization order.
-	for node := s.moduleList; node != nil; node = node.next {
+	for m := s.moduleList; m != nil; m = m.next {
 		// If closing this module errs, proceed anyway to close the others.
-		if m := node.module; m != nil {
-			if e := m.closeWithExitCode(ctx, exitCode); e != nil && err == nil {
-				// TODO: use multiple errors handling in Go 1.20.
-				err = e // first error
-			}
+		if e := m.closeWithExitCode(ctx, exitCode); e != nil && err == nil {
+			// TODO: use multiple errors handling in Go 1.20.
+			err = e // first error
 		}
 	}
 	s.moduleList = nil

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -65,8 +65,8 @@ func (s *Store) requireModules(moduleNames map[string]struct{}) (map[string]*Mod
 	return ret, nil
 }
 
-// registerModule registers
-// This makes the module visible for import, and ensures it is closed when the store is.
+// registerModule registers a ModuleInstance into the store.
+// This makes the ModuleInstance visible for import if it's not anonymous, and ensures it is closed when the store is.
 func (s *Store) registerModule(m *ModuleInstance) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -28,7 +28,7 @@ func (s *Store) deleteModule(m *ModuleInstance) error {
 	m.next = nil
 
 	if m.ModuleName != "" {
-		delete(s.nameToNode, m.ModuleName)
+		delete(s.nameToModule, m.ModuleName)
 	}
 	return nil
 }
@@ -37,7 +37,7 @@ func (s *Store) deleteModule(m *ModuleInstance) error {
 func (s *Store) module(moduleName string) (*ModuleInstance, error) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	m, ok := s.nameToNode[moduleName]
+	m, ok := s.nameToModule[moduleName]
 	if !ok {
 		return nil, fmt.Errorf("module[%s] not in store", moduleName)
 	}
@@ -56,7 +56,7 @@ func (s *Store) requireModules(moduleNames map[string]struct{}) (map[string]*Mod
 	defer s.mux.RUnlock()
 
 	for n := range moduleNames {
-		module, ok := s.nameToNode[n]
+		module, ok := s.nameToModule[n]
 		if !ok {
 			return nil, fmt.Errorf("module[%s] not instantiated", n)
 		}
@@ -71,7 +71,7 @@ func (s *Store) registerModule(m *ModuleInstance) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
-	if s.nameToNode == nil {
+	if s.nameToModule == nil {
 		return errors.New("already closed")
 	}
 
@@ -83,10 +83,10 @@ func (s *Store) registerModule(m *ModuleInstance) error {
 	s.moduleList = m
 
 	if m.ModuleName != "" {
-		if _, ok := s.nameToNode[m.ModuleName]; ok {
+		if _, ok := s.nameToModule[m.ModuleName]; ok {
 			return fmt.Errorf("module[%s] has already been instantiated", m.ModuleName)
 		}
-		s.nameToNode[m.ModuleName] = m
+		s.nameToModule[m.ModuleName] = m
 	}
 	return nil
 }
@@ -97,7 +97,7 @@ func (s *Store) registerModule(m *ModuleInstance) error {
 func (s *Store) AliasModule(src, dst string) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	s.nameToNode[dst] = s.nameToNode[src]
+	s.nameToModule[dst] = s.nameToModule[src]
 	return nil
 }
 

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -75,19 +75,19 @@ func (s *Store) registerModule(m *ModuleInstance) error {
 		return errors.New("already closed")
 	}
 
-	// Add the newest node to the moduleNamesList as the head.
-	m.next = s.moduleList
-	if m.next != nil {
-		m.next.prev = m
-	}
-	s.moduleList = m
-
 	if m.ModuleName != "" {
 		if _, ok := s.nameToModule[m.ModuleName]; ok {
 			return fmt.Errorf("module[%s] has already been instantiated", m.ModuleName)
 		}
 		s.nameToModule[m.ModuleName] = m
 	}
+
+	// Add the newest node to the moduleNamesList as the head.
+	m.next = s.moduleList
+	if m.next != nil {
+		m.next.prev = m
+	}
+	s.moduleList = m
 	return nil
 }
 

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -6,30 +6,9 @@ import (
 	"github.com/tetratelabs/wazero/api"
 )
 
-// moduleListNode is a node in a doubly linked list of names.
-type moduleListNode struct {
-	name       string
-	module     *ModuleInstance
-	next, prev *moduleListNode
-}
-
-// setModule makes the module visible for import.
-func (s *Store) setModule(m *ModuleInstance) error {
-	s.mux.Lock()
-	defer s.mux.Unlock()
-
-	node, ok := s.nameToNode[m.ModuleName]
-	if !ok {
-		return fmt.Errorf("module[%s] name has not been required", m.ModuleName)
-	}
-
-	node.module = m
-	return nil
-}
-
 // deleteModule makes the moduleName available for instantiation again.
-func (s *Store) deleteModule(node *moduleListNode) error {
-	if node == nil {
+func (s *Store) deleteModule(m *ModuleInstance) error {
+	if m == nil {
 		return nil
 	}
 
@@ -37,22 +16,22 @@ func (s *Store) deleteModule(node *moduleListNode) error {
 	defer s.mux.Unlock()
 
 	// remove this module name
-	if node.prev != nil {
-		node.prev.next = node.next
+	if m.prev != nil {
+		m.prev.next = m.next
 	}
-	if node.next != nil {
-		node.next.prev = node.prev
+	if m.next != nil {
+		m.next.prev = m.prev
 	}
-	if s.moduleList == node {
-		s.moduleList = node.next
+	if s.moduleList == m {
+		s.moduleList = m.next
 	}
-	// clear the node state so it does not enter any other branch
+	// clear the m state so it does not enter any other branch
 	// on subsequent calls to deleteModule
-	node.prev = nil
-	node.next = nil
+	m.prev = nil
+	m.next = nil
 
-	if node.name != "" {
-		delete(s.nameToNode, node.name)
+	if m.ModuleName != "" {
+		delete(s.nameToNode, m.ModuleName)
 	}
 	return nil
 }
@@ -61,16 +40,15 @@ func (s *Store) deleteModule(node *moduleListNode) error {
 func (s *Store) module(moduleName string) (*ModuleInstance, error) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	node, ok := s.nameToNode[moduleName]
+	m, ok := s.nameToNode[moduleName]
 	if !ok {
 		return nil, fmt.Errorf("module[%s] not in store", moduleName)
 	}
 
-	if node.module == nil {
+	if m == nil {
 		return nil, fmt.Errorf("module[%s] not set in store", moduleName)
 	}
-
-	return node.module, nil
+	return m, nil
 }
 
 // requireModules returns all instantiated modules whose names equal the keys in the input, or errs if any are missing.
@@ -81,50 +59,31 @@ func (s *Store) requireModules(moduleNames map[string]struct{}) (map[string]*Mod
 	defer s.mux.RUnlock()
 
 	for n := range moduleNames {
-		node, ok := s.nameToNode[n]
+		module, ok := s.nameToNode[n]
 		if !ok {
 			return nil, fmt.Errorf("module[%s] not instantiated", n)
 		}
-		ret[n] = node.module
+		ret[n] = module
 	}
 	return ret, nil
 }
 
-// requireModuleName is a pre-flight check to reserve a module.
-// This must be reverted on error with deleteModule if initialization fails.
-func (s *Store) requireModuleName(moduleName string) (*moduleListNode, error) {
-	node := &moduleListNode{name: moduleName}
-
-	s.mux.Lock()
-	defer s.mux.Unlock()
-	if _, ok := s.nameToNode[moduleName]; ok {
-		return nil, fmt.Errorf("module[%s] has already been instantiated", moduleName)
-	}
-
-	// add the newest node to the moduleNamesList as the head.
-	node.next = s.moduleList
-	if node.next != nil {
-		node.next.prev = node
-	}
-	s.moduleList = node
-	s.nameToNode[moduleName] = node
-	return node, nil
-}
-
-func (s *Store) registerAnonymous() *moduleListNode {
-	node := &moduleListNode{name: ""}
-
+// registerModule registers
+// This makes the module visible for import, and ensures it is closed when the store is.
+func (s *Store) registerModule(m *ModuleInstance) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
 	// add the newest node to the moduleNamesList as the head.
-	node.next = s.moduleList
-	if node.next != nil {
-		node.next.prev = node
+	m.next = s.moduleList
+	if m.next != nil {
+		m.next.prev = m
 	}
-	s.moduleList = node
+	s.moduleList = m
 
-	return node
+	if m.ModuleName != "" {
+		s.nameToNode[m.ModuleName] = m
+	}
 }
 
 // AliasModule aliases the instantiated module named `src` as `dst`.

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -13,14 +13,14 @@ func TestStore_registerModule(t *testing.T) {
 
 	t.Run("adds module", func(t *testing.T) {
 		require.NoError(t, s.registerModule(m1))
-		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToNode)
+		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
 	})
 
 	t.Run("adds second module", func(t *testing.T) {
 		m2 := &ModuleInstance{ModuleName: "m2"}
 		require.NoError(t, s.registerModule(m2))
-		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}, s.nameToNode)
+		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}, s.nameToModule)
 		require.Equal(t, m2, s.moduleList)
 	})
 
@@ -42,7 +42,7 @@ func TestStore_deleteModule(t *testing.T) {
 		require.NoError(t, s.deleteModule(m2))
 
 		// Leaves the other module alone
-		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToNode)
+		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
 	})
 
@@ -53,7 +53,7 @@ func TestStore_deleteModule(t *testing.T) {
 	t.Run("delete last module", func(t *testing.T) {
 		require.NoError(t, s.deleteModule(m1))
 
-		require.Zero(t, len(s.nameToNode))
+		require.Zero(t, len(s.nameToModule))
 		require.Nil(t, s.moduleList)
 	})
 }
@@ -107,11 +107,11 @@ func TestStore_requireModules(t *testing.T) {
 func TestStore_AliasModule(t *testing.T) {
 	s := newStore()
 	m1 := &ModuleInstance{ModuleName: "m1"}
-	s.nameToNode[m1.ModuleName] = m1
+	s.nameToModule[m1.ModuleName] = m1
 
 	t.Run("alias module", func(t *testing.T) {
 		require.NoError(t, s.AliasModule("m1", "m2"))
-		require.Equal(t, map[string]*ModuleInstance{"m1": m1, "m2": m1}, s.nameToNode)
+		require.Equal(t, map[string]*ModuleInstance{"m1": m1, "m2": m1}, s.nameToModule)
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
 	})
@@ -137,7 +137,7 @@ func newTestStore() (*Store, *ModuleInstance, *ModuleInstance) {
 
 	m1.prev = m2
 	m2.next = m1
-	s.nameToNode = map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}
+	s.nameToModule = map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}
 	s.moduleList = m2
 	return s, m1, m2
 }

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -136,6 +136,7 @@ func newTestStore() (*Store, *ModuleInstance, *ModuleInstance) {
 	m2 := &ModuleInstance{ModuleName: "m2"}
 
 	m1.prev = m2
+	m2.next = m1
 	s.nameToNode = map[string]*ModuleInstance{m1.ModuleName: m1, m2.ModuleName: m2}
 	s.moduleList = m2
 	return s, m1, m2

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -41,7 +41,7 @@ func TestStore_deleteModule(t *testing.T) {
 	t.Run("delete one module", func(t *testing.T) {
 		require.NoError(t, s.deleteModule(m2))
 
-		// Leaves the other module alone
+		// Leaves the other module alone.
 		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, s.nameToModule)
 		require.Equal(t, m1, s.moduleList)
 	})
@@ -55,6 +55,27 @@ func TestStore_deleteModule(t *testing.T) {
 
 		require.Zero(t, len(s.nameToModule))
 		require.Nil(t, s.moduleList)
+	})
+
+	t.Run("delete middle", func(t *testing.T) {
+		s := newStore()
+		one, two, three := &ModuleInstance{ModuleName: "1"}, &ModuleInstance{ModuleName: "2"}, &ModuleInstance{ModuleName: "3"}
+		require.NoError(t, s.registerModule(one))
+		require.NoError(t, s.registerModule(two))
+		require.NoError(t, s.registerModule(three))
+		require.Equal(t, three, s.moduleList)
+		require.Nil(t, three.prev)
+		require.Equal(t, two, three.next)
+		require.Equal(t, two.prev, three)
+		require.Equal(t, one, two.next)
+		require.Equal(t, one.prev, two)
+		require.Nil(t, one.next)
+		require.NoError(t, s.deleteModule(two))
+		require.Equal(t, three, s.moduleList)
+		require.Nil(t, three.prev)
+		require.Equal(t, one, three.next)
+		require.Equal(t, one.prev, three)
+		require.Nil(t, one.next)
 	})
 }
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -114,8 +114,8 @@ func TestStore_Instantiate(t *testing.T) {
 	defer mod.Close(testCtx)
 
 	t.Run("ModuleInstance defaults", func(t *testing.T) {
-		require.Equal(t, s.nameToNode["bar"].module, mod)
-		require.Equal(t, s.nameToNode["bar"].module.MemoryInstance, mod.MemoryInstance)
+		require.Equal(t, s.nameToNode["bar"], mod)
+		require.Equal(t, s.nameToNode["bar"].MemoryInstance, mod.MemoryInstance)
 		require.Equal(t, s, mod.s)
 		require.Equal(t, sysCtx, mod.Sys)
 	})

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -114,8 +114,8 @@ func TestStore_Instantiate(t *testing.T) {
 	defer mod.Close(testCtx)
 
 	t.Run("ModuleInstance defaults", func(t *testing.T) {
-		require.Equal(t, s.nameToNode["bar"], mod)
-		require.Equal(t, s.nameToNode["bar"].MemoryInstance, mod.MemoryInstance)
+		require.Equal(t, s.nameToModule["bar"], mod)
+		require.Equal(t, s.nameToModule["bar"].MemoryInstance, mod.MemoryInstance)
 		require.Equal(t, s, mod.s)
 		require.Equal(t, sysCtx, mod.Sys)
 	})
@@ -191,7 +191,7 @@ func TestStore_hammer(t *testing.T) {
 	imported, err := s.Instantiate(testCtx, m, importedModuleName, nil, []FunctionTypeID{0})
 	require.NoError(t, err)
 
-	_, ok := s.nameToNode[imported.Name()]
+	_, ok := s.nameToModule[imported.Name()]
 	require.True(t, ok)
 
 	importingModule := &Module{
@@ -246,7 +246,7 @@ func TestStore_hammer_close(t *testing.T) {
 	imported, err := s.Instantiate(testCtx, m, importedModuleName, nil, []FunctionTypeID{0})
 	require.NoError(t, err)
 
-	_, ok := s.nameToNode[imported.Name()]
+	_, ok := s.nameToModule[imported.Name()]
 	require.True(t, ok)
 
 	importingModule := &Module{
@@ -317,7 +317,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 		_, err = s.Instantiate(testCtx, m, importedModuleName, nil, []FunctionTypeID{0})
 		require.NoError(t, err)
 
-		hm := s.nameToNode[importedModuleName]
+		hm := s.nameToModule[importedModuleName]
 		require.NotNil(t, hm)
 
 		_, err = s.Instantiate(testCtx, &Module{
@@ -338,7 +338,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 		_, err = s.Instantiate(testCtx, m, importedModuleName, nil, []FunctionTypeID{0})
 		require.NoError(t, err)
 
-		hm := s.nameToNode[importedModuleName]
+		hm := s.nameToModule[importedModuleName]
 		require.NotNil(t, hm)
 
 		engine := s.Engine.(*mockEngine)
@@ -370,7 +370,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 		_, err = s.Instantiate(testCtx, m, importedModuleName, nil, []FunctionTypeID{0})
 		require.NoError(t, err)
 
-		hm := s.nameToNode[importedModuleName]
+		hm := s.nameToModule[importedModuleName]
 		require.NotNil(t, hm)
 
 		startFuncIndex := uint32(1)


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                       │   old.txt   │               new.txt               │
                                       │   sec/op    │   sec/op     vs base                │
Initialization/interpreter-10            14.41µ ± 1%   14.47µ ± 1%        ~ (p=0.353 n=10)
Initialization/interpreter-multiple-10   17.87µ ± 2%   15.88µ ± 3%  -11.14% (p=0.000 n=10)
Initialization/compiler-10               14.87µ ± 1%   14.92µ ± 1%        ~ (p=0.218 n=10)
Initialization/compiler-multiple-10      18.68µ ± 1%   17.20µ ± 3%   -7.89% (p=0.000 n=10)
geomean                                  16.35µ        15.58µ        -4.71%

                                       │   old.txt    │               new.txt               │
                                       │     B/op     │     B/op      vs base               │
Initialization/interpreter-10            132.6Ki ± 0%   132.5Ki ± 0%  -0.02% (p=0.000 n=10)
Initialization/interpreter-multiple-10   132.6Ki ± 0%   132.6Ki ± 0%  -0.02% (p=0.000 n=10)
Initialization/compiler-10               132.6Ki ± 0%   132.5Ki ± 0%  -0.02% (p=0.000 n=10)
Initialization/compiler-multiple-10      132.6Ki ± 0%   132.6Ki ± 0%  -0.02% (p=0.000 n=10)
geomean                                  132.6Ki        132.5Ki       -0.02%

                                       │  old.txt   │              new.txt              │
                                       │ allocs/op  │ allocs/op   vs base               │
Initialization/interpreter-10            26.00 ± 0%   25.00 ± 0%  -3.85% (p=0.000 n=10)
Initialization/interpreter-multiple-10   26.00 ± 0%   25.00 ± 0%  -3.85% (p=0.000 n=10)
Initialization/compiler-10               26.00 ± 0%   25.00 ± 0%  -3.85% (p=0.000 n=10)
Initialization/compiler-multiple-10      26.00 ± 0%   25.00 ± 0%  -3.85% (p=0.000 n=10)
geomean                                  26.00        25.00       -3.85%

```