### PR TITLE
compiler: optimize allocation of asm.Node slice

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -1241,8 +1241,8 @@ func compileWasmFunction(cmp compiler, ir *wazeroir.CompilationResult, asmNodes 
 	needSourceOffsets := len(ir.IROperationSourceOffsetsInWasmBinary) > 0
 	var irOpBegins []asm.Node
 	if needSourceOffsets {
+		irOpBegins = append(asmNodes.nodes[:0], make([]asm.Node, len(ir.Operations))...)
 		defer func() { asmNodes.nodes = irOpBegins }()
-		irOpBegins = asmNodes.nodes[:0]
 	}
 
 	var skip bool
@@ -1252,7 +1252,7 @@ func compileWasmFunction(cmp compiler, ir *wazeroir.CompilationResult, asmNodes 
 			// If this compilation requires source offsets for DWARF based back trace,
 			// we emit a NOP node at the beginning of each IR operation to get the
 			// binary offset of the beginning of the corresponding compiled native code.
-			irOpBegins = append(irOpBegins, cmp.compileNOP())
+			irOpBegins[i] = cmp.compileNOP()
 		}
 
 		// Compiler determines whether skip the entire label.


### PR DESCRIPTION
This PR is a follow up to #1465. A lot of small heap allocations occur when initially growing the scratch space of `asm.Node`, and again when the size of the buffer causes the growth factor to fall from 2x to 1.25x. To reduce the memory footprint, we can pre-size the buffer instead of incrementally appending on each IR operation processed during function compilation.

Overall, the change has a small but measurable impact on the memory footprint when compiling Python:

```
File: wazero
Type: alloc_space
Time: May 15, 2023 at 12:08am (PDT)
Showing nodes accounting for -6408.61kB, 2.06% of 311668.95kB total
      flat  flat%   sum%        cum   cum%
-10799.86kB  3.47%  3.47% -5504.92kB  1.77%  github.com/tetratelabs/wazero/internal/engine/compiler.compileWasmFunction
-3616.47kB  1.16%  4.63% -3616.47kB  1.16%  github.com/tetratelabs/wazero/internal/asm/arm64.(*nodePool).allocNode (inline)
 3591.59kB  1.15%  3.47%  3591.59kB  1.15%  github.com/tetratelabs/wazero/internal/engine/compiler.(*runtimeValueLocationStack).push (inline)
 3082.01kB  0.99%  2.48%  3082.01kB  0.99%  github.com/tetratelabs/wazero/internal/engine/compiler.(*runtimeValueLocationStack).cloneFrom (inline)
-3030.81kB  0.97%  3.46% -3030.81kB  0.97%  github.com/tetratelabs/wazero/internal/wazeroir.(*Compiler).emit
-1934.83kB  0.62%  4.08% -1934.83kB  0.62%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeCustomSection (inline)
 1300.89kB  0.42%  3.66% -7226.71kB  2.32%  github.com/tetratelabs/wazero/internal/engine/compiler.(*engine).CompileModule
 1095.84kB  0.35%  3.31%  1095.84kB  0.35%  github.com/tetratelabs/wazero/internal/asm/arm64.(*AssemblerImpl).encodeADR
 1059.18kB  0.34%  2.97%  1059.18kB  0.34%  github.com/tetratelabs/wazero/internal/asm/arm64.(*AssemblerImpl).encodeRelativeBranch
 1037.45kB  0.33%  2.64%  1037.45kB  0.33%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeCode
 1026.90kB  0.33%  2.31%  1026.90kB  0.33%  debug/dwarf.(*Data).parseAbbrev
  704.90kB  0.23%  2.08%   704.90kB  0.23%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeDataSegment
 -536.37kB  0.17%  2.25%  -536.37kB  0.17%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeFunctionSection
  524.09kB  0.17%  2.08%   524.09kB  0.17%  github.com/tetratelabs/wazero/internal/wasm.(*controlBlockStack).push (inline)
 -522.70kB  0.17%  2.25%  -522.70kB  0.17%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeElementInitValueVector
  518.65kB  0.17%  2.09%   518.65kB  0.17%  github.com/tetratelabs/wazero/internal/wasm.(*Module).declaredFunctionIndexes
   82.79kB 0.027%  2.06%    82.79kB 0.027%  github.com/tetratelabs/wazero/internal/engine/compiler.(*arm64Compiler).label
    8.12kB 0.0026%  2.06% -3022.68kB  0.97%  github.com/tetratelabs/wazero/internal/wazeroir.(*Compiler).handleInstruction
```