### PR TITLE
Bulk Lazy initialization of FunctionDefinitions 

### DIFF
--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -298,8 +298,7 @@ func Test_loggingListener(t *testing.T) {
 			} else {
 				m.CodeSection = []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}}
 			}
-			m.BuildFunctionDefinitions()
-			def := &m.FunctionDefinitionSection[0]
+			def := m.FunctionDefinition(0)
 			l := lf.NewFunctionListener(def)
 
 			out.Reset()
@@ -333,10 +332,9 @@ func Test_loggingListener_indentation(t *testing.T) {
 			FunctionNames: wasm.NameMap{{Index: 0, Name: "fn1"}, {Index: 1, Name: "fn2"}},
 		},
 	}
-	m.BuildFunctionDefinitions()
-	def1 := &m.FunctionDefinitionSection[0]
+	def1 := m.FunctionDefinition(0)
 	l1 := lf.NewFunctionListener(def1)
-	def2 := &m.FunctionDefinitionSection[1]
+	def2 := m.FunctionDefinition(1)
 	l2 := lf.NewFunctionListener(def2)
 
 	ctx := l1.Before(testCtx, nil, def1, []uint64{}, nil)

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -547,7 +547,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 			cmp.Init(typ, nil, lsn != nil)
 			withGoFunc = true
 			if body, err = compileGoDefinedHostFunction(cmp); err != nil {
-				def := module.FunctionDefinitionSection[funcIndex+importedFuncs]
+				def := module.FunctionDefinition(funcIndex + importedFuncs)
 				return fmt.Errorf("error compiling host go func[%s]: %w", def.DebugName(), err)
 			}
 			compiledFn.goFunc = codeSeg.GoFunc
@@ -560,7 +560,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 
 			body, compiledFn.stackPointerCeil, compiledFn.sourceOffsetMap, err = compileWasmFunction(cmp, ir)
 			if err != nil {
-				def := module.FunctionDefinitionSection[funcIndex+importedFuncs]
+				def := module.FunctionDefinition(funcIndex + importedFuncs)
 				return fmt.Errorf("error compiling wasm func[%s]: %w", def.DebugName(), err)
 			}
 		}
@@ -699,7 +699,7 @@ func (ce *callEngine) Definition() api.FunctionDefinition {
 
 func (f *function) definition() api.FunctionDefinition {
 	compiled := f.parent
-	return &compiled.parent.source.FunctionDefinitionSection[compiled.index]
+	return compiled.parent.source.FunctionDefinition(compiled.index)
 }
 
 // Call implements the same method as documented on wasm.ModuleEngine.

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -382,7 +382,6 @@ func ptrAsUint64(f *function) uint64 {
 func TestCallEngine_deferredOnCall(t *testing.T) {
 	vv := &wasm.FunctionType{}
 	s := &wasm.Module{
-		FunctionDefinitionSectionInitialized: 1,
 		FunctionDefinitionSection: []wasm.FunctionDefinition{
 			{Debugname: "1", Functype: vv}, {Debugname: "2", Functype: vv}, {Debugname: "3", Functype: vv},
 		},
@@ -597,8 +596,7 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 			},
 			index: 0,
 			parent: &compiledModule{source: &wasm.Module{
-				FunctionDefinitionSectionInitialized: 1,
-				FunctionDefinitionSection:            []wasm.FunctionDefinition{{}},
+				FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
 			}},
 		},
 	}
@@ -627,8 +625,7 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 			},
 			index: 0,
 			parent: &compiledModule{source: &wasm.Module{
-				FunctionDefinitionSectionInitialized: 1,
-				FunctionDefinitionSection:            []wasm.FunctionDefinition{{}},
+				FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
 			}},
 		},
 	}

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -219,7 +219,6 @@ func TestCompiler_CompileModule(t *testing.T) {
 			},
 			ID: wasm.ModuleID{},
 		}
-		errModule.BuildFunctionDefinitions()
 
 		e := et.NewEngine(api.CoreFeaturesV1).(*engine)
 		err := e.CompileModule(testCtx, errModule, nil, false)
@@ -336,7 +335,6 @@ func TestCompiler_SliceAllocatedOnHeap(t *testing.T) {
 		},
 		ID: wasm.ModuleID{1},
 	}
