### PR TITLE
fd_readdir: reverts to special cased dirent cache

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2222,8 +2222,8 @@ func Test_fdReaddir_Rewind(t *testing.T) {
 		resultBuf[i] = '?'
 	}
 
-	// Set the cookie beyond the existing entries.
-	cookie += uint64(len(dirents))
+	// Advance the cookie beyond the existing entries.
+	cookie += 5
 	// Nothing to read from, so bufUsed must be zero.
 	require.Zero(t, int(read(cookie, bufSize)))
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -2171,11 +2171,11 @@ func Test_fdReaddir(t *testing.T) {
 				uint64(fd), uint64(buf), uint64(tc.bufLen), uint64(tc.cookie), uint64(resultBufused))
 
 			// read back the bufused and compare memory against it
-			bufUsed, ok := mod.Memory().ReadUint32Le(resultBufused)
+			bufused, ok := mod.Memory().ReadUint32Le(resultBufused)
 			require.True(t, ok)
-			require.Equal(t, tc.expectedBufused, bufUsed)
+			require.Equal(t, tc.expectedBufused, bufused)
 
-			mem, ok := mod.Memory().Read(buf, bufUsed)
+			mem, ok := mod.Memory().Read(buf, bufused)
 			require.True(t, ok)
 
 			if tc.expectedMem != nil {
@@ -2188,65 +2188,53 @@ func Test_fdReaddir(t *testing.T) {
 	}
 }
 
+// This is similar to https://github.com/WebAssembly/wasi-testsuite/blob/ac32f57400cdcdd0425d3085c24fc7fc40011d1c/tests/rust/src/bin/fd_readdir.rs#L120
 func Test_fdReaddir_Rewind(t *testing.T) {
-	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
+	tmpDir := t.TempDir()
+
+	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(os.DirFS(tmpDir)))
 	defer r.Close(testCtx)
 
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 
-	fd, errno := fsc.OpenFile(fsc.RootFS(), "dir", os.O_RDONLY, 0)
+	fd, errno := fsc.OpenFile(fsc.RootFS(), ".", os.O_RDONLY, 0)
 	require.EqualErrno(t, 0, errno)
 
 	mem := mod.Memory()
-	const resultBufused, buf, bufSize = 0, 8, 200
-	read := func(cookie, bufSize uint64) (bufUsed uint32) {
+	const resultBufused, buf = 0, 8
+	fdReaddir := func(cookie uint64) uint32 {
 		requireErrnoResult(t, wasip1.ErrnoSuccess, mod, wasip1.FdReaddirName,
-			uint64(fd), buf, bufSize, cookie, uint64(resultBufused))
-
-		bufUsed, ok := mem.ReadUint32Le(resultBufused)
+			uint64(fd), buf, 256, cookie, uint64(resultBufused))
+		bufused, ok := mem.ReadUint32Le(resultBufused)
 		require.True(t, ok)
-		return bufUsed
+		return bufused
 	}
 
-	cookie := uint64(0)
-	// Initial read.
-	initialBufUsed := read(cookie, bufSize)
-	// Ensure that all is read.
-	require.Equal(t, len(dirents), int(initialBufUsed))
-	resultBuf, ok := mem.Read(buf, initialBufUsed)
-	require.True(t, ok)
-	require.Equal(t, dirents, resultBuf)
+	// Read the empty directory, which should only have the dot entries.
+	bufused := fdReaddir(0)
+	dotDirentsLen := (wasip1.DirentSize + 1) + (wasip1.DirentSize + 2)
+	require.Equal(t, dotDirentsLen, bufused)
 
-	// Mask the result.
-	for i := range resultBuf {
-		resultBuf[i] = '?'
-	}
+	// Write a new file to the directory
+	fileName := "file"
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, fileName), nil, 0o0666))
+	fileDirentLen := wasip1.DirentSize + uint32(len(fileName))
 
-	// Advance the cookie beyond the existing entries.
-	cookie += 5
-	// Nothing to read from, so bufUsed must be zero.
-	require.Zero(t, int(read(cookie, bufSize)))
+	// Read it again, which should see the new file.
+	bufused = fdReaddir(0)
+	require.Equal(t, dotDirentsLen+fileDirentLen, bufused)
 
