### PR TITLE
platform: fix minor linting issue

### DIFF
--- a/internal/platform/mremap_other.go
+++ b/internal/platform/mremap_other.go
@@ -8,7 +8,10 @@ func remapCodeSegmentAMD64(code []byte, size int) ([]byte, error) {
 		return nil, err
 	}
 	copy(b, code)
-	munmapCodeSegment(code)
+	err = munmapCodeSegment(code)
+	if err != nil {
+		return nil, err
+	}
 	return b, nil
 }
 
@@ -18,6 +21,9 @@ func remapCodeSegmentARM64(code []byte, size int) ([]byte, error) {
 		return nil, err
 	}
 	copy(b, code)
-	munmapCodeSegment(code)
+	err = munmapCodeSegment(code)
+	if err != nil {
+		return nil, err
+	}
 	return b, nil
 }

--- a/internal/platform/mremap_other.go
+++ b/internal/platform/mremap_other.go
@@ -8,11 +8,23 @@ func remapCodeSegmentAMD64(code []byte, size int) ([]byte, error) {
 		return nil, err
 	}
 	copy(b, code)
-	err = munmapCodeSegment(code)
-	if err != nil {
-		return nil, err
-	}
+	mustMunmapCodeSegment(code)
 	return b, nil
+}
+
+// mustMunmapCodeSegment panics instead of returning an error to the
+// application.
+//
+// # Why panic?
+//
+// It is less disruptive to the application to leak the previous block if it
+// could be unmapped than to leak the new block and return an error.
+// Realistically, either scenarios are pretty hard to debug, so we panic. There
+// is less as the dominant runtime.GOOS (linux) doesn't use this anyway.
+func mustMunmapCodeSegment(code []byte) {
+	if err := munmapCodeSegment(code); err != nil {
+		panic(err)
+	}
 }
 
 func remapCodeSegmentARM64(code []byte, size int) ([]byte, error) {
@@ -21,9 +33,6 @@ func remapCodeSegmentARM64(code []byte, size int) ([]byte, error) {
 		return nil, err
 	}
 	copy(b, code)
-	err = munmapCodeSegment(code)
-	if err != nil {
-		return nil, err
-	}
+	mustMunmapCodeSegment(code)
 	return b, nil
 }


### PR DESCRIPTION
return value is not checked in internal/platform/mremap_other.go
for munmapCodeSegment(code)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>

Probably we forgot to run `make lint` on this one.
