### PR TITLE
Fix base rights for character devices

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -230,6 +230,8 @@ func fdFdstatGetFn(_ context.Context, mod api.Module, params []uint64) syscall.E
 		fsRightsBase = dirRightsBase
 		fsRightsInheriting = fileRightsBase | dirRightsBase
 	case wasip1.FILETYPE_CHARACTER_DEVICE:
+		// According to wasi-libc,
+		// > A tty is a character device that we can't seek or tell on.
 		// See https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/sources/isatty.c#L13-L18
 		fsRightsBase = fileRightsBase &^ wasip1.RIGHT_FD_SEEK &^ wasip1.RIGHT_FD_TELL
 	default:

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -229,6 +229,9 @@ func fdFdstatGetFn(_ context.Context, mod api.Module, params []uint64) syscall.E
 		// be given seek permission (RIGHT_FD_SEEK).
 		fsRightsBase = dirRightsBase
 		fsRightsInheriting = fileRightsBase | dirRightsBase
+	case wasip1.FILETYPE_CHARACTER_DEVICE:
+		// See https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/sources/isatty.c#L13-L18
+		fsRightsBase = fileRightsBase &^ wasip1.RIGHT_FD_SEEK &^ wasip1.RIGHT_FD_TELL
 	default:
 		fsRightsBase = fileRightsBase
 	}


### PR DESCRIPTION
While testing the latest `python.wasm` from https://github.com/vmware-labs/webassembly-language-runtimes, we were not able to get the python shell working. Turns out this was a rights issue with `fd=0`.

Per https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/sources/isatty.c#L13-L18, "A tty is a character device that we can't seek or tell on.".

This change re-use `fileRightsBase` and remove FD_SEEK and FD_TELL rights for all character devices.