### PR TITLE
Simplifies filesystem implementations

### DIFF
--- a/imports/wasi_snapshot_preview1/wasi_bench_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_bench_test.go
@@ -219,7 +219,6 @@ func Benchmark_fdReaddir(b *testing.B) {
 				if f.File, errno = fsc.RootFS().OpenFile(".", os.O_RDONLY, 0); errno != 0 {
 					b.Fatal(errno)
 				}
-				fsc.CloseReaddir(fd)
 
 				// Make an initial call to build the state of an unread directory
 				if bc.continued {

--- a/internal/fsapi/dir.go
+++ b/internal/fsapi/dir.go
@@ -9,20 +9,22 @@ import (
 
 // Dirent is an entry read from a directory.
 //
-// This is a portable variant of syscall.Dirent containing fields needed for
-// WebAssembly ABI including WASI snapshot-01 and wasi-filesystem. Unlike
-// fs.DirEntry, this may include the Ino.
+// # Notes
+//
+//   - This extends `dirent` defined in POSIX with some fields defined by
+//     Linux. See https://man7.org/linux/man-pages/man3/readdir.3.html and
+//     https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/dirent.h.html
 type Dirent struct {
-	// ^^ Dirent name matches syscall.Dirent
-
-	// Name is the base name of the directory entry.
-	Name string
-
 	// Ino is the file serial number, or zero if not available.
 	Ino uint64
 
+	// Name is the base name of the directory entry. Empty is invalid.
+	Name string
+
 	// Type is fs.FileMode masked on fs.ModeType. For example, zero is a
 	// regular file, fs.ModeDir is a directory and fs.ModeIrregular is unknown.
+	//
+	// Note: This is defined by Linux, not POSIX.
 	Type fs.FileMode
 }
 

--- a/internal/sysfs/dir.go
+++ b/internal/sysfs/dir.go
@@ -13,12 +13,12 @@ func adjustReaddirErr(f fsapi.File, isClosed bool, err error) syscall.Errno {
 		return 0 // e.g. Readdir on darwin returns io.EOF, but linux doesn't.
 	} else if errno := platform.UnwrapOSError(err); errno != 0 {
 		errno = dirError(f, isClosed, errno)
-		// Ignore errors when the file was closed or removed.
+		// Comply with errors allowed on fsapi.File Readdir
 		switch errno {
-		case syscall.EIO, syscall.EBADF: // closed while open
-			return 0
-		case syscall.ENOENT: // Linux error when removed while open
-			return 0
+		case syscall.EINVAL: // os.File Readdir can return this
+			return syscall.EBADF
+		case syscall.ENOTDIR: // dirError can return this
+			return syscall.EBADF
 		}
 		return errno
 	}

--- a/internal/sysfs/open_file.go
+++ b/internal/sysfs/open_file.go
@@ -7,13 +7,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 )
-
-func newOsFile(openPath string, openFlag int, openPerm fs.FileMode, f *os.File) fsapi.File {
-	return newDefaultOsFile(openPath, openFlag, openPerm, f)
-}
 
 // OpenFile is like os.OpenFile except it returns syscall.Errno. A zero
 // syscall.Errno is success.

--- a/internal/sysfs/open_file_js.go
+++ b/internal/sysfs/open_file_js.go
@@ -8,10 +8,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/platform"
 )
 
-func newOsFile(openPath string, openFlag int, openPerm fs.FileMode, f *os.File) File {
-	return newDefaultOsFile(openPath, openFlag, openPerm, f)
-}
-
 func openFile(path string, flag int, perm fs.FileMode) (*os.File, syscall.Errno) {
 	flag &= ^(O_DIRECTORY | O_NOFOLLOW) // erase placeholders
 	f, err := os.OpenFile(path, flag, perm)

--- a/internal/sysfs/open_file_sun.go
+++ b/internal/sysfs/open_file_sun.go
@@ -7,13 +7,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 )
-
-func newOsFile(openPath string, openFlag int, openPerm fs.FileMode, f *os.File) fsapi.File {
-	return newDefaultOsFile(openPath, openFlag, openPerm, f)
-}
 
 func openFile(path string, flag int, perm fs.FileMode) (*os.File, syscall.Errno) {
 	f, err := os.OpenFile(path, flag, perm)


### PR DESCRIPTION
This performs a number of simplifying changes to files, particularly around directories. Some of them against my earlier advice to @evacchi!

* use POSIX errors only for readdir.
* stop using a separate subtype for windows osFile as the code is simpler with an if statement.
* stop using a separate table for directory stream descriptors. We aren't yet testing this works, so it is distracting. It was my bad advice to start doing this.