### PR TITLE
wasi: Move ReadDir out of the FileEntry structure.

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -836,7 +836,7 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 	}
 	rd := f.File
 	// Discard the bool value because we validated the fd already.
-	dir, _ := fsc.LookupReadDir(fd)
+	dir, _ := fsc.LookupReaddir(fd)
 
 	if cookie == 0 && dir.CountRead > 0 {
 		// This means that there was a previous call to the dir, but cookie is reset.
@@ -845,7 +845,7 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 		if _, errno = rd.Seek(0, io.SeekStart); errno != 0 {
 			return errno
 		}
-		*dir = sys.ReadDir{}
+		*dir = sys.Readdir{}
 	}
 
 	// First, determine the maximum directory entries that can be encoded as
@@ -953,7 +953,7 @@ func dotDirents(f *sys.FileEntry) ([]fsapi.Dirent, syscall.Errno) {
 const largestDirent = int64(math.MaxUint32 - wasip1.DirentSize)
 
 // lastDirents is broken out from fdReaddirFn for testability.
-func lastDirents(dir *sys.ReadDir, cookie int64) (dirents []fsapi.Dirent, errno syscall.Errno) {
+func lastDirents(dir *sys.Readdir, cookie int64) (dirents []fsapi.Dirent, errno syscall.Errno) {
 	if cookie < 0 {
 		errno = syscall.EINVAL // invalid as we will never send a negative cookie.
 		return

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -834,7 +834,9 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 	if errno != 0 {
 		return errno
 	}
-	rd, dir := f.File, f.ReadDir
+	// rd, dir := f.File, f.ReadDir
+	rd := f.File
+	dir, _ := fsc.LookupReadDir(fd)
 
 	if cookie == 0 && dir.CountRead > 0 {
 		// This means that there was a previous call to the dir, but cookie is reset.
@@ -843,8 +845,9 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 		if _, errno = rd.Seek(0, io.SeekStart); errno != 0 {
 			return errno
 		}
-		f.ReadDir = &sys.ReadDir{}
-		dir = f.ReadDir
+		// f.ReadDir = &sys.ReadDir{}
+		// dir = f.ReadDir
+		dir, _ = fsc.ResetReadDir(fd)
 	}
 
 	// First, determine the maximum directory entries that can be encoded as
@@ -1109,9 +1112,9 @@ func openedDir(fsc *sys.FSContext, fd int32) (*sys.FileEntry, syscall.Errno) {
 		// and https://en.wikibooks.org/wiki/C_Programming/POSIX_Reference/dirent.h
 		return nil, syscall.EBADF
 	} else {
-		if f.ReadDir == nil {
-			f.ReadDir = &sys.ReadDir{}
-		}
+		//if f.ReadDir == nil {
+		//	f.ReadDir = &sys.ReadDir{}
+		//}
 		return f, 0
 	}
 }

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -845,8 +845,6 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 		if _, errno = rd.Seek(0, io.SeekStart); errno != 0 {
 			return errno
 		}
-		// f.ReadDir = &sys.ReadDir{}
-		// dir = f.ReadDir
 		*dir = sys.ReadDir{}
 	}
 

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -870,9 +870,7 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 
 	// Add entries for dot and dot-dot as wasi-testsuite requires them.
 	if cookie == 0 && dirents == nil {
-		if f, ok := fsc.LookupFile(fd); !ok {
-			return syscall.EBADF
-		} else if dirents, errno = dotDirents(f); errno != 0 {
+		if dirents, errno = dotDirents(f); errno != 0 {
 			return errno
 		}
 		dir.Dirents = dirents

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -837,6 +837,10 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 	// rd, dir := f.File, f.ReadDir
 	rd := f.File
 	dir, _ := fsc.LookupReadDir(fd)
+	if dir == nil {
+		dir = &sys.ReadDir{}
+		fsc.InsertReadDirAt(dir, fd)
+	}
 
 	if cookie == 0 && dir.CountRead > 0 {
 		// This means that there was a previous call to the dir, but cookie is reset.
@@ -847,7 +851,7 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 		}
 		// f.ReadDir = &sys.ReadDir{}
 		// dir = f.ReadDir
-		dir, _ = fsc.ResetReadDir(fd)
+		*dir = sys.ReadDir{}
 	}
 
 	// First, determine the maximum directory entries that can be encoded as

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -837,10 +837,6 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 	// rd, dir := f.File, f.ReadDir
 	rd := f.File
 	dir, _ := fsc.LookupReadDir(fd)
-	if dir == nil {
-		dir = &sys.ReadDir{}
-		fsc.InsertReadDirAt(dir, fd)
-	}
 
 	if cookie == 0 && dir.CountRead > 0 {
 		// This means that there was a previous call to the dir, but cookie is reset.

--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -834,8 +834,8 @@ func fdReaddirFn(_ context.Context, mod api.Module, params []uint64) syscall.Err
 	if errno != 0 {
 		return errno
 	}
-	// rd, dir := f.File, f.ReadDir
 	rd := f.File
+	// Discard the bool value because we validated the fd already.
 	dir, _ := fsc.LookupReadDir(fd)
 
 	if cookie == 0 && dir.CountRead > 0 {
@@ -1097,7 +1097,7 @@ func writeDirent(buf []byte, dNext uint64, ino uint64, dNamlen uint32, dType fs.
 	le.PutUint32(buf[20:], uint32(filetype)) //  d_type
 }
 
-// openedDir returns the directory and 0 if the fd points to a readable directory.
+// openedDir returns the sys.FileEntry for the directory and 0 if the fd points to a readable directory.
 func openedDir(fsc *sys.FSContext, fd int32) (*sys.FileEntry, syscall.Errno) {
 	if f, ok := fsc.LookupFile(fd); !ok {
 		return nil, syscall.EBADF
@@ -1112,9 +1112,6 @@ func openedDir(fsc *sys.FSContext, fd int32) (*sys.FileEntry, syscall.Errno) {
 		// and https://en.wikibooks.org/wiki/C_Programming/POSIX_Reference/dirent.h
 		return nil, syscall.EBADF
 	} else {
-		//if f.ReadDir == nil {
-		//	f.ReadDir = &sys.ReadDir{}
-		//}
 		return f, 0
 	}
 }

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2417,9 +2417,8 @@ func Test_fdReaddir_Errors(t *testing.T) {
 		fd                         int32
 		buf, bufLen, resultBufused uint32
 		cookie                     int64
-		// readDir                    *sys.ReadDir
-		expectedErrno wasip1.Errno
-		expectedLog   string
+		expectedErrno              wasip1.Errno
+		expectedLog                string
 	}{
 		{
 			name:          "out-of-memory reading buf",
@@ -2492,8 +2491,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			name: "negative cookie invalid",
 			fd:   dirFD,
 			buf:  0, bufLen: 1000,
-			cookie: -1,
-			// readDir:       &sys.ReadDir{CountRead: 1},
+			cookie:        -1,
 			resultBufused: 2000,
 			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `
@@ -2515,7 +2513,6 @@ func Test_fdReaddir_Errors(t *testing.T) {
 				defer dir.Close()
 
 				file.File = dir
-				// file.ReadDir = nil
 				fsc.CloseReadDir(tc.fd)
 			}
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2512,7 +2512,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 
 				file.File = dir
 				// file.ReadDir = nil
-				fsc.DeleteReadDir(tc.fd)
+				fsc.CloseReadDir(tc.fd)
 			}
 
 			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdReaddirName,

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2036,7 +2036,7 @@ func Test_fdReaddir(t *testing.T) {
 
 	type result struct {
 		entry   fsapi.File
-		readDir *sys.ReadDir
+		readDir *sys.Readdir
 	}
 
 	tests := []struct {
@@ -2047,7 +2047,7 @@ func Test_fdReaddir(t *testing.T) {
 		expectedMem     []byte
 		expectedMemSize int
 		expectedBufused uint32
-		expectedReadDir *sys.ReadDir
+		expectedReadDir *sys.Readdir
 	}{
 		{
 			name: "empty dir",
@@ -2061,7 +2061,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          0,
 			expectedBufused: wasip1.DirentSize + 1, // one dot entry
 			expectedMem:     direntDot,
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 2,
 				Dirents:   testDirents[0:2], // dot and dot-dot
 			},
@@ -2078,7 +2078,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          0,
 			expectedBufused: 129, // length of all entries
 			expectedMem:     dirents,
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents,
 			},
@@ -2095,7 +2095,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          0,
 			expectedBufused: wasip1.DirentSize,             // == bufLen which is the size of the dirent
 			expectedMem:     direntDot[:wasip1.DirentSize], // header without name
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents[0:3],
 			},
@@ -2112,7 +2112,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          0,
 			expectedBufused: 25, // length to read exactly first.
 			expectedMem:     direntDot,
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents[0:3],
 			},
@@ -2127,7 +2127,7 @@ func Test_fdReaddir(t *testing.T) {
 
 				return result{
 					entry: dir,
-					readDir: &sys.ReadDir{
+					readDir: &sys.Readdir{
 						CountRead: 3,
 						Dirents:   append(testDirents[0:2], dirent...),
 					},
@@ -2137,7 +2137,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          1,  // d_next of first
 			expectedBufused: 27, // length to read exactly second.
 			expectedMem:     direntDotDot,
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 4,
 				Dirents:   testDirents[1:4],
 			},
@@ -2151,7 +2151,7 @@ func Test_fdReaddir(t *testing.T) {
 				require.EqualErrno(t, 0, errno)
 				return result{
 					entry: dir,
-					readDir: &sys.ReadDir{
+					readDir: &sys.Readdir{
 						CountRead: 3,
 						Dirents:   append(testDirents[0:2], dirent...),
 					},
@@ -2162,7 +2162,7 @@ func Test_fdReaddir(t *testing.T) {
 			expectedBufused: 30, // length to read some more, but not enough for a header, so buf was exhausted.
 			expectedMem:     direntDotDot,
 			expectedMemSize: len(direntDotDot), // we do not want to compare the full buffer since we don't know what the leftover 4 bytes will contain.
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 4,
 				Dirents:   testDirents[1:4],
 			},
@@ -2175,7 +2175,7 @@ func Test_fdReaddir(t *testing.T) {
 				dirent, errno := dir.Readdir(1)
 				require.EqualErrno(t, 0, errno)
 
-				rdd := &sys.ReadDir{
+				rdd := &sys.Readdir{
 					CountRead: 3,
 					Dirents:   append(testDirents[0:2], dirent...),
 				}
@@ -2188,7 +2188,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          1,  // d_next of first
 			expectedBufused: 50, // length to read exactly second and the header of third.
 			expectedMem:     append(direntDotDot, dirent1[0:24]...),
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents[1:5],
 			},
@@ -2201,7 +2201,7 @@ func Test_fdReaddir(t *testing.T) {
 				dirent, errno := dir.Readdir(1)
 				require.EqualErrno(t, 0, errno)
 
-				rdd := &sys.ReadDir{
+				rdd := &sys.Readdir{
 					CountRead: 3,
 					Dirents:   append(testDirents[0:2], dirent...),
 				}
@@ -2211,7 +2211,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          1,  // d_next of first
 			expectedBufused: 53, // length to read exactly one second and third.
 			expectedMem:     append(direntDotDot, dirent1...),
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents[1:5],
 			},
@@ -2224,7 +2224,7 @@ func Test_fdReaddir(t *testing.T) {
 				two, errno := dir.Readdir(2)
 				require.EqualErrno(t, 0, errno)
 
-				rdd := &sys.ReadDir{
+				rdd := &sys.Readdir{
 					CountRead: 4,
 					Dirents:   append(testDirents[0:2], two[0:]...),
 				}
@@ -2234,7 +2234,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          2,  // d_next of second.
 			expectedBufused: 27, // length to read exactly third.
 			expectedMem:     dirent1,
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents[2:],
 			},
@@ -2247,11 +2247,11 @@ func Test_fdReaddir(t *testing.T) {
 				two, errno := dir.Readdir(2)
 				require.EqualErrno(t, 0, errno)
 
-				rdd := &sys.ReadDir{
+				rdd := &sys.Readdir{
 					CountRead: 4,
 					Dirents:   append(testDirents[0:2], two[0:]...),
 				}
-				readDir, _ := fsc.LookupReadDir(fd)
+				readDir, _ := fsc.LookupReaddir(fd)
 				*readDir = *rdd
 				return result{entry: dir, readDir: rdd}
 			},
@@ -2259,7 +2259,7 @@ func Test_fdReaddir(t *testing.T) {
 			cookie:          2,   // d_next of second.
 			expectedBufused: 78,  // length to read the rest
 			expectedMem:     append(dirent1, dirent2...),
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents[2:],
 			},
@@ -2272,7 +2272,7 @@ func Test_fdReaddir(t *testing.T) {
 				_, errno = dir.Readdir(3)
 				require.EqualErrno(t, 0, errno)
 
-				rdd := &sys.ReadDir{
+				rdd := &sys.Readdir{
 					CountRead: 5,
 					Dirents:   testDirents,
 				}
@@ -2281,7 +2281,7 @@ func Test_fdReaddir(t *testing.T) {
 			bufLen:          300, // length is long enough for third and more
 			cookie:          5,   // d_next after entries.
 			expectedBufused: 0,   // nothing read
-			expectedReadDir: &sys.ReadDir{
+			expectedReadDir: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents,
 			},
@@ -2303,7 +2303,7 @@ func Test_fdReaddir(t *testing.T) {
 
 			file.File = dir
 			if rdd != nil {
-				readDir, _ := fsc.LookupReadDir(fd)
+				readDir, _ := fsc.LookupReaddir(fd)
 				*readDir = *rdd
 			}
 
@@ -2329,7 +2329,7 @@ func Test_fdReaddir(t *testing.T) {
 				require.Equal(t, tc.expectedMem, mem[:tc.expectedMemSize])
 			}
 
-			rdd, ok = fsc.LookupReadDir(fd)
+			rdd, ok = fsc.LookupReaddir(fd)
 			require.True(t, ok)
 			require.Equal(t, tc.expectedReadDir, rdd)
 		})
@@ -2513,7 +2513,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 				defer dir.Close()
 
 				file.File = dir
-				fsc.CloseReadDir(tc.fd)
+				fsc.CloseReaddir(tc.fd)
 			}
 
 			requireErrnoResult(t, tc.expectedErrno, mod, wasip1.FdReaddirName,

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2251,7 +2251,8 @@ func Test_fdReaddir(t *testing.T) {
 					CountRead: 4,
 					Dirents:   append(testDirents[0:2], two[0:]...),
 				}
-				fsc.InsertReadDirAt(rdd, fd)
+				readDir, _ := fsc.LookupReadDir(fd)
+				*readDir = *rdd
 				return result{entry: dir, readDir: rdd}
 			},
 			bufLen:          300, // length is long enough for third and more
@@ -2301,7 +2302,10 @@ func Test_fdReaddir(t *testing.T) {
 			defer dir.Close()
 
 			file.File = dir
-			fsc.InsertReadDirAt(rdd, fd)
+			if rdd != nil {
+				readDir, _ := fsc.LookupReadDir(fd)
+				*readDir = *rdd
+			}
 
 			maskMemory(t, mod, int(tc.bufLen))
 
@@ -2413,7 +2417,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 		fd                         int32
 		buf, bufLen, resultBufused uint32
 		cookie                     int64
-		//readDir                    *sys.ReadDir
+		// readDir                    *sys.ReadDir
 		expectedErrno wasip1.Errno
 		expectedLog   string
 	}{
@@ -2489,7 +2493,7 @@ func Test_fdReaddir_Errors(t *testing.T) {
 			fd:   dirFD,
 			buf:  0, bufLen: 1000,
 			cookie: -1,
-			//readDir:       &sys.ReadDir{CountRead: 1},
+			// readDir:       &sys.ReadDir{CountRead: 1},
 			resultBufused: 2000,
 			expectedErrno: wasip1.ErrnoInval,
 			expectedLog: `

--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -16,7 +16,7 @@ import (
 func Test_lastDirents(t *testing.T) {
 	tests := []struct {
 		name            string
-		f               *sys.ReadDir
+		f               *sys.Readdir
 		cookie          int64
 		expectedDirents []fsapi.Dirent
 		expectedErrno   syscall.Errno
@@ -31,7 +31,7 @@ func Test_lastDirents(t *testing.T) {
 		},
 		{
 			name: "cookie is negative",
-			f: &sys.ReadDir{
+			f: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents,
 			},
@@ -40,7 +40,7 @@ func Test_lastDirents(t *testing.T) {
 		},
 		{
 			name: "cookie is greater than last d_next",
-			f: &sys.ReadDir{
+			f: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents,
 			},
@@ -49,7 +49,7 @@ func Test_lastDirents(t *testing.T) {
 		},
 		{
 			name: "cookie is last pos",
-			f: &sys.ReadDir{
+			f: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents,
 			},
@@ -58,7 +58,7 @@ func Test_lastDirents(t *testing.T) {
 		},
 		{
 			name: "cookie is one before last pos",
-			f: &sys.ReadDir{
+			f: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents,
 			},
@@ -67,7 +67,7 @@ func Test_lastDirents(t *testing.T) {
 		},
 		{
 			name: "cookie is before current entries",
-			f: &sys.ReadDir{
+			f: &sys.Readdir{
 				CountRead: 5,
 				Dirents:   testDirents,
 			},
@@ -76,7 +76,7 @@ func Test_lastDirents(t *testing.T) {
 		},
 		{
 			name: "read from the beginning (cookie=0)",
-			f: &sys.ReadDir{
+			f: &sys.Readdir{
 				CountRead: 3,
 				Dirents:   testDirents,
 			},
@@ -91,7 +91,7 @@ func Test_lastDirents(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			f := tc.f
 			if f == nil {
-				f = &sys.ReadDir{}
+				f = &sys.Readdir{}
 			}
 			entries, errno := lastDirents(f, tc.cookie)
 			require.EqualErrno(t, tc.expectedErrno, errno)

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -219,7 +219,8 @@ func Benchmark_fdReaddir(b *testing.B) {
 				if f.File, errno = fsc.RootFS().OpenFile(".", os.O_RDONLY, 0); errno != 0 {
 					b.Fatal(errno)
 				}
-				f.ReadDir = nil
+				// f.ReadDir = nil
+				fsc.DeleteReadDir(fd)
 
 				// Make an initial call to build the state of an unread directory
 				if bc.continued {

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -219,7 +219,6 @@ func Benchmark_fdReaddir(b *testing.B) {
 				if f.File, errno = fsc.RootFS().OpenFile(".", os.O_RDONLY, 0); errno != 0 {
 					b.Fatal(errno)
 				}
-				// f.ReadDir = nil
 				fsc.CloseReadDir(fd)
 
 				// Make an initial call to build the state of an unread directory

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -220,7 +220,7 @@ func Benchmark_fdReaddir(b *testing.B) {
 					b.Fatal(errno)
 				}
 				// f.ReadDir = nil
-				fsc.DeleteReadDir(fd)
+				fsc.CloseReadDir(fd)
 
 				// Make an initial call to build the state of an unread directory
 				if bc.continued {

--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -219,7 +219,7 @@ func Benchmark_fdReaddir(b *testing.B) {
 				if f.File, errno = fsc.RootFS().OpenFile(".", os.O_RDONLY, 0); errno != 0 {
 					b.Fatal(errno)
 				}
-				fsc.CloseReadDir(fd)
+				fsc.CloseReaddir(fd)
 
 				// Make an initial call to build the state of an unread directory
 				if bc.continued {

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -133,14 +133,8 @@ func (c *FSContext) LookupReadDir(fd int32) (*ReadDir, bool) {
 	}
 }
 
-// InsertReadDirAt inserts a ReadDir struct at the given index
-// Deprecated: Only necessary in tests.
-func (c *FSContext) InsertReadDirAt(dir *ReadDir, idx int32) bool {
-	return c.readDirs.InsertAt(dir, idx)
-}
-
 // CloseReadDir delete the ReadDir struct at the given index
-// Deprecated: Only necessary in tests.
+// Currently only necessary in tests.
 func (c *FSContext) CloseReadDir(idx int32) {
 	c.readDirs.Delete(idx)
 }

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -133,8 +133,8 @@ func (c *FSContext) InsertReadDirAt(dir *ReadDir, idx int32) bool {
 	return c.readDirs.InsertAt(dir, idx)
 }
 
-// DeleteReadDir delete the ReadDir struct at the given index
-func (c *FSContext) DeleteReadDir(idx int32) {
+// CloseReadDir delete the ReadDir struct at the given index
+func (c *FSContext) CloseReadDir(idx int32) {
 	c.readDirs.Delete(idx)
 }
 
@@ -173,7 +173,7 @@ func (c *FSContext) CloseFile(fd int32) syscall.Errno {
 		return syscall.EBADF
 	}
 	c.openedFiles.Delete(fd)
-	c.readDirs.Delete(fd)
+	c.CloseReadDir(fd)
 	return platform.UnwrapOSError(f.File.Close())
 }
 

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -124,17 +124,23 @@ func (c *FSContext) LookupFile(fd int32) (*FileEntry, bool) {
 }
 
 // LookupReadDir returns a ReadDir struct or creates an empty one if it was not present.
-func (c *FSContext) LookupReadDir(fd int32) (*ReadDir, bool) {
-	if item, _ := c.readDirs.Lookup(fd); item != nil {
+//
+// Note: this currently assumes that idx == fd, where fd is the file descriptor of the directory.
+// CloseFile will delete this idx from the internal store. In the future, idx may be independent
+// of a file fd, and the idx may have to be disposed with an explicit CloseReadDir.
+func (c *FSContext) LookupReadDir(idx int32) (*ReadDir, bool) {
+	if item, _ := c.readDirs.Lookup(idx); item != nil {
 		return item, true
 	} else {
 		item = &ReadDir{}
-		return item, c.readDirs.InsertAt(item, fd)
+		return item, c.readDirs.InsertAt(item, idx)
 	}
 }
 
 // CloseReadDir delete the ReadDir struct at the given index
-// Currently only necessary in tests.
+//
+// Note: Currently only necessary in tests. In the future, the idx will have to be disposed explicitly,
+// unless we maintain a map fd -> []idx and we let CloseFile close all the idx in []idx.
 func (c *FSContext) CloseReadDir(idx int32) {
 	c.readDirs.Delete(idx)
 }

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -125,24 +125,17 @@ func (c *FSContext) LookupFile(fd int32) (*FileEntry, bool) {
 
 // LookupReadDir returns a ReadDir struct if it is in the table
 func (c *FSContext) LookupReadDir(fd int32) (*ReadDir, bool) {
-	if item, found := c.readDirs.Lookup(fd); !found {
-		return c.ResetReadDir(fd)
-	} else {
-		return item, c.readDirs.InsertAt(item, fd)
-	}
+	return c.readDirs.Lookup(fd)
 }
 
-func (c *FSContext) SetReadDir(dir *ReadDir, fd int32) bool {
-	return c.readDirs.InsertAt(dir, fd)
+// InsertReadDirAt inserts a ReadDir struct at the given index
+func (c *FSContext) InsertReadDirAt(dir *ReadDir, idx int32) bool {
+	return c.readDirs.InsertAt(dir, idx)
 }
 
-func (c *FSContext) ResetReadDir(fd int32) (*ReadDir, bool) {
-	item := &ReadDir{}
-	return item, c.readDirs.InsertAt(item, fd)
-}
-
-func (c *FSContext) DeleteReadDir(fd int32) {
-	c.readDirs.Delete(fd)
+// DeleteReadDir delete the ReadDir struct at the given index
+func (c *FSContext) DeleteReadDir(idx int32) {
+	c.readDirs.Delete(idx)
 }
 
 // Renumber assigns the file pointed by the descriptor `from` to `to`.


### PR DESCRIPTION
Decouple file fd from ReadDir so that it is possible to return
multiple ReadDir structs for a given fd (one per call to ReadDir).

Future work necessary to support e.g. directory-entry-stream
see https://github.com/WebAssembly/wasi-filesystem/blob/main/wit/types.wit#L787

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>