### PR TITLE
Clears O_CREATE when re-opening a file to set flags

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -205,7 +205,7 @@ func fdFdstatGetFn(_ context.Context, mod api.Module, params []uint64) syscall.E
 		if f.File.IsNonblock() {
 			fdflags |= wasip1.FD_NONBLOCK
 		}
-	} else if f.File.AccessMode() != syscall.O_RDONLY {
+	} else if f.IsAppend() {
 		fdflags |= wasip1.FD_APPEND
 	}
 


### PR DESCRIPTION
Specifically O_CREATE|O_EXCL triggers EEXIST errors when re-opening a file. This ensures we clear the O_CREATE flag, as the goal is to re-create the file descriptor, not the file.

This also fixes a bug where we unconditionally write O_APPEND to any writable file in fdstat results.