### PR TITLE
wazero: add -count option to compile command

### DIFF
--- a/cmd/wazero/wazero.go
+++ b/cmd/wazero/wazero.go
@@ -73,16 +73,20 @@ func doCompile(args []string, stdErr io.Writer) int {
 	flags.BoolVar(&help, "h", false, "Prints usage.")
 
 	var count int
-	flags.IntVar(&count, "count", 1,
-		"Number of times to perform the compilation. This is useful to benchmark performance of the wazero compiler.")
-
 	var cpuProfile string
-	flags.StringVar(&cpuProfile, "cpuprofile", "",
-		"Enables cpu profiling and writes the profile at the given path.")
-
 	var memProfile string
-	flags.StringVar(&memProfile, "memprofile", "",
-		"Enables memory profiling and writes the profile at the given path.")
+	if version.GetWazeroVersion() != version.Default {
+		count = 1
+	} else {
+		flags.IntVar(&count, "count", 1,
+			"Number of times to perform the compilation. This is useful to benchmark performance of the wazero compiler.")
+
+		flags.StringVar(&cpuProfile, "cpuprofile", "",
+			"Enables cpu profiling and writes the profile at the given path.")
+
+		flags.StringVar(&memProfile, "memprofile", "",
+			"Enables memory profiling and writes the profile at the given path.")
+	}
 
 	cacheDir := cacheDirFlag(flags)
 
@@ -183,12 +187,14 @@ func doRun(args []string, stdOut io.Writer, stdErr logging.Writer) int {
 			"This may be specified multiple times. Supported values: all,clock,filesystem,memory,proc,poll,random")
 
 	var cpuProfile string
-	flags.StringVar(&cpuProfile, "cpuprofile", "",
-		"Enables cpu profiling and writes the profile at the given path.")
-
 	var memProfile string
-	flags.StringVar(&memProfile, "memprofile", "",
-		"Enables memory profiling and writes the profile at the given path.")
+	if version.GetWazeroVersion() == version.Default {
+		flags.StringVar(&cpuProfile, "cpuprofile", "",
+			"Enables cpu profiling and writes the profile at the given path.")
+
+		flags.StringVar(&memProfile, "memprofile", "",
+			"Enables memory profiling and writes the profile at the given path.")
+	}
 
 	cacheDir := cacheDirFlag(flags)
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// Default is the default version value used when none was found.
+const Default = "dev"
+
 // version holds the current version from the go.mod of downstream users or set by ldflag for wazero CLI.
 var version string
 
@@ -36,7 +39,7 @@ func GetWazeroVersion() (ret string) {
 		}
 	}
 	if versionMissing(ret) {
-		return "dev" // don't return parens
+		return Default // don't return parens
 	}
 
 	// Cache for the subsequent calls.


### PR DESCRIPTION
This option has been useful to run the compilation multiple times in order to get more samples when recording CPU or memory profiles.

I don't have a lot of context on what the intent was for the `compile` subcommand, so maybe this option is out of place, so feel free to let me know if this should be done differently!