-	// Ensure buffer is intact.
-	for i := range resultBuf {
-		require.Equal(t, byte('?'), resultBuf[i])
-	}
+	// Read it again, using the file position.
+	bufused = fdReaddir(2)
+	require.Equal(t, fileDirentLen, bufused)
 
-	// Here, we rewind the directory by setting cookie=0 on the same file descriptor.
-	cookie = 0
-	usedAfterRewind := read(cookie, bufSize)
-	// Ensure that all is read.
-	require.Equal(t, len(dirents), int(usedAfterRewind))
-	resultBuf, ok = mem.Read(buf, usedAfterRewind)
-	require.True(t, ok)
-	require.Equal(t, dirents, resultBuf)
 	require.Equal(t, `
-==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=8,buf_len=200,cookie=0)
-<== (bufused=129,errno=ESUCCESS)
-==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=8,buf_len=200,cookie=5)
-<== (bufused=0,errno=ESUCCESS)
-==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=8,buf_len=200,cookie=0)
-<== (bufused=129,errno=ESUCCESS)
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=8,buf_len=256,cookie=0)
+<== (bufused=51,errno=ESUCCESS)
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=8,buf_len=256,cookie=0)
+<== (bufused=79,errno=ESUCCESS)
+==> wasi_snapshot_preview1.fd_readdir(fd=4,buf=8,buf_len=256,cookie=2)
+<== (bufused=28,errno=ESUCCESS)
 `, "\n"+log.String())
 }
 

