### PR TITLE
readdir: defer re-opening when Seek(0,SeekStart) on a directory

### DIFF
--- a/internal/fsapi/dir.go
+++ b/internal/fsapi/dir.go
@@ -75,11 +75,6 @@ func (DirFile) Pread([]byte, int64) (int, syscall.Errno) {
 	return 0, syscall.EISDIR
 }
 
-// Seek implements File.Seek
-func (DirFile) Seek(int64, int) (int64, syscall.Errno) {
-	return 0, syscall.EISDIR
-}
-
 // PollRead implements File.PollRead
 func (DirFile) PollRead(*time.Duration) (ready bool, errno syscall.Errno) {
 	return false, syscall.ENOSYS

--- a/internal/sysfs/dir_test.go
+++ b/internal/sysfs/dir_test.go
@@ -52,6 +52,11 @@ func TestReaddir(t *testing.T) {
 				require.EqualErrno(t, 0, errno)
 				require.Zero(t, newOffset)
 
+				// redundantly seek to zero again
+				newOffset, errno = dotF.Seek(0, io.SeekStart)
+				require.EqualErrno(t, 0, errno)
+				require.Zero(t, newOffset)
+
 				// We should be able to read again
 				testReaddirAll(t, dotF, tc.expectIno)
 			})


### PR DESCRIPTION
This defers re-opening the directory on `Seek(0, SeekStart)`.

I noticed that in the current code, [we unconditionally seek to zero before reading a directory](https://github.com/tetratelabs/wazero/blob/main/internal/sys/fs.go#L175-L178). I think this is incorrect and later will try to remove this, but meanwhile we can make the impact less.

Seek 0 costs a syscall or worse re-opening the file, if on windows or `fs.File`. Currently, we already re-open the directory on first call to `Readdir` on windows, so this behavior requires 2 re-opens at the moment.

The errno in `Seek` is mostly about the position/location. Zero is always valid, so we don't need to return an error immediately on that. If we defer a re-open, we get multiple benefits:
* we don't re-open a windows directory twice on `Readdir` after `Seek(0, SeekStart)`
* we also don't re-open a fs.File backed directory, if `Seek(0, SeekStart)` was called twice.

I also re-jigged the tests a bit to trigger this even if testing that this prevents called twice is a bit too tricky to attempt right now.