### PR TITLE
experimental: expose source offset to Listener

### DIFF
--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -18,6 +18,11 @@ type StackIterator interface {
 	Next() bool
 	// FunctionDefinition returns the function type of the current function.
 	FunctionDefinition() api.FunctionDefinition
+	// SourceOffset returns the offset in the Code section where
+	// the function call occured (it is translated for native
+	// functions). Returns 0 if the source offset cannot be
+	// calculated.
+	SourceOffset() uint64
 	// Parameters returns api.ValueType-encoded parameters of the current
 	// function. Do not modify the content of the slice, and copy out any value
 	// you need.

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -13,19 +13,22 @@ import (
 // iteration. As a result, parameter values may be different than the ones their
 // function was called with.
 type StackIterator interface {
-	// Next moves the iterator to the next function in the stack. Returns false
-	// if it reached the bottom of the stack.
+	// Next moves the iterator to the next function in the stack. Returns
+	// false if it reached the bottom of the stack.
 	Next() bool
 	// FunctionDefinition returns the function type of the current function.
 	FunctionDefinition() api.FunctionDefinition
-	// SourceOffset returns the offset in the Code section where
-	// the function call occured (it is translated for native
-	// functions). Returns 0 if the source offset cannot be
-	// calculated.
+	// SourceOffset computes the offset in the module Code section where the
+	// call occured (translated for native functions), or the beginning of
+	// function for the top of the stack. Returns 0 if the source offset
+	// cannot be calculated.
+	//
+	// The source offset is meant to help map the function calls to their
+	// location in the original source files.
 	SourceOffset() uint64
 	// Parameters returns api.ValueType-encoded parameters of the current
-	// function. Do not modify the content of the slice, and copy out any value
-	// you need.
+	// function. Do not modify the content of the slice, and copy out any
+	// value you need.
 	Parameters() []uint64
 }
 

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -89,19 +89,28 @@ func Example_stackIterator() {
 	it := &fakeStackIterator{}
 
 	for it.Next() {
-		fmt.Println("function:", it.FunctionDefinition().DebugName(), "args", it.Args())
+		fmt.Println("function:", it.FunctionDefinition().DebugName())
+		fmt.Println("\tparameters:", it.Parameters())
+		fmt.Println("\tsource offset:", it.SourceOffset())
 	}
 
 	// Output:
-	// function: fn0 args [1 2 3]
-	// function: fn1 args []
-	// function: fn2 args [4]
+	// function: fn0
+	// 	parameters: [1 2 3]
+	// 	source offset: 1234
+	// function: fn1
+	// 	parameters: []
+	// 	source offset: 7286
+	// function: fn2
+	// 	parameters: [4]
+	// 	source offset: 935891
 }
 
 type fakeStackIterator struct {
 	iteration int
 	def       api.FunctionDefinition
 	args      []uint64
+	offset    uint64
 }
 
 func (s *fakeStackIterator) Next() bool {
@@ -109,12 +118,15 @@ func (s *fakeStackIterator) Next() bool {
 	case 0:
 		s.def = &mockFunctionDefinition{debugName: "fn0"}
 		s.args = []uint64{1, 2, 3}
+		s.offset = 1234
 	case 1:
 		s.def = &mockFunctionDefinition{debugName: "fn1"}
 		s.args = []uint64{}
+		s.offset = 7286
 	case 2:
 		s.def = &mockFunctionDefinition{debugName: "fn2"}
 		s.args = []uint64{4}
+		s.offset = 935891
 	case 3:
 		return false
 	}
@@ -126,9 +138,15 @@ func (s *fakeStackIterator) FunctionDefinition() api.FunctionDefinition {
 	return s.def
 }
 
-func (s *fakeStackIterator) Args() []uint64 {
+func (s *fakeStackIterator) Parameters() []uint64 {
 	return s.args
 }
+
+func (s *fakeStackIterator) SourceOffset() uint64 {
+	return s.offset
+}
+
+var _ experimental.StackIterator = &fakeStackIterator{}
 
 type mockFunctionDefinition struct {
 	debugName string

--- a/experimental/wazerotest/wazerotest.go
+++ b/experimental/wazerotest/wazerotest.go
@@ -647,9 +647,10 @@ func (def memoryDefinition) Max() (uint32, bool) {
 
 // StackFrame represents a frame on the call stack.
 type StackFrame struct {
-	Function api.Function
-	Params   []uint64
-	Results  []uint64
+	Function     api.Function
+	Params       []uint64
+	Results      []uint64
+	SourceOffset uint64
 }
 
 type stackIterator struct {
@@ -669,6 +670,10 @@ func (si *stackIterator) FunctionDefinition() api.FunctionDefinition {
 
 func (si *stackIterator) Parameters() []uint64 {
 	return si.stack[si.index].Params
+}
+
+func (si *stackIterator) SourceOffset() uint64 {
+	return si.stack[si.index].SourceOffset
 }
 
 func (si *stackIterator) reset() {

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -881,6 +881,9 @@ func (f *function) getSourceOffsetInWasmBinary(pc uint64) uint64 {
 		return srcMap.irOperationOffsetsInNativeBinary[i] >= pcOffsetInNativeBinary
 	})
 	if index == 0 && len(srcMap.irOperationSourceOffsetsInWasmBinary) > 0 {
+		// When pc is the beginning of the function, the next IR
+		// operation (returned by sort.Search) is the first of the
+		// offset map.
 		return srcMap.irOperationSourceOffsetsInWasmBinary[0]
 	}
 
@@ -1147,7 +1150,7 @@ func (si *stackIterator) SourceOffset() uint64 {
 	p := si.fn.parent
 
 	if len(p.sourceOffsetMap.irOperationSourceOffsetsInWasmBinary) == 0 {
-		return 0
+		return 0 // source not available
 	}
 
 	return si.fn.getSourceOffsetInWasmBinary(si.pc)

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -1121,7 +1121,7 @@ func (si *stackIterator) clear() {
 	si.started = false
 }
 
-// Next implements experimental.StackIterator.
+// Next implements the same method as documtend on experimental.StackIterator.
 func (si *stackIterator) Next() bool {
 	if !si.started {
 		si.started = true
@@ -1141,7 +1141,8 @@ func (si *stackIterator) Next() bool {
 	return si.fn != nil
 }
 
-// SourceOffset implements experimental.StackIterator.
+// SourceOffset implements the same method as documented on
+// experimental.StackIterator.
 func (si *stackIterator) SourceOffset() uint64 {
 	p := si.fn.parent
 
@@ -1152,12 +1153,14 @@ func (si *stackIterator) SourceOffset() uint64 {
 	return si.fn.getSourceOffsetInWasmBinary(si.pc)
 }
 
-// FunctionDefinition implements experimental.StackIterator.
+// FunctionDefinition implements the same method as documented on
+// experimental.StackIterator.
 func (si *stackIterator) FunctionDefinition() api.FunctionDefinition {
 	return si.fn.definition()
 }
 
-// Parameters implements experimental.StackIterator.
+// Parameters implements the same method as documented on
+// experimental.StackIterator.
 func (si *stackIterator) Parameters() []uint64 {
 	return si.stack[si.base : si.base+si.fn.funcType.ParamNumInUint64]
 }

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -148,6 +148,10 @@ func TestCompiler_BeforeListenerStackIterator(t *testing.T) {
 	enginetest.RunTestModuleEngineBeforeListenerStackIterator(t, et)
 }
 
+func TestCompiler_BeforeListenerStackIteratorSourceOffset(t *testing.T) {
+	enginetest.RunTestModuleEngineStackIteratorOffset(t, et)
+}
+
 func TestCompiler_BeforeListenerGlobals(t *testing.T) {
 	enginetest.RunTestModuleEngineBeforeListenerGlobals(t, et)
 }

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -240,7 +240,7 @@ func (si *stackIterator) clear() {
 	si.fn = nil
 }
 
-// Next implements experimental.StackIterator.
+// Next implements the same method as documented on experimental.StackIterator.
 func (si *stackIterator) Next() bool {
 	if !si.started {
 		si.started = true
@@ -259,12 +259,14 @@ func (si *stackIterator) Next() bool {
 	return true
 }
 
-// FunctionDefinition implements experimental.StackIterator.
+// FunctionDefinition implements the same method as documented on
+// experimental.StackIterator.
 func (si *stackIterator) FunctionDefinition() api.FunctionDefinition {
 	return si.fn.definition()
 }
 
-// SourceOffset implements experimental.StackIterator.
+// SourceOffset implements the same method as documented on
+// experimental.StackIterator.
 func (si *stackIterator) SourceOffset() uint64 {
 	offsetsMap := si.fn.parent.offsetsInWasmBinary
 	pc := si.pc
@@ -274,7 +276,8 @@ func (si *stackIterator) SourceOffset() uint64 {
 	return 0
 }
 
-// Parameters implements experimental.StackIterator.
+// Parameters implements the same method as documented on
+// experimental.StackIterator.
 func (si *stackIterator) Parameters() []uint64 {
 	paramsCount := si.fn.funcType.ParamNumInUint64
 	top := len(si.stack)

--- a/internal/engine/interpreter/interpreter_test.go
+++ b/internal/engine/interpreter/interpreter_test.go
@@ -575,6 +575,10 @@ func TestCompiler_BeforeListenerStackIterator(t *testing.T) {
 	enginetest.RunTestModuleEngineBeforeListenerStackIterator(t, et)
 }
 
+func TestCompiler_BeforeListenerStackIteratorSourceOffset(t *testing.T) {
+	enginetest.RunTestModuleEngineStackIteratorOffset(t, et)
+}
+
 func TestCompiler_BeforeListenerGlobals(t *testing.T) {
 	enginetest.RunTestModuleEngineBeforeListenerGlobals(t, et)
 }


### PR DESCRIPTION
This change provides a user of `experimental.StackIterator` the ability to retrieve the offset in the Code section of each function call in the frame of the stack. It enables capabilities such as source-mapping to be implemented by the user outside of wazero (removing the need for #1403).

It works by retrieving the return address of each stack frame and using the `irOperationSourceOffsetsInWasmBinary` attached to the function associated with that stack frame.

Though it works in my tests and on the few programs I used, I feel quite out of my depth here; I'd love some guidance and feedback! :) 

Question 1 – This source offsets mapping is only produced by the compiler when DWARF sections are present in the module. In practice, it's a reasonable limitation for us since we currently are only interested in using this information to correlate with DWARF data anyway. However, we may want to look at other applications in the future. It also meant that I had to provide a minimal DWARF info section for `dwarf/debug` not to trip up and the compiler to emit the offsets map. Would you be interested in adding either a flag to enable the mapping generation regardless of the presence of DWARF sections?

Question 2 – because the stack iterator is used in the`Before` listener hook, the topmost frame of the call stack is always the called function that triggered the listener. As such, I think the source offset should be the offset of the first byte of that function in the code section. In that case, I have observed that the pc is just lower than the first entry of `irOperationSourceOffsetsInWasmBinary` (hence the change in `getSourceOffsetInWasmBinary`). I am struggling to understand why? Returning the first entry of that collection seems to give the expected results, but I don't rationalize it.

I appreciate your consideration!