--- a/imports/wasi_snapshot_preview1/fs_unit_test.go
+++ b/imports/wasi_snapshot_preview1/fs_unit_test.go
@@ -15,83 +15,83 @@ import (
 
 func Test_maxDirents(t *testing.T) {
 	tests := []struct {
-		name                        string
-		dirents                     []fsapi.Dirent
-		maxLen                      uint32
-		expectedCount               uint32
-		expectedwriteTruncatedEntry bool
-		expectedBufused             uint32
+		name                 string
+		dirents              []fsapi.Dirent
+		bufLen               uint32
+		expectedBufToWrite   uint32
+		expectedDirentCount  int
+		expectedTruncatedLen uint32
 	}{
 		{
 			name: "no entries",
 		},
 		{
-			name:                        "can't fit one",
-			dirents:                     testDirents,
-			maxLen:                      23,
-			expectedBufused:             23,
-			expectedwriteTruncatedEntry: false,
+			name:                 "can't fit one",
+			dirents:              testDirents,
+			bufLen:               23,
+			expectedBufToWrite:   23,
+			expectedDirentCount:  1,
+			expectedTruncatedLen: 23,
 		},
 		{
-			name:                        "only fits header",
-			dirents:                     testDirents,
-			maxLen:                      24,
-			expectedBufused:             24,
-			expectedwriteTruncatedEntry: true,
+			name:                 "only fits header",
+			dirents:              testDirents,
+			bufLen:               wasip1.DirentSize,
+			expectedBufToWrite:   wasip1.DirentSize,
+			expectedDirentCount:  1,
+			expectedTruncatedLen: wasip1.DirentSize,
 		},
 		{
-			name:            "one",
-			dirents:         testDirents,
-			maxLen:          25,
-			expectedCount:   1,
-			expectedBufused: 25,
+			name:                "one",
+			dirents:             testDirents,
+			bufLen:              25,
+			expectedBufToWrite:  25,
+			expectedDirentCount: 1,
 		},
 		{
-			name:                        "one but not room for two's name",
-			dirents:                     testDirents,
-			maxLen:                      25 + 25,
-			expectedCount:               1,
-			expectedwriteTruncatedEntry: true, // can write DirentSize
-			expectedBufused:             25 + 25,
+			name:                 "one but not room for two's name",
+			dirents:              testDirents,
+			bufLen:               25 + 25,
+			expectedBufToWrite:   25 + wasip1.DirentSize,
+			expectedDirentCount:  2,
+			expectedTruncatedLen: wasip1.DirentSize, // can write DirentSize
 		},
 		{
-			name:            "two",
-			dirents:         testDirents,
-			maxLen:          25 + 26,
-			expectedCount:   2,
-			expectedBufused: 25 + 26,
+			name:                "two",
+			dirents:             testDirents,
+			bufLen:              25 + 26,
+			expectedBufToWrite:  25 + 26,
+			expectedDirentCount: 2,
 		},
 		{
-			name:                        "two but not three's dirent",
-			dirents:                     testDirents,
-			maxLen:                      25 + 26 + 20,
-			expectedCount:               2,
-			expectedwriteTruncatedEntry: false, // 20 + 4 == DirentSize
-			expectedBufused:             25 + 26 + 20,
+			name:                 "two but not three's dirent",
+			dirents:              testDirents,
+			bufLen:               25 + 26 + 20,
+			expectedBufToWrite:   25 + 26 + 20,
+			expectedDirentCount:  3,
+			expectedTruncatedLen: 20, // 20 + 4 == DirentSize
 		},
 		{
-			name:                        "two but not three's name",
-			dirents:                     testDirents,
-			maxLen:                      25 + 26 + 26,
-			expectedCount:               2,
-			expectedwriteTruncatedEntry: true, // can write DirentSize
-			expectedBufused:             25 + 26 + 26,
+			name:                 "two but not three's name",
+			dirents:              testDirents,
+			bufLen:               25 + 26 + 25,
+			expectedBufToWrite:   25 + 26 + wasip1.DirentSize,
+			expectedDirentCount:  3,
+			expectedTruncatedLen: wasip1.DirentSize, // can write DirentSize
 		},
 		{
-			name:                        "three",
-			dirents:                     testDirents,
-			maxLen:                      25 + 26 + 27,
-			expectedCount:               3,
-			expectedwriteTruncatedEntry: false, // end of dir
-			expectedBufused:             25 + 26 + 27,
+			name:                "three",
+			dirents:             testDirents,
+			bufLen:              25 + 26 + 27,
+			expectedBufToWrite:  25 + 26 + 27,
+			expectedDirentCount: 3,
 		},
 		{
-			name:                        "max",
-			dirents:                     testDirents,
-			maxLen:                      100,
-			expectedCount:               3,
-			expectedwriteTruncatedEntry: false, // end of dir
-			expectedBufused:             25 + 26 + 27,
+			name:                "max",
+			dirents:             testDirents,
+			bufLen:              100,
+			expectedBufToWrite:  25 + 26 + 27,
+			expectedDirentCount: 3,
 		},
 	}
 
@@ -99,18 +99,10 @@ func Test_maxDirents(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			readdir, _ := sys.NewReaddir(
-				func() ([]fsapi.Dirent, syscall.Errno) {
-					return tc.dirents, 0
-				},
-				func(n uint64) ([]fsapi.Dirent, syscall.Errno) {
-					return nil, 0
-				},
-			)
-			_, bufused, direntCount, writeTruncatedEntry := maxDirents(readdir, tc.maxLen)
-			require.Equal(t, tc.expectedCount, direntCount)
-			require.Equal(t, tc.expectedwriteTruncatedEntry, writeTruncatedEntry)
-			require.Equal(t, tc.expectedBufused, bufused)
+			bufToWrite, direntCount, truncatedLen := maxDirents(tc.dirents, tc.bufLen)
+			require.Equal(t, tc.expectedBufToWrite, bufToWrite)
+			require.Equal(t, tc.expectedDirentCount, direntCount)
+			require.Equal(t, tc.expectedTruncatedLen, truncatedLen)
 		})
 	}
 }
