### PR TITLE
wasm: reduces allocs during import resolution

### DIFF
--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -302,6 +302,9 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 			{Body: []byte{wasm.OpcodeCall, 0, wasm.OpcodeEnd}},
 		},
 		ImportSection: []wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 1}},
+		ImportPerModule: map[string][]*wasm.Import{
+			hostModuleName: {{Module: hostModuleName, Name: hostFnName, DescFunc: 1}},
+		},
 		ExportSection: []wasm.Export{
 			{Type: wasm.ExternTypeFunc, Index: 1, Name: stackCorruption},
 			{Type: wasm.ExternTypeFunc, Index: 2, Name: callStackCorruption},

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -95,8 +95,9 @@ func RunTestEngine_MemoryGrowInRecursiveCall(t *testing.T, et EngineTester) {
 				Body: []byte{wasm.OpcodeI32Const, 1, wasm.OpcodeMemoryGrow, wasm.OpcodeDrop, wasm.OpcodeEnd},
 			},
 		},
-		MemorySection: &wasm.Memory{Max: 1000},
-		ImportSection: []wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 0}},
+		MemorySection:   &wasm.Memory{Max: 1000},
+		ImportSection:   []wasm.Import{{Module: hostModuleName, Name: hostFnName, DescFunc: 0}},
+		ImportPerModule: map[string][]*wasm.Import{hostModuleName: {{Module: hostModuleName, Name: hostFnName, DescFunc: 0}}},
 	}
 	m.BuildFunctionDefinitions()
 	m.BuildMemoryDefinitions()

--- a/internal/wasm/binary/decoder.go
+++ b/internal/wasm/binary/decoder.go
@@ -106,7 +106,7 @@ func DecodeModule(
 		case wasm.SectionIDType:
 			m.TypeSection, err = decodeTypeSection(enabledFeatures, r)
 		case wasm.SectionIDImport:
-			m.ImportSection, m.ImportFunctionCount, m.ImportGlobalCount, m.ImportMemoryCount, m.ImportTableCount, err = decodeImportSection(r, memSizer, memoryLimitPages, enabledFeatures)
+			m.ImportSection, m.ImportPerModule, m.ImportFunctionCount, m.ImportGlobalCount, m.ImportMemoryCount, m.ImportTableCount, err = decodeImportSection(r, memSizer, memoryLimitPages, enabledFeatures)
 			if err != nil {
 				return nil, err // avoid re-wrapping the error.
 			}

--- a/internal/wasm/binary/decoder_test.go
+++ b/internal/wasm/binary/decoder_test.go
@@ -52,38 +52,45 @@ func TestDecodeModule(t *testing.T) {
 				ImportSection: []wasm.Import{
 					{
 						Module: "Math", Name: "Mul",
-						Type:     wasm.ExternTypeFunc,
-						DescFunc: 1,
+						Type:         wasm.ExternTypeFunc,
+						DescFunc:     1,
+						IndexPerType: 0,
 					},
 					{
 						Module: "foo", Name: "bar",
-						Type:      wasm.ExternTypeTable,
-						DescTable: wasm.Table{Type: wasm.ValueTypeFuncref},
+						Type:         wasm.ExternTypeTable,
+						DescTable:    wasm.Table{Type: wasm.ValueTypeFuncref},
+						IndexPerType: 0,
 					},
 					{
 						Module: "Math", Name: "Add",
-						Type:     wasm.ExternTypeFunc,
-						DescFunc: 0,
+						Type:         wasm.ExternTypeFunc,
+						DescFunc:     0,
+						IndexPerType: 1,
 					},
 					{
 						Module: "bar", Name: "mem",
-						Type:    wasm.ExternTypeMemory,
-						DescMem: &wasm.Memory{IsMaxEncoded: true},
+						Type:         wasm.ExternTypeMemory,
+						DescMem:      &wasm.Memory{IsMaxEncoded: true},
+						IndexPerType: 0,
 					},
 					{
 						Module: "foo", Name: "bar2",
-						Type:       wasm.ExternTypeGlobal,
-						DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeI32},
+						Type:         wasm.ExternTypeGlobal,
+						DescGlobal:   wasm.GlobalType{ValType: wasm.ValueTypeI32},
+						IndexPerType: 0,
 					},
 					{
 						Module: "foo", Name: "bar3",
-						Type:       wasm.ExternTypeGlobal,
-						DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeI32},
+						Type:         wasm.ExternTypeGlobal,
+						DescGlobal:   wasm.GlobalType{ValType: wasm.ValueTypeI32},
+						IndexPerType: 1,
 					},
 					{
 						Module: "foo", Name: "bar4",
-						Type:       wasm.ExternTypeGlobal,
-						DescGlobal: wasm.GlobalType{ValType: wasm.ValueTypeI32},
+						Type:         wasm.ExternTypeGlobal,
+						DescGlobal:   wasm.GlobalType{ValType: wasm.ValueTypeI32},
+						IndexPerType: 2,
 					},
 				},
 			},
