### PR TITLE
compiler: fix benchmarks in compiler, engine; add to Makefile, update API calls

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -169,7 +169,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - run: make bench.check
+      - run: make bench
 
   # This ensures that internal/integration_test/fuzz is runnable, and is not intended to
   # run full-length fuzzing while trying to find low-hanging frontend bugs.

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,6 @@ bench:
 		cd - ;\
 	done
 
-.PHONY: bench.check
-bench.check:
-	@go build ./internal/integration_test/bench/...
-	@# Don't use -test.benchmem as it isn't accurate when comparing against CGO libs
-	@for d in vs/time vs/wasmedge vs/wasmer vs/wasmtime ; do \
-		cd ./internal/integration_test/$$d ; \
-		go test -bench=. . -tags='wasmedge' $(ensureCompilerFastest) ; \
-		cd - ;\
-	done
-
 bench_testdata_dir := internal/integration_test/bench/testdata
 .PHONY: build.bench
 build.bench:

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,13 @@ ensureCompilerFastest := -ldflags '-X github.com/tetratelabs/wazero/internal/int
 .PHONY: bench
 bench:
 	@go test -run=NONE -benchmem -bench=. ./internal/engine/compiler/...
-	@go test -run=NONE -benchmem -bench=. ./internal/integration_test/bench/...
-	@go test -benchmem -bench=. ./internal/integration_test/vs/... $(ensureCompilerFastest)
+	@go build ./internal/integration_test/bench/...
+	@# Don't use -test.benchmem as it isn't accurate when comparing against CGO libs
+	@for d in vs/time vs/wasmedge vs/wasmer vs/wasmtime ; do \
+		cd ./internal/integration_test/$$d ; \
+		go test -bench=. . -tags='wasmedge' $(ensureCompilerFastest) ; \
+		cd - ;\
+	done
 
 .PHONY: bench.check
 bench.check:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ go_test_options ?= -timeout 300s
 ensureCompilerFastest := -ldflags '-X github.com/tetratelabs/wazero/internal/integration_test/vs.ensureCompilerFastest=true'
 .PHONY: bench
 bench:
+	@go test -run=NONE -benchmem -bench=. ./internal/engine/compiler/...
 	@go test -run=NONE -benchmem -bench=. ./internal/integration_test/bench/...
 	@go test -benchmem -bench=. ./internal/integration_test/vs/... $(ensureCompilerFastest)
 

--- a/internal/engine/compiler/engine_bench_test.go
+++ b/internal/engine/compiler/engine_bench_test.go
@@ -22,7 +22,9 @@ func BenchmarkCallEngine_builtinFunctionFunctionListener(b *testing.B) {
 			index: 0,
 			parent: &compiledModule{
 				source: &wasm.Module{
-					FunctionDefinitionSection: []wasm.FunctionDefinition{{}},
+					TypeSection:     []wasm.FunctionType{{}},
+					FunctionSection: []wasm.Index{0},
+					CodeSection:     []wasm.Code{{Body: []byte{wasm.OpcodeEnd}}},
 				},
 			},
 		},


### PR DESCRIPTION
Some benchmarks were not running in CI. We enable them,
add them to the Makefile, and ensure that all are up-to-date.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>

---

looking into this. Essentially, the panic is due to codeSegment not being mmap'd; so this is enough:

```
func (j *compilerEnv) execBench(b *testing.B, codeSegment []byte) {
	executable := requireExecutable(codeSegment)
	b.StartTimer()
```

(unless you want to measure the mmap overhead too)

once this is done, there is another panic due to the change to how `functionDefintition`s are now loaded; looking into that too. Will open a PR.

as for running this in the CI, shall we add this to the Makefile?

```
bench:
	@go test -run=NONE -benchmem -bench=. ./internal/engine/compiler/...
	@go test -run=NONE -benchmem -bench=. ./internal/integration_test/bench/...
	@go test -benchmem -bench=. ./internal/integration_test/vs/... $(ensureCompilerFastest)

```

Fixes #1464.
