### PR TITLE
Removes AccessMode from platform.File

### DIFF
--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -234,10 +234,8 @@ func processFDEventRead(fsc *internalsys.FSContext, fd int32) wasip1.Errno {
 
 // processFDEventWrite returns ErrnoNotsup if the file exists and ErrnoBadf otherwise.
 func processFDEventWrite(fsc *internalsys.FSContext, fd int32) wasip1.Errno {
-	if f, ok := fsc.LookupFile(fd); ok {
-		if f.File.AccessMode() != syscall.O_RDONLY {
-			return wasip1.ErrnoNotsup
-		}
+	if _, ok := fsc.LookupFile(fd); ok {
+		return wasip1.ErrnoNotsup
 	}
 	return wasip1.ErrnoBadf
 }

--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -288,12 +288,13 @@ func syscallWrite(mod api.Module, fd int32, offset interface{}, buf []byte) (n i
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	if f, ok := fsc.LookupFile(fd); !ok {
 		errno = syscall.EBADF
-	} else if f.File.AccessMode() == syscall.O_RDONLY {
-		errno = syscall.EBADF
 	} else if offset != nil {
 		n, errno = f.File.Pwrite(buf, toInt64(offset))
 	} else {
 		n, errno = f.File.Write(buf)
+	}
+	if errno == syscall.ENOSYS {
+		errno = syscall.EBADF // e.g. unimplemented for write
 	}
 	return
 }

--- a/internal/platform/dir.go
+++ b/internal/platform/dir.go
@@ -56,11 +56,6 @@ func adjustReaddirErr(f File, isClosed bool, err error) syscall.Errno {
 // DirFile is embeddable to reduce the amount of functions to implement a file.
 type DirFile struct{}
 
-// AccessMode implements File.AccessMode
-func (DirFile) AccessMode() int {
-	return syscall.O_RDONLY
-}
-
 // IsAppend implements File.IsAppend
 func (DirFile) IsAppend() bool {
 	return false

--- a/internal/platform/file_test.go
+++ b/internal/platform/file_test.go
@@ -24,11 +24,6 @@ type NoopFile struct {
 	UnimplementedFile
 }
 
-// The current design requires the user to implement AccessMode.
-func (NoopFile) AccessMode() int {
-	return syscall.O_RDONLY
-}
-
 // The current design requires the user to consciously implement Close.
 // However, we could change UnimplementedFile to return zero.
 func (NoopFile) Close() (errno syscall.Errno) { return }
@@ -952,16 +947,6 @@ func TestNewStdioFile(t *testing.T) {
 			require.Zero(t, st.Ctim)
 			require.Zero(t, st.Mtim)
 			require.Zero(t, st.Atim)
-		})
-
-		t.Run(tc.name+" AccessMode", func(t *testing.T) {
-			accessMode := tc.f.AccessMode()
-			switch tc.f {
-			case stdin, stdinFile:
-				require.Equal(t, syscall.O_RDONLY, accessMode)
-			case stdout, stdoutFile:
-				require.Equal(t, syscall.O_WRONLY, accessMode)
-			}
 		})
 	}
 }

--- a/internal/platform/osfile.go
+++ b/internal/platform/osfile.go
@@ -47,11 +47,6 @@ func (f *osFile) Ino() (uint64, syscall.Errno) {
 	}
 }
 
-// AccessMode implements File.AccessMode
-func (f *osFile) AccessMode() int {
-	return f.flag & (syscall.O_RDONLY | syscall.O_WRONLY | syscall.O_RDWR)
-}
-
 // IsAppend implements File.IsAppend
 func (f *osFile) IsAppend() bool {
 	return f.flag&syscall.O_APPEND == syscall.O_APPEND

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -80,11 +80,6 @@ func (r *readFile) Ino() (uint64, syscall.Errno) {
 	return r.f.Ino()
 }
 
-// AccessMode implements the same method as documented on platform.File.
-func (r *readFile) AccessMode() int {
-	return r.f.AccessMode()
-}
-
 // IsNonblock implements the same method as documented on platform.File.
 func (r *readFile) IsNonblock() bool {
 	return r.f.IsNonblock()


### PR DESCRIPTION
In the beginning, we checked by type if a command like read or write might succeed. Temporarily, we switched to exposing the AccessMode, which could be incorrect or drift. Now, we use the underlying error instead. Removing `platform.AccessMode` was a TODO left until the code was consolidated enough to address it coherently.