### PR TITLE
compiler: avoid some unsafe.Pointers

### DIFF
--- a/internal/engine/compiler/arch.go
+++ b/internal/engine/compiler/arch.go
@@ -11,10 +11,9 @@ var newArchContext func() archContext
 
 // nativecall is used by callEngine.execWasmFunction and the entrypoint to enter the compiled native code.
 // codeSegment is the pointer to the initial instruction of the compiled native code.
-// ce is "*callEngine" as uintptr.
 //
 // Note: this is implemented in per-arch Go assembler file. For example, arch_amd64.s implements this for amd64.
-func nativecall(codeSegment, ce uintptr, moduleInstanceAddress *wasm.ModuleInstance)
+func nativecall(codeSegment uintptr, ce *callEngine, moduleInstanceAddress *wasm.ModuleInstance)
 
 // registerNameFn is used for debugging purpose to have register symbols in the string of runtimeValueLocation.
 var registerNameFn func(register asm.Register) string

--- a/internal/engine/compiler/compiler_bench_test.go
+++ b/internal/engine/compiler/compiler_bench_test.go
@@ -114,8 +114,7 @@ func (j *compilerEnv) execBench(b *testing.B, codeSegment []byte) {
 	for i := 0; i < b.N; i++ {
 		nativecall(
 			uintptr(unsafe.Pointer(&codeSegment[0])),
-			uintptr(unsafe.Pointer(j.ce)),
-			j.moduleInstance,
+			j.ce, j.moduleInstance,
 		)
 	}
 	b.StopTimer()

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -37,10 +37,7 @@ func TestCompiler_compileHostFunction(t *testing.T) {
 
 	// Re-enter the return address.
 	require.NotEqual(t, uintptr(0), uintptr(env.ce.returnAddress))
-	nativecall(env.ce.returnAddress,
-		uintptr(unsafe.Pointer(env.callEngine())),
-		env.module(),
-	)
+	nativecall(env.ce.returnAddress, env.callEngine(), env.module())
 
 	// After that, the code must exit with returned status.
 	require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -249,10 +249,7 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 				// Reenter from the return address.
 				returnAddress := env.ce.returnAddress
 				require.True(t, returnAddress != 0, "returnAddress was zero %d", returnAddress)
-				nativecall(
-					returnAddress, uintptr(unsafe.Pointer(env.callEngine())),
-					env.module(),
-				)
+				nativecall(returnAddress, env.callEngine(), env.module())
 
 				// Check the result. This should be "Returned".
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"testing"
-	"unsafe"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -41,7 +40,7 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 	// Reenter from the return address.
 	nativecall(
 		env.ce.returnAddress,
-		uintptr(unsafe.Pointer(env.callEngine())),
+		env.callEngine(),
 		env.module(),
 	)
 

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -213,8 +213,7 @@ func (j *compilerEnv) exec(machineCode []byte) {
 
 	nativecall(
 		uintptr(unsafe.Pointer(&executable[0])),
-		uintptr(unsafe.Pointer(j.ce)),
-		j.moduleInstance,
+		j.ce, j.moduleInstance,
 	)
 }
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -998,7 +998,7 @@ func (ce *callEngine) execWasmFunction(ctx context.Context, m *wasm.ModuleInstan
 entry:
 	{
 		// Call into the native code.
-		nativecall(codeAddr, uintptr(unsafe.Pointer(ce)), modAddr)
+		nativecall(codeAddr, ce, modAddr)
 
 		// Check the status code from Compiler code.
 		switch status := ce.exitContext.statusCode; status {

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -129,11 +129,6 @@ type (
 		// initialFn is the initial function for this call engine.
 		initialFn *function
 
-		// ctx is the context.Context passed to all the host function calls.
-		// This is modified when there's a function listener call, otherwise it's always the context.Context
-		// passed to the Call API.
-		ctx context.Context
-
 		// stackIterator provides a way to iterate over the stack for Listeners.
 		// It is setup and valid only during a call to a Listener hook.
 		stackIterator stackIterator


### PR DESCRIPTION
These seem unneeded, so best to avoid.