### PR TITLE
Adds AccessMode Write and Pwrite to platform.File

### DIFF
--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -232,10 +232,12 @@ func processFDEventRead(fsc *internalsys.FSContext, fd int32) wasip1.Errno {
 
 // processFDEventWrite returns ErrnoNotsup if the file exists and ErrnoBadf otherwise.
 func processFDEventWrite(fsc *internalsys.FSContext, fd int32) wasip1.Errno {
-	if internalsys.WriterForFile(fsc, fd) == nil {
-		return wasip1.ErrnoBadf
+	if f, ok := fsc.LookupFile(fd); ok {
+		if f.File.AccessMode() != syscall.O_RDONLY {
+			return wasip1.ErrnoNotsup
+		}
 	}
-	return wasip1.ErrnoNotsup
+	return wasip1.ErrnoBadf
 }
 
 // writeEvent writes the event corresponding to the processed subscription.

--- a/internal/platform/open_file_test.go
+++ b/internal/platform/open_file_test.go
@@ -1,7 +1,6 @@
 package platform
 
 import (
-	"io"
 	"os"
 	path "path/filepath"
 	"runtime"
@@ -73,8 +72,8 @@ func TestOpenFile_Errors(t *testing.T) {
 		f := openFsFile(t, path, os.O_RDONLY, 0)
 		defer f.Close()
 
-		_, err := f.File().(io.Writer).Write([]byte{1, 2, 3, 4})
-		require.EqualErrno(t, syscall.EBADF, UnwrapOSError(err))
+		_, errno := f.Write([]byte{1, 2, 3, 4})
+		require.EqualErrno(t, syscall.EBADF, errno)
 	})
 
 	t.Run("writing to a directory is EBADF", func(t *testing.T) {
@@ -84,8 +83,8 @@ func TestOpenFile_Errors(t *testing.T) {
 		f := openFsFile(t, path, os.O_RDONLY, 0)
 		defer f.Close()
 
-		_, err := f.File().(io.Writer).Write([]byte{1, 2, 3, 4})
-		require.EqualErrno(t, syscall.EBADF, UnwrapOSError(err))
+		_, errno := f.Write([]byte{1, 2, 3, 4})
+		require.EqualErrno(t, syscall.EBADF, errno)
 	})
 
 	// This is similar to https://github.com/WebAssembly/wasi-testsuite/blob/dc7f8d27be1030cd4788ebdf07d9b57e5d23441e/tests/rust/src/bin/dangling_symlink.rs

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	noopStdin  = &FileEntry{Name: "stdin", File: platform.NewFsFile("", NewStdioFileReader(eofReader{}, noopStdinStat, PollerDefaultStdin))}
-	noopStdout = &FileEntry{Name: "stdout", File: platform.NewFsFile("", &stdioFileWriter{w: io.Discard, s: noopStdoutStat})}
-	noopStderr = &FileEntry{Name: "stderr", File: platform.NewFsFile("", &stdioFileWriter{w: io.Discard, s: noopStderrStat})}
+	noopStdin  = &FileEntry{Name: "stdin", File: platform.NewFsFile("", syscall.O_RDONLY, NewStdioFileReader(eofReader{}, noopStdinStat, PollerDefaultStdin))}
+	noopStdout = &FileEntry{Name: "stdout", File: platform.NewFsFile("", syscall.O_WRONLY, &stdioFileWriter{w: io.Discard, s: noopStdoutStat})}
+	noopStderr = &FileEntry{Name: "stderr", File: platform.NewFsFile("", syscall.O_WRONLY, &stdioFileWriter{w: io.Discard, s: noopStderrStat})}
 )
 
 //go:embed testdata
@@ -365,18 +365,6 @@ func TestFSContext_ChangeOpenFlag(t *testing.T) {
 	f2, ok := fsc.openedFiles.Lookup(fd)
 	require.True(t, ok)
 	require.Equal(t, f2.openFlag&syscall.O_APPEND, 0)
-}
-
-func TestWriterForFile(t *testing.T) {
-	c := Context{}
-	err := c.NewFSContext(nil, nil, nil, sysfs.UnimplementedFS{})
-	require.NoError(t, err)
-	testFS := &c.fsc
-
-	require.Nil(t, WriterForFile(testFS, FdStdin))
-	require.Equal(t, noopStdout.File.File(), WriterForFile(testFS, FdStdout))
-	require.Equal(t, noopStderr.File.File(), WriterForFile(testFS, FdStderr))
-	require.Nil(t, WriterForFile(testFS, FdPreopen))
 }
 
 func TestStdioStat(t *testing.T) {

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -48,7 +48,7 @@ func (a *adapter) Open(name string) (fs.File, error) {
 func (a *adapter) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	path = cleanPath(path)
 	f, err := a.fs.Open(path)
-	return platform.NewFsFile(path, f), platform.UnwrapOSError(err)
+	return platform.NewFsFile(path, flag, f), platform.UnwrapOSError(err)
 }
 
 // Stat implements FS.Stat
@@ -59,7 +59,7 @@ func (a *adapter) Stat(path string) (platform.Stat_t, syscall.Errno) {
 		return platform.Stat_t{}, platform.UnwrapOSError(err)
 	}
 	defer f.Close()
-	return platform.NewFsFile(path, f).Stat()
+	return platform.NewFsFile(path, syscall.O_RDONLY, f).Stat()
 }
 
 // Lstat implements FS.Lstat

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -46,7 +46,7 @@ func (d *dirFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File
 	if errno != 0 {
 		return nil, errno
 	}
-	return platform.NewFsFile(path, f), 0
+	return platform.NewFsFile(path, flag, f), 0
 }
 
 // Lstat implements FS.Lstat

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -67,7 +67,7 @@ func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.Fil
 	if errno != 0 {
 		return nil, errno
 	}
-	return platform.NewFsFile(path, maskForReads(f.File())), 0
+	return platform.NewFsFile(path, flag, maskForReads(f.File())), 0
 }
 
 // maskForReads masks the file with read-only interfaces used by wazero.

--- a/internal/sysfs/rootfs.go
+++ b/internal/sysfs/rootfs.go
@@ -137,7 +137,7 @@ func (c *CompositeFS) OpenFile(path string, flag int, perm fs.FileMode) (f platf
 		case ".", "/", "":
 			if len(c.rootGuestPaths) > 0 {
 				dir := &openRootDir{c: c, f: f.File().(fs.ReadDirFile)}
-				f = platform.NewFsFile(path, dir)
+				f = platform.NewFsFile(path, syscall.O_RDONLY, dir)
 			}
 		}
 	}
