### PR TITLE
wazero: allow cpu and memory profiling when compiling or running modules

### DIFF
--- a/cmd/wazero/wazero_test.go
+++ b/cmd/wazero/wazero_test.go
@@ -762,25 +762,11 @@ func runMain(t *testing.T, workdir string, args []string) (int, string, string) 
 		os.Args = oldArgs
 	})
 	os.Args = append([]string{"wazero"}, args...)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
-	var exitCode int
-	var stdout, stderr bytes.Buffer
-	var exited bool
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				exited = true
-			}
-		}()
-		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-		doMain(&stdout, &stderr, func(code int) {
-			exitCode = code
-			panic(code) // to exit the func and set the exit status.
-		})
-	}()
-
-	require.True(t, exited)
-
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	exitCode := doMain(stdout, stderr)
 	return exitCode, stdout.String(), stderr.String()
 }
 


### PR DESCRIPTION
This PR adds two new command line options to the `compile` and `run` subcommands: `-cpuprofile` and `-memprofile`.

The intent is to be able to generate CPU and memory profiles of wazero when compiling or running modules. Note that here we are generating profiles for the host (wazero) not the the guest module.

The motivation came from noticing that the compilation of the python version distributed at https://github.com/vmware-labs/webassembly-language-runtimes/releases/tag/python%2F3.11.3%2B20230428-7d1b259 was taking a noticeable amount of time. We can now use the `compile` command to investigate where time is being spent in wazero:
```
$ wazero compile -cpuprofile profile.out python-3.11.3.wasm
```

Performance profiles need to be written when the program exits, so I revisited the implementation of `cmd/wazero` to be able to use `defer` statements: I removed the `exit` callback, which was a reference to `os.Exit` and doesn't run defers; functions of the `main` package now return an exit code instead.

Please take a look and let me know if anything should be changed!