### PR TITLE
compiler: zero-copy code assembly

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -583,7 +583,7 @@ func (a *AssemblerImpl) encodeOnNextJmpNOPPAdding(buf asm.Buffer, n *nodeImpl) e
 	return a.encodeNOPPadding(buf, instructionLen)
 }
 
-// maybeNOPPadding maybe appends NOP instructions before the node `n`.
+// encodeNOPPadding maybe appends NOP instructions before the node `n`.
 // This is necessary to avoid Intel's jump erratum:
 // https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
 func (a *AssemblerImpl) encodeNOPPadding(buf asm.Buffer, instructionLen int32) error {

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -923,6 +923,19 @@ func errorEncodingUnsupported(n *nodeImpl) error {
 }
 
 func (a *AssemblerImpl) encodeNoneToNone(buf asm.Buffer, n *nodeImpl) (err error) {
+	// Throughout the encoding methods, we use this pair of base offset and
+	// code buffer to write instructions.
+	//
+	// The code buffer is allocated at the end of the current buffer to a size
+	// large enough to hold all the bytes that may be written by the method.
+	//
+	// We use Go's append builtin to write to the buffer because it allows the
+	// compiler to generate much better code than if we made calls to write
+	// methods to mutate an encapsulated byte slice.
+	//
+	// At the end of the method, we truncate the buffer size back to the base
+	// plus the length of the code buffer so the end of the buffer points right
+	// after the last byte that was written.
 	base := buf.Len()
 	code := buf.Append(4)[:0]
 

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -688,7 +688,7 @@ func (a *AssemblerImpl) padNOP(buf asm.Buffer, num int) {
 		if singleNopNum > len(nopOpcodes) {
 			singleNopNum = len(nopOpcodes)
 		}
-		buf.Write(nopOpcodes[singleNopNum-1][:singleNopNum])
+		buf.AppendBytes(nopOpcodes[singleNopNum-1][:singleNopNum])
 		num -= singleNopNum
 	}
 }

--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -1,7 +1,6 @@
 package amd64
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -222,7 +221,6 @@ type (
 	AssemblerImpl struct {
 		root    *nodeImpl
 		current *nodeImpl
-		buf     *bytes.Buffer
 		asm.BaseAssemblerImpl
 		readInstructionAddressNodes []*nodeImpl
 
@@ -251,7 +249,6 @@ type (
 func NewAssembler() *AssemblerImpl {
 	return &AssemblerImpl{
 		nodePool:                       nodePool{index: nodePageSize},
-		buf:                            bytes.NewBuffer(nil),
 		pool:                           asm.NewStaticConstPool(),
 		MaxDisplacementForConstantPool: defaultMaxDisplacementForConstantPool,
 	}
@@ -317,7 +314,6 @@ func (a *AssemblerImpl) Reset() {
 	pool := a.pool
 	pool.Reset()
 	*a = AssemblerImpl{
-		buf:                         a.buf,
 		nodePool:                    a.nodePool,
 		pool:                        pool,
 		readInstructionAddressNodes: a.readInstructionAddressNodes[:0],
@@ -327,7 +323,6 @@ func (a *AssemblerImpl) Reset() {
 			JumpTableEntries:           a.JumpTableEntries[:0],
 		},
 	}
-	a.buf.Reset()
 	a.nodePool.reset()
 }
 
@@ -361,37 +356,37 @@ func (a *AssemblerImpl) addNode(node *nodeImpl) {
 }
 
 // encodeNode encodes the given node into writer.
-func (a *AssemblerImpl) encodeNode(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeNode(buf asm.Buffer, n *nodeImpl) (err error) {
 	switch n.types {
 	case operandTypesNoneToNone:
-		err = a.encodeNoneToNone(n)
+		err = a.encodeNoneToNone(buf, n)
 	case operandTypesNoneToRegister:
-		err = a.encodeNoneToRegister(n)
+		err = a.encodeNoneToRegister(buf, n)
 	case operandTypesNoneToMemory:
-		err = a.encodeNoneToMemory(n)
+		err = a.encodeNoneToMemory(buf, n)
 	case operandTypesNoneToBranch:
 		// Branching operand can be encoded as relative jumps.
-		err = a.encodeRelativeJump(n)
+		err = a.encodeRelativeJump(buf, n)
 	case operandTypesRegisterToNone:
-		err = a.encodeRegisterToNone(n)
+		err = a.encodeRegisterToNone(buf, n)
 	case operandTypesRegisterToRegister:
-		err = a.encodeRegisterToRegister(n)
+		err = a.encodeRegisterToRegister(buf, n)
 	case operandTypesRegisterToMemory:
-		err = a.encodeRegisterToMemory(n)
+		err = a.encodeRegisterToMemory(buf, n)
 	case operandTypesRegisterToConst:
-		err = a.encodeRegisterToConst(n)
+		err = a.encodeRegisterToConst(buf, n)
 	case operandTypesMemoryToRegister:
-		err = a.encodeMemoryToRegister(n)
+		err = a.encodeMemoryToRegister(buf, n)
 	case operandTypesMemoryToConst:
-		err = a.encodeMemoryToConst(n)
+		err = a.encodeMemoryToConst(buf, n)
 	case operandTypesConstToRegister:
-		err = a.encodeConstToRegister(n)
+		err = a.encodeConstToRegister(buf, n)
 	case operandTypesConstToMemory:
-		err = a.encodeConstToMemory(n)
+		err = a.encodeConstToMemory(buf, n)
 	case operandTypesStaticConstToRegister:
-		err = a.encodeStaticConstToRegister(n)
+		err = a.encodeStaticConstToRegister(buf, n)
 	case operandTypesRegisterToStaticConst:
-		err = a.encodeRegisterToStaticConst(n)
+		err = a.encodeRegisterToStaticConst(buf, n)
 	default:
 		err = fmt.Errorf("encoder undefined for [%s] operand type", n.types)
 	}
@@ -402,15 +397,15 @@ func (a *AssemblerImpl) encodeNode(n *nodeImpl) (err error) {
 }
 
 // Assemble implements asm.AssemblerBase
-func (a *AssemblerImpl) Assemble() ([]byte, error) {
+func (a *AssemblerImpl) Assemble(buf asm.Buffer) error {
 	a.initializeNodesForEncoding()
 
 	// Continue encoding until we are not forced to re-assemble which happens when
 	// a short relative jump ends up the offset larger than 8-bit length.
 	for {
-		err := a.encode()
+		err := a.encode(buf)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if !a.forceReAssemble {
@@ -418,16 +413,16 @@ func (a *AssemblerImpl) Assemble() ([]byte, error) {
 		} else {
 			// We reset the length of buffer but don't delete the underlying slice since
 			// the binary size will roughly the same after reassemble.
-			a.buf.Reset()
+			buf.Reset()
 			// Reset the re-assemble flag in order to avoid the infinite loop!
 			a.forceReAssemble = false
 		}
 	}
 
-	code := a.buf.Bytes()
+	code := buf.Bytes()
 	for _, n := range a.readInstructionAddressNodes {
 		if err := a.finalizeReadInstructionAddressNode(code, n); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
@@ -442,10 +437,7 @@ func (a *AssemblerImpl) Assemble() ([]byte, error) {
 		binary.LittleEndian.PutUint32(code[displacementOffsetInInstruction:], uint32(int32(displacement)))
 	}
 
-	if err := a.FinalizeJumpTableEntry(code); err != nil {
-		return nil, err
-	}
-	return code, nil
+	return a.FinalizeJumpTableEntry(code)
 }
 
 // initializeNodesForEncoding initializes nodeImpl.flag and determine all the jumps
@@ -489,29 +481,29 @@ func (a *AssemblerImpl) initializeNodesForEncoding() {
 	}
 }
 
-func (a *AssemblerImpl) encode() (err error) {
+func (a *AssemblerImpl) encode(buf asm.Buffer) (err error) {
 	for n := a.root; n != nil; n = n.next {
 		// If an instruction needs NOP padding, we do so before encoding it.
 		// https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
-		if err = a.maybeNOPPadding(n); err != nil {
+		if err = a.maybeNOPPadding(buf, n); err != nil {
 			return
 		}
 
 		// After the padding, we can finalize the offset of this instruction in the binary.
-		n.offsetInBinary = uint64(a.buf.Len())
+		n.offsetInBinary = uint64(buf.Len())
 
-		if err = a.encodeNode(n); err != nil {
+		if err = a.encodeNode(buf, n); err != nil {
 			return
 		}
 
 		if n.forwardJumpOrigins != nil {
-			if err = a.resolveForwardRelativeJumps(n); err != nil {
+			if err = a.resolveForwardRelativeJumps(buf, n); err != nil {
 				err = fmt.Errorf("invalid relative forward jumps: %w", err)
 				break
 			}
 		}
 
-		a.maybeFlushConstants(n.next == nil)
+		a.maybeFlushConstants(buf, n.next == nil)
 	}
 	return
 }
@@ -552,28 +544,28 @@ var nopPaddingInfo = [instructionEnd]struct {
 // maybeNOPPadding maybe appends NOP instructions before the node `n`.
 // This is necessary to avoid Intel's jump erratum:
 // https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
-func (a *AssemblerImpl) maybeNOPPadding(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) maybeNOPPadding(buf asm.Buffer, n *nodeImpl) (err error) {
 	var instructionLen int32
 	// See in Section 2.1 in for when we have to pad NOP.
 	// https://www.intel.com/content/dam/support/us/en/documents/processors/mitigations-jump-conditional-code-erratum.pdf
 	if info := nopPaddingInfo[n.instruction]; info.jmp {
 		// In order to know the instruction length before writing into the binary,
 		// we try encoding it.
-		prevLen := a.buf.Len()
+		prevLen := buf.Len()
 
 		// Assign the temporary offset which may or may not be correct depending on the padding decision.
 		n.offsetInBinary = uint64(prevLen)
 
 		// Encode the node and get the instruction length.
-		if err = a.encodeNode(n); err != nil {
+		if err = a.encodeNode(buf, n); err != nil {
 			return
 		}
-		instructionLen = int32(a.buf.Len() - prevLen)
+		instructionLen = int32(buf.Len() - prevLen)
 
 		// Revert the written bytes.
-		a.buf.Truncate(prevLen)
+		buf.Truncate(prevLen)
 	} else if info.onNextJmp {
-		instructionLen, err = a.fusedInstructionLength(n)
+		instructionLen, err = a.fusedInstructionLength(buf, n)
 		if err != nil {
 			return err
 		}
@@ -585,19 +577,19 @@ func (a *AssemblerImpl) maybeNOPPadding(n *nodeImpl) (err error) {
 	const mask = boundaryInBytes - 1
 
 	var padNum int
-	currentPos := int32(a.buf.Len())
+	currentPos := int32(buf.Len())
 	if used := currentPos & mask; used+instructionLen >= boundaryInBytes {
 		padNum = int(boundaryInBytes - used)
 	}
 
-	a.padNOP(padNum)
+	a.padNOP(buf, padNum)
 	return
 }
 
 // fusedInstructionLength returns the length of "macro fused instruction" if the
 // instruction sequence starting from `n` can be fused by processor. Otherwise,
 // returns zero.
-func (a *AssemblerImpl) fusedInstructionLength(n *nodeImpl) (ret int32, err error) {
+func (a *AssemblerImpl) fusedInstructionLength(buf asm.Buffer, n *nodeImpl) (ret int32, err error) {
 	// Find the next non-NOP instruction.
 	next := n.next
 	for ; next != nil && next.instruction == NOP; next = next.next {
@@ -645,20 +637,20 @@ func (a *AssemblerImpl) fusedInstructionLength(n *nodeImpl) (ret int32, err erro
 	// Now the instruction is ensured to be fused by the processor.
 	// In order to know the fused instruction length before writing into the binary,
 	// we try encoding it.
-	savedLen := uint64(a.buf.Len())
+	savedLen := uint64(buf.Len())
 
 	// Encode the nodes into the buffer.
-	if err = a.encodeNode(n); err != nil {
+	if err = a.encodeNode(buf, n); err != nil {
 		return
 	}
-	if err = a.encodeNode(next); err != nil {
+	if err = a.encodeNode(buf, next); err != nil {
 		return
 	}
 
-	ret = int32(uint64(a.buf.Len()) - savedLen)
+	ret = int32(uint64(buf.Len()) - savedLen)
 
 	// Revert the written bytes.
-	a.buf.Truncate(int(savedLen))
+	buf.Truncate(int(savedLen))
 	return
 }
 
@@ -678,13 +670,13 @@ var nopOpcodes = [][11]byte{
 	{0x66, 0x66, 0x66, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00},
 }
 
-func (a *AssemblerImpl) padNOP(num int) {
+func (a *AssemblerImpl) padNOP(buf asm.Buffer, num int) {
 	for num > 0 {
 		singleNopNum := num
 		if singleNopNum > len(nopOpcodes) {
 			singleNopNum = len(nopOpcodes)
 		}
-		a.buf.Write(nopOpcodes[singleNopNum-1][:singleNopNum])
+		buf.Write(nopOpcodes[singleNopNum-1][:singleNopNum])
 		num -= singleNopNum
 	}
 }
@@ -918,37 +910,37 @@ func errorEncodingUnsupported(n *nodeImpl) error {
 	return fmt.Errorf("%s is unsupported for %s type", InstructionName(n.instruction), n.types)
 }
 
-func (a *AssemblerImpl) encodeNoneToNone(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeNoneToNone(buf asm.Buffer, n *nodeImpl) (err error) {
 	switch n.instruction {
 	case CDQ:
 		// https://www.felixcloutier.com/x86/cwd:cdq:cqo
-		err = a.buf.WriteByte(0x99)
+		err = buf.WriteByte(0x99)
 	case CQO:
 		// https://www.felixcloutier.com/x86/cwd:cdq:cqo
-		_, err = a.buf.Write([]byte{rexPrefixW, 0x99})
+		err = buf.Write2Bytes(rexPrefixW, 0x99)
 	case NOP:
 		// Simply optimize out the NOP instructions.
 	case RET:
 		// https://www.felixcloutier.com/x86/ret
-		err = a.buf.WriteByte(0xc3)
+		err = buf.WriteByte(0xc3)
 	case UD2:
 		// https://mudongliang.github.io/x86/html/file_module_x86_id_318.html
-		_, err = a.buf.Write([]byte{0x0f, 0x0b})
+		err = buf.Write2Bytes(0x0f, 0x0b)
 	case REPMOVSQ:
-		_, err = a.buf.Write([]byte{0xf3, rexPrefixW, 0xa5})
+		err = buf.Write3Bytes(0xf3, rexPrefixW, 0xa5)
 	case REPSTOSQ:
-		_, err = a.buf.Write([]byte{0xf3, rexPrefixW, 0xab})
+		err = buf.Write3Bytes(0xf3, rexPrefixW, 0xab)
 	case STD:
-		_, err = a.buf.Write([]byte{0xfd})
+		err = buf.WriteByte(0xfd)
 	case CLD:
-		_, err = a.buf.Write([]byte{0xfc})
+		err = buf.WriteByte(0xfc)
 	default:
 		err = errorEncodingUnsupported(n)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeNoneToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeNoneToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	regBits, prefix := register3bits(n.dstReg, registerSpecifierPositionModRMFieldRM)
 
 	// https://wiki.osdev.org/X86-64_Instruction_Encoding#ModR.2FM
@@ -976,7 +968,7 @@ func (a *AssemblerImpl) encodeNoneToRegister(n *nodeImpl) (err error) {
 
 	if prefix != rexPrefixNone {
 		// https://wiki.osdev.org/X86-64_Instruction_Encoding#Encoding
-		if err = a.buf.WriteByte(prefix); err != nil {
+		if err = buf.WriteByte(prefix); err != nil {
 			return
 		}
 	}
@@ -984,59 +976,59 @@ func (a *AssemblerImpl) encodeNoneToRegister(n *nodeImpl) (err error) {
 	switch n.instruction {
 	case JMP:
 		// https://www.felixcloutier.com/x86/jmp
-		_, err = a.buf.Write([]byte{0xff, modRM})
+		err = buf.Write2Bytes(0xff, modRM)
 	case SETCC:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x93, modRM})
+		err = buf.Write3Bytes(0x0f, 0x93, modRM)
 	case SETCS:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x92, modRM})
+		err = buf.Write3Bytes(0x0f, 0x92, modRM)
 	case SETEQ:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x94, modRM})
+		err = buf.Write3Bytes(0x0f, 0x94, modRM)
 	case SETGE:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x9d, modRM})
+		err = buf.Write3Bytes(0x0f, 0x9d, modRM)
 	case SETGT:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x9f, modRM})
+		err = buf.Write3Bytes(0x0f, 0x9f, modRM)
 	case SETHI:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x97, modRM})
+		err = buf.Write3Bytes(0x0f, 0x97, modRM)
 	case SETLE:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x9e, modRM})
+		err = buf.Write3Bytes(0x0f, 0x9e, modRM)
 	case SETLS:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x96, modRM})
+		err = buf.Write3Bytes(0x0f, 0x96, modRM)
 	case SETLT:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x9c, modRM})
+		err = buf.Write3Bytes(0x0f, 0x9c, modRM)
 	case SETNE:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x95, modRM})
+		err = buf.Write3Bytes(0x0f, 0x95, modRM)
 	case SETPC:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x9b, modRM})
+		err = buf.Write3Bytes(0x0f, 0x9b, modRM)
 	case SETPS:
 		// https://www.felixcloutier.com/x86/setcc
-		_, err = a.buf.Write([]byte{0x0f, 0x9a, modRM})
+		err = buf.Write3Bytes(0x0f, 0x9a, modRM)
 	case NEGQ:
 		// https://www.felixcloutier.com/x86/neg
-		_, err = a.buf.Write([]byte{0xf7, modRM})
+		err = buf.Write2Bytes(0xf7, modRM)
 	case INCQ:
 		// https://www.felixcloutier.com/x86/inc
-		_, err = a.buf.Write([]byte{0xff, modRM})
+		err = buf.Write2Bytes(0xff, modRM)
 	case DECQ:
 		// https://www.felixcloutier.com/x86/dec
-		_, err = a.buf.Write([]byte{0xff, modRM})
+		err = buf.Write2Bytes(0xff, modRM)
 	default:
 		err = errorEncodingUnsupported(n)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeNoneToMemory(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeNoneToMemory(buf asm.Buffer, n *nodeImpl) (err error) {
 	rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.getMemoryLocation(true)
 	if err != nil {
 		return err
@@ -1062,17 +1054,17 @@ func (a *AssemblerImpl) encodeNoneToMemory(n *nodeImpl) (err error) {
 	}
 
 	if rexPrefix != rexPrefixNone {
-		a.buf.WriteByte(rexPrefix)
+		buf.WriteByte(rexPrefix)
 	}
 
-	a.buf.Write([]byte{opcode, modRM})
+	buf.Write2Bytes(opcode, modRM)
 
 	if sbiExist {
-		a.buf.WriteByte(sbi)
+		buf.WriteByte(sbi)
 	}
 
 	if displacementWidth != 0 {
-		a.writeConst(n.dstConst, displacementWidth)
+		writeConst(buf, n.dstConst, displacementWidth)
 	}
 	return
 }
@@ -1107,7 +1099,7 @@ var relativeJumpOpcodes = [...]relativeJumpOpcode{
 	JMP: {short: []byte{0xeb}, long: []byte{0xe9}},
 }
 
-func (a *AssemblerImpl) resolveForwardRelativeJumps(target *nodeImpl) (err error) {
+func (a *AssemblerImpl) resolveForwardRelativeJumps(buf asm.Buffer, target *nodeImpl) (err error) {
 	offsetInBinary := int64(target.OffsetInBinary())
 	origin := target.forwardJumpOrigins
 	for ; origin != nil; origin = origin.forwardJumpOrigins {
@@ -1127,19 +1119,19 @@ func (a *AssemblerImpl) resolveForwardRelativeJumps(target *nodeImpl) (err error
 				// will always enter the "long jump offset encoding" block below
 				origin.flag ^= nodeFlagShortForwardJump
 			} else {
-				a.buf.Bytes()[origin.OffsetInBinary()+uint64(instructionLen)-1] = byte(offset)
+				buf.Bytes()[origin.OffsetInBinary()+uint64(instructionLen)-1] = byte(offset)
 			}
 		} else { // long jump offset encoding.
 			if offset > math.MaxInt32 {
 				return fmt.Errorf("too large jump offset %d for encoding %s", offset, InstructionName(origin.instruction))
 			}
-			binary.LittleEndian.PutUint32(a.buf.Bytes()[origin.OffsetInBinary()+uint64(instructionLen)-4:], uint32(offset))
+			binary.LittleEndian.PutUint32(buf.Bytes()[origin.OffsetInBinary()+uint64(instructionLen)-4:], uint32(offset))
 		}
 	}
 	return nil
 }
 
-func (a *AssemblerImpl) encodeRelativeJump(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRelativeJump(buf asm.Buffer, n *nodeImpl) (err error) {
 	if n.jumpTarget == nil {
 		err = fmt.Errorf("jump target must not be nil for relative %s", InstructionName(n.instruction))
 		return
@@ -1165,16 +1157,16 @@ func (a *AssemblerImpl) encodeRelativeJump(n *nodeImpl) (err error) {
 	}
 
 	if isShortJump {
-		a.buf.Write(op.short)
-		a.writeConst(offsetOfEIP, 8)
+		buf.Write(op.short)
+		buf.WriteByte(byte(offsetOfEIP))
 	} else {
-		a.buf.Write(op.long)
-		a.writeConst(offsetOfEIP, 32)
+		buf.Write(op.long)
+		buf.WriteUint32(uint32(offsetOfEIP))
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeRegisterToNone(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToNone(buf asm.Buffer, n *nodeImpl) (err error) {
 	regBits, prefix := register3bits(n.srcReg, registerSpecifierPositionModRMFieldRM)
 
 	// https://wiki.osdev.org/X86-64_Instruction_Encoding#ModR.2FM
@@ -1215,10 +1207,10 @@ func (a *AssemblerImpl) encodeRegisterToNone(n *nodeImpl) (err error) {
 	}
 
 	if prefix != rexPrefixNone {
-		a.buf.WriteByte(prefix)
+		buf.WriteByte(prefix)
 	}
 
-	a.buf.Write([]byte{opcode, modRM})
+	buf.Write2Bytes(opcode, modRM)
 	return
 }
 
@@ -1622,7 +1614,7 @@ var registerToRegisterShiftOpcode = [instructionEnd]*struct {
 	SHRQ: {opcode: []byte{0xd3}, modRMExtension: 0b00_101_000, rPrefix: rexPrefixW},
 }
 
-func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	// Alias for readability
 	inst := n.instruction
 
@@ -1661,14 +1653,14 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		}
 
 		if mandatoryPrefix != 0 {
-			a.buf.WriteByte(mandatoryPrefix)
+			buf.WriteByte(mandatoryPrefix)
 		}
 
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
-		a.buf.Write(opcode)
-		a.buf.WriteByte(modRM)
+		buf.Write(opcode)
+		buf.WriteByte(modRM)
 		return nil
 	}
 
@@ -1686,39 +1678,38 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		}
 
 		if op.mandatoryPrefix != 0 {
-			a.buf.WriteByte(op.mandatoryPrefix)
+			buf.WriteByte(op.mandatoryPrefix)
 		}
 
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
-		a.buf.Write(op.opcode)
-
-		a.buf.WriteByte(modRM)
+		buf.Write(op.opcode)
+		buf.WriteByte(modRM)
 
 		if op.needArg {
-			a.writeConst(int64(n.arg), 8)
+			buf.WriteByte(n.arg)
 		}
 		return nil
 	} else if op := registerToRegisterShiftOpcode[inst]; op != nil {
 		reg3bits, rexPrefix := register3bits(n.dstReg, registerSpecifierPositionModRMFieldRM)
 		rexPrefix |= op.rPrefix
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
 
 		// https://wiki.osdev.org/X86-64_Instruction_Encoding#ModR.2FM
 		modRM := 0b11_000_000 |
 			(op.modRMExtension) |
 			reg3bits
-		a.buf.Write(op.opcode)
-		a.buf.WriteByte(modRM)
+		buf.Write(op.opcode)
+		buf.WriteByte(modRM)
 		return nil
 	}
 	return errorEncodingUnsupported(n)
 }
 
-func (a *AssemblerImpl) encodeRegisterToMemory(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToMemory(buf asm.Buffer, n *nodeImpl) (err error) {
 	rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.getMemoryLocation(true)
 	if err != nil {
 		return err
@@ -1859,32 +1850,31 @@ func (a *AssemblerImpl) encodeRegisterToMemory(n *nodeImpl) (err error) {
 
 	if mandatoryPrefix != 0 {
 		// https://wiki.osdev.org/X86-64_Instruction_Encoding#Mandatory_prefix
-		a.buf.WriteByte(mandatoryPrefix)
+		buf.WriteByte(mandatoryPrefix)
 	}
 
 	if rexPrefix != rexPrefixNone {
-		a.buf.WriteByte(rexPrefix)
+		buf.WriteByte(rexPrefix)
 	}
 
-	a.buf.Write(opcode)
-
-	a.buf.WriteByte(modRM)
+	buf.Write(opcode)
+	buf.WriteByte(modRM)
 
 	if sbiExist {
-		a.buf.WriteByte(sbi)
+		buf.WriteByte(sbi)
 	}
 
 	if displacementWidth != 0 {
-		a.writeConst(n.dstConst, displacementWidth)
+		writeConst(buf, n.dstConst, displacementWidth)
 	}
 
 	if needArg {
-		a.writeConst(int64(n.arg), 8)
+		buf.WriteByte(n.arg)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeRegisterToConst(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToConst(buf asm.Buffer, n *nodeImpl) (err error) {
 	regBits, prefix := register3bits(n.srcReg, registerSpecifierPositionModRMFieldRM)
 
 	switch n.instruction {
@@ -1893,21 +1883,21 @@ func (a *AssemblerImpl) encodeRegisterToConst(n *nodeImpl) (err error) {
 			prefix |= rexPrefixW
 		}
 		if prefix != rexPrefixNone {
-			a.buf.WriteByte(prefix)
+			buf.WriteByte(prefix)
 		}
 		is8bitConst := fitInSigned8bit(n.dstConst)
 		// https://www.felixcloutier.com/x86/cmp
 		if n.srcReg == RegAX && !is8bitConst {
-			a.buf.Write([]byte{0x3d})
+			buf.WriteByte(0x3d)
 		} else {
 			// https://wiki.osdev.org/X86-64_Instruction_Encoding#ModR.2FM
 			modRM := 0b11_000_000 | // Specifying that opeand is register.
 				0b00_111_000 | // CMP with immediate needs "/7" extension.
 				regBits
 			if is8bitConst {
-				a.buf.Write([]byte{0x83, modRM})
+				buf.Write2Bytes(0x83, modRM)
 			} else {
-				a.buf.Write([]byte{0x81, modRM})
+				buf.Write2Bytes(0x81, modRM)
 			}
 		}
 	default:
@@ -1915,9 +1905,9 @@ func (a *AssemblerImpl) encodeRegisterToConst(n *nodeImpl) (err error) {
 	}
 
 	if fitInSigned8bit(n.dstConst) {
-		a.writeConst(n.dstConst, 8)
+		buf.WriteByte(byte(n.dstConst))
 	} else {
-		a.writeConst(n.dstConst, 32)
+		buf.WriteUint32(uint32(n.dstConst))
 	}
 	return
 }
@@ -1945,7 +1935,7 @@ func (a *AssemblerImpl) finalizeReadInstructionAddressNode(code []byte, n *nodeI
 	return nil
 }
 
-func (a *AssemblerImpl) encodeReadInstructionAddress(n *nodeImpl) error {
+func (a *AssemblerImpl) encodeReadInstructionAddress(buf asm.Buffer, n *nodeImpl) error {
 	dstReg3Bits, rexPrefix := register3bits(n.dstReg, registerSpecifierPositionModRMFieldReg)
 
 	a.readInstructionAddressNodes = append(a.readInstructionAddressNodes, n)
@@ -1958,14 +1948,14 @@ func (a *AssemblerImpl) encodeReadInstructionAddress(n *nodeImpl) error {
 	modRM := 0b00_000_101 | // Indicate "LEAQ [RIP + 32bit displacement], dstReg" encoding.
 		(dstReg3Bits << 3) // Place the dstReg on ModRM:reg.
 
-	a.buf.Write([]byte{rexPrefix, opcode, modRM})
-	a.writeConst(int64(0), 32) // Preserve
+	buf.Write3Bytes(rexPrefix, opcode, modRM)
+	buf.WriteUint32(0) // Preserve
 	return nil
 }
 
-func (a *AssemblerImpl) encodeMemoryToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeMemoryToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	if n.instruction == LEAQ && n.readInstructionAddressBeforeTargetInstruction != NONE {
-		return a.encodeReadInstructionAddress(n)
+		return a.encodeReadInstructionAddress(buf, n)
 	}
 
 	rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.getMemoryLocation(false)
@@ -2122,32 +2112,31 @@ func (a *AssemblerImpl) encodeMemoryToRegister(n *nodeImpl) (err error) {
 
 	if mandatoryPrefix != 0 {
 		// https://wiki.osdev.org/X86-64_Instruction_Encoding#Mandatory_prefix
-		a.buf.WriteByte(mandatoryPrefix)
+		buf.WriteByte(mandatoryPrefix)
 	}
 
 	if rexPrefix != rexPrefixNone {
-		a.buf.WriteByte(rexPrefix)
+		buf.WriteByte(rexPrefix)
 	}
 
-	a.buf.Write(opcode)
-
-	a.buf.WriteByte(modRM)
+	buf.Write(opcode)
+	buf.WriteByte(modRM)
 
 	if sbiExist {
-		a.buf.WriteByte(sbi)
+		buf.WriteByte(sbi)
 	}
 
 	if displacementWidth != 0 {
-		a.writeConst(n.srcConst, displacementWidth)
+		writeConst(buf, n.srcConst, displacementWidth)
 	}
 
 	if needArg {
-		a.writeConst(int64(n.arg), 8)
+		buf.WriteByte(n.arg)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeConstToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	regBits, rexPrefix := register3bits(n.dstReg, registerSpecifierPositionModRMFieldRM)
 
 	isFloatReg := isVectorRegister(n.dstReg)
@@ -2179,78 +2168,78 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		// https://www.felixcloutier.com/x86/add
 		rexPrefix |= rexPrefixW
 		if n.dstReg == RegAX && !isSigned8bitConst {
-			a.buf.Write([]byte{rexPrefix, 0x05})
+			buf.Write2Bytes(rexPrefix, 0x05)
 		} else {
 			modRM := 0b11_000_000 | // Specifying that opeand is register.
 				regBits
 			if isSigned8bitConst {
-				a.buf.Write([]byte{rexPrefix, 0x83, modRM})
+				buf.Write3Bytes(rexPrefix, 0x83, modRM)
 			} else {
-				a.buf.Write([]byte{rexPrefix, 0x81, modRM})
+				buf.Write3Bytes(rexPrefix, 0x81, modRM)
 			}
 		}
 		if isSigned8bitConst {
-			a.writeConst(n.srcConst, 8)
+			buf.WriteByte(byte(n.srcConst))
 		} else {
-			a.writeConst(n.srcConst, 32)
+			buf.WriteUint32(uint32(n.srcConst))
 		}
 	case ANDQ:
 		// https://www.felixcloutier.com/x86/and
 		rexPrefix |= rexPrefixW
 		if n.dstReg == RegAX && !isSigned8bitConst {
-			a.buf.Write([]byte{rexPrefix, 0x25})
+			buf.Write2Bytes(rexPrefix, 0x25)
 		} else {
 			modRM := 0b11_000_000 | // Specifying that opeand is register.
 				0b00_100_000 | // AND with immediate needs "/4" extension.
 				regBits
 			if isSigned8bitConst {
-				a.buf.Write([]byte{rexPrefix, 0x83, modRM})
+				buf.Write3Bytes(rexPrefix, 0x83, modRM)
 			} else {
-				a.buf.Write([]byte{rexPrefix, 0x81, modRM})
+				buf.Write3Bytes(rexPrefix, 0x81, modRM)
 			}
 		}
 		if fitInSigned8bit(n.srcConst) {
-			a.writeConst(n.srcConst, 8)
+			buf.WriteByte(byte(n.srcConst))
 		} else {
-			a.writeConst(n.srcConst, 32)
+			buf.WriteUint32(uint32(n.srcConst))
 		}
 	case TESTQ:
 		// https://www.felixcloutier.com/x86/test
 		rexPrefix |= rexPrefixW
 		if n.dstReg == RegAX && !isSigned8bitConst {
-			a.buf.Write([]byte{rexPrefix, 0xa9})
+			buf.Write2Bytes(rexPrefix, 0xa9)
 		} else {
 			modRM := 0b11_000_000 | // Specifying that operand is register
 				regBits
-			a.buf.Write([]byte{rexPrefix, 0xf7, modRM})
+			buf.Write3Bytes(rexPrefix, 0xf7, modRM)
 		}
-		a.writeConst(n.srcConst, 32)
+		buf.WriteUint32(uint32(n.srcConst))
 	case MOVL:
 		// https://www.felixcloutier.com/x86/mov
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
-		a.buf.Write([]byte{0xb8 | regBits})
-		a.writeConst(n.srcConst, 32)
+		buf.WriteByte(0xb8 | regBits)
+		buf.WriteUint32(uint32(n.srcConst))
 	case MOVQ:
 		// https://www.felixcloutier.com/x86/mov
 		if fitIn32bit(n.srcConst) {
 			if n.srcConst > math.MaxInt32 {
 				if rexPrefix != rexPrefixNone {
-					a.buf.WriteByte(rexPrefix)
+					buf.WriteByte(rexPrefix)
 				}
-				a.buf.Write([]byte{0xb8 | regBits})
+				buf.WriteByte(0xb8 | regBits)
 			} else {
 				rexPrefix |= rexPrefixW
 				modRM := 0b11_000_000 | // Specifying that opeand is register.
 					regBits
-				a.buf.Write([]byte{rexPrefix, 0xc7, modRM})
+				buf.Write3Bytes(rexPrefix, 0xc7, modRM)
 			}
-			a.writeConst(n.srcConst, 32)
+			buf.WriteUint32(uint32(n.srcConst))
 		} else {
 			rexPrefix |= rexPrefixW
-			a.buf.Write([]byte{rexPrefix, 0xb8 | regBits})
-			a.writeConst(n.srcConst, 64)
+			buf.Write2Bytes(rexPrefix, 0xb8|regBits)
+			buf.WriteUint64(uint64(n.srcConst))
 		}
 	case SHLQ:
 		// https://www.felixcloutier.com/x86/sal:sar:shl:shr
@@ -2259,10 +2248,9 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			0b00_100_000 | // SHL with immediate needs "/4" extension.
 			regBits
 		if n.srcConst == 1 {
-			a.buf.Write([]byte{rexPrefix, 0xd1, modRM})
+			buf.Write3Bytes(rexPrefix, 0xd1, modRM)
 		} else {
-			a.buf.Write([]byte{rexPrefix, 0xc1, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write4Bytes(rexPrefix, 0xc1, modRM, byte(n.srcConst))
 		}
 	case SHRQ:
 		// https://www.felixcloutier.com/x86/sal:sar:shl:shr
@@ -2271,10 +2259,9 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			0b00_101_000 | // SHR with immediate needs "/5" extension.
 			regBits
 		if n.srcConst == 1 {
-			a.buf.Write([]byte{rexPrefix, 0xd1, modRM})
+			buf.Write3Bytes(rexPrefix, 0xd1, modRM)
 		} else {
-			a.buf.Write([]byte{rexPrefix, 0xc1, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write4Bytes(rexPrefix, 0xc1, modRM, byte(n.srcConst))
 		}
 	case PSLLD:
 		// https://www.felixcloutier.com/x86/psllw:pslld:psllq
@@ -2282,11 +2269,9 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			0b00_110_000 | // PSLL with immediate needs "/6" extension.
 			regBits
 		if rexPrefix != rexPrefixNone {
-			a.buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x72, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x72, modRM, byte(n.srcConst)})
 		} else {
-			a.buf.Write([]byte{0x66, 0x0f, 0x72, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, 0x0f, 0x72, modRM, byte(n.srcConst)})
 		}
 	case PSLLQ:
 		// https://www.felixcloutier.com/x86/psllw:pslld:psllq
@@ -2294,11 +2279,9 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			0b00_110_000 | // PSLL with immediate needs "/6" extension.
 			regBits
 		if rexPrefix != rexPrefixNone {
-			a.buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x73, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x73, modRM, byte(n.srcConst)})
 		} else {
-			a.buf.Write([]byte{0x66, 0x0f, 0x73, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, 0x0f, 0x73, modRM, byte(n.srcConst)})
 		}
 	case PSRLD:
 		// https://www.felixcloutier.com/x86/psrlw:psrld:psrlq
@@ -2307,11 +2290,9 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			0b00_010_000 | // PSRL with immediate needs "/2" extension.
 			regBits
 		if rexPrefix != rexPrefixNone {
-			a.buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x72, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x72, modRM, byte(n.srcConst)})
 		} else {
-			a.buf.Write([]byte{0x66, 0x0f, 0x72, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, 0x0f, 0x72, modRM, byte(n.srcConst)})
 		}
 	case PSRLQ:
 		// https://www.felixcloutier.com/x86/psrlw:psrld:psrlq
@@ -2319,20 +2300,18 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			0b00_010_000 | // PSRL with immediate needs "/2" extension.
 			regBits
 		if rexPrefix != rexPrefixNone {
-			a.buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x73, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, rexPrefix, 0x0f, 0x73, modRM, byte(n.srcConst)})
 		} else {
-			a.buf.Write([]byte{0x66, 0x0f, 0x73, modRM})
-			a.writeConst(n.srcConst, 8)
+			buf.Write([]byte{0x66, 0x0f, 0x73, modRM, byte(n.srcConst)})
 		}
 	case PSRAW, PSRAD:
 		// https://www.felixcloutier.com/x86/psraw:psrad:psraq
 		modRM := 0b11_000_000 | // Specifying that operand is register.
 			0b00_100_000 | // PSRAW with immediate needs "/4" extension.
 			regBits
-		a.buf.WriteByte(0x66)
+		buf.WriteByte(0x66)
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
 
 		var op byte
@@ -2342,54 +2321,51 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			op = 0x71
 		}
 
-		a.buf.Write([]byte{0x0f, op, modRM})
-		a.writeConst(n.srcConst, 8)
+		buf.Write4Bytes(0x0f, op, modRM, byte(n.srcConst))
 	case PSRLW:
 		// https://www.felixcloutier.com/x86/psrlw:psrld:psrlq
 		modRM := 0b11_000_000 | // Specifying that operand is register.
 			0b00_010_000 | // PSRLW with immediate needs "/2" extension.
 			regBits
-		a.buf.WriteByte(0x66)
+		buf.WriteByte(0x66)
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
-		a.buf.Write([]byte{0x0f, 0x71, modRM})
-		a.writeConst(n.srcConst, 8)
+		buf.Write([]byte{0x0f, 0x71, modRM, byte(n.srcConst)})
 	case PSLLW:
 		// https://www.felixcloutier.com/x86/psllw:pslld:psllq
 		modRM := 0b11_000_000 | // Specifying that operand is register.
 			0b00_110_000 | // PSLLW with immediate needs "/6" extension.
 			regBits
-		a.buf.WriteByte(0x66)
+		buf.WriteByte(0x66)
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
-		a.buf.Write([]byte{0x0f, 0x71, modRM})
-		a.writeConst(n.srcConst, 8)
+		buf.Write([]byte{0x0f, 0x71, modRM, byte(n.srcConst)})
 	case XORL, XORQ:
 		// https://www.felixcloutier.com/x86/xor
 		if inst == XORQ {
 			rexPrefix |= rexPrefixW
 		}
 		if rexPrefix != rexPrefixNone {
-			a.buf.WriteByte(rexPrefix)
+			buf.WriteByte(rexPrefix)
 		}
 		if n.dstReg == RegAX && !isSigned8bitConst {
-			a.buf.Write([]byte{0x35})
+			buf.WriteByte(0x35)
 		} else {
 			modRM := 0b11_000_000 | // Specifying that opeand is register.
 				0b00_110_000 | // XOR with immediate needs "/6" extension.
 				regBits
 			if isSigned8bitConst {
-				a.buf.Write([]byte{0x83, modRM})
+				buf.Write2Bytes(0x83, modRM)
 			} else {
-				a.buf.Write([]byte{0x81, modRM})
+				buf.Write2Bytes(0x81, modRM)
 			}
 		}
 		if fitInSigned8bit(n.srcConst) {
-			a.writeConst(n.srcConst, 8)
+			buf.WriteByte(byte(n.srcConst))
 		} else {
-			a.writeConst(n.srcConst, 32)
+			buf.WriteUint32(uint32(n.srcConst))
 		}
 	default:
 		err = errorEncodingUnsupported(n)
@@ -2397,7 +2373,7 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 	return
 }
 
-func (a *AssemblerImpl) encodeMemoryToConst(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeMemoryToConst(buf asm.Buffer, n *nodeImpl) (err error) {
 	if !fitIn32bit(n.dstConst) {
 		return fmt.Errorf("too large target const %d for %s", n.dstConst, InstructionName(n.instruction))
 	}
@@ -2427,24 +2403,24 @@ func (a *AssemblerImpl) encodeMemoryToConst(n *nodeImpl) (err error) {
 	}
 
 	if rexPrefix != rexPrefixNone {
-		a.buf.WriteByte(rexPrefix)
+		buf.WriteByte(rexPrefix)
 	}
 
-	a.buf.Write([]byte{opcode, modRM})
+	buf.Write2Bytes(opcode, modRM)
 
 	if sbiExist {
-		a.buf.WriteByte(sbi)
+		buf.WriteByte(sbi)
 	}
 
 	if displacementWidth != 0 {
-		a.writeConst(n.srcConst, displacementWidth)
+		writeConst(buf, n.srcConst, displacementWidth)
 	}
 
-	a.writeConst(c, constWidth)
+	writeConst(buf, c, constWidth)
 	return
 }
 
-func (a *AssemblerImpl) encodeConstToMemory(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeConstToMemory(buf asm.Buffer, n *nodeImpl) (err error) {
 	rexPrefix, modRM, sbi, sbiExist, displacementWidth, err := n.getMemoryLocation(true)
 	if err != nil {
 		return err
@@ -2477,41 +2453,31 @@ func (a *AssemblerImpl) encodeConstToMemory(n *nodeImpl) (err error) {
 	}
 
 	if rexPrefix != rexPrefixNone {
-		a.buf.WriteByte(rexPrefix)
+		buf.WriteByte(rexPrefix)
 	}
 
-	a.buf.Write([]byte{opcode, modRM})
+	buf.Write2Bytes(opcode, modRM)
 
 	if sbiExist {
-		a.buf.WriteByte(sbi)
+		buf.WriteByte(sbi)
 	}
 
 	if displacementWidth != 0 {
-		a.writeConst(n.dstConst, displacementWidth)
+		writeConst(buf, n.dstConst, displacementWidth)
 	}
 
-	a.writeConst(c, constWidth)
+	writeConst(buf, c, constWidth)
 	return
 }
 
-func (a *AssemblerImpl) writeConst(v int64, length byte) {
+func writeConst(buf asm.Buffer, v int64, length byte) {
 	switch length {
 	case 8:
-		a.buf.WriteByte(byte(int8(v)))
+		buf.WriteByte(byte(v))
 	case 32:
-		a.buf.WriteByte(byte(v))
-		a.buf.WriteByte(byte(v >> 8))
-		a.buf.WriteByte(byte(v >> 16))
-		a.buf.WriteByte(byte(v >> 24))
+		buf.WriteUint32(uint32(v))
 	case 64:
-		a.buf.WriteByte(byte(v))
-		a.buf.WriteByte(byte(v >> 8))
-		a.buf.WriteByte(byte(v >> 16))
-		a.buf.WriteByte(byte(v >> 24))
-		a.buf.WriteByte(byte(v >> 32))
-		a.buf.WriteByte(byte(v >> 40))
-		a.buf.WriteByte(byte(v >> 48))
-		a.buf.WriteByte(byte(v >> 56))
+		buf.WriteUint64(uint64(v))
 	default:
 		panic("BUG: length must be one of 8, 32 or 64")
 	}

--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -32,7 +32,7 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	buf := code.Next()
-	buf.Write([]byte{0, 0, 0, 0, 0})
+	buf.AppendBytes([]byte{0, 0, 0, 0, 0})
 
 	staticConsts := asm.NewStaticConstPool()
 	staticConsts.AddConst(asm.NewStaticConst(nil), 1234)

--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -1,7 +1,6 @@
 package amd64
 
 import (
-	"bytes"
 	"strconv"
 	"testing"
 
@@ -29,7 +28,12 @@ func TestNodePool_allocNode(t *testing.T) {
 
 func TestAssemblerImpl_Reset(t *testing.T) {
 	// Existing values.
-	buf := bytes.NewBuffer(make([]byte, 5, 100))
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
+	buf := code.Next()
+	buf.Write([]byte{0, 0, 0, 0, 0})
+
 	staticConsts := asm.NewStaticConstPool()
 	staticConsts.AddConst(asm.NewStaticConst(nil), 1234)
 	readInstructionAddressNodes := make([]*nodeImpl, 5)
@@ -44,16 +48,15 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 			pages: []*nodePage{new(nodePage), new(nodePage)},
 			index: 12,
 		},
-		buf:                         buf,
 		pool:                        staticConsts,
 		readInstructionAddressNodes: readInstructionAddressNodes,
 		BaseAssemblerImpl:           ba,
 	}
 	a.Reset()
+	buf.Reset()
 
 	// Check each field.
-	require.Equal(t, buf, a.buf)
-	require.Equal(t, 100, buf.Cap())
+	require.Equal(t, 65536, buf.Cap())
 	require.Equal(t, 0, buf.Len())
 
 	require.Zero(t, len(a.nodePool.pages))
@@ -102,9 +105,14 @@ func TestAssemblerImpl_Assemble(t *testing.T) {
 		target := a.CompileStandAlone(dummyInstruction)
 		jmp.AssignJumpTarget(target)
 
-		actual, err := a.Assemble()
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
+		buf := code.Next()
+		err := a.Assemble(buf)
 		require.NoError(t, err)
 
+		actual := buf.Bytes()
 		require.Equal(t, []byte{0x73, 0x3, 0x99, 0x99, 0x99, 0x99}, actual)
 	})
 	t.Run("re-assemble", func(t *testing.T) {
@@ -120,8 +128,11 @@ func TestAssemblerImpl_Assemble(t *testing.T) {
 
 		a.initializeNodesForEncoding()
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		// For the first encoding, we must be forced to reassemble.
-		err := a.encode()
+		err := a.encode(code.Next())
 		require.NoError(t, err)
 		require.True(t, a.forceReAssemble)
 	})
@@ -265,7 +276,10 @@ func TestAssemblerImpl_newNode(t *testing.T) {
 
 func TestAssemblerImpl_encodeNode(t *testing.T) {
 	a := NewAssembler()
-	err := a.encodeNode(&nodeImpl{
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+	buf := code.Next()
+	err := a.encodeNode(buf, &nodeImpl{
 		instruction: ADDPD,
 		types:       operandTypesRegisterToMemory,
 	})
@@ -302,9 +316,15 @@ func TestAssemblerImpl_padNOP(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(strconv.Itoa(tc.num), func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
+			buf := code.Next()
+
 			a := NewAssembler()
-			a.padNOP(tc.num)
-			actual := a.buf.Bytes()
+			a.padNOP(buf, tc.num)
+
+			actual := buf.Bytes()
 			require.Equal(t, tc.expected, actual)
 		})
 	}
@@ -495,13 +515,17 @@ func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(InstructionName(tc.inst), func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler()
-			err := a.encodeNoneToNone(&nodeImpl{instruction: tc.inst, types: operandTypesNoneToNone})
+			buf := code.Next()
+			err := a.encodeNoneToNone(buf, &nodeImpl{instruction: tc.inst, types: operandTypesNoneToNone})
 			if tc.expErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tc.exp, a.buf.Bytes())
+				require.Equal(t, tc.exp, buf.Bytes())
 			}
 		})
 	}
@@ -1646,13 +1670,19 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		tc.n.types = operandTypesMemoryToRegister
 		a := NewAssembler()
-		err := a.encodeMemoryToRegister(tc.n)
+		buf := code.Next()
+		err := a.encodeMemoryToRegister(buf, tc.n)
 		require.NoError(t, err, tc.name)
 
-		actual, err := a.Assemble()
+		err = a.Assemble(buf)
 		require.NoError(t, err, tc.name)
+
+		actual := buf.Bytes()
 		require.Equal(t, tc.exp, actual, tc.name)
 	}
 }
@@ -1701,13 +1731,19 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		tc := tt
 		a := NewAssembler()
-		err := a.encodeConstToRegister(tc.n)
+		buf := code.Next()
+		err := a.encodeConstToRegister(buf, tc.n)
 		require.NoError(t, err, tc.name)
 
-		actual, err := a.Assemble()
+		err = a.Assemble(buf)
 		require.NoError(t, err, tc.name)
+
+		actual := buf.Bytes()
 		require.Equal(t, tc.exp, actual, tc.name)
 	}
 }

--- a/internal/asm/amd64/impl_1_test.go
+++ b/internal/asm/amd64/impl_1_test.go
@@ -31,7 +31,7 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 	code := asm.CodeSegment{}
 	defer func() { require.NoError(t, code.Unmap()) }()
 
-	buf := code.Next()
+	buf := code.NextCodeSection()
 	buf.AppendBytes([]byte{0, 0, 0, 0, 0})
 
 	staticConsts := asm.NewStaticConstPool()
@@ -108,7 +108,7 @@ func TestAssemblerImpl_Assemble(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.Assemble(buf)
 		require.NoError(t, err)
 
@@ -132,7 +132,7 @@ func TestAssemblerImpl_Assemble(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// For the first encoding, we must be forced to reassemble.
-		err := a.encode(code.Next())
+		err := a.encode(code.NextCodeSection())
 		require.NoError(t, err)
 		require.True(t, a.forceReAssemble)
 	})
@@ -278,7 +278,7 @@ func TestAssemblerImpl_encodeNode(t *testing.T) {
 	a := NewAssembler()
 	code := asm.CodeSegment{}
 	defer func() { require.NoError(t, code.Unmap()) }()
-	buf := code.Next()
+	buf := code.NextCodeSection()
 	err := a.encodeNode(buf, &nodeImpl{
 		instruction: ADDPD,
 		types:       operandTypesRegisterToMemory,
@@ -319,7 +319,7 @@ func TestAssemblerImpl_padNOP(t *testing.T) {
 			code := asm.CodeSegment{}
 			defer func() { require.NoError(t, code.Unmap()) }()
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 
 			a := NewAssembler()
 			a.padNOP(buf, tc.num)
@@ -519,7 +519,7 @@ func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeNoneToNone(buf, &nodeImpl{instruction: tc.inst, types: operandTypesNoneToNone})
 			if tc.expErr {
 				require.Error(t, err)
@@ -1675,7 +1675,7 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 
 		tc.n.types = operandTypesMemoryToRegister
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeMemoryToRegister(buf, tc.n)
 		require.NoError(t, err, tc.name)
 
@@ -1736,7 +1736,7 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 
 		tc := tt
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeConstToRegister(buf, tc.n)
 		require.NoError(t, err, tc.name)
 

--- a/internal/asm/amd64/impl_2_test.go
+++ b/internal/asm/amd64/impl_2_test.go
@@ -13,7 +13,7 @@ func TestAssemblerImpl_EncodeNoneToRegister(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeNoneToRegister(buf, &nodeImpl{
 			instruction: ADDL,
 			types:       operandTypesNoneToRegister, dstReg: RegAX,
@@ -36,7 +36,7 @@ func TestAssemblerImpl_EncodeNoneToRegister(t *testing.T) {
 
 			for _, tt := range tests {
 				a := NewAssembler()
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.encodeNoneToRegister(buf, tt.n)
 				require.EqualError(t, err, tt.expErr, tt.expErr)
 			}
@@ -233,7 +233,7 @@ func TestAssemblerImpl_EncodeNoneToRegister(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeNoneToRegister(buf, &nodeImpl{instruction: tc.inst, dstReg: tc.dst})
 		require.NoError(t, err, tc.name)
 		require.Equal(t, tc.exp, buf.Bytes(), tc.name)
@@ -260,7 +260,7 @@ func TestAssemblerImpl_EncodeNoneToMemory(t *testing.T) {
 
 				tc := tc
 				a := NewAssembler()
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.encodeNoneToMemory(buf, tc.n)
 				require.EqualError(t, err, tc.expErr)
 			})
@@ -480,7 +480,7 @@ func TestAssemblerImpl_EncodeNoneToMemory(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeNoneToMemory(buf, &nodeImpl{
 			types:       operandTypesNoneToMemory,
 			instruction: tc.inst, dstReg: tc.dst, dstConst: tc.dstOffset,
@@ -507,7 +507,7 @@ func TestAssemblerImpl_EncodeRegisterToNone(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToNone(buf, tc.n)
 			require.EqualError(t, err, tc.expErr, tc, tc.expErr)
 		}
@@ -592,7 +592,7 @@ func TestAssemblerImpl_EncodeRegisterToNone(t *testing.T) {
 
 	for _, tc := range tests {
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeRegisterToNone(buf, &nodeImpl{
 			instruction: tc.inst,
 			types:       operandTypesRegisterToNone, srcReg: tc.reg,
@@ -620,7 +620,7 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 				defer func() { require.NoError(t, code.Unmap()) }()
 
 				a := NewAssembler()
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.encodeRegisterToRegister(buf, tc.n)
 				require.EqualError(t, err, tc.expErr)
 			})
@@ -1260,7 +1260,7 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeRegisterToRegister(buf, tc.n)
 		require.NoError(t, err, tc.name)
 

--- a/internal/asm/amd64/impl_3_test.go
+++ b/internal/asm/amd64/impl_3_test.go
@@ -36,7 +36,7 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 
 		for _, tc := range tests {
 			a := NewAssembler()
-			b := code.Next()
+			b := code.NextCodeSection()
 			require.EqualError(t, a.encodeRegisterToMemory(b, tc.n), tc.expErr)
 		}
 	})
@@ -956,7 +956,7 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 	for _, tc := range tests {
 		tc.n.types = operandTypesRegisterToMemory
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeRegisterToMemory(buf, tc.n)
 		require.NoError(t, err, tc.name)
 

--- a/internal/asm/amd64/impl_4_test.go
+++ b/internal/asm/amd64/impl_4_test.go
@@ -49,7 +49,7 @@ func TestAssemblerImpl_encodeConstToRegister(t *testing.T) {
 
 		for _, tc := range tests {
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeConstToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -287,7 +287,7 @@ func TestAssemblerImpl_encodeConstToRegister(t *testing.T) {
 
 	for _, tc := range tests {
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeConstToRegister(buf, &nodeImpl{
 			instruction: tc.inst,
 			types:       operandTypesConstToRegister, srcConst: tc.c, dstReg: tc.dstReg,
@@ -320,7 +320,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 			a.CompileStandAlone(targetBeforeInstruction)
 			a.CompileStandAlone(CDQ) // Target.
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.Assemble(buf)
 			require.NoError(t, err, tc.name)
 
@@ -336,7 +336,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 		a.CompileReadInstructionAddress(RegR10, NOP)
 		a.CompileStandAlone(CDQ)
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.Assemble(buf)
 		require.EqualError(t, err, "BUG: target instruction not found for read instruction address")
 	})
@@ -349,7 +349,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 		a.CompileStandAlone(RET)
 		a.CompileStandAlone(CDQ)
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 
 		for n := a.root; n != nil; n = n.next {
 			n.offsetInBinary = uint64(buf.Len())
@@ -384,7 +384,7 @@ func TestAssemblerImpl_encodeRegisterToConst(t *testing.T) {
 
 		for _, tc := range tests {
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToNone(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -602,7 +602,7 @@ func TestAssemblerImpl_encodeRegisterToConst(t *testing.T) {
 
 	for _, tc := range tests {
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeRegisterToConst(buf, &nodeImpl{
 			instruction: tc.inst,
 			types:       operandTypesRegisterToConst, srcReg: tc.srcReg, dstConst: tc.c,

--- a/internal/asm/amd64/impl_5_test.go
+++ b/internal/asm/amd64/impl_5_test.go
@@ -42,7 +42,7 @@ func TestAssemblerImpl_EncodeConstToMemory(t *testing.T) {
 
 		for _, tc := range tests {
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeConstToMemory(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -656,7 +656,7 @@ func TestAssemblerImpl_EncodeConstToMemory(t *testing.T) {
 
 	for _, tc := range tests {
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeConstToMemory(buf, &nodeImpl{
 			instruction: tc.inst,
 			types:       operandTypesConstToMemory, srcConst: tc.c, dstReg: tc.baseReg, dstConst: int64(tc.offset),
@@ -682,7 +682,7 @@ func TestAssemblerImpl_EncodeMemoryToConst(t *testing.T) {
 
 		for _, tc := range tests {
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeMemoryToConst(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -936,7 +936,7 @@ func TestAssemblerImpl_EncodeMemoryToConst(t *testing.T) {
 
 	for _, tc := range tests {
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeMemoryToConst(buf, &nodeImpl{
 			instruction: tc.inst,
 			types:       operandTypesMemoryToConst, srcReg: tc.baseReg, srcConst: tc.offset, dstConst: tc.c,
@@ -957,7 +957,7 @@ func TestAssemblerImpl_ResolveForwardRelativeJumps(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler()
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.resolveForwardRelativeJumps(buf, target)
 			require.EqualError(t, err, "too large jump offset 9223372036854775802 for encoding JMP")
 		})
@@ -991,7 +991,7 @@ func TestAssemblerImpl_ResolveForwardRelativeJumps(t *testing.T) {
 				a := NewAssembler()
 
 				// Grow the capacity of buffer so that we could put the offset.
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				buf.AppendBytes([]byte{0, 0, 0, 0, 0, 0}) // Relative long jumps are at most 6 bytes.
 
 				err := a.resolveForwardRelativeJumps(buf, target)
@@ -1039,7 +1039,7 @@ func TestAssemblerImpl_ResolveForwardRelativeJumps(t *testing.T) {
 				origin.jumpTarget = target
 
 				a := NewAssembler()
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.resolveForwardRelativeJumps(buf, target)
 				require.NoError(t, err)
 
@@ -1076,7 +1076,7 @@ func TestAssemblerImpl_ResolveForwardRelativeJumps(t *testing.T) {
 				a := NewAssembler()
 
 				// Grow the capacity of buffer so that we could put the offset.
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				buf.AppendBytes([]byte{0, 0}) // Relative short jumps are of 2 bytes.
 
 				err := a.resolveForwardRelativeJumps(buf, target)

--- a/internal/asm/amd64/impl_5_test.go
+++ b/internal/asm/amd64/impl_5_test.go
@@ -992,7 +992,7 @@ func TestAssemblerImpl_ResolveForwardRelativeJumps(t *testing.T) {
 
 				// Grow the capacity of buffer so that we could put the offset.
 				buf := code.Next()
-				buf.Write([]byte{0, 0, 0, 0, 0, 0}) // Relative long jumps are at most 6 bytes.
+				buf.AppendBytes([]byte{0, 0, 0, 0, 0, 0}) // Relative long jumps are at most 6 bytes.
 
 				err := a.resolveForwardRelativeJumps(buf, target)
 				require.NoError(t, err)
@@ -1077,7 +1077,7 @@ func TestAssemblerImpl_ResolveForwardRelativeJumps(t *testing.T) {
 
 				// Grow the capacity of buffer so that we could put the offset.
 				buf := code.Next()
-				buf.Write([]byte{0, 0}) // Relative short jumps are of 2 bytes.
+				buf.AppendBytes([]byte{0, 0}) // Relative short jumps are of 2 bytes.
 
 				err := a.resolveForwardRelativeJumps(buf, target)
 				require.NoError(t, err)

--- a/internal/asm/amd64/impl_6_test.go
+++ b/internal/asm/amd64/impl_6_test.go
@@ -168,12 +168,17 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			t.Run(tc.name, func(t *testing.T) {
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				a := NewAssembler()
 				tc.setupFn(a)
 
-				actual, err := a.Assemble()
+				buf := code.Next()
+				err := a.Assemble(buf)
 				require.NoError(t, err)
 
+				actual := buf.Bytes()
 				require.Equal(t, tc.expected, actual)
 			})
 		}
@@ -673,6 +678,9 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tc := range tests {
 			t.Run(fmt.Sprintf("%s/backward=%v", InstructionName(tc.jmpInst), tc.backward), func(t *testing.T) {
 				a := NewAssembler()
@@ -692,8 +700,11 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 					}
 				}
 
-				actual, err := a.Assemble()
+				buf := code.Next()
+				err := a.Assemble(buf)
 				require.NoError(t, err)
+
+				actual := buf.Bytes()
 				require.Equal(t, tc.exp, actual)
 			})
 		}

--- a/internal/asm/amd64/impl_6_test.go
+++ b/internal/asm/amd64/impl_6_test.go
@@ -174,7 +174,7 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 				a := NewAssembler()
 				tc.setupFn(a)
 
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.Assemble(buf)
 				require.NoError(t, err)
 
@@ -700,7 +700,7 @@ func TestAssemblerImpl_Assemble_NOPPadding(t *testing.T) {
 					}
 				}
 
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.Assemble(buf)
 				require.NoError(t, err)
 

--- a/internal/asm/amd64/impl_7_test.go
+++ b/internal/asm/amd64/impl_7_test.go
@@ -457,7 +457,7 @@ func TestAssemblerImpl_Assemble_NOPPadding_fusedJumps(t *testing.T) {
 				jmp.AssignJumpTarget(target)
 			}
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.Assemble(buf)
 			require.NoError(t, err, name)
 
@@ -483,7 +483,7 @@ func TestAssemblerImpl_encodeNoneToBranch_errors(t *testing.T) {
 
 	for _, tc := range tests {
 		a := NewAssembler()
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeRelativeJump(buf, tc.n)
 		require.EqualError(t, err, tc.expErr)
 	}
@@ -504,7 +504,7 @@ func TestAssemblerImpl_encodeNoneToBranch_backward_jumps(t *testing.T) {
 			offsetInBinary: OffsetInBinaryField,
 		}
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeRelativeJump(buf, node)
 		require.Error(t, err)
 	})
@@ -560,7 +560,7 @@ func TestAssemblerImpl_encodeNoneToBranch_backward_jumps(t *testing.T) {
 		jmp := a.CompileJump(tc.jmpInst)
 		jmp.AssignJumpTarget(target)
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.Assemble(buf)
 		require.NoError(t, err, name)
 
@@ -623,7 +623,7 @@ func TestAssemblerImpl_encodeNoneToBranch_forward_jumps(t *testing.T) {
 		target := a.CompileStandAlone(dummyInstruction)
 		jmp.AssignJumpTarget(target)
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.Assemble(buf)
 		require.NoError(t, err, name)
 

--- a/internal/asm/amd64/impl_staticconst.go
+++ b/internal/asm/amd64/impl_staticconst.go
@@ -22,6 +22,7 @@ func (a *AssemblerImpl) maybeFlushConstants(buf asm.Buffer, isEndOfFunction bool
 		// than MaxDisplacementForConstantPool, we have to emit the constant pool now, otherwise
 		// a const might be unreachable by a literal move whose maximum offset is +- 2^31.
 		((a.pool.PoolSizeInBytes+buf.Len())-int(a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
+
 		if !isEndOfFunction {
 			// Adds the jump instruction to skip the constants if this is not the end of function.
 			//
@@ -33,7 +34,8 @@ func (a *AssemblerImpl) maybeFlushConstants(buf asm.Buffer, isEndOfFunction bool
 				buf.WriteUint32(uint32(a.pool.PoolSizeInBytes))
 			} else {
 				// short jump: https://www.felixcloutier.com/x86/jmp
-				buf.Write2Bytes(0xeb, byte(a.pool.PoolSizeInBytes))
+				buf.WriteByte(0xeb)
+				buf.WriteByte(byte(a.pool.PoolSizeInBytes))
 			}
 		}
 

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -49,8 +49,8 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 
 		a := NewAssembler()
 		// Invoking maybeFlushConstants before encoding consts usage should not panic.
-		a.maybeFlushConstants(code.Next(), false)
-		a.maybeFlushConstants(code.Next(), true)
+		a.maybeFlushConstants(code.NextCodeSection(), false)
+		a.maybeFlushConstants(code.NextCodeSection(), true)
 	})
 
 	largeData := make([]byte, 256)
@@ -121,7 +121,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			a := NewAssembler()
 			a.MaxDisplacementForConstantPool = tc.maxDisplacement
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			buf.AppendBytes(tc.dummyBodyBeforeFlush)
 
 			for i, c := range tc.consts {
@@ -228,7 +228,7 @@ func TestAssemblerImpl_encodeRegisterToStaticConst(t *testing.T) {
 				a.CompileStandAlone(UD2)
 			}
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err = a.Assemble(buf)
 			require.NoError(t, err)
 
@@ -630,7 +630,7 @@ func TestAssemblerImpl_encodeStaticConstToRegister(t *testing.T) {
 				a.CompileStandAlone(UD2)
 			}
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err = a.Assemble(buf)
 			require.NoError(t, err)
 

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -44,10 +44,13 @@ func TestAssemblerImpl_CompileRegisterToStaticConst(t *testing.T) {
 
 func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 	t.Run("no consts", func(t *testing.T) {
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		a := NewAssembler()
 		// Invoking maybeFlushConstants before encoding consts usage should not panic.
-		a.maybeFlushConstants(false)
-		a.maybeFlushConstants(true)
+		a.maybeFlushConstants(code.Next(), false)
+		a.maybeFlushConstants(code.Next(), true)
 	})
 
 	largeData := make([]byte, 256)
@@ -112,9 +115,14 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler()
 			a.MaxDisplacementForConstantPool = tc.maxDisplacement
-			a.buf.Write(tc.dummyBodyBeforeFlush)
+
+			buf := code.Next()
+			buf.Write(tc.dummyBodyBeforeFlush)
 
 			for i, c := range tc.consts {
 				sc := asm.NewStaticConst(c)
@@ -126,9 +134,9 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			}
 
 			a.pool.FirstUseOffsetInBinary = tc.firstUseOffsetInBinary
-			a.maybeFlushConstants(tc.endOfFunction)
+			a.maybeFlushConstants(buf, tc.endOfFunction)
 
-			require.Equal(t, tc.exp, a.buf.Bytes())
+			require.Equal(t, tc.exp, buf.Bytes())
 		})
 	}
 }
@@ -208,6 +216,9 @@ func TestAssemblerImpl_encodeRegisterToStaticConst(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler()
 
 			err := a.CompileRegisterToStaticConst(tc.ins, tc.reg, asm.NewStaticConst(tc.c))
@@ -217,9 +228,11 @@ func TestAssemblerImpl_encodeRegisterToStaticConst(t *testing.T) {
 				a.CompileStandAlone(UD2)
 			}
 
-			actual, err := a.Assemble()
+			buf := code.Next()
+			err = a.Assemble(buf)
 			require.NoError(t, err)
 
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -605,6 +618,9 @@ func TestAssemblerImpl_encodeStaticConstToRegister(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler()
 
 			err := a.CompileStaticConstToRegister(tc.ins, asm.NewStaticConst(tc.c), tc.reg)
@@ -614,9 +630,11 @@ func TestAssemblerImpl_encodeStaticConstToRegister(t *testing.T) {
 				a.CompileStandAlone(UD2)
 			}
 
-			actual, err := a.Assemble()
+			buf := code.Next()
+			err = a.Assemble(buf)
 			require.NoError(t, err)
 
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}

--- a/internal/asm/amd64/impl_staticconst_test.go
+++ b/internal/asm/amd64/impl_staticconst_test.go
@@ -122,7 +122,7 @@ func TestAssemblerImpl_maybeFlushConstants(t *testing.T) {
 			a.MaxDisplacementForConstantPool = tc.maxDisplacement
 
 			buf := code.Next()
-			buf.Write(tc.dummyBodyBeforeFlush)
+			buf.AppendBytes(tc.dummyBodyBeforeFlush)
 
 			for i, c := range tc.consts {
 				sc := asm.NewStaticConst(c)

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1,7 +1,6 @@
 package arm64
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -201,7 +200,6 @@ const (
 type AssemblerImpl struct {
 	root    *nodeImpl
 	current *nodeImpl
-	buf     *bytes.Buffer
 	asm.BaseAssemblerImpl
 	relativeJumpNodes   []*nodeImpl
 	adrInstructionNodes []*nodeImpl
@@ -261,7 +259,6 @@ func (n *nodePool) reset() {
 func NewAssembler(temporaryRegister asm.Register) *AssemblerImpl {
 	return &AssemblerImpl{
 		nodePool:                       nodePool{index: nodePageSize},
-		buf:                            bytes.NewBuffer(nil),
 		temporaryRegister:              temporaryRegister,
 		pool:                           asm.NewStaticConstPool(),
 		MaxDisplacementForConstantPool: defaultMaxDisplacementForConstPool,
@@ -286,7 +283,6 @@ func (a *AssemblerImpl) Reset() {
 	pool := a.pool
 	pool.Reset()
 	*a = AssemblerImpl{
-		buf:                 a.buf,
 		nodePool:            a.nodePool,
 		pool:                pool,
 		temporaryRegister:   a.temporaryRegister,
@@ -297,7 +293,6 @@ func (a *AssemblerImpl) Reset() {
 			JumpTableEntries:           a.JumpTableEntries[:0],
 		},
 	}
-	a.buf.Reset()
 	a.nodePool.reset()
 }
 
@@ -333,44 +328,46 @@ func (a *AssemblerImpl) addNode(node *nodeImpl) {
 }
 
 // Assemble implements asm.AssemblerBase
-func (a *AssemblerImpl) Assemble() ([]byte, error) {
+func (a *AssemblerImpl) Assemble(buf asm.Buffer) error {
 	// arm64 has 32-bit fixed length instructions,
 	// but note that some nodes are encoded as multiple instructions,
 	// so the resulting binary might not be the size of count*8.
-	a.buf.Grow(a.nodeCount * 8)
+	buf.Grow(a.nodeCount * 8)
 
 	for n := a.root; n != nil; n = n.next {
-		n.offsetInBinary = uint64(a.buf.Len())
-		if err := a.encodeNode(n); err != nil {
-			return nil, err
+		n.offsetInBinary = uint64(buf.Len())
+		if err := a.encodeNode(buf, n); err != nil {
+			return err
 		}
-		a.maybeFlushConstPool(n.next == nil)
+		if err := a.maybeFlushConstPool(buf, n.next == nil); err != nil {
+			return err
+		}
 	}
 
-	code := a.buf.Bytes()
+	code := buf.Bytes()
 
 	if err := a.FinalizeJumpTableEntry(code); err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, rel := range a.relativeJumpNodes {
 		if err := a.relativeBranchFinalize(code, rel); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	for _, adr := range a.adrInstructionNodes {
 		if err := a.finalizeADRInstructionNode(code, adr); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return code, nil
+	return nil
 }
 
 const defaultMaxDisplacementForConstPool = (1 << 20) - 1 - 4 // -4 for unconditional branch to skip the constants.
 
 // maybeFlushConstPool flushes the constant pool if endOfBinary or a boundary condition was met.
-func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
+func (a *AssemblerImpl) maybeFlushConstPool(buf asm.Buffer, endOfBinary bool) (err error) {
 	if a.pool.Empty() {
 		return
 	}
@@ -381,7 +378,7 @@ func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
 		// Also, if the offset between the first usage of the constant pool and
 		// the first constant would exceed 2^20 -1(= 2MiB-1), which is the maximum offset
 		// for LDR(literal)/ADR instruction, flush all the constants in the pool.
-		(a.buf.Len()+a.pool.PoolSizeInBytes-int(a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
+		(buf.Len()+a.pool.PoolSizeInBytes-int(a.pool.FirstUseOffsetInBinary)) >= a.MaxDisplacementForConstantPool {
 
 		// Before emitting consts, we have to add br instruction to skip the const pool.
 		// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L1123-L1129
@@ -395,70 +392,72 @@ func (a *AssemblerImpl) maybeFlushConstPool(endOfBinary bool) {
 			skipOffset = 0
 		}
 
-		a.buf.Write([]byte{
+		buf.Write4Bytes(
 			byte(skipOffset),
-			byte(skipOffset >> 8),
-			byte(skipOffset >> 16),
+			byte(skipOffset>>8),
+			byte(skipOffset>>16),
 			0x14,
-		})
+		)
 
 		// Then adding the consts into the binary.
 		for _, c := range a.pool.Consts {
-			c.SetOffsetInBinary(uint64(a.buf.Len()))
-			a.buf.Write(c.Raw)
+			c.SetOffsetInBinary(uint64(buf.Len()))
+			buf.Write(c.Raw)
 		}
 
 		// arm64 instructions are 4-byte (32-bit) aligned, so we must pad the zero consts here.
-		if pad := a.buf.Len() % 4; pad != 0 {
-			a.buf.Write(make([]byte, 4-pad))
+		if pad := buf.Len() % 4; pad != 0 {
+			buf.Write(make([]byte, 4-pad))
 		}
 
 		// After the flush, reset the constant pool.
 		a.pool.Reset()
 	}
+
+	return
 }
 
 // encodeNode encodes the given node into writer.
-func (a *AssemblerImpl) encodeNode(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeNode(buf asm.Buffer, n *nodeImpl) (err error) {
 	switch n.types {
 	case operandTypesNoneToNone:
-		err = a.encodeNoneToNone(n)
+		err = a.encodeNoneToNone(buf, n)
 	case operandTypesNoneToRegister:
-		err = a.encodeJumpToRegister(n)
+		err = a.encodeJumpToRegister(buf, n)
 	case operandTypesNoneToBranch:
-		err = a.encodeRelativeBranch(n)
+		err = a.encodeRelativeBranch(buf, n)
 	case operandTypesRegisterToRegister:
-		err = a.encodeRegisterToRegister(n)
+		err = a.encodeRegisterToRegister(buf, n)
 	case operandTypesLeftShiftedRegisterToRegister:
-		err = a.encodeLeftShiftedRegisterToRegister(n)
+		err = a.encodeLeftShiftedRegisterToRegister(buf, n)
 	case operandTypesTwoRegistersToRegister:
-		err = a.encodeTwoRegistersToRegister(n)
+		err = a.encodeTwoRegistersToRegister(buf, n)
 	case operandTypesThreeRegistersToRegister:
-		err = a.encodeThreeRegistersToRegister(n)
+		err = a.encodeThreeRegistersToRegister(buf, n)
 	case operandTypesTwoRegistersToNone:
-		err = a.encodeTwoRegistersToNone(n)
+		err = a.encodeTwoRegistersToNone(buf, n)
 	case operandTypesRegisterAndConstToNone:
-		err = a.encodeRegisterAndConstToNone(n)
+		err = a.encodeRegisterAndConstToNone(buf, n)
 	case operandTypesRegisterToMemory:
-		err = a.encodeRegisterToMemory(n)
+		err = a.encodeRegisterToMemory(buf, n)
 	case operandTypesMemoryToRegister:
-		err = a.encodeMemoryToRegister(n)
+		err = a.encodeMemoryToRegister(buf, n)
 	case operandTypesRegisterAndConstToRegister, operandTypesConstToRegister:
-		err = a.encodeConstToRegister(n)
+		err = a.encodeConstToRegister(buf, n)
 	case operandTypesRegisterToVectorRegister:
-		err = a.encodeRegisterToVectorRegister(n)
+		err = a.encodeRegisterToVectorRegister(buf, n)
 	case operandTypesVectorRegisterToRegister:
-		err = a.encodeVectorRegisterToRegister(n)
+		err = a.encodeVectorRegisterToRegister(buf, n)
 	case operandTypesMemoryToVectorRegister:
-		err = a.encodeMemoryToVectorRegister(n)
+		err = a.encodeMemoryToVectorRegister(buf, n)
 	case operandTypesVectorRegisterToMemory:
-		err = a.encodeVectorRegisterToMemory(n)
+		err = a.encodeVectorRegisterToMemory(buf, n)
 	case operandTypesVectorRegisterToVectorRegister:
-		err = a.encodeVectorRegisterToVectorRegister(n)
+		err = a.encodeVectorRegisterToVectorRegister(buf, n)
 	case operandTypesStaticConstToVectorRegister:
-		err = a.encodeStaticConstToVectorRegister(n)
+		err = a.encodeStaticConstToVectorRegister(buf, n)
 	case operandTypesTwoVectorRegistersToVectorRegister:
-		err = a.encodeTwoVectorRegistersToVectorRegister(n)
+		err = a.encodeTwoVectorRegistersToVectorRegister(buf, n)
 	default:
 		err = fmt.Errorf("encoder undefined for [%s] operand type", n.types)
 	}
@@ -765,18 +764,19 @@ func errorEncodingUnsupported(n *nodeImpl) error {
 	return fmt.Errorf("%s is unsupported for %s type", InstructionName(n.instruction), n.types)
 }
 
-func (a *AssemblerImpl) encodeNoneToNone(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeNoneToNone(buf asm.Buffer, n *nodeImpl) error {
 	switch n.instruction {
 	case UDF:
-		a.buf.Write([]byte{0, 0, 0, 0})
+		buf.Write4Bytes(0, 0, 0, 0)
+		return nil
 	case NOP:
+		return nil
 	default:
-		err = errorEncodingUnsupported(n)
+		return errorEncodingUnsupported(n)
 	}
-	return
 }
 
-func (a *AssemblerImpl) encodeJumpToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeJumpToRegister(buf asm.Buffer, n *nodeImpl) error {
 	// "Unconditional branch (register)" in https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions
 	var opc byte
 	switch n.instruction {
@@ -793,13 +793,13 @@ func (a *AssemblerImpl) encodeJumpToRegister(n *nodeImpl) (err error) {
 		return fmt.Errorf("invalid destination register: %w", err)
 	}
 
-	a.buf.Write([]byte{
-		0x00 | (regBits << 5),
-		0x00 | (regBits >> 3),
-		0b000_11111 | (opc << 5),
-		0b1101011_0 | (opc >> 3),
-	})
-	return
+	buf.Write4Bytes(
+		0x00|(regBits<<5),
+		0x00|(regBits>>3),
+		0b000_11111|(opc<<5),
+		0b1101011_0|(opc>>3),
+	)
+	return err
 }
 
 func (a *AssemblerImpl) relativeBranchFinalize(code []byte, n *nodeImpl) error {
@@ -874,7 +874,7 @@ func (a *AssemblerImpl) relativeBranchFinalize(code []byte, n *nodeImpl) error {
 	return nil
 }
 
-func (a *AssemblerImpl) encodeRelativeBranch(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRelativeBranch(buf asm.Buffer, n *nodeImpl) error {
 	switch n.instruction {
 	case B, BCONDEQ, BCONDGE, BCONDGT, BCONDHI, BCONDHS, BCONDLE, BCONDLO, BCONDLS, BCONDLT, BCONDMI, BCONDNE, BCONDVS, BCONDPL:
 	default:
@@ -886,9 +886,9 @@ func (a *AssemblerImpl) encodeRelativeBranch(n *nodeImpl) (err error) {
 	}
 
 	// At this point, we don't yet know that target's branch, so emit the placeholder (4 bytes).
-	a.buf.Write([]byte{0, 0, 0, 0})
+	buf.Write4Bytes(0, 0, 0, 0)
 	a.relativeJumpNodes = append(a.relativeJumpNodes, n)
-	return
+	return nil
 }
 
 func checkRegisterToRegisterType(src, dst asm.Register, requireSrcInt, requireDstInt bool) (err error) {
@@ -905,7 +905,7 @@ func checkRegisterToRegisterType(src, dst asm.Register, requireSrcInt, requireDs
 	return
 }
 
-func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	switch inst := n.instruction; inst {
 	case ADD, ADDW, SUB:
 		if err = checkRegisterToRegisterType(n.srcReg, n.dstReg, true, true); err != nil {
@@ -923,12 +923,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		}
 
 		srcRegBits, dstRegBits := registerBits(n.srcReg), registerBits(n.dstReg)
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			dstRegBits >> 3,
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			dstRegBits>>3,
 			srcRegBits,
-			(sfops << 5) | 0b01011,
-		})
+			(sfops<<5)|0b01011,
+		)
 	case CLZ, CLZW, RBIT, RBITW:
 		if err = checkRegisterToRegisterType(n.srcReg, n.dstReg, true, true); err != nil {
 			return
@@ -954,12 +954,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		}
 
 		srcRegBits, dstRegBits := registerBits(n.srcReg), registerBits(n.dstReg)
-		a.buf.Write([]byte{
-			(srcRegBits << 5) | dstRegBits,
-			opcode<<2 | (srcRegBits >> 3),
+		buf.Write4Bytes(
+			(srcRegBits<<5)|dstRegBits,
+			opcode<<2|(srcRegBits>>3),
 			0b110_00000,
-			(sf << 7) | 0b0_1011010,
-		})
+			(sf<<7)|0b0_1011010,
+		)
 	case CSET:
 		if !isConditionalRegister(n.srcReg) {
 			return fmt.Errorf("CSET requires conditional register but got %s", RegisterName(n.srcReg))
@@ -1011,12 +1011,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		}
 
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CSET--Conditional-Set--an-alias-of-CSINC-?lang=en
-		a.buf.Write([]byte{
-			0b111_00000 | dstRegBits,
-			(conditionalBits << 4) | 0b0000_0111,
+		buf.Write4Bytes(
+			0b111_00000|dstRegBits,
+			(conditionalBits<<4)|0b0000_0111,
 			0b100_11111,
 			0b10011010,
-		})
+		)
 
 	case FABSD, FABSS, FNEGD, FNEGS, FSQRTD, FSQRTS, FCVTSD, FCVTDS, FRINTMD, FRINTMS,
 		FRINTND, FRINTNS, FRINTPD, FRINTPS, FRINTZD, FRINTZS:
@@ -1062,12 +1062,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		case FRINTZS:
 			opcode, tp = 0b001011, 0b00
 		}
-		a.buf.Write([]byte{
-			(srcRegBits << 5) | dstRegBits,
-			(opcode << 7) | 0b0_10000_00 | (srcRegBits >> 3),
-			tp<<6 | 0b00_1_00000 | opcode>>1,
+		buf.Write4Bytes(
+			(srcRegBits<<5)|dstRegBits,
+			(opcode<<7)|0b0_10000_00|(srcRegBits>>3),
+			tp<<6|0b00_1_00000|opcode>>1,
 			0b0_00_11110,
-		})
+		)
 
 	case FADDD, FADDS, FDIVS, FDIVD, FMAXD, FMAXS, FMIND, FMINS, FMULS, FMULD:
 		if err = checkRegisterToRegisterType(n.srcReg, n.dstReg, false, false); err != nil {
@@ -1102,12 +1102,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			opcode, tp = 0b0000, 0b01
 		}
 
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			opcode<<4 | 0b0000_10_00 | (dstRegBits >> 3),
-			tp<<6 | 0b00_1_00000 | srcRegBits,
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			opcode<<4|0b0000_10_00|(dstRegBits>>3),
+			tp<<6|0b00_1_00000|srcRegBits,
 			0b0001_1110,
-		})
+		)
 
 	case FCVTZSD, FCVTZSDW, FCVTZSS, FCVTZSSW, FCVTZUD, FCVTZUDW, FCVTZUS, FCVTZUSW:
 		if err = checkRegisterToRegisterType(n.srcReg, n.dstReg, false, true); err != nil {
@@ -1138,12 +1138,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			sf, tp, opcode = 0b0, 0b00, 0b001
 		}
 
-		a.buf.Write([]byte{
-			(srcRegBits << 5) | dstRegBits,
-			0 | (srcRegBits >> 3),
-			tp<<6 | 0b00_1_11_000 | opcode,
-			sf<<7 | 0b0_0_0_11110,
-		})
+		buf.Write4Bytes(
+			(srcRegBits<<5)|dstRegBits,
+			0|(srcRegBits>>3),
+			tp<<6|0b00_1_11_000|opcode,
+			sf<<7|0b0_0_0_11110,
+		)
 
 	case FMOVD, FMOVS:
 		isSrcInt, isDstInt := isIntRegister(n.srcReg), isIntRegister(n.dstReg)
@@ -1158,34 +1158,34 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			if inst == FMOVD {
 				tp = 0b01
 			}
-			a.buf.Write([]byte{
-				(srcRegBits << 5) | dstRegBits,
-				0b0_10000_00 | (srcRegBits >> 3),
-				tp<<6 | 0b00_1_00000,
+			buf.Write4Bytes(
+				(srcRegBits<<5)|dstRegBits,
+				0b0_10000_00|(srcRegBits>>3),
+				tp<<6|0b00_1_00000,
 				0b000_11110,
-			})
+			)
 		} else if isSrcInt && !isDstInt { // Int to float.
 			var tp, sf byte
 			if inst == FMOVD {
 				tp, sf = 0b01, 0b1
 			}
-			a.buf.Write([]byte{
-				(srcRegBits << 5) | dstRegBits,
-				srcRegBits >> 3,
-				tp<<6 | 0b00_1_00_111,
-				sf<<7 | 0b0_00_11110,
-			})
+			buf.Write4Bytes(
+				(srcRegBits<<5)|dstRegBits,
+				srcRegBits>>3,
+				tp<<6|0b00_1_00_111,
+				sf<<7|0b0_00_11110,
+			)
 		} else { // Float to int.
 			var tp, sf byte
 			if inst == FMOVD {
 				tp, sf = 0b01, 0b1
 			}
-			a.buf.Write([]byte{
-				(srcRegBits << 5) | dstRegBits,
-				srcRegBits >> 3,
-				tp<<6 | 0b00_1_00_110,
-				sf<<7 | 0b0_00_11110,
-			})
+			buf.Write4Bytes(
+				(srcRegBits<<5)|dstRegBits,
+				srcRegBits>>3,
+				tp<<6|0b00_1_00_110,
+				sf<<7|0b0_00_11110,
+			)
 		}
 
 	case MOVD, MOVW:
@@ -1197,12 +1197,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		if n.srcReg == RegSP || n.dstReg == RegSP {
 			// Moving between stack pointers.
 			// https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/MOV--to-from-SP---Move-between-register-and-stack-pointer--an-alias-of-ADD--immediate--
-			a.buf.Write([]byte{
-				(srcRegBits << 5) | dstRegBits,
-				srcRegBits >> 3,
+			buf.Write4Bytes(
+				(srcRegBits<<5)|dstRegBits,
+				srcRegBits>>3,
 				0x0,
 				0b1001_0001,
-			})
+			)
 			return
 		}
 
@@ -1210,12 +1210,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			// If this is 64-bit mov from zero register, then we encode this as MOVK.
 			// See "Move wide (immediate)" in
 			// https://developer.arm.com/documentation/ddi0602/2021-06/Index-by-Encoding/Data-Processing----Immediate
-			a.buf.Write([]byte{
+			buf.Write4Bytes(
 				dstRegBits,
 				0x0,
 				0b1000_0000,
 				0b1_10_10010,
-			})
+			)
 		} else {
 			// MOV can be encoded as ORR (shifted register): "ORR Wd, WZR, Wm".
 			// https://developer.arm.com/documentation/100069/0609/A64-General-Instructions/MOV--register-
@@ -1223,12 +1223,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			if inst == MOVD {
 				sf = 0b1
 			}
-			a.buf.Write([]byte{
-				(zeroRegisterBits << 5) | dstRegBits,
-				zeroRegisterBits >> 3,
-				0b000_00000 | srcRegBits,
-				sf<<7 | 0b0_01_01010,
-			})
+			buf.Write4Bytes(
+				(zeroRegisterBits<<5)|dstRegBits,
+				zeroRegisterBits>>3,
+				0b000_00000|srcRegBits,
+				sf<<7|0b0_01_01010,
+			)
 		}
 
 	case MRS:
@@ -1239,12 +1239,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		// For how to specify FPSR register, see "Accessing FPSR" in:
 		// https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/FPSR--Floating-point-Status-Register?lang=en
 		dstRegBits := registerBits(n.dstReg)
-		a.buf.Write([]byte{
-			0b001<<5 | dstRegBits,
-			0b0100<<4 | 0b0100,
-			0b0011_0000 | 0b11<<3 | 0b011,
+		buf.Write4Bytes(
+			0b001<<5|dstRegBits,
+			0b0100<<4|0b0100,
+			0b0011_0000|0b11<<3|0b011,
 			0b1101_0101,
-		})
+		)
 
 	case MSR:
 		if n.dstReg != RegFPSR {
@@ -1254,12 +1254,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 		// For how to specify FPSR register, see "Accessing FPSR" in:
 		// https://developer.arm.com/documentation/ddi0595/2021-12/AArch64-Registers/FPSR--Floating-point-Status-Register?lang=en
 		srcRegBits := registerBits(n.srcReg)
-		a.buf.Write([]byte{
-			0b001<<5 | srcRegBits,
-			0b0100<<4 | 0b0100,
-			0b0001_0000 | 0b11<<3 | 0b011,
+		buf.Write4Bytes(
+			0b001<<5|srcRegBits,
+			0b0100<<4|0b0100,
+			0b0001_0000|0b11<<3|0b011,
 			0b1101_0101,
-		})
+		)
 
 	case MUL, MULW:
 		// Multiplications are encoded as MADD (zero register, src, dst), dst = zero + (src * dst) = src * dst.
@@ -1276,12 +1276,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 
 		srcRegBits, dstRegBits := registerBits(n.srcReg), registerBits(n.dstReg)
 
-		a.buf.Write([]byte{
-			dstRegBits<<5 | dstRegBits,
-			zeroRegisterBits<<2 | dstRegBits>>3,
+		buf.Write4Bytes(
+			dstRegBits<<5|dstRegBits,
+			zeroRegisterBits<<2|dstRegBits>>3,
 			srcRegBits,
-			sf<<7 | 0b11011,
-		})
+			sf<<7|0b11011,
+		)
 
 	case NEG, NEGW:
 		srcRegBits, dstRegBits := registerBits(n.srcReg), registerBits(n.dstReg)
@@ -1297,12 +1297,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			sf = 0b1
 		}
 
-		a.buf.Write([]byte{
-			(zeroRegisterBits << 5) | dstRegBits,
-			zeroRegisterBits >> 3,
+		buf.Write4Bytes(
+			(zeroRegisterBits<<5)|dstRegBits,
+			zeroRegisterBits>>3,
 			srcRegBits,
-			sf<<7 | 0b0_10_00000 | 0b0_00_01011,
-		})
+			sf<<7|0b0_10_00000|0b0_00_01011,
+		)
 
 	case SDIV, SDIVW, UDIV, UDIVW:
 		srcRegBits, dstRegBits := registerBits(n.srcReg), registerBits(n.dstReg)
@@ -1325,12 +1325,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			sf, opcode = 0b0, 0b000010
 		}
 
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			opcode<<2 | (dstRegBits >> 3),
-			0b110_00000 | srcRegBits,
-			sf<<7 | 0b0_00_11010,
-		})
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			opcode<<2|(dstRegBits>>3),
+			0b110_00000|srcRegBits,
+			sf<<7|0b0_00_11010,
+		)
 
 	case SCVTFD, SCVTFWD, SCVTFS, SCVTFWS, UCVTFD, UCVTFS, UCVTFWD, UCVTFWS:
 		srcRegBits, dstRegBits := registerBits(n.srcReg), registerBits(n.dstReg)
@@ -1361,12 +1361,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			sf, tp, opcode = 0b0, 0b00, 0b011
 		}
 
-		a.buf.Write([]byte{
-			(srcRegBits << 5) | dstRegBits,
-			srcRegBits >> 3,
-			tp<<6 | 0b00_1_00_000 | opcode,
-			sf<<7 | 0b0_0_0_11110,
-		})
+		buf.Write4Bytes(
+			(srcRegBits<<5)|dstRegBits,
+			srcRegBits>>3,
+			tp<<6|0b00_1_00_000|opcode,
+			sf<<7|0b0_0_0_11110,
+		)
 
 	case SXTB, SXTBW, SXTH, SXTHW, SXTW:
 		if err = checkRegisterToRegisterType(n.srcReg, n.dstReg, true, true); err != nil {
@@ -1380,12 +1380,12 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			if inst == MOVD {
 				sf = 0b1
 			}
-			a.buf.Write([]byte{
-				(zeroRegisterBits << 5) | dstRegBits,
-				zeroRegisterBits >> 3,
-				0b000_00000 | srcRegBits,
-				sf<<7 | 0b0_01_01010,
-			})
+			buf.Write4Bytes(
+				(zeroRegisterBits<<5)|dstRegBits,
+				zeroRegisterBits>>3,
+				0b000_00000|srcRegBits,
+				sf<<7|0b0_01_01010,
+			)
 			return
 		}
 
@@ -1410,19 +1410,19 @@ func (a *AssemblerImpl) encodeRegisterToRegister(n *nodeImpl) (err error) {
 			n, sf, imms = 0b1, 0b1, 0x1f
 		}
 
-		a.buf.Write([]byte{
-			(srcRegBits << 5) | dstRegBits,
-			imms<<2 | (srcRegBits >> 3),
-			n << 6,
-			sf<<7 | opc<<5 | 0b10011,
-		})
+		buf.Write4Bytes(
+			(srcRegBits<<5)|dstRegBits,
+			imms<<2|(srcRegBits>>3),
+			n<<6,
+			sf<<7|opc<<5|0b10011,
+		)
 	default:
 		return errorEncodingUnsupported(n)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeLeftShiftedRegisterToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeLeftShiftedRegisterToRegister(buf asm.Buffer, n *nodeImpl) error {
 	baseRegBits, err := intRegisterBits(n.srcReg)
 	if err != nil {
 		return err
@@ -1444,19 +1444,19 @@ func (a *AssemblerImpl) encodeLeftShiftedRegisterToRegister(n *nodeImpl) (err er
 			return fmt.Errorf("shift amount must fit in unsigned 6-bit integer (0-64) but got %d", n.srcConst)
 		}
 		shiftByte := byte(n.srcConst)
-		a.buf.Write([]byte{
-			(baseRegBits << 5) | dstRegBits,
-			(shiftByte << 2) | (baseRegBits >> 3),
-			(logicalLeftShiftBits << 6) | shiftTargetRegBits,
+		buf.Write4Bytes(
+			(baseRegBits<<5)|dstRegBits,
+			(shiftByte<<2)|(baseRegBits>>3),
+			(logicalLeftShiftBits<<6)|shiftTargetRegBits,
 			0b1000_1011,
-		})
+		)
+		return err
 	default:
 		return errorEncodingUnsupported(n)
 	}
-	return
 }
 
-func (a *AssemblerImpl) encodeTwoRegistersToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeTwoRegistersToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	switch inst := n.instruction; inst {
 	case AND, ANDW, ORR, ORRW, EOR, EORW:
 		// See "Logical (shifted register)" in
@@ -1477,12 +1477,12 @@ func (a *AssemblerImpl) encodeTwoRegistersToRegister(n *nodeImpl) (err error) {
 		case EORW:
 			sf, opc = 0b0, 0b10
 		}
-		a.buf.Write([]byte{
-			(srcReg2Bits << 5) | dstRegBits,
-			srcReg2Bits >> 3,
+		buf.Write4Bytes(
+			(srcReg2Bits<<5)|dstRegBits,
+			srcReg2Bits>>3,
 			srcRegBits,
-			sf<<7 | opc<<5 | 0b01010,
-		})
+			sf<<7|opc<<5|0b01010,
+		)
 	case ASR, ASRW, LSL, LSLW, LSR, LSRW, ROR, RORW:
 		// See "Data-processing (2 source)" in
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Register?lang=en
@@ -1507,12 +1507,12 @@ func (a *AssemblerImpl) encodeTwoRegistersToRegister(n *nodeImpl) (err error) {
 		case RORW:
 			sf, opcode = 0b0, 0b001011
 		}
-		a.buf.Write([]byte{
-			(srcReg2Bits << 5) | dstRegBits,
-			opcode<<2 | (srcReg2Bits >> 3),
-			0b110_00000 | srcRegBits,
-			sf<<7 | 0b0_00_11010,
-		})
+		buf.Write4Bytes(
+			(srcReg2Bits<<5)|dstRegBits,
+			opcode<<2|(srcReg2Bits>>3),
+			0b110_00000|srcRegBits,
+			sf<<7|0b0_00_11010,
+		)
 	case SDIV, SDIVW, UDIV, UDIVW:
 		srcRegBits, srcReg2Bits, dstRegBits := registerBits(n.srcReg), registerBits(n.srcReg2), registerBits(n.dstReg)
 
@@ -1530,12 +1530,12 @@ func (a *AssemblerImpl) encodeTwoRegistersToRegister(n *nodeImpl) (err error) {
 			sf, opcode = 0b0, 0b000010
 		}
 
-		a.buf.Write([]byte{
-			(srcReg2Bits << 5) | dstRegBits,
-			opcode<<2 | (srcReg2Bits >> 3),
-			0b110_00000 | srcRegBits,
-			sf<<7 | 0b0_00_11010,
-		})
+		buf.Write4Bytes(
+			(srcReg2Bits<<5)|dstRegBits,
+			opcode<<2|(srcReg2Bits>>3),
+			0b110_00000|srcRegBits,
+			sf<<7|0b0_00_11010,
+		)
 	case SUB, SUBW:
 		srcRegBits, srcReg2Bits, dstRegBits := registerBits(n.srcReg), registerBits(n.srcReg2), registerBits(n.dstReg)
 
@@ -1546,12 +1546,12 @@ func (a *AssemblerImpl) encodeTwoRegistersToRegister(n *nodeImpl) (err error) {
 			sf = 0b1
 		}
 
-		a.buf.Write([]byte{
-			(srcReg2Bits << 5) | dstRegBits,
-			srcReg2Bits >> 3,
+		buf.Write4Bytes(
+			(srcReg2Bits<<5)|dstRegBits,
+			srcReg2Bits>>3,
 			srcRegBits,
-			sf<<7 | 0b0_10_01011,
-		})
+			sf<<7|0b0_10_01011,
+		)
 	case FSUBD, FSUBS:
 		srcRegBits, srcReg2Bits, dstRegBits := registerBits(n.srcReg), registerBits(n.srcReg2), registerBits(n.dstReg)
 
@@ -1561,19 +1561,19 @@ func (a *AssemblerImpl) encodeTwoRegistersToRegister(n *nodeImpl) (err error) {
 		if inst == FSUBD {
 			tp = 0b01
 		}
-		a.buf.Write([]byte{
-			(srcReg2Bits << 5) | dstRegBits,
-			0b0011_10_00 | (srcReg2Bits >> 3),
-			tp<<6 | 0b00_1_00000 | srcRegBits,
+		buf.Write4Bytes(
+			(srcReg2Bits<<5)|dstRegBits,
+			0b0011_10_00|(srcReg2Bits>>3),
+			tp<<6|0b00_1_00000|srcRegBits,
 			0b0_00_11110,
-		})
+		)
 	default:
 		return errorEncodingUnsupported(n)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeThreeRegistersToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeThreeRegistersToRegister(buf asm.Buffer, n *nodeImpl) error {
 	switch n.instruction {
 	case MSUB, MSUBW:
 		// Dst = Src2 - (Src1 * Src3)
@@ -1601,19 +1601,19 @@ func (a *AssemblerImpl) encodeThreeRegistersToRegister(n *nodeImpl) (err error) 
 			sf = 0b1
 		}
 
-		a.buf.Write([]byte{
-			(src3RegBits << 5) | dstRegBits,
-			0b1_0000000 | (src2RegBits << 2) | (src3RegBits >> 3),
+		buf.Write4Bytes(
+			(src3RegBits<<5)|dstRegBits,
+			0b1_0000000|(src2RegBits<<2)|(src3RegBits>>3),
 			src1RegBits,
-			sf<<7 | 0b00_11011,
-		})
+			sf<<7|0b00_11011,
+		)
+		return err
 	default:
 		return errorEncodingUnsupported(n)
 	}
-	return
 }
 
-func (a *AssemblerImpl) encodeTwoRegistersToNone(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeTwoRegistersToNone(buf asm.Buffer, n *nodeImpl) error {
 	switch n.instruction {
 	case CMPW, CMP:
 		// Compare on two registers is an alias for "SUBS (src1, src2) ZERO"
@@ -1635,12 +1635,13 @@ func (a *AssemblerImpl) encodeTwoRegistersToNone(n *nodeImpl) (err error) {
 			op = 0b011
 		}
 
-		a.buf.Write([]byte{
-			(src2RegBits << 5) | zeroRegisterBits,
-			src2RegBits >> 3,
+		buf.Write4Bytes(
+			(src2RegBits<<5)|zeroRegisterBits,
+			src2RegBits>>3,
 			src1RegBits,
-			0b01011 | (op << 5),
-		})
+			0b01011|(op<<5),
+		)
+		return err
 	case FCMPS, FCMPD:
 		// "Floating-point compare" section in:
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
@@ -1657,19 +1658,19 @@ func (a *AssemblerImpl) encodeTwoRegistersToNone(n *nodeImpl) (err error) {
 		if n.instruction == FCMPD {
 			ftype = 0b01
 		}
-		a.buf.Write([]byte{
-			src2RegBits << 5,
-			0b001000_00 | (src2RegBits >> 3),
-			ftype<<6 | 0b1_00000 | src1RegBits,
+		buf.Write4Bytes(
+			src2RegBits<<5,
+			0b001000_00|(src2RegBits>>3),
+			ftype<<6|0b1_00000|src1RegBits,
 			0b000_11110,
-		})
+		)
+		return err
 	default:
 		return errorEncodingUnsupported(n)
 	}
-	return
 }
 
-func (a *AssemblerImpl) encodeRegisterAndConstToNone(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterAndConstToNone(buf asm.Buffer, n *nodeImpl) error {
 	if n.instruction != CMP {
 		return errorEncodingUnsupported(n)
 	}
@@ -1686,13 +1687,13 @@ func (a *AssemblerImpl) encodeRegisterAndConstToNone(n *nodeImpl) (err error) {
 		return err
 	}
 
-	a.buf.Write([]byte{
-		(srcRegBits << 5) | zeroRegisterBits,
-		(byte(n.srcConst) << 2) | (srcRegBits >> 3),
-		byte(n.srcConst >> 6),
+	buf.Write4Bytes(
+		(srcRegBits<<5)|zeroRegisterBits,
+		(byte(n.srcConst)<<2)|(srcRegBits>>3),
+		byte(n.srcConst>>6),
 		0b111_10001,
-	})
-	return
+	)
+	return err
 }
 
 func fitInSigned9Bits(v int64) bool {
@@ -1700,38 +1701,40 @@ func fitInSigned9Bits(v int64) bool {
 }
 
 func (a *AssemblerImpl) encodeLoadOrStoreWithRegisterOffset(
-	baseRegBits, offsetRegBits, targetRegBits byte, opcode, size, v byte,
+	buf asm.Buffer, baseRegBits, offsetRegBits, targetRegBits byte, opcode, size, v byte,
 ) {
 	// See "Load/store register (register offset)".
 	// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Loads-and-Stores?lang=en#ldst_regoff
-	a.buf.Write([]byte{
-		(baseRegBits << 5) | targetRegBits,
-		0b011_010_00 | (baseRegBits >> 3),
-		opcode<<6 | 0b00_1_00000 | offsetRegBits,
-		size<<6 | v<<2 | 0b00_111_0_00,
-	})
+	buf.Write4Bytes(
+		(baseRegBits<<5)|targetRegBits,
+		0b011_010_00|(baseRegBits>>3),
+		opcode<<6|0b00_1_00000|offsetRegBits,
+		size<<6|v<<2|0b00_111_0_00,
+	)
 }
 
 // validateMemoryOffset validates the memory offset if the given offset can be encoded in the assembler.
 // In theory, offset can be any, but for simplicity of our homemade assembler, we limit the offset range
 // that can be encoded enough for supporting compiler.
-func validateMemoryOffset(offset int64) (err error) {
+func validateMemoryOffset(offset int64) error {
 	if offset > 255 && offset%4 != 0 {
 		// This is because we only have large offsets for load/store with Wasm value stack or reading type IDs, and its offset
 		// is always multiplied by 4 or 8 (== the size of uint32 or uint64 == the type of wasm.FunctionTypeID or value stack in Go)
-		err = fmt.Errorf("large memory offset (>255) must be a multiple of 4 but got %d", offset)
+		return fmt.Errorf("large memory offset (>255) must be a multiple of 4 but got %d", offset)
 	} else if offset < -256 { // 9-bit signed integer's minimum = 2^8.
-		err = fmt.Errorf("negative memory offset must be larget than or equal -256 but got %d", offset)
+		return fmt.Errorf("negative memory offset must be larget than or equal -256 but got %d", offset)
 	} else if offset > 1<<31-1 {
 		return fmt.Errorf("large memory offset must be less than %d but got %d", 1<<31-1, offset)
+	} else {
+		return nil
 	}
-	return
 }
 
 // encodeLoadOrStoreWithConstOffset encodes load/store instructions with the constant offset.
 //
 // Note: Encoding strategy intentionally matches the Go assembler: https://go.dev/doc/asm
 func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
+	buf asm.Buffer,
 	baseRegBits, targetRegBits byte,
 	offset int64,
 	opcode, size, v byte,
@@ -1746,12 +1749,12 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Loads-and-Stores?lang=en#ldapstl_unscaled
 		if offset < 0 || offset%datasize != 0 {
 			// This case is encoded as one "unscaled signed store".
-			a.buf.Write([]byte{
-				(baseRegBits << 5) | targetRegBits,
-				byte(offset<<4) | (baseRegBits >> 3),
-				opcode<<6 | (0b00_00_11111 & byte(offset>>4)),
-				size<<6 | v<<2 | 0b00_1_11_0_00,
-			})
+			buf.Write4Bytes(
+				(baseRegBits<<5)|targetRegBits,
+				byte(offset<<4)|(baseRegBits>>3),
+				opcode<<6|(0b00_00_11111&byte(offset>>4)),
+				size<<6|v<<2|0b00_1_11_0_00,
+			)
 			return
 		}
 	}
@@ -1761,12 +1764,12 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 	if offset%datasize == 0 &&
 		offset < (1<<12)<<datasizeLog2 {
 		m := offset / datasize
-		a.buf.Write([]byte{
-			(baseRegBits << 5) | targetRegBits,
-			(byte(m << 2)) | (baseRegBits >> 3),
-			opcode<<6 | 0b00_111111&byte(m>>6),
-			size<<6 | v<<2 | 0b00_1_11_0_01,
-		})
+		buf.Write4Bytes(
+			(baseRegBits<<5)|targetRegBits,
+			(byte(m<<2))|(baseRegBits>>3),
+			opcode<<6|0b00_111111&byte(m>>6),
+			size<<6|v<<2|0b00_1_11_0_01,
+		)
 		return
 	}
 
@@ -1779,7 +1782,7 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 	// the const is not used but it is added into the const pool.
 	c := asm.NewStaticConst(make([]byte, 4))
 	binary.LittleEndian.PutUint32(c.Raw, uint32(offset))
-	a.pool.AddConst(c, uint64(a.buf.Len()))
+	a.pool.AddConst(c, uint64(buf.Len()))
 
 	// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L3529-L3532
 	// If the offset is within 24-bits, we can load it with two ADD instructions.
@@ -1790,34 +1793,40 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 		hi >>= 12
 
 		// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L3534-L3535
-		a.buf.Write([]byte{
-			(baseRegBits << 5) | tmpRegBits,
-			(byte(hi) << 2) | (baseRegBits >> 3),
-			0b01<<6 /* shift by 12 */ | byte(hi>>6),
-			sfops<<5 | 0b10001,
-		})
+		buf.Write4Bytes(
+			(baseRegBits<<5)|tmpRegBits,
+			(byte(hi)<<2)|(baseRegBits>>3),
+			0b01<<6 /* shift by 12 */ |byte(hi>>6),
+			sfops<<5|0b10001,
+		)
+		if err != nil {
+			return
+		}
 
-		a.buf.Write([]byte{
-			(tmpRegBits << 5) | targetRegBits,
-			(byte(m << 2)) | (tmpRegBits >> 3),
-			opcode<<6 | 0b00_111111&byte(m>>6),
-			size<<6 | v<<2 | 0b00_1_11_0_01,
-		})
+		buf.Write4Bytes(
+			(tmpRegBits<<5)|targetRegBits,
+			(byte(m<<2))|(tmpRegBits>>3),
+			opcode<<6|0b00_111111&byte(m>>6),
+			size<<6|v<<2|0b00_1_11_0_01,
+		)
 	} else {
 		// This case we load the const via ldr(literal) into tem register,
 		// and the target const is placed after this instruction below.
-		loadLiteralOffsetInBinary := uint64(a.buf.Len())
+		loadLiteralOffsetInBinary := uint64(buf.Len())
 
 		// First we emit the ldr(literal) with offset zero as we don't yet know the const's placement in the binary.
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--literal---Load-Register--literal--
-		a.buf.Write([]byte{tmpRegBits, 0x0, 0x0, 0b00_011_0_00})
+		buf.Write4Bytes(tmpRegBits, 0x0, 0x0, 0b00_011_0_00)
+		if err != nil {
+			return
+		}
 
 		// Set the callback for the constant, and we set properly the offset in the callback.
 
 		c.AddOffsetFinalizedCallback(func(offsetOfConst uint64) {
 			// ldr(literal) encodes offset divided by 4.
 			offset := (int(offsetOfConst) - int(loadLiteralOffsetInBinary)) / 4
-			bin := a.buf.Bytes()
+			bin := buf.Bytes()
 			bin[loadLiteralOffsetInBinary] |= byte(offset << 5)
 			bin[loadLiteralOffsetInBinary+1] |= byte(offset >> 3)
 			bin[loadLiteralOffsetInBinary+2] |= byte(offset >> 11)
@@ -1825,17 +1834,17 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 
 		// Then, load the constant with the register offset.
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--register---Load-Register--register--
-		a.buf.Write([]byte{
-			(baseRegBits << 5) | targetRegBits,
-			0b011_010_00 | (baseRegBits >> 3),
-			opcode<<6 | 0b00_1_00000 | tmpRegBits,
-			size<<6 | v<<2 | 0b00_111_0_00,
-		})
+		buf.Write4Bytes(
+			(baseRegBits<<5)|targetRegBits,
+			0b011_010_00|(baseRegBits>>3),
+			opcode<<6|0b00_1_00000|tmpRegBits,
+			size<<6|v<<2|0b00_111_0_00,
+		)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeRegisterToMemory(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToMemory(buf asm.Buffer, n *nodeImpl) (err error) {
 	// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Loads-and-Stores?lang=en#ldst_regoff
 	var (
 		size, v                byte
@@ -1880,31 +1889,31 @@ func (a *AssemblerImpl) encodeRegisterToMemory(n *nodeImpl) (err error) {
 		if err != nil {
 			return err
 		}
-		a.encodeLoadOrStoreWithRegisterOffset(baseRegBits, offsetRegBits, srcRegBits, opcode, size, v)
+		a.encodeLoadOrStoreWithRegisterOffset(buf, baseRegBits, offsetRegBits, srcRegBits, opcode, size, v)
 	} else {
-		err = a.encodeLoadOrStoreWithConstOffset(baseRegBits, srcRegBits, n.dstConst, opcode, size, v, datasize, datasizeLog2)
+		err = a.encodeLoadOrStoreWithConstOffset(buf, baseRegBits, srcRegBits, n.dstConst, opcode, size, v, datasize, datasizeLog2)
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeADR(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeADR(buf asm.Buffer, n *nodeImpl) (err error) {
 	dstRegBits, err := intRegisterBits(n.dstReg)
 	if err != nil {
 		return err
 	}
 
-	adrInstructionOffsetInBinary := uint64(a.buf.Len())
+	adrInstructionOffsetInBinary := uint64(buf.Len())
 
 	// At this point, we don't yet know the target offset to read from,
 	// so we emit the ADR instruction with 0 offset, and replace later in the callback.
 	// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADR--Form-PC-relative-address-?lang=en
-	a.buf.Write([]byte{dstRegBits, 0x0, 0x0, 0b10000})
+	buf.Write4Bytes(dstRegBits, 0x0, 0x0, 0b10000)
 
 	// This case, the ADR's target offset is for the staticConst's initial address.
 	if sc := n.staticConst; sc != nil {
 		a.pool.AddConst(sc, adrInstructionOffsetInBinary)
 		sc.AddOffsetFinalizedCallback(func(offsetOfConst uint64) {
-			adrInstructionBytes := a.buf.Bytes()[adrInstructionOffsetInBinary : adrInstructionOffsetInBinary+4]
+			adrInstructionBytes := buf.Bytes()[adrInstructionOffsetInBinary : adrInstructionOffsetInBinary+4]
 			offset := int(offsetOfConst) - int(adrInstructionOffsetInBinary)
 
 			// See https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADR--Form-PC-relative-address-?lang=en
@@ -1958,7 +1967,7 @@ func (a *AssemblerImpl) finalizeADRInstructionNode(code []byte, n *nodeImpl) (er
 	return nil
 }
 
-func (a *AssemblerImpl) encodeMemoryToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeMemoryToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Loads-and-Stores?lang=en#ldst_regoff
 	var (
 		size, v, opcode        byte
@@ -1967,7 +1976,7 @@ func (a *AssemblerImpl) encodeMemoryToRegister(n *nodeImpl) (err error) {
 	)
 	switch n.instruction {
 	case ADR:
-		return a.encodeADR(n)
+		return a.encodeADR(buf, n)
 	case FLDRD:
 		size, v, datasize, datasizeLog2, opcode, isTargetFloat = 0b11, 0x1, 8, 3, 0b01, true
 	case FLDRS:
@@ -2013,10 +2022,10 @@ func (a *AssemblerImpl) encodeMemoryToRegister(n *nodeImpl) (err error) {
 		if err != nil {
 			return err
 		}
-		a.encodeLoadOrStoreWithRegisterOffset(baseRegBits, offsetRegBits, dstRegBits, opcode,
+		a.encodeLoadOrStoreWithRegisterOffset(buf, baseRegBits, offsetRegBits, dstRegBits, opcode,
 			size, v)
 	} else {
-		err = a.encodeLoadOrStoreWithConstOffset(baseRegBits, dstRegBits, n.srcConst, opcode,
+		err = a.encodeLoadOrStoreWithConstOffset(buf, baseRegBits, dstRegBits, n.srcConst, opcode,
 			size, v, datasize, datasizeLog2)
 	}
 	return
@@ -2084,25 +2093,26 @@ func getLowestBit(x uint64) uint64 {
 	return x & (^x + 1)
 }
 
-func (a *AssemblerImpl) addOrSub64BitRegisters(sfops byte, sp bool, dstRegBits, src1RegBits, src2RegBits byte) {
+func (a *AssemblerImpl) addOrSub64BitRegisters(buf asm.Buffer, sfops byte, sp bool, dstRegBits, src1RegBits, src2RegBits byte) error {
 	// src1Reg = src1Reg +/- src2Reg
-
+	var err error
 	if sp {
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADD--extended-register---Add--extended-register--?lang=en
-		a.buf.Write([]byte{
-			(src1RegBits << 5) | dstRegBits,
-			0b011<<5 | src1RegBits>>3,
-			1<<5 | src2RegBits,
-			sfops<<5 | 0b01011,
-		})
+		buf.Write4Bytes(
+			(src1RegBits<<5)|dstRegBits,
+			0b011<<5|src1RegBits>>3,
+			1<<5|src2RegBits,
+			sfops<<5|0b01011,
+		)
 	} else {
-		a.buf.Write([]byte{
-			(src1RegBits << 5) | dstRegBits,
-			src1RegBits >> 3,
+		buf.Write4Bytes(
+			(src1RegBits<<5)|dstRegBits,
+			src1RegBits>>3,
 			src2RegBits,
-			sfops<<5 | 0b01011,
-		})
+			sfops<<5|0b01011,
+		)
 	}
+	return err
 }
 
 func bitmaskImmediate(c uint64, is64bit bool) (immr, imms, N byte) {
@@ -2149,7 +2159,7 @@ func bitmaskImmediate(c uint64, is64bit bool) (immr, imms, N byte) {
 	return
 }
 
-func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeConstToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	// Alias for readability.
 	c := n.srcConst
 
@@ -2168,12 +2178,12 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			return
 		}
 		immr, imms, N := bitmaskImmediate(uint64(c), false)
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			imms<<2 | dstRegBits>>3,
-			N<<6 | immr,
-			sf<<7 | opc<<5 | 0b10010,
-		})
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			imms<<2|dstRegBits>>3,
+			N<<6|immr,
+			sf<<7|opc<<5|0b10010,
+		)
 		return
 	case ANDIMM64:
 		var sf, opc byte = 0b1, 0b00
@@ -2182,12 +2192,12 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			return
 		}
 		immr, imms, N := bitmaskImmediate(uint64(c), true)
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			imms<<2 | dstRegBits>>3,
-			N<<6 | immr,
-			sf<<7 | opc<<5 | 0b10010,
-		})
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			imms<<2|dstRegBits>>3,
+			N<<6|immr,
+			sf<<7|opc<<5|0b10010,
+		)
 		return
 	}
 
@@ -2215,7 +2225,7 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		isSP := n.srcReg == RegSP || n.dstReg == RegSP
 		if c == 0 {
 			// If the constant equals zero, we encode it as ADD (register) with zero register.
-			a.addOrSub64BitRegisters(sfops, isSP, dstRegBits, srcRegBits, zeroRegisterBits)
+			err = a.addOrSub64BitRegisters(buf, sfops, isSP, dstRegBits, srcRegBits, zeroRegisterBits)
 			return
 		}
 
@@ -2224,20 +2234,20 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L2992
 
 			if c <= 0xfff {
-				a.buf.Write([]byte{
-					(srcRegBits << 5) | dstRegBits,
-					(byte(c) << 2) | (srcRegBits >> 3),
-					byte(c >> 6),
-					sfops<<5 | 0b10001,
-				})
+				buf.Write4Bytes(
+					(srcRegBits<<5)|dstRegBits,
+					(byte(c)<<2)|(srcRegBits>>3),
+					byte(c>>6),
+					sfops<<5|0b10001,
+				)
 			} else {
 				c >>= 12
-				a.buf.Write([]byte{
-					(srcRegBits << 5) | dstRegBits,
-					(byte(c) << 2) | (srcRegBits >> 3),
-					0b01<<6 /* shift by 12 */ | byte(c>>6),
-					sfops<<5 | 0b10001,
-				})
+				buf.Write4Bytes(
+					(srcRegBits<<5)|dstRegBits,
+					(byte(c)<<2)|(srcRegBits>>3),
+					0b01<<6 /* shift by 12 */ |byte(c>>6),
+					sfops<<5|0b10001,
+				)
 			}
 			return
 		}
@@ -2249,10 +2259,10 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			tmpRegBits := registerBits(a.temporaryRegister)
 
 			// MOVZ $c, tmpReg with shifting.
-			a.load16bitAlignedConst(c>>(16*t), byte(t), tmpRegBits, false, true)
+			a.load16bitAlignedConst(buf, c>>(16*t), byte(t), tmpRegBits, false, true)
 
 			// ADD/SUB tmpReg, dstReg
-			a.addOrSub64BitRegisters(sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
+			a.addOrSub64BitRegisters(buf, sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
 			return
 		} else if t := const16bitAligned(^c); t >= 0 {
 			// Also if the reverse of the const can fit within 16-bit range, do the same ^^.
@@ -2260,10 +2270,10 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			tmpRegBits := registerBits(a.temporaryRegister)
 
 			// MOVN $c, tmpReg with shifting.
-			a.load16bitAlignedConst(^c>>(16*t), byte(t), tmpRegBits, true, true)
+			a.load16bitAlignedConst(buf, ^c>>(16*t), byte(t), tmpRegBits, true, true)
 
 			// ADD/SUB tmpReg, dstReg
-			a.addOrSub64BitRegisters(sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
+			a.addOrSub64BitRegisters(buf, sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
 			return
 		}
 
@@ -2272,45 +2282,45 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 			// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L6570-L6583
 			tmpRegBits := registerBits(a.temporaryRegister)
 			// OOR $c, tmpReg
-			a.loadConstViaBitMaskImmediate(uc, tmpRegBits, true)
+			a.loadConstViaBitMaskImmediate(buf, uc, tmpRegBits, true)
 
 			// ADD/SUB tmpReg, dstReg
-			a.addOrSub64BitRegisters(sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
+			a.addOrSub64BitRegisters(buf, sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
 			return
 		}
 
 		// If the value fits within 24-bit, then we emit two add instructions
 		if 0 <= c && c <= 0xffffff && inst != SUBS && inst != ADDS {
 			// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L3849-L3862
-			a.buf.Write([]byte{
-				(dstRegBits << 5) | dstRegBits,
-				(byte(c) << 2) | (dstRegBits >> 3),
-				byte(c & 0xfff >> 6),
-				sfops<<5 | 0b10001,
-			})
+			buf.Write4Bytes(
+				(dstRegBits<<5)|dstRegBits,
+				(byte(c)<<2)|(dstRegBits>>3),
+				byte(c&0xfff>>6),
+				sfops<<5|0b10001,
+			)
 			c = c >> 12
-			a.buf.Write([]byte{
-				(dstRegBits << 5) | dstRegBits,
-				(byte(c) << 2) | (dstRegBits >> 3),
-				0b01_000000 /* shift by 12 */ | byte(c>>6),
-				sfops<<5 | 0b10001,
-			})
+			buf.Write4Bytes(
+				(dstRegBits<<5)|dstRegBits,
+				(byte(c)<<2)|(dstRegBits>>3),
+				0b01_000000 /* shift by 12 */ |byte(c>>6),
+				sfops<<5|0b10001,
+			)
 			return
 		}
 
 		// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L3163-L3203
 		// Otherwise we use MOVZ and MOVNs for loading const into tmpRegister.
 		tmpRegBits := registerBits(a.temporaryRegister)
-		a.load64bitConst(c, tmpRegBits)
-		a.addOrSub64BitRegisters(sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
+		a.load64bitConst(buf, c, tmpRegBits)
+		a.addOrSub64BitRegisters(buf, sfops, isSP, dstRegBits, srcRegBits, tmpRegBits)
 	case MOVW:
 		if c == 0 {
-			a.buf.Write([]byte{
-				(zeroRegisterBits << 5) | dstRegBits,
-				zeroRegisterBits >> 3,
-				0b000_00000 | zeroRegisterBits,
+			buf.Write4Bytes(
+				(zeroRegisterBits<<5)|dstRegBits,
+				zeroRegisterBits>>3,
+				0b000_00000|zeroRegisterBits,
 				0b0_01_01010,
-			})
+			)
 			return
 		}
 
@@ -2320,7 +2330,7 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		ic := int64(c32)
 		if ic >= 0 && (ic <= 0xfff || (ic&0xfff) == 0 && (uint64(ic>>12) <= 0xfff)) {
 			if isBitMaskImmediate(uint64(c)) {
-				a.loadConstViaBitMaskImmediate(uint64(c), dstRegBits, false)
+				a.loadConstViaBitMaskImmediate(buf, uint64(c), dstRegBits, false)
 				return
 			}
 		}
@@ -2328,32 +2338,32 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		if t := const16bitAligned(int64(c32)); t >= 0 {
 			// If the const can fit within 16-bit alignment, for example, 0xffff, 0xffff_0000 or 0xffff_0000_0000_0000
 			// We could load it into temporary with movk.
-			a.load16bitAlignedConst(int64(c32)>>(16*t), byte(t), dstRegBits, false, false)
+			a.load16bitAlignedConst(buf, int64(c32)>>(16*t), byte(t), dstRegBits, false, false)
 		} else if t := const16bitAligned(int64(^c32)); t >= 0 {
 			// Also, if the reverse of the const can fit within 16-bit range, do the same ^^.
-			a.load16bitAlignedConst(int64(^c32)>>(16*t), byte(t), dstRegBits, true, false)
+			a.load16bitAlignedConst(buf, int64(^c32)>>(16*t), byte(t), dstRegBits, true, false)
 		} else if isBitMaskImmediate(uint64(c)) {
-			a.loadConstViaBitMaskImmediate(uint64(c), dstRegBits, false)
+			a.loadConstViaBitMaskImmediate(buf, uint64(c), dstRegBits, false)
 		} else {
 			// Otherwise, we use MOVZ and MOVK to load it.
 			// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L6623-L6630
 			c16 := uint16(c32)
 			// MOVZ: https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
-			a.buf.Write([]byte{
-				(byte(c16) << 5) | dstRegBits,
-				byte(c16 >> 3),
-				1<<7 | byte(c16>>11),
+			buf.Write4Bytes(
+				(byte(c16)<<5)|dstRegBits,
+				byte(c16>>3),
+				1<<7|byte(c16>>11),
 				0b0_10_10010,
-			})
+			)
 			// MOVK: https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVK
 			c16 = uint16(c32 >> 16)
 			if c16 != 0 {
-				a.buf.Write([]byte{
-					(byte(c16) << 5) | dstRegBits,
-					byte(c16 >> 3),
-					1<<7 | 0b0_01_00000 /* shift by 16 */ | byte(c16>>11),
+				buf.Write4Bytes(
+					(byte(c16)<<5)|dstRegBits,
+					byte(c16>>3),
+					1<<7|0b0_01_00000 /* shift by 16 */ |byte(c16>>11),
 					0b0_11_10010,
-				})
+				)
 			}
 		}
 	case MOVD:
@@ -2361,7 +2371,7 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L1798-L1852
 		if c >= 0 && (c <= 0xfff || (c&0xfff) == 0 && (uint64(c>>12) <= 0xfff)) {
 			if isBitMaskImmediate(uint64(c)) {
-				a.loadConstViaBitMaskImmediate(uint64(c), dstRegBits, true)
+				a.loadConstViaBitMaskImmediate(buf, uint64(c), dstRegBits, true)
 				return
 			}
 		}
@@ -2369,14 +2379,14 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		if t := const16bitAligned(c); t >= 0 {
 			// If the const can fit within 16-bit alignment, for example, 0xffff, 0xffff_0000 or 0xffff_0000_0000_0000
 			// We could load it into temporary with movk.
-			a.load16bitAlignedConst(c>>(16*t), byte(t), dstRegBits, false, true)
+			a.load16bitAlignedConst(buf, c>>(16*t), byte(t), dstRegBits, false, true)
 		} else if t := const16bitAligned(^c); t >= 0 {
 			// Also, if the reverse of the const can fit within 16-bit range, do the same ^^.
-			a.load16bitAlignedConst((^c)>>(16*t), byte(t), dstRegBits, true, true)
+			a.load16bitAlignedConst(buf, (^c)>>(16*t), byte(t), dstRegBits, true, true)
 		} else if isBitMaskImmediate(uint64(c)) {
-			a.loadConstViaBitMaskImmediate(uint64(c), dstRegBits, true)
+			a.loadConstViaBitMaskImmediate(buf, uint64(c), dstRegBits, true)
 		} else {
-			a.load64bitConst(c, dstRegBits)
+			a.load64bitConst(buf, c, dstRegBits)
 		}
 	case LSR:
 		if c == 0 {
@@ -2389,12 +2399,12 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 
 		// LSR(immediate) is an alias of UBFM
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LSR--immediate---Logical-Shift-Right--immediate---an-alias-of-UBFM-?lang=en
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			0b111111_00 | dstRegBits>>3,
-			0b01_000000 | byte(c),
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			0b111111_00|dstRegBits>>3,
+			0b01_000000|byte(c),
 			0b110_10011,
-		})
+		)
 	case LSL:
 		if c == 0 {
 			err = errors.New("LSL with zero constant should be optimized out")
@@ -2407,12 +2417,12 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 		// LSL(immediate) is an alias of UBFM
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LSL--immediate---Logical-Shift-Left--immediate---an-alias-of-UBFM-
 		cb := byte(c)
-		a.buf.Write([]byte{
-			(dstRegBits << 5) | dstRegBits,
-			(0b111111-cb)<<2 | dstRegBits>>3,
-			0b01_000000 | (64 - cb),
+		buf.Write4Bytes(
+			(dstRegBits<<5)|dstRegBits,
+			(0b111111-cb)<<2|dstRegBits>>3,
+			0b01_000000|(64-cb),
 			0b110_10011,
-		})
+		)
 
 	default:
 		return errorEncodingUnsupported(n)
@@ -2420,41 +2430,41 @@ func (a *AssemblerImpl) encodeConstToRegister(n *nodeImpl) (err error) {
 	return
 }
 
-func (a *AssemblerImpl) movk(v uint64, shfitNum int, dstRegBits byte) {
+func (a *AssemblerImpl) movk(buf asm.Buffer, v uint64, shfitNum int, dstRegBits byte) {
 	// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVK
-	a.buf.Write([]byte{
-		(byte(v) << 5) | dstRegBits,
-		byte(v >> 3),
-		1<<7 | byte(shfitNum)<<5 | (0b000_11111 & byte(v>>11)),
+	buf.Write4Bytes(
+		(byte(v)<<5)|dstRegBits,
+		byte(v>>3),
+		1<<7|byte(shfitNum)<<5|(0b000_11111&byte(v>>11)),
 		0b1_11_10010,
-	})
+	)
 }
 
-func (a *AssemblerImpl) movz(v uint64, shfitNum int, dstRegBits byte) {
+func (a *AssemblerImpl) movz(buf asm.Buffer, v uint64, shfitNum int, dstRegBits byte) {
 	// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
-	a.buf.Write([]byte{
-		(byte(v) << 5) | dstRegBits,
-		byte(v >> 3),
-		1<<7 | byte(shfitNum)<<5 | (0b000_11111 & byte(v>>11)),
+	buf.Write4Bytes(
+		(byte(v)<<5)|dstRegBits,
+		byte(v>>3),
+		1<<7|byte(shfitNum)<<5|(0b000_11111&byte(v>>11)),
 		0b1_10_10010,
-	})
+	)
 }
 
-func (a *AssemblerImpl) movn(v uint64, shfitNum int, dstRegBits byte) {
+func (a *AssemblerImpl) movn(buf asm.Buffer, v uint64, shfitNum int, dstRegBits byte) {
 	// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
-	a.buf.Write([]byte{
-		(byte(v) << 5) | dstRegBits,
-		byte(v >> 3),
-		1<<7 | byte(shfitNum)<<5 | (0b000_11111 & byte(v>>11)),
+	buf.Write4Bytes(
+		(byte(v)<<5)|dstRegBits,
+		byte(v>>3),
+		1<<7|byte(shfitNum)<<5|(0b000_11111&byte(v>>11)),
 		0b1_00_10010,
-	})
+	)
 }
 
 // load64bitConst loads a 64-bit constant into the register, following the same logic to decide how to load large 64-bit
 // consts as in the Go assembler.
 //
 // See https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L6632-L6759
-func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
+func (a *AssemblerImpl) load64bitConst(buf asm.Buffer, c int64, dstRegBits byte) {
 	var bits [4]uint64
 	var zeros, negs int
 	for i := 0; i < 4; i++ {
@@ -2470,7 +2480,7 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 		// one MOVZ instruction.
 		for i, v := range bits {
 			if v != 0 {
-				a.movz(v, i, dstRegBits)
+				a.movz(buf, v, i, dstRegBits)
 			}
 		}
 	} else if negs == 3 {
@@ -2478,7 +2488,7 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 		for i, v := range bits {
 			if v != 0xffff {
 				v = ^v
-				a.movn(v, i, dstRegBits)
+				a.movn(buf, v, i, dstRegBits)
 			}
 		}
 	} else if zeros == 2 {
@@ -2487,10 +2497,10 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 		for i, v := range bits {
 			if !movz && v != 0 { // MOVZ.
 				// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
-				a.movz(v, i, dstRegBits)
+				a.movz(buf, v, i, dstRegBits)
 				movz = true
 			} else if v != 0 {
-				a.movk(v, i, dstRegBits)
+				a.movk(buf, v, i, dstRegBits)
 			}
 		}
 
@@ -2501,10 +2511,10 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 			if !movn && v != 0xffff {
 				v = ^v
 				// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVN
-				a.movn(v, i, dstRegBits)
+				a.movn(buf, v, i, dstRegBits)
 				movn = true
 			} else if v != 0xffff {
-				a.movk(v, i, dstRegBits)
+				a.movk(buf, v, i, dstRegBits)
 			}
 		}
 
@@ -2514,10 +2524,10 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 		for i, v := range bits {
 			if !movz && v != 0 { // MOVZ.
 				// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
-				a.movz(v, i, dstRegBits)
+				a.movz(buf, v, i, dstRegBits)
 				movz = true
 			} else if v != 0 {
-				a.movk(v, i, dstRegBits)
+				a.movk(buf, v, i, dstRegBits)
 			}
 		}
 
@@ -2528,10 +2538,10 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 			if !movn && v != 0xffff {
 				v = ^v
 				// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVN
-				a.movn(v, i, dstRegBits)
+				a.movn(buf, v, i, dstRegBits)
 				movn = true
 			} else if v != 0xffff {
-				a.movk(v, i, dstRegBits)
+				a.movk(buf, v, i, dstRegBits)
 			}
 		}
 
@@ -2541,17 +2551,17 @@ func (a *AssemblerImpl) load64bitConst(c int64, dstRegBits byte) {
 		for i, v := range bits {
 			if !movz && v != 0 { // MOVZ.
 				// https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
-				a.movz(v, i, dstRegBits)
+				a.movz(buf, v, i, dstRegBits)
 				movz = true
 			} else if v != 0 {
-				a.movk(v, i, dstRegBits)
+				a.movk(buf, v, i, dstRegBits)
 			}
 		}
 
 	}
 }
 
-func (a *AssemblerImpl) load16bitAlignedConst(c int64, shiftNum byte, regBits byte, reverse bool, dst64bit bool) {
+func (a *AssemblerImpl) load16bitAlignedConst(buf asm.Buffer, c int64, shiftNum byte, regBits byte, reverse bool, dst64bit bool) {
 	var lastByte byte
 	if reverse {
 		// MOVN: https://developer.arm.com/documentation/dui0802/a/A64-General-Instructions/MOVZ
@@ -2563,17 +2573,17 @@ func (a *AssemblerImpl) load16bitAlignedConst(c int64, shiftNum byte, regBits by
 	if dst64bit {
 		lastByte |= 0b1 << 7
 	}
-	a.buf.Write([]byte{
-		(byte(c) << 5) | regBits,
-		byte(c >> 3),
-		1<<7 | (shiftNum << 5) | byte(c>>11),
+	buf.Write4Bytes(
+		(byte(c)<<5)|regBits,
+		byte(c>>3),
+		1<<7|(shiftNum<<5)|byte(c>>11),
 		lastByte,
-	})
+	)
 }
 
 // loadConstViaBitMaskImmediate loads the constant with ORR (bitmask immediate).
 // https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ORR--immediate---Bitwise-OR--immediate--?lang=en
-func (a *AssemblerImpl) loadConstViaBitMaskImmediate(c uint64, regBits byte, dst64bit bool) {
+func (a *AssemblerImpl) loadConstViaBitMaskImmediate(buf asm.Buffer, c uint64, regBits byte, dst64bit bool) {
 	var size uint32
 	switch {
 	case c != c>>32|c<<32:
@@ -2623,12 +2633,12 @@ func (a *AssemblerImpl) loadConstViaBitMaskImmediate(c uint64, regBits byte, dst
 	if dst64bit {
 		sf = 0b1
 	}
-	a.buf.Write([]byte{
-		(zeroRegisterBits << 5) | regBits,
-		s<<2 | (zeroRegisterBits >> 3),
-		n<<6 | r,
-		sf<<7 | 0b0_01_10010,
-	})
+	buf.Write4Bytes(
+		(zeroRegisterBits<<5)|regBits,
+		s<<2|(zeroRegisterBits>>3),
+		n<<6|r,
+		sf<<7|0b0_01_10010,
+	)
 }
 
 func getOnesSequenceSize(x uint64) (size, nonZeroPos uint32) {
@@ -2686,7 +2696,7 @@ func checkArrangementIndexPair(arr VectorArrangement, index VectorIndex) (err er
 	return
 }
 
-func (a *AssemblerImpl) encodeMemoryToVectorRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeMemoryToVectorRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	srcBaseRegBits, err := intRegisterBits(n.srcReg)
 	if err != nil {
 		return err
@@ -2720,9 +2730,9 @@ func (a *AssemblerImpl) encodeMemoryToVectorRegister(n *nodeImpl) (err error) {
 			if err != nil {
 				return err
 			}
-			a.encodeLoadOrStoreWithRegisterOffset(srcBaseRegBits, offsetRegBits, dstVectorRegBits, opcode, size, v)
+			a.encodeLoadOrStoreWithRegisterOffset(buf, srcBaseRegBits, offsetRegBits, dstVectorRegBits, opcode, size, v)
 		} else {
-			err = a.encodeLoadOrStoreWithConstOffset(srcBaseRegBits, dstVectorRegBits,
+			err = a.encodeLoadOrStoreWithConstOffset(buf, srcBaseRegBits, dstVectorRegBits,
 				n.srcConst, opcode, size, v, dataSize, dataSizeLog2)
 		}
 	case LD1R:
@@ -2752,12 +2762,12 @@ func (a *AssemblerImpl) encodeMemoryToVectorRegister(n *nodeImpl) (err error) {
 
 		// No offset encoding.
 		// https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/LD1R--Load-one-single-element-structure-and-Replicate-to-all-lanes--of-one-register--?lang=en#iclass_as_post_index
-		a.buf.Write([]byte{
-			(srcBaseRegBits << 5) | dstVectorRegBits,
-			0b11_000000 | size<<2 | srcBaseRegBits>>3,
+		buf.Write4Bytes(
+			(srcBaseRegBits<<5)|dstVectorRegBits,
+			0b11_000000|size<<2|srcBaseRegBits>>3,
 			0b01_000000,
-			q<<6 | 0b1101,
-		})
+			q<<6|0b1101,
+		)
 	default:
 		return errorEncodingUnsupported(n)
 	}
@@ -2786,7 +2796,7 @@ func arrangementSizeQ(arr VectorArrangement) (size, q byte) {
 	return
 }
 
-func (a *AssemblerImpl) encodeVectorRegisterToMemory(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeVectorRegisterToMemory(buf asm.Buffer, n *nodeImpl) (err error) {
 	srcVectorRegBits, err := vectorRegisterBits(n.srcReg)
 	if err != nil {
 		return err
@@ -2821,9 +2831,9 @@ func (a *AssemblerImpl) encodeVectorRegisterToMemory(n *nodeImpl) (err error) {
 			if err != nil {
 				return err
 			}
-			a.encodeLoadOrStoreWithRegisterOffset(dstBaseRegBits, offsetRegBits, srcVectorRegBits, opcode, size, v)
+			a.encodeLoadOrStoreWithRegisterOffset(buf, dstBaseRegBits, offsetRegBits, srcVectorRegBits, opcode, size, v)
 		} else {
-			err = a.encodeLoadOrStoreWithConstOffset(dstBaseRegBits, srcVectorRegBits,
+			err = a.encodeLoadOrStoreWithConstOffset(buf, dstBaseRegBits, srcVectorRegBits,
 				n.dstConst, opcode, size, v, dataSize, dataSizeLog2)
 		}
 	default:
@@ -2832,7 +2842,7 @@ func (a *AssemblerImpl) encodeVectorRegisterToMemory(n *nodeImpl) (err error) {
 	return
 }
 
-func (a *AssemblerImpl) encodeStaticConstToVectorRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeStaticConstToVectorRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	if n.instruction != VMOV {
 		return errorEncodingUnsupported(n)
 	}
@@ -2855,7 +2865,7 @@ func (a *AssemblerImpl) encodeStaticConstToVectorRegister(n *nodeImpl) (err erro
 		opc, constLength = 0b10, 16
 	}
 
-	loadLiteralOffsetInBinary := uint64(a.buf.Len())
+	loadLiteralOffsetInBinary := uint64(buf.Len())
 	a.pool.AddConst(n.staticConst, loadLiteralOffsetInBinary)
 
 	if len(n.staticConst.Raw) != constLength {
@@ -2863,11 +2873,11 @@ func (a *AssemblerImpl) encodeStaticConstToVectorRegister(n *nodeImpl) (err erro
 			n.vectorArrangement, constLength, len(n.staticConst.Raw))
 	}
 
-	a.buf.Write([]byte{dstRegBits, 0x0, 0x0, opc<<6 | 0b11100})
+	buf.Write4Bytes(dstRegBits, 0x0, 0x0, opc<<6|0b11100)
 	n.staticConst.AddOffsetFinalizedCallback(func(offsetOfConst uint64) {
 		// LDR (literal, SIMD&FP) encodes offset divided by 4.
 		offset := (int(offsetOfConst) - int(loadLiteralOffsetInBinary)) / 4
-		bin := a.buf.Bytes()
+		bin := buf.Bytes()
 		bin[loadLiteralOffsetInBinary] |= byte(offset << 5)
 		bin[loadLiteralOffsetInBinary+1] |= byte(offset >> 3)
 		bin[loadLiteralOffsetInBinary+2] |= byte(offset >> 11)
@@ -3562,49 +3572,49 @@ func immResolverForSIMDSiftLeftByImmediate(shiftAmount int64, arr VectorArrangem
 
 // encodeAdvancedSIMDCopy encodes instruction as "Advanced SIMD copy" in
 // https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
-func (a *AssemblerImpl) encodeAdvancedSIMDCopy(srcRegBits, dstRegBits, op, imm5, imm4, q byte) {
-	a.buf.Write([]byte{
-		(srcRegBits << 5) | dstRegBits,
-		imm4<<3 | 0b1<<2 | srcRegBits>>3,
+func (a *AssemblerImpl) encodeAdvancedSIMDCopy(buf asm.Buffer, srcRegBits, dstRegBits, op, imm5, imm4, q byte) {
+	buf.Write4Bytes(
+		(srcRegBits<<5)|dstRegBits,
+		imm4<<3|0b1<<2|srcRegBits>>3,
 		imm5,
-		q<<6 | op<<5 | 0b1110,
-	})
+		q<<6|op<<5|0b1110,
+	)
 }
 
 // encodeAdvancedSIMDThreeSame encodes instruction as  "Advanced SIMD three same" in
 // https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
-func (a *AssemblerImpl) encodeAdvancedSIMDThreeSame(src1, src2, dst, opcode, size, q, u byte) {
-	a.buf.Write([]byte{
-		(src2 << 5) | dst,
-		opcode<<3 | 1<<2 | src2>>3,
-		size<<6 | 0b1<<5 | src1,
-		q<<6 | u<<5 | 0b1110,
-	})
+func (a *AssemblerImpl) encodeAdvancedSIMDThreeSame(buf asm.Buffer, src1, src2, dst, opcode, size, q, u byte) {
+	buf.Write4Bytes(
+		(src2<<5)|dst,
+		opcode<<3|1<<2|src2>>3,
+		size<<6|0b1<<5|src1,
+		q<<6|u<<5|0b1110,
+	)
 }
 
 // encodeAdvancedSIMDThreeDifferent encodes instruction as  "Advanced SIMD three different" in
 // https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
-func (a *AssemblerImpl) encodeAdvancedSIMDThreeDifferent(src1, src2, dst, opcode, size, q, u byte) {
-	a.buf.Write([]byte{
-		(src2 << 5) | dst,
-		opcode<<4 | src2>>3,
-		size<<6 | 0b1<<5 | src1,
-		q<<6 | u<<5 | 0b1110,
-	})
+func (a *AssemblerImpl) encodeAdvancedSIMDThreeDifferent(buf asm.Buffer, src1, src2, dst, opcode, size, q, u byte) {
+	buf.Write4Bytes(
+		(src2<<5)|dst,
+		opcode<<4|src2>>3,
+		size<<6|0b1<<5|src1,
+		q<<6|u<<5|0b1110,
+	)
 }
 
 // encodeAdvancedSIMDPermute encodes instruction as  "Advanced SIMD permute" in
 // https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
-func (a *AssemblerImpl) encodeAdvancedSIMDPermute(src1, src2, dst, opcode, size, q byte) {
-	a.buf.Write([]byte{
-		(src2 << 5) | dst,
-		opcode<<4 | 0b1<<3 | src2>>3,
-		size<<6 | src1,
-		q<<6 | 0b1110,
-	})
+func (a *AssemblerImpl) encodeAdvancedSIMDPermute(buf asm.Buffer, src1, src2, dst, opcode, size, q byte) {
+	buf.Write4Bytes(
+		(src2<<5)|dst,
+		opcode<<4|0b1<<3|src2>>3,
+		size<<6|src1,
+		q<<6|0b1110,
+	)
 }
 
-func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	var srcVectorRegBits byte
 	if n.srcReg != RegRZR {
 		srcVectorRegBits, err = vectorRegisterBits(n.srcReg)
@@ -3627,7 +3637,7 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if err != nil {
 			return err
 		}
-		a.encodeAdvancedSIMDCopy(srcVectorRegBits, dstVectorRegBits, simdCopy.op, imm5, imm4, q)
+		a.encodeAdvancedSIMDCopy(buf, srcVectorRegBits, dstVectorRegBits, simdCopy.op, imm5, imm4, q)
 		return nil
 	}
 
@@ -3638,12 +3648,12 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.buf.Write([]byte{
-			(srcVectorRegBits << 5) | dstVectorRegBits,
-			scalarPairwise.opcode<<4 | 1<<3 | srcVectorRegBits>>3,
-			size<<6 | 0b11<<4 | scalarPairwise.opcode>>4,
-			0b1<<6 | scalarPairwise.u<<5 | 0b11110,
-		})
+		buf.Write4Bytes(
+			(srcVectorRegBits<<5)|dstVectorRegBits,
+			scalarPairwise.opcode<<4|1<<3|srcVectorRegBits>>3,
+			size<<6|0b11<<4|scalarPairwise.opcode>>4,
+			0b1<<6|scalarPairwise.u<<5|0b11110,
+		)
 		return
 	}
 
@@ -3654,12 +3664,12 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.buf.Write([]byte{
-			(srcVectorRegBits << 5) | dstVectorRegBits,
-			twoRegMisc.opcode<<4 | 0b1<<3 | srcVectorRegBits>>3,
-			qs.size<<6 | 0b1<<5 | twoRegMisc.opcode>>4,
-			qs.q<<6 | twoRegMisc.u<<5 | 0b01110,
-		})
+		buf.Write4Bytes(
+			(srcVectorRegBits<<5)|dstVectorRegBits,
+			twoRegMisc.opcode<<4|0b1<<3|srcVectorRegBits>>3,
+			qs.size<<6|0b1<<5|twoRegMisc.opcode>>4,
+			qs.q<<6|twoRegMisc.u<<5|0b01110,
+		)
 		return nil
 	}
 
@@ -3668,7 +3678,7 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.encodeAdvancedSIMDThreeSame(srcVectorRegBits, dstVectorRegBits, dstVectorRegBits, threeSame.opcode, qs.size, qs.q, threeSame.u)
+		a.encodeAdvancedSIMDThreeSame(buf, srcVectorRegBits, dstVectorRegBits, dstVectorRegBits, threeSame.opcode, qs.size, qs.q, threeSame.u)
 		return nil
 	}
 
@@ -3677,7 +3687,7 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.encodeAdvancedSIMDThreeDifferent(srcVectorRegBits, dstVectorRegBits, dstVectorRegBits, threeDifferent.opcode, qs.size, qs.q, threeDifferent.u)
+		a.encodeAdvancedSIMDThreeDifferent(buf, srcVectorRegBits, dstVectorRegBits, dstVectorRegBits, threeDifferent.opcode, qs.size, qs.q, threeDifferent.u)
 		return nil
 	}
 
@@ -3688,12 +3698,12 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.buf.Write([]byte{
-			(srcVectorRegBits << 5) | dstVectorRegBits,
-			acrossLanes.opcode<<4 | 0b1<<3 | srcVectorRegBits>>3,
-			qs.size<<6 | 0b11000<<1 | acrossLanes.opcode>>4,
-			qs.q<<6 | acrossLanes.u<<5 | 0b01110,
-		})
+		buf.Write4Bytes(
+			(srcVectorRegBits<<5)|dstVectorRegBits,
+			acrossLanes.opcode<<4|0b1<<3|srcVectorRegBits>>3,
+			qs.size<<6|0b11000<<1|acrossLanes.opcode>>4,
+			qs.q<<6|acrossLanes.u<<5|0b01110,
+		)
 		return nil
 	}
 
@@ -3702,12 +3712,12 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.buf.Write([]byte{
-			(srcVectorRegBits << 5) | dstVectorRegBits,
-			lookup.Len<<5 | lookup.op<<4 | srcVectorRegBits>>3,
-			lookup.op2<<6 | dstVectorRegBits,
-			q<<6 | 0b1110,
-		})
+		buf.Write4Bytes(
+			(srcVectorRegBits<<5)|dstVectorRegBits,
+			lookup.Len<<5|lookup.op<<4|srcVectorRegBits>>3,
+			lookup.op2<<6|dstVectorRegBits,
+			q<<6|0b1110,
+		)
 		return
 	}
 
@@ -3722,24 +3732,24 @@ func (a *AssemblerImpl) encodeVectorRegisterToVectorRegister(n *nodeImpl) (err e
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
 
-		a.buf.Write([]byte{
-			(srcVectorRegBits << 5) | dstVectorRegBits,
-			shiftByImmediate.opcode<<3 | 0b1<<2 | srcVectorRegBits>>3,
-			immh<<3 | immb,
-			q<<6 | shiftByImmediate.U<<5 | 0b1111,
-		})
+		buf.Write4Bytes(
+			(srcVectorRegBits<<5)|dstVectorRegBits,
+			shiftByImmediate.opcode<<3|0b1<<2|srcVectorRegBits>>3,
+			immh<<3|immb,
+			q<<6|shiftByImmediate.U<<5|0b1111,
+		)
 		return nil
 	}
 
 	if permute, ok := advancedSIMDPermute[n.instruction]; ok {
 		size, q := arrangementSizeQ(n.vectorArrangement)
-		a.encodeAdvancedSIMDPermute(srcVectorRegBits, dstVectorRegBits, dstVectorRegBits, permute.opcode, size, q)
+		a.encodeAdvancedSIMDPermute(buf, srcVectorRegBits, dstVectorRegBits, dstVectorRegBits, permute.opcode, size, q)
 		return
 	}
 	return errorEncodingUnsupported(n)
 }
 
-func (a *AssemblerImpl) encodeTwoVectorRegistersToVectorRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeTwoVectorRegistersToVectorRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	var srcRegBits, srcRegBits2, dstRegBits byte
 	srcRegBits, err = vectorRegisterBits(n.srcReg)
 	if err != nil {
@@ -3761,7 +3771,7 @@ func (a *AssemblerImpl) encodeTwoVectorRegistersToVectorRegister(n *nodeImpl) (e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.encodeAdvancedSIMDThreeSame(srcRegBits, srcRegBits2, dstRegBits, threeSame.opcode, qs.size, qs.q, threeSame.u)
+		a.encodeAdvancedSIMDThreeSame(buf, srcRegBits, srcRegBits2, dstRegBits, threeSame.opcode, qs.size, qs.q, threeSame.u)
 		return nil
 	}
 
@@ -3770,13 +3780,13 @@ func (a *AssemblerImpl) encodeTwoVectorRegistersToVectorRegister(n *nodeImpl) (e
 		if !ok {
 			return fmt.Errorf("unsupported vector arrangement %s for %s", n.vectorArrangement, InstructionName(n.instruction))
 		}
-		a.encodeAdvancedSIMDThreeDifferent(srcRegBits, srcRegBits2, dstRegBits, threeDifferent.opcode, qs.size, qs.q, threeDifferent.u)
+		a.encodeAdvancedSIMDThreeDifferent(buf, srcRegBits, srcRegBits2, dstRegBits, threeDifferent.opcode, qs.size, qs.q, threeDifferent.u)
 		return nil
 	}
 
 	if permute, ok := advancedSIMDPermute[n.instruction]; ok {
 		size, q := arrangementSizeQ(n.vectorArrangement)
-		a.encodeAdvancedSIMDPermute(srcRegBits, srcRegBits2, dstRegBits, permute.opcode, size, q)
+		a.encodeAdvancedSIMDPermute(buf, srcRegBits, srcRegBits2, dstRegBits, permute.opcode, size, q)
 		return
 	}
 
@@ -3793,18 +3803,18 @@ func (a *AssemblerImpl) encodeTwoVectorRegistersToVectorRegister(n *nodeImpl) (e
 		default:
 			return fmt.Errorf("invalid arrangement %s for EXT", n.vectorArrangement)
 		}
-		a.buf.Write([]byte{
-			(srcRegBits2 << 5) | dstRegBits,
-			imm4<<3 | srcRegBits2>>3,
+		buf.Write4Bytes(
+			(srcRegBits2<<5)|dstRegBits,
+			imm4<<3|srcRegBits2>>3,
 			srcRegBits,
-			q<<6 | 0b101110,
-		})
+			q<<6|0b101110,
+		)
 		return
 	}
 	return
 }
 
-func (a *AssemblerImpl) encodeVectorRegisterToRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeVectorRegisterToRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	if err = checkArrangementIndexPair(n.vectorArrangement, n.srcVectorIndex); err != nil {
 		return
 	}
@@ -3824,13 +3834,13 @@ func (a *AssemblerImpl) encodeVectorRegisterToRegister(n *nodeImpl) (err error) 
 		if err != nil {
 			return err
 		}
-		a.encodeAdvancedSIMDCopy(srcVecRegBits, dstRegBits, simdCopy.op, imm5, imm4, q)
+		a.encodeAdvancedSIMDCopy(buf, srcVecRegBits, dstRegBits, simdCopy.op, imm5, imm4, q)
 		return nil
 	}
 	return errorEncodingUnsupported(n)
 }
 
-func (a *AssemblerImpl) encodeRegisterToVectorRegister(n *nodeImpl) (err error) {
+func (a *AssemblerImpl) encodeRegisterToVectorRegister(buf asm.Buffer, n *nodeImpl) (err error) {
 	srcRegBits, err := intRegisterBits(n.srcReg)
 	if err != nil {
 		return err
@@ -3846,7 +3856,7 @@ func (a *AssemblerImpl) encodeRegisterToVectorRegister(n *nodeImpl) (err error) 
 		if err != nil {
 			return err
 		}
-		a.encodeAdvancedSIMDCopy(srcRegBits, dstVectorRegBits, simdCopy.op, imm5, imm4, q)
+		a.encodeAdvancedSIMDCopy(buf, srcRegBits, dstVectorRegBits, simdCopy.op, imm5, imm4, q)
 		return nil
 	}
 	return errorEncodingUnsupported(n)

--- a/internal/asm/arm64/impl.go
+++ b/internal/asm/arm64/impl.go
@@ -1603,7 +1603,7 @@ func (a *AssemblerImpl) encodeThreeRegistersToRegister(buf asm.Buffer, n *nodeIm
 			src1RegBits,
 			sf<<7|0b00_11011,
 		)
-		return err
+		return nil
 	default:
 		return errorEncodingUnsupported(n)
 	}
@@ -1637,7 +1637,7 @@ func (a *AssemblerImpl) encodeTwoRegistersToNone(buf asm.Buffer, n *nodeImpl) er
 			src1RegBits,
 			0b01011|(op<<5),
 		)
-		return err
+		return nil
 	case FCMPS, FCMPD:
 		// "Floating-point compare" section in:
 		// https://developer.arm.com/documentation/ddi0596/2021-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
@@ -1660,7 +1660,7 @@ func (a *AssemblerImpl) encodeTwoRegistersToNone(buf asm.Buffer, n *nodeImpl) er
 			ftype<<6|0b1_00000|src1RegBits,
 			0b000_11110,
 		)
-		return err
+		return nil
 	default:
 		return errorEncodingUnsupported(n)
 	}
@@ -1689,7 +1689,7 @@ func (a *AssemblerImpl) encodeRegisterAndConstToNone(buf asm.Buffer, n *nodeImpl
 		byte(n.srcConst>>6),
 		0b111_10001,
 	)
-	return err
+	return nil
 }
 
 func fitInSigned9Bits(v int64) bool {
@@ -1795,9 +1795,6 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 			0b01<<6 /* shift by 12 */ |byte(hi>>6),
 			sfops<<5|0b10001,
 		)
-		if err != nil {
-			return
-		}
 
 		buf.Append4Bytes(
 			(tmpRegBits<<5)|targetRegBits,
@@ -1813,9 +1810,6 @@ func (a *AssemblerImpl) encodeLoadOrStoreWithConstOffset(
 		// First we emit the ldr(literal) with offset zero as we don't yet know the const's placement in the binary.
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--literal---Load-Register--literal--
 		buf.Append4Bytes(tmpRegBits, 0x0, 0x0, 0b00_011_0_00)
-		if err != nil {
-			return
-		}
 
 		// Set the callback for the constant, and we set properly the offset in the callback.
 

--- a/internal/asm/arm64/impl_1_test.go
+++ b/internal/asm/arm64/impl_1_test.go
@@ -31,7 +31,7 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 	code := asm.CodeSegment{}
 	defer func() { require.NoError(t, code.Unmap()) }()
 
-	buf := code.Next()
+	buf := code.NextCodeSection()
 	buf.AppendBytes([]byte{0, 0, 0, 0, 0})
 
 	staticConsts := asm.NewStaticConstPool()
@@ -636,7 +636,7 @@ func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		a := NewAssembler(asm.NilRegister)
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeNoneToNone(buf, &nodeImpl{instruction: ADD})
 		require.EqualError(t, err, "ADD is unsupported for NoneToNone type")
 	})
@@ -645,7 +645,7 @@ func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		a := NewAssembler(asm.NilRegister)
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeNoneToNone(buf, &nodeImpl{instruction: NOP})
 		require.NoError(t, err)
 
@@ -658,7 +658,7 @@ func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		a := NewAssembler(asm.NilRegister)
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.encodeNoneToNone(buf, &nodeImpl{instruction: UDF})
 		require.NoError(t, err)
 
@@ -856,7 +856,7 @@ func TestAssemblerImpl_EncodeVectorRegisterToMemory(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(RegR10)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeVectorRegisterToMemory(buf, tc.n)
 			require.NoError(t, err)
 
@@ -1077,7 +1077,7 @@ func TestAssemblerImpl_EncodeMemoryToVectorRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(RegR10)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeMemoryToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 
@@ -2325,7 +2325,7 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeVectorRegisterToVectorRegister(buf, &nodeImpl{
 				instruction:       tc.inst,
 				srcReg:            tc.x1,
@@ -2434,7 +2434,7 @@ func TestAssemblerImpl_EncodeVectorRegisterToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeVectorRegisterToRegister(buf, tc.n)
 			require.NoError(t, err)
 
@@ -2493,7 +2493,7 @@ func TestAssemblerImpl_EncodeLeftShiftedRegisterToRegister(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeLeftShiftedRegisterToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -2617,7 +2617,7 @@ func TestAssemblerImpl_EncodeLeftShiftedRegisterToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeLeftShiftedRegisterToRegister(buf, tc.n)
 			require.NoError(t, err)
 
@@ -2662,7 +2662,7 @@ func TestAssemblerImpl_encodeTwoRegistersToNone(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeTwoRegistersToNone(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -2858,7 +2858,7 @@ func TestAssemblerImpl_encodeTwoRegistersToNone(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeTwoRegistersToNone(buf, tc.n)
 			require.NoError(t, err)
 
@@ -2894,7 +2894,7 @@ func TestAssemblerImpl_EncodeThreeRegistersToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeThreeRegistersToRegister(buf, &nodeImpl{
 				instruction: tc.inst, srcReg: src1, srcReg2: src2, dstReg: src3, dstReg2: dst,
 			})
@@ -3764,7 +3764,7 @@ func TestAssemblerImpl_encodeTwoVectorRegistersToVectorRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeTwoVectorRegistersToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 
@@ -3850,7 +3850,7 @@ func TestAssemblerImpl_EncodeRegisterToVectorRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 
@@ -3964,7 +3964,7 @@ func TestAssemblerImpl_maybeFlushConstPool(t *testing.T) {
 			})
 
 			a.MaxDisplacementForConstantPool = 0
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			a.maybeFlushConstPool(buf, false)
 			require.True(t, called)
 
@@ -4045,7 +4045,7 @@ func TestAssemblerImpl_EncodeStaticConstToVectorRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeStaticConstToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 			a.maybeFlushConstPool(buf, true)
@@ -4094,7 +4094,7 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 
 			a := NewAssembler(asm.NilRegister)
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			buf.AppendBytes(make([]byte, beforeADRByteNum))
 
 			err := a.encodeADR(buf, &nodeImpl{instruction: ADR, dstReg: tc.reg, staticConst: sc})

--- a/internal/asm/arm64/impl_1_test.go
+++ b/internal/asm/arm64/impl_1_test.go
@@ -32,7 +32,7 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	buf := code.Next()
-	buf.Write([]byte{0, 0, 0, 0, 0})
+	buf.AppendBytes([]byte{0, 0, 0, 0, 0})
 
 	staticConsts := asm.NewStaticConstPool()
 	staticConsts.AddConst(asm.NewStaticConst(nil), 1234)
@@ -4095,7 +4095,7 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 			a := NewAssembler(asm.NilRegister)
 
 			buf := code.Next()
-			buf.Write(make([]byte, beforeADRByteNum))
+			buf.AppendBytes(make([]byte, beforeADRByteNum))
 
 			err := a.encodeADR(buf, &nodeImpl{instruction: ADR, dstReg: tc.reg, staticConst: sc})
 			require.NoError(t, err)

--- a/internal/asm/arm64/impl_1_test.go
+++ b/internal/asm/arm64/impl_1_test.go
@@ -1,7 +1,6 @@
 package arm64
 
 import (
-	"bytes"
 	"encoding/hex"
 	"testing"
 
@@ -29,7 +28,12 @@ func TestNodePool_allocNode(t *testing.T) {
 
 func TestAssemblerImpl_Reset(t *testing.T) {
 	// Existing values.
-	buf := bytes.NewBuffer(make([]byte, 5, 100))
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
+	buf := code.Next()
+	buf.Write([]byte{0, 0, 0, 0, 0})
+
 	staticConsts := asm.NewStaticConstPool()
 	staticConsts.AddConst(asm.NewStaticConst(nil), 1234)
 	adrInstructionNodes := make([]*nodeImpl, 5)
@@ -45,7 +49,6 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 			pages: []*nodePage{new(nodePage), new(nodePage)},
 			index: 12,
 		},
-		buf:                 buf,
 		pool:                staticConsts,
 		temporaryRegister:   RegV2,
 		relativeJumpNodes:   relativeJumpNodes,
@@ -53,10 +56,10 @@ func TestAssemblerImpl_Reset(t *testing.T) {
 		BaseAssemblerImpl:   ba,
 	}
 	a.Reset()
+	buf.Reset()
 
 	// Check each field.
-	require.Equal(t, buf, a.buf)
-	require.Equal(t, 100, buf.Cap())
+	require.Equal(t, 65536, buf.Cap())
 	require.Equal(t, 0, buf.Len())
 
 	require.Zero(t, len(a.nodePool.pages))
@@ -629,25 +632,37 @@ func Test_checkRegisterToRegisterType(t *testing.T) {
 
 func TestAssemblerImpl_encodeNoneToNone(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		a := NewAssembler(asm.NilRegister)
-		err := a.encodeNoneToNone(&nodeImpl{instruction: ADD})
+		buf := code.Next()
+		err := a.encodeNoneToNone(buf, &nodeImpl{instruction: ADD})
 		require.EqualError(t, err, "ADD is unsupported for NoneToNone type")
 	})
 	t.Run("NOP", func(t *testing.T) {
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		a := NewAssembler(asm.NilRegister)
-		err := a.encodeNoneToNone(&nodeImpl{instruction: NOP})
+		buf := code.Next()
+		err := a.encodeNoneToNone(buf, &nodeImpl{instruction: NOP})
 		require.NoError(t, err)
 
 		// NOP must be ignored.
-		actual := a.buf.Bytes()
+		actual := buf.Bytes()
 		require.Zero(t, len(actual))
 	})
 	t.Run("UDF", func(t *testing.T) {
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		a := NewAssembler(asm.NilRegister)
-		err := a.encodeNoneToNone(&nodeImpl{instruction: UDF})
+		buf := code.Next()
+		err := a.encodeNoneToNone(buf, &nodeImpl{instruction: UDF})
 		require.NoError(t, err)
 
-		actual := a.buf.Bytes()
+		actual := buf.Bytes()
 		require.Equal(t, []byte{0x0, 0x0, 0x0, 0x0}, actual, hex.EncodeToString(actual))
 	})
 }
@@ -837,14 +852,20 @@ func TestAssemblerImpl_EncodeVectorRegisterToMemory(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(RegR10)
-			err := a.encodeVectorRegisterToMemory(tc.n)
+			buf := code.Next()
+			err := a.encodeVectorRegisterToMemory(buf, tc.n)
 			require.NoError(t, err)
 
-			a.maybeFlushConstPool(true)
+			a.maybeFlushConstPool(buf, true)
 
-			actual, err := a.Assemble()
+			err = a.Assemble(buf)
 			require.NoError(t, err)
+
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -1052,14 +1073,20 @@ func TestAssemblerImpl_EncodeMemoryToVectorRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(RegR10)
-			err := a.encodeMemoryToVectorRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeMemoryToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 
-			a.maybeFlushConstPool(true)
+			a.maybeFlushConstPool(buf, true)
 
-			actual, err := a.Assemble()
+			err = a.Assemble(buf)
 			require.NoError(t, err)
+
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -2294,8 +2321,12 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeVectorRegisterToVectorRegister(&nodeImpl{
+			buf := code.Next()
+			err := a.encodeVectorRegisterToVectorRegister(buf, &nodeImpl{
 				instruction:       tc.inst,
 				srcReg:            tc.x1,
 				srcConst:          tc.c,
@@ -2305,7 +2336,7 @@ func TestAssemblerImpl_EncodeVectorRegisterToVectorRegister(t *testing.T) {
 				dstVectorIndex:    tc.dstIndex,
 			})
 			require.NoError(t, err)
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -2399,11 +2430,15 @@ func TestAssemblerImpl_EncodeVectorRegisterToRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeVectorRegisterToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeVectorRegisterToRegister(buf, tc.n)
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -2452,10 +2487,14 @@ func TestAssemblerImpl_EncodeLeftShiftedRegisterToRegister(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeLeftShiftedRegisterToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeLeftShiftedRegisterToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -2574,11 +2613,15 @@ func TestAssemblerImpl_EncodeLeftShiftedRegisterToRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeLeftShiftedRegisterToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeLeftShiftedRegisterToRegister(buf, tc.n)
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -2613,10 +2656,14 @@ func TestAssemblerImpl_encodeTwoRegistersToNone(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeTwoRegistersToNone(tc.n)
+			buf := code.Next()
+			err := a.encodeTwoRegistersToNone(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -2807,11 +2854,15 @@ func TestAssemblerImpl_encodeTwoRegistersToNone(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeTwoRegistersToNone(tc.n)
+			buf := code.Next()
+			err := a.encodeTwoRegistersToNone(buf, tc.n)
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -2839,13 +2890,17 @@ func TestAssemblerImpl_EncodeThreeRegistersToRegister(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeThreeRegistersToRegister(&nodeImpl{
+			buf := code.Next()
+			err := a.encodeThreeRegistersToRegister(buf, &nodeImpl{
 				instruction: tc.inst, srcReg: src1, srcReg2: src2, dstReg: src3, dstReg2: dst,
 			})
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual[:4])
 		})
 	}
@@ -3705,11 +3760,15 @@ func TestAssemblerImpl_encodeTwoVectorRegistersToVectorRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeTwoVectorRegistersToVectorRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeTwoVectorRegistersToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -3787,11 +3846,15 @@ func TestAssemblerImpl_EncodeRegisterToVectorRegister(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeRegisterToVectorRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeRegisterToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -3888,6 +3951,9 @@ func TestAssemblerImpl_maybeFlushConstPool(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
 			sc := asm.NewStaticConst(tc.c)
 			a.pool.AddConst(sc, 0)
@@ -3898,10 +3964,11 @@ func TestAssemblerImpl_maybeFlushConstPool(t *testing.T) {
 			})
 
 			a.MaxDisplacementForConstantPool = 0
-			a.maybeFlushConstPool(false)
+			buf := code.Next()
+			a.maybeFlushConstPool(buf, false)
 			require.True(t, called)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual)
 		})
 	}
@@ -3974,14 +4041,19 @@ func TestAssemblerImpl_EncodeStaticConstToVectorRegister(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeStaticConstToVectorRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeStaticConstToVectorRegister(buf, tc.n)
 			require.NoError(t, err)
-			a.maybeFlushConstPool(true)
+			a.maybeFlushConstPool(buf, true)
 
-			actual, err := a.Assemble()
+			err = a.Assemble(buf)
 			require.NoError(t, err)
 
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}
@@ -4015,25 +4087,27 @@ func TestAssemblerImpl_encodeADR_staticConst(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			sc := asm.NewStaticConst([]byte{1, 2, 3, 4}) // Arbitrary data is fine.
 
 			a := NewAssembler(asm.NilRegister)
 
-			a.buf.Write(make([]byte, beforeADRByteNum))
+			buf := code.Next()
+			buf.Write(make([]byte, beforeADRByteNum))
 
-			err := a.encodeADR(&nodeImpl{instruction: ADR, dstReg: tc.reg, staticConst: sc})
+			err := a.encodeADR(buf, &nodeImpl{instruction: ADR, dstReg: tc.reg, staticConst: sc})
 			require.NoError(t, err)
-
 			require.Equal(t, 1, len(a.pool.Consts))
 			require.Equal(t, sc, a.pool.Consts[0])
-
 			require.Equal(t, beforeADRByteNum, a.pool.FirstUseOffsetInBinary)
 
 			// Finalize the ADR instruction bytes.
 			sc.SetOffsetInBinary(tc.offsetOfConstInBinary)
 
-			actualBytes := a.buf.Bytes()[beforeADRByteNum : beforeADRByteNum+4]
-			require.Equal(t, tc.expADRInstructionBytes, actualBytes, hex.EncodeToString(actualBytes))
+			actual := buf.Bytes()[beforeADRByteNum : beforeADRByteNum+4]
+			require.Equal(t, tc.expADRInstructionBytes, actual, hex.EncodeToString(actual))
 		})
 	}
 }

--- a/internal/asm/arm64/impl_2_test.go
+++ b/internal/asm/arm64/impl_2_test.go
@@ -37,7 +37,7 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeConstToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -1389,7 +1389,7 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAssembler(RegR27)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeConstToRegister(buf, tc.n)
 			require.NoError(t, err)
 

--- a/internal/asm/arm64/impl_2_test.go
+++ b/internal/asm/arm64/impl_2_test.go
@@ -31,10 +31,14 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeConstToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeConstToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -1378,15 +1382,21 @@ func TestAssemblerImpl_EncodeConstToRegister(t *testing.T) {
 		{name: "LSR/dst=R30/0x3f", n: &nodeImpl{instruction: LSR, dstReg: RegR30, srcConst: 63}, exp: []byte{0xde, 0xff, 0x7f, 0xd3}},
 	}
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAssembler(RegR27)
-			err := a.encodeConstToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeConstToRegister(buf, tc.n)
 			require.NoError(t, err)
 
-			actual, err := a.Assemble()
+			err = a.Assemble(buf)
 			require.NoError(t, err)
+
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual, hex.EncodeToString(actual))
 		})
 	}

--- a/internal/asm/arm64/impl_3_test.go
+++ b/internal/asm/arm64/impl_3_test.go
@@ -23,10 +23,14 @@ func TestAssemblerImpl_EncodeTwoRegistersToRegister(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeTwoRegistersToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeTwoRegistersToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -599,11 +603,15 @@ func TestAssemblerImpl_EncodeTwoRegistersToRegister(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeTwoRegistersToRegister(&nodeImpl{instruction: tc.inst, srcReg: tc.src, srcReg2: tc.src2, dstReg: tc.dst})
+			buf := code.Next()
+			err := a.encodeTwoRegistersToRegister(buf, &nodeImpl{instruction: tc.inst, srcReg: tc.src, srcReg2: tc.src2, dstReg: tc.dst})
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual[:4])
 		})
 	}
@@ -638,10 +646,14 @@ func TestAssemblerImpl_EncodeRegisterAndConstToNone(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeRegisterAndConstToNone(tc.n)
+			buf := code.Next()
+			err := a.encodeRegisterAndConstToNone(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -672,11 +684,15 @@ func TestAssemblerImpl_EncodeRegisterAndConstToNone(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeRegisterAndConstToNone(&nodeImpl{instruction: tc.inst, srcReg: tc.reg, srcConst: tc.c})
+			buf := code.Next()
+			err := a.encodeRegisterAndConstToNone(buf, &nodeImpl{instruction: tc.inst, srcReg: tc.reg, srcConst: tc.c})
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual[:4])
 		})
 	}
@@ -697,10 +713,14 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeRegisterToRegister(tc.n)
+			buf := code.Next()
+			err := a.encodeRegisterToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -1193,11 +1213,15 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeRegisterToRegister(&nodeImpl{instruction: tc.inst, srcReg: tc.src, dstReg: tc.dst})
+			buf := code.Next()
+			err := a.encodeRegisterToRegister(buf, &nodeImpl{instruction: tc.inst, srcReg: tc.src, dstReg: tc.dst})
 			require.NoError(t, err)
 
-			actual := a.buf.Bytes()
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual[:4], hex.EncodeToString(actual[:4]))
 		})
 	}

--- a/internal/asm/arm64/impl_3_test.go
+++ b/internal/asm/arm64/impl_3_test.go
@@ -29,7 +29,7 @@ func TestAssemblerImpl_EncodeTwoRegistersToRegister(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeTwoRegistersToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -607,7 +607,7 @@ func TestAssemblerImpl_EncodeTwoRegistersToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeTwoRegistersToRegister(buf, &nodeImpl{instruction: tc.inst, srcReg: tc.src, srcReg2: tc.src2, dstReg: tc.dst})
 			require.NoError(t, err)
 
@@ -652,7 +652,7 @@ func TestAssemblerImpl_EncodeRegisterAndConstToNone(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterAndConstToNone(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -688,7 +688,7 @@ func TestAssemblerImpl_EncodeRegisterAndConstToNone(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterAndConstToNone(buf, &nodeImpl{instruction: tc.inst, srcReg: tc.reg, srcConst: tc.c})
 			require.NoError(t, err)
 
@@ -719,7 +719,7 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -1217,7 +1217,7 @@ func TestAssemblerImpl_EncodeRegisterToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToRegister(buf, &nodeImpl{instruction: tc.inst, srcReg: tc.src, dstReg: tc.dst})
 			require.NoError(t, err)
 

--- a/internal/asm/arm64/impl_4_test.go
+++ b/internal/asm/arm64/impl_4_test.go
@@ -36,7 +36,7 @@ func TestAssemblerImpl_encodeJumpToRegister(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeJumpToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -93,7 +93,7 @@ func TestAssemblerImpl_encodeJumpToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeJumpToRegister(buf, &nodeImpl{instruction: tc.inst, dstReg: tc.reg})
 			require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeMemoryToRegister(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -666,7 +666,7 @@ func TestAssemblerImpl_EncodeMemoryToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			a := NewAssembler(RegR27)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeMemoryToRegister(buf, tc.n)
 			require.NoError(t, err)
 
@@ -716,7 +716,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 				a.CompileConstToRegister(MOVD, 0x3e8, RegR10) // Target.
 				target := a.current
 
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.Assemble(buf)
 				require.NoError(t, err)
 				// The binary should start with ADR instruction.
@@ -754,7 +754,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 		a.CompileReadInstructionAddress(RegR27, NOP)
 		a.CompileConstToRegister(MOVD, 1000, RegR10)
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		err := a.Assemble(buf)
 		require.EqualError(t, err, "BUG: target instruction NOP not found for ADR")
 	})
@@ -774,7 +774,7 @@ func TestAssemblerImpl_encodeReadInstructionAddress(t *testing.T) {
 				a.CompileJumpToRegister(RET, RegR25)
 				a.CompileConstToRegister(MOVD, 1000, RegR10)
 
-				buf := code.Next()
+				buf := code.NextCodeSection()
 
 				for n := a.root; n != nil; n = n.next {
 					n.offsetInBinary = uint64(buf.Len())

--- a/internal/asm/arm64/impl_5_test.go
+++ b/internal/asm/arm64/impl_5_test.go
@@ -25,7 +25,7 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToMemory(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
@@ -814,7 +814,7 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 			a := NewAssembler(RegR27)
 			tc.n.types = operandTypesRegisterToMemory
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.encodeRegisterToMemory(buf, tc.n)
 			require.NoError(t, err)
 

--- a/internal/asm/arm64/impl_5_test.go
+++ b/internal/asm/arm64/impl_5_test.go
@@ -19,10 +19,14 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 			},
 		}
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		for _, tt := range tests {
 			tc := tt
 			a := NewAssembler(asm.NilRegister)
-			err := a.encodeRegisterToMemory(tc.n)
+			buf := code.Next()
+			err := a.encodeRegisterToMemory(buf, tc.n)
 			require.EqualError(t, err, tc.expErr)
 		}
 	})
@@ -804,12 +808,20 @@ func TestAssemblerImpl_EncodeRegisterToMemory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(RegR27)
 			tc.n.types = operandTypesRegisterToMemory
-			err := a.encodeRegisterToMemory(tc.n)
+
+			buf := code.Next()
+			err := a.encodeRegisterToMemory(buf, tc.n)
 			require.NoError(t, err)
-			actual, err := a.Assemble()
+
+			err = a.Assemble(buf)
 			require.NoError(t, err)
+
+			actual := buf.Bytes()
 			require.Equal(t, tc.exp, actual)
 		})
 	}

--- a/internal/asm/arm64/impl_6_test.go
+++ b/internal/asm/arm64/impl_6_test.go
@@ -40,7 +40,7 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 				a := NewAssembler(asm.NilRegister)
 				n := &nodeImpl{instruction: tc.inst, types: operandTypesNoneToBranch, offsetInBinary: 0, jumpTarget: &nodeImpl{offsetInBinary: tc.offset}}
 
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.encodeRelativeBranch(buf, n)
 				require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 
 				a := NewAssembler(asm.NilRegister)
 
-				buf := code.Next()
+				buf := code.NextCodeSection()
 				err := a.encodeRelativeBranch(buf, tc.n)
 				if err != nil {
 					require.EqualError(t, err, tc.expErr)
@@ -383,7 +383,7 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 				br.AssignJumpTarget(backwardTarget)
 			}
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			err := a.Assemble(buf)
 			require.NoError(t, err)
 

--- a/internal/asm/arm64/impl_6_test.go
+++ b/internal/asm/arm64/impl_6_test.go
@@ -34,11 +34,17 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			t.Run(tc.name, func(t *testing.T) {
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				a := NewAssembler(asm.NilRegister)
 				n := &nodeImpl{instruction: tc.inst, types: operandTypesNoneToBranch, offsetInBinary: 0, jumpTarget: &nodeImpl{offsetInBinary: tc.offset}}
-				err := a.encodeRelativeBranch(n)
+
+				buf := code.Next()
+				err := a.encodeRelativeBranch(buf, n)
 				require.NoError(t, err)
-				_, err = a.Assemble()
+
+				err = a.Assemble(buf)
 				require.NoError(t, err)
 			})
 		}
@@ -70,12 +76,17 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 		for _, tt := range tests {
 			tc := tt
 			t.Run(tc.expErr, func(t *testing.T) {
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				a := NewAssembler(asm.NilRegister)
-				err := a.encodeRelativeBranch(tc.n)
+
+				buf := code.Next()
+				err := a.encodeRelativeBranch(buf, tc.n)
 				if err != nil {
 					require.EqualError(t, err, tc.expErr)
 				} else {
-					_, err = a.Assemble()
+					err = a.Assemble(buf)
 					require.EqualError(t, err, tc.expErr)
 				}
 			})
@@ -348,6 +359,9 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			a := NewAssembler(asm.NilRegister)
 
 			for i := 0; i < tc.instructionsInPreamble; i++ {
@@ -369,9 +383,11 @@ func TestAssemblerImpl_EncodeRelativeJump(t *testing.T) {
 				br.AssignJumpTarget(backwardTarget)
 			}
 
-			actual, err := a.Assemble()
+			buf := code.Next()
+			err := a.Assemble(buf)
 			require.NoError(t, err)
 
+			actual := buf.Bytes()
 			require.Equal(t, tc.expHex, hex.EncodeToString(actual))
 		})
 	}

--- a/internal/asm/assembler.go
+++ b/internal/asm/assembler.go
@@ -140,7 +140,7 @@ type AssemblerBase interface {
 	Reset()
 
 	// Assemble produces the final binary for the assembled operations.
-	Assemble() ([]byte, error)
+	Assemble(Buffer) error
 
 	// SetJumpTargetOnNext instructs the assembler that the next node must be
 	// assigned to the given node's jump destination.

--- a/internal/asm/buffer.go
+++ b/internal/asm/buffer.go
@@ -107,7 +107,7 @@ func (seg *CodeSegment) Bytes() []byte {
 //
 // Buffers are passed by value, but they hold a reference to the code segment
 // that they were created from.
-func (seg *CodeSegment) Next() Buffer {
+func (seg *CodeSegment) NextCodeSection() Buffer {
 	// Align 16-bytes boundary.
 	seg.appendBytes(zero[:seg.size&15])
 	return Buffer{seg: seg, off: seg.size}

--- a/internal/asm/buffer.go
+++ b/internal/asm/buffer.go
@@ -202,22 +202,19 @@ func (buf Buffer) Truncate(n int) {
 	buf.seg.size = buf.off + n
 }
 
+func (buf Buffer) WriteByte(b byte) {
+	buf.seg.writeByte(b)
+}
+
+func (buf Buffer) WriteUint32(u uint32) {
+	buf.seg.writeUint32(u)
+}
+
+func (buf Buffer) Write4Bytes(a, b, c, d byte) {
+	buf.seg.writeUint32(uint32(a) | uint32(b)<<8 | uint32(c)<<16 | uint32(d)<<24)
+}
+
 func (buf Buffer) Write(b []byte) (int, error) {
 	buf.seg.write(b)
 	return len(b), nil
-}
-
-func (buf Buffer) WriteByte(b byte) error {
-	buf.seg.writeByte(b)
-	return nil
-}
-
-func (buf Buffer) WriteUint32(u uint32) error {
-	buf.seg.writeUint32(u)
-	return nil
-}
-
-func (buf Buffer) Write4Bytes(a, b, c, d byte) error {
-	buf.seg.writeUint32(uint32(a) | uint32(b)<<8 | uint32(c)<<16 | uint32(d)<<24)
-	return nil
 }

--- a/internal/asm/buffer.go
+++ b/internal/asm/buffer.go
@@ -10,6 +10,17 @@ import (
 
 var zero [16]byte
 
+// CodeSegment represents a memory mapped segment where native CPU instructions
+// are written.
+//
+// To construct code segments, the program must call Next to obtain a buffer
+// view capable of writing data at the end of the segment. Next must be called
+// before generating the code of a function because it aligns the next write on
+// 16 bytes.
+//
+// Instances of CodeSegment hold references to memory which is NOT managed by
+// the garbage collector and therefore must be released *manually* by calling
+// their Unmap method to prevent memory leaks.
 type CodeSegment struct {
 	code []byte
 	size int
@@ -119,6 +130,8 @@ func (seg *CodeSegment) grow(n int) {
 	seg.code = b
 }
 
+// Buffer is a reference type representing a section beginning at the end of a
+// code segment where new instructions can be written.
 type Buffer struct {
 	seg *CodeSegment
 	off int

--- a/internal/asm/buffer.go
+++ b/internal/asm/buffer.go
@@ -109,7 +109,7 @@ func (seg *CodeSegment) Bytes() []byte {
 // that they were created from.
 func (seg *CodeSegment) Next() Buffer {
 	// Align 16-bytes boundary.
-	seg.write(zero[:seg.size&15])
+	seg.appendBytes(zero[:seg.size&15])
 	return Buffer{seg: seg, off: seg.size}
 }
 
@@ -123,11 +123,7 @@ func (seg *CodeSegment) append(n int) []byte {
 	return seg.code[i:j:j]
 }
 
-func (seg *CodeSegment) write(b []byte) {
-	copy(seg.append(len(b)), b)
-}
-
-func (seg *CodeSegment) writeByte(b byte) {
+func (seg *CodeSegment) appendByte(b byte) {
 	seg.size++
 	if seg.size > len(seg.code) {
 		seg.grow(0)
@@ -135,7 +131,11 @@ func (seg *CodeSegment) writeByte(b byte) {
 	seg.code[seg.size-1] = b
 }
 
-func (seg *CodeSegment) writeUint32(u uint32) {
+func (seg *CodeSegment) appendBytes(b []byte) {
+	copy(seg.append(len(b)), b)
+}
+
+func (seg *CodeSegment) appendUint32(u uint32) {
 	seg.size += 4
 	if seg.size > len(seg.code) {
 		seg.grow(0)
@@ -198,23 +198,22 @@ func (buf Buffer) Append(n int) []byte {
 	return buf.seg.append(n)
 }
 
+func (buf Buffer) AppendByte(b byte) {
+	buf.seg.appendByte(b)
+}
+
+func (buf Buffer) AppendBytes(b []byte) {
+	buf.seg.appendBytes(b)
+}
+
+func (buf Buffer) Append4Bytes(a, b, c, d byte) {
+	buf.seg.appendUint32(uint32(a) | uint32(b)<<8 | uint32(c)<<16 | uint32(d)<<24)
+}
+
+func (buf Buffer) AppendUint32(u uint32) {
+	buf.seg.appendUint32(u)
+}
+
 func (buf Buffer) Truncate(n int) {
 	buf.seg.size = buf.off + n
-}
-
-func (buf Buffer) WriteByte(b byte) {
-	buf.seg.writeByte(b)
-}
-
-func (buf Buffer) WriteUint32(u uint32) {
-	buf.seg.writeUint32(u)
-}
-
-func (buf Buffer) Write4Bytes(a, b, c, d byte) {
-	buf.seg.writeUint32(uint32(a) | uint32(b)<<8 | uint32(c)<<16 | uint32(d)<<24)
-}
-
-func (buf Buffer) Write(b []byte) (int, error) {
-	buf.seg.write(b)
-	return len(b), nil
 }

--- a/internal/asm/buffer.go
+++ b/internal/asm/buffer.go
@@ -1,0 +1,206 @@
+package asm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+)
+
+var zero [16]byte
+
+type CodeSegment struct {
+	code []byte
+	size int
+}
+
+func MakeCodeSegment(code []byte) CodeSegment {
+	return CodeSegment{code: code}
+}
+
+func (seg *CodeSegment) Map(size int) error {
+	if seg.code != nil {
+		return fmt.Errorf("code segment already initialized to memory mapping of size %d", len(seg.code))
+	}
+	b, err := platform.MmapCodeSegment(size)
+	if err != nil {
+		return err
+	}
+	seg.code = b
+	seg.size = 0
+	return nil
+}
+
+func (seg *CodeSegment) Unmap() error {
+	if seg.code != nil {
+		if err := platform.MunmapCodeSegment(seg.code[:cap(seg.code)]); err != nil {
+			return err
+		}
+		seg.code = nil
+	}
+	return nil
+}
+
+func (seg *CodeSegment) Addr() uintptr {
+	if len(seg.code) > 0 {
+		return uintptr(unsafe.Pointer(&seg.code[0]))
+	}
+	return 0
+}
+
+func (seg *CodeSegment) Size() uintptr {
+	return uintptr(seg.size)
+}
+
+func (seg *CodeSegment) Len() int {
+	return len(seg.code)
+}
+
+func (seg *CodeSegment) Bytes() []byte {
+	return seg.code
+}
+
+func (seg *CodeSegment) Next() Buffer {
+	// Align 16-bytes boundary.
+	seg.write(zero[:seg.size&15])
+	return Buffer{seg: seg, off: seg.size}
+}
+
+func (seg *CodeSegment) write(b []byte) {
+	i := seg.size
+	j := seg.size + len(b)
+	if j > len(seg.code) {
+		seg.grow(len(b))
+	}
+	seg.size += copy(seg.code[i:j], b)
+}
+
+func (seg *CodeSegment) writeByte(b byte) {
+	seg.size++
+	if seg.size > len(seg.code) {
+		seg.grow(0)
+	}
+	seg.code[seg.size-1] = b
+}
+
+func (seg *CodeSegment) writeUint16(u uint16) {
+	seg.size += 2
+	if seg.size > len(seg.code) {
+		seg.grow(0)
+	}
+	binary.LittleEndian.PutUint16(seg.code[seg.size-2:seg.size], u)
+}
+
+func (seg *CodeSegment) writeUint32(u uint32) {
+	seg.size += 4
+	if seg.size > len(seg.code) {
+		seg.grow(0)
+	}
+	binary.LittleEndian.PutUint32(seg.code[seg.size-4:seg.size], u)
+}
+
+func (seg *CodeSegment) writeUint64(u uint64) {
+	seg.size += 8
+	if seg.size > len(seg.code) {
+		seg.grow(0)
+	}
+	binary.LittleEndian.PutUint64(seg.code[seg.size-8:seg.size], u)
+}
+
+func (seg *CodeSegment) grow(n int) {
+	size := len(seg.code)
+	want := seg.size + n
+	if size >= want {
+		return
+	}
+	if size == 0 {
+		size = 65536
+	}
+	for size < want {
+		size *= 2
+	}
+	if len(seg.code) == size {
+		panic(fmt.Errorf("remapping to same segment size: %d", size))
+	}
+	b, err := platform.RemapCodeSegment(seg.code, size)
+	if err != nil {
+		// The only reason for growing the buffer to error is if we run
+		// out of memory, so panic for now as it greatly simplifies error
+		// handling to assume writing to the buffer would never fail.
+		panic(err)
+	}
+	seg.code = b
+}
+
+type Buffer struct {
+	seg *CodeSegment
+	off int
+}
+
+func (buf Buffer) Cap() int {
+	return len(buf.seg.code) - buf.off
+}
+
+func (buf Buffer) Len() int {
+	return buf.seg.size - buf.off
+}
+
+func (buf Buffer) Bytes() []byte {
+	i := buf.off
+	j := buf.seg.size
+	return buf.seg.Bytes()[i:j:j]
+}
+
+func (buf Buffer) Write(b []byte) (int, error) {
+	buf.seg.write(b)
+	return len(b), nil
+}
+
+func (buf Buffer) WriteByte(b byte) error {
+	buf.seg.writeByte(b)
+	return nil
+}
+
+func (buf Buffer) WriteUint16(u uint16) error {
+	buf.seg.writeUint16(u)
+	return nil
+}
+
+func (buf Buffer) WriteUint32(u uint32) error {
+	buf.seg.writeUint32(u)
+	return nil
+}
+
+func (buf Buffer) WriteUint64(u uint64) error {
+	buf.seg.writeUint64(u)
+	return nil
+}
+
+func (buf Buffer) Write2Bytes(a, b byte) error {
+	buf.seg.writeUint16(uint16(a) | uint16(b)<<8)
+	return nil
+}
+
+func (buf Buffer) Write3Bytes(a, b, c byte) error {
+	buf.Write4Bytes(a, b, c, 0)
+	buf.seg.size--
+	return nil
+}
+
+func (buf Buffer) Write4Bytes(a, b, c, d byte) error {
+	buf.seg.writeUint32(uint32(a) | uint32(b)<<8 | uint32(c)<<16 | uint32(d)<<24)
+	return nil
+}
+
+func (buf Buffer) Grow(n int) {
+	buf.seg.grow(n)
+}
+
+func (buf Buffer) Reset() {
+	buf.seg.size = buf.off
+}
+
+func (buf Buffer) Truncate(n int) {
+	buf.seg.size = buf.off + n
+}

--- a/internal/asm/buffer_test.go
+++ b/internal/asm/buffer_test.go
@@ -1,7 +1,6 @@
 package asm_test
 
 import (
-	"io"
 	"testing"
 	"unsafe"
 
@@ -42,22 +41,12 @@ func TestCodeSegmentMapUnmap(t *testing.T) {
 	})
 }
 
-func TestBufferWrite(t *testing.T) {
-	withBuffer(t, func(buf asm.Buffer) {
-		_, err := io.WriteString(buf, "Hello World!")
-		require.NoError(t, err)
-		require.NotEqual(t, 0, buf.Cap())
-		require.Equal(t, 12, buf.Len())
-		require.Equal(t, []byte("Hello World!"), buf.Bytes())
-	})
-}
-
-func TestBufferWriteByte(t *testing.T) {
+func TestBufferAppendByte(t *testing.T) {
 	withBuffer(t, func(buf asm.Buffer) {
 		data := []byte("Hello World!")
 
 		for i, c := range data {
-			buf.WriteByte(c)
+			buf.AppendByte(c)
 			require.NotEqual(t, 0, buf.Cap())
 			require.Equal(t, i+1, buf.Len())
 			require.Equal(t, data[:i+1], buf.Bytes())
@@ -65,13 +54,22 @@ func TestBufferWriteByte(t *testing.T) {
 	})
 }
 
-func TestBufferWriteUint32(t *testing.T) {
+func TestBufferAppendBytes(t *testing.T) {
+	withBuffer(t, func(buf asm.Buffer) {
+		buf.AppendBytes([]byte("Hello World!"))
+		require.NotEqual(t, 0, buf.Cap())
+		require.Equal(t, 12, buf.Len())
+		require.Equal(t, []byte("Hello World!"), buf.Bytes())
+	})
+}
+
+func TestBufferAppendUint32(t *testing.T) {
 	withBuffer(t, func(buf asm.Buffer) {
 		values := []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 		bytes := unsafe.Slice(*(**byte)(unsafe.Pointer(&values)), 4*len(values))
 
 		for i, v := range values {
-			buf.WriteUint32(v)
+			buf.AppendUint32(v)
 			require.NotEqual(t, 0, buf.Cap())
 			require.Equal(t, 4*(i+1), buf.Len())
 			require.Equal(t, bytes[:4*(i+1)], buf.Bytes())
@@ -81,8 +79,7 @@ func TestBufferWriteUint32(t *testing.T) {
 
 func TestBufferReset(t *testing.T) {
 	withBuffer(t, func(buf asm.Buffer) {
-		_, err := io.WriteString(buf, "Hello World!")
-		require.NoError(t, err)
+		buf.AppendBytes([]byte("Hello World!"))
 		require.NotEqual(t, 0, buf.Cap())
 		require.Equal(t, 12, buf.Len())
 		require.Equal(t, []byte("Hello World!"), buf.Bytes())
@@ -95,8 +92,7 @@ func TestBufferReset(t *testing.T) {
 
 func TestBufferTruncate(t *testing.T) {
 	withBuffer(t, func(buf asm.Buffer) {
-		_, err := io.WriteString(buf, "Hello World!")
-		require.NoError(t, err)
+		buf.AppendBytes([]byte("Hello World!"))
 		require.NotEqual(t, 0, buf.Cap())
 		require.Equal(t, 12, buf.Len())
 		require.Equal(t, []byte("Hello World!"), buf.Bytes())

--- a/internal/asm/buffer_test.go
+++ b/internal/asm/buffer_test.go
@@ -15,7 +15,7 @@ func TestCodeSegmentZeroValue(t *testing.T) {
 		require.Equal(t, 0, code.Len())
 		require.Equal(t, ([]byte)(nil), code.Bytes())
 
-		buf := code.Next()
+		buf := code.NextCodeSection()
 		require.Equal(t, 0, buf.Cap())
 		require.Equal(t, 0, buf.Len())
 		require.Equal(t, ([]byte)(nil), buf.Bytes())
@@ -113,7 +113,7 @@ func withBuffer(t *testing.T, f func(asm.Buffer)) {
 	withCodeSegment(t, func(code *asm.CodeSegment) {
 		// Repeat the test multiple times to ensure that Next works as expected.
 		for i := 0; i < 10; i++ {
-			f(code.Next())
+			f(code.NextCodeSection())
 		}
 	})
 }

--- a/internal/asm/buffer_test.go
+++ b/internal/asm/buffer_test.go
@@ -57,8 +57,7 @@ func TestBufferWriteByte(t *testing.T) {
 		data := []byte("Hello World!")
 
 		for i, c := range data {
-			err := buf.WriteByte(c)
-			require.NoError(t, err)
+			buf.WriteByte(c)
 			require.NotEqual(t, 0, buf.Cap())
 			require.Equal(t, i+1, buf.Len())
 			require.Equal(t, data[:i+1], buf.Bytes())
@@ -72,7 +71,7 @@ func TestBufferWriteUint32(t *testing.T) {
 		bytes := unsafe.Slice(*(**byte)(unsafe.Pointer(&values)), 4*len(values))
 
 		for i, v := range values {
-			require.NoError(t, buf.WriteUint32(v))
+			buf.WriteUint32(v)
 			require.NotEqual(t, 0, buf.Cap())
 			require.Equal(t, 4*(i+1), buf.Len())
 			require.Equal(t, bytes[:4*(i+1)], buf.Bytes())

--- a/internal/asm/buffer_test.go
+++ b/internal/asm/buffer_test.go
@@ -1,0 +1,124 @@
+package asm_test
+
+import (
+	"io"
+	"testing"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/internal/asm"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestCodeSegmentZeroValue(t *testing.T) {
+	withCodeSegment(t, func(code *asm.CodeSegment) {
+		require.Equal(t, uintptr(0), code.Addr())
+		require.Equal(t, uintptr(0), code.Size())
+		require.Equal(t, 0, code.Len())
+		require.Equal(t, ([]byte)(nil), code.Bytes())
+
+		buf := code.Next()
+		require.Equal(t, 0, buf.Cap())
+		require.Equal(t, 0, buf.Len())
+		require.Equal(t, ([]byte)(nil), buf.Bytes())
+	})
+}
+
+func TestCodeSegmentMapUnmap(t *testing.T) {
+	withCodeSegment(t, func(code *asm.CodeSegment) {
+		const size = 4096
+		require.NoError(t, code.Map(size))
+		require.NotEqual(t, uintptr(0), code.Addr())
+		require.Equal(t, uintptr(size), code.Size())
+		require.Equal(t, size, code.Len())
+		require.NotEqual(t, ([]byte)(nil), code.Bytes())
+
+		for i := 0; i < 3; i++ {
+			require.NoError(t, code.Unmap())
+			require.Equal(t, uintptr(0), code.Addr())
+			require.Equal(t, uintptr(0), code.Size())
+			require.Equal(t, 0, code.Len())
+			require.Equal(t, ([]byte)(nil), code.Bytes())
+		}
+	})
+}
+
+func TestBufferWrite(t *testing.T) {
+	withBuffer(t, func(buf asm.Buffer) {
+		_, err := io.WriteString(buf, "Hello World!")
+		require.NoError(t, err)
+		require.NotEqual(t, 0, buf.Cap())
+		require.Equal(t, 12, buf.Len())
+		require.Equal(t, []byte("Hello World!"), buf.Bytes())
+	})
+}
+
+func TestBufferWriteByte(t *testing.T) {
+	withBuffer(t, func(buf asm.Buffer) {
+		data := []byte("Hello World!")
+
+		for i, c := range data {
+			err := buf.WriteByte(c)
+			require.NoError(t, err)
+			require.NotEqual(t, 0, buf.Cap())
+			require.Equal(t, i+1, buf.Len())
+			require.Equal(t, data[:i+1], buf.Bytes())
+		}
+	})
+}
+
+func TestBufferWriteUint32(t *testing.T) {
+	withBuffer(t, func(buf asm.Buffer) {
+		values := []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		bytes := unsafe.Slice(*(**byte)(unsafe.Pointer(&values)), 4*len(values))
+
+		for i, v := range values {
+			require.NoError(t, buf.WriteUint32(v))
+			require.NotEqual(t, 0, buf.Cap())
+			require.Equal(t, 4*(i+1), buf.Len())
+			require.Equal(t, bytes[:4*(i+1)], buf.Bytes())
+		}
+	})
+}
+
+func TestBufferReset(t *testing.T) {
+	withBuffer(t, func(buf asm.Buffer) {
+		_, err := io.WriteString(buf, "Hello World!")
+		require.NoError(t, err)
+		require.NotEqual(t, 0, buf.Cap())
+		require.Equal(t, 12, buf.Len())
+		require.Equal(t, []byte("Hello World!"), buf.Bytes())
+
+		buf.Reset()
+		require.Equal(t, 0, buf.Len())
+		require.Equal(t, []byte{}, buf.Bytes())
+	})
+}
+
+func TestBufferTruncate(t *testing.T) {
+	withBuffer(t, func(buf asm.Buffer) {
+		_, err := io.WriteString(buf, "Hello World!")
+		require.NoError(t, err)
+		require.NotEqual(t, 0, buf.Cap())
+		require.Equal(t, 12, buf.Len())
+		require.Equal(t, []byte("Hello World!"), buf.Bytes())
+
+		buf.Truncate(5)
+		require.Equal(t, 5, buf.Len())
+		require.Equal(t, []byte("Hello"), buf.Bytes())
+	})
+}
+
+func withCodeSegment(t *testing.T, f func(*asm.CodeSegment)) {
+	code := asm.NewCodeSegment(nil)
+	defer func() { require.NoError(t, code.Unmap()) }()
+	f(code)
+}
+
+func withBuffer(t *testing.T, f func(asm.Buffer)) {
+	withCodeSegment(t, func(code *asm.CodeSegment) {
+		// Repeat the test multiple times to ensure that Next works as expected.
+		for i := 0; i < 10; i++ {
+			f(code.Next())
+		}
+	})
+}

--- a/internal/engine/compiler/compiler.go
+++ b/internal/engine/compiler/compiler.go
@@ -16,9 +16,9 @@ type compiler interface {
 	// compilePreamble is called before compiling any wazeroir operation.
 	// This is used, for example, to initialize the reserved registers, etc.
 	compilePreamble() error
-	// compile generates the byte slice of native code.
+	// compile generates the native code into buf.
 	// stackPointerCeil is the max stack pointer that the target function would reach.
-	compile() (code []byte, stackPointerCeil uint64, err error)
+	compile(buf asm.Buffer) (stackPointerCeil uint64, err error)
 	// compileGoHostFunction adds the trampoline code from which native code can jump into the Go-defined host function.
 	// TODO: maybe we wouldn't need to have trampoline for host functions.
 	compileGoDefinedHostFunction() error

--- a/internal/engine/compiler/compiler_bench_test.go
+++ b/internal/engine/compiler/compiler_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -18,6 +19,10 @@ func BenchmarkCompiler_compileMemoryCopy(b *testing.B) {
 		for _, overlap := range []bool{false, true} {
 			b.Run(fmt.Sprintf("%v-%v", size, overlap), func(b *testing.B) {
 				env := newCompilerEnvironment()
+				buf := asm.CodeSegment{}
+				defer func() {
+					require.NoError(b, buf.Unmap())
+				}()
 
 				mem := env.memory()
 				testMem := make([]byte, len(mem))
@@ -47,11 +52,12 @@ func BenchmarkCompiler_compileMemoryCopy(b *testing.B) {
 				err = compiler.compileMemoryCopy()
 				require.NoError(b, err)
 				err = compiler.(compilerImpl).compileReturnFunction()
+
 				require.NoError(b, err)
-				code, _, err := compiler.compile()
+				_, err = compiler.compile(buf.Next())
 				require.NoError(b, err)
 
-				env.execBench(b, code)
+				env.execBench(b, buf.Bytes())
 
 				for i := 0; i < b.N; i += 1 {
 					copy(testMem[destOffset:destOffset+size], testMem[sourceOffset:sourceOffset+size])
@@ -71,6 +77,10 @@ func BenchmarkCompiler_compileMemoryFill(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("%v", size), func(b *testing.B) {
 			env := newCompilerEnvironment()
+			buf := asm.CodeSegment{}
+			defer func() {
+				require.NoError(b, buf.Unmap())
+			}()
 
 			compiler := newCompiler()
 			compiler.Init(&wasm.FunctionType{}, &wazeroir.CompilationResult{HasMemory: true}, false)
@@ -91,7 +101,7 @@ func BenchmarkCompiler_compileMemoryFill(b *testing.B) {
 			require.NoError(b, err)
 			err = compiler.(compilerImpl).compileReturnFunction()
 			require.NoError(b, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(buf.Next())
 			require.NoError(b, err)
 
 			mem := env.memory()
@@ -101,7 +111,7 @@ func BenchmarkCompiler_compileMemoryFill(b *testing.B) {
 				testMem[i] = byte(i)
 			}
 
-			env.execBench(b, code)
+			env.execBench(b, buf.Bytes())
 
 			for i := startOffset; i < startOffset+size; i++ {
 				testMem[i] = value

--- a/internal/engine/compiler/compiler_bench_test.go
+++ b/internal/engine/compiler/compiler_bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkCompiler_compileMemoryCopy(b *testing.B) {
 				err = compiler.(compilerImpl).compileReturnFunction()
 
 				require.NoError(b, err)
-				_, err = compiler.compile(buf.Next())
+				_, err = compiler.compile(buf.NextCodeSection())
 				require.NoError(b, err)
 
 				env.execBench(b, buf.Bytes())
@@ -101,7 +101,7 @@ func BenchmarkCompiler_compileMemoryFill(b *testing.B) {
 			require.NoError(b, err)
 			err = compiler.(compilerImpl).compileReturnFunction()
 			require.NoError(b, err)
-			_, err = compiler.compile(buf.Next())
+			_, err = compiler.compile(buf.NextCodeSection())
 			require.NoError(b, err)
 
 			mem := env.memory()

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"testing"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -53,10 +54,13 @@ func TestCompiler_conditional_value_saving(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate and run the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	// expect 101 = 100(== the integer const) + 1 (== flag value == the result of (1.0 <= 1.0))
 	require.Equal(t, uint32(101), env.stackTopAsUint32())

--- a/internal/engine/compiler/compiler_conditional_save_test.go
+++ b/internal/engine/compiler/compiler_conditional_save_test.go
@@ -58,7 +58,7 @@ func TestCompiler_conditional_value_saving(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate and run the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 

--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -26,7 +26,7 @@ func TestCompiler_compileHostFunction(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate the machine code for the test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 
 	// Set the caller's function which always exists in the real usecase.
@@ -263,7 +263,7 @@ func TestCompiler_compileBrIf(t *testing.T) {
 					code := asm.CodeSegment{}
 					defer func() { require.NoError(t, code.Unmap()) }()
 
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 
 					// The generated code looks like this:
@@ -308,7 +308,7 @@ func TestCompiler_compileBrTable(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// Generate the code under test and run.
-		_, err := c.compile(code.Next())
+		_, err := c.compile(code.NextCodeSection())
 		require.NoError(t, err)
 		env.exec(code.Bytes())
 
@@ -509,7 +509,7 @@ func TestCompiler_compileBr(t *testing.T) {
 
 		// Compile and execute the code under test.
 		// Note: we don't invoke "compiler.return()" as the code emitted by compilerBr is enough to exit.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 		env.exec(code.Bytes())
 
@@ -549,7 +549,7 @@ func TestCompiler_compileBr(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		// The generated code looks like this:)
@@ -596,7 +596,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// Generate the code under test and run.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 		env.exec(code.Bytes())
 
@@ -634,7 +634,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// Generate the code under test and run.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 		env.exec(code.Bytes())
 
@@ -676,7 +676,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// Generate the code under test and run.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 		env.exec(code.Bytes())
 
@@ -725,7 +725,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 			code := asm.CodeSegment{}
 			defer func() { require.NoError(t, code.Unmap()) }()
 
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			makeExecutable(code.Bytes())
@@ -773,7 +773,7 @@ func TestCompiler_compileCallIndirect(t *testing.T) {
 				defer func() { require.NoError(t, code.Unmap()) }()
 
 				// Generate the code under test and run.
-				_, err = compiler.compile(code.Next())
+				_, err = compiler.compile(code.NextCodeSection())
 				require.NoError(t, err)
 				env.exec(code.Bytes())
 
@@ -817,7 +817,7 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		_, err = compiler.compile(code1.Next())
+		_, err = compiler.compile(code1.NextCodeSection())
 		require.NoError(t, err)
 
 		makeExecutable(code1.Bytes())
@@ -846,7 +846,7 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test and run.
-	_, err = compiler.compile(code2.Next())
+	_, err = compiler.compile(code2.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code2.Bytes())
 }
@@ -891,7 +891,7 @@ func TestCompiler_compileCall(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		makeExecutable(code.Bytes())
@@ -931,7 +931,7 @@ func TestCompiler_compileCall(t *testing.T) {
 	code := asm.CodeSegment{}
 	defer func() { require.NoError(t, code.Unmap()) }()
 
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -78,10 +79,13 @@ func TestCompiler_compileReinterpret(t *testing.T) {
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
 
+							code := asm.CodeSegment{}
+							defer func() { require.NoError(t, code.Unmap()) }()
+
 							// Generate and run the code under test.
-							code, _, err := compiler.compile()
+							_, err = compiler.compile(code.Next())
 							require.NoError(t, err)
-							env.exec(code)
+							env.exec(code.Bytes())
 
 							// Reinterpret must preserve the bit-pattern.
 							if is32Bit {
@@ -121,10 +125,13 @@ func TestCompiler_compileExtend(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate and run the code under test.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					require.Equal(t, uint64(1), env.stackPointer())
 					if signed {
@@ -209,10 +216,13 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate and run the code under test.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					// Check the result.
 					expStatus := nativeCallStatusCodeReturned
@@ -408,10 +418,13 @@ func TestCompiler_compileFConvertFromI(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate and run the code under test.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					// Check the result.
 					require.Equal(t, uint64(1), env.stackPointer())
@@ -479,10 +492,13 @@ func TestCompiler_compileF64PromoteFromF32(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			// Check the result.
 			require.Equal(t, uint64(1), env.stackPointer())
@@ -525,10 +541,13 @@ func TestCompiler_compileF32DemoteFromF64(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			// Check the result.
 			require.Equal(t, uint64(1), env.stackPointer())

--- a/internal/engine/compiler/compiler_conversion_test.go
+++ b/internal/engine/compiler/compiler_conversion_test.go
@@ -83,7 +83,7 @@ func TestCompiler_compileReinterpret(t *testing.T) {
 							defer func() { require.NoError(t, code.Unmap()) }()
 
 							// Generate and run the code under test.
-							_, err = compiler.compile(code.Next())
+							_, err = compiler.compile(code.NextCodeSection())
 							require.NoError(t, err)
 							env.exec(code.Bytes())
 
@@ -129,7 +129,7 @@ func TestCompiler_compileExtend(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate and run the code under test.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 
@@ -220,7 +220,7 @@ func TestCompiler_compileITruncFromF(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate and run the code under test.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 
@@ -422,7 +422,7 @@ func TestCompiler_compileFConvertFromI(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate and run the code under test.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 
@@ -496,7 +496,7 @@ func TestCompiler_compileF64PromoteFromF32(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -545,7 +545,7 @@ func TestCompiler_compileF32DemoteFromF64(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"testing"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -44,12 +45,15 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run the code assembled above.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			// Since we call global.get, the top of the stack must be the global value.
 			require.Equal(t, globalValue, env.stackTopAsUint64())
@@ -85,12 +89,15 @@ func TestCompiler_compileGlobalGet_v128(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
 
 	// Run the code assembled above.
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	require.Equal(t, uint64(2), env.stackPointer())
 	require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
@@ -147,10 +154,13 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			// The global value should be set to valueToSet.
 			actual := env.globals()[index]
@@ -193,10 +203,13 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	require.Equal(t, uint64(0), env.stackPointer())
 	require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)

--- a/internal/engine/compiler/compiler_global_test.go
+++ b/internal/engine/compiler/compiler_global_test.go
@@ -49,7 +49,7 @@ func TestCompiler_compileGlobalGet(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run the code assembled above.
@@ -93,7 +93,7 @@ func TestCompiler_compileGlobalGet_v128(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 
 	// Run the code assembled above.
@@ -158,7 +158,7 @@ func TestCompiler_compileGlobalSet(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -207,7 +207,7 @@ func TestCompiler_compileGlobalSet_v128(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -134,7 +134,7 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			env.exec(code.Bytes())
@@ -199,7 +199,7 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 				defer func() { require.NoError(t, code.Unmap()) }()
 
 				// Generate and run the code under test.
-				_, err = compiler.compile(code.Next())
+				_, err = compiler.compile(code.NextCodeSection())
 				require.NoError(t, err)
 				env.exec(code.Bytes())
 
@@ -246,7 +246,7 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 
 				// Generate code under test with the given stackPointerCeil.
 				compiler.setStackPointerCeil(tc.stackPointerCeil)
-				_, err = compiler.compile(code.Next())
+				_, err = compiler.compile(code.NextCodeSection())
 				require.NoError(t, err)
 
 				// And run the code with the specified stackBasePointer.

--- a/internal/engine/compiler/compiler_initialization_test.go
+++ b/internal/engine/compiler/compiler_initialization_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -129,11 +130,14 @@ func TestCompiler_compileModuleContextInitialization(t *testing.T) {
 
 			compiler.compileExitFromNativeCode(nativeCallStatusCodeReturned)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			// Check the exit status.
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
@@ -191,10 +195,13 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 
 				compiler.compileExitFromNativeCode(nativeCallStatusCodeReturned)
 
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				// Generate and run the code under test.
-				code, _, err := compiler.compile()
+				_, err = compiler.compile(code.Next())
 				require.NoError(t, err)
-				env.exec(code)
+				env.exec(code.Bytes())
 
 				// The status code must be "Returned", not "BuiltinFunctionCall".
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
@@ -234,14 +241,17 @@ func TestCompiler_compileMaybeGrowStack(t *testing.T) {
 				err = compiler.compileReturnFunction()
 				require.NoError(t, err)
 
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				// Generate code under test with the given stackPointerCeil.
 				compiler.setStackPointerCeil(tc.stackPointerCeil)
-				code, _, err := compiler.compile()
+				_, err = compiler.compile(code.Next())
 				require.NoError(t, err)
 
 				// And run the code with the specified stackBasePointer.
 				env.setStackBasePointer(tc.stackBasePointer)
-				env.exec(code)
+				env.exec(code.Bytes())
 
 				// Check if the call exits with builtin function call status.
 				require.Equal(t, nativeCallStatusCodeCallBuiltInFunction, env.compilerStatus())

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -28,10 +29,13 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate and run the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	// After the initial exec, the code must exit with builtin function call status and funcaddress for memory grow.
 	require.Equal(t, nativeCallStatusCodeCallBuiltInFunction, env.compilerStatus())
@@ -65,10 +69,13 @@ func TestCompiler_compileMemorySize(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate and run the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 	require.Equal(t, uint32(defaultMemoryPageNumInTest), env.stackTopAsUint32())
@@ -261,10 +268,13 @@ func TestCompiler_compileLoad(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			// Verify the loaded value.
 			require.Equal(t, uint64(1), env.stackPointer())
@@ -393,10 +403,13 @@ func TestCompiler_compileStore(t *testing.T) {
 			require.Zero(t, len(compiler.runtimeValueLocationStack().usedRegisters.list()))
 			requireRuntimeLocationStackPointerEqual(t, uint64(0), compiler)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Set the value on the left and right neighboring memoryregion,
@@ -408,7 +421,7 @@ func TestCompiler_compileStore(t *testing.T) {
 			binary.LittleEndian.PutUint64(mem[ceil:ceil+8], expectedNeighbor8Bytes)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			tc.storedValueVerifyFn(t, mem)
 
@@ -461,13 +474,15 @@ func TestCompiler_MemoryOutOfBounds(t *testing.T) {
 					}
 
 					require.NoError(t, err)
-
 					require.NoError(t, compiler.compileReturnFunction())
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate the code under test and run.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					mem := env.memory()
 					if ceil := int64(base) + int64(offset) + int64(targetSizeInByte); int64(len(mem)) < ceil {

--- a/internal/engine/compiler/compiler_memory_test.go
+++ b/internal/engine/compiler/compiler_memory_test.go
@@ -33,7 +33,7 @@ func TestCompiler_compileMemoryGrow(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate and run the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 
@@ -73,7 +73,7 @@ func TestCompiler_compileMemorySize(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate and run the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 
@@ -272,7 +272,7 @@ func TestCompiler_compileLoad(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -409,7 +409,7 @@ func TestCompiler_compileStore(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Set the value on the left and right neighboring memoryregion,
@@ -480,7 +480,7 @@ func TestCompiler_MemoryOutOfBounds(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate the code under test and run.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -6,6 +6,7 @@ import (
 	"math/bits"
 	"testing"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/moremath"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -68,12 +69,15 @@ func TestCompiler_compileConsts(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate the code under test.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
 
 					// Run native code.
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					// Compiler status must be returned.
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
@@ -193,10 +197,13 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
 
+							code := asm.CodeSegment{}
+							defer func() { require.NoError(t, code.Unmap()) }()
+
 							// Compile and execute the code under test.
-							code, _, err := compiler.compile()
+							_, err = compiler.compile(code.Next())
 							require.NoError(t, err)
-							env.exec(code)
+							env.exec(code.Bytes())
 
 							// Check the stack.
 							require.Equal(t, uint64(1), env.stackPointer())
@@ -370,10 +377,13 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								err = compiler.compileReturnFunction()
 								require.NoError(t, err)
 
+								code := asm.CodeSegment{}
+								defer func() { require.NoError(t, code.Unmap()) }()
+
 								// Compile and execute the code under test.
-								code, _, err := compiler.compile()
+								_, err = compiler.compile(code.Next())
 								require.NoError(t, err)
-								env.exec(code)
+								env.exec(code.Bytes())
 
 								// Check the stack.
 								require.Equal(t, uint64(1), env.stackPointer())
@@ -494,10 +504,13 @@ func TestCompiler_compileShr(t *testing.T) {
 						err = compiler.compileReturnFunction()
 						require.NoError(t, err)
 
+						code := asm.CodeSegment{}
+						defer func() { require.NoError(t, code.Unmap()) }()
+
 						// Compile and execute the code under test.
-						code, _, err := compiler.compile()
+						_, err = compiler.compile(code.Next())
 						require.NoError(t, err)
-						env.exec(code)
+						env.exec(code.Bytes())
 
 						// Check the stack.
 						require.Equal(t, uint64(1), env.stackPointer())
@@ -667,10 +680,13 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
 
+							code := asm.CodeSegment{}
+							defer func() { require.NoError(t, code.Unmap()) }()
+
 							// Compile and execute the code under test.
-							code, _, err := compiler.compile()
+							_, err = compiler.compile(code.Next())
 							require.NoError(t, err)
-							env.exec(code)
+							env.exec(code.Bytes())
 
 							// There should only be one value on the stack
 							require.Equal(t, uint64(1), env.stackPointer())
@@ -822,10 +838,13 @@ func TestCompiler_compile_Clz_Ctz_Popcnt(t *testing.T) {
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
 
+							code := asm.CodeSegment{}
+							defer func() { require.NoError(t, code.Unmap()) }()
+
 							// Generate and run the code under test.
-							code, _, err := compiler.compile()
+							_, err = compiler.compile(code.Next())
 							require.NoError(t, err)
-							env.exec(code)
+							env.exec(code.Bytes())
 
 							// One value must be pushed as a result.
 							require.Equal(t, uint64(1), env.stackPointer())
@@ -1039,10 +1058,13 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate and run the code under test.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 					require.Equal(t, uint64(1), env.stackPointer()) // Result must be pushed!
@@ -1342,10 +1364,13 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					err = compiler.compileReturnFunction()
 					require.NoError(t, err)
 
+					code := asm.CodeSegment{}
+					defer func() { require.NoError(t, code.Unmap()) }()
+
 					// Generate and run the code under test.
-					code, _, err := compiler.compile()
+					_, err = compiler.compile(code.Next())
 					require.NoError(t, err)
-					env.exec(code)
+					env.exec(code.Bytes())
 
 					require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 					require.Equal(t, uint64(1), env.stackPointer()) // Result must be pushed!
@@ -1487,10 +1512,13 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 							err = compiler.compileReturnFunction()
 							require.NoError(t, err)
 
+							code := asm.CodeSegment{}
+							defer func() { require.NoError(t, code.Unmap()) }()
+
 							// Compile and execute the code under test.
-							code, _, err := compiler.compile()
+							_, err = compiler.compile(code.Next())
 							require.NoError(t, err)
-							env.exec(code)
+							env.exec(code.Bytes())
 
 							switch kind {
 							case wazeroir.OperationKindDiv:

--- a/internal/engine/compiler/compiler_numeric_test.go
+++ b/internal/engine/compiler/compiler_numeric_test.go
@@ -73,7 +73,7 @@ func TestCompiler_compileConsts(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate the code under test.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 
 					// Run native code.
@@ -201,7 +201,7 @@ func TestCompiler_compile_Add_Sub_Mul(t *testing.T) {
 							defer func() { require.NoError(t, code.Unmap()) }()
 
 							// Compile and execute the code under test.
-							_, err = compiler.compile(code.Next())
+							_, err = compiler.compile(code.NextCodeSection())
 							require.NoError(t, err)
 							env.exec(code.Bytes())
 
@@ -381,7 +381,7 @@ func TestCompiler_compile_And_Or_Xor_Shl_Rotl_Rotr(t *testing.T) {
 								defer func() { require.NoError(t, code.Unmap()) }()
 
 								// Compile and execute the code under test.
-								_, err = compiler.compile(code.Next())
+								_, err = compiler.compile(code.NextCodeSection())
 								require.NoError(t, err)
 								env.exec(code.Bytes())
 
@@ -508,7 +508,7 @@ func TestCompiler_compileShr(t *testing.T) {
 						defer func() { require.NoError(t, code.Unmap()) }()
 
 						// Compile and execute the code under test.
-						_, err = compiler.compile(code.Next())
+						_, err = compiler.compile(code.NextCodeSection())
 						require.NoError(t, err)
 						env.exec(code.Bytes())
 
@@ -684,7 +684,7 @@ func TestCompiler_compile_Le_Lt_Gt_Ge_Eq_Eqz_Ne(t *testing.T) {
 							defer func() { require.NoError(t, code.Unmap()) }()
 
 							// Compile and execute the code under test.
-							_, err = compiler.compile(code.Next())
+							_, err = compiler.compile(code.NextCodeSection())
 							require.NoError(t, err)
 							env.exec(code.Bytes())
 
@@ -842,7 +842,7 @@ func TestCompiler_compile_Clz_Ctz_Popcnt(t *testing.T) {
 							defer func() { require.NoError(t, code.Unmap()) }()
 
 							// Generate and run the code under test.
-							_, err = compiler.compile(code.Next())
+							_, err = compiler.compile(code.NextCodeSection())
 							require.NoError(t, err)
 							env.exec(code.Bytes())
 
@@ -1062,7 +1062,7 @@ func TestCompiler_compile_Min_Max_Copysign(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate and run the code under test.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 
@@ -1368,7 +1368,7 @@ func TestCompiler_compile_Abs_Neg_Ceil_Floor_Trunc_Nearest_Sqrt(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Generate and run the code under test.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 
@@ -1516,7 +1516,7 @@ func TestCompiler_compile_Div_Rem(t *testing.T) {
 							defer func() { require.NoError(t, code.Unmap()) }()
 
 							// Compile and execute the code under test.
-							_, err = compiler.compile(code.Next())
+							_, err = compiler.compile(code.NextCodeSection())
 							require.NoError(t, err)
 							env.exec(code.Bytes())
 

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/internal/wazeroir"
@@ -64,10 +65,13 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				err = compiler.compileReturnFunction()
 				require.NoError(t, err)
 
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				// Generate and run the code under test.
-				code, _, err := compiler.compile()
+				_, err = compiler.compile(code.Next())
 				require.NoError(t, err)
-				env.exec(code)
+				env.exec(code.Bytes())
 
 				require.Equal(t, uint64(1), env.stackPointer())
 				require.Equal(t, tc.expected, env.stackTopAsInt32())
@@ -137,10 +141,13 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				err = compiler.compileReturnFunction()
 				require.NoError(t, err)
 
+				code := asm.CodeSegment{}
+				defer func() { require.NoError(t, code.Unmap()) }()
+
 				// Generate and run the code under test.
-				code, _, err := compiler.compile()
+				_, err = compiler.compile(code.Next())
 				require.NoError(t, err)
-				env.exec(code)
+				env.exec(code.Bytes())
 
 				require.Equal(t, uint64(1), env.stackPointer())
 				require.Equal(t, tc.expected, env.stackTopAsInt64())
@@ -211,10 +218,13 @@ func TestCompiler_compileMemoryCopy(t *testing.T) {
 			err = compiler.compileMemoryCopy()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Setup the source memory region.
@@ -224,7 +234,7 @@ func TestCompiler_compileMemoryCopy(t *testing.T) {
 			}
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if !tc.requireOutOfBoundsError {
 				exp := make([]byte, checkCeil)
@@ -295,10 +305,13 @@ func TestCompiler_compileMemoryFill(t *testing.T) {
 			err = compiler.compileMemoryFill()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Setup the memory region.
@@ -308,7 +321,7 @@ func TestCompiler_compileMemoryFill(t *testing.T) {
 			}
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if !tc.requireOutOfBoundsError {
 				exp := make([]byte, checkCeil)
@@ -352,14 +365,17 @@ func TestCompiler_compileDataDrop(t *testing.T) {
 			err = compiler.compileDataDrop(operationPtr(wazeroir.NewOperationDataDrop(uint32(i))))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 
@@ -433,14 +449,17 @@ func TestCompiler_compileMemoryInit(t *testing.T) {
 			err = compiler.compileMemoryInit(operationPtr(wazeroir.NewOperationMemoryInit(tc.dataIndex)))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if !tc.expOutOfBounds {
 				mem := env.memory()
@@ -488,14 +507,17 @@ func TestCompiler_compileElemDrop(t *testing.T) {
 			err = compiler.compileElemDrop(operationPtr(wazeroir.NewOperationElemDrop(uint32(i))))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 
@@ -566,10 +588,13 @@ func TestCompiler_compileTableCopy(t *testing.T) {
 			err = compiler.compileTableCopy(operationPtr(wazeroir.NewOperationTableCopy(0, 0)))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Setup the table.
@@ -580,7 +605,7 @@ func TestCompiler_compileTableCopy(t *testing.T) {
 			}
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if !tc.requireOutOfBoundsError {
 				exp := make([]wasm.Reference, tableSize)
@@ -664,14 +689,17 @@ func TestCompiler_compileTableInit(t *testing.T) {
 				table[i] = uintptr(i)
 			}
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if !tc.expOutOfBounds {
 				require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
@@ -779,14 +807,17 @@ func TestCompiler_compileTableSet(t *testing.T) {
 			err = compiler.compileTableSet(operationPtr(wazeroir.NewOperationTableSet(tc.tableIndex)))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if tc.expError {
 				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
@@ -907,14 +938,17 @@ func TestCompiler_compileTableGet(t *testing.T) {
 			err = compiler.compileTableGet(operationPtr(wazeroir.NewOperationTableGet(tc.tableIndex)))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			if tc.expError {
 				require.Equal(t, nativeCallStatusCodeInvalidTableAccess, env.compilerStatus())
@@ -951,14 +985,17 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 			err = compiler.compileRefFunc(operationPtr(wazeroir.NewOperationRefFunc(uint32(i))))
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
 			// Run code.
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 			require.Equal(t, uint64(1), env.stackPointer())

--- a/internal/engine/compiler/compiler_post1_0_test.go
+++ b/internal/engine/compiler/compiler_post1_0_test.go
@@ -69,7 +69,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				defer func() { require.NoError(t, code.Unmap()) }()
 
 				// Generate and run the code under test.
-				_, err = compiler.compile(code.Next())
+				_, err = compiler.compile(code.NextCodeSection())
 				require.NoError(t, err)
 				env.exec(code.Bytes())
 
@@ -145,7 +145,7 @@ func TestCompiler_compileSignExtend(t *testing.T) {
 				defer func() { require.NoError(t, code.Unmap()) }()
 
 				// Generate and run the code under test.
-				_, err = compiler.compile(code.Next())
+				_, err = compiler.compile(code.NextCodeSection())
 				require.NoError(t, err)
 				env.exec(code.Bytes())
 
@@ -224,7 +224,7 @@ func TestCompiler_compileMemoryCopy(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Setup the source memory region.
@@ -311,7 +311,7 @@ func TestCompiler_compileMemoryFill(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Setup the memory region.
@@ -371,7 +371,7 @@ func TestCompiler_compileDataDrop(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -455,7 +455,7 @@ func TestCompiler_compileMemoryInit(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -513,7 +513,7 @@ func TestCompiler_compileElemDrop(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -594,7 +594,7 @@ func TestCompiler_compileTableCopy(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Setup the table.
@@ -695,7 +695,7 @@ func TestCompiler_compileTableInit(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -813,7 +813,7 @@ func TestCompiler_compileTableSet(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -944,7 +944,7 @@ func TestCompiler_compileTableGet(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -991,7 +991,7 @@ func TestCompiler_compileRefFunc(t *testing.T) {
 			// Generate the code under test.
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.

--- a/internal/engine/compiler/compiler_stack_test.go
+++ b/internal/engine/compiler/compiler_stack_test.go
@@ -58,7 +58,7 @@ func TestCompiler_releaseRegisterToStack(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run native code after growing the value stack.
@@ -144,7 +144,7 @@ func TestCompiler_compileLoadValueOnStackToRegister(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run native code after growing the value stack, and place the original value.
@@ -220,7 +220,7 @@ func TestCompiler_compilePick_v128(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Compile and execute the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -319,7 +319,7 @@ func TestCompiler_compilePick(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Compile and execute the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -366,7 +366,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		env.exec(code.Bytes())
@@ -410,7 +410,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		env.exec(code.Bytes())
@@ -467,7 +467,7 @@ func TestCompiler_compileDrop(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		env.exec(code.Bytes())
@@ -619,7 +619,7 @@ func TestCompiler_compileSelect(t *testing.T) {
 					defer func() { require.NoError(t, code.Unmap()) }()
 
 					// Run code.
-					_, err = compiler.compile(code.Next())
+					_, err = compiler.compile(code.NextCodeSection())
 					require.NoError(t, err)
 					env.exec(code.Bytes())
 
@@ -693,7 +693,7 @@ func TestCompiler_compileSwap_v128(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.
@@ -771,7 +771,7 @@ func TestCompiler_compileSet(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			// Run code.

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/moremath"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -86,10 +87,13 @@ func TestCompiler_compileV128Add(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -177,10 +181,13 @@ func TestCompiler_compileV128Sub(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -552,10 +559,13 @@ func TestCompiler_compileV128Load(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -756,10 +766,13 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, uint64(2), env.stackPointer())
 			lo, hi := env.stackTopAsV128()
@@ -808,10 +821,13 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, uint64(0), env.stackPointer())
 
@@ -947,10 +963,13 @@ func TestCompiler_compileV128StoreLane(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, tc.exp[:], env.memory()[:16])
 		})
@@ -1123,10 +1142,13 @@ func TestCompiler_compileV128ExtractLane(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			switch tc.shape {
 			case wazeroir.ShapeI8x16, wazeroir.ShapeI16x8, wazeroir.ShapeI32x4, wazeroir.ShapeF32x4:
@@ -1357,10 +1379,13 @@ func TestCompiler_compileV128ReplaceLane(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -1455,10 +1480,13 @@ func TestCompiler_compileV128Splat(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -1502,10 +1530,13 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 			require.Equal(t, uint64(1), env.stackPointer())
@@ -1664,10 +1695,13 @@ func TestCompiler_compileV128AllTrue(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 			require.Equal(t, uint64(1), env.stackPointer())
@@ -1764,10 +1798,13 @@ func TestCompiler_compileV128Swizzle(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -1869,10 +1906,13 @@ func TestCompiler_compileV128Shuffle(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -2001,11 +2041,13 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
-			// Generate and run the code under test.
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
 
-			code, _, err := compiler.compile()
+			// Generate and run the code under test.
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			actual := env.stackTopAsUint32()
 			require.Equal(t, tc.exp, actual)
@@ -2035,10 +2077,13 @@ func TestCompiler_compileV128_Not(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate and run the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	lo, hi := env.stackTopAsV128()
 	require.Equal(t, ^originalLo, lo)
@@ -2256,10 +2301,13 @@ func TestCompiler_compileV128_And_Or_Xor_AndNot(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -2341,10 +2389,13 @@ func TestCompiler_compileV128Bitselect(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -2623,10 +2674,13 @@ func TestCompiler_compileV128Shl(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -2896,10 +2950,13 @@ func TestCompiler_compileV128Shr(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -3325,10 +3382,13 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -3400,10 +3460,13 @@ func TestCompiler_compileV128AvgrU(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -3463,10 +3526,13 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -3547,10 +3613,13 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -3641,10 +3710,13 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -3735,10 +3807,13 @@ func TestCompiler_compileV128Abs(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -3805,10 +3880,13 @@ func TestCompiler_compileV128Div(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -3991,10 +4069,13 @@ func TestCompiler_compileV128Min(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -4212,10 +4293,13 @@ func TestCompiler_compileV128Max(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -4347,10 +4431,13 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -4453,10 +4540,13 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -4520,10 +4610,13 @@ func TestCompiler_compileV128Popcnt(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -4697,10 +4790,13 @@ func TestCompiler_compileV128Round(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -4983,10 +5079,13 @@ func TestCompiler_compileV128_Pmax_Pmin(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -5670,10 +5769,13 @@ func TestCompiler_compileV128ExtMul(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6138,10 +6240,13 @@ func TestCompiler_compileV128Extend(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6216,10 +6321,13 @@ func TestCompiler_compileV128Q15mulrSatS(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6286,10 +6394,13 @@ func TestCompiler_compileFloatPromote(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6367,10 +6478,13 @@ func TestCompiler_compileV128FloatDemote(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6572,10 +6686,13 @@ func TestCompiler_compileV128ExtAddPairwise(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6812,10 +6929,13 @@ func TestCompiler_compileV128Narrow(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -6943,10 +7063,13 @@ func TestCompiler_compileV128FConvertFromI(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -7009,10 +7132,13 @@ func TestCompiler_compileV128Dot(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -7154,10 +7280,13 @@ func TestCompiler_compileV128ITruncSatFromF(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 
@@ -7201,10 +7330,13 @@ func TestCompiler_compileSelect_v128(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		// Generate and run the code under test.
-		code, _, err := compiler.compile()
+		_, err = compiler.compile(code.Next())
 		require.NoError(t, err)
-		env.exec(code)
+		env.exec(code.Bytes())
 
 		require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 

--- a/internal/engine/compiler/compiler_vec_test.go
+++ b/internal/engine/compiler/compiler_vec_test.go
@@ -91,7 +91,7 @@ func TestCompiler_compileV128Add(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -185,7 +185,7 @@ func TestCompiler_compileV128Sub(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -563,7 +563,7 @@ func TestCompiler_compileV128Load(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -770,7 +770,7 @@ func TestCompiler_compileV128LoadLane(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -825,7 +825,7 @@ func TestCompiler_compileV128Store(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -967,7 +967,7 @@ func TestCompiler_compileV128StoreLane(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1146,7 +1146,7 @@ func TestCompiler_compileV128ExtractLane(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1383,7 +1383,7 @@ func TestCompiler_compileV128ReplaceLane(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1484,7 +1484,7 @@ func TestCompiler_compileV128Splat(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1534,7 +1534,7 @@ func TestCompiler_compileV128AnyTrue(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1699,7 +1699,7 @@ func TestCompiler_compileV128AllTrue(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1802,7 +1802,7 @@ func TestCompiler_compileV128Swizzle(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -1910,7 +1910,7 @@ func TestCompiler_compileV128Shuffle(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -2045,7 +2045,7 @@ func TestCompiler_compileV128Bitmask(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -2081,7 +2081,7 @@ func TestCompiler_compileV128_Not(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate and run the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 
@@ -2305,7 +2305,7 @@ func TestCompiler_compileV128_And_Or_Xor_AndNot(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -2393,7 +2393,7 @@ func TestCompiler_compileV128Bitselect(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -2678,7 +2678,7 @@ func TestCompiler_compileV128Shl(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -2954,7 +2954,7 @@ func TestCompiler_compileV128Shr(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3386,7 +3386,7 @@ func TestCompiler_compileV128Cmp(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3464,7 +3464,7 @@ func TestCompiler_compileV128AvgrU(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3530,7 +3530,7 @@ func TestCompiler_compileV128Sqrt(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3617,7 +3617,7 @@ func TestCompiler_compileV128Mul(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3714,7 +3714,7 @@ func TestCompiler_compileV128Neg(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3811,7 +3811,7 @@ func TestCompiler_compileV128Abs(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -3884,7 +3884,7 @@ func TestCompiler_compileV128Div(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -4073,7 +4073,7 @@ func TestCompiler_compileV128Min(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -4297,7 +4297,7 @@ func TestCompiler_compileV128Max(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -4435,7 +4435,7 @@ func TestCompiler_compileV128AddSat(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -4544,7 +4544,7 @@ func TestCompiler_compileV128SubSat(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -4614,7 +4614,7 @@ func TestCompiler_compileV128Popcnt(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -4794,7 +4794,7 @@ func TestCompiler_compileV128Round(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -5083,7 +5083,7 @@ func TestCompiler_compileV128_Pmax_Pmin(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -5773,7 +5773,7 @@ func TestCompiler_compileV128ExtMul(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -6244,7 +6244,7 @@ func TestCompiler_compileV128Extend(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -6325,7 +6325,7 @@ func TestCompiler_compileV128Q15mulrSatS(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -6398,7 +6398,7 @@ func TestCompiler_compileFloatPromote(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -6482,7 +6482,7 @@ func TestCompiler_compileV128FloatDemote(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -6690,7 +6690,7 @@ func TestCompiler_compileV128ExtAddPairwise(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -6933,7 +6933,7 @@ func TestCompiler_compileV128Narrow(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -7067,7 +7067,7 @@ func TestCompiler_compileV128FConvertFromI(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -7136,7 +7136,7 @@ func TestCompiler_compileV128Dot(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -7284,7 +7284,7 @@ func TestCompiler_compileV128ITruncSatFromF(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -7334,7 +7334,7 @@ func TestCompiler_compileSelect_v128(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// Generate and run the code under test.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 		env.exec(code.Bytes())
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -531,11 +531,8 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 	asmNodes := new(asmNodes)
 	offsets := new(offsets)
 
-	// The executable code is allocated in memory mappings of held by executable,
-	// and grown on demand when we exhaust the memory mapping capacity.
-	//
-	// The executableOffset variable tracks the position where the next function
-	// code will be written, and is always aligned on 16 bytes boundaries.
+	// The executable code is allocated in memory mappings held by the
+	// CodeSegment, which gros on demand when it exhausts its capacity.
 	var executable asm.CodeSegment
 	defer func() {
 		// At the end of the function, the executable is set on the compiled

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -474,8 +474,9 @@ func (s nativeCallStatusCode) String() (ret string) {
 // releaseCompiledModule is a runtime.SetFinalizer function that munmaps the compiledModule.executable.
 func releaseCompiledModule(cm *compiledModule) {
 	if err := cm.executable.Unmap(); err != nil {
-		// munmap failure cannot recover, and happen asynchronously on the finalizer thread. While finalizer
-		// functions can return errors, they are ignored.
+		// munmap failure cannot recover, and happen asynchronously on the
+		// finalizer thread. While finalizer functions can return errors,
+		// they are ignored.
 		panic(fmt.Errorf("compiler: failed to munmap code segment: %w", err))
 	}
 }

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -548,7 +548,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 
 	for i := range module.CodeSection {
 		typ := &module.TypeSection[module.FunctionSection[i]]
-		buf := executable.Next()
+		buf := executable.NextCodeSection()
 		funcIndex := wasm.Index(i)
 		compiledFn := &cm.functions[i]
 		compiledFn.executableOffset = executable.Size()

--- a/internal/engine/compiler/engine_cache_test.go
+++ b/internal/engine/compiler/engine_cache_test.go
@@ -27,6 +27,10 @@ func concat(ins ...[]byte) (ret []byte) {
 	return
 }
 
+func makeCodeSegment(bytes ...byte) asm.CodeSegment {
+	return *asm.NewCodeSegment(bytes)
+}
+
 func TestSerializeCompiledModule(t *testing.T) {
 	tests := []struct {
 		in  *compiledModule
@@ -34,7 +38,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 	}{
 		{
 			in: &compiledModule{
-				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
+				executable: makeCodeSegment(1, 2, 3, 4, 5),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
@@ -54,7 +58,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 		{
 			in: &compiledModule{
 				ensureTermination: true,
-				executable:        asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
+				executable:        makeCodeSegment(1, 2, 3, 4, 5),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
@@ -74,7 +78,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 		{
 			in: &compiledModule{
 				ensureTermination: true,
-				executable:        asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5, 1, 2, 3}),
+				executable:        makeCodeSegment(1, 2, 3, 4, 5, 1, 2, 3),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 					{executableOffset: 5, stackPointerCeil: 0xffffffff},
@@ -155,7 +159,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5}, // machine code.
 			),
 			expCompiledModule: &compiledModule{
-				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
+				executable: makeCodeSegment(1, 2, 3, 4, 5),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345, index: 0},
 				},
@@ -178,7 +182,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			),
 			expCompiledModule: &compiledModule{
 				ensureTermination: true,
-				executable:        asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
+				executable:        makeCodeSegment(1, 2, 3, 4, 5),
 				functions:         []compiledFunction{{executableOffset: 0, stackPointerCeil: 12345, index: 0}},
 			},
 			expStaleCache: false,
@@ -204,7 +208,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			),
 			importedFunctionCount: 1,
 			expCompiledModule: &compiledModule{
-				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+				executable: makeCodeSegment(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345, index: 1},
 					{executableOffset: 7, stackPointerCeil: 0xffffffff, index: 2},
@@ -357,7 +361,7 @@ func TestEngine_getCompiledModuleFromCache(t *testing.T) {
 			},
 			expHit: true,
 			expCompiledModule: &compiledModule{
-				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+				executable: makeCodeSegment(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 				functions: []compiledFunction{
 					{stackPointerCeil: 12345, executableOffset: 0, index: 0},
 					{stackPointerCeil: 0xffffffff, executableOffset: 5, index: 1},
@@ -418,7 +422,7 @@ func TestEngine_addCompiledModuleToCache(t *testing.T) {
 		tc := filecache.New(t.TempDir())
 		e := engine{fileCache: tc}
 		cm := &compiledModule{
-			executable: asm.MakeCodeSegment([]byte{1, 2, 3}),
+			executable: makeCodeSegment(1, 2, 3),
 			functions:  []compiledFunction{{stackPointerCeil: 123}},
 		}
 		m := &wasm.Module{ID: sha256.Sum256(nil), IsHostModule: true} // Host module!
@@ -434,7 +438,7 @@ func TestEngine_addCompiledModuleToCache(t *testing.T) {
 		e := engine{fileCache: tc}
 		m := &wasm.Module{}
 		cm := &compiledModule{
-			executable: asm.MakeCodeSegment([]byte{1, 2, 3}),
+			executable: makeCodeSegment(1, 2, 3),
 			functions:  []compiledFunction{{stackPointerCeil: 123}},
 		}
 		err := e.addCompiledModuleToCache(m, cm)

--- a/internal/engine/compiler/engine_cache_test.go
+++ b/internal/engine/compiler/engine_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"testing/iotest"
 
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/filecache"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u32"
@@ -33,7 +34,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 	}{
 		{
 			in: &compiledModule{
-				executable: []byte{1, 2, 3, 4, 5},
+				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
@@ -53,7 +54,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 		{
 			in: &compiledModule{
 				ensureTermination: true,
-				executable:        []byte{1, 2, 3, 4, 5},
+				executable:        asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
@@ -73,7 +74,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 		{
 			in: &compiledModule{
 				ensureTermination: true,
-				executable:        []byte{1, 2, 3, 4, 5, 1, 2, 3},
+				executable:        asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5, 1, 2, 3}),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 					{executableOffset: 5, stackPointerCeil: 0xffffffff},
@@ -154,7 +155,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5}, // machine code.
 			),
 			expCompiledModule: &compiledModule{
-				executable: []byte{1, 2, 3, 4, 5},
+				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345, index: 0},
 				},
@@ -177,7 +178,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			),
 			expCompiledModule: &compiledModule{
 				ensureTermination: true,
-				executable:        []byte{1, 2, 3, 4, 5},
+				executable:        asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5}),
 				functions:         []compiledFunction{{executableOffset: 0, stackPointerCeil: 12345, index: 0}},
 			},
 			expStaleCache: false,
@@ -203,7 +204,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			),
 			importedFunctionCount: 1,
 			expCompiledModule: &compiledModule{
-				executable: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345, index: 1},
 					{executableOffset: 7, stackPointerCeil: 0xffffffff, index: 2},
@@ -356,7 +357,7 @@ func TestEngine_getCompiledModuleFromCache(t *testing.T) {
 			},
 			expHit: true,
 			expCompiledModule: &compiledModule{
-				executable: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				executable: asm.MakeCodeSegment([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 				functions: []compiledFunction{
 					{stackPointerCeil: 12345, executableOffset: 0, index: 0},
 					{stackPointerCeil: 0xffffffff, executableOffset: 5, index: 1},
@@ -416,7 +417,10 @@ func TestEngine_addCompiledModuleToCache(t *testing.T) {
 	t.Run("host module", func(t *testing.T) {
 		tc := filecache.New(t.TempDir())
 		e := engine{fileCache: tc}
-		cm := &compiledModule{executable: []byte{1, 2, 3}, functions: []compiledFunction{{stackPointerCeil: 123}}}
+		cm := &compiledModule{
+			executable: asm.MakeCodeSegment([]byte{1, 2, 3}),
+			functions:  []compiledFunction{{stackPointerCeil: 123}},
+		}
 		m := &wasm.Module{ID: sha256.Sum256(nil), IsHostModule: true} // Host module!
 		err := e.addCompiledModuleToCache(m, cm)
 		require.NoError(t, err)
@@ -429,7 +433,10 @@ func TestEngine_addCompiledModuleToCache(t *testing.T) {
 		tc := filecache.New(t.TempDir())
 		e := engine{fileCache: tc}
 		m := &wasm.Module{}
-		cm := &compiledModule{executable: []byte{1, 2, 3}, functions: []compiledFunction{{stackPointerCeil: 123}}}
+		cm := &compiledModule{
+			executable: asm.MakeCodeSegment([]byte{1, 2, 3}),
+			functions:  []compiledFunction{{stackPointerCeil: 123}},
+		}
 		err := e.addCompiledModuleToCache(m, cm)
 		require.NoError(t, err)
 

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/experimental/logging"
+	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/bitpack"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
@@ -232,7 +233,11 @@ func TestCompiler_CompileModule(t *testing.T) {
 }
 
 func TestCompiler_Releasecode_Panic(t *testing.T) {
-	captured := require.CapturePanic(func() { releaseCompiledModule(&compiledModule{executable: []byte{1, 2}}) })
+	captured := require.CapturePanic(func() {
+		releaseCompiledModule(&compiledModule{
+			executable: asm.MakeCodeSegment([]byte{1, 2}),
+		})
+	})
 	require.Contains(t, captured.Error(), "compiler: failed to munmap code segment")
 }
 

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/experimental/logging"
-	"github.com/tetratelabs/wazero/internal/asm"
 	"github.com/tetratelabs/wazero/internal/bitpack"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/enginetest"
@@ -235,7 +234,7 @@ func TestCompiler_CompileModule(t *testing.T) {
 func TestCompiler_Releasecode_Panic(t *testing.T) {
 	captured := require.CapturePanic(func() {
 		releaseCompiledModule(&compiledModule{
-			executable: asm.MakeCodeSegment([]byte{1, 2}),
+			executable: makeCodeSegment(1, 2),
 		})
 	})
 	require.Contains(t, captured.Error(), "compiler: failed to munmap code segment")

--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -328,7 +328,7 @@ func (c *amd64Compiler) compileGoDefinedHostFunction() error {
 }
 
 // compile implements compiler.compile for the amd64 architecture.
-func (c *amd64Compiler) compile() (code []byte, stackPointerCeil uint64, err error) {
+func (c *amd64Compiler) compile(buf asm.Buffer) (stackPointerCeil uint64, err error) {
 	// c.stackPointerCeil tracks the stack pointer ceiling (max seen) value across all runtimeValueLocationStack(s)
 	// used for all labels (via setLocationStack), excluding the current one.
 	// Hence, we check here if the final block's max one exceeds the current c.stackPointerCeil.
@@ -341,7 +341,7 @@ func (c *amd64Compiler) compile() (code []byte, stackPointerCeil uint64, err err
 	// Note this MUST be called before Assemble() below.
 	c.assignStackPointerCeil(stackPointerCeil)
 
-	code, err = c.assembler.Assemble()
+	err = c.assembler.Assemble(buf)
 	return
 }
 

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -37,7 +37,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		executable := code.Bytes()
@@ -71,7 +71,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test and run.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 }
@@ -200,7 +200,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						defer func() { require.NoError(t, code.Unmap()) }()
 
 						// Generate the code under test.
-						_, err = compiler.compile(code.Next())
+						_, err = compiler.compile(code.NextCodeSection())
 						require.NoError(t, err)
 						// Run code.
 						env.exec(code.Bytes())
@@ -333,7 +333,7 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						defer func() { require.NoError(t, code.Unmap()) }()
 
 						// Generate the code under test.
-						_, err = compiler.compile(code.Next())
+						_, err = compiler.compile(code.NextCodeSection())
 						require.NoError(t, err)
 
 						// Run code.
@@ -374,7 +374,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 
 		// If generate the code without JMP after readInstructionAddress,
 		// the call back added must return error.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.Error(t, err)
 	})
 
@@ -410,7 +410,7 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		defer func() { require.NoError(t, code.Unmap()) }()
 
 		// Generate the code under test.
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		// Run code.
@@ -534,7 +534,7 @@ func TestAmd64Compiler_ensureClz_ABM(t *testing.T) {
 			code := asm.CodeSegment{}
 			defer func() { require.NoError(t, code.Unmap()) }()
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			_, err = compiler.compile(buf)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedCode, hex.EncodeToString(buf.Bytes()))
@@ -592,7 +592,7 @@ func TestAmd64Compiler_ensureCtz_ABM(t *testing.T) {
 			code := asm.CodeSegment{}
 			defer func() { require.NoError(t, code.Unmap()) }()
 
-			buf := code.Next()
+			buf := code.NextCodeSection()
 			_, err = compiler.compile(buf)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedCode, hex.EncodeToString(buf.Bytes()))

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -17,6 +17,9 @@ import (
 // In short, the offset register for call_indirect might be the same as amd64CallingConventionDestinationFunctionModuleInstanceAddressRegister
 // and that must not be a failure.
 func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	env := newCompilerEnvironment()
 	table := make([]wasm.Reference, 1)
 	env.addTable(&wasm.TableInstance{References: table})
@@ -34,13 +37,15 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
-		c, _, err := compiler.compile()
+		_, err = compiler.compile(code.Next())
 		require.NoError(t, err)
 
-		executable := requireExecutable(c)
+		executable := code.Bytes()
+		makeExecutable(executable)
+
 		f := function{
-			parent:             &compiledFunction{parent: &compiledModule{executable: executable}},
-			codeInitialAddress: uintptr(unsafe.Pointer(&executable[0])),
+			parent:             &compiledFunction{parent: &compiledModule{executable: code}},
+			codeInitialAddress: code.Addr(),
 			moduleInstance:     env.moduleInstance,
 			typeID:             0,
 		}
@@ -66,9 +71,9 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate the code under test and run.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 }
 
 func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
@@ -189,14 +194,16 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// the failure in a subsequent instruction.
 						err = compiler.compileAdd(operationPtr(wazeroir.NewOperationAdd(wazeroir.UnsignedTypeI32)))
 						require.NoError(t, err)
-
 						require.NoError(t, compiler.compileReturnFunction())
 
+						code := asm.CodeSegment{}
+						defer func() { require.NoError(t, code.Unmap()) }()
+
 						// Generate the code under test.
-						code, _, err := compiler.compile()
+						_, err = compiler.compile(code.Next())
 						require.NoError(t, err)
 						// Run code.
-						env.exec(code)
+						env.exec(code.Bytes())
 
 						// Verify the stack is in the form of ["any value previously used by DX" + the result of operation]
 						require.Equal(t, uint64(1), env.stackPointer())
@@ -320,15 +327,17 @@ func TestAmd64Compiler_compile_Mul_Div_Rem(t *testing.T) {
 						// the failure in a subsequent instruction.
 						err = compiler.compileAdd(operationPtr(wazeroir.NewOperationAdd(wazeroir.UnsignedTypeI64)))
 						require.NoError(t, err)
-
 						require.NoError(t, compiler.compileReturnFunction())
 
+						code := asm.CodeSegment{}
+						defer func() { require.NoError(t, code.Unmap()) }()
+
 						// Generate the code under test.
-						code, _, err := compiler.compile()
+						_, err = compiler.compile(code.Next())
 						require.NoError(t, err)
 
 						// Run code.
-						env.exec(code)
+						env.exec(code.Bytes())
 
 						// Verify the stack is in the form of ["any value previously used by DX" + the result of operation]
 						switch kind {
@@ -360,9 +369,12 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		// Set the acquisition target instruction to the one after JMP.
 		compiler.assembler.CompileReadInstructionAddress(amd64.RegAX, amd64.JMP)
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		// If generate the code without JMP after readInstructionAddress,
 		// the call back added must return error.
-		_, _, err = compiler.compile()
+		_, err = compiler.compile(code.Next())
 		require.Error(t, err)
 	})
 
@@ -394,12 +406,15 @@ func TestAmd64Compiler_readInstructionAddress(t *testing.T) {
 		err = compiler.compileReturnFunction()
 		require.NoError(t, err)
 
+		code := asm.CodeSegment{}
+		defer func() { require.NoError(t, code.Unmap()) }()
+
 		// Generate the code under test.
-		code, _, err := compiler.compile()
+		_, err = compiler.compile(code.Next())
 		require.NoError(t, err)
 
 		// Run code.
-		env.exec(code)
+		env.exec(code.Bytes())
 
 		require.Equal(t, nativeCallStatusCodeReturned, env.compilerStatus())
 		require.Equal(t, uint64(1), env.stackPointer())
@@ -516,10 +531,13 @@ func TestAmd64Compiler_ensureClz_ABM(t *testing.T) {
 
 			compiler.compileNOP() // pad for jump target (when no ABM)
 
-			code, _, err := compiler.compile()
-			require.NoError(t, err)
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
 
-			require.Equal(t, tt.expectedCode, hex.EncodeToString(code))
+			buf := code.Next()
+			_, err = compiler.compile(buf)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedCode, hex.EncodeToString(buf.Bytes()))
 		})
 	}
 }
@@ -571,10 +589,13 @@ func TestAmd64Compiler_ensureCtz_ABM(t *testing.T) {
 
 			compiler.compileNOP() // pad for jump target (when no ABM)
 
-			code, _, err := compiler.compile()
-			require.NoError(t, err)
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
 
-			require.Equal(t, tt.expectedCode, hex.EncodeToString(code))
+			buf := code.Next()
+			_, err = compiler.compile(buf)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedCode, hex.EncodeToString(buf.Bytes()))
 		})
 	}
 }

--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -140,7 +140,7 @@ func (c *arm64Compiler) compileNOP() asm.Node {
 }
 
 // compile implements compiler.compile for the arm64 architecture.
-func (c *arm64Compiler) compile() (code []byte, stackPointerCeil uint64, err error) {
+func (c *arm64Compiler) compile(buf asm.Buffer) (stackPointerCeil uint64, err error) {
 	// c.stackPointerCeil tracks the stack pointer ceiling (max seen) value across all runtimeValueLocationStack(s)
 	// used for all labels (via setLocationStack), excluding the current one.
 	// Hence, we check here if the final block's max one exceeds the current c.stackPointerCeil.
@@ -153,7 +153,7 @@ func (c *arm64Compiler) compile() (code []byte, stackPointerCeil uint64, err err
 	// Note: this must be called before Assemble() below.
 	c.assignStackPointerCeil(stackPointerCeil)
 
-	code, err = c.assembler.Assemble()
+	err = c.assembler.Assemble(buf)
 	return
 }
 

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -35,7 +35,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		code := asm.CodeSegment{}
 		defer func() { require.NoError(t, code.Unmap()) }()
 
-		_, err = compiler.compile(code.Next())
+		_, err = compiler.compile(code.NextCodeSection())
 		require.NoError(t, err)
 
 		executable := code.Bytes()
@@ -71,7 +71,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate the code under test and run.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 }
@@ -105,7 +105,7 @@ func TestArm64Compiler_readInstructionAddress(t *testing.T) {
 	code := asm.CodeSegment{}
 	defer func() { require.NoError(t, code.Unmap()) }()
 
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -47,10 +47,13 @@ func TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate and run the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	lo, hi := env.stackTopAsV128()
 	var actual [16]byte
@@ -219,10 +222,13 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte
@@ -298,10 +304,13 @@ func TestAmd64Compiler_compileV128Neg_NaNOnTemporary(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			require.Equal(t, nativeCallStatusCodeReturned, env.callEngine().statusCode)
 

--- a/internal/engine/compiler/impl_vec_amd64_test.go
+++ b/internal/engine/compiler/impl_vec_amd64_test.go
@@ -51,7 +51,7 @@ func TestAmd64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate and run the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 	env.exec(code.Bytes())
 
@@ -226,7 +226,7 @@ func TestAmd64Compiler_compileV128ShrI64x2SignedImpl(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 
@@ -308,7 +308,7 @@ func TestAmd64Compiler_compileV128Neg_NaNOnTemporary(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 			env.exec(code.Bytes())
 

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -46,11 +46,14 @@ func TestArm64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	err = compiler.compileReturnFunction()
 	require.NoError(t, err)
 
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
 	// Generate and run the code under test.
-	code, _, err := compiler.compile()
+	_, err = compiler.compile(code.Next())
 	require.NoError(t, err)
 
-	env.exec(code)
+	env.exec(code.Bytes())
 
 	lo, hi := env.stackTopAsV128()
 	var actual [16]byte
@@ -183,11 +186,14 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			err = compiler.compileReturnFunction()
 			require.NoError(t, err)
 
+			code := asm.CodeSegment{}
+			defer func() { require.NoError(t, code.Unmap()) }()
+
 			// Generate and run the code under test.
-			code, _, err := compiler.compile()
+			_, err = compiler.compile(code.Next())
 			require.NoError(t, err)
 
-			env.exec(code)
+			env.exec(code.Bytes())
 
 			lo, hi := env.stackTopAsV128()
 			var actual [16]byte

--- a/internal/engine/compiler/impl_vec_arm64_test.go
+++ b/internal/engine/compiler/impl_vec_arm64_test.go
@@ -50,7 +50,7 @@ func TestArm64Compiler_V128Shuffle_ConstTable_MiddleOfFunction(t *testing.T) {
 	defer func() { require.NoError(t, code.Unmap()) }()
 
 	// Generate and run the code under test.
-	_, err = compiler.compile(code.Next())
+	_, err = compiler.compile(code.NextCodeSection())
 	require.NoError(t, err)
 
 	env.exec(code.Bytes())
@@ -190,7 +190,7 @@ func TestArm64Compiler_V128Shuffle_combinations(t *testing.T) {
 			defer func() { require.NoError(t, code.Unmap()) }()
 
 			// Generate and run the code under test.
-			_, err = compiler.compile(code.Next())
+			_, err = compiler.compile(code.NextCodeSection())
 			require.NoError(t, err)
 
 			env.exec(code.Bytes())


### PR DESCRIPTION
This PR modifies the assembler and compiler to remove the copy from the assembler's internal buffer to the memory-mapped code segments.

To do this, I introduced two types in `internal/asm`: `CodeSegment` and `Buffer`. The former represents the code segments generated by the compiler, and the latter is similar to `bytes.Buffer` but is backed by a `CodeSegment` to support assembling instructions directly into the memory-mapped regions.

The intent is to further reduce the memory footprint of the compiler by dropping the need for the intermediary buffer but also to improve the compute time by avoiding a copy and creating opportunities to write instructions more efficiently.

Regarding the second point, I added two methods on the `Buffer` type to improve the assembler throughput.

On ARM64, all instructions are 4 bytes long, so instead of using a `Write([]byte)` method (which always makes a call to `runtime.memmove`), I added a `Write4Bytes` methods which combines all four bytes into a 32 bits integer and writes it to the underlying buffer. 

On AMD64, I revisited the implementation to support writing directly to the output buffer via calls to Go's `append` builtin. This allows the compiler to generate much better code, almost always inlining the writes.

## Benchmarks

The first round of benchmarks I am recording here comes from the internal integration tests. In those benchmarks, we see observe a measurable drop in memory utilization (5-14%) and a 10% lower compute footprint on amd64. 
```
$ go test -v -run '^$' -bench BenchmarkCompilation -benchmem -count 6 ./internal/integration_test/bench/
```
```
goos: linux
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
                                 │ /tmp/bench.0 │            /tmp/bench.1            │
                                 │    sec/op    │   sec/op     vs base               │
Compilation/with_extern_cache       317.0µ ± 3%   316.7µ ± 2%        ~ (p=0.937 n=6)
Compilation/without_extern_cache    5.659m ± 2%   5.056m ± 2%  -10.65% (p=0.002 n=6)
Compilation/interpreter             1.257m ± 0%   1.247m ± 1%   -0.80% (p=0.002 n=6)
geomean                             1.311m        1.259m        -3.97%

                                 │ /tmp/bench.0 │            /tmp/bench.1            │
                                 │     B/op     │     B/op      vs base              │
Compilation/with_extern_cache      48.96Ki ± 0%   48.94Ki ± 0%  -0.04% (p=0.002 n=6)
Compilation/without_extern_cache   629.9Ki ± 0%   597.9Ki ± 0%  -5.08% (p=0.002 n=6)
Compilation/interpreter            759.0Ki ± 0%   759.0Ki ± 0%       ~ (p=0.327 n=6)
geomean                            286.0Ki        281.1Ki       -1.74%

                                 │ /tmp/bench.0 │            /tmp/bench.1             │
                                 │  allocs/op   │  allocs/op   vs base                │
Compilation/with_extern_cache        420.0 ± 0%    420.0 ± 0%       ~ (p=1.000 n=6) ¹
Compilation/without_extern_cache    1.083k ± 0%   1.073k ± 0%  -0.88% (p=0.002 n=6)
Compilation/interpreter              627.0 ± 0%    626.5 ± 0%       ~ (p=0.545 n=6)
geomean                              658.2         656.1       -0.32%
¹ all samples are equal
```
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                 │ /tmp/bench.0 │           /tmp/bench.1            │
                                 │    sec/op    │   sec/op     vs base              │
Compilation/with_extern_cache       148.4µ ± 2%   149.6µ ± 3%       ~ (p=0.818 n=6)
Compilation/without_extern_cache    1.902m ± 6%   1.851m ± 5%       ~ (p=0.093 n=6)
Compilation/interpreter             663.7µ ± 1%   658.0µ ± 1%  -0.86% (p=0.015 n=6)
geomean                             572.3µ        566.9µ       -0.93%

                                 │ /tmp/bench.0 │            /tmp/bench.1             │
                                 │     B/op     │     B/op      vs base               │
Compilation/with_extern_cache      48.81Ki ± 0%   48.80Ki ± 0%        ~ (p=0.374 n=6)
Compilation/without_extern_cache   655.5Ki ± 0%   565.7Ki ± 0%  -13.71% (p=0.002 n=6)
Compilation/interpreter            758.9Ki ± 0%   758.9Ki ± 0%        ~ (p=0.548 n=6)
geomean                            289.6Ki        275.7Ki        -4.80%

                                 │ /tmp/bench.0 │            /tmp/bench.1            │
                                 │  allocs/op   │ allocs/op   vs base                │
Compilation/with_extern_cache        420.0 ± 0%   420.0 ± 0%       ~ (p=1.000 n=6) ¹
Compilation/without_extern_cache     938.0 ± 0%   934.0 ± 0%  -0.43% (p=0.002 n=6)
Compilation/interpreter              626.0 ± 0%   626.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                              627.1        626.2       -0.14%
¹ all samples are equal
```

The second set of benchmarks here show the differences on the compilation of Python, which I usually run this way:
```sh
# run a few passes of compilation to measure both the baseline and the change
$ time ./wazero compile -count 5 -cpuprofile /tmp/profile.out ~/wasm/bin/python-3.11.3.wasm
...
# analyse with pprof
$ go tool pprof -text -base /tmp/profile.base /tmp/profile.out
```

Overall, the most interesting gains here are a 7% drop in compilation time on amd64, and a few MiB shaved off by removing the intermediary buffer. We're not seeing similar improvements on CPU usage on arm64 tho I'm wondering if this is due to Darwin not dealing with page faults on memory mappings as well as Linux, it seems a lot more time is spent writing to those memory segments (so it might be the bottleneck).

**linux/amd64**
```
File: wazero
Type: cpu
Time: May 18, 2023 at 12:14am (PDT)
Duration: 15.95s, Total samples = 15.72s (98.58%)
Showing nodes accounting for -1.10s, 7.00% of 15.72s total
Dropped 10 nodes (cum <= 0.08s)
      flat  flat%   sum%        cum   cum%
     0.79s  5.03%  5.03%     -0.64s  4.07%  github.com/tetratelabs/wazero/internal/asm/amd64.(*AssemblerImpl).encode
    -0.58s  3.69%  1.34%     -1.17s  7.44%  github.com/tetratelabs/wazero/internal/asm/amd64.(*AssemblerImpl).maybeNOPPadding
    -0.56s  3.56%  2.23%     -0.85s  5.41%  bytes.(*Buffer).WriteByte
```
```
File: wazero
Type: alloc_space
Time: May 18, 2023 at 12:13am (PDT)
Showing nodes accounting for -15.31MB, 1.67% of 917.83MB total
Dropped 3 nodes (cum <= 4.59MB)
      flat  flat%   sum%        cum   cum%
  -12.04MB  1.31%  1.31%   -12.04MB  1.31%  github.com/tetratelabs/wazero/internal/engine/compiler.(*runtimeValueLocationStack).push (inline)
   -9.80MB  1.07%  2.38%    -9.80MB  1.07%  bytes.growSlice
    5.73MB  0.62%  1.76%     6.73MB  0.73%  github.com/tetratelabs/wazero/internal/wasm/binary.decodeDataSegment
   -5.55MB  0.61%  2.36%    -5.55MB  0.61%  github.com/tetratelabs/wazero/internal/asm/amd64.(*nodePool).allocNode (inline)
```

**darwin/arm64**
```
Type: cpu
Time: May 18, 2023 at 12:03am (PDT)
Duration: 5.69s, Total samples = 5.31s (93.39%)
Showing nodes accounting for -0.13s, 2.45% of 5.31s total
Dropped 8 nodes (cum <= 0.03s)
      flat  flat%   sum%        cum   cum%
     1.61s 30.32% 30.32%      1.61s 30.32%  encoding/binary.littleEndian.PutUint32 (inline)
    -1.44s 27.12%  3.20%     -1.44s 27.12%  runtime.memmove
    -0.06s  1.13%  2.07%     -0.16s  3.01%  bytes.(*Buffer).Write
    -0.06s  1.13%  0.94%      0.60s 11.30%  github.com/tetratelabs/wazero/internal/asm/arm64.(*AssemblerImpl).encodeLoadOrStoreWithConstOffset
```
```
Type: alloc_space
Time: May 18, 2023 at 12:06am (PDT)
Showing nodes accounting for -45.46MB, 5.12% of 887.49MB total
Dropped 3 nodes (cum <= 4.44MB)
      flat  flat%   sum%        cum   cum%
  -22.27MB  2.51%  2.51%   -22.27MB  2.51%  bytes.growSlice
  -16.13MB  1.82%  4.33%   -16.13MB  1.82%  github.com/tetratelabs/wazero/internal/asm/arm64.(*nodePool).allocNode (inline)
   -5.50MB  0.62%  4.95%    -5.50MB  0.62%  debug/dwarf.(*Data).parseAbbrev
    4.95MB  0.56%  4.39%     4.95MB  0.56%  github.com/tetratelabs/wazero/internal/bitpack.newDeltaArray[...] (inline)
   -4.03MB  0.45%  4.84%    -4.03MB  0.45%  github.com/tetratelabs/wazero/internal/engine/compiler.(*runtimeValueLocationStack).push (inline)
```

Finally, I ran `make fuzz fuzz_timeout_seconds=180` to increase confidence in the change since it is touching a lot of core pieces of the compiler:
```
Done 358310 runs in 181 second(s)
```

## Comments

Overall, this is a lot of code change for a ~10% improvement, which is likely a sign that we are entering the land of diminishing returns in this direction. I wanted to measure how much the removal of the intermediary assembler buffer would impact, so now we know! But I've been too close to the issue to emit a fair judgment on whether the gains are worth the change.

Feel free to chime in with any comments or feedback!