### PR TITLE
Cleanup aliased modules when the main module is deleted

### DIFF
--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -119,6 +119,11 @@ type (
 		s *Store
 		// prev and next hold the nodes in the linked list of ModuleInstance held by Store.
 		prev, next *ModuleInstance
+		// aliases holds the module names that are aliases of this module registered in the store.
+		// Access to this field must be guarded by s.mux.
+		//
+		// Note: This is currently only used for spectests and will be nil in most cases.
+		aliases []string
 		// Definitions is derived from *Module, and is constructed during compilation phrase.
 		Definitions []FunctionDefinition
 	}

--- a/internal/wasm/store_module_list_test.go
+++ b/internal/wasm/store_module_list_test.go
@@ -108,16 +108,27 @@ func TestStore_module(t *testing.T) {
 }
 
 func TestStore_AliasModule(t *testing.T) {
-	s := newStore()
-	m1 := &ModuleInstance{ModuleName: "m1"}
-	s.nameToModule[m1.ModuleName] = m1
-
 	t.Run("alias module", func(t *testing.T) {
+		s := newStore()
+		m1 := &ModuleInstance{ModuleName: "m1"}
+		s.nameToModule[m1.ModuleName] = m1
+
 		require.NoError(t, s.AliasModule("m1", "m2"))
 		require.Equal(t, map[string]*ModuleInstance{"m1": m1, "m2": m1}, s.nameToModule)
 		// Doesn't affect module names
 		require.Nil(t, s.moduleList)
 		require.Equal(t, nameToModuleShrinkThreshold, s.nameToModuleCap)
+	})
+
+	t.Run("delete aliased module", func(t *testing.T) {
+		s := newStore()
+		m1 := &ModuleInstance{ModuleName: "m1"}
+		s.nameToModule[m1.ModuleName] = m1
+
+		require.NoError(t, s.AliasModule("m1", "m2"))
+		require.NoError(t, s.deleteModule(m1))
+		_, ok := s.nameToModule["m2"]
+		require.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
When a module is deleted which has been aliased, the aliases are not cleaned up meaning the original module will be closed and unusable but never get GC'd. I understand that aliases are currently only used in spect tests however `*store.AliasModule` is an exported method covered by tests so it feels right to fix the bug. This fix should have almost no meaningful impact to normal uses as `Module.aliases` will remain `nil` for all modules if no aliases are ever created.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                       │   old.txt    │               new.txt                │
                                       │    sec/op    │    sec/op     vs base                │
Initialization/interpreter-10            10.94µ ± ∞ ¹   10.84µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/interpreter-multiple-10   9.698µ ± ∞ ¹   9.356µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/compiler-10               10.52µ ± ∞ ¹   10.42µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/compiler-multiple-10      10.59µ ± ∞ ¹   11.07µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                  10.42µ         10.40µ        -0.26%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                       │    old.txt    │                new.txt                │
                                       │     B/op      │     B/op       vs base                │
Initialization/interpreter-10            132.3Ki ± ∞ ¹   132.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/interpreter-multiple-10   132.3Ki ± ∞ ¹   132.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/compiler-10               132.3Ki ± ∞ ¹   132.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/compiler-multiple-10      132.3Ki ± ∞ ¹   132.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                  132.3Ki         132.3Ki        +0.02%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                       │   old.txt   │               new.txt               │
                                       │  allocs/op  │  allocs/op   vs base                │
Initialization/interpreter-10            23.00 ± ∞ ¹   23.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/interpreter-multiple-10   23.00 ± ∞ ¹   23.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/compiler-10               23.00 ± ∞ ¹   23.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
Initialization/compiler-multiple-10      23.00 ± ∞ ¹   23.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                  23.00         23.00        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```