### PR TITLE
asm/amd64: optimizes initializeNodesForEncoding

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -471,15 +471,10 @@ func (a *AssemblerImpl) initializeNodesForEncoding() {
 					target.forwardJumpTarget = true
 				}
 
-				// We add this node `n` into the end of the linked list (.forwardJumpOrigins)
-				// beginning from the `target.forwardJumpOrigins`.
-				if head := target.forwardJumpOrigins; head == nil {
-					target.forwardJumpOrigins = n
-				} else {
-					// Insert the current `n` as the head of the list.
-					n.forwardJumpOrigins = head
-					target.forwardJumpOrigins = n
-				}
+				// We add this node `n` into the end of the linked list (.forwardJumpOrigins) beginning from the `target.forwardJumpOrigins`.
+				// Insert the current `n` as the head of the list.
+				n.forwardJumpOrigins = target.forwardJumpOrigins
+				target.forwardJumpOrigins = n
 			}
 		}
 	}

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -472,16 +472,13 @@ func (a *AssemblerImpl) initializeNodesForEncoding() {
 				}
 
 				// We add this node `n` into the end of the linked list (.forwardJumpOrigins)
-				// beginning from the `target`.
-				tail := target
-				for {
-					if tail.forwardJumpOrigins == nil {
-						// If we found the tail, let's append it.
-						tail.forwardJumpOrigins = n
-						break
-					} else {
-						tail = tail.forwardJumpOrigins
-					}
+				// beginning from the `target.forwardJumpOrigins`.
+				if head := target.forwardJumpOrigins; head == nil {
+					target.forwardJumpOrigins = n
+				} else {
+					// Insert the current `n` as the head of the list.
+					n.forwardJumpOrigins = head
+					target.forwardJumpOrigins = n
 				}
 			}
 		}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: AMD Ryzen 9 3950X 16-Core Processor            
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/without_extern_cache-32   3.833m ± 2%   3.884m ± 3%       ~ (p=0.535 n=7)
Compilation_sqlite3/compiler-32       413.2m ± 1%   398.3m ± 1%  -3.59% (p=0.001 n=7)
geomean                               39.80m        39.33m       -1.16%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/without_extern_cache-32   664.5Ki ± 0%   664.4Ki ± 0%       ~ (p=0.456 n=7)
Compilation_sqlite3/compiler-32       49.40Mi ± 0%   49.40Mi ± 0%       ~ (p=0.165 n=7)
geomean                               5.662Mi        5.661Mi       -0.00%

                                    │   old.txt   │               new.txt               │
                                    │  allocs/op  │  allocs/op   vs base                │
Compilation/without_extern_cache-32    852.0 ± 0%    852.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation_sqlite3/compiler-32       28.70k ± 0%   28.69k ± 0%       ~ (p=0.172 n=7)
geomean                               4.945k        4.944k       -0.02%

```