### PR TITLE
wasip1: support non-blocking mode on stdio

### DIFF
--- a/internal/platform/nonblock_unix.go
+++ b/internal/platform/nonblock_unix.go
@@ -1,0 +1,7 @@
+package platform
+
+import "syscall"
+
+func SetNonblock(fd uintptr, enable bool) error {
+	return syscall.SetNonblock(int(fd), enable)
+}

--- a/internal/platform/nonblock_unix.go
+++ b/internal/platform/nonblock_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package platform
 
 import "syscall"

--- a/internal/platform/nonblock_windows.go
+++ b/internal/platform/nonblock_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package platform
 
 import "syscall"

--- a/internal/platform/nonblock_windows.go
+++ b/internal/platform/nonblock_windows.go
@@ -1,0 +1,7 @@
+package platform
+
+import "syscall"
+
+func SetNonblock(fd uintptr, enable bool) error {
+	return syscall.SetNonblock(syscall.Handle(fd), enable)
+}

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -71,7 +71,7 @@ func (w *StdioFileWriter) IsNonblock() bool {
 // the underlying file descriptor.
 func (w *StdioFileWriter) SetNonblock(enable bool) error {
 	if f, ok := w.w.(*os.File); ok {
-		if err := syscall.SetNonblock(int(f.Fd()), enable); err != nil {
+		if err := platform.SetNonblock(f.Fd(), enable); err != nil {
 			return err
 		}
 		w.nonblock = enable
@@ -162,7 +162,7 @@ func (r *StdioFileReader) IsNonblock() bool {
 // the underlying file descriptor.
 func (r *StdioFileReader) SetNonblock(enable bool) error {
 	if f, ok := r.r.(*os.File); ok {
-		if err := syscall.SetNonblock(int(f.Fd()), enable); err != nil {
+		if err := platform.SetNonblock(f.Fd(), enable); err != nil {
 			return err
 		}
 		r.nonblock = enable

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -20,8 +20,8 @@ import (
 
 var (
 	noopStdin  = &FileEntry{Name: "stdin", File: platform.NewFsFile("", syscall.O_RDONLY, NewStdioFileReader(eofReader{}, noopStdinStat, PollerDefaultStdin))}
-	noopStdout = &FileEntry{Name: "stdout", File: platform.NewFsFile("", syscall.O_WRONLY, &stdioFileWriter{w: io.Discard, s: noopStdoutStat})}
-	noopStderr = &FileEntry{Name: "stderr", File: platform.NewFsFile("", syscall.O_WRONLY, &stdioFileWriter{w: io.Discard, s: noopStderrStat})}
+	noopStdout = &FileEntry{Name: "stdout", File: platform.NewFsFile("", syscall.O_WRONLY, &StdioFileWriter{w: io.Discard, s: noopStdoutStat})}
+	noopStderr = &FileEntry{Name: "stderr", File: platform.NewFsFile("", syscall.O_WRONLY, &StdioFileWriter{w: io.Discard, s: noopStderrStat})}
 )
 
 //go:embed testdata


### PR DESCRIPTION
This PR adds the ability to configure non-blocking mode on standard input and output when the underlying files are of type `*os.File`.

This is going to be needed to enable testing the latest Go changes with wazero, see https://go-review.googlesource.com/c/go/+/493356