### PR TITLE
Adds Utimens to platform.File

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -457,7 +457,7 @@ func fdFilestatSetTimesFn(_ context.Context, mod api.Module, params []uint64) sy
 	}
 
 	// Try to update the file timestamps by file-descriptor.
-	errno = platform.UtimensFile(f.File.File(), &times)
+	errno = f.File.Utimens(&times)
 
 	// Fall back to path based, despite it being less precise.
 	switch errno {

--- a/internal/platform/bench_test.go
+++ b/internal/platform/bench_test.go
@@ -9,13 +9,15 @@ import (
 	"testing"
 )
 
-func Benchmark_UtimensFile(b *testing.B) {
+func BenchmarkFsFileUtimesNs(b *testing.B) {
 	tmpDir := b.TempDir()
-	f, err := os.Create(path.Join(tmpDir, "file"))
+	path := path.Join(tmpDir, "file")
+	f, err := os.Create(path)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer f.Close()
+	fs := NewFsFile(path, syscall.O_RDONLY, f)
 
 	times := &[2]syscall.Timespec{
 		{Sec: 123, Nsec: 4 * 1e3},
@@ -24,8 +26,8 @@ func Benchmark_UtimensFile(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := UtimensFile(f, times); err != 0 {
-			b.Fatal(err)
+		if errno := fs.Utimens(times); errno != 0 {
+			b.Fatal(errno)
 		}
 	}
 }

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -240,6 +240,15 @@ func (r *lazyDir) Chown(uid, gid int) syscall.Errno {
 	}
 }
 
+// Utimens implements the same method as documented on platform.File
+func (r *lazyDir) Utimens(times *[2]syscall.Timespec) syscall.Errno {
+	if f, ok := r.file(); !ok {
+		return syscall.EBADF
+	} else {
+		return f.Utimens(times)
+	}
+}
+
 // File implements the same method as documented on platform.File
 func (r *lazyDir) File() fs.File {
 	if f, ok := r.file(); !ok {

--- a/internal/sysfs/sysfs.go
+++ b/internal/sysfs/sysfs.go
@@ -346,9 +346,10 @@ type FS interface {
 	// # Parameters
 	//
 	// The `times` parameter includes the access and modification timestamps to
-	// assign. Special syscall.Timespec NSec values UTIME_NOW and UTIME_OMIT may be
-	// specified instead of real timestamps. A nil `times` parameter behaves the
-	// same as if both were set to UTIME_NOW.
+	// assign. Special syscall.Timespec NSec values platform.UTIME_NOW and
+	// platform.UTIME_OMIT may be specified instead of real timestamps. A nil
+	// `times` parameter behaves the same as if both were set to
+	// platform.UTIME_NOW.
 	//
 	// When the `symlinkFollow` parameter is true and the path is a symbolic link,
 	// the target of expanding that link is updated.
@@ -363,11 +364,7 @@ type FS interface {
 	//
 	// # Notes
 	//
-	//   - This is like syscall.Utimes, except the path is relative to this
-	//     filesystem. It also doesn't have flags to control expansion of
-	//     symbolic links. Neither does this support the support special values
-	//     UTIME_NOW or UTIME_NOW.
-	//   - This is like `utimensat` with `AT_FDCWD` in POSIX. See
-	//     https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
+	//   - This is like syscall.UtimesNano and `utimensat` with `AT_FDCWD` in
+	//     POSIX. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
 	Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) syscall.Errno
 }


### PR DESCRIPTION
This adds `Utimens` to `platform.File`, used to implement `fd_filestat_set_times`.

See #1417