### PR TITLE
ci: run -race on PRs as well

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -76,12 +76,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
 
-      - run: make test
-        if: ${{ github.event_name  == 'pull_request' }}
-
-      # Run tests with -race only on main branch push.
+      # Run -race could be really slow without -short, so run them together on this workflow.
+      # Since -short is not added in the scratch tests, all the tests are run in CI in practice.
       - run: make test go_test_options='-timeout 10m -race -short'
-        if: ${{ github.event_name  == 'push' }}
 
       - name: "Generate coverage report"  # only once (not per OS)
         if: runner.os == 'Linux'

--- a/internal/integration_test/fuzzcases/fuzzcases_test.go
+++ b/internal/integration_test/fuzzcases/fuzzcases_test.go
@@ -319,6 +319,7 @@ func Test733(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if testing.Short() {
 				// Note: this case uses large memory space, so can be slow like 1 to 2 seconds even without -race.
+				// The reason is that this test requires roughly 2GB of in-Wasm memory.
 				t.SkipNow()
 			}
 			f := mod.ExportedFunction(name)


### PR DESCRIPTION
we recently missed two race bugs introduced via PRs but detected on the main branch.
The reason is that previously we had run tests with -race only on main branch.

This enables the race detection on PRs as well.