### PR TITLE
experimental: rename NewListener => NewFunctionListener

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -322,7 +322,7 @@ func (b *hostModuleBuilder) Compile(ctx context.Context) (CompiledModule, error)
 	}
 
 	c := &compiledModule{module: module, compiledEngine: b.r.store.Engine}
-	listeners, err := buildListeners(ctx, module)
+	listeners, err := buildFunctionListeners(ctx, module)
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -40,9 +40,9 @@ type FunctionListenerFactoryKey struct{}
 // FunctionListenerFactory returns FunctionListeners to be notified when a
 // function is called.
 type FunctionListenerFactory interface {
-	// NewListener returns a FunctionListener for a defined function. If nil is
-	// returned, no listener will be notified.
-	NewListener(api.FunctionDefinition) FunctionListener
+	// NewFunctionListener returns a FunctionListener for a defined function.
+	// If nil is returned, no listener will be notified.
+	NewFunctionListener(api.FunctionDefinition) FunctionListener
 	// ^^ A single instance can be returned to avoid instantiating a listener
 	// per function, especially as they may be thousands of functions. Shared
 	// listeners use their FunctionDefinition parameter to clarify.
@@ -109,8 +109,8 @@ func (f FunctionListenerFunc) After(context.Context, api.Module, api.FunctionDef
 // functions and methods as factory of function listeners.
 type FunctionListenerFactoryFunc func(api.FunctionDefinition) FunctionListener
 
-// NewListener satisfies the FunctionListenerFactory interface, calls f.
-func (f FunctionListenerFactoryFunc) NewListener(def api.FunctionDefinition) FunctionListener {
+// NewFunctionListener satisfies the FunctionListenerFactory interface, calls f.
+func (f FunctionListenerFactoryFunc) NewFunctionListener(def api.FunctionDefinition) FunctionListener {
 	return f(def)
 }
 
@@ -133,10 +133,10 @@ func MultiFunctionListenerFactory(factories ...FunctionListenerFactory) Function
 
 type multiFunctionListenerFactory []FunctionListenerFactory
 
-func (multi multiFunctionListenerFactory) NewListener(def api.FunctionDefinition) FunctionListener {
+func (multi multiFunctionListenerFactory) NewFunctionListener(def api.FunctionDefinition) FunctionListener {
 	var lstns []FunctionListener
 	for _, factory := range multi {
-		if lstn := factory.NewListener(def); lstn != nil {
+		if lstn := factory.NewFunctionListener(def); lstn != nil {
 			lstns = append(lstns, lstn)
 		}
 	}

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -35,8 +35,8 @@ func (u uniqGoFuncs) callees() []string {
 	return ret
 }
 
-// NewListener implements FunctionListenerFactory.NewListener
-func (u uniqGoFuncs) NewListener(def api.FunctionDefinition) experimental.FunctionListener {
+// NewFunctionListener implements FunctionListenerFactory.NewFunctionListener
+func (u uniqGoFuncs) NewFunctionListener(def api.FunctionDefinition) experimental.FunctionListener {
 	if def.GoFunction() == nil {
 		return nil // only track go funcs
 	}

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -31,7 +31,7 @@ func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefini
 	r.afterNames = append(r.afterNames, def.DebugName())
 }
 
-func (r *recorder) NewListener(definition api.FunctionDefinition) experimental.FunctionListener {
+func (r *recorder) NewFunctionListener(definition api.FunctionDefinition) experimental.FunctionListener {
 	r.m[definition.Name()] = struct{}{}
 	return r
 }
@@ -153,7 +153,7 @@ func TestMultiFunctionListenerFactory(t *testing.T) {
 	)
 
 	function := module.Function(0).Definition()
-	listener := factory.NewListener(function)
+	listener := factory.NewFunctionListener(function)
 	listener.Before(context.Background(), module, function, stack[2].Params, experimental.NewStackIterator(stack...))
 
 	if n != 2 {
@@ -203,7 +203,7 @@ func BenchmarkMultiFunctionListener(b *testing.B) {
 				}),
 			)
 			function := module.Function(0).Definition()
-			listener := factory.NewListener(function)
+			listener := factory.NewFunctionListener(function)
 			experimental.BenchmarkFunctionListener(b.N, module, stack, listener)
 		})
 	}

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -93,9 +93,9 @@ type flusher interface {
 	Flush() error
 }
 
-// NewListener implements the same method as documented on
+// NewFunctionListener implements the same method as documented on
 // experimental.FunctionListener.
-func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+func (f *loggingListenerFactory) NewFunctionListener(fnd api.FunctionDefinition) experimental.FunctionListener {
 	exported := len(fnd.ExportNames()) > 0
 	if f.hostOnly && // choose functions defined or callable by the host
 		fnd.GoFunction() == nil && // not defined by the host

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -300,7 +300,7 @@ func Test_loggingListener(t *testing.T) {
 			}
 			m.BuildFunctionDefinitions()
 			def := &m.FunctionDefinitionSection[0]
-			l := lf.NewListener(def)
+			l := lf.NewFunctionListener(def)
 
 			out.Reset()
 			ctx := l.Before(testCtx, nil, def, tc.params, nil)
@@ -335,9 +335,9 @@ func Test_loggingListener_indentation(t *testing.T) {
 	}
 	m.BuildFunctionDefinitions()
 	def1 := &m.FunctionDefinitionSection[0]
-	l1 := lf.NewListener(def1)
+	l1 := lf.NewFunctionListener(def1)
 	def2 := &m.FunctionDefinitionSection[1]
-	l2 := lf.NewListener(def2)
+	l2 := lf.NewFunctionListener(def2)
 
 	ctx := l1.Before(testCtx, nil, def1, []uint64{}, nil)
 	ctx1 := l2.Before(ctx, nil, def2, []uint64{}, nil)
@@ -358,7 +358,7 @@ func BenchmarkLoggingListener(b *testing.B) {
 
 	function := module.Function(0)
 	factory := logging.NewLoggingListenerFactory(discard{})
-	listener := factory.NewListener(function.Definition())
+	listener := factory.NewFunctionListener(function.Definition())
 
 	stack := []experimental.StackFrame{
 		{Function: function},

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -156,7 +156,7 @@ func RunTestModuleEngineCall(t *testing.T, et EngineTester) {
 	}
 
 	m.BuildFunctionDefinitions()
-	listeners := buildListeners(et.ListenerFactory(), m)
+	listeners := buildFunctionListeners(et.ListenerFactory(), m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -213,7 +213,7 @@ func RunTestModuleEngineCallWithStack(t *testing.T, et EngineTester) {
 	}
 
 	m.BuildFunctionDefinitions()
-	listeners := buildListeners(et.ListenerFactory(), m)
+	listeners := buildFunctionListeners(et.ListenerFactory(), m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -656,7 +656,7 @@ func RunTestModuleEngineBeforeListenerStackIterator(t *testing.T, et EngineTeste
 	}
 	m.BuildFunctionDefinitions()
 
-	listeners := buildListeners(fnListener, m)
+	listeners := buildFunctionListeners(fnListener, m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -777,7 +777,7 @@ func RunTestModuleEngineBeforeListenerGlobals(t *testing.T, et EngineTester) {
 	}
 	m.BuildFunctionDefinitions()
 
-	listeners := buildListeners(fnListener, m)
+	listeners := buildFunctionListeners(fnListener, m)
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -807,7 +807,7 @@ type fnListener struct {
 	afterFn  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
 }
 
-func (f *fnListener) NewListener(api.FunctionDefinition) experimental.FunctionListener {
+func (f *fnListener) NewFunctionListener(api.FunctionDefinition) experimental.FunctionListener {
 	return f
 }
 
@@ -950,7 +950,7 @@ func RunTestModuleEngineStackIteratorOffset(t *testing.T, et EngineTester) {
 
 	m.BuildFunctionDefinitions()
 
-	listeners := buildListeners(fnListener, m)
+	listeners := buildFunctionListeners(fnListener, m)
 	err = e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
 
@@ -1060,7 +1060,7 @@ func RunTestModuleEngineMemory(t *testing.T, et EngineTester) {
 		},
 	}
 	m.BuildFunctionDefinitions()
-	listeners := buildListeners(et.ListenerFactory(), m)
+	listeners := buildFunctionListeners(et.ListenerFactory(), m)
 
 	err := e.CompileModule(testCtx, m, listeners, false)
 	require.NoError(t, err)
@@ -1192,7 +1192,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ID: wasm.ModuleID{0},
 	}
 	hostModule.BuildFunctionDefinitions()
-	lns := buildListeners(fnlf, hostModule)
+	lns := buildFunctionListeners(fnlf, hostModule)
 	err := e.CompileModule(testCtx, hostModule, lns, false)
 	require.NoError(t, err)
 	host := &wasm.ModuleInstance{
@@ -1229,7 +1229,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ID: wasm.ModuleID{1},
 	}
 	importedModule.BuildFunctionDefinitions()
-	lns = buildListeners(fnlf, importedModule)
+	lns = buildFunctionListeners(fnlf, importedModule)
 	err = e.CompileModule(testCtx, importedModule, lns, false)
 	require.NoError(t, err)
 
@@ -1264,7 +1264,7 @@ func setupCallTests(t *testing.T, e wasm.Engine, divBy *wasm.Code, fnlf experime
 		ID: wasm.ModuleID{2},
 	}
 	importingModule.BuildFunctionDefinitions()
-	lns = buildListeners(fnlf, importingModule)
+	lns = buildFunctionListeners(fnlf, importingModule)
 	err = e.CompileModule(testCtx, importingModule, lns, false)
 	require.NoError(t, err)
 
@@ -1367,14 +1367,14 @@ func linkModuleToEngine(module *wasm.ModuleInstance, me wasm.ModuleEngine) {
 	module.Engine = me // for Compiler, links the module to the module-engine compiled from it (moduleInstanceEngineOffset).
 }
 
-func buildListeners(factory experimental.FunctionListenerFactory, m *wasm.Module) []experimental.FunctionListener {
+func buildFunctionListeners(factory experimental.FunctionListenerFactory, m *wasm.Module) []experimental.FunctionListener {
 	if factory == nil || len(m.FunctionSection) == 0 {
 		return nil
 	}
 	listeners := make([]experimental.FunctionListener, len(m.FunctionSection))
 	importCount := m.ImportFunctionCount
 	for i := 0; i < len(listeners); i++ {
-		listeners[i] = factory.NewListener(&m.FunctionDefinitionSection[uint32(i)+importCount])
+		listeners[i] = factory.NewFunctionListener(&m.FunctionDefinitionSection[uint32(i)+importCount])
 	}
 	return listeners
 }

--- a/internal/testing/proxy/proxy.go
+++ b/internal/testing/proxy/proxy.go
@@ -22,13 +22,13 @@ type loggingListenerFactory struct {
 	delegate experimental.FunctionListenerFactory
 }
 
-// NewListener implements the same method as documented on
+// NewFunctionListener implements the same method as documented on
 // experimental.FunctionListener.
-func (f *loggingListenerFactory) NewListener(fnd api.FunctionDefinition) experimental.FunctionListener {
+func (f *loggingListenerFactory) NewFunctionListener(fnd api.FunctionDefinition) experimental.FunctionListener {
 	if fnd.ModuleName() == proxyModuleName {
 		return nil // don't log proxy stuff
 	}
-	return f.delegate.NewListener(fnd)
+	return f.delegate.NewFunctionListener(fnd)
 }
 
 // NewModuleBinary creates the proxy module to proxy a function call against

--- a/runtime.go
+++ b/runtime.go
@@ -228,7 +228,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	}
 	c.typeIDs = typeIDs
 
-	listeners, err := buildListeners(ctx, internal)
+	listeners, err := buildFunctionListeners(ctx, internal)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	return c, nil
 }
 
-func buildListeners(ctx context.Context, internal *wasm.Module) ([]experimentalapi.FunctionListener, error) {
+func buildFunctionListeners(ctx context.Context, internal *wasm.Module) ([]experimentalapi.FunctionListener, error) {
 	// Test to see if internal code are using an experimental feature.
 	fnlf := ctx.Value(experimentalapi.FunctionListenerFactoryKey{})
 	if fnlf == nil {
@@ -249,7 +249,7 @@ func buildListeners(ctx context.Context, internal *wasm.Module) ([]experimentala
 	importCount := internal.ImportFunctionCount
 	listeners := make([]experimentalapi.FunctionListener, len(internal.FunctionSection))
 	for i := 0; i < len(listeners); i++ {
-		listeners[i] = factory.NewListener(&internal.FunctionDefinitionSection[uint32(i)+importCount])
+		listeners[i] = factory.NewFunctionListener(&internal.FunctionDefinitionSection[uint32(i)+importCount])
 	}
 	return listeners, nil
 }


### PR DESCRIPTION
As discussed in the #wazero-dev Slack channel, this PR renames `NewListener` to `NewFunctionListener` to keep the method name consistent with its return type.