### PR TITLE
compiler(amd64): reusers static consts properly

### DIFF
--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -14,7 +14,7 @@ import (
 const defaultMaxDisplacementForConstantPool = 1 << 30
 
 func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
-	if a.pool.FirstUseOffsetInBinary == nil {
+	if a.pool.Empty() {
 		return
 	}
 
@@ -22,7 +22,7 @@ func (a *AssemblerImpl) maybeFlushConstants(isEndOfFunction bool) {
 		// If the distance between (the first use in binary) and (end of constant pool) can be larger
 		// than MaxDisplacementForConstantPool, we have to emit the constant pool now, otherwise
 		// a const might be unreachable by a literal move whose maximum offset is +- 2^31.
-		((a.pool.PoolSizeInBytes+a.buf.Len())-int(*a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
+		((a.pool.PoolSizeInBytes+a.buf.Len())-int(a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
 		if !isEndOfFunction {
 			// Adds the jump instruction to skip the constants if this is not the end of function.
 			//

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -127,7 +127,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 				})
 			}
 
-			a.pool.FirstUseOffsetInBinary = &tc.firstUseOffsetInBinary
+			a.pool.FirstUseOffsetInBinary = tc.firstUseOffsetInBinary
 			a.maybeFlushConstants(tc.endOfFunction)
 
 			require.Equal(t, tc.exp, a.buf.Bytes())

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -354,7 +354,7 @@ const defaultMaxDisplacementForConstPool = (1 << 20) - 1 - 4 // -4 for unconditi
 
 // maybeFlushConstPool flushes the constant pool if endOfBinary or a boundary condition was met.
 func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
-	if a.pool.FirstUseOffsetInBinary == nil {
+	if a.pool.Empty() {
 		return
 	}
 
@@ -364,7 +364,7 @@ func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
 		// Also, if the offset between the first usage of the constant pool and
 		// the first constant would exceed 2^20 -1(= 2MiB-1), which is the maximum offset
 		// for LDR(literal)/ADR instruction, flush all the constants in the pool.
-		(a.buf.Len()+a.pool.PoolSizeInBytes-int(*a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
+		(a.buf.Len()+a.pool.PoolSizeInBytes-int(a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
 
 		// Before emitting consts, we have to add br instruction to skip the const pool.
 		// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L1123-L1129

--- a/internal/asm/arm64/impl_1_test.go
+++ b/internal/asm/arm64/impl_1_test.go
@@ -4044,7 +4044,7 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 			require.Equal(t, 1, len(a.pool.Consts))
 			require.Equal(t, sc, a.pool.Consts[0])
 
-			require.Equal(t, beforeADRByteNum, *a.pool.FirstUseOffsetInBinary)
+			require.Equal(t, beforeADRByteNum, a.pool.FirstUseOffsetInBinary)
 
 			// Finalize the ADR instruction bytes.
 			sc.SetOffsetInBinary(tc.offsetOfConstInBinary)

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -80,7 +80,7 @@ func (s *StaticConst) SetOffsetInBinary(offset uint64) {
 // StaticConstPool holds a bulk of StaticConst which are yet to be emitted into the binary.
 type StaticConstPool struct {
 	// FirstUseOffsetInBinary holds the offset of the first instruction which accesses this const pool .
-	FirstUseOffsetInBinary *NodeOffsetInBinary
+	FirstUseOffsetInBinary NodeOffsetInBinary
 	Consts                 []*StaticConst
 	// addedConsts is used to deduplicate the consts to reduce the final size of binary.
 	// Note: we can use map on .consts field and remove this field,
@@ -91,7 +91,7 @@ type StaticConstPool struct {
 }
 
 func NewStaticConstPool() StaticConstPool {
-	return StaticConstPool{addedConsts: map[*StaticConst]struct{}{}}
+	return StaticConstPool{addedConsts: map[*StaticConst]struct{}{}, FirstUseOffsetInBinary: math.MaxUint64}
 }
 
 // Reset resets the *StaticConstPool for reuse.
@@ -102,7 +102,11 @@ func (p *StaticConstPool) Reset() {
 	// Reuse the slice to avoid re-allocations.
 	p.Consts = p.Consts[:0]
 	p.PoolSizeInBytes = 0
-	p.FirstUseOffsetInBinary = nil
+	p.FirstUseOffsetInBinary = math.MaxUint64
+}
+
+func (p *StaticConstPool) Empty() bool {
+	return p.FirstUseOffsetInBinary == math.MaxUint64
 }
 
 // AddConst adds a *StaticConst into the pool if it's not already added.
@@ -111,9 +115,11 @@ func (p *StaticConstPool) AddConst(c *StaticConst, useOffset NodeOffsetInBinary)
 		return
 	}
 
-	if p.FirstUseOffsetInBinary == nil {
-		p.FirstUseOffsetInBinary = &useOffset
+	if p.Empty() {
+		p.FirstUseOffsetInBinary = useOffset
 	}
+
+	c.offsetFinalizedCallbacks = c.offsetFinalizedCallbacks[:0]
 
 	p.Consts = append(p.Consts, c)
 	p.PoolSizeInBytes += len(c.Raw)

--- a/internal/asm/assembler_test.go
+++ b/internal/asm/assembler_test.go
@@ -18,20 +18,20 @@ func TestStaticConst_AddOffsetFinalizedCallback(t *testing.T) {
 	// Add first const.
 	c := NewStaticConst([]byte{1})
 	p.AddConst(c, firstUseOffset)
-	require.Equal(t, firstUseOffset, *p.FirstUseOffsetInBinary)
+	require.Equal(t, firstUseOffset, p.FirstUseOffsetInBinary)
 	require.Equal(t, 1, len(p.Consts))
 	require.Equal(t, 1, len(p.addedConsts))
 
 	// Adding the same *StaticConst doesn't affect the state.
 	p.AddConst(c, firstUseOffset+10000)
-	require.Equal(t, firstUseOffset, *p.FirstUseOffsetInBinary)
+	require.Equal(t, firstUseOffset, p.FirstUseOffsetInBinary)
 	require.Equal(t, 1, len(p.Consts))
 	require.Equal(t, 1, len(p.addedConsts))
 
 	// Add another const.
 	c2 := NewStaticConst([]byte{1, 2})
 	p.AddConst(c2, firstUseOffset+100)
-	require.Equal(t, firstUseOffset, *p.FirstUseOffsetInBinary) // first use doesn't change!
+	require.Equal(t, firstUseOffset, p.FirstUseOffsetInBinary) // first use doesn't change!
 	require.Equal(t, 2, len(p.Consts))
 	require.Equal(t, 2, len(p.addedConsts))
 }

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -18,24 +18,25 @@ import (
 )
 
 var (
-	minimum32BitSignedInt                  int32  = math.MinInt32
-	maximum32BitSignedInt                  int32  = math.MaxInt32
-	maximum32BitUnsignedInt                uint32 = math.MaxUint32
-	minimum64BitSignedInt                  int64  = math.MinInt64
-	maximum64BitSignedInt                  int64  = math.MaxInt64
-	maximum64BitUnsignedInt                uint64 = math.MaxUint64
-	float32SignBitMask                     uint32 = 1 << 31
-	float32RestBitMask                            = ^float32SignBitMask
-	float64SignBitMask                     uint64 = 1 << 63
-	float64RestBitMask                            = ^float64SignBitMask
-	float32ForMinimumSigned32bitInteger           = uint32(0xCF00_0000)
-	float64ForMinimumSigned32bitInteger           = uint64(0xC1E0_0000_0020_0000)
-	float32ForMinimumSigned64bitInteger           = uint32(0xDF00_0000)
-	float64ForMinimumSigned64bitInteger           = uint64(0xC3E0_0000_0000_0000)
-	float32ForMaximumSigned32bitIntPlusOne        = uint32(0x4F00_0000)
-	float64ForMaximumSigned32bitIntPlusOne        = uint64(0x41E0_0000_0000_0000)
-	float32ForMaximumSigned64bitIntPlusOne        = uint32(0x5F00_0000)
-	float64ForMaximumSigned64bitIntPlusOne        = uint64(0x43E0_0000_0000_0000)
+	_minimum32BitSignedInt                  int32  = math.MinInt32
+	_maximum32BitSignedInt                  int32  = math.MaxInt32
+	_maximum32BitUnsignedInt                uint32 = math.MaxUint32
+	_minimum64BitSignedInt                  int64  = math.MinInt64
+	_maximum64BitSignedInt                  int64  = math.MaxInt64
+	_maximum64BitUnsignedInt                uint64 = math.MaxUint64
+	_float32SignBitMask                     uint32 = 1 << 31
+	_float32RestBitMask                            = ^_float32SignBitMask
+	_float64SignBitMask                     uint64 = 1 << 63
+	_float64RestBitMask                            = ^_float64SignBitMask
+	_float32ForMinimumSigned32bitInteger           = uint32(0xCF00_0000)
+	_float64ForMinimumSigned32bitInteger           = uint64(0xC1E0_0000_0020_0000)
+	_float32ForMinimumSigned64bitInteger           = uint32(0xDF00_0000)
+	_float64ForMinimumSigned64bitInteger           = uint64(0xC3E0_0000_0000_0000)
+	_float32ForMaximumSigned32bitIntPlusOne        = uint32(0x4F00_0000)
+	_float64ForMaximumSigned32bitIntPlusOne        = uint64(0x41E0_0000_0000_0000)
+	_float32ForMaximumSigned64bitIntPlusOne        = uint32(0x5F00_0000)
+	_float64ForMaximumSigned64bitIntPlusOne        = uint64(0x43E0_0000_0000_0000)
+	minimum32BitSignedInt                          = asm.NewStaticConst(u32.LeBytes(uint32(_minimum32BitSignedInt)))
 )
 
 var (
@@ -101,6 +102,26 @@ type amd64Compiler struct {
 	// frameIDMax tracks the maximum value of frame id per function.
 	frameIDMax int
 	brTableTmp []runtimeValueLocation
+
+	fourZeros,
+	eightZeros,
+	maximum32BitSignedInt,
+	maximum32BitUnsignedInt,
+	minimum64BitSignedInt,
+	maximum64BitSignedInt,
+	maximum64BitUnsignedInt,
+	float32SignBitMask,
+	float32RestBitMask,
+	float64SignBitMask,
+	float64RestBitMask,
+	float32ForMinimumSigned32bitInteger,
+	float64ForMinimumSigned32bitInteger,
+	float32ForMinimumSigned64bitInteger,
+	float64ForMinimumSigned64bitInteger,
+	float32ForMaximumSigned32bitIntPlusOne,
+	float64ForMaximumSigned32bitIntPlusOne,
+	float32ForMaximumSigned64bitIntPlusOne,
+	float64ForMaximumSigned64bitIntPlusOne *asm.StaticConst
 }
 
 func newAmd64Compiler() compiler {
@@ -109,6 +130,26 @@ func newAmd64Compiler() compiler {
 		locationStackForEntrypoint: newRuntimeValueLocationStack(),
 		cpuFeatures:                platform.CpuFeatures,
 	}
+
+	c.fourZeros = asm.NewStaticConst([]byte{0, 0, 0, 0})
+	c.eightZeros = asm.NewStaticConst([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	c.maximum32BitSignedInt = asm.NewStaticConst(u32.LeBytes(uint32(_maximum32BitSignedInt)))
+	c.maximum32BitUnsignedInt = asm.NewStaticConst(u32.LeBytes(_maximum32BitUnsignedInt))
+	c.minimum64BitSignedInt = asm.NewStaticConst(u64.LeBytes(uint64(_minimum64BitSignedInt)))
+	c.maximum64BitSignedInt = asm.NewStaticConst(u64.LeBytes(uint64(_maximum64BitSignedInt)))
+	c.maximum64BitUnsignedInt = asm.NewStaticConst(u64.LeBytes(_maximum64BitUnsignedInt))
+	c.float32SignBitMask = asm.NewStaticConst(u32.LeBytes(_float32SignBitMask))
+	c.float32RestBitMask = asm.NewStaticConst(u32.LeBytes(_float32RestBitMask))
+	c.float64SignBitMask = asm.NewStaticConst(u64.LeBytes(_float64SignBitMask))
+	c.float64RestBitMask = asm.NewStaticConst(u64.LeBytes(_float64RestBitMask))
+	c.float32ForMinimumSigned32bitInteger = asm.NewStaticConst(u32.LeBytes(_float32ForMinimumSigned32bitInteger))
+	c.float64ForMinimumSigned32bitInteger = asm.NewStaticConst(u64.LeBytes(_float64ForMinimumSigned32bitInteger))
+	c.float32ForMinimumSigned64bitInteger = asm.NewStaticConst(u32.LeBytes(_float32ForMinimumSigned64bitInteger))
+	c.float64ForMinimumSigned64bitInteger = asm.NewStaticConst(u64.LeBytes(_float64ForMinimumSigned64bitInteger))
+	c.float32ForMaximumSigned32bitIntPlusOne = asm.NewStaticConst(u32.LeBytes(_float32ForMaximumSigned32bitIntPlusOne))
+	c.float64ForMaximumSigned32bitIntPlusOne = asm.NewStaticConst(u64.LeBytes(_float64ForMaximumSigned32bitIntPlusOne))
+	c.float32ForMaximumSigned64bitIntPlusOne = asm.NewStaticConst(u32.LeBytes(_float32ForMaximumSigned64bitIntPlusOne))
+	c.float64ForMaximumSigned64bitIntPlusOne = asm.NewStaticConst(u64.LeBytes(_float64ForMaximumSigned64bitIntPlusOne))
 	return c
 }
 
@@ -118,14 +159,33 @@ func (c *amd64Compiler) Init(typ *wasm.FunctionType, ir *wazeroir.CompilationRes
 	c.locationStackForEntrypoint.reset()
 	c.resetLabels()
 	*c = amd64Compiler{
-		ir:                         ir,
-		withListener:               withListener,
-		typ:                        typ,
-		assembler:                  c.assembler,
-		cpuFeatures:                c.cpuFeatures,
-		labels:                     c.labels,
-		locationStackForEntrypoint: c.locationStackForEntrypoint,
-		brTableTmp:                 c.brTableTmp,
+		ir:                                     ir,
+		withListener:                           withListener,
+		typ:                                    typ,
+		assembler:                              c.assembler,
+		cpuFeatures:                            c.cpuFeatures,
+		labels:                                 c.labels,
+		locationStackForEntrypoint:             c.locationStackForEntrypoint,
+		brTableTmp:                             c.brTableTmp,
+		fourZeros:                              c.fourZeros,
+		eightZeros:                             c.eightZeros,
+		maximum32BitSignedInt:                  c.maximum32BitSignedInt,
+		maximum32BitUnsignedInt:                c.maximum32BitUnsignedInt,
+		minimum64BitSignedInt:                  c.minimum64BitSignedInt,
+		maximum64BitSignedInt:                  c.maximum64BitSignedInt,
+		maximum64BitUnsignedInt:                c.maximum64BitUnsignedInt,
+		float32SignBitMask:                     c.float32SignBitMask,
+		float32RestBitMask:                     c.float32RestBitMask,
+		float64SignBitMask:                     c.float64SignBitMask,
+		float64RestBitMask:                     c.float64RestBitMask,
+		float32ForMinimumSigned32bitInteger:    c.float32ForMinimumSigned32bitInteger,
+		float64ForMinimumSigned32bitInteger:    c.float64ForMinimumSigned32bitInteger,
+		float32ForMinimumSigned64bitInteger:    c.float32ForMinimumSigned64bitInteger,
+		float64ForMinimumSigned64bitInteger:    c.float64ForMinimumSigned64bitInteger,
+		float32ForMaximumSigned32bitIntPlusOne: c.float32ForMaximumSigned32bitIntPlusOne,
+		float64ForMaximumSigned32bitIntPlusOne: c.float64ForMaximumSigned32bitIntPlusOne,
+		float32ForMaximumSigned64bitIntPlusOne: c.float32ForMaximumSigned64bitIntPlusOne,
+		float64ForMaximumSigned64bitIntPlusOne: c.float64ForMaximumSigned64bitIntPlusOne,
 	}
 
 	// Reuses the initial location stack for the compilation of subsequent functions.
@@ -1555,13 +1615,11 @@ func (c *amd64Compiler) performDivisionOnInts(isRem, is32Bit, signed bool) error
 		// next we check if the quotient is the most negative value for the signed integer.
 		// That means whether or not we try to do (math.MaxInt32 / -1) or (math.Math.Int64 / -1) respectively.
 		if is32Bit {
-			if err := c.assembler.CompileRegisterToStaticConst(amd64.CMPL, x1.register,
-				asm.NewStaticConst(u32.LeBytes(uint32(minimum32BitSignedInt)))); err != nil {
+			if err := c.assembler.CompileRegisterToStaticConst(amd64.CMPL, x1.register, minimum32BitSignedInt); err != nil {
 				return err
 			}
 		} else {
-			if err := c.assembler.CompileRegisterToStaticConst(amd64.CMPQ, x1.register,
-				asm.NewStaticConst(u64.LeBytes(uint64(minimum64BitSignedInt)))); err != nil {
+			if err := c.assembler.CompileRegisterToStaticConst(amd64.CMPQ, x1.register, c.minimum64BitSignedInt); err != nil {
 				return err
 			}
 		}
@@ -1828,13 +1886,13 @@ func (c *amd64Compiler) compileNeg(o *wazeroir.UnionOperation) (err error) {
 	// since we cannot take XOR directly with float reg and const.
 	// And then negate the value by XOR it with the sign-bit mask.
 	if wazeroir.Float(o.B1) == wazeroir.Float32 {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, asm.NewStaticConst(u32.LeBytes(float32SignBitMask)), tmpReg)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, c.float32SignBitMask, tmpReg)
 		if err != nil {
 			return err
 		}
 		c.assembler.CompileRegisterToRegister(amd64.XORPS, tmpReg, target.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, asm.NewStaticConst(u64.LeBytes(float64SignBitMask)), tmpReg)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, c.float64SignBitMask, tmpReg)
 		if err != nil {
 			return err
 		}
@@ -2017,9 +2075,9 @@ func (c *amd64Compiler) compileCopysign(o *wazeroir.UnionOperation) error {
 
 	// Move the rest bit mask to the temp register.
 	if is32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, asm.NewStaticConst(u32.LeBytes(float32RestBitMask)), tmpReg)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, c.float32RestBitMask, tmpReg)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, asm.NewStaticConst(u64.LeBytes(float64RestBitMask)), tmpReg)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, c.float64RestBitMask, tmpReg)
 	}
 	if err != nil {
 		return err
@@ -2034,9 +2092,9 @@ func (c *amd64Compiler) compileCopysign(o *wazeroir.UnionOperation) error {
 
 	// Move the sign bit mask to the temp register.
 	if is32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, asm.NewStaticConst(u32.LeBytes(float32SignBitMask)), tmpReg)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, c.float32SignBitMask, tmpReg)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, asm.NewStaticConst(u64.LeBytes(float64SignBitMask)), tmpReg)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, c.float64SignBitMask, tmpReg)
 	}
 	if err != nil {
 		return err
@@ -2136,11 +2194,9 @@ func (c *amd64Compiler) emitUnsignedI32TruncFromFloat(isFloat32Bit, nonTrapping 
 
 	// First, we check the source float value is above or equal math.MaxInt32+1.
 	if isFloat32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-			asm.NewStaticConst(u32.LeBytes(float32ForMaximumSigned32bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.float32ForMaximumSigned32bitIntPlusOne, source.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-			asm.NewStaticConst(u64.LeBytes(float64ForMaximumSigned32bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.float64ForMaximumSigned32bitIntPlusOne, source.register)
 	}
 	if err != nil {
 		return err
@@ -2195,11 +2251,9 @@ func (c *amd64Compiler) emitUnsignedI32TruncFromFloat(isFloat32Bit, nonTrapping 
 	// First, we subtract the math.MaxInt32+1 from the original value so it can fit in signed 32-bit integer.
 	c.assembler.SetJumpTargetOnNext(jmpAboveOrEqualMaxIn32PlusOne)
 	if isFloat32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSS,
-			asm.NewStaticConst(u32.LeBytes(float32ForMaximumSigned32bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSS, c.float32ForMaximumSigned32bitIntPlusOne, source.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSD,
-			asm.NewStaticConst(u64.LeBytes(float64ForMaximumSigned32bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSD, c.float64ForMaximumSigned32bitIntPlusOne, source.register)
 	}
 	if err != nil {
 		return err
@@ -2222,8 +2276,7 @@ func (c *amd64Compiler) emitUnsignedI32TruncFromFloat(isFloat32Bit, nonTrapping 
 
 	// Otherwise, we successfully converted the source float minus (math.MaxInt32+1) to int.
 	// So, we retrieve the original source float value by adding the sign mask.
-	if err = c.assembler.CompileStaticConstToRegister(amd64.ADDL,
-		asm.NewStaticConst(u32.LeBytes(float32SignBitMask)), result); err != nil {
+	if err = c.assembler.CompileStaticConstToRegister(amd64.ADDL, c.float32SignBitMask, result); err != nil {
 		return err
 	}
 
@@ -2233,8 +2286,7 @@ func (c *amd64Compiler) emitUnsignedI32TruncFromFloat(isFloat32Bit, nonTrapping 
 	if !nonTrapping {
 		c.compileExitFromNativeCode(nativeCallStatusIntegerOverflow)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL,
-			asm.NewStaticConst(u32.LeBytes(maximum32BitUnsignedInt)), result)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, c.maximum32BitUnsignedInt, result)
 		if err != nil {
 			return err
 		}
@@ -2269,18 +2321,16 @@ func (c *amd64Compiler) emitUnsignedI64TruncFromFloat(isFloat32Bit, nonTrapping 
 
 	// First, we check the source float value is above or equal math.MaxInt64+1.
 	if isFloat32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-			asm.NewStaticConst(u32.LeBytes(float32ForMaximumSigned64bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.float32ForMaximumSigned64bitIntPlusOne, source.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-			asm.NewStaticConst(u64.LeBytes(float64ForMaximumSigned64bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.float64ForMaximumSigned64bitIntPlusOne, source.register)
 	}
 	if err != nil {
 		return err
 	}
 
 	// Check the parity flag (set when the value is NaN), and if it is set, we should raise an exception.
-	jmpIfNotNaN := c.assembler.CompileJump(amd64.JPC) // jump if parity is not set.
+	jmpIfNotNaN := c.assembler.CompileJump(amd64.JPC) // jump if parity is c.not set.
 
 	var nonTrappingNaNJump asm.Node
 	if !nonTrapping {
@@ -2328,11 +2378,9 @@ func (c *amd64Compiler) emitUnsignedI64TruncFromFloat(isFloat32Bit, nonTrapping 
 	// First, we subtract the math.MaxInt64+1 from the original value so it can fit in signed 64-bit integer.
 	c.assembler.SetJumpTargetOnNext(jmpAboveOrEqualMaxIn32PlusOne)
 	if isFloat32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSS,
-			asm.NewStaticConst(u32.LeBytes(float32ForMaximumSigned64bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSS, c.float32ForMaximumSigned64bitIntPlusOne, source.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSD,
-			asm.NewStaticConst(u64.LeBytes(float64ForMaximumSigned64bitIntPlusOne)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.SUBSD, c.float64ForMaximumSigned64bitIntPlusOne, source.register)
 	}
 	if err != nil {
 		return err
@@ -2355,8 +2403,7 @@ func (c *amd64Compiler) emitUnsignedI64TruncFromFloat(isFloat32Bit, nonTrapping 
 
 	// Otherwise, we successfully converted the the source float minus (math.MaxInt64+1) to int.
 	// So, we retrieve the original source float value by adding the sign mask.
-	if err = c.assembler.CompileStaticConstToRegister(amd64.ADDQ,
-		asm.NewStaticConst(u64.LeBytes(float64SignBitMask)), result); err != nil {
+	if err = c.assembler.CompileStaticConstToRegister(amd64.ADDQ, c.float64SignBitMask, result); err != nil {
 		return err
 	}
 
@@ -2366,8 +2413,7 @@ func (c *amd64Compiler) emitUnsignedI64TruncFromFloat(isFloat32Bit, nonTrapping 
 	if !nonTrapping {
 		c.compileExitFromNativeCode(nativeCallStatusIntegerOverflow)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ,
-			asm.NewStaticConst(u64.LeBytes(maximum64BitUnsignedInt)), result)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, c.maximum64BitUnsignedInt, result)
 		if err != nil {
 			return err
 		}
@@ -2411,7 +2457,7 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 	// 1) the source float value is either +-Inf or NaN, or it exceeds representative ranges of 32bit signed integer, or
 	// 2) the source equals the minimum signed 32-bit (=-2147483648.000000) whose bit pattern is float32ForMinimumSigned32bitIntegerAddress for 32 bit float
 	// 	  or float64ForMinimumSigned32bitIntegerAddress for 64bit float.
-	err = c.assembler.CompileStaticConstToRegister(amd64.CMPL, asm.NewStaticConst(u32.LeBytes(float32SignBitMask)), result)
+	err = c.assembler.CompileStaticConstToRegister(amd64.CMPL, c.float32SignBitMask, result)
 	if err != nil {
 		return err
 	}
@@ -2445,11 +2491,9 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 	// meaning that the value exceeds the lower bound of 32-bit signed integer range.
 	c.assembler.SetJumpTargetOnNext(jmpIfNotNaN)
 	if isFloat32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-			asm.NewStaticConst(u32.LeBytes(float32ForMinimumSigned32bitInteger)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.float32ForMinimumSigned32bitInteger, source.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-			asm.NewStaticConst(u64.LeBytes(float64ForMinimumSigned32bitInteger)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.float64ForMinimumSigned32bitInteger, source.register)
 	}
 	if err != nil {
 		return err
@@ -2467,11 +2511,9 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 		// At this point, the value is the minimum signed 32-bit int (=-2147483648.000000) or larger than 32-bit maximum.
 		// So, check if the value equals the minimum signed 32-bit int.
 		if isFloat32Bit {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-				asm.NewStaticConst([]byte{0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.fourZeros, source.register)
 		} else {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-				asm.NewStaticConst([]byte{0, 0, 0, 0, 0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.eightZeros, source.register)
 		}
 		if err != nil {
 			return err
@@ -2495,8 +2537,7 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 		}
 
 		// If the value exceeds the lower bound, we "saturate" it to the minimum.
-		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVL,
-			asm.NewStaticConst(u32.LeBytes(uint32(minimum32BitSignedInt))), result); err != nil {
+		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, minimum32BitSignedInt, result); err != nil {
 			return err
 		}
 		nonTrappingSaturatedMinimumJump := c.assembler.CompileJump(amd64.JMP)
@@ -2504,11 +2545,9 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 		// Otherwise, the value is the minimum signed 32-bit int (=-2147483648.000000) or larger than 32-bit maximum.
 		c.assembler.SetJumpTargetOnNext(jmpIfNotExceedsLowerBound)
 		if isFloat32Bit {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-				asm.NewStaticConst([]byte{0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.fourZeros, source.register)
 		} else {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-				asm.NewStaticConst([]byte{0, 0, 0, 0, 0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.eightZeros, source.register)
 		}
 		if err != nil {
 			return err
@@ -2516,8 +2555,7 @@ func (c *amd64Compiler) emitSignedI32TruncFromFloat(isFloat32Bit, nonTrapping bo
 		jmpIfMinimumSignedInt := c.assembler.CompileJump(amd64.JCS) // jump if the value is minus (= the minimum signed 32-bit int).
 
 		// If the value exceeds signed 32-bit maximum, we saturate it to the maximum.
-		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVL,
-			asm.NewStaticConst(u32.LeBytes(uint32(maximum32BitSignedInt))), result); err != nil {
+		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVL, c.maximum32BitSignedInt, result); err != nil {
 			return err
 		}
 
@@ -2557,8 +2595,7 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 	// 1) the source float value is either +-Inf or NaN, or it exceeds representative ranges of 32bit signed integer, or
 	// 2) the source equals the minimum signed 32-bit (=-9223372036854775808.0) whose bit pattern is float32ForMinimumSigned64bitIntegerAddress for 32 bit float
 	// 	  or float64ForMinimumSigned64bitIntegerAddress for 64bit float.
-	err = c.assembler.CompileStaticConstToRegister(amd64.CMPQ,
-		asm.NewStaticConst(u64.LeBytes(float64SignBitMask)), result)
+	err = c.assembler.CompileStaticConstToRegister(amd64.CMPQ, c.float64SignBitMask, result)
 	if err != nil {
 		return err
 	}
@@ -2591,11 +2628,9 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 	// meaning that the value exceeds the lower bound of 64-bit signed integer range.
 	c.assembler.SetJumpTargetOnNext(jmpIfNotNaN)
 	if isFloat32Bit {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-			asm.NewStaticConst(u32.LeBytes(float32ForMinimumSigned64bitInteger)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.float32ForMinimumSigned64bitInteger, source.register)
 	} else {
-		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-			asm.NewStaticConst(u64.LeBytes(float64ForMinimumSigned64bitInteger)), source.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.float64ForMinimumSigned64bitInteger, source.register)
 	}
 	if err != nil {
 		return err
@@ -2608,11 +2643,9 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 		// At this point, the value is the minimum signed 64-bit int (=-9223372036854775808.0) or larger than 64-bit maximum.
 		// So, check if the value equals the minimum signed 64-bit int.
 		if isFloat32Bit {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS,
-				asm.NewStaticConst([]byte{0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.fourZeros, source.register)
 		} else {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD,
-				asm.NewStaticConst([]byte{0, 0, 0, 0, 0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.eightZeros, source.register)
 		}
 		if err != nil {
 			return err
@@ -2631,8 +2664,7 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 		jmpIfNotExceedsLowerBound := c.assembler.CompileJump(amd64.JCC)
 
 		// If the value exceeds the lower bound, we "saturate" it to the minimum.
-		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ,
-			asm.NewStaticConst(u64.LeBytes(uint64(minimum64BitSignedInt))), result)
+		err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, c.minimum64BitSignedInt, result)
 		if err != nil {
 			return err
 		}
@@ -2643,9 +2675,9 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 		// So, check if the value equals the minimum signed 64-bit int.
 		c.assembler.SetJumpTargetOnNext(jmpIfNotExceedsLowerBound)
 		if isFloat32Bit {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, asm.NewStaticConst([]byte{0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISS, c.fourZeros, source.register)
 		} else {
-			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, asm.NewStaticConst([]byte{0, 0, 0, 0, 0, 0, 0, 0}), source.register)
+			err = c.assembler.CompileStaticConstToRegister(amd64.UCOMISD, c.eightZeros, source.register)
 		}
 		if err != nil {
 			return err
@@ -2654,7 +2686,7 @@ func (c *amd64Compiler) emitSignedI64TruncFromFloat(isFloat32Bit, nonTrapping bo
 		jmpIfMinimumSignedInt := c.assembler.CompileJump(amd64.JCS) // jump if the value is minus (= the minimum signed 64-bit int).
 
 		// If the value exceeds signed 64-bit maximum, we saturate it to the maximum.
-		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, asm.NewStaticConst(u64.LeBytes(uint64(maximum64BitSignedInt))), result); err != nil {
+		if err = c.assembler.CompileStaticConstToRegister(amd64.MOVQ, c.maximum64BitSignedInt, result); err != nil {
 			return err
 		}
 
@@ -3070,9 +3102,9 @@ func (c *amd64Compiler) compileEqz(o *wazeroir.UnionOperation) (err error) {
 	unsignedInt := wazeroir.UnsignedInt(o.B1)
 	switch unsignedInt {
 	case wazeroir.UnsignedInt32:
-		err = c.assembler.CompileStaticConstToRegister(amd64.CMPL, asm.NewStaticConst([]byte{0, 0, 0, 0}), v.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.CMPL, c.fourZeros, v.register)
 	case wazeroir.UnsignedInt64:
-		err = c.assembler.CompileStaticConstToRegister(amd64.CMPQ, asm.NewStaticConst([]byte{0, 0, 0, 0, 0, 0, 0, 0}), v.register)
+		err = c.assembler.CompileStaticConstToRegister(amd64.CMPQ, c.eightZeros, v.register)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
This reduces the allocations drastically (sec/op results is fuzzy as it's run on rosetta2).

```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: VirtualApple @ 2.50GHz
                                    │ old_amd64.txt │           new_amd64.txt           │
                                    │    sec/op     │   sec/op     vs base              │
Compilation/with_extern_cache-10        302.2µ ± 3%   323.1µ ± 6%  +6.93% (p=0.017 n=7)
Compilation/without_extern_cache-10     4.001m ± 0%   3.940m ± 1%  -1.53% (p=0.001 n=7)
Compilation/interpreter-10              907.0µ ± 0%   899.2µ ± 1%  -0.86% (p=0.001 n=7)
Compilation_sqlite3/compiler-10         699.7m ± 4%   638.9m ± 4%  -8.69% (p=0.001 n=7)
Compilation_sqlite3/interpreter-10      120.2m ± 1%   114.9m ± 3%  -4.39% (p=0.001 n=7)
geomean                                 9.839m        9.658m       -1.84%

                                    │ old_amd64.txt │           new_amd64.txt            │
                                    │     B/op      │     B/op      vs base              │
Compilation/with_extern_cache-10       37.11Ki ± 0%   37.10Ki ± 0%       ~ (p=0.154 n=7)
Compilation/without_extern_cache-10    685.3Ki ± 0%   678.1Ki ± 0%  -1.04% (p=0.001 n=7)
Compilation/interpreter-10             488.5Ki ± 0%   488.4Ki ± 0%       ~ (p=0.245 n=7)
Compilation_sqlite3/compiler-10        55.31Mi ± 0%   53.09Mi ± 0%  -4.02% (p=0.001 n=7)
Compilation_sqlite3/interpreter-10     51.77Mi ± 0%   51.77Mi ± 0%       ~ (p=0.209 n=7)
geomean                                2.014Mi        1.993Mi       -1.03%

                                    │ old_amd64.txt │            new_amd64.txt             │
                                    │   allocs/op   │  allocs/op   vs base                 │
Compilation/with_extern_cache-10         352.0 ± 0%    351.0 ± 0%   -0.28% (p=0.001 n=7)
Compilation/without_extern_cache-10     2.116k ± 0%   1.631k ± 0%  -22.92% (p=0.001 n=7)
Compilation/interpreter-10               490.0 ± 0%    490.0 ± 0%        ~ (p=1.000 n=7) ¹
Compilation_sqlite3/compiler-10         343.2k ± 0%   216.3k ± 0%  -36.97% (p=0.001 n=7)
Compilation_sqlite3/interpreter-10      14.00k ± 0%   14.00k ± 0%        ~ (p=0.689 n=7)
geomean                                 4.454k        3.853k       -13.49%

```