-	m.BuildFunctionDefinitions()
 
 	err = s.Engine.CompileModule(testCtx, m, nil, false)
 	require.NoError(t, err)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -382,6 +382,7 @@ func ptrAsUint64(f *function) uint64 {
 func TestCallEngine_deferredOnCall(t *testing.T) {
 	vv := &wasm.FunctionType{}
 	s := &wasm.Module{
+		FunctionDefinitionSectionInitialized: 1,
 		FunctionDefinitionSection: []wasm.FunctionDefinition{
 			{Debugname: "1", Functype: vv}, {Debugname: "2", Functype: vv}, {Debugname: "3", Functype: vv},
 		},
@@ -596,7 +597,8 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 			},
 			index: 0,
 			parent: &compiledModule{source: &wasm.Module{
-				FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
+				FunctionDefinitionSectionInitialized: 1,
+				FunctionDefinitionSection:            []wasm.FunctionDefinition{{}},
 			}},
 		},
 	}
@@ -625,7 +627,8 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 			},
 			index: 0,
 			parent: &compiledModule{source: &wasm.Module{
-				FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
+				FunctionDefinitionSectionInitialized: 1,
+				FunctionDefinitionSection:            []wasm.FunctionDefinition{{}},
 			}},
 		},
 	}

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -380,11 +380,10 @@ func ptrAsUint64(f *function) uint64 {
 }
 
 func TestCallEngine_deferredOnCall(t *testing.T) {
-	vv := &wasm.FunctionType{}
 	s := &wasm.Module{
-		FunctionDefinitionSection: []wasm.FunctionDefinition{
-			{Debugname: "1", Functype: vv}, {Debugname: "2", Functype: vv}, {Debugname: "3", Functype: vv},
-		},
+		FunctionSection: []wasm.Index{0, 1, 2},
+		CodeSection:     []wasm.Code{{}, {}, {}},
+		TypeSection:     []wasm.FunctionType{{}, {}, {}},
 	}
 	f1 := &function{
 		funcType: &wasm.FunctionType{ParamNumInUint64: 2},
@@ -427,9 +426,9 @@ func TestCallEngine_deferredOnCall(t *testing.T) {
 	err := ce.deferredOnCall(errors.New("some error"))
 	require.EqualError(t, err, `some error (recovered by wazero)
 wasm stack trace:
-	3()
-	2()
-	1()`)
+	.$2()
+	.$1()
+	.$0()`)
 
 	// After recover, the state of callEngine must be reset except that the underlying slices must be intact
 	// for the subsequent calls to avoid additional allocations on each call.
@@ -596,7 +595,9 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 			},
 			index: 0,
 			parent: &compiledModule{source: &wasm.Module{
-				FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
+				FunctionSection: []wasm.Index{0},
+				CodeSection:     []wasm.Code{{}},
+				TypeSection:     []wasm.FunctionType{{}},
 			}},
 		},
 	}
@@ -625,7 +626,9 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 			},
 			index: 0,
 			parent: &compiledModule{source: &wasm.Module{
-				FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
+				FunctionSection: []wasm.Index{0},
+				CodeSection:     []wasm.Code{{}},
+				TypeSection:     []wasm.FunctionType{{}},
 			}},
 		},
 	}

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -318,7 +318,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 			}
 			err = e.lowerIR(ir, compiled)
 			if err != nil {
-				def := module.FunctionDefinitionSection[uint32(i)+module.ImportFunctionCount]
+				def := module.FunctionDefinition(uint32(i) + module.ImportFunctionCount)
 				return fmt.Errorf("failed to lower func[%s] to wazeroir: %w", def.DebugName(), err)
 			}
 		}
@@ -470,7 +470,7 @@ func (ce *callEngine) Definition() api.FunctionDefinition {
 
 func (f *function) definition() api.FunctionDefinition {
 	compiled := f.parent
-	return &compiled.source.FunctionDefinitionSection[compiled.index]
+	return compiled.source.FunctionDefinition(compiled.index)
 }
 
 // Call implements the same method as documented on api.Function.

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -514,7 +514,6 @@ func TestInterpreter_Compile(t *testing.T) {
 			},
 			ID: wasm.ModuleID{},
 		}
-		errModule.BuildFunctionDefinitions()
 
 		err := e.CompileModule(testCtx, errModule, nil, false)
 		require.EqualError(t, err, "handling instruction: apply stack failed for call: reading immediates: EOF")

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -172,7 +172,6 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 		},
 		ID: wasm.ModuleID{1, 2, 3, 4, 5},
 	}
-	hostModule.BuildFunctionDefinitions()
 
 	host := &wasm.ModuleInstance{ModuleName: "host", TypeIDs: []wasm.FunctionTypeID{0}}
 	host.Exports = hostModule.Exports
@@ -211,7 +210,6 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 		ID:            wasm.ModuleID{1},
 	}
 
-	importingModule.BuildFunctionDefinitions()
 	err = eng.CompileModule(testCtx, importingModule, nil, false)
 	requireNoError(err)
 

--- a/internal/integration_test/bench/hostfunc_bench_test.go
+++ b/internal/integration_test/bench/hostfunc_bench_test.go
@@ -174,10 +174,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 	}
 	hostModule.BuildFunctionDefinitions()
 
-	host := &wasm.ModuleInstance{
-		ModuleName: "host", TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: hostModule.FunctionDefinitionSection,
-	}
+	host := &wasm.ModuleInstance{ModuleName: "host", TypeIDs: []wasm.FunctionTypeID{0}}
 	host.Exports = hostModule.Exports
 
 	err := eng.CompileModule(testCtx, hostModule, nil, false)
@@ -218,10 +215,7 @@ func setupHostCallBench(requireNoError func(error)) *wasm.ModuleInstance {
 	err = eng.CompileModule(testCtx, importingModule, nil, false)
 	requireNoError(err)
 
-	importing := &wasm.ModuleInstance{
-		TypeIDs:     []wasm.FunctionTypeID{0},
-		Definitions: importingModule.FunctionDefinitionSection,
-	}
+	importing := &wasm.ModuleInstance{TypeIDs: []wasm.FunctionTypeID{0}}
 	importing.Exports = importingModule.Exports
 
 	importingMe, err := eng.NewModuleEngine(importingModule, importing)

--- a/internal/integration_test/spectest/spectest.go
+++ b/internal/integration_test/spectest/spectest.go
@@ -329,7 +329,6 @@ func addSpectestModule(t *testing.T, ctx context.Context, s *wasm.Store, enabled
 
 	maybeSetMemoryCap(mod)
 	mod.BuildMemoryDefinitions()
-	mod.BuildFunctionDefinitions()
 
 	err = mod.Validate(enabledFeatures)
 	require.NoError(t, err)
@@ -403,7 +402,6 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Ca
 
 						maybeSetMemoryCap(mod)
 						mod.BuildMemoryDefinitions()
-						mod.BuildFunctionDefinitions()
 						err = s.Engine.CompileModule(ctx, mod, nil, false)
 						require.NoError(t, err, msg)
 
@@ -544,7 +542,6 @@ func Run(t *testing.T, testDataFS embed.FS, ctx context.Context, fc filecache.Ca
 							mod.AssignModuleID(buf, false, false)
 
 							maybeSetMemoryCap(mod)
-							mod.BuildFunctionDefinitions()
 							err = s.Engine.CompileModule(ctx, mod, nil, false)
 							require.NoError(t, err, msg)
 
@@ -581,7 +578,6 @@ func requireInstantiationError(t *testing.T, ctx context.Context, s *wasm.Store,
 
 	maybeSetMemoryCap(mod)
 	mod.BuildMemoryDefinitions()
-	mod.BuildFunctionDefinitions()
 	err = s.Engine.CompileModule(ctx, mod, nil, false)
 	if err != nil {
 		return

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -161,10 +161,7 @@ func RunTestModuleEngineCall(t *testing.T, et EngineTester) {
 	require.NoError(t, err)
 
 	// To use the function, we first need to add it to a module.
-	module := &wasm.ModuleInstance{
-		ModuleName: t.Name(), TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: m.FunctionDefinitionSection,
-	}
+	module := &wasm.ModuleInstance{ModuleName: t.Name(), TypeIDs: []wasm.FunctionTypeID{0}}
 
 	// Compile the module
 	me, err := e.NewModuleEngine(m, module)
@@ -218,10 +215,7 @@ func RunTestModuleEngineCallWithStack(t *testing.T, et EngineTester) {
 	require.NoError(t, err)
 
 	// To use the function, we first need to add it to a module.
-	module := &wasm.ModuleInstance{
-		ModuleName: t.Name(), TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: m.FunctionDefinitionSection,
-	}
+	module := &wasm.ModuleInstance{ModuleName: t.Name(), TypeIDs: []wasm.FunctionTypeID{0}}
 
 	// Compile the module
 	me, err := e.NewModuleEngine(m, module)
@@ -661,10 +655,9 @@ func RunTestModuleEngineBeforeListenerStackIterator(t *testing.T, et EngineTeste
 	require.NoError(t, err)
 
 	module := &wasm.ModuleInstance{
-		ModuleName:  t.Name(),
-		TypeIDs:     []wasm.FunctionTypeID{0, 1, 2, 3},
-		Definitions: m.FunctionDefinitionSection,
-		Exports:     exportMap(m),
+		ModuleName: t.Name(),
+		TypeIDs:    []wasm.FunctionTypeID{0, 1, 2, 3},
+		Exports:    exportMap(m),
 	}
 
 	me, err := e.NewModuleEngine(m, module)
@@ -782,10 +775,9 @@ func RunTestModuleEngineBeforeListenerGlobals(t *testing.T, et EngineTester) {
 	require.NoError(t, err)
 
 	module := &wasm.ModuleInstance{
-		ModuleName:  t.Name(),
-		TypeIDs:     []wasm.FunctionTypeID{0, 1, 2, 3},
-		Definitions: m.FunctionDefinitionSection,
-		Exports:     exportMap(m),
+		ModuleName: t.Name(),
+		TypeIDs:    []wasm.FunctionTypeID{0, 1, 2, 3},
+		Exports:    exportMap(m),
 		Globals: []*wasm.GlobalInstance{
 			{Val: 100, Type: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true}},
 			{Val: 200, Type: wasm.GlobalType{ValType: wasm.ValueTypeI32, Mutable: true}},
@@ -1071,7 +1063,6 @@ func RunTestModuleEngineMemory(t *testing.T, et EngineTester) {
 		MemoryInstance: wasm.NewMemoryInstance(m.MemorySection),
 		DataInstances:  []wasm.DataInstance{m.DataSection[0].Init},
 		TypeIDs:        []wasm.FunctionTypeID{0, 1},
-		Definitions:    m.FunctionDefinitionSection,
 	}
 	memory := module.MemoryInstance
 
@@ -1195,10 +1186,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 	lns := buildFunctionListeners(fnlf, hostModule)
 	err := e.CompileModule(testCtx, hostModule, lns, false)
 	require.NoError(t, err)
-	host := &wasm.ModuleInstance{
-		ModuleName: hostModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: hostModule.FunctionDefinitionSection,
-	}
+	host := &wasm.ModuleInstance{ModuleName: hostModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0}}
 	host.Exports = exportMap(hostModule)
 
 	hostME, err := e.NewModuleEngine(hostModule, host)
@@ -1235,7 +1223,6 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 
 	imported := &wasm.ModuleInstance{
 		ModuleName: importedModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: importedModule.FunctionDefinitionSection,
 	}
 	imported.Exports = exportMap(importedModule)
 
@@ -1269,10 +1256,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 	require.NoError(t, err)
 
 	// Add the exported function.
-	importing := &wasm.ModuleInstance{
-		ModuleName: importingModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: importingModule.FunctionDefinitionSection,
-	}
+	importing := &wasm.ModuleInstance{ModuleName: importingModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0}}
 	importing.Exports = exportMap(importingModule)
 
 	// Compile the importing module
@@ -1302,10 +1286,7 @@ func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code) *wasm.Mo
 	hostModule.BuildFunctionDefinitions()
 	err := e.CompileModule(testCtx, hostModule, nil, false)
 	require.NoError(t, err)
-	host := &wasm.ModuleInstance{
-		ModuleName: hostModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: hostModule.FunctionDefinitionSection,
-	}
+	host := &wasm.ModuleInstance{ModuleName: hostModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0}}
 	host.Exports = exportMap(hostModule)
 
 	hostMe, err := e.NewModuleEngine(hostModule, host)
@@ -1341,10 +1322,7 @@ func setupCallMemTests(t *testing.T, e wasm.Engine, readMem *wasm.Code) *wasm.Mo
 	require.NoError(t, err)
 
 	// Add the exported function.
-	importing := &wasm.ModuleInstance{
-		ModuleName: importingModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0},
-		Definitions: importingModule.FunctionDefinitionSection,
-	}
+	importing := &wasm.ModuleInstance{ModuleName: importingModule.NameSection.ModuleName, TypeIDs: []wasm.FunctionTypeID{0}}
 	// Note: adds imported functions readMemFn and callReadMemFn at index 0 and 1.
 	importing.Exports = exportMap(importingModule)
 

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -44,6 +44,14 @@ func (m *Module) FunctionDefinition(index Index) *FunctionDefinition {
 // Note: This is exported for tests who don't use wazero.Runtime or
 // NewHostModule to compile the module.
 func (m *Module) buildFunctionDefinitions() {
+	m.functionDefinitionSectionWriteMutex.Lock()
+	defer m.functionDefinitionSectionWriteMutex.Unlock()
+
+	// Lock acquired, ensure the count is still zero.
+	if len(m.FunctionDefinitionSection) != 0 {
+		return
+	}
+
 	var moduleName string
 	var functionNames NameMap
 	var localNames, resultNames IndirectNameMap

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -31,16 +31,13 @@ func (m *Module) ExportedFunctions() map[string]api.FunctionDefinition {
 
 // FunctionDefinition returns the FunctionDefinition for the given `index`.
 func (m *Module) FunctionDefinition(index Index) *FunctionDefinition {
-	// TODO: lazy initialization per function.
+	// TODO: function initialization is lazy, but bulk. Make it per function.
 	m.functionDefinitionSectionInitOnce.Do(m.buildFunctionDefinitions)
 	return &m.FunctionDefinitionSection[index]
 }
 
 // buildFunctionDefinitions generates function metadata that can be parsed from
 // the module. This must be called after all validation.
-//
-// Note: This is exported for tests who don't use wazero.Runtime or
-// NewHostModule to compile the module.
 func (m *Module) buildFunctionDefinitions() {
 	// In tests, we may have initialized FunctionDefinitionSection
 	// without going through buildFunctionDefinitions().

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -31,16 +31,19 @@ func (m *Module) ExportedFunctions() map[string]api.FunctionDefinition {
 
 // FunctionDefinition returns the FunctionDefinition for the given `index`.
 func (m *Module) FunctionDefinition(index Index) *FunctionDefinition {
-	// TODO: lazy initialization.
+	// TODO: lazy initialization per function.
+	if len(m.FunctionDefinitionSection) == 0 {
+		m.buildFunctionDefinitions()
+	}
 	return &m.FunctionDefinitionSection[index]
 }
 
-// BuildFunctionDefinitions generates function metadata that can be parsed from
+// buildFunctionDefinitions generates function metadata that can be parsed from
 // the module. This must be called after all validation.
 //
 // Note: This is exported for tests who don't use wazero.Runtime or
 // NewHostModule to compile the module.
-func (m *Module) BuildFunctionDefinitions() {
+func (m *Module) buildFunctionDefinitions() {
 	var moduleName string
 	var functionNames NameMap
 	var localNames, resultNames IndirectNameMap

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -10,11 +10,8 @@ import (
 //
 // Note: Unlike ExportedFunctions, there is no unique constraint on imports.
 func (m *Module) ImportedFunctions() (ret []api.FunctionDefinition) {
-	for i := range m.FunctionDefinitionSection {
-		d := &m.FunctionDefinitionSection[i]
-		if d.importDesc != nil {
-			ret = append(ret, d)
-		}
+	for i := uint32(0); i < m.ImportFunctionCount; i++ {
+		ret = append(ret, m.FunctionDefinition(i))
 	}
 	return
 }
@@ -22,13 +19,20 @@ func (m *Module) ImportedFunctions() (ret []api.FunctionDefinition) {
 // ExportedFunctions returns the definitions of each exported function.
 func (m *Module) ExportedFunctions() map[string]api.FunctionDefinition {
 	ret := map[string]api.FunctionDefinition{}
-	for i := range m.FunctionDefinitionSection {
-		d := &m.FunctionDefinitionSection[i]
-		for _, e := range d.exportNames {
-			ret[e] = d
+	for i := range m.ExportSection {
+		exp := &m.ExportSection[i]
+		if exp.Type == ExternTypeFunc {
+			d := m.FunctionDefinition(exp.Index)
+			ret[exp.Name] = d
 		}
 	}
 	return ret
+}
+
+// FunctionDefinition returns the FunctionDefinition for the given `index`.
+func (m *Module) FunctionDefinition(index Index) *FunctionDefinition {
+	// TODO: lazy initialization.
+	return &m.FunctionDefinitionSection[index]
 }
 
 // BuildFunctionDefinitions generates function metadata that can be parsed from

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -43,15 +43,6 @@ func (m *Module) buildFunctionDefinitions() {
 }
 
 func (m *Module) buildFunctionDefinitionsOnce() {
-	// In tests, we may have initialized FunctionDefinitionSection
-	// without going through buildFunctionDefinitions().
-	//
-	// This is generally a redundant check, but since we are
-	// already on the slow path, we can afford it.
-	if len(m.FunctionDefinitionSection) != 0 {
-		return
-	}
-
 	var moduleName string
 	var functionNames NameMap
 	var localNames, resultNames IndirectNameMap

--- a/internal/wasm/function_definition.go
+++ b/internal/wasm/function_definition.go
@@ -32,13 +32,17 @@ func (m *Module) ExportedFunctions() map[string]api.FunctionDefinition {
 // FunctionDefinition returns the FunctionDefinition for the given `index`.
 func (m *Module) FunctionDefinition(index Index) *FunctionDefinition {
 	// TODO: function initialization is lazy, but bulk. Make it per function.
-	m.functionDefinitionSectionInitOnce.Do(m.buildFunctionDefinitions)
+	m.buildFunctionDefinitions()
 	return &m.FunctionDefinitionSection[index]
 }
 
 // buildFunctionDefinitions generates function metadata that can be parsed from
 // the module. This must be called after all validation.
 func (m *Module) buildFunctionDefinitions() {
+	m.functionDefinitionSectionInitOnce.Do(m.buildFunctionDefinitionsOnce)
+}
+
+func (m *Module) buildFunctionDefinitionsOnce() {
 	// In tests, we may have initialized FunctionDefinitionSection
 	// without going through buildFunctionDefinitions().
 	//

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -253,7 +253,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc.m.BuildFunctionDefinitions()
+			tc.m.buildFunctionDefinitions()
 			require.Equal(t, tc.expected, tc.m.FunctionDefinitionSection)
 			require.Equal(t, tc.expectedImports, tc.m.ImportedFunctions())
 			require.Equal(t, tc.expectedExports, tc.m.ExportedFunctions())

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -281,5 +281,4 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 			require.Equal(t, tc.expectedExports, tc.m.ExportedFunctions())
 		})
 	}
-
 }

--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -73,7 +73,6 @@ func NewHostModule(
 	// TODO: refactor engines so that we can properly cache compiled machine codes for host modules.
 	m.AssignModuleID([]byte(fmt.Sprintf("@@@@@@@@%p", m)), // @@@@@@@@ = any 8 bytes different from Wasm header.
 		false, false)
-	m.BuildFunctionDefinitions()
 	return
 }
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -169,7 +169,7 @@ type Module struct {
 	// IsHostModule true if this is the host module, false otherwise.
 	IsHostModule bool
 
-	// functionDefinitionSection is a wazero-specific section.
+	// FunctionDefinitionSection is a wazero-specific section.
 	FunctionDefinitionSection []FunctionDefinition
 
 	// MemoryDefinitionSection is a wazero-specific section.

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/ieee754"
@@ -168,6 +169,8 @@ type Module struct {
 
 	// IsHostModule true if this is the host module, false otherwise.
 	IsHostModule bool
+
+	functionDefinitionSectionWriteMutex sync.Mutex
 
 	// FunctionDefinitionSection is a wazero-specific section.
 	FunctionDefinitionSection []FunctionDefinition

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -170,9 +170,7 @@ type Module struct {
 	// IsHostModule true if this is the host module, false otherwise.
 	IsHostModule bool
 
-	functionDefinitionSectionWriteMutex sync.Mutex
-
-	FunctionDefinitionSectionInitialized uint32
+	functionDefinitionSectionInitOnce sync.Once
 
 	// FunctionDefinitionSection is a wazero-specific section.
 	FunctionDefinitionSection []FunctionDefinition

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -240,7 +240,6 @@ func (m *Module) typeOfFunction(funcIdx Index) *FunctionType {
 		return nil
 	}
 	return &m.TypeSection[typeIdx]
-
 }
 
 func (m *Module) Validate(enabledFeatures api.CoreFeatures) error {

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -172,6 +172,8 @@ type Module struct {
 
 	functionDefinitionSectionWriteMutex sync.Mutex
 
+	FunctionDefinitionSectionInitialized uint32
+
 	// FunctionDefinitionSection is a wazero-specific section.
 	FunctionDefinitionSection []FunctionDefinition
 

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -203,7 +203,7 @@ func (m *ModuleInstance) ExportedFunctionDefinitions() map[string]api.FunctionDe
 	result := map[string]api.FunctionDefinition{}
 	for name, exp := range m.Exports {
 		if exp.Type == ExternTypeFunc {
-			result[name] = &m.Definitions[exp.Index]
+			result[name] = m.Source.FunctionDefinition(exp.Index)
 		}
 	}
 	return result

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -376,8 +376,9 @@ func TestModule_validateStartSection(t *testing.T) {
 	t.Run("imported valid func", func(t *testing.T) {
 		index := Index(1)
 		m := Module{
-			StartSection: &index,
-			TypeSection:  []FunctionType{{}, {Results: []ValueType{ValueTypeI32}}},
+			StartSection:        &index,
+			TypeSection:         []FunctionType{{}, {Results: []ValueType{ValueTypeI32}}},
+			ImportFunctionCount: 2,
 			ImportSection: []Import{
 				{Type: ExternTypeFunc, DescFunc: 1},
 				// import with index 1 is global but this should be skipped when searching imported functions.

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -127,7 +127,7 @@ type (
 		//
 		// Note: This is currently only used for spectests and will be nil in most cases.
 		aliases []string
-		// Definitions is derived from *Module, and is constructed during compilation phrase.
+		// Source is a pointer to the Module from which this ModuleInstance derives.
 		Source *Module
 	}
 

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -211,7 +211,6 @@ func TestStore_hammer(t *testing.T) {
 			{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 		},
 	}
-	importingModule.BuildFunctionDefinitions()
 
 	// Concurrent instantiate, close should test if locks work on the ns. If they don't, we should see leaked modules
 	// after all of these complete, or an error raised.
@@ -271,7 +270,6 @@ func TestStore_hammer_close(t *testing.T) {
 			{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 		},
 	}
-	importingModule.BuildFunctionDefinitions()
 
 	const instCount = 10000
 	instances := make([]api.Module, instCount)
@@ -371,7 +369,6 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 			},
 		}
-		importingModule.BuildFunctionDefinitions()
 
 		_, err = s.Instantiate(testCtx, importingModule, importingModuleName, nil, []FunctionTypeID{0})
 		require.EqualError(t, err, "some engine creation error")
@@ -399,7 +396,6 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 				{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0},
 			},
 		}
-		importingModule.BuildFunctionDefinitions()
 
 		_, err = s.Instantiate(testCtx, importingModule, importingModuleName, nil, []FunctionTypeID{0})
 		require.EqualError(t, err, "start function[1] failed: call failed")

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -692,19 +692,21 @@ func Test_resolveImports(t *testing.T) {
 					"":   {Type: ExternTypeFunc, Index: 4},
 				},
 				ModuleName: moduleName,
-				Definitions: []FunctionDefinition{
-					{},
-					{},
-					{Functype: &FunctionType{Params: []ValueType{i32}, Results: []ValueType{ValueTypeV128}}},
-					{},
-					{Functype: &FunctionType{Params: []ValueType{ExternTypeFunc}, Results: []ValueType{}}},
+				Source: &Module{
+					FunctionSection: []Index{0, 0, 1, 0, 0},
+					TypeSection: []FunctionType{
+						{Params: []ValueType{ExternTypeFunc}},
+						{Params: []ValueType{i32}, Results: []ValueType{ValueTypeV128}},
+					},
 				},
 			}
+
 			module := &Module{
 				TypeSection: []FunctionType{
 					{Params: []ValueType{i32}, Results: []ValueType{ValueTypeV128}},
 					{Params: []ValueType{ExternTypeFunc}},
 				},
+				ImportFunctionCount: 2,
 				ImportPerModule: map[string][]*Import{
 					moduleName: {
 						{Module: moduleName, Name: name, Type: ExternTypeFunc, DescFunc: 0, IndexPerType: 0},
@@ -713,7 +715,7 @@ func Test_resolveImports(t *testing.T) {
 				},
 			}
 
-			m := &ModuleInstance{Engine: &mockModuleEngine{resolveImportsCalled: map[Index]Index{}}, s: s}
+			m := &ModuleInstance{Engine: &mockModuleEngine{resolveImportsCalled: map[Index]Index{}}, s: s, Source: module}
 			err := m.resolveImports(module)
 			require.NoError(t, err)
 
@@ -727,9 +729,14 @@ func Test_resolveImports(t *testing.T) {
 				Exports: map[string]*Export{
 					name: {Type: ExternTypeFunc, Index: 0},
 				},
-				ModuleName:  moduleName,
-				TypeIDs:     []FunctionTypeID{123435},
-				Definitions: []FunctionDefinition{{Functype: &FunctionType{}}},
+				ModuleName: moduleName,
+				TypeIDs:    []FunctionTypeID{123435},
+				Source: &Module{
+					FunctionSection: []Index{0},
+					TypeSection: []FunctionType{
+						{Params: []ValueType{}},
+					},
+				},
 			}
 			module := &Module{
 				TypeSection: []FunctionType{{Results: []ValueType{ValueTypeF32}}},
@@ -738,7 +745,7 @@ func Test_resolveImports(t *testing.T) {
 				},
 			}
 
-			m := &ModuleInstance{Engine: &mockModuleEngine{resolveImportsCalled: map[Index]Index{}}, s: s}
+			m := &ModuleInstance{Engine: &mockModuleEngine{resolveImportsCalled: map[Index]Index{}}, s: s, Source: module}
 			err := m.resolveImports(module)
 			require.EqualError(t, err, "import func[test.target]: signature mismatch: v_f32 != v_v")
 		})

--- a/runtime.go
+++ b/runtime.go
@@ -215,8 +215,8 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 		return nil, err
 	}
 
-	// Now that the module is validated, cache the function and memory definitions.
-	internal.BuildFunctionDefinitions()
+	// Now that the module is validated, cache the memory definitions.
+	// TODO: lazy initialization of memory definition.
 	internal.BuildMemoryDefinitions()
 
 	c := &compiledModule{module: internal, compiledEngine: r.store.Engine}

--- a/runtime.go
+++ b/runtime.go
@@ -249,7 +249,7 @@ func buildFunctionListeners(ctx context.Context, internal *wasm.Module) ([]exper
 	importCount := internal.ImportFunctionCount
 	listeners := make([]experimentalapi.FunctionListener, len(internal.FunctionSection))
 	for i := 0; i < len(listeners); i++ {
-		listeners[i] = factory.NewFunctionListener(&internal.FunctionDefinitionSection[uint32(i)+importCount])
+		listeners[i] = factory.NewFunctionListener(internal.FunctionDefinition(uint32(i) + importCount))
 	}
 	return listeners, nil
 }


### PR DESCRIPTION
`BuildFunctionDefinitions` is one of the most heavy allocation source during compilation,
which should be deferred when it's actually required (e.g. facing runtime errors).

This refactors the usage of FunctionDefinition, and defer the initialization of `[]FunctionDefinition`
to the time when `Module.FunctionDefinition` is called.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                   │   old.txt   │              new.txt              │
                                   │   sec/op    │   sec/op     vs base              │
Compilation_sqlite3/compiler-10      134.4m ± 1%   134.3m ± 5%       ~ (p=0.620 n=7)
Compilation_sqlite3/interpreter-10   45.75m ± 0%   45.67m ± 1%       ~ (p=0.456 n=7)
geomean                              78.42m        78.30m       -0.16%

                                   │   old.txt    │              new.txt               │
                                   │     B/op     │     B/op      vs base              │
Compilation_sqlite3/compiler-10      54.32Mi ± 0%   54.04Mi ± 0%  -0.51% (p=0.001 n=7)
Compilation_sqlite3/interpreter-10   51.75Mi ± 0%   51.47Mi ± 0%  -0.54% (p=0.001 n=7)
geomean                              53.02Mi        52.74Mi       -0.52%

                                   │   old.txt   │              new.txt               │
                                   │  allocs/op  │  allocs/op   vs base               │
Compilation_sqlite3/compiler-10      26.06k ± 0%   23.00k ± 0%  -11.72% (p=0.001 n=7)
Compilation_sqlite3/interpreter-10   13.90k ± 0%   10.84k ± 0%  -22.00% (p=0.001 n=7)
geomean                              19.03k        15.79k       -17.02%

```