### PR TITLE
compiled: fix compileMemoryAccessOffsetSetup comment

### DIFF
--- a/internal/engine/compiler/impl_arm64.go
+++ b/internal/engine/compiler/impl_arm64.go
@@ -2822,7 +2822,7 @@ func (c *arm64Compiler) compileStoreImpl(offsetArg uint32, storeInst asm.Instruc
 	return nil
 }
 
-// compileMemoryAccessOffsetSetup pops the top value from the stack (called "base"), stores "base + offsetArg + targetSizeInBytes"
+// compileMemoryAccessOffsetSetup pops the top value from the stack (called "base"), stores "base + offsetArg"
 // into a register, and returns the stored register. We call the result "offset" because we access the memory
 // as memory.Buffer[offset: offset+targetSizeInBytes].
 //


### PR DESCRIPTION
I've been looking at the assembler just for fun, and after a while trying to grok this function, I believe it is actually an issue with the comment and not my understanding. But if not, let me know and close this PR :)

The function does compute `"base + offsetArg + targetSizeInBytes"` for the purpose of a bounds check, but what it returns is `"base + offsetArg"`, I think