### PR TITLE
compiler(amd64): optimize mem to register operations

### DIFF
--- a/internal/asm/amd64/impl.go
+++ b/internal/asm/amd64/impl.go
@@ -2043,6 +2043,21 @@ func (a *AssemblerImpl) encodeMemoryToRegister(buf asm.Buffer, n *nodeImpl) (err
 		// https://www.felixcloutier.com/x86/add
 		rexPrefix |= rexPrefixW
 		opcode = []byte{0x03}
+	case ADDSD:
+		// https://www.felixcloutier.com/x86/addsd
+		opcode = []byte{0x0f, 0x58}
+		mandatoryPrefix = 0xf2
+	case ADDSS:
+		// https://www.felixcloutier.com/x86/addss
+		opcode = []byte{0x0f, 0x58}
+		mandatoryPrefix = 0xf3
+	case ANDL:
+		// https://www.felixcloutier.com/x86/and
+		opcode = []byte{0x23}
+	case ANDQ:
+		// https://www.felixcloutier.com/x86/and
+		rexPrefix |= rexPrefixW
+		opcode = []byte{0x23}
 	case CMPL:
 		// https://www.felixcloutier.com/x86/cmp
 		opcode = []byte{0x39}
@@ -2050,6 +2065,14 @@ func (a *AssemblerImpl) encodeMemoryToRegister(buf asm.Buffer, n *nodeImpl) (err
 		// https://www.felixcloutier.com/x86/cmp
 		rexPrefix |= rexPrefixW
 		opcode = []byte{0x39}
+	case DIVSD:
+		// https://www.felixcloutier.com/x86/divsd
+		opcode = []byte{0x0f, 0x5e}
+		mandatoryPrefix = 0xf2
+	case DIVSS:
+		// https://www.felixcloutier.com/x86/divss
+		opcode = []byte{0x0f, 0x5e}
+		mandatoryPrefix = 0xf3
 	case LEAQ:
 		// https://www.felixcloutier.com/x86/lea
 		rexPrefix |= rexPrefixW
@@ -2113,6 +2136,24 @@ func (a *AssemblerImpl) encodeMemoryToRegister(buf asm.Buffer, n *nodeImpl) (err
 		// https://www.felixcloutier.com/x86/movzx
 		rexPrefix |= rexPrefixW
 		opcode = []byte{0x0f, 0xb7}
+	case MULSD:
+		// https://www.felixcloutier.com/x86/mulsd
+		opcode = []byte{0x0f, 0x59}
+		mandatoryPrefix = 0xf2
+	case MULSS:
+		// https://www.felixcloutier.com/x86/mulss
+		opcode = []byte{0x0f, 0x59}
+		mandatoryPrefix = 0xf3
+	case ORL:
+		// https://www.felixcloutier.com/x86/or
+		opcode = []byte{0x0b}
+	case ORQ:
+		// https://www.felixcloutier.com/x86/or
+		rexPrefix |= rexPrefixW
+		opcode = []byte{0x0b}
+	case SUBL:
+		// https://www.felixcloutier.com/x86/add
+		opcode = []byte{0x2b}
 	case SUBQ:
 		// https://www.felixcloutier.com/x86/sub
 		rexPrefix |= rexPrefixW
@@ -2125,6 +2166,13 @@ func (a *AssemblerImpl) encodeMemoryToRegister(buf asm.Buffer, n *nodeImpl) (err
 		// https://www.felixcloutier.com/x86/subss
 		opcode = []byte{0x0f, 0x5c}
 		mandatoryPrefix = 0xf3
+	case XORL:
+		// https://www.felixcloutier.com/x86/xor
+		opcode = []byte{0x33}
+	case XORQ:
+		// https://www.felixcloutier.com/x86/xor
+		rexPrefix |= rexPrefixW
+		opcode = []byte{0x33}
 	case UCOMISD:
 		// https://www.felixcloutier.com/x86/ucomisd
 		opcode = []byte{0x0f, 0x2e}


### PR DESCRIPTION
This one is more of a micro optimization.
Doesn't seem to make a measurable difference in the SQLite benchmark.

But it does tick in the `integration_test`:
```
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/vs/compiler
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
                          │  before.txt  │              after.txt              │
                          │    sec/op    │    sec/op     vs base               │
Allocation/Compile-12       10.18m ±  1%   10.04m ±  4%        ~ (p=0.818 n=6)
Allocation/Instantiate-12   200.7µ ±  5%   193.9µ ±  5%        ~ (p=0.132 n=6)
Allocation/Call-12          2.199µ ±  5%   2.187µ ±  4%        ~ (p=0.310 n=6)
Factorial/Compile-12        38.55µ ± 10%   37.87µ ± 20%        ~ (p=0.937 n=6)
Factorial/Instantiate-12    12.05µ ±  3%   11.73µ ±  3%        ~ (p=0.093 n=6)
Factorial/Call-12           715.8n ±  2%   715.2n ±  3%        ~ (p=0.818 n=6)
HostCall/Compile-12         34.46µ ±  4%   33.73µ ± 11%        ~ (p=0.180 n=6)
HostCall/Instantiate-12     23.15µ ±  2%   22.64µ ±  4%        ~ (p=0.093 n=6)
HostCall/Call-12            92.05n ±  3%   89.67n ±  9%        ~ (p=0.065 n=6)
Memory/i32/Compile-12       32.04µ ±  9%   29.39µ ±  3%   -8.27% (p=0.015 n=6)
Memory/i32/Instantiate-12   24.68µ ± 48%   24.69µ ± 33%        ~ (p=0.699 n=6)
Memory/i32/Call-12          312.2n ±  4%   243.5n ±  4%  -21.99% (p=0.002 n=6)
Memory/i64/Compile-12       39.53µ ±  3%   29.10µ ±  3%  -26.40% (p=0.002 n=6)
Memory/i64/Instantiate-12   25.54µ ± 23%   23.73µ ± 19%        ~ (p=0.240 n=6)
Memory/i64/Call-12          301.9n ±  5%   245.2n ±  3%  -18.77% (p=0.002 n=6)
Shorthash/Compile-12        6.442m ±  1%   5.261m ±  3%  -18.33% (p=0.002 n=6)
Shorthash/Instantiate-12    1.503m ±  5%   1.318m ±  3%  -12.35% (p=0.002 n=6)
geomean                     22.24µ         20.45µ         -8.04%

                          │   before.txt   │              after.txt               │
                          │      B/op      │     B/op      vs base                │
Allocation/Compile-12       1.556Mi ± 0%     1.555Mi ± 0%       ~ (p=0.240 n=6)
Allocation/Instantiate-12   234.6Ki ± 0%     234.6Ki ± 0%       ~ (p=1.000 n=6)
Allocation/Call-12            48.00 ± 0%       48.00 ± 0%       ~ (p=1.000 n=6) ¹
Factorial/Compile-12        33.59Ki ± 1%     33.59Ki ± 1%       ~ (p=0.987 n=6)
Factorial/Instantiate-12    11.72Ki ± 0%     11.72Ki ± 0%       ~ (p=1.000 n=6) ¹
Factorial/Call-12             16.00 ± 0%       16.00 ± 0%       ~ (p=1.000 n=6) ¹
HostCall/Compile-12         32.56Ki ± 3%     32.56Ki ± 6%       ~ (p=0.623 n=6)
HostCall/Instantiate-12     18.64Ki ± 0%     18.64Ki ± 0%       ~ (p=1.000 n=6) ¹
HostCall/Call-12              16.00 ± 0%       16.00 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i32/Compile-12       22.16Ki ± 9%     22.16Ki ± 0%       ~ (p=1.000 n=6)
Memory/i32/Instantiate-12   79.98Ki ± 0%     79.98Ki ± 0%       ~ (p=1.000 n=6) ¹
Memory/i32/Call-12            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i64/Compile-12       22.16Ki ± 0%     22.18Ki ± 0%       ~ (p=0.080 n=6)
Memory/i64/Instantiate-12   79.98Ki ± 0%     79.98Ki ± 0%       ~ (p=1.000 n=6) ¹
Memory/i64/Call-12            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Shorthash/Compile-12        4.100Mi ± 0%     4.100Mi ± 0%       ~ (p=0.065 n=6)
Shorthash/Instantiate-12    1.145Mi ± 0%     1.145Mi ± 0%  +0.00% (p=0.013 n=6)
geomean                                  ²                 +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │  before.txt   │              after.txt              │
                          │   allocs/op   │  allocs/op   vs base                │
Allocation/Compile-12       1.953k ± 0%     1.951k ± 0%  -0.10% (p=0.004 n=6)
Allocation/Instantiate-12    547.0 ± 0%      547.0 ± 0%       ~ (p=1.000 n=6) ¹
Allocation/Call-12           5.000 ± 0%      5.000 ± 0%       ~ (p=1.000 n=6) ¹
Factorial/Compile-12         161.0 ± 0%      161.0 ± 0%       ~ (p=1.000 n=6) ¹
Factorial/Instantiate-12     28.00 ± 0%      28.00 ± 0%       ~ (p=1.000 n=6) ¹
Factorial/Call-12            2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=6) ¹
HostCall/Compile-12          206.0 ± 0%      206.0 ± 0%       ~ (p=1.000 n=6) ¹
HostCall/Instantiate-12      50.00 ± 0%      50.00 ± 0%       ~ (p=1.000 n=6) ¹
HostCall/Call-12             2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i32/Compile-12        124.0 ± 0%      124.0 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i32/Instantiate-12    32.00 ± 0%      32.00 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i32/Call-12           0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i64/Compile-12        124.0 ± 0%      124.0 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i64/Instantiate-12    32.00 ± 0%      32.00 ± 0%       ~ (p=1.000 n=6) ¹
Memory/i64/Call-12           0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
Shorthash/Compile-12        2.067k ± 0%     2.067k ± 0%       ~ (p=0.545 n=6)
Shorthash/Instantiate-12     518.0 ± 0%      518.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                 ²                -0.01%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
``` 