### PR TITLE
Adds Path to platform.File and refactors tests

### DIFF
--- a/internal/platform/chown_unix_test.go
+++ b/internal/platform/chown_unix_test.go
@@ -18,8 +18,8 @@ func TestChown(t *testing.T) {
 	dir := path.Join(tmpDir, "dir")
 	require.NoError(t, os.Mkdir(dir, 0o0777))
 
-	dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
-	require.EqualErrno(t, 0, errno)
+	dirF := openFsFile(t, dir, syscall.O_RDONLY, 0)
+	defer dirF.Close()
 
 	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
@@ -66,8 +66,8 @@ func TestDefaultFileChown(t *testing.T) {
 	dir := path.Join(tmpDir, "dir")
 	require.NoError(t, os.Mkdir(dir, 0o0777))
 
-	dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
-	require.EqualErrno(t, 0, errno)
+	dirF := openFsFile(t, dir, syscall.O_RDONLY, 0)
+	defer dirF.Close()
 
 	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
@@ -116,8 +116,8 @@ func TestLchown(t *testing.T) {
 	dir := path.Join(tmpDir, "dir")
 	require.NoError(t, os.Mkdir(dir, 0o0777))
 
-	dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
-	require.EqualErrno(t, 0, errno)
+	dirF := openFsFile(t, dir, syscall.O_RDONLY, 0)
+	defer dirF.Close()
 
 	dirStat, err := dirF.File().Stat()
 	require.NoError(t, err)
@@ -127,8 +127,8 @@ func TestLchown(t *testing.T) {
 	link := path.Join(tmpDir, "link")
 	require.NoError(t, os.Symlink(dir, link))
 
-	linkF, errno := OpenFile(link, syscall.O_RDONLY, 0)
-	require.EqualErrno(t, 0, errno)
+	linkF := openFsFile(t, link, syscall.O_RDONLY, 0)
+	defer linkF.Close()
 
 	linkStat, err := linkF.File().Stat()
 	require.NoError(t, err)

--- a/internal/platform/datasync_linux.go
+++ b/internal/platform/datasync_linux.go
@@ -7,14 +7,11 @@ import (
 	"syscall"
 )
 
-func fdatasync(f fs.File) syscall.Errno {
+func datasync(f fs.File) syscall.Errno {
 	if fd, ok := f.(fdFile); ok {
 		return UnwrapOSError(syscall.Fdatasync(int(fd.Fd())))
 	}
 
 	// Attempt to sync everything, even if we only need to sync the data.
-	if s, ok := f.(syncFile); ok {
-		return UnwrapOSError(s.Sync())
-	}
-	return 0
+	return sync(f)
 }

--- a/internal/platform/datasync_unsupported.go
+++ b/internal/platform/datasync_unsupported.go
@@ -7,10 +7,7 @@ import (
 	"syscall"
 )
 
-func fdatasync(f fs.File) syscall.Errno {
+func datasync(f fs.File) syscall.Errno {
 	// Attempt to sync everything, even if we only need to sync the data.
-	if s, ok := f.(syncFile); ok {
-		return UnwrapOSError(s.Sync())
-	}
-	return 0
+	return sync(f)
 }

--- a/internal/platform/futimens_test.go
+++ b/internal/platform/futimens_test.go
@@ -167,8 +167,7 @@ func testFutimens(t *testing.T, usePath bool) {
 						}
 					}
 
-					f, errno := OpenFile(path, flag, 0)
-					require.EqualErrno(t, 0, errno)
+					f := openFsFile(t, path, flag, 0)
 
 					errno = UtimensFile(f.File(), tc.times)
 					require.Zero(t, f.Close())
@@ -222,11 +221,10 @@ func TestUtimensFile(t *testing.T) {
 		err := os.WriteFile(file, []byte{}, 0o700)
 		require.NoError(t, err)
 
-		fileF, errno := OpenFile(file, syscall.O_RDWR, 0)
-		require.EqualErrno(t, 0, errno)
+		fileF := openFsFile(t, file, syscall.O_RDWR, 0)
 		require.Zero(t, fileF.Close())
 
-		errno = UtimensFile(fileF.File(), nil)
+		errno := UtimensFile(fileF.File(), nil)
 		require.EqualErrno(t, syscall.EBADF, errno)
 	})
 
@@ -235,8 +233,7 @@ func TestUtimensFile(t *testing.T) {
 		err := os.Mkdir(dir, 0o700)
 		require.NoError(t, err)
 
-		dirF, errno := OpenFile(dir, syscall.O_RDONLY, 0)
-		require.EqualErrno(t, 0, errno)
+		dirF := openFsFile(t, dir, syscall.O_RDONLY, 0)
 		require.Zero(t, dirF.Close())
 
 		err = UtimensFile(dirF.File(), nil)

--- a/internal/platform/open_file.go
+++ b/internal/platform/open_file.go
@@ -17,7 +17,10 @@ const (
 
 // OpenFile is like os.OpenFile except it returns syscall.Errno. A zero
 // syscall.Errno is success.
-func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
+func OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
 	f, err := os.OpenFile(path, flag, perm)
-	return &DefaultFile{F: f}, UnwrapOSError(err)
+	// Note: This does not return a platform.File because sysfs.FS that returns
+	// one may want to hide the real OS path. For example, this is needed for
+	// pre-opens.
+	return f, UnwrapOSError(err)
 }

--- a/internal/platform/open_file_js.go
+++ b/internal/platform/open_file_js.go
@@ -12,8 +12,8 @@ const (
 	O_NOFOLLOW  = 1 << 30
 )
 
-func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
+func OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
 	flag &= ^(O_DIRECTORY | O_NOFOLLOW) // erase placeholders
 	f, err := os.OpenFile(path, flag, perm)
-	return &DefaultFile{F: f}, UnwrapOSError(err)
+	return f, UnwrapOSError(err)
 }

--- a/internal/platform/open_file_sun.go
+++ b/internal/platform/open_file_sun.go
@@ -14,7 +14,7 @@ const (
 	O_NOFOLLOW  = syscall.O_NOFOLLOW
 )
 
-func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
+func OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
 	f, err := os.OpenFile(path, flag, perm)
-	return &DefaultFile{F: f}, UnwrapOSError(err)
+	return f, UnwrapOSError(err)
 }

--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -28,12 +28,12 @@ const (
 	O_NOFOLLOW  = 1 << 30
 )
 
-func OpenFile(path string, flag int, perm fs.FileMode) (File, syscall.Errno) {
+func OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) {
 	if f, errno := openFile(path, flag, perm); errno != 0 {
 		return nil, errno
-	} else {
+	} else { // TODO: revisit windowsWrappedFile once fsFile is complete
 		f := &windowsWrappedFile{WriteFile: f, path: path, flag: flag, perm: perm}
-		return &DefaultFile{F: f}, 0
+		return f, 0
 	}
 }
 

--- a/internal/platform/stat_test.go
+++ b/internal/platform/stat_test.go
@@ -192,7 +192,7 @@ func TestStatFile(t *testing.T) {
 		require.NotEqual(t, uint64(0), st.Ino)
 	})
 
-	t.Run("closed fsFile", func(t *testing.T) {
+	t.Run("closed file", func(t *testing.T) {
 		require.Zero(t, fileF.Close())
 		_, errno := fileF.Stat()
 		require.EqualErrno(t, syscall.EBADF, errno)

--- a/internal/platform/sync.go
+++ b/internal/platform/sync.go
@@ -1,0 +1,13 @@
+package platform
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+func sync(f fs.File) syscall.Errno {
+	if s, ok := f.(syncFile); ok {
+		return UnwrapOSError(s.Sync())
+	}
+	return 0
+}

--- a/internal/platform/wrap_windows.go
+++ b/internal/platform/wrap_windows.go
@@ -63,6 +63,8 @@ func (w *windowsWrappedFile) Write(p []byte) (n int, err error) {
 	}
 
 	n, err = w.WriteFile.Write(p)
+	// ERROR_ACCESS_DENIED is often returned instead of EBADF
+	// when a file is used after close.
 	if errors.Is(err, ERROR_ACCESS_DENIED) {
 		err = syscall.EBADF
 	}

--- a/internal/platform/wrap_windows.go
+++ b/internal/platform/wrap_windows.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"errors"
 	"io/fs"
 	"syscall"
 )
@@ -61,7 +62,11 @@ func (w *windowsWrappedFile) Write(p []byte) (n int, err error) {
 		return
 	}
 
-	return w.WriteFile.Write(p)
+	n, err = w.WriteFile.Write(p)
+	if errors.Is(err, ERROR_ACCESS_DENIED) {
+		err = syscall.EBADF
+	}
+	return
 }
 
 // Close implements io.Closer

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	noopStdin  = &FileEntry{Name: "stdin", File: &platform.DefaultFile{F: NewStdioFileReader(eofReader{}, noopStdinStat, PollerDefaultStdin)}}
-	noopStdout = &FileEntry{Name: "stdout", File: &platform.DefaultFile{F: &stdioFileWriter{w: io.Discard, s: noopStdoutStat}}}
-	noopStderr = &FileEntry{Name: "stderr", File: &platform.DefaultFile{F: &stdioFileWriter{w: io.Discard, s: noopStderrStat}}}
+	noopStdin  = &FileEntry{Name: "stdin", File: platform.NewFsFile("", NewStdioFileReader(eofReader{}, noopStdinStat, PollerDefaultStdin))}
+	noopStdout = &FileEntry{Name: "stdout", File: platform.NewFsFile("", &stdioFileWriter{w: io.Discard, s: noopStdoutStat})}
+	noopStderr = &FileEntry{Name: "stderr", File: platform.NewFsFile("", &stdioFileWriter{w: io.Discard, s: noopStderrStat})}
 )
 
 //go:embed testdata

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -48,7 +48,7 @@ func (a *adapter) Open(name string) (fs.File, error) {
 func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	path = cleanPath(path)
 	f, err := a.fs.Open(path)
-	return &platform.DefaultFile{F: f}, platform.UnwrapOSError(err)
+	return platform.NewFsFile(path, f), platform.UnwrapOSError(err)
 }
 
 // Stat implements FS.Stat
@@ -59,7 +59,7 @@ func (a *adapter) Stat(path string) (platform.Stat_t, syscall.Errno) {
 		return platform.Stat_t{}, platform.UnwrapOSError(err)
 	}
 	defer f.Close()
-	return (&platform.DefaultFile{F: f}).Stat()
+	return platform.NewFsFile(path, f).Stat()
 }
 
 // Lstat implements FS.Lstat

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -42,7 +42,11 @@ func (d *dirFS) Open(name string) (fs.File, error) {
 
 // OpenFile implements FS.OpenFile
 func (d *dirFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
-	return platform.OpenFile(d.join(path), flag, perm)
+	f, errno := platform.OpenFile(d.join(path), flag, perm)
+	if errno != 0 {
+		return nil, errno
+	}
+	return platform.NewFsFile(path, f), 0
 }
 
 // Lstat implements FS.Lstat

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -67,7 +67,7 @@ func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.Fil
 	if errno != 0 {
 		return nil, errno
 	}
-	return &platform.DefaultFile{F: maskForReads(f.File())}, 0
+	return platform.NewFsFile(path, maskForReads(f.File())), 0
 }
 
 // maskForReads masks the file with read-only interfaces used by wazero.

--- a/internal/sysfs/rootfs.go
+++ b/internal/sysfs/rootfs.go
@@ -137,7 +137,7 @@ func (c *CompositeFS) OpenFile(path string, flag int, perm fs.FileMode) (f platf
 		case ".", "/", "":
 			if len(c.rootGuestPaths) > 0 {
 				dir := &openRootDir{c: c, f: f.File().(fs.ReadDirFile)}
-				f = &platform.DefaultFile{F: dir}
+				f = platform.NewFsFile(path, dir)
 			}
 		}
 	}
@@ -483,7 +483,7 @@ type fakeRootFS struct{ UnimplementedFS }
 func (*fakeRootFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	switch path {
 	case ".", "/", "":
-		return &platform.DefaultFile{F: fakeRootDir{}}, 0
+		return platform.NewFsFile(path, fakeRootDir{}), 0
 	}
 	return nil, syscall.ENOENT
 }

--- a/internal/sysfs/sysfs.go
+++ b/internal/sysfs/sysfs.go
@@ -48,7 +48,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` or `flag` is invalid.
 	//   - syscall.ENOENT: `path` doesn't exist and `flag` doesn't contain
 	//     os.O_CREATE.
@@ -83,7 +83,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.ENOENT: `path` doesn't exist.
 	//
 	// # Notes
@@ -103,7 +103,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.ENOENT: `path` doesn't exist.
 	//
 	// # Notes
@@ -123,7 +123,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.EEXIST: `path` exists and is a directory.
 	//   - syscall.ENOTDIR: `path` exists and is a file.
@@ -144,7 +144,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.ENOENT: `path` does not exist.
 	//
@@ -164,7 +164,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.ENOENT: `path` does not exist.
 	//
@@ -182,7 +182,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.ENOENT: `path` does not exist.
 	//
@@ -200,7 +200,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `from` or `to` is invalid.
 	//   - syscall.ENOENT: `from` or `to` don't exist.
 	//   - syscall.ENOTDIR: `from` is a directory and `to` exists as a file.
@@ -222,7 +222,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.ENOENT: `path` doesn't exist.
 	//   - syscall.ENOTDIR: `path` exists, but isn't a directory.
@@ -242,7 +242,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.ENOENT: `path` doesn't exist.
 	//   - syscall.EISDIR: `path` exists, but is a directory.
@@ -264,7 +264,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EPERM: `oldPath` is invalid.
 	//   - syscall.ENOENT: `oldPath` doesn't exist.
 	//   - syscall.EISDIR: `newPath` exists, but is a directory.
@@ -283,7 +283,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EPERM: `oldPath` or `newPath` is invalid.
 	//   - syscall.EEXIST: `newPath` exists.
 	//
@@ -308,7 +308,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//
 	// # Notes
@@ -327,9 +327,10 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid or size is negative.
-	//   - syscall.ENOENT: `path` doesn't exist
+	//   - syscall.ENOENT: `path` doesn't exist.
+	//   - syscall.EISDIR: `path` is a directory.
 	//   - syscall.EACCES: `path` doesn't have write access.
 	//
 	// # Notes
@@ -356,7 +357,7 @@ type FS interface {
 	// # Errors
 	//
 	// A zero syscall.Errno is success. The below are expected otherwise:
-	//   - syscall.ENOSYS the implementation does not support this function.
+	//   - syscall.ENOSYS: the implementation does not support this function.
 	//   - syscall.EINVAL: `path` is invalid.
 	//   - syscall.EEXIST: `path` exists and is a directory.
 	//   - syscall.ENOTDIR: `path` exists and is a file.


### PR DESCRIPTION
This adds Path which is non-empty when the file is a normal file or directory. This immediately supports the re-open use case, and later may make some things in windows easier.

This also adds a platform.NewFsFile function which makes some call sites better.

Finally, this fixes a bug hidden by how our tests were written, where the wrong errno was returned when a file was used after close in windows.