### PR TITLE
fs: stops pre-fetching the inode of dot-dot ("..")

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -4919,8 +4919,8 @@ func requireOpenFile(t *testing.T, tmpDir string, pathName string, data []byte, 
 	return mod, fd, log, r
 }
 
-// Test_fdReaddir_dotEntriesHaveRealInodes because wasi-testsuite requires it.
-func Test_fdReaddir_dotEntriesHaveRealInodes(t *testing.T) {
+// Test_fdReaddir_dotEntryHasARealInode because wasi-testsuite requires it.
+func Test_fdReaddir_dotEntryHasARealInode(t *testing.T) {
 	if runtime.GOOS == "windows" && !platform.IsGo120 {
 		t.Skip("windows before go 1.20 has trouble reading the inode information on directories.")
 	}
@@ -4954,11 +4954,10 @@ func Test_fdReaddir_dotEntriesHaveRealInodes(t *testing.T) {
 	dirents = append(dirents, 3, 0, 0, 0)             // d_type = directory
 	dirents = append(dirents, '.')                    // name
 
-	// get the real inode of the parent directory
-	st, errno = preopen.Stat(".")
 	require.EqualErrno(t, 0, errno)
 	dirents = append(dirents, 2, 0, 0, 0, 0, 0, 0, 0) // d_next = 2
-	dirents = append(dirents, u64.LeBytes(st.Ino)...) // d_ino
+	// See /RATIONALE.md for why we don't attempt to get an inode for ".."
+	dirents = append(dirents, 0, 0, 0, 0, 0, 0, 0, 0) // d_ino
 	dirents = append(dirents, 2, 0, 0, 0)             // d_namlen = 2 characters
 	dirents = append(dirents, 3, 0, 0, 0)             // d_type = directory
 	dirents = append(dirents, '.', '.')               // name
@@ -5021,7 +5020,8 @@ func Test_fdReaddir_opened_file_written(t *testing.T) {
 	st, errno = preopen.Stat(".")
 	require.EqualErrno(t, 0, errno)
 	dirents = append(dirents, 2, 0, 0, 0, 0, 0, 0, 0) // d_next = 2
-	dirents = append(dirents, u64.LeBytes(st.Ino)...) // d_ino
+	// See /RATIONALE.md for why we don't attempt to get an inode for ".."
+	dirents = append(dirents, 0, 0, 0, 0, 0, 0, 0, 0) // d_ino
 	dirents = append(dirents, 2, 0, 0, 0)             // d_namlen = 2 characters
 	dirents = append(dirents, 3, 0, 0, 0)             // d_type = directory
 	dirents = append(dirents, '.', '.')               // name

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"io/fs"
 	"net"
-	"path"
 	"syscall"
 
 	"github.com/tetratelabs/wazero/internal/descriptor"
@@ -160,15 +159,8 @@ func synthesizeDotEntries(f *FileEntry) (result []fsapi.Dirent, errno syscall.Er
 		return nil, errno
 	}
 	result = append(result, fsapi.Dirent{Name: ".", Ino: dotIno, Type: fs.ModeDir})
-	dotDotIno := uint64(0)
-	if !f.IsPreopen && f.Name != "." {
-		if st, errno := f.FS.Stat(path.Dir(f.Name)); errno != 0 {
-			return nil, errno
-		} else {
-			dotDotIno = st.Ino
-		}
-	}
-	result = append(result, fsapi.Dirent{Name: "..", Ino: dotDotIno, Type: fs.ModeDir})
+	// See /RATIONALE.md for why we don't attempt to get an inode for ".."
+	result = append(result, fsapi.Dirent{Name: "..", Ino: 0, Type: fs.ModeDir})
 	return result, 0
 }
 


### PR DESCRIPTION
We pre-fetched inodes of both dot (".") and dot-dot ("..") when wasi-testsuite started validating them. On close inspection, it only validates the one on dot, so we can skip the problems trying to get the one for dot-dot.