### PR TITLE
debug: includes Go stack trace in the face of Go runtime errors

### DIFF
--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -44,23 +44,23 @@ func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
 func TestCompiler_Engine_NewModuleEngine(t *testing.T) {
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
-	enginetest.RunTestEngine_NewModuleEngine(t, et)
+	enginetest.RunTestEngineNewModuleEngine(t, et)
 }
 
 func TestCompiler_MemoryGrowInRecursiveCall(t *testing.T) {
 	defer functionLog.Reset()
-	enginetest.RunTestEngine_MemoryGrowInRecursiveCall(t, et)
+	enginetest.RunTestEngineMemoryGrowInRecursiveCall(t, et)
 }
 
 func TestCompiler_ModuleEngine_LookupFunction(t *testing.T) {
 	defer functionLog.Reset()
-	enginetest.RunTestModuleEngine_LookupFunction(t, et)
+	enginetest.RunTestModuleEngineLookupFunction(t, et)
 }
 
 func TestCompiler_ModuleEngine_Call(t *testing.T) {
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
-	enginetest.RunTestModuleEngine_Call(t, et)
+	enginetest.RunTestModuleEngineCall(t, et)
 	require.Equal(t, `
 --> .$0(1,2)
 <-- (1,2)
@@ -70,7 +70,7 @@ func TestCompiler_ModuleEngine_Call(t *testing.T) {
 func TestCompiler_ModuleEngine_Call_HostFn(t *testing.T) {
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
-	enginetest.RunTestModuleEngine_Call_HostFn(t, et)
+	enginetest.RunTestModuleEngineCallHostFn(t, et)
 }
 
 func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
@@ -131,11 +131,11 @@ func TestCompiler_ModuleEngine_Call_Errors(t *testing.T) {
 func TestCompiler_ModuleEngine_Memory(t *testing.T) {
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)
-	enginetest.RunTestModuleEngine_Memory(t, et)
+	enginetest.RunTestModuleEngineMemory(t, et)
 }
 
 func TestCompiler_BeforeListenerStackIterator(t *testing.T) {
-	enginetest.RunTestModuleEngine_BeforeListenerStackIterator(t, et)
+	enginetest.RunTestModuleEngineBeforeListenerStackIterator(t, et)
 }
 
 // requireSupportedOSArch is duplicated also in the platform package to ensure no cyclic dependency.

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -85,20 +85,20 @@ func (e engineTester) NewEngine(enabledFeatures api.CoreFeatures) wasm.Engine {
 
 func TestInterpreter_MemoryGrowInRecursiveCall(t *testing.T) {
 	defer functionLog.Reset()
-	enginetest.RunTestEngine_MemoryGrowInRecursiveCall(t, et)
+	enginetest.RunTestEngineMemoryGrowInRecursiveCall(t, et)
 }
 
 func TestInterpreter_Engine_NewModuleEngine(t *testing.T) {
-	enginetest.RunTestEngine_NewModuleEngine(t, et)
+	enginetest.RunTestEngineNewModuleEngine(t, et)
 }
 
 func TestInterpreter_ModuleEngine_LookupFunction(t *testing.T) {
-	enginetest.RunTestModuleEngine_LookupFunction(t, et)
+	enginetest.RunTestModuleEngineLookupFunction(t, et)
 }
 
 func TestInterpreter_ModuleEngine_Call(t *testing.T) {
 	defer functionLog.Reset()
-	enginetest.RunTestModuleEngine_Call(t, et)
+	enginetest.RunTestModuleEngineCall(t, et)
 	require.Equal(t, `
 --> .$0(1,2)
 <-- (1,2)
@@ -107,7 +107,7 @@ func TestInterpreter_ModuleEngine_Call(t *testing.T) {
 
 func TestInterpreter_ModuleEngine_Call_HostFn(t *testing.T) {
 	defer functionLog.Reset()
-	enginetest.RunTestModuleEngine_Call_HostFn(t, et)
+	enginetest.RunTestModuleEngineCallHostFn(t, et)
 }
 
 func TestInterpreter_ModuleEngine_Call_Errors(t *testing.T) {
@@ -165,7 +165,7 @@ func TestInterpreter_ModuleEngine_Call_Errors(t *testing.T) {
 }
 
 func TestInterpreter_ModuleEngine_Memory(t *testing.T) {
-	enginetest.RunTestModuleEngine_Memory(t, et)
+	enginetest.RunTestModuleEngineMemory(t, et)
 }
 
 func TestInterpreter_NonTrappingFloatToIntConversion(t *testing.T) {
@@ -563,5 +563,5 @@ func TestEngine_CachedcodesPerModule(t *testing.T) {
 }
 
 func TestCompiler_BeforeListenerStackIterator(t *testing.T) {
-	enginetest.RunTestModuleEngine_BeforeListenerStackIterator(t, et)
+	enginetest.RunTestModuleEngineBeforeListenerStackIterator(t, et)
 }

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -449,7 +449,8 @@ wasm stack trace:
 			require.NotNil(t, err)
 
 			errStr := err.Error()
-			// If the Go runtime errors
+			// If this faces a Go runtime error, the error includes the Go stack trace which makes the test unstable,
+			// so we trim them here.
 			if index := strings.Index(errStr, wasmdebug.GoRuntimeErrorTracePrefix); index > -1 {
 				errStr = strings.TrimSpace(errStr[:index])
 			}

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -21,7 +21,6 @@ package enginetest
 import (
 	"context"
 	"errors"
-	"github.com/tetratelabs/wazero/internal/wasmdebug"
 	"math"
 	"strings"
 	"testing"
@@ -31,6 +30,7 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
 	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wasmdebug"
 	"github.com/tetratelabs/wazero/internal/wasmruntime"
 )
 
@@ -270,7 +270,7 @@ func RunTestModuleEngineLookupFunction(t *testing.T, et EngineTester) {
 func runTestModuleEngineCallHostFnMem(t *testing.T, et EngineTester, readMem *wasm.Code) {
 	e := et.NewEngine(api.CoreFeaturesV1)
 	defer e.Close()
-	importing := setupCallMemTests(t, e, readMem, et.ListenerFactory())
+	importing := setupCallMemTests(t, e, readMem)
 
 	importingMemoryVal := uint64(6)
 	importing.MemoryInstance = &wasm.MemoryInstance{Buffer: u64.LeBytes(importingMemoryVal), Min: 1, Cap: 1, Max: 1}
@@ -627,7 +627,7 @@ type fnListener struct {
 	afterFn  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
 }
 
-func (f *fnListener) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+func (f *fnListener) NewListener(api.FunctionDefinition) experimental.FunctionListener {
 	return f
 }
 
@@ -914,7 +914,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 	return imported, importing
 }
 
-func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code, fnlf experimental.FunctionListenerFactory) *wasm.ModuleInstance {
+func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code) *wasm.ModuleInstance {
 	ft := wasm.FunctionType{Results: []wasm.ValueType{i64}, ResultNumInUint64: 1}
 
 	hostModule := &wasm.Module{

--- a/internal/wasmdebug/debug.go
+++ b/internal/wasmdebug/debug.go
@@ -112,6 +112,10 @@ type stackTrace struct {
 	frames []string
 }
 
+// GoRuntimeErrorTracePrefix is the prefix coming before the Go runtime stack trace included in the face of runtime.Error.
+// This is exported for testing purpose.
+const GoRuntimeErrorTracePrefix = "Go runtime stack trace:"
+
 func (s *stackTrace) FromRecovered(recovered interface{}) error {
 	if false {
 		debug.PrintStack()
@@ -131,8 +135,8 @@ func (s *stackTrace) FromRecovered(recovered interface{}) error {
 	// If we have a runtime.Error, something severe happened which should include the stack trace. This could be
 	// a nil pointer from wazero or a user-defined function from HostModuleBuilder.
 	if runtimeErr, ok := recovered.(runtime.Error); ok {
-		// TODO: consider adding debug.Stack(), but last time we attempted, some tests became unstable.
-		return fmt.Errorf("%w (recovered by wazero)\nwasm stack trace:\n\t%s", runtimeErr, stack)
+		return fmt.Errorf("%w (recovered by wazero)\nwasm stack trace:\n\t%s\n\n%s\n%s",
+			runtimeErr, stack, GoRuntimeErrorTracePrefix, debug.Stack())
 	}
 
 	// At this point we expect the error was from a function defined by HostModuleBuilder that intentionally called panic.


### PR DESCRIPTION
this improves the debuggability of the issues like #1399 

Below is the example output for this change on debugging 1399:

```
2023/04/25 10:35:16 runtime error: invalid memory address or nil pointer dereference (recovered by wazero)
wasm stack trace:
        env.hostTalk(i32,i32,i32,i32) i32
        .hello(i32,i32) i64

Go runtime stack trace:
goroutine 1 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x64
github.com/tetratelabs/wazero/internal/wasmdebug.(*stackTrace).FromRecovered(0x140001e78d0?, {0x100285760?, 0x100396360?})
        /Users/mathetake/wazero/internal/wasmdebug/debug.go:139 +0xc4
github.com/tetratelabs/wazero/internal/engine/compiler.(*callEngine).deferredOnCall(0x14000178900, {0x100285760, 0x100396360})
        /Users/mathetake/wazero/internal/engine/compiler/engine.go:803 +0x25c
github.com/tetratelabs/wazero/internal/engine/compiler.(*callEngine).Call.func1()
        /Users/mathetake/wazero/internal/engine/compiler/engine.go:691 +0x4c
panic({0x100285760, 0x100396360})
        /usr/local/go/src/runtime/panic.go:884 +0x1f4
main.glob..func2({0x1002a8e80, 0x14000112000}, {0x1002aa528, 0x140001786c0}, {0x14000249048, 0x4, 0x140001e7c01?})
        /Users/mathetake/wazero-step-by-step/chapter-04/host/main.go:50 +0x170
github.com/tetratelabs/wazero/api.GoModuleFunc.Call(0x1078d8038?, {0x1002a8e80?, 0x14000112000?}, {0x1002aa528?, 0x140001786c0?}, {0x14000249048?, 0x140001e7c88?, 0x1000fb1e4?})
        /Users/mathetake/wazero/api/wasm.go:411 +0x54
github.com/tetratelabs/wazero/internal/engine/compiler.(*callEngine).execWasmFunction(0x14000178900, {0x1002a8e80?, 0x14000112000?}, 0x1003a4300?)
        /Users/mathetake/wazero/internal/engine/compiler/engine.go:953 +0x158
github.com/tetratelabs/wazero/internal/engine/compiler.(*callEngine).Call(0x14000178900, {0x1002a8e80, 0x14000112000}, {0x14000112af0?, 0x2, 0x1b68?})
        /Users/mathetake/wazero/internal/engine/compiler/engine.go:705 +0x2b4
main.main()
        /Users/mathetake/wazero-step-by-step/chapter-04/host/main.go:165 +0x534

```