### PR TITLE
fix(sysfs): return non-zero ino when adapting fs.FS

### DIFF
--- a/internal/sysfs/dir_test.go
+++ b/internal/sysfs/dir_test.go
@@ -29,7 +29,7 @@ func TestReaddir(t *testing.T) {
 		expectIno bool
 	}{
 		{name: "os.DirFS", fs: dirFS, expectIno: runtime.GOOS != "windows"}, // To test readdirFile
-		{name: "fstest.MapFS", fs: fstest.FS, expectIno: false},             // To test adaptation of ReadDirFile
+		{name: "fstest.MapFS", fs: fstest.FS, expectIno: true},              // To test adaptation of ReadDirFile
 	}
 
 	for _, tc := range tests {

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -145,8 +145,8 @@ func TestFileIno(t *testing.T) {
 		expectedIno uint64
 	}{
 		{name: "os.DirFS", fs: dirFS, expectedIno: st.Ino},
-		{name: "embed.api.FS", fs: embedFS},
-		{name: "fstest.MapFS", fs: mapFS},
+		{name: "embed.api.FS", fs: embedFS, expectedIno: 12638153115695167473},
+		{name: "fstest.MapFS", fs: mapFS, expectedIno: 12638153115695167473},
 	}
 
 	for _, tc := range tests {

--- a/internal/sysfs/readfs_test.go
+++ b/internal/sysfs/readfs_test.go
@@ -140,7 +140,7 @@ func TestReadFS_Open_Read(t *testing.T) {
 
 	tests := []test{
 		{name: "DirFS", fs: NewReadFS(NewDirFS(tmpDir)), expectIno: true},
-		{name: "fstest.MapFS", fs: NewReadFS(Adapt(fstest.FS)), expectIno: false},
+		{name: "fstest.MapFS", fs: NewReadFS(Adapt(fstest.FS)), expectIno: true},
 	}
 
 	// We can't correct operating system portability issues with os.DirFS on


### PR DESCRIPTION
Fixes https://github.com/tetratelabs/wazero/issues/1553

This is probably a really stupid idea. However, I found (in the issue linked) that the Go wasip1 implementation will just drop directory entries on the floor with a `0` ino. So `Readdir` just always returns nothing when your supply wazero with an implementation of `fs.FS`.

https://github.com/golang/go/blob/master/src/syscall/dirent.go#L78-L80

So my stupid idea was to just hash the name of the file (with parent for dirent) to a uint64 to represent the ino.
This is probably madness, but it does work for me and my `fs.FS` implementations can now support reading directories when I do this and the binary has been compiled from Go 1.21 with the `wasip1` target.

I branched off of `v1.2.1` to validate this as currently when I work from the HEAD of `main` I consistently get:
```
panic: open .: Bad file number

goroutine 1 [running]:
main.main()
	/Users/georgemac/github/georgemac/wasm-invoke/cmd/walk/main.go:11 +0x14
	==> wasi_snapshot_preview1.proc_exit(rval=2)
```

That is just from `main` itself, even with `os.DirFS`. Something seems up there.

Anyway, this is mostly food for thought and open to alternative ideas. My first approach was to just have a package level uint64 and read it with `atomic.AddUint64(&inos, 1)`.