@@ -483,7 +483,7 @@ type fakeRootFS struct{ UnimplementedFS }
 func (*fakeRootFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	switch path {
 	case ".", "/", "":
-		return platform.NewFsFile(path, fakeRootDir{}), 0
+		return platform.NewFsFile(path, flag, fakeRootDir{}), 0
 	}
 	return nil, syscall.ENOENT
 }

--- a/internal/sysfs/sysfs.go
+++ b/internal/sysfs/sysfs.go
@@ -450,37 +450,3 @@ func (rs *seekToOffsetReader) Read(p []byte) (int, error) {
 	rs.offset += int64(n)
 	return n, err
 }
-
-// WriterAtOffset gets an io.Writer from a fs.File that writes to an offset,
-// yet doesn't affect the underlying position. This is used to implement
-// syscall.Pwrite.
-func WriterAtOffset(f fs.File, offset int64) io.Writer {
-	if ret, ok := f.(io.WriterAt); ok {
-		return &writerAtOffset{ret, offset}
-	} else {
-		return enosysWriter{}
-	}
-}
-
-type enosysWriter struct{}
-
-// enosysWriter implements io.Writer
-func (rs enosysWriter) Write([]byte) (n int, err error) {
-	return 0, syscall.ENOSYS
-}
-
-type writerAtOffset struct {
-	r      io.WriterAt
-	offset int64
-}
-
-// Write implements io.Writer
-func (r *writerAtOffset) Write(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil // less overhead on zero-length writes.
-	}
-
-	n, err := r.r.WriteAt(p, r.offset)
-	r.offset += int64(n)
-	return n, err
-}


### PR DESCRIPTION
This adds `file.AccessMode` to substitute for type checking that formerly was used to see if the file might be writeable (e.g. casting to `io.Writer` so that you can check before actually writing).

This allows us to implement `File.Write` and `File.Pwrite` which might return `syscall.ENOSYS` on read-only implementations.

See #1417