### PR TITLE
asm/amd64: avoids allocations in static const offset resolution

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -39,7 +39,7 @@ type nodeImpl struct {
 	// jumpOriginsHead true if this is the target of all the nodes in the singly linked list jumpOrigins,
 	// and can be traversed from this nodeImpl's forwardJumpOrigins.
 	forwardJumpTarget bool
-	// staticConstReferrersAdded true is this node is added into AssemblerImpl.staticConstReferrers.
+	// staticConstReferrersAdded true if this node is already added into AssemblerImpl.staticConstReferrers.
 	// Only used when staticConst is not nil. Through re-assembly, we might end up adding multiple times which causes unnecessary
 	// allocations, so we use this flag to do it once.
 	staticConstReferrersAdded bool


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: AMD Ryzen 9 3950X 16-Core Processor
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/without_extern_cache-32   4.461m ± 2%   4.439m ± 3%       ~ (p=0.620 n=7)
Compilation_sqlite3/compiler-32       531.5m ± 2%   533.1m ± 2%       ~ (p=1.000 n=7)
geomean                               48.70m        48.65m       -0.10%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/without_extern_cache-32   678.9Ki ± 0%   665.1Ki ± 0%  -2.03% (p=0.001 n=7)
Compilation_sqlite3/compiler-32       53.09Mi ± 0%   49.46Mi ± 0%  -6.83% (p=0.001 n=7)
geomean                               5.933Mi        5.668Mi       -4.46%

                                    │   old.txt    │              new.txt               │
                                    │  allocs/op   │  allocs/op   vs base               │
Compilation/without_extern_cache-32    1635.0 ± 0%    925.0 ± 0%  -43.43% (p=0.001 n=7)
Compilation_sqlite3/compiler-32       216.31k ± 0%   37.00k ± 0%  -82.89% (p=0.001 n=7)
geomean                                18.81k        5.851k       -68.89%
```