### PR TITLE
asm/amd64: removes nodeImpl.forwardJumpTarget

### DIFF
--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -28,16 +28,15 @@ func TestNodePool_allocNode(t *testing.T) {
 
 	// Taint the existing content on the page.
 	np.pages[np.page][np.pos] = nodeImpl{
-		offsetInBinaryField: 10,
-		jumpTarget:          &nodeImpl{},
-		flag:                nodeFlagInitializedForEncoding,
-		next:                &nodeImpl{},
-		staticConst:         asm.NewStaticConst([]byte{1, 2}),
+		offsetInBinary: 10,
+		jumpTarget:     &nodeImpl{},
+		flag:           nodeFlagInitializedForEncoding,
+		next:           &nodeImpl{},
+		staticConst:    asm.NewStaticConst([]byte{1, 2}),
 		readInstructionAddressBeforeTargetInstruction: RET,
-		forwardJumpTarget: true,
-		arg:               1,
-		types:             operandTypesConstToRegister,
-		srcReg:            RegBX, dstReg: RegBX,
+		arg:    1,
+		types:  operandTypesConstToRegister,
+		srcReg: RegBX, dstReg: RegBX,
 		srcConst: 1234, dstConst: 1234,
 		srcMemIndex: RegBX, dstMemIndex: RegBX,
 		srcMemScale: 0xf, dstMemScale: 0xf,
@@ -148,7 +147,7 @@ func TestAssemblerImpl_Assemble(t *testing.T) {
 		a.initializeNodesForEncoding()
 
 		// For the first encoding, we must be forced to reassemble.
-		err := a.Encode()
+		err := a.encode()
 		require.NoError(t, err)
 		require.True(t, a.forceReAssemble)
 	})

--- a/internal/asm/amd64/impl_4_test.go
+++ b/internal/asm/amd64/impl_4_test.go
@@ -327,14 +327,14 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 		a.CompileStandAlone(CDQ)
 
 		for n := a.root; n != nil; n = n.next {
-			n.offsetInBinaryField = uint64(a.buf.Len())
+			n.offsetInBinary = uint64(a.buf.Len())
 
 			err := a.encodeNode(n)
 			require.NoError(t, err)
 		}
 
 		targetNode := a.current
-		targetNode.offsetInBinaryField = uint64(math.MaxInt64)
+		targetNode.offsetInBinary = uint64(math.MaxInt64)
 
 		n := a.readInstructionAddressNodes[0]
 		err := a.finalizeReadInstructionAddressNode(nil, n)

--- a/internal/asm/amd64/impl_7_test.go
+++ b/internal/asm/amd64/impl_7_test.go
@@ -485,10 +485,10 @@ func TestAssemblerImpl_encodeNoneToBranch_backward_jumps(t *testing.T) {
 		targetOffsetInBinaryField := uint64(0)
 		OffsetInBinaryField := uint64(math.MaxInt32)
 		node := &nodeImpl{
-			instruction:         JMP,
-			jumpTarget:          &nodeImpl{offsetInBinaryField: targetOffsetInBinaryField},
-			flag:                nodeFlagBackwardJump,
-			offsetInBinaryField: OffsetInBinaryField,
+			instruction:    JMP,
+			jumpTarget:     &nodeImpl{offsetInBinary: targetOffsetInBinaryField},
+			flag:           nodeFlagBackwardJump,
+			offsetInBinary: OffsetInBinaryField,
 		}
 		err := a.encodeRelativeJump(node)
 		require.Error(t, err)


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: AMD Ryzen 9 3950X 16-Core Processor
                                    │   old.txt   │              new.txt              │
                                    │   sec/op    │   sec/op     vs base              │
Compilation/without_extern_cache-32   3.820m ± 3%   3.777m ± 2%       ~ (p=0.535 n=7)
Compilation_sqlite3/compiler-32       395.2m ± 2%   388.6m ± 2%  -1.66% (p=0.038 n=7)
geomean                               38.85m        38.31m       -1.40%

                                    │   old.txt    │              new.txt               │
                                    │     B/op     │     B/op      vs base              │
Compilation/without_extern_cache-32   664.4Ki ± 0%   664.5Ki ± 0%  +0.02% (p=0.038 n=7)
Compilation_sqlite3/compiler-32       49.40Mi ± 0%   49.40Mi ± 0%       ~ (p=0.476 n=7)
geomean                               5.661Mi        5.662Mi       +0.01%

                                    │   old.txt   │               new.txt               │
                                    │  allocs/op  │  allocs/op   vs base                │
Compilation/without_extern_cache-32    852.0 ± 0%    852.0 ± 0%       ~ (p=1.000 n=7) ¹
Compilation_sqlite3/compiler-32       28.70k ± 0%   28.70k ± 0%       ~ (p=0.681 n=7)
geomean                               4.945k        4.945k       +0.00%
```