@@ -120,6 +127,14 @@ func TestDecodeModule(t *testing.T) {
 			for i := range tc.input.TypeSection {
 				tp := &(tc.input.TypeSection)[i]
 				_ = tp.String()
+			}
+			if len(tc.input.ImportSection) > 0 {
+				expImportPerModule := make(map[string][]*wasm.Import)
+				for i := range m.ImportSection {
+					imp := &m.ImportSection[i]
+					expImportPerModule[imp.Module] = append(expImportPerModule[imp.Module], imp)
+				}
+				tc.input.ImportPerModule = expImportPerModule
 			}
 			require.Equal(t, tc.input, m)
 		})

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -33,7 +33,8 @@ func decodeImportSection(
 	enabledFeatures api.CoreFeatures,
 ) (result []wasm.Import,
 	perModule map[string][]*wasm.Import,
-	funcCount, globalCount, memoryCount, tableCount wasm.Index, err error) {
+	funcCount, globalCount, memoryCount, tableCount wasm.Index, err error,
+) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		err = fmt.Errorf("get size of vector: %w", err)

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -49,12 +49,16 @@ func decodeImportSection(
 		}
 		switch imp.Type {
 		case wasm.ExternTypeFunc:
+			imp.IndexPerType = funcCount
 			funcCount++
 		case wasm.ExternTypeGlobal:
+			imp.IndexPerType = globalCount
 			globalCount++
 		case wasm.ExternTypeMemory:
+			imp.IndexPerType = memoryCount
 			memoryCount++
 		case wasm.ExternTypeTable:
+			imp.IndexPerType = tableCount
 			tableCount++
 		}
 		perModule[imp.Module] = append(perModule[imp.Module], imp)

