### PR TITLE
experimental: remove error parameter from FunctionListener.After

### DIFF
--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -328,8 +328,6 @@ func BenchmarkFunctionListener(n int, module api.Module, stack []StackFrame, lis
 // indirect in terms of depth and breadth. The test could show a tree 3 calls deep where the there are a couple calls at
 // each depth under the root. The main thing this can help prevent is accidentally swapping the context internally.
 
-// TODO: Errors aren't handled, and the After hook should accept one along with the result values.
-
 // TODO: The context parameter of the After hook is not the same as the Before hook. This means interceptor patterns
 // are awkward. e.g. something like timing is difficult as it requires propagating a stack. Otherwise, nested calls will
 // overwrite each other's "since" time. Propagating a stack is further awkward as the After hook needs to know the

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -50,7 +50,7 @@ func (u uniqGoFuncs) Before(ctx context.Context, _ api.Module, def api.FunctionD
 }
 
 // After implements FunctionListener.After
-func (u uniqGoFuncs) After(context.Context, api.Module, api.FunctionDefinition, error, []uint64) {}
+func (u uniqGoFuncs) After(context.Context, api.Module, api.FunctionDefinition, []uint64) {}
 
 // This shows how to make a listener that counts go function calls.
 func Example_customListenerFactory() {

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -27,7 +27,7 @@ func (r *recorder) Before(ctx context.Context, _ api.Module, def api.FunctionDef
 	return ctx
 }
 
-func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefinition, _ error, _ []uint64) {
+func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64) {
 	r.afterNames = append(r.afterNames, def.DebugName())
 }
 
@@ -116,7 +116,7 @@ func TestMultiFunctionListenerFactory(t *testing.T) {
 	}
 
 	n := 0
-	f := func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) {
+	f := func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) {
 		n++
 		i := 0
 		for stackIterator.Next() {
@@ -180,12 +180,12 @@ func BenchmarkMultiFunctionListener(b *testing.B) {
 	}{
 		{
 			scenario: "simple function listener",
-			function: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) {
+			function: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) {
 			},
 		},
 		{
 			scenario: "stack iterator",
-			function: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) {
+			function: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) {
 				for stackIterator.Next() {
 				}
 			},

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -203,7 +203,7 @@ func (l *loggingListener) Before(ctx context.Context, mod api.Module, _ api.Func
 	// We're starting to log: increase the indentation level.
 	nestLevel++
 
-	l.logIndented(ctx, mod, nestLevel, true, params, nil, nil)
+	l.logIndented(ctx, mod, nestLevel, true, params, nil)
 
 	// We need to propagate this invocation's parameters to the after callback.
 	state = &logState{w: l.w, nestLevel: nestLevel}
@@ -220,19 +220,19 @@ func (l *loggingListener) Before(ctx context.Context, mod api.Module, _ api.Func
 
 // After logs to stdout the module and function name, prefixed with '<--' and
 // indented based on the call nesting level.
-func (l *loggingListener) After(ctx context.Context, mod api.Module, _ api.FunctionDefinition, err error, results []uint64) {
+func (l *loggingListener) After(ctx context.Context, mod api.Module, _ api.FunctionDefinition, results []uint64) {
 	// Note: We use the nest level directly even though it is the "next" nesting level.
 	// This works because our indent of zero nesting is one tab.
 	if state, ok := ctx.Value(logging.LoggerKey{}).(*logState); ok {
 		if state == unsampledLogState {
 			return
 		}
-		l.logIndented(ctx, mod, state.nestLevel, false, state.params, err, results)
+		l.logIndented(ctx, mod, state.nestLevel, false, state.params, results)
 	}
 }
 
 // logIndented logs an indented l.w like this: "-->\t\t\t$nestLevel$funcName\n"
-func (l *loggingListener) logIndented(ctx context.Context, mod api.Module, nestLevel int, isBefore bool, params []uint64, err error, results []uint64) {
+func (l *loggingListener) logIndented(ctx context.Context, mod api.Module, nestLevel int, isBefore bool, params []uint64, results []uint64) {
 	for i := 1; i < nestLevel; i++ {
 		l.w.WriteByte('\t') //nolint
 	}
@@ -241,12 +241,7 @@ func (l *loggingListener) logIndented(ctx context.Context, mod api.Module, nestL
 		l.logParams(ctx, mod, params)
 	} else { // after
 		l.w.WriteString(l.afterPrefix) //nolint
-		if err != nil {
-			l.w.WriteString(" error: ")  //nolint
-			l.w.WriteString(err.Error()) //nolint
-		} else {
-			l.logResults(ctx, mod, params, results)
-		}
+		l.logResults(ctx, mod, params, results)
 	}
 	l.w.WriteByte('\n') //nolint
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -1183,7 +1183,7 @@ func (ce *callEngine) builtinFunctionFunctionListenerBefore(ctx context.Context,
 
 func (ce *callEngine) builtinFunctionFunctionListenerAfter(ctx context.Context, mod api.Module, fn *function) {
 	base := int(ce.stackBasePointerInBytes >> 3)
-	fn.parent.listener.After(ctx, mod, fn.definition(), nil, ce.stack[base:base+fn.funcType.ResultNumInUint64])
+	fn.parent.listener.After(ctx, mod, fn.definition(), ce.stack[base:base+fn.funcType.ResultNumInUint64])
 
 	i := len(ce.contextStack) - 1
 	ce.ctx = ce.contextStack[i]

--- a/internal/engine/compiler/engine_bench_test.go
+++ b/internal/engine/compiler/engine_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkCallEngine_builtinFunctionFunctionListener(b *testing.B) {
 				before: func(context.Context, api.Module, api.FunctionDefinition, []uint64, experimental.StackIterator) context.Context {
 					return context.Background()
 				},
-				after: func(context.Context, api.Module, api.FunctionDefinition, error, []uint64) {
+				after: func(context.Context, api.Module, api.FunctionDefinition, []uint64) {
 				},
 			},
 			index: 0,

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -589,9 +589,9 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 		funcType: &wasm.FunctionType{ParamNumInUint64: 3},
 		parent: &compiledFunction{
 			listener: mockListener{
-				before: func(ctx context.Context, _ api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) context.Context {
+				before: func(ctx context.Context, _ api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) context.Context {
 					require.Equal(t, currentContext, ctx)
-					require.Equal(t, []uint64{2, 3, 4}, paramValues)
+					require.Equal(t, []uint64{2, 3, 4}, params)
 					assertStackIterator(t, stackIterator, []stackEntry{{def: def, args: []uint64{2, 3, 4}}})
 					return nextContext
 				},
@@ -620,9 +620,9 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 		funcType: &wasm.FunctionType{ResultNumInUint64: 1},
 		parent: &compiledFunction{
 			listener: mockListener{
-				after: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64) {
+				after: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
 					require.Equal(t, currentContext, ctx)
-					require.Equal(t, []uint64{5}, resultValues)
+					require.Equal(t, []uint64{5}, results)
 				},
 			},
 			index: 0,
@@ -645,16 +645,16 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 }
 
 type mockListener struct {
-	before func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) context.Context
-	after  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
+	before func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) context.Context
+	after  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64)
 }
 
-func (m mockListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) context.Context {
-	return m.before(ctx, mod, def, paramValues, stackIterator)
+func (m mockListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) context.Context {
+	return m.before(ctx, mod, def, params, stackIterator)
 }
 
-func (m mockListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64) {
-	m.after(ctx, mod, def, err, resultValues)
+func (m mockListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
+	m.after(ctx, mod, def, results)
 }
 
 func TestFunction_getSourceOffsetInWasmBinary(t *testing.T) {

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -608,7 +608,7 @@ func (ce *callEngine) callGoFunc(ctx context.Context, m *wasm.ModuleInstance, f 
 	if lsn != nil {
 		// TODO: This doesn't get the error due to use of panic to propagate them.
 		results := stack[:typ.ResultNumInUint64]
-		lsn.After(ctx, m, f.definition(), nil, results)
+		lsn.After(ctx, m, f.definition(), results)
 	}
 }
 
@@ -4087,7 +4087,7 @@ func (ce *callEngine) callNativeFuncWithListener(ctx context.Context, m *wasm.Mo
 	ctx = fnl.Before(ctx, m, def, ce.peekValues(len(typ.Params)), &ce.stackIterator)
 	ce.stackIterator.clear()
 	ce.callNativeFunc(ctx, m, f)
-	fnl.After(ctx, m, def, nil, ce.peekValues(len(typ.Results)))
+	fnl.After(ctx, m, def, ce.peekValues(len(typ.Results)))
 	return ctx
 }
 

--- a/internal/testing/enginetest/enginetest.go
+++ b/internal/testing/enginetest/enginetest.go
@@ -556,7 +556,7 @@ func RunTestModuleEngineBeforeListenerStackIterator(t *testing.T, et EngineTeste
 	}
 
 	fnListener := &fnListener{
-		beforeFn: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, si experimental.StackIterator) context.Context {
+		beforeFn: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, si experimental.StackIterator) context.Context {
 			require.True(t, len(expectedCallstacks) > 0)
 			expectedCallstack := expectedCallstacks[0]
 			for si.Next() {
@@ -693,7 +693,7 @@ func RunTestModuleEngineBeforeListenerGlobals(t *testing.T, et EngineTester) {
 	}
 
 	fnListener := &fnListener{
-		beforeFn: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, si experimental.StackIterator) context.Context {
+		beforeFn: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, si experimental.StackIterator) context.Context {
 			require.True(t, len(expectedGlobals) > 0)
 
 			imod := mod.(experimental.InternalModule)
@@ -803,24 +803,24 @@ func RunTestModuleEngineBeforeListenerGlobals(t *testing.T, et EngineTester) {
 }
 
 type fnListener struct {
-	beforeFn func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) context.Context
-	afterFn  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64)
+	beforeFn func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) context.Context
+	afterFn  func(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64)
 }
 
 func (f *fnListener) NewFunctionListener(api.FunctionDefinition) experimental.FunctionListener {
 	return f
 }
 
-func (f *fnListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, stackIterator experimental.StackIterator) context.Context {
+func (f *fnListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) context.Context {
 	if f.beforeFn != nil {
-		return f.beforeFn(ctx, mod, def, paramValues, stackIterator)
+		return f.beforeFn(ctx, mod, def, params, stackIterator)
 	}
 	return ctx
 }
 
-func (f *fnListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error, resultValues []uint64) {
+func (f *fnListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
 	if f.afterFn != nil {
-		f.afterFn(ctx, mod, def, err, resultValues)
+		f.afterFn(ctx, mod, def, results)
 	}
 }
 
@@ -835,7 +835,7 @@ func RunTestModuleEngineStackIteratorOffset(t *testing.T, et EngineTester) {
 	var tape [][]frame
 
 	fnListener := &fnListener{
-		beforeFn: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, paramValues []uint64, si experimental.StackIterator) context.Context {
+		beforeFn: func(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, si experimental.StackIterator) context.Context {
 			var stack []frame
 			for si.Next() {
 				fn := si.Function()


### PR DESCRIPTION
Following up on our discussion in #wazero-dev, I would like to suggest we remove the `error` parameter from `FunctionListener.After` since it is currently unused: wazero always passes the value `nil`.

I believe this change is worth it so users of `FunctionListener` do not have to concern themselves with understanding how to deal with the parameter nor write tests for code paths that will never be taken. It also means that we do not need to write documentation explaining why the parameter exists, and why it's currently unused.

Since this is still an experimental API, the breaking change should be acceptable, as well as considering bringing back a form of error handling in the future when we do have the ability to propagate errors to function listeners.

---

As part of this PR, I also made a few aesthetic changes:
- I renamed `paramValues` and `resultValues` to `params` and `results` since those were terms that were much more common within wazero to represent parameters and result values of function calls
- I modified the internal implementation of the logging listener's `logIndented` method to accept a function parameter instead of a boolean in order to configure which of the `logParams` or `logResults` methods gets called

---

Please take a look and let me know if you would like to see anything changed!