### PR TITLE
Generically convert to string in hammer recovery

### DIFF
--- a/internal/testing/hammer/hammer.go
+++ b/internal/testing/hammer/hammer.go
@@ -76,7 +76,7 @@ func (h *hammer) Run(test func(name string), onRunning func()) {
 				if recovered := recover(); recovered != nil {
 					// Has been seen to be string, runtime.errorString, and it may be others. Let
 					// printing take care of conversion in a generic way.
-					h.t.Error(fmt.Sprintf("%s", recovered))
+					h.t.Error(recovered)
 				}
 				finished <- 1
 			}()

--- a/internal/testing/hammer/hammer.go
+++ b/internal/testing/hammer/hammer.go
@@ -74,7 +74,9 @@ func (h *hammer) Run(test func(name string), onRunning func()) {
 		go func() { // Launch goroutine 'p'
 			defer func() { // Ensure each require.XX failure is visible on hammer test fail.
 				if recovered := recover(); recovered != nil {
-					h.t.Error(recovered.(string))
+					// Has been seen to be string, runtime.errorString, and it may be others. Let
+					// printing take care of conversion in a generic way.
+					h.t.Error(fmt.Sprintf("%s", recovered))
 				}
 				finished <- 1
 			}()


### PR DESCRIPTION
While working with hammer tests, I did notice type mismatch panics here but didn't actually send a fix for it. This will make sure any crashes such as OOM are reported as such instead of just deadlocking by panicing before being able to signal `finished`.