### PR TITLE
api: adds CallWithStack to avoid allocations

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -382,7 +382,7 @@ type Function interface {
 	//   - This is similar to GoFunc, except for using calling functions
 	//     instead of implementing them. Moreover, this is used regardless of
 	//     whether the callee is a host or wasm defined function.
-	CallWithStack(ctx context.Context, stack []uint64) ([]uint64, error)
+	CallWithStack(ctx context.Context, stack []uint64) error
 
 	internalapi.WazeroOnly
 }

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -367,19 +367,15 @@ type Function interface {
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
 
 	// CallWithStack is an optimized variation of Call that saves memory
-	// allocations when the stack slice is large enough to hold the maximum
-	// length of function parameters and results.
+	// allocations when the stack slice is reused across calls.
 	//
+	// Stack length must be at least the max of parameter or result length.
 	// The caller adds parameters in order to the stack, and reads any results
-	// in order from the result stack, except in the error case.
+	// in order from the stack, except in the error case.
 	//
 	// # Notes
 	//
-	//   - When the stack parameter is large enough to hold the max count of
-	//     parameters and results, it is returned. Otherwise, a new slice is
-	//     allocated and returned. This means the caller should always prefer
-	//     using the result slice for subsequent calls.
-	//   - This is similar to GoFunc, except for using calling functions
+	//   - This is similar to GoModuleFunction, except for using calling functions
 	//     instead of implementing them. Moreover, this is used regardless of
 	//     whether the callee is a host or wasm defined function.
 	CallWithStack(ctx context.Context, stack []uint64) error

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -366,6 +366,24 @@ type Function interface {
 	// the end-to-end demonstrations of how these terminations can be performed.
 	Call(ctx context.Context, params ...uint64) ([]uint64, error)
 
+	// CallWithStack is an optimized variation of Call that saves memory
+	// allocations when the stack slice is large enough to hold the maximum
+	// length of function parameters and results.
+	//
+	// The caller adds parameters in order to the stack, and reads any results
+	// in order from the result stack, except in the error case.
+	//
+	// # Notes
+	//
+	//   - When the stack parameter is large enough to hold the max count of
+	//     parameters and results, it is returned. Otherwise, a new slice is
+	//     allocated and returned. This means the caller should always prefer
+	//     using the result slice for subsequent calls.
+	//   - This is similar to GoFunc, except for using calling functions
+	//     instead of implementing them. Moreover, this is used regardless of
+	//     whether the callee is a host or wasm defined function.
+	CallWithStack(ctx context.Context, stack []uint64) ([]uint64, error)
+
 	internalapi.WazeroOnly
 }
 

--- a/api/wasm.go
+++ b/api/wasm.go
@@ -373,6 +373,20 @@ type Function interface {
 	// The caller adds parameters in order to the stack, and reads any results
 	// in order from the stack, except in the error case.
 	//
+	// For example, the following reuses the same stack slice to call searchFn
+	// repeatedly saving one allocation per iteration:
+	//
+	//	stack := make([]uint64, 4)
+	//	for i, search := range searchParams {
+	//		// copy the next params to the stack
+	//		copy(stack, search)
+	//		if err := searchFn.CallWithStack(ctx, stack); err != nil {
+	//			return err
+	//		} else if stack[0] == 1 { // found
+	//			return i // searchParams[i] matched!
+	//		}
+	//	}
+	//
 	// # Notes
 	//
 	//   - This is similar to GoModuleFunction, except for using calling functions

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -714,21 +714,11 @@ func (ce *callEngine) Call(ctx context.Context, params ...uint64) (results []uin
 
 // CallWithStack implements the same method as documented on wasm.ModuleEngine.
 func (ce *callEngine) CallWithStack(ctx context.Context, stack []uint64) error {
-	var params, results []uint64
-
-	ft := ce.initialFn.funcType
-	if n := ft.ParamNumInUint64; n > len(stack) {
-		return fmt.Errorf("need %d params, but stack size is %d", n, len(stack))
-	} else {
-		params = stack[:n]
+	params, results, err := wasm.SplitCallStack(ce.initialFn.funcType, stack)
+	if err != nil {
+		return err
 	}
-	if n := ft.ResultNumInUint64; n > len(stack) {
-		return fmt.Errorf("need %d results, but stack size is %d", n, len(stack))
-	} else {
-		results = stack[:n]
-	}
-
-	_, err := ce.call(ctx, params, results)
+	_, err = ce.call(ctx, params, results)
 	return err
 }
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -717,15 +717,15 @@ func (ce *callEngine) CallWithStack(ctx context.Context, stack []uint64) error {
 	var params, results []uint64
 
 	ft := ce.initialFn.funcType
-	if n := ft.ParamNumInUint64; n < len(stack) {
+	if n := ft.ParamNumInUint64; n > len(stack) {
 		return fmt.Errorf("need %d params, but stack size is %d", n, len(stack))
 	} else {
-		params = params[:n]
+		params = stack[:n]
 	}
-	if n := ft.ResultNumInUint64; n < len(stack) {
+	if n := ft.ResultNumInUint64; n > len(stack) {
 		return fmt.Errorf("need %d results, but stack size is %d", n, len(stack))
 	} else {
-		results = results[:n]
+		results = stack[:n]
 	}
 
 	_, err := ce.call(ctx, params, results)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -67,6 +67,16 @@ func TestCompiler_ModuleEngine_Call(t *testing.T) {
 `, "\n"+functionLog.String())
 }
 
+func TestCompiler_ModuleEngine_CallWithStack(t *testing.T) {
+	defer functionLog.Reset()
+	requireSupportedOSArch(t)
+	enginetest.RunTestModuleEngineCallWithStack(t, et)
+	require.Equal(t, `
+--> .$0(1,2)
+<-- (1,2)
+`, "\n"+functionLog.String())
+}
+
 func TestCompiler_ModuleEngine_Call_HostFn(t *testing.T) {
 	defer functionLog.Reset()
 	requireSupportedOSArch(t)

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -464,21 +464,11 @@ func (ce *callEngine) Call(ctx context.Context, params ...uint64) (results []uin
 
 // CallWithStack implements the same method as documented on api.Function.
 func (ce *callEngine) CallWithStack(ctx context.Context, stack []uint64) error {
-	var params, results []uint64
-
-	ft := ce.compiled.funcType
-	if n := ft.ParamNumInUint64; n > len(stack) {
-		return fmt.Errorf("need %d params, but stack size is %d", n, len(stack))
-	} else {
-		params = stack[:n]
+	params, results, err := wasm.SplitCallStack(ce.compiled.funcType, stack)
+	if err != nil {
+		return err
 	}
-	if n := ft.ResultNumInUint64; n > len(stack) {
-		return fmt.Errorf("need %d results, but stack size is %d", n, len(stack))
-	} else {
-		results = stack[:n]
-	}
-
-	_, err := ce.call(ctx, params, results)
+	_, err = ce.call(ctx, params, results)
 	return err
 }
 

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -467,15 +467,15 @@ func (ce *callEngine) CallWithStack(ctx context.Context, stack []uint64) error {
 	var params, results []uint64
 
 	ft := ce.compiled.funcType
-	if n := ft.ParamNumInUint64; n < len(stack) {
+	if n := ft.ParamNumInUint64; n > len(stack) {
 		return fmt.Errorf("need %d params, but stack size is %d", n, len(stack))
 	} else {
-		params = params[:n]
+		params = stack[:n]
 	}
-	if n := ft.ResultNumInUint64; n < len(stack) {
+	if n := ft.ResultNumInUint64; n > len(stack) {
 		return fmt.Errorf("need %d results, but stack size is %d", n, len(stack))
 	} else {
-		results = results[:n]
+		results = stack[:n]
 	}
 
 	_, err := ce.call(ctx, params, results)

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -105,6 +105,15 @@ func TestInterpreter_ModuleEngine_Call(t *testing.T) {
 `, "\n"+functionLog.String())
 }
 
+func TestCompiler_ModuleEngine_CallWithStack(t *testing.T) {
+	defer functionLog.Reset()
+	enginetest.RunTestModuleEngineCallWithStack(t, et)
+	require.Equal(t, `
+--> .$0(1,2)
+<-- (1,2)
+`, "\n"+functionLog.String())
+}
+
 func TestInterpreter_ModuleEngine_Call_HostFn(t *testing.T) {
 	defer functionLog.Reset()
 	enginetest.RunTestModuleEngineCallHostFn(t, et)

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -58,6 +58,23 @@ func BenchmarkHostFunctionCall(b *testing.B) {
 				}
 			}
 		})
+
+		b.Run(fn+"_with_stack", func(b *testing.B) {
+			ce := getCallEngine(m, fn)
+
+			b.ResetTimer()
+			stack := []uint64{offset}
+			for i := 0; i < b.N; i++ {
+				stack[0] = offset
+				err := ce.CallWithStack(testCtx, stack)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if uint32(stack[0]) != math.Float32bits(val) {
+					b.Fail()
+				}
+			}
+		})
 	}
 }
 

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkHostFunctionCall(b *testing.B) {
 			ce := getCallEngine(m, fn)
 
 			b.ResetTimer()
-			stack := []uint64{offset}
+			stack := make([]uint64, 1)
 			for i := 0; i < b.N; i++ {
 				stack[0] = offset
 				err := ce.CallWithStack(testCtx, stack)

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -190,6 +190,58 @@ func RunTestModuleEngineCall(t *testing.T, et EngineTester) {
 	})
 }
 
+func RunTestModuleEngineCallWithStack(t *testing.T, et EngineTester) {
+	e := et.NewEngine(api.CoreFeaturesV2)
+
+	// Define a basic function which defines two parameters and two results.
+	// This is used to test results when incorrect arity is used.
+	m := &wasm.Module{
+		TypeSection: []wasm.FunctionType{
+			{
+				Params:            []wasm.ValueType{i64, i64},
+				Results:           []wasm.ValueType{i64, i64},
+				ParamNumInUint64:  2,
+				ResultNumInUint64: 2,
+			},
+		},
+		FunctionSection: []wasm.Index{0},
+		CodeSection: []wasm.Code{
+			{Body: []byte{wasm.OpcodeLocalGet, 0, wasm.OpcodeLocalGet, 1, wasm.OpcodeEnd}},
+		},
+	}
+
+	m.BuildFunctionDefinitions()
+	listeners := buildListeners(et.ListenerFactory(), m)
+	err := e.CompileModule(testCtx, m, listeners, false)
+	require.NoError(t, err)
+
+	// To use the function, we first need to add it to a module.
+	module := &wasm.ModuleInstance{
+		ModuleName: t.Name(), TypeIDs: []wasm.FunctionTypeID{0},
+		Definitions: m.FunctionDefinitionSection,
+	}
+
+	// Compile the module
+	me, err := e.NewModuleEngine(m, module)
+	require.NoError(t, err)
+	linkModuleToEngine(module, me)
+
+	// Ensure the base case doesn't fail: A single parameter should work as that matches the function signature.
+	const funcIndex = 0
+	ce := me.NewFunction(funcIndex)
+
+	stack := []uint64{1, 2}
+	err = ce.CallWithStack(testCtx, stack)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2}, stack)
+
+	t.Run("errs when not enough parameters", func(t *testing.T) {
+		ce := me.NewFunction(funcIndex)
+		err = ce.CallWithStack(testCtx, nil)
+		require.EqualError(t, err, "need 2 params, but stack size is 0")
+	})
+}
+
 func RunTestModuleEngineLookupFunction(t *testing.T, et EngineTester) {
 	e := et.NewEngine(api.CoreFeaturesV1)
 

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -79,26 +79,6 @@ func (f *reflectGoFunction) Call(ctx context.Context, stack []uint64) {
 	callGoFunc(ctx, nil, f.fn, stack)
 }
 
-// PopValues pops the specified number of api.ValueType parameters off the
-// stack into a parameter slice for use in api.GoFunction or api.GoModuleFunction.
-//
-// For example, if the host function F requires the (x1 uint32, x2 float32)
-// parameters, and the stack is [..., A, B], then the function is called as
-// F(A, B) where A and B are interpreted as uint32 and float32 respectively.
-//
-// Note: the popper intentionally doesn't return bool or error because the
-// caller's stack depth is trusted.
-func PopValues(count int, popper func() uint64) []uint64 {
-	if count == 0 {
-		return nil
-	}
-	params := make([]uint64, count)
-	for i := count - 1; i >= 0; i-- {
-		params[i] = popper()
-	}
-	return params
-}
-
 // callGoFunc executes the reflective function by converting params to Go
 // types. The results of the function call are converted back to api.ValueType.
 func callGoFunc(ctx context.Context, mod api.Module, fn *reflect.Value, stack []uint64) {

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -136,43 +136,6 @@ func (s *stack) pop() (result uint64) {
 	return
 }
 
-func TestPopValues(t *testing.T) {
-	stackVals := []uint64{1, 2, 3, 4, 5, 6, 7}
-	tests := []struct {
-		name     string
-		count    int
-		expected []uint64
-	}{
-		{
-			name: "pop zero doesn't allocate a slice ",
-		},
-		{
-			name:     "pop 1",
-			count:    1,
-			expected: []uint64{7},
-		},
-		{
-			name:     "pop 2",
-			count:    2,
-			expected: []uint64{6, 7},
-		},
-		{
-			name:     "pop 3",
-			count:    3,
-			expected: []uint64{5, 6, 7},
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-
-		t.Run(tc.name, func(t *testing.T) {
-			vals := PopValues(tc.count, (&stack{stackVals}).pop)
-			require.Equal(t, tc.expected, vals)
-		})
-	}
-}
-
 func Test_callGoFunc(t *testing.T) {
 	tPtr := uintptr(unsafe.Pointer(t))
 	inst := &ModuleInstance{}

--- a/internal/wasm/gofunc_test.go
+++ b/internal/wasm/gofunc_test.go
@@ -124,18 +124,6 @@ func Test_parseGoFunc_Errors(t *testing.T) {
 	}
 }
 
-// stack simulates the value stack in a way easy to be tested.
-type stack struct {
-	vals []uint64
-}
-
-func (s *stack) pop() (result uint64) {
-	stackTopIndex := len(s.vals) - 1
-	result = s.vals[stackTopIndex]
-	s.vals = s.vals[:stackTopIndex]
-	return
-}
-
 func Test_callGoFunc(t *testing.T) {
 	tPtr := uintptr(unsafe.Pointer(t))
 	inst := &ModuleInstance{}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -488,7 +488,12 @@ func (e *mockModuleEngine) Close(context.Context) {
 func (ce *mockCallEngine) Definition() api.FunctionDefinition { return nil }
 
 // Call implements the same method as documented on api.Function.
-func (ce *mockCallEngine) Call(_ context.Context, _ ...uint64) (results []uint64, err error) {
+func (ce *mockCallEngine) Call(ctx context.Context, _ ...uint64) (results []uint64, err error) {
+	return ce.CallWithStack(ctx, nil)
+}
+
+// CallWithStack implements the same method as documented on api.Function.
+func (ce *mockCallEngine) CallWithStack(_ context.Context, _ []uint64) (results []uint64, err error) {
 	if ce.callFailIndex >= 0 && ce.index == Index(ce.callFailIndex) {
 		err = errors.New("call failed")
 		return

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -489,16 +489,15 @@ func (ce *mockCallEngine) Definition() api.FunctionDefinition { return nil }
 
 // Call implements the same method as documented on api.Function.
 func (ce *mockCallEngine) Call(ctx context.Context, _ ...uint64) (results []uint64, err error) {
-	return ce.CallWithStack(ctx, nil)
+	return nil, ce.CallWithStack(ctx, nil)
 }
 
 // CallWithStack implements the same method as documented on api.Function.
-func (ce *mockCallEngine) CallWithStack(_ context.Context, _ []uint64) (results []uint64, err error) {
+func (ce *mockCallEngine) CallWithStack(_ context.Context, _ []uint64) error {
 	if ce.callFailIndex >= 0 && ce.index == Index(ce.callFailIndex) {
-		err = errors.New("call failed")
-		return
+		return errors.New("call failed")
 	}
-	return
+	return nil
 }
 
 func TestStore_getFunctionTypeID(t *testing.T) {


### PR DESCRIPTION
This implements the API discussed in #1332.

It still needs unit tests, and redoing the benchmarks to confirm the improvements. 