### PR TITLE
explicitly documents ModuleConfig defaults to _start

### DIFF
--- a/config.go
+++ b/config.go
@@ -493,7 +493,7 @@ type ModuleConfig interface {
 	// # Notes
 	//
 	//   - If a start function doesn't exist, it is skipped. However, any that
-	//	   do exist are called in order.
+	//     do exist are called in order.
 	//   - Start functions are not intended to be called multiple times.
 	//     Functions that should be called multiple times should be invoked
 	//     manually via api.Module's `ExportedFunction` method.

--- a/config.go
+++ b/config.go
@@ -492,10 +492,14 @@ type ModuleConfig interface {
 	//
 	// # Notes
 	//
-	//   - If any function doesn't exist, it is skipped. However, all functions
-	//	  that do exist are called in order.
-	//   - Some start functions may exit the module during instantiate with a
-	//	  sys.ExitError (e.g. emscripten), preventing use of exported functions.
+	//   - If a start function doesn't exist, it is skipped. However, any that
+	//	   do exist are called in order.
+	//   - Start functions are not intended to be called multiple times.
+	//     Functions that should be called multiple times should be invoked
+	//     manually via api.Module's `ExportedFunction` method.
+	//   - Start functions commonly exit the module during instantiation,
+	//     preventing use of any functions later. This is the case in "wasip1",
+	//     which defines the default value "_start".
 	WithStartFunctions(...string) ModuleConfig
 
 	// WithStderr configures where standard error (file descriptor 2) is written. Defaults to io.Discard.

--- a/runtime.go
+++ b/runtime.go
@@ -31,7 +31,8 @@ import (
 //   - Closing this closes any CompiledModule or Module it instantiated.
 type Runtime interface {
 	// Instantiate instantiates a module from the WebAssembly binary (%.wasm)
-	// with default configuration.
+	// with default configuration, which notably calls the "_start" function,
+	// if it exists.
 	//
 	// Here's an example:
 	//	ctx := context.Background()


### PR DESCRIPTION
wazero defines a helper function, `Instantiate`, which doesn't accept a `ModuleConfig`. This highlights that the default will call wasip1's `_start` function if it exists.

This does not fix #1561 but it documents the footgun we allow until that is fixed.