### PR TITLE
Changes build to test go 1.21rc2

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -39,8 +39,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:  # not cache: true as we also need to cache golint
+          cache: false
           go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/cache@v3
@@ -64,6 +65,7 @@ jobs:
       matrix:  # Use versions consistent with wazero's Go support policy.
         os: [ubuntu-22.04, macos-12, windows-2022]
         go-version:
+          - "1.21.0-rc.2"  # Test the pending next version
           - "1.20"  # Current Go version
           - "1.18"  # Floor Go version of wazero (current - 2)
 
@@ -71,10 +73,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
 
       # Ensure the pagefile is large enough to execute tests like TestStore_hammer_close on Windows.
       - name: configure Pagefile
@@ -106,6 +107,7 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
+          - "1.21.0-rc.2"  # Test the pending next version
           - "1.20"  # Current Go version
           - "1.18"  # Floor Go version of wazero (current - 2)
         arch:
@@ -117,10 +119,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
 
       - name: Build test binaries
         # Exclude benchmarks as we don't run those in Docker
@@ -164,10 +165,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
 
       - run: make bench
 
@@ -179,10 +179,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
 
       - uses: actions/cache@v3
         id: cache

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -41,10 +41,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
 
       - name: Install TinyGo
         run: |  # installing via curl so commands are similar on OS/x

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -97,7 +97,7 @@ jobs:
           path:
             ./zigbin/
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -135,7 +135,7 @@ jobs:
           echo "TINYGOROOT=/usr/local/tinygo" >> $GITHUB_ENV
           echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         if: steps.binary-cache.outputs.cache-hit != 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -216,7 +216,7 @@ jobs:
           path:
             ./tinygobin/
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -251,7 +251,7 @@ jobs:
             ~/go/pkg/mod
           key: integration-test-wasi-testsuite-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -298,7 +298,7 @@ jobs:
         os: [ubuntu-22.04, macos-12] # GOOS=js isn't supposed to work on windows. See #1222
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -332,8 +332,9 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: ${{ env.GO_VERSION }}
 
       # Go's source code changes, sometimes many times a day. To balance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: ${{ env.GO_VERSION }}
 
       - uses: actions/cache@v3

--- a/.github/workflows/spectest.yaml
+++ b/.github/workflows/spectest.yaml
@@ -39,10 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
 
       - run: make spectest.${{ matrix.spec-version }}
 
