### PR TITLE
Adds SplitCallStack for use in CallWithStack

### DIFF
--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1935,3 +1935,19 @@ var (
 	blockType_v_funcref   = &FunctionType{Results: []ValueType{ValueTypeFuncref}, ResultNumInUint64: 1}
 	blockType_v_externref = &FunctionType{Results: []ValueType{ValueTypeExternref}, ResultNumInUint64: 1}
 )
+
+// SplitCallStack returns the input stack resliced to the count of params and
+// results, or errors if it isn't long enough for either.
+func SplitCallStack(ft *FunctionType, stack []uint64) (params []uint64, results []uint64, err error) {
+	if n := ft.ParamNumInUint64; n > len(stack) {
+		return nil, nil, fmt.Errorf("need %d params, but stack size is %d", n, len(stack))
+	} else if n > 0 {
+		params = stack[:n]
+	}
+	if n := ft.ResultNumInUint64; n > len(stack) {
+		return nil, nil, fmt.Errorf("need %d results, but stack size is %d", n, len(stack))
+	} else if n > 0 {
+		results = stack[:n]
+	}
+	return
+}

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1939,13 +1939,13 @@ var (
 // SplitCallStack returns the input stack resliced to the count of params and
 // results, or errors if it isn't long enough for either.
 func SplitCallStack(ft *FunctionType, stack []uint64) (params []uint64, results []uint64, err error) {
-	if n := ft.ParamNumInUint64; n > len(stack) {
-		return nil, nil, fmt.Errorf("need %d params, but stack size is %d", n, len(stack))
+	if n, len := ft.ParamNumInUint64, len(stack); n > len {
+		return nil, nil, fmt.Errorf("need %d params, but stack size is %d", n, len)
 	} else if n > 0 {
 		params = stack[:n]
 	}
-	if n := ft.ResultNumInUint64; n > len(stack) {
-		return nil, nil, fmt.Errorf("need %d results, but stack size is %d", n, len(stack))
+	if n, len := ft.ResultNumInUint64, len(stack); n > len {
+		return nil, nil, fmt.Errorf("need %d results, but stack size is %d", n, len)
 	} else if n > 0 {
 		results = stack[:n]
 	}

--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -1939,13 +1939,14 @@ var (
 // SplitCallStack returns the input stack resliced to the count of params and
 // results, or errors if it isn't long enough for either.
 func SplitCallStack(ft *FunctionType, stack []uint64) (params []uint64, results []uint64, err error) {
-	if n, len := ft.ParamNumInUint64, len(stack); n > len {
-		return nil, nil, fmt.Errorf("need %d params, but stack size is %d", n, len)
+	stackLen := len(stack)
+	if n := ft.ParamNumInUint64; n > stackLen {
+		return nil, nil, fmt.Errorf("need %d params, but stack size is %d", n, stackLen)
 	} else if n > 0 {
 		params = stack[:n]
 	}
-	if n, len := ft.ResultNumInUint64, len(stack); n > len {
-		return nil, nil, fmt.Errorf("need %d results, but stack size is %d", n, len)
+	if n := ft.ResultNumInUint64; n > stackLen {
+		return nil, nil, fmt.Errorf("need %d results, but stack size is %d", n, stackLen)
 	} else if n > 0 {
 		results = stack[:n]
 	}

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -103,8 +103,8 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 				},
 				TypeSection: []FunctionType{
 					v_v,
-					{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
-					{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					f64i32_v128i64,
+					f64f32_i64,
 				},
 			},
 			expected: []FunctionDefinition{
@@ -112,13 +112,13 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					index:       0,
 					debugName:   ".$0",
 					exportNames: []string{"function_index=0"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
+					funcType:    &f64i32_v128i64,
 				},
 				{
 					index:       1,
 					debugName:   ".$1",
 					exportNames: []string{"function_index=1"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					funcType:    &f64f32_i64,
 				},
 				{
 					index:       2,
@@ -132,13 +132,13 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					index:       0,
 					debugName:   ".$0",
 					exportNames: []string{"function_index=0"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
+					funcType:    &f64i32_v128i64,
 				},
 				"function_index=1": &FunctionDefinition{
 					index:       1,
 					exportNames: []string{"function_index=1"},
 					debugName:   ".$1",
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					funcType:    &f64f32_i64,
 				},
 				"function_index=2": &FunctionDefinition{
 					index:       2,
@@ -162,8 +162,8 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 				CodeSection:     []Code{{Body: []byte{OpcodeEnd}}, {Body: []byte{OpcodeEnd}}},
 				TypeSection: []FunctionType{
 					v_v,
-					{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
-					{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					f64i32_v128i64,
+					f64f32_i64,
 				},
 			},
 			expected: []FunctionDefinition{
@@ -172,13 +172,13 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					debugName:   ".$0",
 					importDesc:  imp,
 					exportNames: []string{"imported_function"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					funcType:    &f64f32_i64,
 				},
 				{
 					index:       1,
 					debugName:   ".$1",
 					exportNames: []string{"function_index=1"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
+					funcType:    &f64i32_v128i64,
 				},
 				{
 					index:       2,
@@ -193,7 +193,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					debugName:   ".$0",
 					importDesc:  imp,
 					exportNames: []string{"imported_function"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					funcType:    &f64f32_i64,
 				},
 			},
 			expectedExports: map[string]api.FunctionDefinition{
@@ -202,13 +202,13 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 					debugName:   ".$0",
 					importDesc:  imp,
 					exportNames: []string{"imported_function"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeF32}, Results: []ValueType{ValueTypeI64}},
+					funcType:    &f64f32_i64,
 				},
 				"function_index=1": &FunctionDefinition{
 					index:       1,
 					debugName:   ".$1",
 					exportNames: []string{"function_index=1"},
-					funcType:    &FunctionType{Params: []ValueType{ValueTypeF64, ValueTypeI32}, Results: []ValueType{ValueTypeV128, ValueTypeI64}},
+					funcType:    &f64i32_v128i64,
 				},
 				"function_index=2": &FunctionDefinition{
 					index:       2,


### PR DESCRIPTION
This adds an internal function `wasm.SplitCallStack` for use in #1407. This is separate because the diff is a lot larger than the destination change ;)