--- a/internal/wasm/binary/section.go
+++ b/internal/wasm/binary/section.go
@@ -31,13 +31,16 @@ func decodeImportSection(
 	memorySizer memorySizer,
 	memoryLimitPages uint32,
 	enabledFeatures api.CoreFeatures,
-) (result []wasm.Import, funcCount, globalCount, memoryCount, tableCount wasm.Index, err error) {
+) (result []wasm.Import,
+	perModule map[string][]*wasm.Import,
+	funcCount, globalCount, memoryCount, tableCount wasm.Index, err error) {
 	vs, _, err := leb128.DecodeUint32(r)
 	if err != nil {
 		err = fmt.Errorf("get size of vector: %w", err)
 		return
 	}
 
+	perModule = make(map[string][]*wasm.Import)
 	result = make([]wasm.Import, vs)
 	for i := uint32(0); i < vs; i++ {
 		imp := &result[i]
@@ -54,6 +57,7 @@ func decodeImportSection(
 		case wasm.ExternTypeTable:
 			tableCount++
 		}
+		perModule[imp.Module] = append(perModule[imp.Module], imp)
 	}
 	return
 }

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -48,6 +48,7 @@ type Module struct {
 	ImportGlobalCount,
 	ImportMemoryCount,
 	ImportTableCount Index
+	ImportPerModule map[string][]*Import
 
 	// FunctionSection contains the index in TypeSection of each function defined in this module.
 	//

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -48,6 +48,8 @@ type Module struct {
 	ImportGlobalCount,
 	ImportMemoryCount,
 	ImportTableCount Index
+	// ImportPerModule maps a module name to the list of Import to be imported from the module.
+	// This is used to do fast import resolution during instantiation.
 	ImportPerModule map[string][]*Import
 
 	// FunctionSection contains the index in TypeSection of each function defined in this module.

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -719,6 +719,8 @@ type Import struct {
 	DescMem *Memory
 	// DescGlobal is the inlined GlobalType when Type equals ExternTypeGlobal
 	DescGlobal GlobalType
+	// IndexPerType has the index of this import per ExternType.
+	IndexPerType Index
 }
 
 // Memory describes the limits of pages (64KB) in a memory.

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -360,7 +360,6 @@ func (s *Store) instantiate(
 }
 
 func (m *ModuleInstance) resolveImports(module *Module) (err error) {
-	var fs, gs, tables Index
 	for moduleName, imports := range module.ImportPerModule {
 		var importedModule *ModuleInstance
 		importedModule, err = m.s.module(moduleName)
@@ -384,8 +383,7 @@ func (m *ModuleInstance) resolveImports(module *Module) (err error) {
 					return
 				}
 
-				m.Engine.ResolveImportedFunction(fs, imported.Index, importedModule.Engine)
-				fs++
+				m.Engine.ResolveImportedFunction(i.IndexPerType, imported.Index, importedModule.Engine)
 			case ExternTypeTable:
 				expected := i.DescTable
 				importedTable := importedModule.Tables[imported.Index]
@@ -410,8 +408,7 @@ func (m *ModuleInstance) resolveImports(module *Module) (err error) {
 						return
 					}
 				}
-				m.Tables[tables] = importedTable
-				tables++
+				m.Tables[i.IndexPerType] = importedTable
 			case ExternTypeMemory:
 				expected := i.DescMem
 				importedMemory := importedModule.MemoryInstance
@@ -441,8 +438,7 @@ func (m *ModuleInstance) resolveImports(module *Module) (err error) {
 						ValueTypeName(expected.ValType), ValueTypeName(importedGlobal.Type.ValType)))
 					return
 				}
-				m.Globals[gs] = importedGlobal
-				gs++
+				m.Globals[i.IndexPerType] = importedGlobal
 			}
 		}
 	}

--- a/internal/wasm/store_module_list.go
+++ b/internal/wasm/store_module_list.go
@@ -39,30 +39,9 @@ func (s *Store) module(moduleName string) (*ModuleInstance, error) {
 	defer s.mux.RUnlock()
 	m, ok := s.nameToModule[moduleName]
 	if !ok {
-		return nil, fmt.Errorf("module[%s] not in store", moduleName)
-	}
-
-	if m == nil {
-		return nil, fmt.Errorf("module[%s] not set in store", moduleName)
+		return nil, fmt.Errorf("module[%s] not instantiated", moduleName)
 	}
 	return m, nil
-}
-
-// requireModules returns all instantiated modules whose names equal the keys in the input, or errs if any are missing.
-func (s *Store) requireModules(moduleNames map[string]struct{}) (map[string]*ModuleInstance, error) {
-	ret := make(map[string]*ModuleInstance, len(moduleNames))
-
-	s.mux.RLock()
-	defer s.mux.RUnlock()
-
-	for n := range moduleNames {
-		module, ok := s.nameToModule[n]
-		if !ok {
-			return nil, fmt.Errorf("module[%s] not instantiated", n)
-		}
-		ret[n] = module
-	}
-	return ret, nil
 }
 
 // registerModule registers a ModuleInstance into the store.

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -102,29 +102,6 @@ func TestStore_module(t *testing.T) {
 	})
 }
 
