### PR TITLE
experimental: remove return value of FunctionListener.Before

### DIFF
--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -95,7 +95,6 @@ type FunctionListener interface {
 	// # Notes
 	//
 	//   - api.Memory is meant for inspection, not modification.
-	//   - Only functions called with api.Function are guaranteed to see this callback.
 	Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error)
 }
 

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -46,8 +46,11 @@ type FunctionListenerFactory interface {
 // FunctionListener can be registered for any function via
 // FunctionListenerFactory to be notified when the function is called.
 type FunctionListener interface {
-	// Before is invoked before a function is called. The returned context will
-	// be used as the context of this function call.
+	// Before is invoked before a function is called.
+	//
+	// There is always one corresponding call to After or Abort for each call to
+	// Before. This guarantee allows the listener to maintain an internal stack
+	// to perform correlations between the entry and exit of functions.
 	//
 	// # Params
 	//
@@ -62,19 +65,31 @@ type FunctionListener interface {
 	//
 	// Note: api.Memory is meant for inspection, not modification.
 	// mod can be cast to InternalModule to read non-exported globals.
-	Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator StackIterator) context.Context
+	Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator StackIterator)
 
 	// After is invoked after a function is called.
 	//
 	// # Params
 	//
-	//   - ctx: the context returned by Before.
+	//   - ctx: the context of the caller function.
 	//   - mod: the calling module.
 	//   - def: the function definition.
 	//   - results: api.ValueType encoded results.
 	//
 	// Note: api.Memory is meant for inspection, not modification.
 	After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64)
+
+	// Abort is invoked when a function does not return due to a trap or panic.
+	//
+	// # Params
+	//
+	//   - ctx: the context of the caller function.
+	//   - mod: the calling module.
+	//   - def: the function definition.
+	//   - err: the error value representing the reason why the function aborted.
+	//
+	// Note: api.Memory is meant for inspection, not modification.
+	Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error)
 }
 
 // FunctionListenerFunc is a function type implementing the FunctionListener
@@ -88,14 +103,18 @@ type FunctionListener interface {
 type FunctionListenerFunc func(context.Context, api.Module, api.FunctionDefinition, []uint64, StackIterator)
 
 // Before satisfies the FunctionListener interface, calls f.
-func (f FunctionListenerFunc) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator StackIterator) context.Context {
+func (f FunctionListenerFunc) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator StackIterator) {
 	f(ctx, mod, def, params, stackIterator)
-	return ctx
 }
 
 // After is declared to satisfy the FunctionListener interface, but it does
 // nothing.
 func (f FunctionListenerFunc) After(context.Context, api.Module, api.FunctionDefinition, []uint64) {
+}
+
+// Abort is declared to satisfy the FunctionListener interface, but it does
+// nothing.
+func (f FunctionListenerFunc) Abort(context.Context, api.Module, api.FunctionDefinition, error) {
 }
 
 // FunctionListenerFactoryFunc is a function type implementing the
@@ -149,18 +168,23 @@ type multiFunctionListener struct {
 	stack stackIterator
 }
 
-func (multi *multiFunctionListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, si StackIterator) context.Context {
+func (multi *multiFunctionListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, si StackIterator) {
 	multi.stack.base = si
 	for _, lstn := range multi.lstns {
 		multi.stack.index = -1
-		ctx = lstn.Before(ctx, mod, def, params, &multi.stack)
+		lstn.Before(ctx, mod, def, params, &multi.stack)
 	}
-	return ctx
 }
 
 func (multi *multiFunctionListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
 	for _, lstn := range multi.lstns {
 		lstn.After(ctx, mod, def, results)
+	}
+}
+
+func (multi *multiFunctionListener) Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error) {
+	for _, lstn := range multi.lstns {
+		lstn.Abort(ctx, mod, def, err)
 	}
 }
 
@@ -319,16 +343,13 @@ func BenchmarkFunctionListener(n int, module api.Module, stack []StackFrame, lis
 
 	for i := 0; i < n; i++ {
 		stackIterator.index = -1
-		callContext := listener.Before(ctx, module, def, params, stackIterator)
-		listener.After(callContext, module, def, results)
+		listener.Before(ctx, module, def, params, stackIterator)
+		listener.After(ctx, module, def, results)
 	}
 }
 
