### PR TITLE
engine: call FunctionListener.Abort in correct order

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -853,9 +853,7 @@ func (ce *callEngine) deferredOnCall(ctx context.Context, m *wasm.ModuleInstance
 		}
 
 		err = builder.FromRecovered(recovered)
-		// Call listeners in revers order since they were captured while
-		// rewinding the call stack.
-		for i := len(functionListeners) - 1; i >= 0; i-- {
+		for i := range functionListeners {
 			functionListeners[i].Abort(ctx, m, functionListeners[i].def, err)
 		}
 	}

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -584,7 +584,7 @@ func (ce *callEngine) recoverOnCall(ctx context.Context, m *wasm.ModuleInstance,
 	}
 
 	err = builder.FromRecovered(v)
-	for i := len(functionListeners) - 1; i >= 0; i-- {
+	for i := range functionListeners {
 		functionListeners[i].Abort(ctx, m, functionListeners[i].def, err)
 	}
 


### PR DESCRIPTION
I have an `experimental.FunctionListener` like so:

```go
type functionListener struct {
	depth int
}

func (f *functionListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) {
	fmt.Println(strings.Repeat(" ", f.depth), ">", def.DebugName())
	f.depth++
}

func (f *functionListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
	f.depth--
	fmt.Println(strings.Repeat(" ", f.depth), "<", def.DebugName())
}

func (f *functionListener) Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error) {
	f.depth--
	fmt.Println(strings.Repeat(" ", f.depth), "<", def.DebugName(), ":", err)
}
```

I have a simple program that calls `proc_exit`:

```go
// GOOS=wasip1 GOARCH=wasm gotip build -o exit.wasm exit.go
package main

import "os"

func main() {
	os.Exit(0)
}
```

If I run the module with wazero, and enable the `FunctionListener`, I see the following:

```
 > ._rt0_wasm_wasip1
  > .runtime.rt0_go
   > .runtime.check
    > .runtime_internal_atomic.Cas
...<snip>...
      > .os.runtime_beforeExit
       > .runtime.runExitHooks
       < .runtime.runExitHooks
      < .os.runtime_beforeExit
      > .syscall.Exit
       > .runtime.exit
        > wasi_snapshot_preview1.proc_exit
        < ._rt0_wasm_wasip1 : module closed with exit_code(0)
       < .wasm_pc_f_loop : module closed with exit_code(0)
      < .runtime.main : module closed with exit_code(0)
     < .main.main : module closed with exit_code(0)
    < .os.Exit : module closed with exit_code(0)
   < .syscall.Exit : module closed with exit_code(0)
  < .runtime.exit : module closed with exit_code(0)
 < wasi_snapshot_preview1.proc_exit : module closed with exit_code(0)
```

The same is true for both the compiler and interpreter.

This PR fixes the issue by reversing the order in which function listeners and their `Abort` methods are called. I now see:

```
      > .os.runtime_beforeExit
       > .runtime.runExitHooks
       < .runtime.runExitHooks
      < .os.runtime_beforeExit
      > .syscall.Exit
       > .runtime.exit
        > wasi_snapshot_preview1.proc_exit
        < wasi_snapshot_preview1.proc_exit : module closed with exit_code(0)
       < .runtime.exit : module closed with exit_code(0)
      < .syscall.Exit : module closed with exit_code(0)
     < .os.Exit : module closed with exit_code(0)
    < .main.main : module closed with exit_code(0)
   < .runtime.main : module closed with exit_code(0)
  < .wasm_pc_f_loop : module closed with exit_code(0)
 < ._rt0_wasm_wasip1 : module closed with exit_code(0)
```

<details>
<summary>For reference, here's the script I used to generate the output:</summary>

```go
package main

import (
	"context"
	"crypto/rand"
	"fmt"
	"os"
	"strings"

	"github.com/tetratelabs/wazero"
	"github.com/tetratelabs/wazero/api"
	"github.com/tetratelabs/wazero/experimental"
	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
)

func main() {
	wasmFile := os.Args[1]
	wasmCode, err := os.ReadFile(wasmFile)
	if err != nil {
		panic(err)
	}

	ctx := context.Background()
	runtime := wazero.NewRuntimeWithConfig(ctx,
		wazero.NewRuntimeConfigCompiler())  // or wazero.NewRuntimeConfigInterpreter()
	defer runtime.Close(ctx)

	listener := &functionListener{}

	ctx = context.WithValue(ctx,
		experimental.FunctionListenerFactoryKey{},
		experimental.FunctionListenerFactoryFunc(func(_ api.FunctionDefinition) experimental.FunctionListener {
			return listener
		}))

	wasi_snapshot_preview1.MustInstantiate(ctx, runtime)

	wasmModule, err := runtime.CompileModule(ctx, wasmCode)
	if err != nil {
		panic(err)
	}
	defer wasmModule.Close(ctx)

	config := wazero.NewModuleConfig().
		WithStdout(os.Stdout).
		WithStderr(os.Stderr).
		WithStdin(os.Stdin).
		WithRandSource(rand.Reader).
		WithSysNanosleep().
		WithSysNanotime().
		WithSysWalltime().
		WithArgs()

	instance, err := runtime.InstantiateWithConfig(ctx, wasmCode, config)
	if err != nil {
		panic(err)
	}
	instance.Close(ctx)
}

type functionListener struct {
	depth int
}

func (f *functionListener) Before(ctx context.Context, mod api.Module, def api.FunctionDefinition, params []uint64, stackIterator experimental.StackIterator) {
	fmt.Println(strings.Repeat(" ", f.depth), ">", def.DebugName())
	f.depth++
}

func (f *functionListener) After(ctx context.Context, mod api.Module, def api.FunctionDefinition, results []uint64) {
	f.depth--
	fmt.Println(strings.Repeat(" ", f.depth), "<", def.DebugName())
}

func (f *functionListener) Abort(ctx context.Context, mod api.Module, def api.FunctionDefinition, err error) {
	f.depth--
	fmt.Println(strings.Repeat(" ", f.depth), "<", def.DebugName(), ":", err)
}
```

</details>