### PR TITLE
compiler(arm64): avoid conditional jumps to the trap handler

### DIFF
--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -255,8 +255,11 @@ func TestArm64Compiler_LargeTrapOffsets(t *testing.T) {
 
 	// Repeat enough times that jump labels are not within (-524288, 524287).
 	// Relative offset -2097164/4(=-524291).
-	// 52429 is empirically the value that starts triggering the bug on arm64.
-	for i := 0; i < 52429; i++ {
+	// At the time of writing, 52429 is empirically the value that starts
+	// triggering the bug on arm64. We impose an arbitrarily higher value
+	// to account for possible future improvement to the number of instructions
+	// we emit.
+	for i := 0; i < 80_000; i++ {
 		err = compiler.compileConstI32(five)
 		require.NoError(t, err)
 

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -236,6 +236,49 @@ func TestArm64Compiler_getSavedTemporaryLocationStack(t *testing.T) {
 	})
 }
 
+// https://github.com/tetratelabs/wazero/issues/1522
+func TestArm64Compiler_LargeTrapOffsets(t *testing.T) {
+	env := newCompilerEnvironment()
+	compiler := env.requireNewCompiler(t, &wasm.FunctionType{}, newCompiler, &wazeroir.CompilationResult{
+		Types: []wasm.FunctionType{{}},
+	})
+	err := compiler.compilePreamble()
+	require.NoError(t, err)
+
+	one := operationPtr(wazeroir.NewOperationConstI32(uint32(1)))
+	five := operationPtr(wazeroir.NewOperationConstI32(uint32(5)))
+	div := operationPtr(wazeroir.NewOperationDiv(wazeroir.SignedTypeInt32))
+
+	// Place the offset value.
+	err = compiler.compileConstI32(one)
+	require.NoError(t, err)
+
+	// Repeat enough times that jump labels are not within (-524288, 524287).
+	// Relative offset -2097164/4(=-524291).
+	// 52429 is empirically the value that starts triggering the bug on arm64.
+	for i := 0; i < 52429; i++ {
+		err = compiler.compileConstI32(five)
+		require.NoError(t, err)
+
+		err = compiler.compileDiv(div)
+		require.NoError(t, err)
+	}
+
+	err = compiler.compileReturnFunction()
+	require.NoError(t, err)
+
+	code := asm.CodeSegment{}
+	defer func() { require.NoError(t, code.Unmap()) }()
+
+	// Generate the code under test and run.
+	_, err = compiler.compile(code.NextCodeSection())
+	require.NoError(t, err)
+
+	env.exec(code.Bytes())
+
+	require.Equal(t, nativeCallStatusCodeReturned.String(), env.compilerStatus().String())
+}
+
 // compile implements compilerImpl.setStackPointerCeil for the amd64 architecture.
 func (c *arm64Compiler) setStackPointerCeil(v uint64) {
 	c.stackPointerCeil = v


### PR DESCRIPTION
Fixes #1522 by avoiding the conditional jump to the trap, relying instead on a conditional jump over an unconditional jump.

As discussed in #1522, an alternative solution might be tracking the count of instructions and after a given N re-emit the trap that was cached at the beginning. But currently we don't have a mechanism to count the current number of instructions and iterating them all the time just to count would be costly; so we would need to modify the assembler to keep a count of the instructions.

Draft because I want to add a proper test case

```
❯ benchstat old/before_c.txt old/after_c.txt after_c.txt
goos: darwin
goarch: arm64
pkg: github.com/ncruces/go-sqlite3/vfs/tests/speedtest1
               │ old/before_c.txt │          old/after_c.txt           │            after_c.txt             │
               │      sec/op      │   sec/op     vs base               │   sec/op     vs base               │
_speedtest1-10        62.31m ± 0%   61.02m ± 0%  -2.07% (p=0.000 n=10)   62.52m ± 0%  +0.33% (p=0.004 n=10)

❯ benchstat old/before_c.txt old/after_c_nodebug.txt after_c_nodebug.txt
goos: darwin
goarch: arm64
pkg: github.com/ncruces/go-sqlite3/vfs/tests/speedtest1
               │ old/before_c.txt │       old/after_c_nodebug.txt       │        after_c_nodebug.txt         │
               │      sec/op      │   sec/op     vs base                │   sec/op     vs base               │
_speedtest1-10        62.31m ± 0%   49.38m ± 0%  -20.75% (p=0.000 n=10)   60.10m ± 1%  -3.54% (p=0.000 n=10)

❯ benchstat old/before_vfs.txt old/after_vfs.txt after_vfs.txt
goos: darwin
goarch: arm64
pkg: github.com/ncruces/go-sqlite3/vfs/tests/speedtest1
               │ old/before_vfs.txt │         old/after_vfs.txt          │         after_vfs.txt         │
               │       sec/op       │   sec/op     vs base               │   sec/op     vs base          │
_speedtest1-10          64.05m ± 0%   62.50m ± 1%  -2.42% (p=0.000 n=10)   63.87m ± 0%  ~ (p=0.052 n=10)

❯ benchstat old/before_vfs.txt old/after_vfs_nodebug.txt after_vfs_nodebug.txt
goos: darwin
goarch: arm64
pkg: github.com/ncruces/go-sqlite3/vfs/tests/speedtest1
               │ old/before_vfs.txt │      old/after_vfs_nodebug.txt      │       after_vfs_nodebug.txt        │
               │       sec/op       │   sec/op     vs base                │   sec/op     vs base               │
_speedtest1-10          64.05m ± 0%   50.72m ± 0%  -20.81% (p=0.000 n=10)   61.50m ± 1%  -3.99% (p=0.000 n=10)
```