-// TODO: We need to add tests to enginetest to ensure contexts nest. A good test can use a combination of call and call
-// indirect in terms of depth and breadth. The test could show a tree 3 calls deep where the there are a couple calls at
-// each depth under the root. The main thing this can help prevent is accidentally swapping the context internally.
-
-// TODO: The context parameter of the After hook is not the same as the Before hook. This means interceptor patterns
-// are awkward. e.g. something like timing is difficult as it requires propagating a stack. Otherwise, nested calls will
-// overwrite each other's "since" time. Propagating a stack is further awkward as the After hook needs to know the
-// position to read from which might be subtle.
+// TODO: the calls to Abort are not yet tested in internal/testing/enginetest,
+// but they are validated indirectly in tests which exercise host logging,
+// like Test_procExit in imports/wasi_snapshot_preview1. Eventually we should
+// add dedicated tests to validate the behavior of the interpreter and compiler
+// engines independently.

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -76,7 +76,11 @@ type FunctionListener interface {
 	//   - def: the function definition.
 	//   - results: api.ValueType encoded results.
 	//
-	// Note: api.Memory is meant for inspection, not modification.
+	// # Notes
+	//
+	//   - api.Memory is meant for inspection, not modification.
+	//   - This is not called when a host function panics, or a guest function traps.
+	//      See Abort for more details.
 	After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64)
 
 	// Abort is invoked when a function does not return due to a trap or panic.

--- a/experimental/listener.go
+++ b/experimental/listener.go
@@ -92,7 +92,10 @@ type FunctionListener interface {
 	//   - def: the function definition.
 	//   - err: the error value representing the reason why the function aborted.
 	//
-	// Note: api.Memory is meant for inspection, not modification.
+	// # Notes
+	//
+	//   - api.Memory is meant for inspection, not modification.
+	//   - Only functions called with api.Function are guaranteed to see this callback.
 	Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error)
 }
 

--- a/experimental/listener_example_test.go
+++ b/experimental/listener_example_test.go
@@ -44,13 +44,15 @@ func (u uniqGoFuncs) NewFunctionListener(def api.FunctionDefinition) experimenta
 }
 
 // Before implements FunctionListener.Before
