### PR TITLE
experimental: add FunctionListener and FunctionListenerFactory implementations

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -322,7 +322,7 @@ func (b *hostModuleBuilder) Compile(ctx context.Context) (CompiledModule, error)
 	}
 
 	c := &compiledModule{module: module, compiledEngine: b.r.store.Engine}
-	listeners, err := buildListeners(ctx, module)
+	listeners, err := buildFunctionListeners(ctx, module)
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -40,9 +40,9 @@ type FunctionListenerFactoryKey struct{}
 // FunctionListenerFactory returns FunctionListeners to be notified when a
 // function is called.
 type FunctionListenerFactory interface {
-	// NewListener returns a FunctionListener for a defined function. If nil is
-	// returned, no listener will be notified.
-	NewListener(api.FunctionDefinition) FunctionListener
+	// NewFunctionListener returns a FunctionListener for a defined function.
+	// If nil is returned, no listener will be notified.
+	NewFunctionListener(api.FunctionDefinition) FunctionListener
 	// ^^ A single instance can be returned to avoid instantiating a listener
 	// per function, especially as they may be thousands of functions. Shared
 	// listeners use their FunctionDefinition parameter to clarify.
@@ -109,8 +109,8 @@ func (f FunctionListenerFunc) After(context.Context, api.Module, api.FunctionDef
 // functions and methods as factory of function listeners.
 type FunctionListenerFactoryFunc func(api.FunctionDefinition) FunctionListener
 
-// NewListener satisfies the FunctionListenerFactory interface, calls f.
-func (f FunctionListenerFactoryFunc) NewListener(def api.FunctionDefinition) FunctionListener {
+// NewFunctionListener satisfies the FunctionListenerFactory interface, calls f.
+func (f FunctionListenerFactoryFunc) NewFunctionListener(def api.FunctionDefinition) FunctionListener {
 	return f(def)
 }
 
@@ -133,10 +133,10 @@ func MultiFunctionListenerFactory(factories ...FunctionListenerFactory) Function
 
 type multiFunctionListenerFactory []FunctionListenerFactory
 
-func (multi multiFunctionListenerFactory) NewListener(def api.FunctionDefinition) FunctionListener {
+func (multi multiFunctionListenerFactory) NewFunctionListener(def api.FunctionDefinition) FunctionListener {
 	var lstns []FunctionListener
 	for _, factory := range multi {
-		if lstn := factory.NewListener(def); lstn != nil {
+		if lstn := factory.NewFunctionListener(def); lstn != nil {
 			lstns = append(lstns, lstn)
 		}
 	}

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -83,6 +83,155 @@ type FunctionListener interface {
 	After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
 }
 
+// FunctionListenerFunc is a function type implementing the FunctionListener
+// interface, making it possible to use regular functions and methods as
+// listeners of function invocation.
+//
+// The FunctionListener interface declares two methods (Before and After),
+// but this type invokes its value only when Before is called. It is best
+// suites for cases where the host does not need to perform correlation
+// between the start and end of the function call.
+type FunctionListenerFunc func(context.Context, api.Module, api.FunctionDefinition, []uint64, StackIterator)
+
+// Before satisfies the FunctionListener interface, calls f.
+func (f FunctionListenerFunc) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator StackIterator) context.Context {
+	f(ctx, mod, def, paramValues, stackIterator)
+	return ctx
+}
+
+// After is declared to satisfy the FunctionListener interface, but it does
+// nothing.
+func (f FunctionListenerFunc) After(context.Context, api.Module, api.FunctionDefinition, error, []uint64) {
+}
+
+// FunctionListenerFactoryFunc is a function type implementing the
+// FunctionListenerFactory interface, making it possible to use regular
+// functions and methods as factory of function listeners.
+type FunctionListenerFactoryFunc func(api.FunctionDefinition) FunctionListener
+
+// NewListener satisfies the FunctionListenerFactory interface, calls f.
+func (f FunctionListenerFactoryFunc) NewListener(def api.FunctionDefinition) FunctionListener {
+	return f(def)
+}
+
+// MultiFunctionListenerFactory constructs a FunctionListenerFactory which
+// combines the listeners created by each of the factories passed as arguments.
+//
+// This function is useful when multiple listeners need to be hooked to a module
+// because the propagation mechanism based on installing a listener factory in
+// the context.Context used when instantiating modules allows for a single
+// listener to be installed.
+//
+// The stack iterator passed to the Before method is reset so that each listener
+// can iterate the call stack independently without impacting the ability of
+// other listeners to do so.
+func MultiFunctionListenerFactory(factories ...FunctionListenerFactory) FunctionListenerFactory {
+	multi := make(multiFunctionListenerFactory, len(factories))
+	copy(multi, factories)
+	return multi
+}
+
+type multiFunctionListenerFactory []FunctionListenerFactory
+
+func (multi multiFunctionListenerFactory) NewListener(def api.FunctionDefinition) FunctionListener {
+	var lstns []FunctionListener
+	for _, factory := range multi {
+		if lstn := factory.NewListener(def); lstn != nil {
+			lstns = append(lstns, lstn)
+		}
+	}
+	switch len(lstns) {
+	case 0:
+		return nil
+	case 1:
+		return lstns[0]
+	default:
+		return &multiFunctionListener{lstns: lstns}
+	}
+}
+
+type multiFunctionListener struct {
+	lstns []FunctionListener
+	stack stackIterator
+}
+
+func (multi *multiFunctionListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, si StackIterator) context.Context {
+	multi.stack.base = si
+	for _, lstn := range multi.lstns {
+		multi.stack.index = -1
+		ctx = lstn.Before(ctx, mod, def, params, &multi.stack)
+	}
+	return ctx
+}
+
+func (multi *multiFunctionListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, results []uint64) {
+	for _, lstn := range multi.lstns {
+		lstn.After(ctx, mod, def, err, results)
+	}
+}
+
+type parameters struct {
+	values []uint64
+	limits []uint8
+}
+
+func (ps *parameters) append(values []uint64) {
+	ps.values = append(ps.values, values...)
+	ps.limits = append(ps.limits, uint8(len(ps.values)))
+}
+
+func (ps *parameters) clear() {
+	ps.values = ps.values[:0]
+	ps.limits = ps.limits[:0]
+}
+
+func (ps *parameters) index(i int) []uint64 {
+	j := uint8(0)
+	k := ps.limits[i]
+	if i > 0 {
+		j = ps.limits[i-1]
+	}
+	return ps.values[j:k:k]
+}
+
+type stackIterator struct {
+	base   StackIterator
+	index  int
+	pcs    []uint64
+	fns    []api.FunctionDefinition
+	params parameters
+}
+
+func (si *stackIterator) Next() bool {
+	if si.base != nil {
+		si.pcs = si.pcs[:0]
+		si.fns = si.fns[:0]
+		si.params.clear()
+
+		for si.base.Next() {
+			si.pcs = append(si.pcs, si.base.SourceOffset())
+			si.fns = append(si.fns, si.base.FunctionDefinition())
+			si.params.append(si.base.Parameters())
+		}
+
+		si.base = nil
+	}
+	si.index++
+	return si.index < len(si.pcs)
+}
+
+func (si *stackIterator) SourceOffset() uint64 {
+	return si.pcs[si.index]
+}
+
+func (si *stackIterator) FunctionDefinition() api.FunctionDefinition {
+	return si.fns[si.index]
+}
+
+func (si *stackIterator) Parameters() []uint64 {
+	return si.params.index(si.index)
+}
+
 // TODO: We need to add tests to enginetest to ensure contexts nest. A good test can use a combination of call and call
 // indirect in terms of depth and breadth. The test could show a tree 3 calls deep where the there are a couple calls at
 // each depth under the root. The main thing this can help prevent is accidentally swapping the context internally.

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -35,8 +35,8 @@ func (u uniqGoFuncs) callees() []string {
 	return ret
 }
 
-// NewListener implements FunctionListenerFactory.NewListener
-func (u uniqGoFuncs) NewListener(def api.FunctionDefinition) experimental.FunctionListener {
+// NewFunctionListener implements FunctionListenerFactory.NewFunctionListener
+func (u uniqGoFuncs) NewFunctionListener(def api.FunctionDefinition) experimental.FunctionListener {
 	if def.GoFunction() == nil {
 		return nil // only track go funcs
 	}

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -207,5 +207,4 @@ func BenchmarkMultiFunctionListener(b *testing.B) {
 			wazerotest.BenchmarkFunctionListener(b, module, stack, listener)
 		})
 	}
-
 }

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -31,7 +31,7 @@ func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefini
 	r.afterNames = append(r.afterNames, def.DebugName())
 }
 
-func (r *recorder) NewListener(definition api.FunctionDefinition) experimental.FunctionListener {
+func (r *recorder) NewFunctionListener(definition api.FunctionDefinition) experimental.FunctionListener {
 	r.m[definition.Name()] = struct{}{}
 	return r
 }
@@ -153,7 +153,7 @@ func TestMultiFunctionListenerFactory(t *testing.T) {
 	)
 
 	function := module.Function(0).Definition()
-	listener := factory.NewListener(function)
+	listener := factory.NewFunctionListener(function)
 	listener.Before(context.Background(), module, function, stack[2].Params, experimental.NewStackIterator(stack...))
 
 	if n != 2 {
@@ -203,7 +203,7 @@ func BenchmarkMultiFunctionListener(b *testing.B) {
 				}),
 			)
 			function := module.Function(0).Definition()
-			listener := factory.NewListener(function)
+			listener := factory.NewFunctionListener(function)
 			experimental.BenchmarkFunctionListener(b.N, module, stack, listener)
 		})
 	}

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -109,7 +109,7 @@ func TestMultiFunctionListenerFactory(t *testing.T) {
 		wazerotest.NewFunction(func(ctx context.Context, mod api.Module, value int32) {}),
 	)
 
