### PR TITLE
Adds IsNonblock SetNonblock PollRead to platform.File

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -363,3 +363,70 @@ func Test_getWasiFiletype_DevNull(t *testing.T) {
 	// Should be a character device, and not contain permissions
 	require.Equal(t, wasip1.FILETYPE_CHARACTER_DEVICE, ft)
 }
+
+func Test_isPreopenedStdio(t *testing.T) {
+	tests := []struct {
+		name     string
+		fd       int32
+		f        *sys.FileEntry
+		expected bool
+	}{
+		{
+			name:     "stdin",
+			fd:       sys.FdStdin,
+			f:        &sys.FileEntry{IsPreopen: true},
+			expected: true,
+		},
+		{
+			name:     "stdin re-opened",
+			fd:       sys.FdStdin,
+			f:        &sys.FileEntry{IsPreopen: false},
+			expected: false,
+		},
+		{
+			name:     "stdout",
+			fd:       sys.FdStdout,
+			f:        &sys.FileEntry{IsPreopen: true},
+			expected: true,
+		},
+		{
+			name:     "stdout re-opened",
+			fd:       sys.FdStdout,
+			f:        &sys.FileEntry{IsPreopen: false},
+			expected: false,
+		},
+		{
+			name:     "stderr",
+			fd:       sys.FdStderr,
+			f:        &sys.FileEntry{IsPreopen: true},
+			expected: true,
+		},
+		{
+			name:     "stderr re-opened",
+			fd:       sys.FdStderr,
+			f:        &sys.FileEntry{IsPreopen: false},
+			expected: false,
+		},
+		{
+			name:     "not stdio pre-open",
+			fd:       sys.FdPreopen,
+			f:        &sys.FileEntry{IsPreopen: true},
+			expected: false,
+		},
+		{
+			name:     "random file",
+			fd:       42,
+			f:        &sys.FileEntry{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name, func(t *testing.T) {
+			ok := isPreopenedStdio(tc.fd, tc.f)
+			require.Equal(t, tc.expected, ok)
+		})
+	}
+}

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/internal/platform"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -50,7 +49,7 @@ type event struct {
 	outOffset uint32
 }
 
