### PR TITLE
asm/amd64: removes map access in encoding 

### DIFF
--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -293,7 +293,7 @@ func TestAssemblerImpl_newNode(t *testing.T) {
 
 func TestAssemblerImpl_encodeNode(t *testing.T) {
 	a := NewAssembler()
-	err := a.EncodeNode(&nodeImpl{
+	err := a.encodeNode(&nodeImpl{
 		instruction: ADDPD,
 		types:       operandTypesRegisterToMemory,
 	})

--- a/internal/asm/amd64/impl_2_test.go
+++ b/internal/asm/amd64/impl_2_test.go
@@ -584,10 +584,6 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 				n:      &nodeImpl{instruction: JMP, types: operandTypesRegisterToRegister, srcReg: RegAX, dstReg: RegAX},
 				expErr: "JMP is unsupported for from:register,to:register type",
 			},
-			{
-				n:      &nodeImpl{instruction: MOVL, types: operandTypesRegisterToRegister, srcReg: RegX0, dstReg: RegX1},
-				expErr: "MOVL for float to float is undefined",
-			},
 		}
 
 		for _, tc := range tests {

--- a/internal/asm/amd64/impl_4_test.go
+++ b/internal/asm/amd64/impl_4_test.go
@@ -329,7 +329,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 		for n := a.root; n != nil; n = n.next {
 			n.offsetInBinaryField = uint64(a.buf.Len())
 
-			err := a.EncodeNode(n)
+			err := a.encodeNode(n)
 			require.NoError(t, err)
 		}
 
@@ -1440,7 +1440,7 @@ func TestNodeImpl_GetRegisterToRegisterModRM(t *testing.T) {
 
 	for _, tc := range tests {
 		n := nodeImpl{srcReg: tc.srcReg, dstReg: tc.dstReg}
-		rexPrefix, modRM, err := n.GetRegisterToRegisterModRM(tc.srcOnModRMReg)
+		rexPrefix, modRM, err := n.getRegisterToRegisterModRM(tc.srcOnModRMReg)
 		require.NoError(t, err, tc.name)
 		require.Equal(t, tc.expRexPrefix, rexPrefix, tc.name)
 		require.Equal(t, tc.expModRM, modRM, tc.name)

--- a/internal/asm/amd64/impl_memorylocation_test.go
+++ b/internal/asm/amd64/impl_memorylocation_test.go
@@ -40,7 +40,7 @@ func TestNodeImpl_GetMemoryLocation_errors(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		_, _, _, _, _, err := tt.n.GetMemoryLocation()
+		_, _, _, _, _, err := tt.n.getMemoryLocation()
 		require.EqualError(t, err, tt.expErr, tt.expErr)
 	}
 }
@@ -61,7 +61,7 @@ func TestNodeImpl_GetMemoryLocation_without_base(t *testing.T) {
 			types:  operandTypesMemoryToRegister,
 			srcReg: asm.NilRegister, srcConst: tc.offset,
 		}
-		rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.GetMemoryLocation()
+		rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.getMemoryLocation()
 		require.NoError(t, err)
 		require.Equal(t, rexPrefixNone, rexPrefix)
 		require.Equal(t, tc.modRM, modRM)
@@ -1688,7 +1688,7 @@ func TestNodeImpl_GetMemoryLocation_with_base(t *testing.T) {
 			types:  operandTypesMemoryToRegister,
 			srcReg: tc.baseReg, srcConst: tc.offset, srcMemIndex: tc.indexReg, srcMemScale: tc.scale,
 		}
-		rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.GetMemoryLocation()
+		rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.getMemoryLocation()
 		require.NoError(t, err, tc.name)
 		require.Equal(t, tc.expRex, rexPrefix, tc.name)
 		require.Equal(t, tc.expModRM, modRM, tc.name)


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: AMD Ryzen 9 3950X 16-Core Processor
                                    │   old.txt   │              new2.txt              │
                                    │   sec/op    │   sec/op     vs base               │
Compilation/without_extern_cache-32   4.101m ± 2%   3.974m ± 1%   -3.12% (p=0.001 n=7)
Compilation_sqlite3/compiler-32       488.4m ± 1%   429.5m ± 2%  -12.05% (p=0.001 n=7)
geomean                               44.76m        41.31m        -7.69%

                                    │   old.txt    │              new2.txt              │
                                    │     B/op     │     B/op      vs base              │
Compilation/without_extern_cache-32   665.1Ki ± 0%   664.5Ki ± 0%  -0.09% (p=0.001 n=7)
Compilation_sqlite3/compiler-32       49.46Mi ± 0%   49.40Mi ± 0%  -0.13% (p=0.001 n=7)
geomean                               5.668Mi        5.662Mi       -0.11%

                                    │   old.txt   │              new2.txt              │
                                    │  allocs/op  │  allocs/op   vs base               │
Compilation/without_extern_cache-32    925.0 ± 0%    852.0 ± 0%   -7.89% (p=0.001 n=7)
Compilation_sqlite3/compiler-32       37.00k ± 0%   28.70k ± 0%  -22.43% (p=0.001 n=7)
geomean                               5.850k        4.945k       -15.47%
```