@@ -65,10 +64,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-          cache: true
 
       - name: Build test binaries
         run: go list -f '{{.Dir}}' ./... | grep 'spectest/${{ matrix.spec-version }}' | xargs -Ipkg go test pkg -c -o spectest.test

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -4888,7 +4888,7 @@ func requireOpenFile(t *testing.T, tmpDir string, pathName string, data []byte, 
 
 // Test_fdReaddir_dotEntryHasARealInode because wasi-testsuite requires it.
 func Test_fdReaddir_dotEntryHasARealInode(t *testing.T) {
-	if runtime.GOOS == "windows" && !platform.IsGo120 {
+	if runtime.GOOS == "windows" && !platform.IsAtLeastGo120 {
 		t.Skip("windows before go 1.20 has trouble reading the inode information on directories.")
 	}
 
@@ -4945,7 +4945,7 @@ func Test_fdReaddir_dotEntryHasARealInode(t *testing.T) {
 // is visible. This is significant on Windows.
 // https://github.com/ziglang/zig/blob/2ccff5115454bab4898bae3de88f5619310bc5c1/lib/std/fs/test.zig#L156-L184
 func Test_fdReaddir_opened_file_written(t *testing.T) {
-	if runtime.GOOS == "windows" && !platform.IsGo120 {
+	if runtime.GOOS == "windows" && !platform.IsAtLeastGo120 {
 		t.Skip("windows before go 1.20 has trouble reading the inode information on directories.")
 	}
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -5,12 +5,17 @@
 package platform
 
 import (
+	"regexp"
 	"runtime"
-	"strings"
 )
 
-// TODO: IsAtLeastGo120
-var IsGo120 = strings.Contains(runtime.Version(), "go1.20")
+// IsAtLeastGo120 checks features added in 1.20. We can remove this when Go
+// 1.22 is out.
+var IsAtLeastGo120 = isAtLeastGo120(runtime.Version())
+
+func isAtLeastGo120(version string) bool {
+	return regexp.MustCompile("go1.[2-9][0-9][^0-9]").MatchString(version)
+}
 
 // archRequirementsVerified is set by platform-specific init to true if the platform is supported
 var archRequirementsVerified bool

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -20,3 +20,23 @@ func Test_archRequirementsVerified(t *testing.T) {
 		require.False(t, archRequirementsVerified)
 	}
 }
+
+func Test_isAtLeastGo120(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{input: "go1.18.10", expected: false},
+		{input: "go1.20.5", expected: true},
+		{input: "devel go1.21-39c50707 Thu Jul 6 23:23:41 2023 +0000", expected: true},
+		{input: "go1.21rc2", expected: true},
+		{input: "go1.90.10", expected: true},
+		{input: "go2.0.0", expected: false},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+
+		require.Equal(t, tc.expected, isAtLeastGo120(tc.input), tc.input)
+	}
+}

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -196,7 +196,7 @@ func statSetsIno() bool {
 		// Go can read the inode via a Windows file handle, but it is
 		// inconsistent on Go 1.18.
 		// TODO: check on 1.19 can!
-		return platform.IsGo120
+		return platform.IsAtLeastGo120
 	}
 }
 
@@ -933,7 +933,7 @@ func TestFileUtimens(t *testing.T) {
 	case "linux", "darwin": // supported
 	case "freebsd": // TODO: support freebsd w/o CGO
 	case "windows":
-		if !platform.IsGo120 {
+		if !platform.IsAtLeastGo120 {
 			t.Skip("windows only works after Go 1.20") // TODO: possibly 1.19 ;)
 		}
 	default: // expect ENOSYS and callers need to fall back to Utimens

--- a/internal/sysfs/futimens.go
+++ b/internal/sysfs/futimens.go
@@ -50,16 +50,11 @@ func Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) syscal
 	return platform.UnwrapOSError(err)
 }
 
-var _zero uintptr //nolint:unused
-
 func timesToPtr(times *[2]syscall.Timespec) unsafe.Pointer { //nolint:unused
-	var _p0 unsafe.Pointer
 	if times != nil {
-		_p0 = unsafe.Pointer(&times[0])
-	} else {
-		_p0 = unsafe.Pointer(&_zero)
+		return unsafe.Pointer(&times[0])
 	}
-	return _p0
+	return unsafe.Pointer(nil)
 }
 
 func utimensPortable(path string, times *[2]syscall.Timespec, symlinkFollow bool) error { //nolint:unused

--- a/internal/sysfs/futimens_windows.go
+++ b/internal/sysfs/futimens_windows.go
@@ -21,7 +21,7 @@ func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) error 
 func futimens(fd uintptr, times *[2]syscall.Timespec) error {
 	// Before Go 1.20, ERROR_INVALID_HANDLE was returned for too many reasons.
 	// Kick out so that callers can use path-based operations instead.
-	if !platform.IsGo120 {
+	if !platform.IsAtLeastGo120 {
 		return syscall.ENOSYS
 	}
 

--- a/internal/sysfs/open_file_windows.go
+++ b/internal/sysfs/open_file_windows.go
@@ -136,7 +136,7 @@ func open(path string, mode int, perm uint32) (fd syscall.Handle, err error) {
 		}
 	}
 
-	if platform.IsGo120 {
+	if platform.IsAtLeastGo120 {
 		// This shouldn't be included before 1.20 to have consistent behavior.
 		// https://github.com/golang/go/commit/0f0aa5d8a6a0253627d58b3aa083b24a1091933f
 		if createmode == syscall.OPEN_EXISTING && access == syscall.GENERIC_READ {

--- a/internal/sysfs/sysfs_test.go
+++ b/internal/sysfs/sysfs_test.go
@@ -324,7 +324,7 @@ func testStat(t *testing.T, testFS fsapi.FS) {
 
 	require.True(t, st.Mode.IsDir())
 	// windows before go 1.20 has trouble reading the inode information on directories.
-	if runtime.GOOS != "windows" || platform.IsGo120 {
+	if runtime.GOOS != "windows" || platform.IsAtLeastGo120 {
 		require.NotEqual(t, uint64(0), st.Dev)
 		require.NotEqual(t, uint64(0), st.Ino)
 	}


### PR DESCRIPTION
This is in preparation for the upcoming Go 1.21 release, which will also raise the floor Go version to 1.19.