### PR TITLE
ci: extend pagefile size on Windows

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -76,6 +76,15 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
 
+      # Ensure the pagefile is large enough to execute tests like TestStore_hammer_close on Windows.
+      - name: configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        if: runner.os == 'Windows'
+        with:
+          minimum-size: 8GB
+          maximum-size: 16GB
+          disk-root: "D:"
+
       # Run -race could be really slow without -short, so run them together on this workflow.
       # Since -short is not added in the scratch tests, all the tests are run in CI in practice.
       - run: make test go_test_options='-timeout 10m -race -short'


### PR DESCRIPTION
Fixes #1476.

To be fair, being this a flaky test, we can't really be sure. However, the issue indeed seem to be related to pagefile size:


```
==6264==ERROR: ThreadSanitizer failed to allocate 0x000001000000 (16777216) bytes at 0x0400a2000000 (error code: 1455)
```

This GH issue indicates a GH Action that extends the pagefile size to address this issue https://github.com/actions/runner-images/issues/785


Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
