### PR TITLE
Fixes race where HostFunc names are needlessly lazy set

### DIFF
--- a/imports/emscripten/emscripten.go
+++ b/imports/emscripten/emscripten.go
@@ -95,6 +95,7 @@ const functionNotifyMemoryGrowth = "emscripten_notify_memory_growth"
 
 var notifyMemoryGrowth = &wasm.HostFunc{
 	ExportName: functionNotifyMemoryGrowth,
+	Name:       functionNotifyMemoryGrowth,
 	ParamTypes: []wasm.ValueType{wasm.ValueTypeI32},
 	ParamNames: []string{"memory_index"},
 	Code:       wasm.Code{GoFunc: api.GoModuleFunc(func(context.Context, api.Module, []uint64) {})},
@@ -134,6 +135,7 @@ const (
 
 var invokeI = &wasm.HostFunc{
 	ExportName:  functionInvokeI,
+	Name:        functionInvokeI,
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"index"},
 	ResultTypes: []api.ValueType{i32},
@@ -150,6 +152,7 @@ func invokeIFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeIi = &wasm.HostFunc{
 	ExportName:  functionInvokeIi,
+	Name:        functionInvokeIi,
 	ParamTypes:  []api.ValueType{i32, i32},
 	ParamNames:  []string{"index", "a1"},
 	ResultTypes: []api.ValueType{i32},
@@ -166,6 +169,7 @@ func invokeIiFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeIii = &wasm.HostFunc{
 	ExportName:  functionInvokeIii,
+	Name:        functionInvokeIii,
 	ParamTypes:  []api.ValueType{i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2"},
 	ResultTypes: []api.ValueType{i32},
@@ -182,6 +186,7 @@ func invokeIiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeIiii = &wasm.HostFunc{
 	ExportName:  functionInvokeIiii,
+	Name:        functionInvokeIiii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3"},
 	ResultTypes: []api.ValueType{i32},
@@ -198,6 +203,7 @@ func invokeIiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeIiiii = &wasm.HostFunc{
 	ExportName:  functionInvokeIiiii,
+	Name:        functionInvokeIiiii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 	ResultTypes: []api.ValueType{i32},
@@ -214,6 +220,7 @@ func invokeIiiiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeV = &wasm.HostFunc{
 	ExportName:  functionInvokeV,
+	Name:        functionInvokeV,
 	ParamTypes:  []api.ValueType{i32},
 	ParamNames:  []string{"index"},
 	ResultTypes: []api.ValueType{},
@@ -229,6 +236,7 @@ func invokeVFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeVi = &wasm.HostFunc{
 	ExportName:  functionInvokeVi,
+	Name:        functionInvokeVi,
 	ParamTypes:  []api.ValueType{i32, i32},
 	ParamNames:  []string{"index", "a1"},
 	ResultTypes: []api.ValueType{},
@@ -244,6 +252,7 @@ func invokeViFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeVii = &wasm.HostFunc{
 	ExportName:  functionInvokeVii,
+	Name:        functionInvokeVii,
 	ParamTypes:  []api.ValueType{i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2"},
 	ResultTypes: []api.ValueType{},
@@ -259,6 +268,7 @@ func invokeViiFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeViii = &wasm.HostFunc{
 	ExportName:  functionInvokeViii,
+	Name:        functionInvokeViii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3"},
 	ResultTypes: []api.ValueType{},
@@ -274,6 +284,7 @@ func invokeViiiFn(ctx context.Context, mod api.Module, stack []uint64) {
 
 var invokeViiii = &wasm.HostFunc{
 	ExportName:  functionInvokeViiii,
+	Name:        functionInvokeViiii,
 	ParamTypes:  []api.ValueType{i32, i32, i32, i32, i32},
 	ParamNames:  []string{"index", "a1", "a2", "a3", "a4"},
 	ResultTypes: []api.ValueType{},

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -20,6 +20,7 @@ import (
 // See https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#proc_exit
 var procExit = &wasm.HostFunc{
 	ExportName: wasip1.ProcExitName,
+	Name:       wasip1.ProcExitName,
 	ParamTypes: []api.ValueType{i32},
 	ParamNames: []string{"rval"},
 	Code:       wasm.Code{GoFunc: api.GoModuleFunc(procExitFn)},

--- a/imports/wasi_snapshot_preview1/wasi.go
+++ b/imports/wasi_snapshot_preview1/wasi.go
@@ -264,6 +264,7 @@ func newHostFunc(
 ) *wasm.HostFunc {
 	return &wasm.HostFunc{
 		ExportName:  name,
+		Name:        name,
 		ParamTypes:  paramTypes,
 		ParamNames:  paramNames,
 		ResultTypes: []api.ValueType{i32},
@@ -291,6 +292,7 @@ func (f wasiFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
 func stubFunction(name string, paramTypes []wasm.ValueType, paramNames ...string) *wasm.HostFunc {
 	return &wasm.HostFunc{
 		ExportName:  name,
+		Name:        name,
 		ParamTypes:  paramTypes,
 		ParamNames:  paramNames,
 		ResultTypes: []api.ValueType{i32},

--- a/internal/gojs/goarch/wasm.go
+++ b/internal/gojs/goarch/wasm.go
@@ -17,6 +17,7 @@ import (
 func StubFunction(name string) *wasm.HostFunc {
 	return &wasm.HostFunc{
 		ExportName: name,
+		Name:       name,
 		ParamTypes: []wasm.ValueType{wasm.ValueTypeI32},
 		ParamNames: []string{"sp"},
 		Code:       wasm.Code{GoFunc: api.GoModuleFunc(func(ctx context.Context, _ api.Module, stack []uint64) {})},

--- a/internal/gojs/util/util.go
+++ b/internal/gojs/util/util.go
@@ -39,6 +39,7 @@ func MustRead(mem api.Memory, funcName string, paramIdx int, offset, byteCount u
 func NewFunc(name string, goFunc api.GoModuleFunc) *wasm.HostFunc {
 	return &wasm.HostFunc{
 		ExportName: name,
+		Name:       name,
 		ParamTypes: []api.ValueType{api.ValueTypeI32},
 		ParamNames: []string{"sp"},
 		Code:       wasm.Code{GoFunc: goFunc},


### PR DESCRIPTION
A prior change broke race tests as it lazy set HostFunc.Name even when saved as a field. This sets name in all places we instantiate HostFunc for use in fields.

Fixes #1373