### PR TITLE
Fix drift in comment in mmap_other

### DIFF
--- a/internal/platform/mmap_other.go
+++ b/internal/platform/mmap_other.go
@@ -1,4 +1,4 @@
-// This uses syscall.Mprotect. Go's SDK only supports this on darwin and linux.
+// Separated from linux which has support for huge pages.
 //go:build darwin || freebsd
 
 package platform


### PR DESCRIPTION
Noticed this comment which seems to have drifted

- `syscall.Mmap` is called, not `Mprotect`
- The code is for darwin and freebsd, not linux

I tried updating to where I suspect the drift might have happened, but happy to tweak further or remove if it seems unneeded