### PR TITLE
Splits EACCES from EPERM on Windows

### DIFF
--- a/internal/platform/errno_windows.go
+++ b/internal/platform/errno_windows.go
@@ -5,7 +5,7 @@ import "syscall"
 // See https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
 const (
 	// ERROR_ACCESS_DENIED is a Windows error returned by syscall.Unlink
-	// instead of syscall.EPERM
+	// instead of syscall.EACCES
 	ERROR_ACCESS_DENIED = syscall.Errno(5)
 
 	// ERROR_INVALID_HANDLE is a Windows error returned by syscall.Write
@@ -59,7 +59,9 @@ func adjustErrno(err syscall.Errno) syscall.Errno {
 		return syscall.EEXIST
 	case ERROR_INVALID_HANDLE:
 		return syscall.EBADF
-	case ERROR_ACCESS_DENIED, ERROR_PRIVILEGE_NOT_HELD:
+	case ERROR_ACCESS_DENIED:
+		return syscall.EACCES
+	case ERROR_PRIVILEGE_NOT_HELD:
 		return syscall.EPERM
 	case ERROR_NEGATIVE_SEEK, ERROR_INVALID_NAME:
 		return syscall.EINVAL

--- a/internal/platform/file.go
+++ b/internal/platform/file.go
@@ -197,10 +197,7 @@ func (f *fsFile) Chown(uid, gid int) syscall.Errno {
 
 // Sync implements File.Sync
 func (f *fsFile) Sync() syscall.Errno {
-	if f, ok := f.file.(syncFile); ok {
-		return UnwrapOSError(f.Sync())
-	}
-	return 0 // don't error
+	return sync(f.file)
 }
 
 // Datasync implements File.Datasync

--- a/internal/platform/file_test.go
+++ b/internal/platform/file_test.go
@@ -102,11 +102,7 @@ func testSync(t *testing.T, sync func(File) syscall.Errno) {
 
 	// Even though it is invalid, try to sync a directory
 	errno := sync(NewFsFile(dPath, d))
-	if runtime.GOOS == "windows" {
-		require.EqualErrno(t, syscall.EACCES, errno)
-	} else {
-		require.EqualErrno(t, 0, errno)
-	}
+	require.EqualErrno(t, 0, errno)
 
 	fPath := path.Join(dPath, t.Name())
 

--- a/internal/platform/file_test.go
+++ b/internal/platform/file_test.go
@@ -96,6 +96,18 @@ func TestFsFileDatasync(t *testing.T) {
 // similar to below. Effectively, this only tests that things don't error.
 func testSync(t *testing.T, sync func(File) syscall.Errno) {
 	dPath := t.TempDir()
+	d, err := os.Open(dPath)
+	require.NoError(t, err)
+	defer d.Close()
+
+	// Even though it is invalid, try to sync a directory
+	errno := sync(NewFsFile(dPath, d))
+	if runtime.GOOS == "windows" {
+		require.EqualErrno(t, syscall.EACCES, errno)
+	} else {
+		require.EqualErrno(t, 0, errno)
+	}
+
 	fPath := path.Join(dPath, t.Name())
 
 	f := openFsFile(t, fPath, os.O_RDWR|os.O_CREATE, 0o600)
@@ -104,11 +116,11 @@ func testSync(t *testing.T, sync func(File) syscall.Errno) {
 	expected := "hello world!"
 
 	// Write the expected data
-	_, err := f.File().(io.Writer).Write([]byte(expected))
+	_, err = f.File().(io.Writer).Write([]byte(expected))
 	require.NoError(t, err)
 
 	// Sync the data.
-	errno := sync(f)
+	errno = sync(f)
 	require.EqualErrno(t, 0, errno)
 
 	// Rewind while the file is still open.

--- a/internal/platform/sync.go
+++ b/internal/platform/sync.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package platform
 
 import (

--- a/internal/platform/sync_windows.go
+++ b/internal/platform/sync_windows.go
@@ -1,0 +1,22 @@
+package platform
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+func sync(f fs.File) syscall.Errno {
+	if s, ok := f.(syncFile); ok {
+		errno := UnwrapOSError(s.Sync())
+		// Coerce error performing stat on a directory to 0, as it won't work
+		// on Windows.
+		switch errno {
+		case syscall.EACCES /* Go 1.20 */, syscall.EBADF /* Go 1.18 */ :
+			if st, err := f.Stat(); err == nil && st.IsDir() {
+				errno = 0
+			}
+		}
+		return errno
+	}
+	return 0
+}

--- a/internal/platform/unlink_windows.go
+++ b/internal/platform/unlink_windows.go
@@ -13,7 +13,7 @@ func Unlink(name string) syscall.Errno {
 		return 0
 	}
 	errno := UnwrapOSError(err)
-	if errno == syscall.EPERM {
+	if errno == syscall.EACCES {
 		lstat, errLstat := os.Lstat(name)
 		if errLstat == nil && lstat.Mode()&os.ModeSymlink != 0 {
 			errno = UnwrapOSError(os.Remove(name))


### PR DESCRIPTION
On Windows, an access error was mapped to EPERM not EACCES.