### PR TITLE
experimental: optimize function listener context stack

### DIFF
--- a/internal/engine/compiler/engine_bench_test.go
+++ b/internal/engine/compiler/engine_bench_test.go
@@ -1,0 +1,44 @@
+package compiler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
+
+func BenchmarkCallEngine_builtinFunctionFunctionListener(b *testing.B) {
+	f := &function{
+		funcType: &wasm.FunctionType{ParamNumInUint64: 3},
+		parent: &compiledFunction{
+			listener: mockListener{
+				before: func(context.Context, api.Module, api.FunctionDefinition, []uint64, experimental.StackIterator) context.Context {
+					return context.Background()
+				},
+				after: func(context.Context, api.Module, api.FunctionDefinition, error, []uint64) {
+				},
+			},
+			index: 0,
+			parent: &compiledModule{
+				source: &wasm.Module{
+					FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
+				},
+			},
+		},
+	}
+
+	ce := &callEngine{
+		ctx:          context.Background(),
+		stack:        []uint64{0, 1, 2, 3, 4, 0, 0, 0},
+		stackContext: stackContext{stackBasePointerInBytes: 16},
+	}
+
+	module := new(wasm.ModuleInstance)
+
+	for i := 0; i < b.N; i++ {
+		ce.builtinFunctionFunctionListenerBefore(ce.ctx, module, f)
+		ce.builtinFunctionFunctionListenerAfter(ce.ctx, module, f)
+	}
+}

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -605,13 +605,13 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 	ce := &callEngine{
 		ctx: currentContext, stack: []uint64{0, 1, 2, 3, 4, 0, 0, 0},
 		stackContext: stackContext{stackBasePointerInBytes: 16},
-		contextStack: &contextStack{self: prevContext},
+		contextStack: []context.Context{prevContext},
 	}
 	ce.builtinFunctionFunctionListenerBefore(ce.ctx, &wasm.ModuleInstance{}, f)
 
 	// Contexts must be stacked.
-	require.Equal(t, currentContext, ce.contextStack.self)
-	require.Equal(t, prevContext, ce.contextStack.prev.self)
+	require.Equal(t, currentContext, ce.contextStack[1])
+	require.Equal(t, prevContext, ce.contextStack[0])
 }
 
 func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
@@ -635,12 +635,12 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 	ce := &callEngine{
 		ctx: currentContext, stack: []uint64{0, 1, 2, 3, 4, 5},
 		stackContext: stackContext{stackBasePointerInBytes: 40},
-		contextStack: &contextStack{self: prevContext},
+		contextStack: []context.Context{prevContext},
 	}
 	ce.builtinFunctionFunctionListenerAfter(ce.ctx, &wasm.ModuleInstance{}, f)
 
 	// Contexts must be popped.
-	require.Nil(t, ce.contextStack)
+	require.Equal(t, 0, len(ce.contextStack))
 	require.Equal(t, prevContext, ce.ctx)
 }
 


### PR DESCRIPTION
This PR changes the context stack used by function listeners to use a vector instead of a linked list in order to reduce the memory footprint; creating the context stack items forced the compiler to put values on the heap, and the extra pointer increased by 50% the memory space needed to track the contexts (3 pointers per item vs 2 now).

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/engine/compiler
                                           │  /tmp/old   │              /tmp/new               │
                                           │   sec/op    │   sec/op     vs base                │
CallEngine_builtinFunctionFunctionListener   37.45n ± 5%   11.10n ± 1%  -70.37% (p=0.000 n=10)

                                           │  /tmp/old  │              /tmp/new              │
                                           │    B/op    │   B/op     vs base                 │
CallEngine_builtinFunctionFunctionListener   24.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                                           │  /tmp/old  │              /tmp/new               │
                                           │ allocs/op  │ allocs/op   vs base                 │
CallEngine_builtinFunctionFunctionListener   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```