### PR TITLE
fs: empty guest path should bind to /

### DIFF
--- a/internal/sys/fs.go
+++ b/internal/sys/fs.go
@@ -413,6 +413,8 @@ func (c *Context) InitFSContext(
 		guestPath := guestPaths[i]
 
 		if StripPrefixesAndTrailingSlash(guestPath) == "" {
+			// Default to bind to '/' when guestPath is effectively empty.
+			guestPath = "/"
 			c.fsc.rootFS = fs
 		}
 		c.fsc.openedFiles.Insert(&FileEntry{


### PR DESCRIPTION
Fixes https://github.com/tetratelabs/wazero/issues/1564.

Commit https://github.com/tetratelabs/wazero/commit/53ce5eea830b3100af7ec8caa13bb38310c0afbf#diff-4fb3ce1d291b912fd6aa5e7f790040234a92683e313d1c757c0fce7be9e43320L397-L400 altered the effective behavior of `.WithFS()`; whereas prior to this patch a single, non-composite FS would always bind to "/" :

https://github.com/tetratelabs/wazero/blob/97d0d70b7321e5c16e584bbb6b3169032208bdec/internal/sys/fs.go#L469-L476

now, the `guestPath` is always used:

https://github.com/tetratelabs/wazero/blob/485b9e3ece346c2dd0912e1a54703d70fa10cdcf/internal/sys/fs.go#L420-L425

we resolve by overriding `guestPath` to `"/"` when `StripPrefixesAndTrailingSlash(guestPath) == ""`