### PR TITLE
packaging: use setx /m to register wazero instead

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,6 +141,10 @@ jobs:
       - name: Test Windows Installer
         if: runner.os == 'Windows'
         run: |
+          SET GARBAGE="12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+          SET GARBAGE="%GARBAGE%%GARBAGE%%GARBAGE%%GARBAGE%%GARBAGE%%GARBAGE%%GARBAGE%%GARBAGE%"
+          SET GARBAGE="%GARBAGE%%GARBAGE%"
+          SETX PATH "%PATH%;%GARBAGE"
           set MSI_FILE="dist\wazero_${{ needs.pre_release.outputs.VERSION }}_windows_amd64.msi"
           call packaging\msi\verify_msi.cmd
         shell: cmd

--- a/packaging/msi/wazero.wxs
+++ b/packaging/msi/wazero.wxs
@@ -94,10 +94,10 @@
             <ComponentRef Id="WazeroBin"/>
         </Feature>
 
-        <!-- Add wazero to the default PATH once installation succeeds.
+        <!-- Add wazero to the SYSTEM PATH once installation succeeds.
              Replace with <Component><Environment> after https://gitlab.gnome.org/GNOME/msitools/-/merge_requests/42 -->
         <Property Id="setx" Value="setx.exe"/>
-        <CustomAction Id="ChangePath" ExeCommand="PATH &quot;%PATH%;[INSTALLDIR]&quot;" Property="setx"
+        <CustomAction Id="ChangePath" ExeCommand="/M PATH &quot;[INSTALLDIR];[%PATH]&quot;" Property="setx"
                       Execute="deferred"/>
         <InstallExecuteSequence>
             <RemoveExistingProducts Before="InstallInitialize"/>


### PR DESCRIPTION
Addresses #1374.

The most important issue with this strategy is that it has
the potential to break the end-user PATH variable if for some
reason the combined length is longer than 1024 chars.

The reason the current strategy is not working are at least two:

1. `%PATH%` is not expanded in:

    <CustomAction Id="ChangePath"
        ExeCommand="PATH &quot;%PATH%;[INSTALLDIR]&quot;"
        Property="setx" ...

    The "correct" syntax seems to be `[%PATH]` instead of `%PATH%`

2. SETX is not working(*) inside MSI (at least on my Win11 machine)
   unless we use the flag `/M` which modifies the env variable
   at the system level.

Furthermore:

- `SETX PATH "C:\Program Files\wazero;%PATH%"` expands `%PATH%`
  AND *truncates* it to 1024 chars. Because of this, *appending* may
  be safer: worst case, it truncates the path you have appended

- However, for some reason I couldn't make it work from within
  the MSI installer, so I still had to prepend...

(*) I assume it's running as a different user than %currentuser% 
and SYSTEM; maybe "Local Service"?

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
