### PR TITLE
wasi: add nonblock_test.go from gotip, fix nonblock read on Unix-like

### DIFF
--- a/imports/wasi_snapshot_preview1/wasi_stdlib_unix_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_unix_test.go
@@ -3,14 +3,22 @@
 package wasi_snapshot_preview1_test
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/sys"
 )
 
 func Test_NonblockingFile(t *testing.T) {
@@ -52,4 +60,97 @@ func Test_NonblockingFile(t *testing.T) {
 	// Check if the first line starts with at least one dot.
 	require.True(t, strings.HasPrefix(lines[0], "."))
 	require.Equal(t, "wazero", lines[1])
+}
+
+type fifo struct {
+	file *os.File
+	path string
+}
+
+func Test_NonblockGotip(t *testing.T) {
+	// - Create `numFifos` FIFOs.
+	// - Instantiate `wasmGotip` with the names of the FIFO in the order of creation
+	// - The test binary opens the FIFOs in the given order and spawns a goroutine for each
+	// - The unit test writes to the FIFO in reverse order.
+	// - Each goroutine reads from the given FIFO and writes the contents to stderr
+	//
+	// The test verifies that the output order matches the write order (i.e. reverse order).
+	//
+	// If I/O was blocking, all goroutines would be blocked waiting for one read call
+	// to return, and the output order wouldn't match.
+	//
+	// Adapted from https://github.com/golang/go/blob/0fcc70ecd56e3b5c214ddaee4065ea1139ae16b5/src/runtime/internal/wasitest/nonblock_test.go
+
+	if wasmGotip == nil {
+		t.Skip("skipping because wasi.go was not compiled (gotip missing or compilation error)")
+	}
+	const numFifos = 8
+
+	for _, mode := range []string{"open", "create"} {
+		t.Run(mode, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			args := []string{"wasi", "nonblock", mode}
+			fifos := make([]*fifo, numFifos)
+			for i := range fifos {
+				tempFile := fmt.Sprintf("wasip1-nonblock-fifo-%d-%d", rand.Uint32(), i)
+				path := filepath.Join(tempDir, tempFile)
+				err := syscall.Mkfifo(path, 0o666)
+				require.NoError(t, err)
+
+				file, err := os.OpenFile(path, os.O_RDWR, 0)
+				require.NoError(t, err)
+				defer file.Close()
+
+				args = append(args, tempFile)
+				fifos[len(fifos)-i-1] = &fifo{file, path}
+			}
+
+			pr, pw := io.Pipe()
+			defer pw.Close()
+
+			var consoleBuf bytes.Buffer
+
+			moduleConfig := wazero.NewModuleConfig().
+				WithArgs(args...).
+				WithFSConfig( // Mount the tempDir as root.
+						wazero.NewFSConfig().WithDirMount(tempDir, "/")).
+				WithStderr(pw). // Write Stderr to pw
+				WithStdout(&consoleBuf).
+				WithStartFunctions().
+				WithSysNanosleep()
+
+			ch := make(chan string, 1)
+			go func() {
+				r := wazero.NewRuntime(testCtx)
+				defer r.Close(testCtx)
+
+				_, err := wasi_snapshot_preview1.Instantiate(testCtx, r)
+				require.NoError(t, err)
+
+				mod, err := r.InstantiateWithConfig(testCtx, wasmGotip, moduleConfig) // clear
+				require.NoError(t, err)
+
+				_, err = mod.ExportedFunction("_start").Call(testCtx)
+				if exitErr, ok := err.(*sys.ExitError); ok {
+					require.Zero(t, exitErr.ExitCode(), consoleBuf.String())
+				}
+				ch <- consoleBuf.String()
+			}()
+
+			scanner := bufio.NewScanner(pr)
+			require.True(t, scanner.Scan(), fmt.Sprintf("expected line: %s", scanner.Err()))
+			require.Equal(t, "waiting", scanner.Text(), fmt.Sprintf("unexpected output: %s", scanner.Text()))
+
+			for _, fifo := range fifos {
+				_, err := fifo.file.WriteString(fifo.path + "\n")
+				require.NoError(t, err)
+				require.True(t, scanner.Scan(), fmt.Sprintf("expected line: %s", scanner.Err()))
+				require.Equal(t, fifo.path, scanner.Text(), fmt.Sprintf("unexpected line: %s", scanner.Text()))
+			}
+
+			s := <-ch
+			require.Equal(t, "", s)
+		})
+	}
 }

--- a/internal/sysfs/file_unix.go
+++ b/internal/sysfs/file_unix.go
@@ -1,0 +1,21 @@
+//go:build unix || darwin || linux
+
+package sysfs
+
+import (
+	"syscall"
+
+	"github.com/tetratelabs/wazero/internal/platform"
+)
+
+const NonBlockingFileIoSupported = true
+
+// readFd exposes syscall.Read.
+func readFd(fd uintptr, buf []byte) (int, syscall.Errno) {
+	if len(buf) == 0 {
+		return 0, 0 // Short-circuit 0-len reads.
+	}
+	n, err := syscall.Read(int(fd), buf)
+	errno := platform.UnwrapOSError(err)
+	return n, errno
+}

--- a/internal/sysfs/file_unsupported.go
+++ b/internal/sysfs/file_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !unix && !linux && !darwin
+
+package sysfs
+
+import "syscall"
+
+const NonBlockingFileIoSupported = false
+
+// readFd returns ENOSYS on unsupported platforms.
+func readFd(fd uintptr, buf []byte) (int, syscall.Errno) {
+	return -1, syscall.ENOSYS
+}

--- a/internal/sysfs/open_file_windows.go
+++ b/internal/sysfs/open_file_windows.go
@@ -13,7 +13,7 @@ import (
 
 func newOsFile(openPath string, openFlag int, openPerm fs.FileMode, f *os.File) fsapi.File {
 	return &windowsOsFile{
-		osFile: osFile{path: openPath, flag: openFlag, perm: openPerm, file: f},
+		osFile: osFile{path: openPath, flag: openFlag, perm: openPerm, file: f, fd: f.Fd()},
 	}
 }
 


### PR DESCRIPTION
Adapt and add the test from [Go's WASI test suite nonblock.go](https://github.com/golang/go/blob/0fcc70ecd56e3b5c214ddaee4065ea1139ae16b5/src/runtime/internal/wasitest/testdata/nonblock.go
) for non-blocking I/O (pipes) to our own suite. Go (almost) straight to the syscall layer for `read()` on supported platforms; i.e., this is currently Unix-only. This also adds the field `fd` to the struct `osFile` because apparently `f.file.Fd()` resets the `O_NONBLOCK` flag on the fd /o\.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
