### PR TITLE
Adds Readdir to platform.File and removes internal use of fs.FS

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -17,7 +17,7 @@ func Test_lastDirents(t *testing.T) {
 		name            string
 		f               *sys.ReadDir
 		cookie          int64
-		expectedDirents []*platform.Dirent
+		expectedDirents []platform.Dirent
 		expectedErrno   syscall.Errno
 	}{
 		{
@@ -102,7 +102,7 @@ func Test_lastDirents(t *testing.T) {
 func Test_maxDirents(t *testing.T) {
 	tests := []struct {
 		name                        string
-		dirents                     []*platform.Dirent
+		dirents                     []platform.Dirent
 		maxLen                      uint32
 		expectedCount               uint32
 		expectedwriteTruncatedEntry bool
@@ -194,13 +194,15 @@ func Test_maxDirents(t *testing.T) {
 }
 
 var (
-	testDirents = func() []*platform.Dirent {
-		dir, err := fstest.FS.Open("dir")
+	testDirents = func() []platform.Dirent {
+		dPath := "dir"
+		d, err := fstest.FS.Open(dPath)
 		if err != nil {
 			panic(err)
 		}
-		defer dir.Close()
-		dirents, errno := platform.Readdir(dir, -1)
+		defer d.Close()
+		pf := platform.NewFsFile(dPath, 0, d)
+		dirents, errno := pf.Readdir(-1)
 		if errno != 0 {
 			panic(errno)
 		}
@@ -233,7 +235,7 @@ var (
 func Test_writeDirents(t *testing.T) {
 	tests := []struct {
 		name                string
-		entries             []*platform.Dirent
+		entries             []platform.Dirent
 		entryCount          uint32
 		writeTruncatedEntry bool
 		expectedEntriesBuf  []byte

--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -324,7 +324,7 @@ func syscallReaddir(_ context.Context, mod api.Module, name string) (*objectArra
 	}
 	defer f.Close() //nolint
 
-	if dirents, errno := platform.Readdir(f.File(), -1); errno != 0 {
+	if dirents, errno := f.Readdir(-1); errno != 0 {
 		return nil, errno
 	} else {
 		entries := make([]interface{}, 0, len(dirents))

--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -32,7 +32,7 @@ func OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) 
 	if f, errno := openFile(path, flag, perm); errno != 0 {
 		return nil, errno
 	} else { // TODO: revisit windowsWrappedFile once fsFile is complete
-		f := &windowsWrappedFile{writeFile: f, path: path, flag: flag, perm: perm}
+		f := &windowsWrappedFile{osFile: f, path: path, flag: flag, perm: perm}
 		return f, 0
 	}
 }

--- a/internal/platform/open_file_windows.go
+++ b/internal/platform/open_file_windows.go
@@ -32,7 +32,7 @@ func OpenFile(path string, flag int, perm fs.FileMode) (fs.File, syscall.Errno) 
 	if f, errno := openFile(path, flag, perm); errno != 0 {
 		return nil, errno
 	} else { // TODO: revisit windowsWrappedFile once fsFile is complete
-		f := &windowsWrappedFile{WriteFile: f, path: path, flag: flag, perm: perm}
+		f := &windowsWrappedFile{writeFile: f, path: path, flag: flag, perm: perm}
 		return f, 0
 	}
 }

--- a/internal/platform/wrap_windows.go
+++ b/internal/platform/wrap_windows.go
@@ -16,7 +16,7 @@ import (
 //
 // Note: Don't test for this type as it is wrapped when using sysfs.NewReadFS.
 type windowsWrappedFile struct {
-	WriteFile
+	writeFile
 	path           string
 	flag           int
 	perm           fs.FileMode

--- a/internal/sys/fs_test.go
+++ b/internal/sys/fs_test.go
@@ -249,7 +249,7 @@ func TestFSContext_ReOpenDir(t *testing.T) {
 		require.True(t, ok)
 
 		// Set arbitrary state.
-		ent.ReadDir = &ReadDir{Dirents: make([]*platform.Dirent, 10), CountRead: 12345}
+		ent.ReadDir = &ReadDir{Dirents: make([]platform.Dirent, 10), CountRead: 12345}
 
 		// Then reopen the same file descriptor.
 		ent, errno = fsc.ReOpenDir(dirFd)

--- a/internal/sysfs/adapter.go
+++ b/internal/sysfs/adapter.go
@@ -3,10 +3,7 @@ package sysfs
 import (
 	"fmt"
 	"io/fs"
-	"os"
 	"path"
-	"runtime"
-	"strings"
 	"syscall"
 
 	"github.com/tetratelabs/wazero/internal/platform"
@@ -37,11 +34,6 @@ type adapter struct {
 // String implements fmt.Stringer
 func (a *adapter) String() string {
 	return fmt.Sprintf("%v", a.fs)
-}
-
-// Open implements the same method as documented on fs.FS
-func (a *adapter) Open(name string) (fs.File, error) {
-	return a.fs.Open(name)
 }
 
 // OpenFile implements FS.OpenFile
@@ -86,27 +78,4 @@ func cleanPath(name string) string {
 	}
 	cleaned = path.Clean(cleaned) // e.g. "sub/." -> "sub"
 	return cleaned
-}
-
-// fsOpen implements the Open method as documented on fs.FS
-func fsOpen(f FS, name string) (fs.File, error) {
-	if !fs.ValidPath(name) { // FS.OpenFile has fewer constraints than fs.FS
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
-	}
-
-	// This isn't a production-grade fs.FS implementation. The only special
-	// cases we address here are to pass testfs.TestFS.
-
-	if runtime.GOOS == "windows" {
-		switch {
-		case strings.Contains(name, "\\"):
-			return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
-		}
-	}
-
-	if f, err := f.OpenFile(name, os.O_RDONLY, 0); err != 0 {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
-	} else {
-		return f.File(), nil
-	}
 }

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -167,33 +167,3 @@ func TestAdapt_HackedWrites(t *testing.T) {
 
 	testOpen_O_RDWR(t, tmpDir, testFS)
 }
-
-func TestAdapt_TestFS(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-	require.NoError(t, fstest.WriteTestFiles(tmpDir))
-	dirFS := os.DirFS(tmpDir)
-
-	// TODO: We can't currently test embed.FS here because the source of
-	// fstest.FS are not real files.
-	tests := []struct {
-		name string
-		fs   fs.FS
-	}{
-		{name: "os.DirFS", fs: dirFS},
-		{name: "fstest.MapFS", fs: fstest.FS},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			// Adapt a normal fs.FS to sysfs.FS
-			testFS := Adapt(tc.fs)
-
-			// Adapt it back to fs.FS and run the tests
-			require.NoError(t, fstest.TestFS(testFS.(fs.FS)))
-		})
-	}
-}

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -35,11 +35,6 @@ func (d *dirFS) String() string {
 	return d.dir
 }
 
-// Open implements the same method as documented on fs.FS
-func (d *dirFS) Open(name string) (fs.File, error) {
-	return fsOpen(d, name)
-}
-
 // OpenFile implements FS.OpenFile
 func (d *dirFS) OpenFile(path string, flag int, perm fs.FileMode) (platform.File, syscall.Errno) {
 	f, errno := platform.OpenFile(d.join(path), flag, perm)

--- a/internal/sysfs/readfs_test.go
+++ b/internal/sysfs/readfs_test.go
@@ -174,20 +174,3 @@ func TestReadFS_Readlink(t *testing.T) {
 	testFS := NewReadFS(writeable)
 	testReadlink(t, testFS, writeable)
 }
-
-func TestReadFS_TestFS(t *testing.T) {
-	t.Parallel()
-
-	// Set up the test files
-	tmpDir := t.TempDir()
-	require.NoError(t, fstest.WriteTestFiles(tmpDir))
-
-	// Create a writeable filesystem
-	testFS := NewDirFS(tmpDir)
-
-	// Wrap it as read-only
-	testFS = NewReadFS(testFS)
-
-	// Run TestFS via the adapter
-	require.NoError(t, fstest.TestFS(testFS.(fs.FS)))
-}


### PR DESCRIPTION
This moves the existing semantics of `Readdir` to `platform.File` which allows us to remove internal use of `fs.File` completely.

Notes:
* While this completes feature parity on platform.File, there is still work to do. Notably, we need to packaging more sensible (not split between platform and sysfs), and separate the os.File impls from things generably usable when backed by a `fs.File`. Finally, the windows implementation should be retrofit to our file type. All these work will proceed next and once done we can polish the shape for possibly experimental export. (ETA weeks probably)
* To retrofit the current impl to `fs.File` is a lot of work, so choosing not to do that, especially not in this PR. We can backfill coverage that isn't already redundant to our testslater, when things settle.
* `Readdir` is unlike the system call, and a TODO is there to possibly refactor this. However, the current implementation works for wasip1 and gojs. We should look at wasip not 1 before doing more engineering on it.

Closes #1417