### PR TITLE
platform: removes unnecessary code

### DIFF
--- a/internal/platform/mmap_unix.go
+++ b/internal/platform/mmap_unix.go
@@ -32,13 +32,11 @@ func mmapCodeSegmentARM64(size int) ([]byte, error) {
 	return mmapCodeSegment(size, mmapProtARM64)
 }
 
-// MprotectRX is like syscall.Mprotect, defined locally so that freebsd compiles.
+// MprotectRX is like syscall.Mprotect with RX permission, defined locally so that freebsd compiles.
 func MprotectRX(b []byte) (err error) {
 	var _p0 unsafe.Pointer
 	if len(b) > 0 {
 		_p0 = unsafe.Pointer(&b[0])
-	} else {
-		_p0 = unsafe.Pointer(&_zero)
 	}
 	const prot = syscall.PROT_READ | syscall.PROT_EXEC
 	_, _, e1 := syscall.Syscall(syscall.SYS_MPROTECT, uintptr(_p0), uintptr(len(b)), uintptr(prot))

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -15,8 +15,6 @@ var IsGo120 = strings.Contains(runtime.Version(), "go1.20")
 // archRequirementsVerified is set by platform-specific init to true if the platform is supported
 var archRequirementsVerified bool
 
-var _zero uintptr
-
 // CompilerSupported is exported for tests and includes constraints here and also the assembler.
 func CompilerSupported() bool {
 	switch runtime.GOOS {


### PR DESCRIPTION
zero length RX shouldn't happen and should be handled much earlier so this is unneeded 