### PR TITLE
compiler: reuse asm.Node slice collecting NOP instructions for source mapping

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/pprof"
 	"strings"
 	"time"
@@ -498,6 +499,7 @@ func writeHeapProfile(stdErr io.Writer, path string) {
 		return
 	}
 	defer f.Close()
+	runtime.GC()
 	if err := pprof.WriteHeapProfile(f); err != nil {
 		fmt.Fprintf(stdErr, "error writing memory profile: %v\n", err)
 	}


### PR DESCRIPTION
This PR modifies `compileWasmFunction` to avoid allocation a temporary slice of `asm.Node` for each function, and instead reuse a buffer across compiled functions.

Tested on the compilation of python, the change removes another ~20MB of the ~240MB that are allocated:
```
$ ./wazero compile -memprofile /tmp/profile.out ~/wasm/bin/python-3.11.3.wasm
```

```
 $ go tool pprof -alloc_space -text -base /tmp/profile.base wazero /tmp/profile.out
File: wazero
Type: alloc_space
Time: May 14, 2023 at 12:28pm (PDT)
Showing nodes accounting for -17.15MB, 3.91% of 438.67MB total
Dropped 2 nodes (cum <= 2.19MB)
      flat  flat%   sum%        cum   cum%
  -32.10MB  7.32%  7.32%   -21.99MB  5.01%  github.com/tetratelabs/wazero/internal/engine/compiler.compileWasmFunction
    3.52MB   0.8%  6.52%     3.52MB   0.8%  github.com/tetratelabs/wazero/internal/engine/compiler.(*runtimeValueLocationStack).push (inline)
    3.01MB  0.69%  5.83%     3.01MB  0.69%  github.com/tetratelabs/wazero/internal/engine/compiler.(*runtimeValueLocationStack).cloneFrom (inline)
    2.48MB  0.57%  5.26%     2.48MB  0.57%  bytes.growSlice
    2.42MB  0.55%  4.71%     2.42MB  0.55%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeDataSegment
       2MB  0.46%  4.26%        2MB  0.46%  debug/dwarf.(*Data).parseAbbrev
   -1.30MB   0.3%  4.55%    -1.30MB   0.3%  github.com/tetratelabs/wazero/internal/wazeroir.(*Compiler).emit
    1.02MB  0.23%  4.32%   -16.22MB  3.70%  github.com/tetratelabs/wazero.(*runtime).CompileModule
    1.01MB  0.23%  4.09%     1.01MB  0.23%  github.com/tetratelabs/wazero/internal/asm/amd64.(*nodePool).allocNode (inline)
      -1MB  0.23%  4.32%       -1MB  0.23%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeCode
    0.64MB  0.14%  4.17%   -22.65MB  5.16%  github.com/tetratelabs/wazero/internal/engine/compiler.(*engine).CompileModule
    0.53MB  0.12%  4.05%     0.53MB  0.12%  github.com/tetratelabs/wazero/internal/wasm.(*Module).declaredFunctionIndexes
    0.52MB  0.12%  3.93%     0.52MB  0.12%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeFunctionSection
   -0.50MB  0.11%  4.05%    -0.50MB  0.11%  github.com/tetratelabs/wazero/internal/engine/compiler.(*amd64Compiler).compileBrTable
    0.48MB  0.11%  3.94%     1.01MB  0.23%  github.com/tetratelabs/wazero/internal/asm/amd64.(*AssemblerImpl).encodeReadInstructionAddress
    0.12MB 0.027%  3.91%     0.12MB 0.027%  github.com/tetratelabs/wazero/internal/engine/compiler.(*amd64Compiler).label
```