-	stack := []wazerotest.StackFrame{
+	stack := []experimental.StackFrame{
 		{Function: module.Function(0), Params: []uint64{1}},
 		{Function: module.Function(1), Params: []uint64{2}},
 		{Function: module.Function(2), Params: []uint64{3}},
@@ -154,7 +154,7 @@ func TestMultiFunctionListenerFactory(t *testing.T) {
 
 	function := module.Function(0).Definition()
 	listener := factory.NewListener(function)
-	listener.Before(context.Background(), module, function, stack[2].Params, wazerotest.NewStackIterator(stack...))
+	listener.Before(context.Background(), module, function, stack[2].Params, experimental.NewStackIterator(stack...))
 
 	if n != 2 {
 		t.Errorf("wrong number of function calls: want=2 got=%d", n)
@@ -168,7 +168,7 @@ func BenchmarkMultiFunctionListener(b *testing.B) {
 		wazerotest.NewFunction(func(ctx context.Context, mod api.Module, value int32) {}),
 	)
 
-	stack := []wazerotest.StackFrame{
+	stack := []experimental.StackFrame{
 		{Function: module.Function(0), Params: []uint64{1}},
 		{Function: module.Function(1), Params: []uint64{2}},
 		{Function: module.Function(2), Params: []uint64{3}},
@@ -204,7 +204,7 @@ func BenchmarkMultiFunctionListener(b *testing.B) {
 			)
 			function := module.Function(0).Definition()
 			listener := factory.NewListener(function)
-			wazerotest.BenchmarkFunctionListener(b, module, stack, listener)
+			experimental.BenchmarkFunctionListener(b.N, module, stack, listener)
 		})
 	}
 }

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -93,9 +93,9 @@ type flusher interface {
 	Flush() error
 }
 
-// NewListener implements the same method as documented on
+// NewFunctionListener implements the same method as documented on
 // experimental.FunctionListener.
-func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+func (f *loggingListenerFactory) NewFunctionListener(fnd api.FunctionDefinition) experimental.FunctionListener {
 	exported := len(fnd.ExportNames()) > 0
 	if f.hostOnly && // choose functions defined or callable by the host
 		fnd.GoFunction() == nil && // not defined by the host

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -300,7 +300,7 @@ func Test_loggingListener(t *testing.T) {
 			}
 			m.BuildFunctionDefinitions()
 			def := &m.FunctionDefinitionSection[0]
-			l := lf.NewListener(def)
+			l := lf.NewFunctionListener(def)
 
 			out.Reset()
 			ctx := l.Before(testCtx, nil, def, tc.params, nil)
@@ -335,9 +335,9 @@ func Test_loggingListener_indentation(t *testing.T) {
 	}
 	m.BuildFunctionDefinitions()
 	def1 := &m.FunctionDefinitionSection[0]
-	l1 := lf.NewListener(def1)
+	l1 := lf.NewFunctionListener(def1)
 	def2 := &m.FunctionDefinitionSection[1]
-	l2 := lf.NewListener(def2)
+	l2 := lf.NewFunctionListener(def2)
 
 	ctx := l1.Before(testCtx, nil, def1, []uint64{}, nil)
 	ctx1 := l2.Before(ctx, nil, def2, []uint64{}, nil)
@@ -358,7 +358,7 @@ func BenchmarkLoggingListener(b *testing.B) {
 
 	function := module.Function(0)
 	factory := logging.NewLoggingListenerFactory(discard{})
-	listener := factory.NewListener(function.Definition())
+	listener := factory.NewFunctionListener(function.Definition())
 
 	stack := []experimental.StackFrame{
 		{Function: function},

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/experimental/logging"
 	"github.com/tetratelabs/wazero/experimental/wazerotest"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -359,11 +360,11 @@ func BenchmarkLoggingListener(b *testing.B) {
 	factory := logging.NewLoggingListenerFactory(discard{})
 	listener := factory.NewListener(function.Definition())
 
-	stack := []wazerotest.StackFrame{
+	stack := []experimental.StackFrame{
 		{Function: function},
 	}
 
-	wazerotest.BenchmarkFunctionListener(b, module, stack, listener)
+	experimental.BenchmarkFunctionListener(b.N, module, stack, listener)
 }
 
 type discard struct{}

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -156,7 +156,7 @@ func RunTestModuleEngineCall(t *testing.T, et EngineTester) {
 	}
 
 	m.BuildFunctionDefinitions()
-	listeners := buildListeners(et.ListenerFactory(), m)
+	listeners := buildFunctionListeners(et.ListenerFactory(), m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -213,7 +213,7 @@ func RunTestModuleEngineCallWithStack(t *testing.T, et EngineTester) {
 	}
 
 	m.BuildFunctionDefinitions()
-	listeners := buildListeners(et.ListenerFactory(), m)
+	listeners := buildFunctionListeners(et.ListenerFactory(), m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -656,7 +656,7 @@ func RunTestModuleEngineBeforeListenerStackIterator(t *testing.T, et EngineTeste
 	}
 	m.BuildFunctionDefinitions()
 
-	listeners := buildListeners(fnListener, m)
+	listeners := buildFunctionListeners(fnListener, m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -777,7 +777,7 @@ func RunTestModuleEngineBeforeListenerGlobals(t *testing.T, et EngineTester) {
 	}
 	m.BuildFunctionDefinitions()
 
-	listeners := buildListeners(fnListener, m)
+	listeners := buildFunctionListeners(fnListener, m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -807,7 +807,7 @@ type fnListener struct {
 	afterFn  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
 }
 
-func (f *fnListener) NewListener(api.FunctionDefinition) experimental.FunctionListener {
+func (f *fnListener) NewFunctionListener(api.FunctionDefinition) experimental.FunctionListener {
 	return f
 }
 
@@ -950,7 +950,7 @@ func RunTestModuleEngineStackIteratorOffset(t *testing.T, et EngineTester) {
 
 	m.BuildFunctionDefinitions()
 
-	listeners := buildListeners(fnListener, m)
+	listeners := buildFunctionListeners(fnListener, m)
 	err = e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -1060,7 +1060,7 @@ func RunTestModuleEngineMemory(t *testing.T, et EngineTester) {
 		},
 	}
 	m.BuildFunctionDefinitions()
-	listeners := buildListeners(et.ListenerFactory(), m)
+	listeners := buildFunctionListeners(et.ListenerFactory(), m)
 
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
@@ -1192,7 +1192,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ID: wasm.ModuleID{0},
 	}
 	hostModule.BuildFunctionDefinitions()
-	lns := buildListeners(fnlf, hostModule)
+	lns := buildFunctionListeners(fnlf, hostModule)
 	err := e.CompileModule(testCtx, hostModule, lns, false)
 	require.NoError(t, err)
 	host := &wasm.ModuleInstance{
@@ -1229,7 +1229,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ID: wasm.ModuleID{1},
 	}
 	importedModule.BuildFunctionDefinitions()
-	lns = buildListeners(fnlf, importedModule)
+	lns = buildFunctionListeners(fnlf, importedModule)
 	err = e.CompileModule(testCtx, importedModule, lns, false)
 	require.NoError(t, err)
 
@@ -1264,7 +1264,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ID: wasm.ModuleID{2},
 	}
 	importingModule.BuildFunctionDefinitions()
-	lns = buildListeners(fnlf, importingModule)
+	lns = buildFunctionListeners(fnlf, importingModule)
 	err = e.CompileModule(testCtx, importingModule, lns, false)
 	require.NoError(t, err)
 
@@ -1367,14 +1367,14 @@ func linkModuleToEngine(module *wasm.ModuleInstance, me wasm.ModuleEngine) {
 	module.Engine = me // for Compiler, links the module to the module-engine compiled from it (moduleInstanceEngineOffset).
 }
 
-func buildListeners(factory experimental.FunctionListenerFactory, m *wasm.Module) []experimental.FunctionListener {
+func buildFunctionListeners(factory experimental.FunctionListenerFactory, m *wasm.Module) []experimental.FunctionListener {
 	if factory == nil || len(m.FunctionSection) == 0 {
 		return nil
 	}
 	listeners := make([]experimental.FunctionListener, len(m.FunctionSection))
 	importCount := m.ImportFunctionCount
 	for i := 0; i < len(listeners); i++ {
-		listeners[i] = factory.NewListener(&m.FunctionDefinitionSection[uint32(i)+importCount])
+		listeners[i] = factory.NewFunctionListener(&m.FunctionDefinitionSection[uint32(i)+importCount])
 	}
 	return listeners
 }

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -22,13 +22,13 @@ type loggingListenerFactory struct {
 	delegate experimental.FunctionListenerFactory
 }
 
-// NewListener implements the same method as documented on
+// NewFunctionListener implements the same method as documented on
 // experimental.FunctionListener.
-func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+func (f *loggingListenerFactory) NewFunctionListener(fnd api.FunctionDefinition) experimental.FunctionListener {
 	if fnd.ModuleName() == proxyModuleName {
 		return nil // don't log proxy stuff
 	}
-	return f.delegate.NewListener(fnd)
+	return f.delegate.NewFunctionListener(fnd)
 }
 
 // NewModuleBinary creates the proxy module to proxy a function call against

--- a/runtime.go
+++ b/runtime.go
@@ -228,7 +228,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	}
 	c.typeIDs = typeIDs
 
-	listeners, err := buildListeners(ctx, internal)
+	listeners, err := buildFunctionListeners(ctx, internal)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	return c, nil
 }
 
-func buildListeners(ctx context.Context, internal *wasm.Module) ([]experimentalapi.FunctionListener, error) {
+func buildFunctionListeners(ctx context.Context, internal *wasm.Module) ([]experimentalapi.FunctionListener, error) {
 	// Test to see if internal code are using an experimental feature.
 	fnlf := ctx.Value(experimentalapi.FunctionListenerFactoryKey{})
 	if fnlf == nil {
@@ -249,7 +249,7 @@ func buildListeners(ctx context.Context, internal *wasm.Module) ([]experimentala
 	importCount := internal.ImportFunctionCount
 	listeners := make([]experimentalapi.FunctionListener, len(internal.FunctionSection))
 	for i := 0; i < len(listeners); i++ {
-		listeners[i] = factory.NewListener(&internal.FunctionDefinitionSection[uint32(i)+importCount])
+		listeners[i] = factory.NewFunctionListener(&internal.FunctionDefinitionSection[uint32(i)+importCount])
 	}
 	return listeners, nil
 }


### PR DESCRIPTION
This PR adds implementations of the `experimental.FunctionListenerFactory` which have been useful to implement listeners in external projects depending on wazero. Bringing those building blocks to wazero will likely benefit other users.

Please take a look and let me know if you would like to see anything changed!