-func pollOneoffFn(ctx context.Context, mod api.Module, params []uint64) syscall.Errno {
+func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) syscall.Errno {
 	in := uint32(params[0])
 	out := uint32(params[1])
 	nsubscriptions := uint32(params[2])
@@ -162,11 +161,14 @@ func pollOneoffFn(ctx context.Context, mod api.Module, params []uint64) syscall.
 
 	// If there are stdin subscribers, check for data with given timeout.
 	if len(stdinSubs) > 0 {
-		reader := getStdioFileReader(mod)
+		stdin, ok := fsc.LookupFile(internalsys.FdStdin)
+		if !ok {
+			return syscall.EBADF
+		}
 		// Wait for the timeout to expire, or for some data to become available on Stdin.
-		stdinReady, err := reader.Poll(timeout)
-		if err != nil {
-			return platform.UnwrapOSError(err)
+		stdinReady, errno := stdin.File.PollRead(&timeout)
+		if errno != 0 {
+			return errno
 		}
 		if stdinReady {
 			// stdin has data ready to for reading, write back all the events
@@ -248,19 +250,4 @@ func writeEvent(outBuf []byte, evt *event) {
 	outBuf[evt.outOffset+9] = 0
 	le.PutUint32(outBuf[evt.outOffset+10:], uint32(evt.eventType))
 	// TODO: When FD events are supported, write outOffset+16
-}
-
-// getStdioFileReader extracts a StdioFileReader for FdStdin from the given api.Module instance.
-// and panics if this is not possible.
-func getStdioFileReader(mod api.Module) *internalsys.StdioFileReader {
-	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
-	if file, ok := fsc.LookupFile(internalsys.FdStdin); ok {
-		// TODO: Make a new StdioFile which implements platform.File similar
-		// to lazyDir. This can add an additional function needed here, so we'd
-		// end up casting file.File not file.File.File()
-		if reader, typeOk := file.File.File().(*internalsys.StdioFileReader); typeOk {
-			return reader
-		}
-	}
-	panic("unexpected error: Stdin must always be a StdioFileReader")
 }

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -528,7 +528,9 @@ func fdReadSubFd(fd byte) []byte {
 // subscription for an EventTypeFdRead on stdin
 var fdReadSub = fdReadSubFd(byte(sys.FdStdin))
 
-// ttyStat returns fs.ModeCharDevice
+// ttyStat returns fs.ModeCharDevice as an approximation for isatty.
+// See go-isatty for a more specific approach:
+// https://github.com/mattn/go-isatty/blob/v0.0.18/isatty_tcgets.go#LL11C1-L12C1
 type ttyStat struct{}
 
 // Stat implements the same method as documented on platform.File
@@ -563,9 +565,5 @@ type pollStdinFile struct {
 
 // PollRead implements the same method as documented on platform.File
 func (p *pollStdinFile) PollRead(*time.Duration) (ready bool, errno syscall.Errno) {
-	if p.ready {
-		return true, 0
-	} else {
-		return false, 0
-	}
+	return p.ready, 0
 }

--- a/imports/wasi_snapshot_preview1/wasi_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"io/fs"
 	"testing"
 	"time"
 
@@ -167,13 +166,3 @@ func (b blockingReader) Read(p []byte) (n int, err error) {
 	<-b.ctx.Done()
 	return 0, nil
 }
-
-// stdinFileInfo implements fs.FileInfo: it is only representing the mode because it is always stdin
-type stdinFileInfo uint32
-
-func (stdinFileInfo) Name() string        { return "stdin" }
-func (stdinFileInfo) Size() int64         { return 0 }
-func (s stdinFileInfo) Mode() fs.FileMode { return fs.FileMode(s) }
-func (stdinFileInfo) ModTime() time.Time  { return time.Unix(0, 0) }
-func (stdinFileInfo) IsDir() bool         { return false }
-func (stdinFileInfo) Sys() interface{}    { return nil }

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -1136,20 +1136,17 @@ func (si *stackIterator) Next() bool {
 	return si.fn != nil
 }
 
-// ProgramCounter implements the same method as documented on
-// experimental.StackIterator.
+// ProgramCounter implements the same method as documented on experimental.StackIterator.
 func (si *stackIterator) ProgramCounter() experimental.ProgramCounter {
 	return experimental.ProgramCounter(si.pc)
 }
 
-// Function implements the same method as documented on
-// experimental.StackIterator.
+// Function implements the same method as documented on experimental.StackIterator.
 func (si *stackIterator) Function() experimental.InternalFunction {
 	return internalFunction{si.fn}
 }
 
-// Parameters implements the same method as documented on
-// experimental.StackIterator.
+// Parameters implements the same method as documented on experimental.StackIterator.
 func (si *stackIterator) Parameters() []uint64 {
 	return si.stack[si.base : si.base+si.fn.funcType.ParamNumInUint64]
 }
@@ -1157,14 +1154,12 @@ func (si *stackIterator) Parameters() []uint64 {
 // internalFunction implements experimental.InternalFunction.
 type internalFunction struct{ *function }
 
-// Definition implements the same method as documented on
-// experimental.InternalFunction.
+// Definition implements the same method as documented on experimental.InternalFunction.
 func (f internalFunction) Definition() api.FunctionDefinition {
 	return f.definition()
 }
 
-// SourceOffsetForPC implements the same method as documented on
-// experimental.InternalFunction.
+// SourceOffsetForPC implements the same method as documented on experimental.InternalFunction.
 func (f internalFunction) SourceOffsetForPC(pc experimental.ProgramCounter) uint64 {
 	p := f.parent
 	if len(p.sourceOffsetMap.irOperationSourceOffsetsInWasmBinary) == 0 {

--- a/internal/platform/file_test.go
+++ b/internal/platform/file_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 	gofstest "testing/fstest"
+	"time"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
@@ -48,6 +49,24 @@ var (
 	readFile  = "wazero.txt"
 	emptyFile = "empty.txt"
 )
+
+func TestFsFileSetNonblock(t *testing.T) {
+	// Test using os.Pipe as it is known to support non-blocking reads.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+	defer w.Close()
+
+	rF := NewFsFile(readFile, syscall.O_RDONLY, r)
+
+	errno := rF.SetNonblock(true)
+	require.EqualErrno(t, 0, errno)
+	require.True(t, rF.IsNonblock())
+
+	errno = rF.SetNonblock(false)
+	require.EqualErrno(t, 0, errno)
+	require.False(t, rF.IsNonblock())
+}
 
 func TestFsFileIsDir(t *testing.T) {
 	dirFS, embedFS, mapFS := dirEmbedMapFS(t, t.TempDir())
@@ -138,6 +157,39 @@ func TestFsFileReadAndPread(t *testing.T) {
 			require.Equal(t, "zer", string(buf))
 		})
 	}
+}
+
+func TestFsFilePollRead(t *testing.T) {
+	// Test using os.Pipe as it is known to support poll.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+	defer w.Close()
+
+	rF := NewFsFile(readFile, syscall.O_RDONLY, r)
+	buf := make([]byte, 10)
+	timeout := time.Duration(0) // return immediately
+
+	// When there's nothing in the pipe, it isn't ready.
+	ready, errno := rF.PollRead(&timeout)
+	require.EqualErrno(t, 0, errno)
+	require.False(t, ready)
+
+	// Write to the pipe to make the data available
+	expected := []byte("wazero")
+	_, err = w.Write([]byte("wazero"))
+	require.NoError(t, err)
+
+	// We should now be able to poll ready
+	ready, errno = rF.PollRead(&timeout)
+	require.EqualErrno(t, 0, errno)
+	require.True(t, ready)
+
+	// We should now be able to read from the pipe
+	n, errno := rF.Read(buf)
+	require.EqualErrno(t, 0, errno)
+	require.Equal(t, len(expected), n)
+	require.Equal(t, expected, buf[:len(expected)])
 }
 
 func requireRead(t *testing.T, f File, buf []byte) {
@@ -591,7 +643,7 @@ func testSync_NoError(t *testing.T, sync func(File) syscall.Errno) {
 	for _, tt := range tests {
 		tc := tt
 
-		t.Run(tc.name, func(b *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			require.EqualErrno(t, 0, sync(tc.f))
 		})
 	}
@@ -742,6 +794,85 @@ func TestFsFileUtimens(t *testing.T) {
 	testEBADFIfDirClosed(t, func(d File) syscall.Errno {
 		return d.Utimens(nil)
 	})
+}
+
+func TestNewStdioFile(t *testing.T) {
+	// simulate regular file attached to stdin
+	f, err := os.CreateTemp(t.TempDir(), "somefile")
+	require.NoError(t, err)
+	defer f.Close()
+
+	stdin, err := NewStdioFile(true, os.Stdin)
+	require.NoError(t, err)
+	stdinStat, err := os.Stdin.Stat()
+	require.NoError(t, err)
+
+	stdinFile, err := NewStdioFile(true, f)
+	require.NoError(t, err)
+
+	stdout, err := NewStdioFile(false, os.Stdout)
+	require.NoError(t, err)
+	stdoutStat, err := os.Stdout.Stat()
+	require.NoError(t, err)
+
+	stdoutFile, err := NewStdioFile(false, f)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		f    File
+		// Depending on how the tests run, os.Stdin won't necessarily be a char
+		// device. We compare against an os.File, to account for this.
+		expectedType fs.FileMode
+	}{
+		{
+			name:         "stdin",
+			f:            stdin,
+			expectedType: stdinStat.Mode().Type(),
+		},
+		{
+			name:         "stdin file",
+			f:            stdinFile,
+			expectedType: 0, // normal file
+		},
+		{
+			name:         "stdout",
+			f:            stdout,
+			expectedType: stdoutStat.Mode().Type(),
+		},
+		{
+			name:         "stdout file",
+			f:            stdoutFile,
+			expectedType: 0, // normal file
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		t.Run(tc.name+" Stat", func(t *testing.T) {
+			st, errno := tc.f.Stat()
+			require.EqualErrno(t, 0, errno)
+			require.Equal(t, tc.expectedType, st.Mode&fs.ModeType)
+			require.Equal(t, uint64(1), st.Nlink)
+
+			// Fake times are needed to pass wasi-testsuite.
+			// See https://github.com/WebAssembly/wasi-testsuite/blob/af57727/tests/rust/src/bin/fd_filestat_get.rs#L1-L19
+			require.Zero(t, st.Ctim)
+			require.Zero(t, st.Mtim)
+			require.Zero(t, st.Atim)
+		})
+
+		t.Run(tc.name+" AccessMode", func(t *testing.T) {
+			accessMode := tc.f.AccessMode()
+			switch tc.f {
+			case stdin, stdinFile:
+				require.Equal(t, syscall.O_RDONLY, accessMode)
+			case stdout, stdoutFile:
+				require.Equal(t, syscall.O_WRONLY, accessMode)
+			}
+		})
+	}
 }
 
 func testEBADFIfDirClosed(t *testing.T, fn func(File) syscall.Errno) bool {

--- a/internal/platform/file_test.go
+++ b/internal/platform/file_test.go
@@ -172,6 +172,10 @@ func TestFsFilePollRead(t *testing.T) {
 
 	// When there's nothing in the pipe, it isn't ready.
 	ready, errno := rF.PollRead(&timeout)
+	if runtime.GOOS == "windows" {
+		require.EqualErrno(t, syscall.ENOSYS, errno)
+		t.Skip("TODO: windows File.PollRead")
+	}
 	require.EqualErrno(t, 0, errno)
 	require.False(t, ready)
 

--- a/internal/platform/nonblock_unix.go
+++ b/internal/platform/nonblock_unix.go
@@ -4,6 +4,6 @@ package platform
 
 import "syscall"
 
-func SetNonblock(fd uintptr, enable bool) error {
+func setNonblock(fd uintptr, enable bool) error {
 	return syscall.SetNonblock(int(fd), enable)
 }

--- a/internal/platform/nonblock_windows.go
+++ b/internal/platform/nonblock_windows.go
@@ -4,6 +4,6 @@ package platform
 
 import "syscall"
 
-func SetNonblock(fd uintptr, enable bool) error {
+func setNonblock(fd uintptr, enable bool) error {
 	return syscall.SetNonblock(syscall.Handle(fd), enable)
 }

--- a/internal/platform/select.go
+++ b/internal/platform/select.go
@@ -2,7 +2,8 @@ package platform
 
 import "time"
 
-// Select exposes the select(2) syscall.
+// _select exposes the select(2) syscall. This is named as such to avoid
+// colliding with they keyword select while not exporting the function.
 //
 // # Notes on Parameters
 //
@@ -26,6 +27,6 @@ import "time"
 //	e.g. the read-end of a pipe or an eventfd on Linux.
 //	When the context is canceled, we may unblock a Select call by writing to the fd, causing it to return immediately.
 //	This however requires to do a bit of housekeeping to hide the "special" FD from the end-user.
-func Select(n int, r, w, e *FdSet, timeout *time.Duration) (int, error) {
+func _select(n int, r, w, e *FdSet, timeout *time.Duration) (int, error) {
 	return syscall_select(n, r, w, e, timeout)
 }

--- a/internal/platform/select_test.go
+++ b/internal/platform/select_test.go
@@ -14,7 +14,7 @@ func TestSelect(t *testing.T) {
 	t.Run("should return immediately with no fds and duration 0", func(t *testing.T) {
 		for {
 			dur := time.Duration(0)
-			n, err := Select(0, nil, nil, nil, &dur)
+			n, err := _select(0, nil, nil, nil, &dur)
 			if err == syscall.EINTR {
 				t.Logf("Select interrupted")
 				continue
@@ -33,7 +33,7 @@ func TestSelect(t *testing.T) {
 			// updated by select(2). We are not accounting for this
 			// in our implementation.
 			start := time.Now()
-			n, err := Select(0, nil, nil, nil, &dur)
+			n, err := _select(0, nil, nil, nil, &dur)
 			took = time.Since(start)
 			if err == syscall.EINTR {
 				t.Logf("Select interrupted after %v", took)
@@ -73,7 +73,7 @@ func TestSelect(t *testing.T) {
 		rFdSet.Set(fd)
 
 		for {
-			n, err := Select(fd+1, rFdSet, nil, nil, nil)
+			n, err := _select(fd+1, rFdSet, nil, nil, nil)
 			if runtime.GOOS == "windows" {
 				// Not implemented for fds != wasiFdStdin
 				require.ErrorIs(t, err, syscall.ENOSYS)

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -107,10 +107,7 @@ func (noopStdioFile) Path() string {
 
 // Stat implements the same method as documented on platform.File
 func (noopStdioFile) Stat() (platform.Stat_t, syscall.Errno) {
-	return platform.Stat_t{
-		Mode:  fs.FileMode(modeDevice),
-		Nlink: 1,
-	}, 0
+	return platform.Stat_t{Mode: modeDevice, Nlink: 1}, 0
 }
 
 // IsDir implements the same method as documented on platform.File
@@ -423,29 +420,29 @@ func (c *Context) NewFSContext(stdin io.Reader, stdout, stderr io.Writer, rootFS
 
 func stdinFile(r io.Reader) (*FileEntry, error) {
 	if r == nil {
-		return &FileEntry{Name: "stdin", File: &noopStdinFile{}}, nil
+		return &FileEntry{Name: "stdin", IsPreopen: true, File: &noopStdinFile{}}, nil
 	} else if f, ok := r.(*os.File); ok {
 		if f, err := platform.NewStdioFile(true, f); err != nil {
 			return nil, err
 		} else {
-			return &FileEntry{Name: "stdin", File: f}, nil
+			return &FileEntry{Name: "stdin", IsPreopen: true, File: f}, nil
 		}
 	} else {
-		return &FileEntry{Name: "stdin", File: &StdinFile{Reader: r}}, nil
+		return &FileEntry{Name: "stdin", IsPreopen: true, File: &StdinFile{Reader: r}}, nil
 	}
 }
 
 func stdioWriterFile(name string, w io.Writer) (*FileEntry, error) {
 	if w == nil {
-		return &FileEntry{Name: name, File: &noopStdoutFile{}}, nil
+		return &FileEntry{Name: name, IsPreopen: true, File: &noopStdoutFile{}}, nil
 	} else if f, ok := w.(*os.File); ok {
 		if f, err := platform.NewStdioFile(false, f); err != nil {
 			return nil, err
 		} else {
-			return &FileEntry{Name: name, File: f}, nil
+			return &FileEntry{Name: name, IsPreopen: true, File: f}, nil
 		}
 	} else {
-		return &FileEntry{Name: name, File: &writerFile{w: w}}, nil
+		return &FileEntry{Name: name, IsPreopen: true, File: &writerFile{w: w}}, nil
 	}
 }
 

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -1,7 +1,6 @@
 package sys
 
 import (
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -31,173 +30,102 @@ const (
 	FdPreopen
 )
 
-const modeDevice = uint32(fs.ModeDevice | 0o640)
+const modeDevice = fs.ModeDevice | 0o640
 
-type StdioFileWriter struct {
+// StdinFile is a fs.ModeDevice file for use implementing FdStdin.
+// This is safer than reading from os.DevNull as it can never overrun
+// operating system file descriptors.
+type StdinFile struct {
+	noopStdinFile
+	io.Reader
+}
+
+// Read implements the same method as documented on platform.File
+func (f *StdinFile) Read(buf []byte) (int, syscall.Errno) {
+	n, err := f.Reader.Read(buf)
+	return n, platform.UnwrapOSError(err)
+}
+
+type writerFile struct {
+	noopStdoutFile
+
 	w io.Writer
-	s fs.FileInfo
-	// Known state of the non-blocking mode. Defaults to false which may not
-	// match the underlying state of the file descriptor if it was opened in
-	// non-blocking mode whe instantiating the module.
-	nonblock bool
 }
 
-// Stat implements fs.File
-func (w *StdioFileWriter) Stat() (fs.FileInfo, error) { return w.s, nil }
-
-// Read implements fs.File
-func (w *StdioFileWriter) Read([]byte) (n int, err error) {
-	return // emulate os.Stdout which returns zero
+// Write implements the same method as documented on platform.File
+func (f *writerFile) Write(buf []byte) (int, syscall.Errno) {
+	n, err := f.w.Write(buf)
+	return n, platform.UnwrapOSError(err)
 }
 
-// Write implements io.Writer
-func (w *StdioFileWriter) Write(p []byte) (n int, err error) {
-	return w.w.Write(p)
+// noopStdinFile is a fs.ModeDevice file for use implementing FdStdin. This is
+// safer than reading from os.DevNull as it can never overrun operating system
+// file descriptors.
+type noopStdinFile struct {
+	noopStdioFile
 }
 
-// Close implements fs.File
-func (w *StdioFileWriter) Close() error {
-	// Don't actually close the underlying file, as we didn't open it!
-	return nil
+// AccessMode implements the same method as documented on platform.File
+func (noopStdinFile) AccessMode() int {
+	return syscall.O_RDONLY
 }
 
-// IsNonblock returns the current known state of non-blocking mode on the
-// underlying file.
-func (w *StdioFileWriter) IsNonblock() bool {
-	return w.nonblock
+// Read implements the same method as documented on platform.File
+func (noopStdinFile) Read([]byte) (int, syscall.Errno) {
+	return 0, 0 // Always EOF
 }
 
-// SetNonblock sets the file to non-blocking mode if the reader has access to
-// the underlying file descriptor.
-func (w *StdioFileWriter) SetNonblock(enable bool) error {
-	if f, ok := w.w.(*os.File); ok {
-		if err := platform.SetNonblock(f.Fd(), enable); err != nil {
-			return err
-		}
-		w.nonblock = enable
-		return nil
-	}
-	return syscall.ENOSYS
+// PollRead implements the same method as documented on platform.File
+func (noopStdinFile) PollRead(*time.Duration) (ready bool, errno syscall.Errno) {
+	return true, 0 // always ready to read nothing
 }
 
-// StdioFilePoller is a strategy for polling a StdioFileReader for a given duration.
-// It returns true if the reader has data ready to be read, false and/or an error otherwise.
-type StdioFilePoller interface {
-	Poll(duration time.Duration) (bool, error)
+// noopStdoutFile is a fs.ModeDevice file for use implementing FdStdout and
+// FdStderr.
+type noopStdoutFile struct {
+	noopStdioFile
 }
 
-// PollerDefaultStdin is a poller that checks standard input.
-var PollerDefaultStdin = &pollerDefaultStdin{}
-
-type pollerDefaultStdin struct{}
-
-// Poll implements StdioFilePoller for pollerDefaultStdin.
-func (*pollerDefaultStdin) Poll(duration time.Duration) (bool, error) {
-	fdSet := platform.FdSet{}
-	fdSet.Set(int(FdStdin))
-	count, err := platform.Select(int(FdStdin+1), &fdSet, nil, nil, &duration)
-	return count > 0, err
+// AccessMode implements the same method as documented on platform.File
+func (noopStdoutFile) AccessMode() int {
+	return syscall.O_WRONLY
 }
 
-// PollerAlwaysReady is a poller that ignores the given timeout, and it returns true and no error.
-var PollerAlwaysReady = &pollerAlwaysReady{}
-
-type pollerAlwaysReady struct{}
-
-// Poll implements StdioFilePoller for pollerAlwaysReady.
-func (*pollerAlwaysReady) Poll(time.Duration) (bool, error) { return true, nil }
-
-// PollerNeverReady is a poller that waits for the given duration, and it always returns false and no error.
-var PollerNeverReady = &pollerNeverReady{}
-
-type pollerNeverReady struct{}
-
-// Poll implements StdioFilePoller for pollerNeverReady.
-func (*pollerNeverReady) Poll(d time.Duration) (bool, error) { time.Sleep(d); return false, nil }
-
-// StdioFileReader implements io.Reader for stdio files.
-type StdioFileReader struct {
-	r    io.Reader
-	s    fs.FileInfo
-	poll StdioFilePoller
-	// See StdioFileWriter.
-	nonblock bool
+// Write implements the same method as documented on platform.File
+func (noopStdoutFile) Write(p []byte) (int, syscall.Errno) {
+	return len(p), 0 // same as io.Discard
 }
 
-// NewStdioFileReader is a constructor for StdioFileReader.
-func NewStdioFileReader(reader io.Reader, fileInfo fs.FileInfo, poll StdioFilePoller) *StdioFileReader {
-	return &StdioFileReader{
-		r:    reader,
-		s:    fileInfo,
-		poll: poll,
-	}
+type noopStdioFile struct {
+	platform.UnimplementedFile
 }
 
-// Poll invokes the StdioFilePoller that was given at the NewStdioFileReader constructor.
-func (r *StdioFileReader) Poll(duration time.Duration) (bool, error) {
-	return r.poll.Poll(duration)
+// Path implements the same method as documented on platform.File
+func (noopStdioFile) Path() string {
+	return ""
 }
 
-// Stat implements fs.File
-func (r *StdioFileReader) Stat() (fs.FileInfo, error) { return r.s, nil }
-
-// Read implements fs.File
-func (r *StdioFileReader) Read(p []byte) (n int, err error) {
-	return r.r.Read(p)
+// Stat implements the same method as documented on platform.File
+func (noopStdioFile) Stat() (platform.Stat_t, syscall.Errno) {
+	return platform.Stat_t{
+		Mode:  fs.FileMode(modeDevice),
+		Nlink: 1,
+	}, 0
 }
 
-// Close implements fs.File
-func (r *StdioFileReader) Close() error {
-	// Don't actually close the underlying file, as we didn't open it!
-	return nil
+// IsDir implements the same method as documented on platform.File
+func (noopStdioFile) IsDir() (bool, syscall.Errno) {
+	return false, 0
 }
 
-// IsNonblock returns the current known state of non-blocking mode on the
-// underlying file.
-func (r *StdioFileReader) IsNonblock() bool {
-	return r.nonblock
-}
+// Close implements the same method as documented on platform.File
+func (noopStdioFile) Close() (errno syscall.Errno) { return }
 
-// SetNonblock sets the file to non-blocking mode if the reader has access to
-// the underlying file descriptor.
-func (r *StdioFileReader) SetNonblock(enable bool) error {
-	if f, ok := r.r.(*os.File); ok {
-		if err := platform.SetNonblock(f.Fd(), enable); err != nil {
-			return err
-		}
-		r.nonblock = enable
-		return nil
-	}
-	return syscall.ENOSYS
-}
+// Once File.File is removed, it will be possible to implement NoopFile.
+func (noopStdioFile) File() fs.File { panic("noop") }
 
-var (
-	noopStdinStat  = stdioFileInfo{0, modeDevice}
-	noopStdoutStat = stdioFileInfo{1, modeDevice}
-	noopStderrStat = stdioFileInfo{2, modeDevice}
-)
-
-// stdioFileInfo implements fs.FileInfo where index zero is the FD and one is the mode.
-type stdioFileInfo [2]uint32
-
-func (s stdioFileInfo) Name() string {
-	switch s[0] {
-	case 0:
-		return "stdin"
-	case 1:
-		return "stdout"
-	case 2:
-		return "stderr"
-	default:
-		panic(fmt.Errorf("BUG: incorrect FD %d", s[0]))
-	}
-}
-
-func (stdioFileInfo) Size() int64         { return 0 }
-func (s stdioFileInfo) Mode() fs.FileMode { return fs.FileMode(s[1]) }
-func (stdioFileInfo) ModTime() time.Time  { return time.Unix(0, 0) }
-func (stdioFileInfo) IsDir() bool         { return false }
-func (stdioFileInfo) Sys() interface{}    { return nil }
+// compile-time check to ensure lazyDir implements platform.File.
+var _ platform.File = (*lazyDir)(nil)
 
 type lazyDir struct {
 	fs sysfs.FS
@@ -212,6 +140,16 @@ func (r *lazyDir) Path() string {
 // AccessMode implements the same method as documented on platform.File
 func (r *lazyDir) AccessMode() int {
 	return syscall.O_RDONLY
+}
+
+// IsNonblock implements the same method as documented on platform.File
+func (r *lazyDir) IsNonblock() bool {
+	return false
+}
+
+// SetNonblock implements the same method as documented on platform.File
+func (r *lazyDir) SetNonblock(bool) syscall.Errno {
+	return syscall.EISDIR
 }
 
 // IsDir implements the same method as documented on platform.File
@@ -241,6 +179,11 @@ func (r *lazyDir) Pread([]byte, int64) (int, syscall.Errno) {
 // Seek implements File.Seek
 func (r *lazyDir) Seek(int64, int) (int64, syscall.Errno) {
 	return 0, syscall.EISDIR
+}
+
+// PollRead implements File.PollRead
+func (r *lazyDir) PollRead(*time.Duration) (ready bool, errno syscall.Errno) {
+	return false, syscall.ENOSYS
 }
 
 // Write implements the same method as documented on platform.File
@@ -436,17 +379,17 @@ type FileTable = descriptor.Table[int32, *FileEntry]
 // the file descriptor table as FdPreopen.
 func (c *Context) NewFSContext(stdin io.Reader, stdout, stderr io.Writer, rootFS sysfs.FS) (err error) {
 	c.fsc.rootFS = rootFS
-	inReader, err := stdinReader(stdin)
+	inFile, err := stdinFile(stdin)
 	if err != nil {
 		return err
 	}
-	c.fsc.openedFiles.Insert(inReader)
-	outWriter, err := stdioWriter(stdout, noopStdoutStat)
+	c.fsc.openedFiles.Insert(inFile)
+	outWriter, err := stdioWriterFile("stdout", stdout)
 	if err != nil {
 		return err
 	}
 	c.fsc.openedFiles.Insert(outWriter)
-	errWriter, err := stdioWriter(stderr, noopStderrStat)
+	errWriter, err := stdioWriterFile("stderr", stderr)
 	if err != nil {
 		return err
 	}
@@ -478,48 +421,32 @@ func (c *Context) NewFSContext(stdin io.Reader, stdout, stderr io.Writer, rootFS
 	return nil
 }
 
-func stdinReader(r io.Reader) (*FileEntry, error) {
+func stdinFile(r io.Reader) (*FileEntry, error) {
 	if r == nil {
-		r = eofReader{}
-	}
-	var freader *StdioFileReader
-	if stdioFileReader, ok := r.(*StdioFileReader); ok {
-		freader = stdioFileReader
-	} else {
-		s, err := stdioStat(r, noopStdinStat)
-		if err != nil {
+		return &FileEntry{Name: "stdin", File: &noopStdinFile{}}, nil
+	} else if f, ok := r.(*os.File); ok {
+		if f, err := platform.NewStdioFile(true, f); err != nil {
 			return nil, err
-		}
-		freader = NewStdioFileReader(r, s, PollerDefaultStdin)
-	}
-	return &FileEntry{
-		Name: noopStdinStat.Name(), File: platform.NewFsFile("", syscall.O_RDONLY, freader),
-	}, nil
-}
-
-func stdioWriter(w io.Writer, defaultStat stdioFileInfo) (*FileEntry, error) {
-	if w == nil {
-		w = io.Discard
-	}
-	s, err := stdioStat(w, defaultStat)
-	if err != nil {
-		return nil, err
-	}
-	return &FileEntry{
-		Name: s.Name(), File: platform.NewFsFile("", syscall.O_WRONLY, &StdioFileWriter{w: w, s: s}),
-	}, nil
-}
-
-func stdioStat(f interface{}, defaultStat stdioFileInfo) (fs.FileInfo, error) {
-	if f, ok := f.(*os.File); ok {
-		if st, err := f.Stat(); err == nil {
-			mode := uint32(st.Mode() & fs.ModeType)
-			return stdioFileInfo{defaultStat[0], mode}, nil
 		} else {
-			return nil, err
+			return &FileEntry{Name: "stdin", File: f}, nil
 		}
+	} else {
+		return &FileEntry{Name: "stdin", File: &StdinFile{Reader: r}}, nil
 	}
-	return defaultStat, nil
+}
+
+func stdioWriterFile(name string, w io.Writer) (*FileEntry, error) {
+	if w == nil {
+		return &FileEntry{Name: name, File: &noopStdoutFile{}}, nil
+	} else if f, ok := w.(*os.File); ok {
+		if f, err := platform.NewStdioFile(false, f); err != nil {
+			return nil, err
+		} else {
+			return &FileEntry{Name: name, File: f}, nil
+		}
+	} else {
+		return &FileEntry{Name: name, File: &writerFile{w: w}}, nil
+	}
 }
 
 // RootFS returns the underlying filesystem. Any files that should be added to

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -108,15 +108,6 @@ func (c *Context) RandSource() io.Reader {
 	return c.randSource
 }
 
-// eofReader is safer than reading from os.DevNull as it can never overrun operating system file descriptors.
-type eofReader struct{}
-
-// Read implements io.Reader
-// Note: This doesn't use a pointer reference as it has no state and an empty struct doesn't allocate.
-func (eofReader) Read([]byte) (int, error) {
-	return 0, io.EOF
-}
-
 // DefaultContext returns Context with no values set except a possible nil fs.FS
 //
 // This is only used for testing.

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -53,17 +53,20 @@ func TestDefaultSysContext(t *testing.T) {
 	require.Equal(t, platform.FakeNanosleep, sysCtx.nanosleep)
 	require.Equal(t, platform.NewFakeRandSource(), sysCtx.RandSource())
 
-	expectedOpenedFiles := FileTable{}
-	expectedOpenedFiles.Insert(noopStdin)
-	expectedOpenedFiles.Insert(noopStdout)
-	expectedOpenedFiles.Insert(noopStderr)
-	expectedOpenedFiles.Insert(&FileEntry{
+	expected := FileTable{}
+	noopStdin, _ := stdinFile(nil)
+	expected.Insert(noopStdin)
+	noopStdout, _ := stdioWriterFile("stdout", nil)
+	expected.Insert(noopStdout)
+	noopStderr, _ := stdioWriterFile("stderr", nil)
+	expected.Insert(noopStderr)
+	expected.Insert(&FileEntry{
 		IsPreopen: true,
 		Name:      "/",
 		FS:        testFS,
 		File:      &lazyDir{fs: testFS},
 	})
-	require.Equal(t, expectedOpenedFiles, sysCtx.FS().openedFiles)
+	require.Equal(t, expected, sysCtx.FS().openedFiles)
 }
 
 func TestFileEntryInode(t *testing.T) {


### PR DESCRIPTION
This adds `IsNonblock`, `SetNonblock` and `PollRead` to `platform.File`
allowing us to implement stdio files with the `platform.File` type
instead of alternate implementations.