### PR TITLE
wasi: improve stdin support for nonblocking, fix stdout

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -423,13 +423,13 @@ func Test_fdFdstatGet_StdioNonblock(t *testing.T) {
 			fd:   sys.FdStdin,
 			expectedMemory: []byte{
 				0, 0, // fs_filetype
-				4, 0, 0, 0, 0, 0, // fs_flags
+				5, 0, 0, 0, 0, 0, // fs_flags
 				0xff, 0x1, 0xe0, 0x8, 0x0, 0x0, 0x0, 0x0, // fs_rights_base
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=0)
-<== (stat={filetype=UNKNOWN,fdflags=NONBLOCK,fs_rights_base=FD_DATASYNC|FD_READ|FD_SEEK|FDSTAT_SET_FLAGS|FD_SYNC|FD_TELL|FD_WRITE|FD_ADVISE|FD_ALLOCATE,fs_rights_inheriting=},errno=ESUCCESS)
+<== (stat={filetype=UNKNOWN,fdflags=APPEND|NONBLOCK,fs_rights_base=FD_DATASYNC|FD_READ|FD_SEEK|FDSTAT_SET_FLAGS|FD_SYNC|FD_TELL|FD_WRITE|FD_ADVISE|FD_ALLOCATE,fs_rights_inheriting=},errno=ESUCCESS)
 `,
 		},
 		{
@@ -437,13 +437,13 @@ func Test_fdFdstatGet_StdioNonblock(t *testing.T) {
 			fd:   sys.FdStdout,
 			expectedMemory: []byte{
 				0, 0, // fs_filetype
-				4, 0, 0, 0, 0, 0, // fs_flags
+				5, 0, 0, 0, 0, 0, // fs_flags
 				0xff, 0x1, 0xe0, 0x8, 0x0, 0x0, 0x0, 0x0, // fs_rights_base
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=1)
-<== (stat={filetype=UNKNOWN,fdflags=NONBLOCK,fs_rights_base=FD_DATASYNC|FD_READ|FD_SEEK|FDSTAT_SET_FLAGS|FD_SYNC|FD_TELL|FD_WRITE|FD_ADVISE|FD_ALLOCATE,fs_rights_inheriting=},errno=ESUCCESS)
+<== (stat={filetype=UNKNOWN,fdflags=APPEND|NONBLOCK,fs_rights_base=FD_DATASYNC|FD_READ|FD_SEEK|FDSTAT_SET_FLAGS|FD_SYNC|FD_TELL|FD_WRITE|FD_ADVISE|FD_ALLOCATE,fs_rights_inheriting=},errno=ESUCCESS)
 `,
 		},
 		{
@@ -451,13 +451,13 @@ func Test_fdFdstatGet_StdioNonblock(t *testing.T) {
 			fd:   sys.FdStderr,
 			expectedMemory: []byte{
 				0, 0, // fs_filetype
-				4, 0, 0, 0, 0, 0, // fs_flags
+				5, 0, 0, 0, 0, 0, // fs_flags
 				0xff, 0x1, 0xe0, 0x8, 0x0, 0x0, 0x0, 0x0, // fs_rights_base
 				0, 0, 0, 0, 0, 0, 0, 0, // fs_rights_inheriting
 			},
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_fdstat_get(fd=2)
-<== (stat={filetype=UNKNOWN,fdflags=NONBLOCK,fs_rights_base=FD_DATASYNC|FD_READ|FD_SEEK|FDSTAT_SET_FLAGS|FD_SYNC|FD_TELL|FD_WRITE|FD_ADVISE|FD_ALLOCATE,fs_rights_inheriting=},errno=ESUCCESS)
+<== (stat={filetype=UNKNOWN,fdflags=APPEND|NONBLOCK,fs_rights_base=FD_DATASYNC|FD_READ|FD_SEEK|FDSTAT_SET_FLAGS|FD_SYNC|FD_TELL|FD_WRITE|FD_ADVISE|FD_ALLOCATE,fs_rights_inheriting=},errno=ESUCCESS)
 `,
 		},
 	}

--- a/imports/wasi_snapshot_preview1/testdata/gotip/wasi.go
+++ b/imports/wasi_snapshot_preview1/testdata/gotip/wasi.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sync"
 	"syscall"
+	"time"
 )
 
 func main() {
@@ -24,7 +25,12 @@ func main() {
 		if err := mainNonblock(os.Args[2], os.Args[3:]); err != nil {
 			panic(err)
 		}
+	case "stdin":
+		if err := mainStdin(); err != nil {
+			panic(err)
+		}
 	}
+
 }
 
 // mainSock is an explicit test of a blocking socket.
@@ -158,5 +164,20 @@ func mainNonblock(mode string, files []string) error {
 	println("waiting")
 	close(ready)
 	wg.Wait()
+	return nil
+}
+
+// Reproducer for https://github.com/tetratelabs/wazero/issues/1538
+func mainStdin() error {
+	go func() {
+		time.Sleep(1 * time.Second)
+		os.Stdout.WriteString("waiting for stdin...\n")
+	}()
+
+	b, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(b)
 	return nil
 }

--- a/imports/wasi_snapshot_preview1/testdata/gotip/wasi.go
+++ b/imports/wasi_snapshot_preview1/testdata/gotip/wasi.go
@@ -29,6 +29,8 @@ func main() {
 		if err := mainStdin(); err != nil {
 			panic(err)
 		}
+	case "stdout":
+		mainStdout()
 	}
 
 }
@@ -180,4 +182,8 @@ func mainStdin() error {
 	}
 	os.Stdout.Write(b)
 	return nil
+}
+
+func mainStdout() {
+	os.Stdout.WriteString("test")
 }

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -481,7 +481,7 @@ func testStdin(t *testing.T, bin []byte) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	moduleConfig := wazero.NewModuleConfig().
-		WithSysWalltime().WithSysNanotime(). // HTTP middleware uses both clocks
+		WithSysNanotime(). // poll_oneoff requires nanotime.
 		WithArgs("wasi", "stdin").
 		WithStdin(r).WithStdout(os.Stdout)
 	ch := make(chan string, 1)

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -456,4 +457,39 @@ func testHTTP(t *testing.T, bin []byte) {
 
 	console := <-ch
 	require.Equal(t, "", console)
+}
+
+func Test_Stdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Nonblocking stdio is not supported on wasip1+windows.")
+	}
+	toolchains := map[string][]byte{}
+	if wasmGotip != nil {
+		toolchains["gotip"] = wasmGotip
+	}
+
+	for toolchain, bin := range toolchains {
+		toolchain := toolchain
+		bin := bin
+		t.Run(toolchain, func(t *testing.T) {
+			testStdin(t, bin)
+		})
+	}
+}
+
+func testStdin(t *testing.T, bin []byte) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	moduleConfig := wazero.NewModuleConfig().
+		WithSysWalltime().WithSysNanotime(). // HTTP middleware uses both clocks
+		WithArgs("wasi", "stdin").
+		WithStdin(r).WithStdout(os.Stdout)
+	ch := make(chan string, 1)
+	go func() {
+		ch <- compileAndRun(t, testCtx, moduleConfig, bin)
+	}()
+	time.Sleep(1 * time.Second)
+	_, _ = w.WriteString("foo")
+	s := <-ch
+	require.Equal(t, "waiting for stdin...\nfoo", s)
 }

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -460,9 +460,6 @@ func testHTTP(t *testing.T, bin []byte) {
 }
 
 func Test_Stdin(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Nonblocking stdio is not supported on wasip1+windows.")
-	}
 	toolchains := map[string][]byte{}
 	if wasmGotip != nil {
 		toolchains["gotip"] = wasmGotip

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -480,7 +480,7 @@ func testStdin(t *testing.T, bin []byte) {
 	moduleConfig := wazero.NewModuleConfig().
 		WithSysNanotime(). // poll_oneoff requires nanotime.
 		WithArgs("wasi", "stdin").
-		WithStdin(r).WithStdout(os.Stdout)
+		WithStdin(r)
 	ch := make(chan string, 1)
 	go func() {
 		ch <- compileAndRun(t, testCtx, moduleConfig, bin)

--- a/internal/sysfs/file.go
+++ b/internal/sysfs/file.go
@@ -69,6 +69,12 @@ type stdioFile struct {
 	st fsapi.Stat_t
 }
 
+// SetAppend implements File.SetAppend
+func (f *stdioFile) SetAppend(bool) syscall.Errno {
+	// Ignore for stdio.
+	return 0
+}
+
 // IsDir implements File.IsDir
 func (f *stdioFile) IsDir() (bool, syscall.Errno) {
 	return false, 0

--- a/internal/sysfs/file.go
+++ b/internal/sysfs/file.go
@@ -75,6 +75,11 @@ func (f *stdioFile) SetAppend(bool) syscall.Errno {
 	return 0
 }
 
+// IsAppend implements File.SetAppend
+func (f *stdioFile) IsAppend() bool {
+	return true
+}
+
 // IsDir implements File.IsDir
 func (f *stdioFile) IsDir() (bool, syscall.Errno) {
 	return false, 0

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -131,6 +131,16 @@ func TestFileSetAppend(t *testing.T) {
 	requireFileContent("wazero6789wazero")
 }
 
+func TestStdioFile_SetAppend(t *testing.T) {
+	// SetAppend should not affect Stdio.
+	file, err := NewStdioFile(false, os.Stdout)
+	require.NoError(t, err)
+	errno := file.SetAppend(true)
+	require.EqualErrno(t, 0, errno)
+	_, errno = file.Write([]byte{})
+	require.EqualErrno(t, 0, errno)
+}
+
 func TestFileIno(t *testing.T) {
 	tmpDir := t.TempDir()
 	dirFS, embedFS, mapFS := dirEmbedMapFS(t, tmpDir)


### PR DESCRIPTION
- Allow nonblocking stdin to go through the "normal" file descriptor flow in `poll_oneoff`.
- Ensure stdio FDs are not closed on `SetAppend`: the default behavior for SetAppend() is to reopen, that is close and then open again: this causes an error on std streams. Just ignore the call on them.

Fixes #1538.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>