-func (u uniqGoFuncs) Before(ctx context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64, _ experimental.StackIterator) context.Context {
+func (u uniqGoFuncs) Before(ctx context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64, _ experimental.StackIterator) {
 	u[def.DebugName()] = struct{}{}
-	return ctx
 }
 
 // After implements FunctionListener.After
 func (u uniqGoFuncs) After(context.Context, api.Module, api.FunctionDefinition, []uint64) {}
+
+// Abort implements FunctionListener.Abort
+func (u uniqGoFuncs) Abort(context.Context, api.Module, api.FunctionDefinition, error) {}
 
 // This shows how to make a listener that counts go function calls.
 func Example_customListenerFactory() {

--- a/experimental/listener_test.go
+++ b/experimental/listener_test.go
@@ -18,17 +18,22 @@ import (
 var _ experimental.FunctionListenerFactory = &recorder{}
 
 type recorder struct {
-	m                       map[string]struct{}
-	beforeNames, afterNames []string
+	m           map[string]struct{}
+	beforeNames []string
+	afterNames  []string
+	abortNames  []string
 }
 
-func (r *recorder) Before(ctx context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64, _ experimental.StackIterator) context.Context {
+func (r *recorder) Before(ctx context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64, _ experimental.StackIterator) {
 	r.beforeNames = append(r.beforeNames, def.DebugName())
-	return ctx
 }
 
 func (r *recorder) After(_ context.Context, _ api.Module, def api.FunctionDefinition, _ []uint64) {
 	r.afterNames = append(r.afterNames, def.DebugName())
+}
+
+func (r *recorder) Abort(_ context.Context, _ api.Module, def api.FunctionDefinition, _ error) {
+	r.abortNames = append(r.abortNames, def.DebugName())
 }
 
 func (r *recorder) NewFunctionListener(definition api.FunctionDefinition) experimental.FunctionListener {

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -175,10 +175,6 @@ func (s *logStack) pop() []uint64 {
 	return params
 }
 
-func (s *logStack) len() int {
-	return len(s.params)
-}
-
 func (s *logStack) count() (n int) {
 	for _, p := range s.params {
 		if p != nil {

--- a/experimental/logging/log_listener.go
+++ b/experimental/logging/log_listener.go
@@ -87,6 +87,7 @@ type loggingListenerFactory struct {
 	w        logging.Writer
 	hostOnly bool
 	scopes   logging.LogScopes
+	stack    logStack
 }
 
 type flusher interface {
@@ -154,19 +155,38 @@ func (f *loggingListenerFactory) NewFunctionListener(fnd api.FunctionDefinition)
 		pLoggers:     pLoggers,
 		pSampler:     pSampler,
 		rLoggers:     rLoggers,
+		stack:        &f.stack,
 	}
 }
 
-// logState saves a copy of params between calls as the slice underlying them
-// is a stack reused for results.
-type logState struct {
-	w         logging.Writer
-	nestLevel int
-	unsampled bool
-	params    []uint64
+type logStack struct {
+	params [][]uint64
 }
 
-var unsampledLogState = &logState{unsampled: true}
+func (s *logStack) push(params []uint64) {
+	s.params = append(s.params, params)
+}
+
+func (s *logStack) pop() []uint64 {
+	i := len(s.params) - 1
+	params := s.params[i]
+	s.params[i] = nil
+	s.params = s.params[:i]
+	return params
+}
+
+func (s *logStack) len() int {
+	return len(s.params)
+}
+
+func (s *logStack) count() (n int) {
+	for _, p := range s.params {
+		if p != nil {
+			n++
+		}
+	}
+	return n
+}
 
 // loggingListener implements experimental.FunctionListener to log entrance and after
 // of each function call.
@@ -176,69 +196,48 @@ type loggingListener struct {
 	pLoggers                  []logging.ParamLogger
 	pSampler                  logging.ParamSampler
 	rLoggers                  []logging.ResultLogger
+	stack                     *logStack
 }
 
 // Before logs to stdout the module and function name, prefixed with '-->' and
 // indented based on the call nesting level.
-func (l *loggingListener) Before(ctx context.Context, mod api.Module, _ api.FunctionDefinition, params []uint64, si experimental.StackIterator) context.Context {
+func (l *loggingListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, _ experimental.StackIterator) {
 	// First, see if this invocation is sampled.
 	sampled := true
 	if s := l.pSampler; s != nil {
 		sampled = s(ctx, mod, params)
 	}
 
-	// Check to see if the calling function was logging.
-	var state *logState
-	var nestLevel int
-	if v := ctx.Value(logging.LoggerKey{}); v != nil {
-		if !sampled { // override to mute this invocation.
-			return context.WithValue(ctx, logging.LoggerKey{}, unsampledLogState)
-		}
-		state = v.(*logState)
-		nestLevel = state.nestLevel
-	} else if !sampled {
-		return ctx // lack of LoggerKey == not sampled.
+	if sampled {
+		l.logIndented(l.stack.count(), l.beforePrefix, func() {
+			l.logParams(ctx, mod, params)
+		})
+		params = append([]uint64{}, params...)
+	} else {
+		params = nil
 	}
 
-	// We're starting to log: increase the indentation level.
-	nestLevel++
-
-	l.logIndented(nestLevel, l.beforePrefix, func() {
-		l.logParams(ctx, mod, params)
-	})
-
-	// We need to propagate this invocation's parameters to the after callback.
-	state = &logState{w: l.w, nestLevel: nestLevel}
-	if pLen := len(params); pLen > 0 {
-		state.params = make([]uint64, pLen)
-		copy(state.params, params) // safe copy
-	} else { // empty
-		state.params = params
-	}
-
-	// Overwrite the logging key with this invocation's state.
-	return context.WithValue(ctx, logging.LoggerKey{}, state)
+	l.stack.push(params)
 }
 
 // After logs to stdout the module and function name, prefixed with '<--' and
 // indented based on the call nesting level.
-func (l *loggingListener) After(ctx context.Context, mod api.Module, _ api.FunctionDefinition, results []uint64) {
-	// Note: We use the nest level directly even though it is the "next" nesting level.
-	// This works because our indent of zero nesting is one tab.
-	if state, ok := ctx.Value(logging.LoggerKey{}).(*logState); ok {
-		if state == unsampledLogState {
-			return
-		}
-		l.logIndented(state.nestLevel, l.afterPrefix, func() {
-			l.logResults(ctx, mod, state.params, results)
+func (l *loggingListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
+	if params := l.stack.pop(); params != nil {
+		l.logIndented(l.stack.count(), l.afterPrefix, func() {
+			l.logResults(ctx, mod, params, results)
 		})
 	}
+}
+
+func (l *loggingListener) Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, _ error) {
+	l.stack.pop()
 }
 
 // logIndented writes an indentation level and prefix prior to calling log to
 // output the log line.
 func (l *loggingListener) logIndented(nestLevel int, prefix string, log func()) {
-	for i := 1; i < nestLevel; i++ {
+	for i := 0; i < nestLevel; i++ {
 		l.w.WriteByte('\t') //nolint
 	}
 	l.w.WriteString(prefix) //nolint

--- a/experimental/logging/log_listener_test.go
+++ b/experimental/logging/log_listener_test.go
@@ -279,8 +279,8 @@ func Test_loggingListener(t *testing.T) {
 			l := lf.NewFunctionListener(def)
 
 			out.Reset()
-			ctx := l.Before(testCtx, nil, def, tc.params, nil)
-			l.After(ctx, nil, def, tc.results)
+			l.Before(testCtx, nil, def, tc.params, nil)
+			l.After(testCtx, nil, def, tc.results)
 			require.Equal(t, tc.expected, out.String())
 		})
 	}
@@ -315,10 +315,10 @@ func Test_loggingListener_indentation(t *testing.T) {
 	def2 := &m.FunctionDefinitionSection[1]
 	l2 := lf.NewFunctionListener(def2)
 
-	ctx := l1.Before(testCtx, nil, def1, []uint64{}, nil)
-	ctx1 := l2.Before(ctx, nil, def2, []uint64{}, nil)
-	l2.After(ctx1, nil, def2, []uint64{})
-	l1.After(ctx, nil, def1, []uint64{})
+	l1.Before(testCtx, nil, def1, []uint64{}, nil)
+	l2.Before(testCtx, nil, def2, []uint64{}, nil)
+	l2.After(testCtx, nil, def2, []uint64{})
+	l1.After(testCtx, nil, def1, []uint64{})
 	require.Equal(t, `--> test.fn1()
 	--> test.fn2()
 	<--

--- a/internal/engine/compiler/engine_bench_test.go
+++ b/internal/engine/compiler/engine_bench_test.go
@@ -14,8 +14,7 @@ func BenchmarkCallEngine_builtinFunctionFunctionListener(b *testing.B) {
 		funcType: &wasm.FunctionType{ParamNumInUint64: 3},
 		parent: &compiledFunction{
 			listener: mockListener{
-				before: func(context.Context, api.Module, api.FunctionDefinition, []uint64, experimental.StackIterator) context.Context {
-					return context.Background()
+				before: func(context.Context, api.Module, api.FunctionDefinition, []uint64, experimental.StackIterator) {
 				},
 				after: func(context.Context, api.Module, api.FunctionDefinition, []uint64) {
 				},
@@ -30,15 +29,15 @@ func BenchmarkCallEngine_builtinFunctionFunctionListener(b *testing.B) {
 	}
 
 	ce := &callEngine{
-		ctx:          context.Background(),
 		stack:        []uint64{0, 1, 2, 3, 4, 0, 0, 0},
 		stackContext: stackContext{stackBasePointerInBytes: 16},
 	}
 
-	module := new(wasm.ModuleInstance)
+	mod := new(wasm.ModuleInstance)
+	ctx := context.Background()
 
 	for i := 0; i < b.N; i++ {
-		ce.builtinFunctionFunctionListenerBefore(ce.ctx, module, f)
-		ce.builtinFunctionFunctionListenerAfter(ce.ctx, module, f)
+		ce.builtinFunctionFunctionListenerBefore(ctx, mod, f)
+		ce.builtinFunctionFunctionListenerAfter(ctx, mod, f)
 	}
 }


### PR DESCRIPTION
Another follow up from our discussion in #wazero-dev, this PR modifies the signature of `FunctionListener.Before` to remove the returned `context.Context`.

This change aims to remove the internal context stack tracking return values of the `Before` methods. For context, I am copying a quote from the Slack discussion:

> While I find the API somewhat elegant, it has proven to be unusable in most cases where we've used FunctionListener because embedding values in a context requires at least one heap allocation, but sometimes two or more. The listeners often being on hot code paths of the guest program, and this heap allocation ends up being extremely costly.
>
> We worked around the issue by implementing internal stacks within the listeners, in the same way, that the wazero engine keeps track of a stack of the context.Context returned by Before. Implementing those stacks as slices allows reusing the underlying memory, which ends up being an extremely cheap mechanism for correlation between the Before and After methods: the allocation of context values added 50 to 100ns of latency per function, while the internal stack ends up adding 5 to 10ns (~10x cheaper).
>
> However, we still end up paying for the engine's internal context stack, despite not needing it. On performance-critical code paths, it almost doubles the overall latency of invoking function listeners.

## Using stacks to correlate Before and After

One of the issues was the fact that `After` was not always being called. For example, if a module hit a trap, or a host function panicked, the call to the `After` method would be skipped, which made it challenging to implement stack-based context tracking internally in the listener. This limitation actually impacted the host logging listeners and caused multiple tests within wazero to fail after making the initial change.

I am suggesting that we address it by adding a third `Abort` method on `FunctionListener`, which is invoked when a module execution is aborted, in which case there are no result values to pass to `After` and instead of communicate the reason for aborting to the call to `Abort`.

The guarantee that either `After` or `Abort` will be called allows listeners to use an internal stack to carry state from `Before` to one of these methods.

## State propagation through the call stack

One of the details that @codefromthecrypt shared in #wazero-dev was that the second reason for returning a `context.Context` was to pass state not just between `Before` and `After`, but also to other listeners and host function calls through the call stack. Use cases for that include telemetry like tracing, where a listener creates a span and injects it in the context that eventually gets passed as input to another callee.

While this use case isn't covered in the change I'm submitting here, I believe that it can be served by injecting a _mutable context value_ (as @codefromthecrypt described it). Here would be an example:

```go
// Completely hypothetical API, just to demonstrate the idea

rootSpan := &tracing.Span{
  ParentSpan: ...,
}

ctx := context.WithValue(ctx, SpanKey{}, &rootSpan)
...
// eventually instantiate module or call exported function with ctx
```
```go
func (f *functionTracer) Before(ctx context.Context, ...) {
  spanPtr := ctx.Value(SpanKey{}).(**tracing.Span)
  span := &tracing.Span{
    ParentSpan: *spanPtr,
    ...
  }
  *spanPtr = span // push
  span.Start()
}

func (f *functionTracer) After(ctx context.Context, ...) {
  spanPtr := ctx.Value(SpanKey{}).(**tracing.Span)
  span := *spanPtr
  span.Finish()
  *spanPtr = spanPtr.Parent // pop
}

// + Abort
```
In the future, injecting and extracting the context value may also be abstracted into a generic mechanism to bridge between the `FunctionListener` interface and higher level abstractions.

Some of the benefits I'm seeing to this approach is that it reduces the baseline cost of function listeners, the higher cost of maintaining stacks is only paid when necessary, and can be optimized individually by each listener to suite the use cases.

The trade off is that we offer something that is a bit less _packaged_, in some ways we are lowering the abstraction level of function listeners, leaving more of the implementation decisions to the host.

Please take a look and let me know if you would like to see anything changed!