@@ -155,40 +147,47 @@ var (
 
 func Test_writeDirents(t *testing.T) {
 	tests := []struct {
-		name                string
-		entries             []fsapi.Dirent
-		entryCount          uint32
-		writeTruncatedEntry bool
-		expectedEntriesBuf  []byte
+		name         string
+		dirents      []fsapi.Dirent
+		entryCount   int
+		truncatedLen uint32
+		expected     []byte
 	}{
 		{
 			name:    "none",
-			entries: testDirents,
+			dirents: testDirents,
 		},
 		{
-			name:               "one",
-			entries:            testDirents,
-			entryCount:         1,
-			expectedEntriesBuf: dirent1,
+			name:       "one",
+			dirents:    testDirents,
+			entryCount: 1,
+			expected:   dirent1,
 		},
 		{
-			name:               "two",
-			entries:            testDirents,
-			entryCount:         2,
-			expectedEntriesBuf: append(dirent1, dirent2...),
+			name:       "two",
+			dirents:    testDirents,
+			entryCount: 2,
+			expected:   append(dirent1, dirent2...),
 		},
 		{
-			name:                "two with truncated",
-			entries:             testDirents,
-			entryCount:          2,
-			writeTruncatedEntry: true,
-			expectedEntriesBuf:  append(append(dirent1, dirent2...), dirent3[0:10]...),
+			name:         "two with truncated dirent",
+			dirents:      testDirents,
+			entryCount:   3,
+			truncatedLen: wasip1.DirentSize,
+			expected:     append(append(dirent1, dirent2...), dirent3[:wasip1.DirentSize]...),
 		},
 		{
-			name:               "three",
-			entries:            testDirents,
-			entryCount:         3,
-			expectedEntriesBuf: append(append(dirent1, dirent2...), dirent3...),
+			name:         "two with truncated smaller than dirent",
+			dirents:      testDirents,
+			entryCount:   3,
+			truncatedLen: 5,
+			expected:     append(append(dirent1, dirent2...), 0, 0, 0, 0, 0),
+		},
+		{
+			name:       "three",
+			dirents:    testDirents,
+			entryCount: 3,
+			expected:   append(append(dirent1, dirent2...), dirent3...),
 		},
 	}
 
@@ -196,10 +195,10 @@ func Test_writeDirents(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			cookie := uint64(1)
-			entriesBuf := make([]byte, len(tc.expectedEntriesBuf))
-			writeDirents(tc.entries, tc.entryCount, tc.writeTruncatedEntry, entriesBuf, cookie)
-			require.Equal(t, tc.expectedEntriesBuf, entriesBuf)
+			d_next := uint64(1)
+			buf := make([]byte, len(tc.expected))
+			writeDirents(buf, tc.dirents, d_next, tc.entryCount, tc.truncatedLen)
+			require.Equal(t, tc.expected, buf)
 		})
 	}
 }

