### PR TITLE
compiler(amd64): avoid emitting useless trap code

### DIFF
--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -4856,6 +4856,7 @@ func (c *amd64Compiler) compileMaybeExitFromNativeCode(skipCondition asm.Instruc
 func (c *amd64Compiler) compileExitFromNativeCode(status nativeCallStatusCode) {
 	if target := c.compiledTrapTargets[status]; target != nil {
 		c.assembler.CompileJump(amd64.JMP).AssignJumpTarget(target)
+		return
 	}
 
 	switch status {


### PR DESCRIPTION
As discussed in https://github.com/tetratelabs/wazero/issues/1522#issuecomment-1595028040 we're missing this `return` and emitting code that never runs (fixed for `arm64` in #1524).