-func TestStore_requireModules(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
-		s, m1, _ := newTestStore()
-
-		modules, err := s.requireModules(map[string]struct{}{m1.ModuleName: {}})
-		require.NoError(t, err)
-		require.Equal(t, map[string]*ModuleInstance{m1.ModuleName: m1}, modules)
-	})
-	t.Run("module not instantiated", func(t *testing.T) {
-		s, _, _ := newTestStore()
-
-		_, err := s.requireModules(map[string]struct{}{"unknown": {}})
-		require.EqualError(t, err, "module[unknown] not instantiated")
-	})
-	t.Run("store closed", func(t *testing.T) {
-		s, _, _ := newTestStore()
-		require.NoError(t, s.CloseWithExitCode(context.Background(), 0))
-
-		_, err := s.requireModules(map[string]struct{}{"unknown": {}})
-		require.Error(t, err)
-	})
-}
-
 func TestStore_AliasModule(t *testing.T) {
 	s := newStore()
 	m1 := &ModuleInstance{ModuleName: "m1"}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -657,7 +657,6 @@ func Test_resolveImports(t *testing.T) {
 	const name = "target"
 
 	t.Run("module not instantiated", func(t *testing.T) {
-		// modules := map[string]*ModuleInstance{}
 		m := &ModuleInstance{s: newStore()}
 		err := m.resolveImports(&Module{ImportPerModule: map[string][]*Import{"unknown": {{}}}})
 		require.EqualError(t, err, "module[unknown] not instantiated")

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -692,8 +692,8 @@ func Test_resolveImports(t *testing.T) {
 				},
 				ImportPerModule: map[string][]*Import{
 					moduleName: {
-						{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 0},
-						{Module: moduleName, Name: "", Type: ExternTypeFunc, DescFunc: 1},
+						{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 0, IndexPerType: 0},
+						{Module: moduleName, Name: "", Type: ExternTypeFunc, DescFunc: 1, IndexPerType: 1},
 					},
 				},
 			}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -657,7 +657,7 @@ func Test_resolveImports(t *testing.T) {
 	const name = "target"
 
 	t.Run("module not instantiated", func(t *testing.T) {
-		//modules := map[string]*ModuleInstance{}
+		// modules := map[string]*ModuleInstance{}
 		m := &ModuleInstance{s: newStore()}
 		err := m.resolveImports(&Module{ImportPerModule: map[string][]*Import{"unknown": {{}}}})
 		require.EqualError(t, err, "module[unknown] not instantiated")
@@ -765,7 +765,8 @@ func Test_resolveImports(t *testing.T) {
 		})
 		t.Run("type mismatch", func(t *testing.T) {
 			s := newStore()
-			s.nameToModule[moduleName] = &ModuleInstance{Globals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}}},
+			s.nameToModule[moduleName] = &ModuleInstance{
+				Globals: []*GlobalInstance{{Type: GlobalType{ValType: ValueTypeI32}}},
 				Exports: map[string]*Export{name: {
 					Type:  ExternTypeGlobal,
 					Index: 0,


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                       │   old.txt   │              new.txt               │
                                       │   sec/op    │   sec/op     vs base               │
Initialization/interpreter-10            14.48µ ± 0%   14.23µ ± 1%  -1.76% (p=0.000 n=30)
Initialization/interpreter-multiple-10   17.90µ ± 5%   17.82µ ± 2%       ~ (p=0.139 n=30)
Initialization/compiler-10               16.69µ ± 1%   15.87µ ± 1%  -4.89% (p=0.000 n=30)
Initialization/compiler-multiple-10      19.53µ ± 1%   18.73µ ± 1%  -4.10% (p=0.000 n=30)
geomean                                  17.05µ        16.57µ       -2.83%

                                       │   old.txt    │               new.txt               │
                                       │     B/op     │     B/op      vs base               │
Initialization/interpreter-10            132.5Ki ± 0%   132.3Ki ± 0%  -0.19% (p=0.000 n=30)
Initialization/interpreter-multiple-10   132.6Ki ± 0%   132.3Ki ± 0%  -0.19% (p=0.000 n=30)
Initialization/compiler-10               132.5Ki ± 0%   132.3Ki ± 0%  -0.19% (p=0.000 n=30)
Initialization/compiler-multiple-10      132.6Ki ± 0%   132.3Ki ± 0%  -0.19% (p=0.000 n=30)
geomean                                  132.6Ki        132.3Ki       -0.19%

                                       │  old.txt   │              new.txt              │
                                       │ allocs/op  │ allocs/op   vs base               │
Initialization/interpreter-10            25.00 ± 0%   23.00 ± 0%  -8.00% (p=0.000 n=30)
Initialization/interpreter-multiple-10   25.00 ± 0%   23.00 ± 0%  -8.00% (p=0.000 n=30)
Initialization/compiler-10               25.00 ± 0%   23.00 ± 0%  -8.00% (p=0.000 n=30)
Initialization/compiler-multiple-10      25.00 ± 0%   23.00 ± 0%  -8.00% (p=0.000 n=30)
geomean                                  25.00        23.00       -8.00%

```