### PR TITLE
Proposal: "close" certain api interfaces for external implementation

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+
+	"github.com/tetratelabs/wazero/internal/internalapi"
 )
 
 // ExternType classifies imports and exports with their respective types.
@@ -188,7 +190,7 @@ type Module interface {
 	// Closer closes this module by delegating to CloseWithExitCode with an exit code of zero.
 	Closer
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // Closer closes a resource.
@@ -239,7 +241,7 @@ type ExportDefinition interface {
 	// so "" is possible.
 	ExportNames() []string
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // MemoryDefinition is a WebAssembly memory exported in a module
@@ -261,7 +263,7 @@ type MemoryDefinition interface {
 	// unbounded.
 	Max() (uint32, bool)
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // FunctionDefinition is a WebAssembly function exported in a module
@@ -325,7 +327,7 @@ type FunctionDefinition interface {
 	// available for one or more results.
 	ResultNames() []string
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // Function is a WebAssembly function exported from an instantiated module
@@ -364,7 +366,7 @@ type Function interface {
 	// the end-to-end demonstrations of how these terminations can be performed.
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // GoModuleFunction is a Function implemented in Go instead of a wasm binary.
@@ -493,7 +495,7 @@ type MutableGlobal interface {
 	// See Global.Type for how to encode this value from a Go type.
 	Set(v uint64)
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // Memory allows restricted access to a module's memory. Notably, this does not allow growing.
@@ -620,7 +622,7 @@ type Memory interface {
 	// WriteString writes the string to the underlying buffer at the offset or returns false if out of range.
 	WriteString(offset uint32, v string) bool
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // CustomSection contains the name and raw data of a custom section.
@@ -635,7 +637,7 @@ type CustomSection interface {
 	// Data is the raw data of the custom section
 	Data() []byte
 
-	wazeroOnly()
+	internalapi.WazeroOnly
 }
 
 // EncodeExternref encodes the input as a ValueTypeExternref.

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -355,6 +355,8 @@ type Function interface {
 	// WithCloseOnContextDone on wazero.RuntimeConfig for detail. See examples in context_done_example_test.go for
 	// the end-to-end demonstrations of how these terminations can be performed.
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
+
+	private()
 }
 
 // GoModuleFunction is a Function implemented in Go instead of a wasm binary.

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -187,6 +187,8 @@ type Module interface {
 
 	// Closer closes this module by delegating to CloseWithExitCode with an exit code of zero.
 	Closer
+
+	wazeroOnly()
 }
 
 // Closer closes a resource.
@@ -236,6 +238,8 @@ type ExportDefinition interface {
 	// Note: The empty name is allowed in the WebAssembly Core Specification,
 	// so "" is possible.
 	ExportNames() []string
+
+	wazeroOnly()
 }
 
 // MemoryDefinition is a WebAssembly memory exported in a module
@@ -256,6 +260,8 @@ type MemoryDefinition interface {
 	// Max returns the possibly zero max count of 64KB pages, or false if
 	// unbounded.
 	Max() (uint32, bool)
+
+	wazeroOnly()
 }
 
 // FunctionDefinition is a WebAssembly function exported in a module
@@ -318,6 +324,8 @@ type FunctionDefinition interface {
 	// ResultNames are index-correlated with ResultTypes or nil if not
 	// available for one or more results.
 	ResultNames() []string
+
+	wazeroOnly()
 }
 
 // Function is a WebAssembly function exported from an instantiated module
@@ -356,7 +364,7 @@ type Function interface {
 	// the end-to-end demonstrations of how these terminations can be performed.
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
 
-	private()
+	wazeroOnly()
 }
 
 // GoModuleFunction is a Function implemented in Go instead of a wasm binary.
@@ -484,6 +492,8 @@ type MutableGlobal interface {
 	//
 	// See Global.Type for how to encode this value from a Go type.
 	Set(v uint64)
+
+	wazeroOnly()
 }
 
 // Memory allows restricted access to a module's memory. Notably, this does not allow growing.
@@ -609,6 +619,8 @@ type Memory interface {
 
 	// WriteString writes the string to the underlying buffer at the offset or returns false if out of range.
 	WriteString(offset uint32, v string) bool
+
+	wazeroOnly()
 }
 
 // CustomSection contains the name and raw data of a custom section.
@@ -622,6 +634,8 @@ type CustomSection interface {
 	Name() string
 	// Data is the raw data of the custom section
 	Data() []byte
+
+	wazeroOnly()
 }
 
 // EncodeExternref encodes the input as a ValueTypeExternref.

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -584,10 +584,10 @@ func TestRun_Errors(t *testing.T) {
 	}
 }
 
-var _ api.FunctionDefinition = importer{}
-
 type importer struct {
 	moduleName, name string
+
+	api.FunctionDefinition
 }
 
 func (i importer) ModuleName() string { return "" }
@@ -616,27 +616,27 @@ func Test_detectImports(t *testing.T) {
 		{
 			message: "other imports",
 			imports: []api.FunctionDefinition{
-				importer{"env", "emscripten_notify_memory_growth"},
+				importer{"env", "emscripten_notify_memory_growth", nil},
 			},
 		},
 		{
 			message: "wasi",
 			imports: []api.FunctionDefinition{
-				importer{wasi_snapshot_preview1.ModuleName, "fd_read"},
+				importer{wasi_snapshot_preview1.ModuleName, "fd_read", nil},
 			},
 			mode: modeWasi,
 		},
 		{
 			message: "unstable_wasi",
 			imports: []api.FunctionDefinition{
-				importer{"wasi_unstable", "fd_read"},
+				importer{"wasi_unstable", "fd_read", nil},
 			},
 			mode: modeWasiUnstable,
 		},
 		{
 			message: "GOARCH=wasm GOOS=js",
 			imports: []api.FunctionDefinition{
-				importer{"go", "syscall/js.valueCall"},
+				importer{"go", "syscall/js.valueCall", nil},
 			},
 			mode: modeGo,
 		},

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/version"
@@ -585,9 +586,8 @@ func TestRun_Errors(t *testing.T) {
 }
 
 type importer struct {
+	internalapi.WazeroOnlyType
 	moduleName, name string
-
-	api.FunctionDefinition
 }
 
 func (i importer) ModuleName() string { return "" }
@@ -616,27 +616,27 @@ func Test_detectImports(t *testing.T) {
 		{
 			message: "other imports",
 			imports: []api.FunctionDefinition{
-				importer{"env", "emscripten_notify_memory_growth", nil},
+				importer{internalapi.WazeroOnlyType{}, "env", "emscripten_notify_memory_growth"},
 			},
 		},
 		{
 			message: "wasi",
 			imports: []api.FunctionDefinition{
-				importer{wasi_snapshot_preview1.ModuleName, "fd_read", nil},
+				importer{internalapi.WazeroOnlyType{}, wasi_snapshot_preview1.ModuleName, "fd_read"},
 			},
 			mode: modeWasi,
 		},
 		{
 			message: "unstable_wasi",
 			imports: []api.FunctionDefinition{
-				importer{"wasi_unstable", "fd_read", nil},
+				importer{internalapi.WazeroOnlyType{}, "wasi_unstable", "fd_read"},
 			},
 			mode: modeWasiUnstable,
 		},
 		{
 			message: "GOARCH=wasm GOOS=js",
 			imports: []api.FunctionDefinition{
-				importer{"go", "syscall/js.valueCall", nil},
+				importer{internalapi.WazeroOnlyType{}, "go", "syscall/js.valueCall"},
 			},
 			mode: modeGo,
 		},

--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -585,6 +585,8 @@ func TestRun_Errors(t *testing.T) {
 	}
 }
 
+var _ api.FunctionDefinition = importer{}
+
 type importer struct {
 	internalapi.WazeroOnlyType
 	moduleName, name string

--- a/config.go
+++ b/config.go
@@ -404,6 +404,8 @@ func (c *compiledModule) CustomSections() []api.CustomSection {
 type customSection struct {
 	name string
 	data []byte
+
+	api.CustomSection
 }
 
 // Name implements wasm.CustomSection.Name

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/engine/compiler"
 	"github.com/tetratelabs/wazero/internal/engine/interpreter"
 	"github.com/tetratelabs/wazero/internal/filecache"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/sysfs"
@@ -402,10 +403,9 @@ func (c *compiledModule) CustomSections() []api.CustomSection {
 
 // customSection implements wasm.CustomSection
 type customSection struct {
+	internalapi.WazeroOnlyType
 	name string
 	data []byte
-
-	api.CustomSection
 }
 
 // Name implements wasm.CustomSection.Name

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/filecache"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/version"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -53,6 +54,8 @@ type (
 	//
 	// This implements api.Function.
 	callEngine struct {
+		internalapi.WazeroOnlyType
+
 		// See note at top of file before modifying this struct.
 
 		// These contexts are read and written by compiled code.
@@ -137,8 +140,6 @@ type (
 		// stackIterator provides a way to iterate over the stack for Listeners.
 		// It is setup and valid only during a call to a Listener hook.
 		stackIterator stackIterator
-
-		api.Function
 	}
 
 	// contextStack is a stack of context.Context.

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -137,6 +137,8 @@ type (
 		// stackIterator provides a way to iterate over the stack for Listeners.
 		// It is setup and valid only during a call to a Listener hook.
 		stackIterator stackIterator
+
+		api.Function
 	}
 
 	// contextStack is a stack of context.Context.

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/filecache"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/moremath"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
@@ -91,6 +92,8 @@ type moduleEngine struct {
 //
 // This implements api.Function.
 type callEngine struct {
+	internalapi.WazeroOnlyType
+
 	// stack contains the operands.
 	// Note that all the values are represented as uint64.
 	stack []uint64
@@ -103,8 +106,6 @@ type callEngine struct {
 
 	// stackiterator Listeners to walk frames and stack.
 	stackIterator stackIterator
-
-	api.Function
 }
 
 func (e *moduleEngine) newCallEngine(compiled *function) *callEngine {

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -103,6 +103,8 @@ type callEngine struct {
 
 	// stackiterator Listeners to walk frames and stack.
 	stackIterator stackIterator
+
+	api.Function
 }
 
 func (e *moduleEngine) newCallEngine(compiled *function) *callEngine {

--- a/internal/internalapi/internal.go
+++ b/internal/internalapi/internal.go
@@ -1,0 +1,9 @@
+package internalapi
+
+type WazeroOnly interface {
+	wazeroOnly()
+}
+
+type WazeroOnlyType struct{}
+
+func (WazeroOnlyType) wazeroOnly() {}

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
 )
 
@@ -106,6 +107,7 @@ func (m *Module) BuildFunctionDefinitions() {
 
 // FunctionDefinition implements api.FunctionDefinition
 type FunctionDefinition struct {
+	internalapi.WazeroOnlyType
 	moduleName  string
 	index       Index
 	name        string
@@ -116,8 +118,6 @@ type FunctionDefinition struct {
 	exportNames []string
 	paramNames  []string
 	resultNames []string
-
-	api.FunctionDefinition
 }
 
 // ModuleName implements the same method as documented on api.FunctionDefinition.

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -116,6 +116,8 @@ type FunctionDefinition struct {
 	exportNames []string
 	paramNames  []string
 	resultNames []string
+
+	api.FunctionDefinition
 }
 
 // ModuleName implements the same method as documented on api.FunctionDefinition.

--- a/internal/wasm/global.go
+++ b/internal/wasm/global.go
@@ -12,6 +12,9 @@ type mutableGlobal struct {
 	g *GlobalInstance
 }
 
+// compile-time check to ensure mutableGlobal is a api.Global.
+var _ api.Global = &mutableGlobal{}
+
 // Type implements the same method as documented on api.Global.
 func (g *mutableGlobal) Type() api.ValueType {
 	return g.g.Type.ValType

--- a/internal/wasm/global.go
+++ b/internal/wasm/global.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 )
 
 type mutableGlobal struct {
+	internalapi.WazeroOnlyType
 	g *GlobalInstance
-
-	api.MutableGlobal
 }
 
 // Type implements the same method as documented on api.Global.

--- a/internal/wasm/global.go
+++ b/internal/wasm/global.go
@@ -8,10 +8,9 @@ import (
 
 type mutableGlobal struct {
 	g *GlobalInstance
-}
 
-// compile-time check to ensure mutableGlobal is a api.Global.
-var _ api.Global = &mutableGlobal{}
+	api.MutableGlobal
+}
 
 // Type implements the same method as documented on api.Global.
 func (g *mutableGlobal) Type() api.ValueType {

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 )
 
 const (
@@ -29,14 +30,14 @@ const (
 // wasm.Store Memories index zero: `store.Memories[0]`
 // See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0.
 type MemoryInstance struct {
+	internalapi.WazeroOnlyType
+
 	Buffer        []byte
 	Min, Cap, Max uint32
 	// mux is used to prevent overlapping calls to Grow.
 	mux sync.RWMutex
 	// definition is known at compile time.
 	definition api.MemoryDefinition
-
-	api.Memory
 }
 
 // NewMemoryInstance creates a new instance based on the parameters in the SectionIDMemory.

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -23,9 +23,6 @@ const (
 	MemoryPageSizeInBits = 16
 )
 
-// compile-time check to ensure MemoryInstance implements api.Memory
-var _ api.Memory = &MemoryInstance{}
-
 // MemoryInstance represents a memory instance in a store, and implements api.Memory.
 //
 // Note: In WebAssembly 1.0 (20191205), there may be up to one Memory per store, which means the precise memory is always
@@ -38,6 +35,8 @@ type MemoryInstance struct {
 	mux sync.RWMutex
 	// definition is known at compile time.
 	definition api.MemoryDefinition
+
+	api.Memory
 }
 
 // NewMemoryInstance creates a new instance based on the parameters in the SectionIDMemory.

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -24,6 +24,9 @@ const (
 	MemoryPageSizeInBits = 16
 )
 
+// compile-time check to ensure MemoryInstance implements api.Memory
+var _ api.Memory = &MemoryInstance{}
+
 // MemoryInstance represents a memory instance in a store, and implements api.Memory.
 //
 // Note: In WebAssembly 1.0 (20191205), there may be up to one Memory per store, which means the precise memory is always

--- a/internal/wasm/memory_definition.go
+++ b/internal/wasm/memory_definition.go
@@ -86,6 +86,8 @@ type MemoryDefinition struct {
 	importDesc  *[2]string
 	exportNames []string
 	memory      *Memory
+
+	api.MemoryDefinition
 }
 
 // ModuleName implements the same method as documented on api.MemoryDefinition.

--- a/internal/wasm/memory_definition.go
+++ b/internal/wasm/memory_definition.go
@@ -1,6 +1,9 @@
 package wasm
 
-import "github.com/tetratelabs/wazero/api"
+import (
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
+)
 
 // ImportedMemories implements the same method as documented on wazero.CompiledModule.
 func (m *Module) ImportedMemories() (ret []api.MemoryDefinition) {
@@ -81,13 +84,12 @@ func (m *Module) BuildMemoryDefinitions() {
 
 // MemoryDefinition implements api.MemoryDefinition
 type MemoryDefinition struct {
+	internalapi.WazeroOnlyType
 	moduleName  string
 	index       Index
 	importDesc  *[2]string
 	exportNames []string
 	memory      *Memory
-
-	api.MemoryDefinition
 }
 
 // ModuleName implements the same method as documented on api.MemoryDefinition.

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -222,7 +223,7 @@ func (m *ModuleInstance) ExportedGlobal(name string) api.Global {
 	}
 	g := m.Globals[exp.Index]
 	if g.Type.Mutable {
-		return &mutableGlobal{g, nil}
+		return &mutableGlobal{internalapi.WazeroOnlyType{}, g}
 	}
 	valType := g.Type.ValType
 	switch valType {

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -222,7 +222,7 @@ func (m *ModuleInstance) ExportedGlobal(name string) api.Global {
 	}
 	g := m.Globals[exp.Index]
 	if g.Type.Mutable {
-		return &mutableGlobal{g}
+		return &mutableGlobal{g, nil}
 	}
 	valType := g.Type.ValType
 	switch valType {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -126,6 +126,8 @@ type (
 		aliases []string
 		// Definitions is derived from *Module, and is constructed during compilation phrase.
 		Definitions []FunctionDefinition
+
+		api.Module
 	}
 
 	// DataInstance holds bytes corresponding to the data segment in a module.

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/sys"
@@ -67,6 +68,8 @@ type (
 	//
 	// This implements api.Module.
 	ModuleInstance struct {
+		internalapi.WazeroOnlyType
+
 		// Closed is used both to guard moduleEngine.CloseWithExitCode and to store the exit code.
 		//
 		// The update value is closedType + exitCode << 32. This ensures an exit code of zero isn't mistaken for never closed.
@@ -126,8 +129,6 @@ type (
 		aliases []string
 		// Definitions is derived from *Module, and is constructed during compilation phrase.
 		Definitions []FunctionDefinition
-
-		api.Module
 	}
 
 	// DataInstance holds bytes corresponding to the data segment in a module.

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -420,6 +420,7 @@ type mockModuleEngine struct {
 type mockCallEngine struct {
 	index         Index
 	callFailIndex int
+	api.Function
 }
 
 func newStore() *Store {

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/hammer"
@@ -418,9 +419,9 @@ type mockModuleEngine struct {
 }
 
 type mockCallEngine struct {
+	internalapi.WazeroOnlyType
 	index         Index
 	callFailIndex int
-	api.Function
 }
 
 func newStore() *Store {


### PR DESCRIPTION
As discussed in https://github.com/tetratelabs/wazero/pull/1332#issuecomment-1510010359, many of the interfaces in [`github.com/tetratelabs/wazero`](https://pkg.go.dev/github.com/tetratelabs/wazero) and [`github.com/tetratelabs/wazero/api`](https://pkg.go.dev/github.com/tetratelabs/wazero/api) are not meant to be externally implemented.

In strict terms, an interface can't be extended after it has been made public. Once made public, alternative implementations may be created, and adding a method to such an interface, means those implementations no longer compile, which breaks semver.

wazero 1.0 shipped with many such interfaces, which we may want to extend (e.g. #1332).

These are the paths available to us:
1. **that ship has sailed**: wazero 1.0 shipped, we simply can't extend these interfaces;
2. **documentation**: document *now* that certain interfaces are not meant to be implemented outside wazero;
3. **this PR**: "enforce" this, avoiding users implementing them by accident.

Option **1** is basically doing nothing. In the context of #1332 I can propose a different alternative, which will basically be a new `api.Function2` (name not important) interface that wraps the [`CallWithStack`](https://github.com/tetratelabs/wazero/pull/1332#issuecomment-1507793809) method. Then users either type-assert this interface, or we create new builders returning this interface.

Options **2** and **3** require deciding which interfaces are only for internal implementation.

Option **2** is a documentation change to [`github.com/tetratelabs/wazero`](https://pkg.go.dev/github.com/tetratelabs/wazero) and [`github.com/tetratelabs/wazero/api`](https://pkg.go.dev/github.com/tetratelabs/wazero/api), and to each such interface.

Option **3** is this PR, repeated for every such interface.

In the documentation of each of these interfaces, you'll [see](https://pkg.go.dev/go/types#Object):
```go
type Interface interface {
	PublicMethod() // public method
	// contains filtered or unexported methods
}
```

When you try to implement such an interface (create your own type and use it as if it implemented it), you get this error message:
```
cannot use &myCallEngine{…} (value of type *myCallEngine) as api.Function value in return statement: *myCallEngine does not implement api.Function (missing method wazeroOnly)
```

If you're doing it for mocking, which is the only way you'd do it for these wazero types, you can still deliberately sidestep the check by embedding the interface:
```go
type mockCallEngine struct {
	index         Index
	callFailIndex int
	api.Function
}
```