### PR TITLE
Makes host function index insertion order

### DIFF
--- a/imports/assemblyscript/assemblyscript.go
+++ b/imports/assemblyscript/assemblyscript.go
@@ -138,11 +138,11 @@ func (e *functionExporter) ExportFunctions(builder wazero.HostModuleBuilder) {
 //
 // See https://github.com/AssemblyScript/assemblyscript/blob/v0.26.7/std/assembly/builtins.ts#L2508
 var abortMessageEnabled = &wasm.HostFunc{
-	ExportNames: []string{AbortName},
-	Name:        "~lib/builtins/abort",
-	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
-	ParamNames:  []string{"message", "fileName", "lineNumber", "columnNumber"},
-	Code:        wasm.Code{GoFunc: api.GoModuleFunc(abortWithMessage)},
+	ExportName: AbortName,
+	Name:       "~lib/builtins/abort",
+	ParamTypes: []api.ValueType{i32, i32, i32, i32},
+	ParamNames: []string{"message", "fileName", "lineNumber", "columnNumber"},
+	Code:       wasm.Code{GoFunc: api.GoModuleFunc(abortWithMessage)},
 }
 
 var abortMessageDisabled = abortMessageEnabled.WithGoModuleFunc(abort)
@@ -185,10 +185,10 @@ var traceDisabled = traceStdout.WithGoModuleFunc(func(context.Context, api.Modul
 
 // traceStdout implements trace to the configured Stdout.
 var traceStdout = &wasm.HostFunc{
-	ExportNames: []string{TraceName},
-	Name:        "~lib/builtins/trace",
-	ParamTypes:  []api.ValueType{i32, i32, f64, f64, f64, f64, f64},
-	ParamNames:  []string{"message", "nArgs", "arg0", "arg1", "arg2", "arg3", "arg4"},
+	ExportName: TraceName,
+	Name:       "~lib/builtins/trace",
+	ParamTypes: []api.ValueType{i32, i32, f64, f64, f64, f64, f64},
+	ParamNames: []string{"message", "nArgs", "arg0", "arg1", "arg2", "arg3", "arg4"},
 	Code: wasm.Code{
 		GoFunc: api.GoModuleFunc(func(_ context.Context, mod api.Module, stack []uint64) {
 			fsc := mod.(*wasm.ModuleInstance).Sys.FS()
@@ -270,7 +270,7 @@ func formatFloat(f float64) string {
 //
 // See https://github.com/AssemblyScript/assemblyscript/blob/v0.26.7/std/assembly/builtins.ts#L2531
 var seed = &wasm.HostFunc{
-	ExportNames: []string{SeedName},
+	ExportName:  SeedName,
 	Name:        "~lib/builtins/seed",
 	ResultTypes: []api.ValueType{f64},
 	ResultNames: []string{"rand"},

--- a/imports/emscripten/emscripten.go
+++ b/imports/emscripten/emscripten.go
@@ -94,11 +94,10 @@ func (functionExporter) ExportFunctions(builder wazero.HostModuleBuilder) {
 const functionNotifyMemoryGrowth = "emscripten_notify_memory_growth"
 
 var notifyMemoryGrowth = &wasm.HostFunc{
-	ExportNames: []string{functionNotifyMemoryGrowth},
-	Name:        functionNotifyMemoryGrowth,
-	ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
-	ParamNames:  []string{"memory_index"},
-	Code:        wasm.Code{GoFunc: api.GoModuleFunc(func(context.Context, api.Module, []uint64) {})},
+	ExportName: functionNotifyMemoryGrowth,
+	ParamTypes: []wasm.ValueType{wasm.ValueTypeI32},
+	ParamNames: []string{"memory_index"},
+	Code:       wasm.Code{GoFunc: api.GoModuleFunc(func(context.Context, api.Module, []uint64) {})},
 }
 
 // All `invoke_` functions have an initial "index" parameter of
@@ -134,8 +133,7 @@ const (
 )
 
 var invokeI = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeI},
-	Name:        functionInvokeI,
+	ExportName:  functionInvokeI,
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"index"},
 	ResultTypes: []api.ValueType{i32},
@@ -151,8 +149,7 @@ func invokeIFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeIi = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeIi},
-	Name:        functionInvokeIi,
+	ExportName:  functionInvokeIi,
 	ParamTypes:  []api.ValueType{i32, i32},
 	ParamNames:  []string{"index", "a1"},
 	ResultTypes: []api.ValueType{i32},
@@ -168,8 +165,7 @@ func invokeIiFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeIii = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeIii},
-	Name:        functionInvokeIii,
+	ExportName:  functionInvokeIii,
 	ParamTypes:  []api.ValueType{i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2"},
 	ResultTypes: []api.ValueType{i32},
@@ -185,8 +181,7 @@ func invokeIiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeIiii = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeIiii},
-	Name:        functionInvokeIiii,
+	ExportName:  functionInvokeIiii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3"},
 	ResultTypes: []api.ValueType{i32},
@@ -202,8 +197,7 @@ func invokeIiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeIiiii = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeIiiii},
-	Name:        functionInvokeIiiii,
+	ExportName:  functionInvokeIiiii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 	ResultTypes: []api.ValueType{i32},
@@ -219,8 +213,7 @@ func invokeIiiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeV = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeV},
-	Name:        functionInvokeV,
+	ExportName:  functionInvokeV,
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"index"},
 	ResultTypes: []api.ValueType{},
@@ -235,8 +228,7 @@ func invokeVFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeVi = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeVi},
-	Name:        functionInvokeVi,
+	ExportName:  functionInvokeVi,
 	ParamTypes:  []api.ValueType{i32, i32},
 	ParamNames:  []string{"index", "a1"},
 	ResultTypes: []api.ValueType{},
@@ -251,8 +243,7 @@ func invokeViFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeVii = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeVii},
-	Name:        functionInvokeVii,
+	ExportName:  functionInvokeVii,
 	ParamTypes:  []api.ValueType{i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2"},
 	ResultTypes: []api.ValueType{},
@@ -267,8 +258,7 @@ func invokeViiFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeViii = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeViii},
-	Name:        functionInvokeViii,
+	ExportName:  functionInvokeViii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3"},
 	ResultTypes: []api.ValueType{},
@@ -283,8 +273,7 @@ func invokeViiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 var invokeViiii = &wasm.HostFunc{
-	ExportNames: []string{functionInvokeViiii},
-	Name:        functionInvokeViiii,
+	ExportName:  functionInvokeViiii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 	ResultTypes: []api.ValueType{},

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -19,13 +19,10 @@ import (
 //
 // See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 var procExit = &wasm.HostFunc{
-	ExportNames: []string{wasip1.ProcExitName},
-	Name:        wasip1.ProcExitName,
-	ParamTypes:  []api.ValueType{i32},
-	ParamNames:  []string{"rval"},
-	Code: wasm.Code{
-		GoFunc: api.GoModuleFunc(procExitFn),
-	},
+	ExportName: wasip1.ProcExitName,
+	ParamTypes: []api.ValueType{i32},
+	ParamNames: []string{"rval"},
+	Code:       wasm.Code{GoFunc: api.GoModuleFunc(procExitFn)},
 }
 
 func procExitFn(ctx context.Context, mod api.Module, params []uint64) {

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -263,8 +263,7 @@ func newHostFunc(
 	paramNames ...string,
 ) *wasm.HostFunc {
 	return &wasm.HostFunc{
-		ExportNames: []string{name},
-		Name:        name,
+		ExportName:  name,
 		ParamTypes:  paramTypes,
 		ParamNames:  paramNames,
 		ResultTypes: []api.ValueType{i32},
@@ -291,8 +290,7 @@ func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
 // stubFunction stubs for GrainLang per #271.
 func stubFunction(name string, paramTypes []wasm.ValueType, paramNames ...string) *wasm.HostFunc {
 	return &wasm.HostFunc{
-		Name:        name,
-		ExportNames: []string{name},
+		ExportName:  name,
 		ParamTypes:  paramTypes,
 		ParamNames:  paramNames,
 		ResultTypes: []api.ValueType{i32},

--- a/internal/gojs/goarch/wasm.go
+++ b/internal/gojs/goarch/wasm.go
@@ -16,11 +16,10 @@ import (
 // This traps (unreachable opcode) to ensure the function is never called.
 func StubFunction(name string) *wasm.HostFunc {
 	return &wasm.HostFunc{
-		ExportNames: []string{name},
-		Name:        name,
-		ParamTypes:  []wasm.ValueType{wasm.ValueTypeI32},
-		ParamNames:  []string{"sp"},
-		Code:        wasm.Code{GoFunc: api.GoModuleFunc(func(ctx context.Context, _ api.Module, stack []uint64) {})},
+		ExportName: name,
+		ParamTypes: []wasm.ValueType{wasm.ValueTypeI32},
+		ParamNames: []string{"sp"},
+		Code:       wasm.Code{GoFunc: api.GoModuleFunc(func(ctx context.Context, _ api.Module, stack []uint64) {})},
 	}
 }
 

--- a/internal/gojs/util/util.go
+++ b/internal/gojs/util/util.go
@@ -38,11 +38,10 @@ func MustRead(mem api.Memory, funcName string, paramIdx int, offset, byteCount u
 
 func NewFunc(name string, goFunc api.GoModuleFunc) *wasm.HostFunc {
 	return &wasm.HostFunc{
-		ExportNames: []string{name},
-		Name:        name,
-		ParamTypes:  []api.ValueType{api.ValueTypeI32},
-		ParamNames:  []string{"sp"},
-		Code:        wasm.Code{GoFunc: goFunc},
+		ExportName: name,
+		ParamTypes: []api.ValueType{api.ValueTypeI32},
+		ParamNames: []string{"sp"},
+		Code:       wasm.Code{GoFunc: goFunc},
 	}
 }
 

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -3,7 +3,6 @@ package wasm
 import (
 	"errors"
 	"fmt"
-	"sort"
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
@@ -16,8 +15,8 @@ type HostFuncExporter interface {
 // HostFunc is a function with an inlined type, used for NewHostModule.
 // Any corresponding FunctionType will be reused or added to the Module.
 type HostFunc struct {
-	// ExportNames is equivalent to the same method on api.FunctionDefinition.
-	ExportNames []string
+	// ExportName is the only value returned by api.FunctionDefinition.
+	ExportName string
 
 	// Name is equivalent to the same method on api.FunctionDefinition.
 	Name string
@@ -45,17 +44,11 @@ func (f *HostFunc) WithGoModuleFunc(fn api.GoModuleFunc) *HostFunc {
 	return &ret
 }
 
-type HostFuncNames struct {
-	Name        string
-	ParamNames  []string
-	ResultNames []string
-}
-
 // NewHostModule is defined internally for use in WASI tests and to keep the code size in the root directory small.
 func NewHostModule(
 	moduleName string,
-	nameToGoFunc map[string]interface{},
-	funcToNames map[string]*HostFuncNames,
+	exportNames []string,
+	nameToHostFunc map[string]*HostFunc,
 	enabledFeatures api.CoreFeatures,
 ) (m *Module, err error) {
 	if moduleName != "" {
@@ -64,10 +57,10 @@ func NewHostModule(
 		return nil, errors.New("a module name must not be empty")
 	}
 
-	if exportCount := uint32(len(nameToGoFunc)); exportCount > 0 {
+	if exportCount := uint32(len(nameToHostFunc)); exportCount > 0 {
 		m.ExportSection = make([]Export, 0, exportCount)
 		m.Exports = make(map[string]*Export, exportCount)
-		if err = addFuncs(m, nameToGoFunc, funcToNames, enabledFeatures); err != nil {
+		if err = addFuncs(m, exportNames, nameToHostFunc, enabledFeatures); err != nil {
 			return
 		}
 	}
@@ -85,73 +78,55 @@ func NewHostModule(
 
 func addFuncs(
 	m *Module,
-	nameToGoFunc map[string]interface{},
-	funcToNames map[string]*HostFuncNames,
+	exportNames []string,
+	nameToHostFunc map[string]*HostFunc,
 	enabledFeatures api.CoreFeatures,
 ) (err error) {
 	if m.NameSection == nil {
 		m.NameSection = &NameSection{}
 	}
 	moduleName := m.NameSection.ModuleName
-	nameToFunc := make(map[string]*HostFunc, len(nameToGoFunc))
-	sortedExportNames := make([]string, len(nameToFunc))
-	for k := range nameToGoFunc {
-		sortedExportNames = append(sortedExportNames, k)
-	}
 
-	// Sort names for consistent iteration
-	sort.Strings(sortedExportNames)
+	for _, k := range exportNames {
+		hf := nameToHostFunc[k]
+		if hf.Name == "" {
+			hf.Name = k // default name to export name
+		}
+		switch hf.Code.GoFunc.(type) {
+		case api.GoModuleFunction, api.GoFunction:
+			continue // already parsed
+		}
 
-	funcNames := make([]string, len(nameToFunc))
-	for _, k := range sortedExportNames {
-		v := nameToGoFunc[k]
-		if hf, ok := v.(*HostFunc); ok {
-			nameToFunc[hf.Name] = hf
-			funcNames = append(funcNames, hf.Name)
-		} else { // reflection
-			params, results, code, ftErr := parseGoReflectFunc(v)
-			if ftErr != nil {
-				return fmt.Errorf("func[%s.%s] %w", moduleName, k, ftErr)
-			}
-			hf = &HostFunc{
-				ExportNames: []string{k},
-				Name:        k,
-				ParamTypes:  params,
-				ResultTypes: results,
-				Code:        code,
-			}
+		// Resolve the code using reflection
+		hf.ParamTypes, hf.ResultTypes, hf.Code, err = parseGoReflectFunc(hf.Code.GoFunc)
+		if err != nil {
+			return fmt.Errorf("func[%s.%s] %w", moduleName, k, err)
+		}
 
-			// Assign names to the function, if they exist.
-			ns := funcToNames[k]
-			if name := ns.Name; name != "" {
-				hf.Name = ns.Name
+		// Assign names to the function, if they exist.
+		params := hf.ParamTypes
+		if paramNames := hf.ParamNames; paramNames != nil {
+			if paramNamesLen := len(paramNames); paramNamesLen != len(params) {
+				return fmt.Errorf("func[%s.%s] has %d params, but %d params names", moduleName, k, paramNamesLen, len(params))
 			}
-			if paramNames := ns.ParamNames; paramNames != nil {
-				if paramNamesLen := len(paramNames); paramNamesLen != len(params) {
-					return fmt.Errorf("func[%s.%s] has %d params, but %d params names", moduleName, k, paramNamesLen, len(params))
-				}
-				hf.ParamNames = paramNames
-			}
-			if resultNames := ns.ResultNames; resultNames != nil {
-				if resultNamesLen := len(resultNames); resultNamesLen != len(results) {
-					return fmt.Errorf("func[%s.%s] has %d results, but %d results names", moduleName, k, resultNamesLen, len(results))
-				}
-				hf.ResultNames = resultNames
-			}
+		}
 
-			nameToFunc[k] = hf
-			funcNames = append(funcNames, k)
+		results := hf.ResultTypes
+		if resultNames := hf.ResultNames; resultNames != nil {
+			if resultNamesLen := len(resultNames); resultNamesLen != len(results) {
+				return fmt.Errorf("func[%s.%s] has %d results, but %d results names", moduleName, k, resultNamesLen, len(results))
+			}
 		}
 	}
 
-	funcCount := uint32(len(nameToFunc))
+	funcCount := uint32(len(exportNames))
 	m.NameSection.FunctionNames = make([]NameAssoc, 0, funcCount)
 	m.FunctionSection = make([]Index, 0, funcCount)
 	m.CodeSection = make([]Code, 0, funcCount)
 
 	idx := Index(0)
-	for _, name := range funcNames {
-		hf := nameToFunc[name]
+	for _, name := range exportNames {
+		hf := nameToHostFunc[name]
 		debugName := wasmdebug.FuncName(moduleName, name, idx)
 		typeIdx, typeErr := m.maybeAddType(hf.ParamTypes, hf.ResultTypes, enabledFeatures)
 		if typeErr != nil {
@@ -159,10 +134,10 @@ func addFuncs(
 		}
 		m.FunctionSection = append(m.FunctionSection, typeIdx)
 		m.CodeSection = append(m.CodeSection, hf.Code)
-		for _, export := range hf.ExportNames {
-			m.ExportSection = append(m.ExportSection, Export{Type: ExternTypeFunc, Name: export, Index: idx})
-			m.Exports[export] = &m.ExportSection[len(m.ExportSection)-1]
-		}
+
+		export := hf.ExportName
+		m.ExportSection = append(m.ExportSection, Export{Type: ExternTypeFunc, Name: export, Index: idx})
+		m.Exports[export] = &m.ExportSection[len(m.ExportSection)-1]
 		m.NameSection.FunctionNames = append(m.NameSection.FunctionNames, NameAssoc{Index: idx, Name: hf.Name})
 
 		if len(hf.ParamNames) > 0 {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -105,7 +105,12 @@ func TestNewStore(t *testing.T) {
 
 func TestStore_Instantiate(t *testing.T) {
 	s := newStore()
-	m, err := NewHostModule("foo", map[string]interface{}{"fn": func() {}}, map[string]*HostFuncNames{"fn": {}}, api.CoreFeaturesV1)
+	m, err := NewHostModule(
+		"foo",
+		[]string{"fn"},
+		map[string]*HostFunc{"fn": {ExportName: "fn", Code: Code{GoFunc: func() {}}}},
+		api.CoreFeaturesV1,
+	)
 	require.NoError(t, err)
 
 	sysCtx := sys.DefaultContext(nil)
@@ -184,7 +189,12 @@ func TestStore_CloseWithExitCode(t *testing.T) {
 func TestStore_hammer(t *testing.T) {
 	const importedModuleName = "imported"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func() {}}, map[string]*HostFuncNames{"fn": {}}, api.CoreFeaturesV1)
+	m, err := NewHostModule(
+		importedModuleName,
+		[]string{"fn"},
+		map[string]*HostFunc{"fn": {ExportName: "fn", Code: Code{GoFunc: func() {}}}},
+		api.CoreFeaturesV1,
+	)
 	require.NoError(t, err)
 
 	s := newStore()
@@ -239,7 +249,12 @@ func TestStore_hammer(t *testing.T) {
 func TestStore_hammer_close(t *testing.T) {
 	const importedModuleName = "imported"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func() {}}, map[string]*HostFuncNames{"fn": {}}, api.CoreFeaturesV1)
+	m, err := NewHostModule(
+		importedModuleName,
+		[]string{"fn"},
+		map[string]*HostFunc{"fn": {ExportName: "fn", Code: Code{GoFunc: func() {}}}},
+		api.CoreFeaturesV1,
+	)
 	require.NoError(t, err)
 
 	s := newStore()
@@ -299,7 +314,12 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 	const importedModuleName = "imported"
 	const importingModuleName = "test"
 
-	m, err := NewHostModule(importedModuleName, map[string]interface{}{"fn": func() {}}, map[string]*HostFuncNames{"fn": {}}, api.CoreFeaturesV1)
+	m, err := NewHostModule(
+		importedModuleName,
+		[]string{"fn"},
+		map[string]*HostFunc{"fn": {ExportName: "fn", Code: Code{GoFunc: func() {}}}},
+		api.CoreFeaturesV1,
+	)
 	require.NoError(t, err)
 
 	t.Run("Fails if module name already in use", func(t *testing.T) {


### PR DESCRIPTION
This makes host functions index consistently on insertion order, rather than lexicographic order. This helps with ABI such as Emscripten, which need an expected order.

This also constrains the internal code around host functions to only one export name. More than one was never used. By restricting this, logic is simpler and smaller.