--- a/internal/fsapi/file.go
+++ b/internal/fsapi/file.go
@@ -226,12 +226,11 @@ type File interface {
 	//
 	//   - This is like `Readdir` on os.File, but unlike `readdir` in POSIX.
 	//     See https://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html
+	//   - Unlike os.File, there is no io.EOF returned on end-of-directory. To
+	//     read the directory completely, the caller must repeat until the
+	//     count read (`len(dirents)`) is less than `n`.
+	//   - See /RATIONALE.md for design notes.
 	Readdir(n int) (dirents []Dirent, errno syscall.Errno)
-	// ^-- TODO: consider being more like POSIX, for example, returning a
-	// closeable Dirent object that can iterate on demand. This would
-	// centralize sizing logic needed by wasi, particularly extra dirents
-	// stored in the sys.FileEntry type. It could possibly reduce the need to
-	// reopen the whole file.
 
 	// Write attempts to write all bytes in `p` to the file, and returns the
 	// count written even on error.

--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -160,8 +160,9 @@ func (d *DirentCache) Read(pos uint64, n uint32) (dirents []fsapi.Dirent, errno 
 	switch {
 	case pos > d.countRead: // farther than read or negative coerced to uint64.
 		return nil, syscall.ENOENT
-	case pos == 0 && d.countRead != uint64(len(d.dirents)):
-		// Rewind if we aren't already caching the first entry.
+	case pos == 0 && d.dirents != nil:
+		// Rewind if we have already read entries. This allows us to see new
+		// entries added after the directory was opened.
 		if _, errno = d.f.Seek(0, io.SeekStart); errno != 0 {
 			return
 		}


### PR DESCRIPTION
This reverts to a design similar to, but more performant than 1.2.0+. Due to missing benchmarks, we accidentally regressed performance while attempting to clean the internal implementation of directory pagination.

For reasons described in #1529, the refactoring was going the wrong way anyway. This goes back to the better performing impl we had before, makes it perform even better, and backfills missing documentation.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1
                                      │ before-refactor.txt │             before.txt             │              now.txt               │
                                      │       sec/op        │   sec/op     vs base               │   sec/op     vs base               │
_fdReaddir/embed.FS-12                          2.255µ ± 7%   2.879µ ± 6%  +27.70% (p=0.002 n=6)   1.554µ ± 4%  -31.09% (p=0.002 n=6)
_fdReaddir/embed.FS_-_two_calls-12              2.897µ ± 1%   3.606µ ± 3%  +24.50% (p=0.002 n=6)   2.224µ ± 3%  -23.22% (p=0.002 n=6)
_fdReaddir/os.DirFS-12                          42.74µ ± 1%   43.62µ ± 1%   +2.07% (p=0.002 n=6)   39.74µ ± 1%   -7.00% (p=0.002 n=6)
_fdReaddir/os.DirFS_-_two_calls-12              43.24µ ± 0%   44.15µ ± 2%   +2.12% (p=0.002 n=6)   40.76µ ± 0%   -5.72% (p=0.002 n=6)
_fdReaddir/sysfs.DirFS-12                       39.71µ ± 0%   41.33µ ± 0%   +4.08% (p=0.002 n=6)   39.64µ ± 1%        ~ (p=0.310 n=6)
_fdReaddir/sysfs.DirFS_-_two_calls-12           40.67µ ± 1%   41.57µ ± 2%   +2.21% (p=0.002 n=6)   40.71µ ± 1%        ~ (p=0.461 n=6)
geomean                                         16.40µ        18.03µ        +9.91%                 14.43µ       -12.02%

                                      │ before-refactor.txt │             before.txt              │              now.txt               │
                                      │        B/op         │     B/op      vs base               │     B/op      vs base              │
_fdReaddir/embed.FS-12                         1.250Ki ± 0%   2.344Ki ± 0%  +87.50% (p=0.002 n=6)   1.219Ki ± 0%  -2.50% (p=0.002 n=6)
_fdReaddir/embed.FS_-_two_calls-12             1.359Ki ± 0%   2.609Ki ± 0%  +91.95% (p=0.002 n=6)   1.328Ki ± 0%  -2.30% (p=0.002 n=6)
_fdReaddir/os.DirFS-12                         6.141Ki ± 0%   8.391Ki ± 0%  +36.64% (p=0.002 n=6)   6.078Ki ± 0%  -1.02% (p=0.002 n=6)
_fdReaddir/os.DirFS_-_two_calls-12             7.445Ki ± 0%   8.672Ki ± 0%  +16.47% (p=0.002 n=6)   7.383Ki ± 0%  -0.84% (p=0.002 n=6)
_fdReaddir/sysfs.DirFS-12                      5.906Ki ± 0%   8.211Ki ± 0%  +39.02% (p=0.002 n=6)   6.031Ki ± 0%  +2.12% (p=0.002 n=6)
_fdReaddir/sysfs.DirFS_-_two_calls-12          7.211Ki ± 0%   8.492Ki ± 0%  +17.77% (p=0.002 n=6)   7.336Ki ± 0%  +1.73% (p=0.002 n=6)
geomean                                        3.860Ki        5.606Ki       +45.22%                 3.842Ki       -0.48%

                                      │ before-refactor.txt │             before.txt             │              now.txt              │
                                      │      allocs/op      │  allocs/op   vs base               │ allocs/op   vs base               │
_fdReaddir/embed.FS-12                          13.000 ± 0%   19.000 ± 0%  +46.15% (p=0.002 n=6)   8.000 ± 0%  -38.46% (p=0.002 n=6)
_fdReaddir/embed.FS_-_two_calls-12               18.00 ± 0%    24.00 ± 0%  +33.33% (p=0.002 n=6)   13.00 ± 0%  -27.78% (p=0.002 n=6)
_fdReaddir/os.DirFS-12                           56.00 ± 0%    66.00 ± 0%  +17.86% (p=0.002 n=6)   52.00 ± 0%   -7.14% (p=0.002 n=6)
_fdReaddir/os.DirFS_-_two_calls-12               64.00 ± 0%    71.00 ± 0%  +10.94% (p=0.002 n=6)   60.00 ± 0%   -6.25% (p=0.002 n=6)
_fdReaddir/sysfs.DirFS-12                        51.00 ± 0%    62.00 ± 0%  +21.57% (p=0.002 n=6)   52.00 ± 0%   +1.96% (p=0.002 n=6)
_fdReaddir/sysfs.DirFS_-_two_calls-12            59.00 ± 0%    67.00 ± 0%  +13.56% (p=0.002 n=6)   60.00 ± 0%   +1.69% (p=0.002 n=6)
geomean                                          36.90         45.50       +23.32%                 31.69       -14.12%
```