### PR TITLE
fs: nonblocking writes should use syscall.Write

### DIFF
--- a/internal/sysfs/file_unix.go
+++ b/internal/sysfs/file_unix.go
@@ -8,7 +8,10 @@ import (
 	"github.com/tetratelabs/wazero/experimental/sys"
 )
 
-const nonBlockingFileIoSupported = true
+const (
+	nonBlockingFileReadSupported  = true
+	nonBlockingFileWriteSupported = true
+)
 
 // readFd exposes syscall.Read.
 func readFd(fd uintptr, buf []byte) (int, sys.Errno) {
@@ -16,6 +19,16 @@ func readFd(fd uintptr, buf []byte) (int, sys.Errno) {
 		return 0, 0 // Short-circuit 0-len reads.
 	}
 	n, err := syscall.Read(int(fd), buf)
+	errno := sys.UnwrapOSError(err)
+	return n, errno
+}
+
+// writeFd exposes syscall.Write.
+func writeFd(fd uintptr, buf []byte) (int, sys.Errno) {
+	if len(buf) == 0 {
+		return 0, 0 // Short-circuit 0-len writes.
+	}
+	n, err := syscall.Write(int(fd), buf)
 	errno := sys.UnwrapOSError(err)
 	return n, errno
 }

--- a/internal/sysfs/file_unsupported.go
+++ b/internal/sysfs/file_unsupported.go
@@ -2,11 +2,19 @@
 
 package sysfs
 
-import "syscall"
+import "github.com/tetratelabs/wazero/experimental/sys"
 
-const nonBlockingFileIoSupported = false
+const (
+	nonBlockingFileReadSupported  = false
+	nonBlockingFileWriteSupported = false
+)
 
 // readFd returns ENOSYS on unsupported platforms.
-func readFd(fd uintptr, buf []byte) (int, syscall.Errno) {
-	return -1, syscall.ENOSYS
+func readFd(fd uintptr, buf []byte) (int, sys.Errno) {
+	return -1, sys.ENOSYS
+}
+
+// writeFd returns ENOSYS on unsupported platforms.
+func writeFd(fd uintptr, buf []byte) (int, sys.Errno) {
+	return -1, sys.ENOSYS
 }

--- a/internal/sysfs/file_windows.go
+++ b/internal/sysfs/file_windows.go
@@ -7,7 +7,10 @@ import (
 	"github.com/tetratelabs/wazero/experimental/sys"
 )
 
-const nonBlockingFileIoSupported = true
+const (
+	nonBlockingFileReadSupported  = true
+	nonBlockingFileWriteSupported = false
+)
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")
 
@@ -55,4 +58,8 @@ func peekNamedPipe(handle syscall.Handle) (uint32, error) {
 		return totalBytesAvail, nil
 	}
 	return totalBytesAvail, err
+}
+
+func writeFd(fd uintptr, buf []byte) (int, sys.Errno) {
+	return -1, sys.ENOSYS
 }


### PR DESCRIPTION
resolves #1538 on non-Windows platforms. Windows will be addressed in #1579.

Using blocking `file.Write` APIs together with nonblocking I/O, causes stdout corruption under certain conditions. 

In particular, a reliable way to reproduce the issue is to capture the stdout of a sub-process running wazero. This PR fixes the writing issue by introducing `writeFd` (similar to `readFd` introduced in #1517), a function that just invokes the syscall directly when I/O is non-blocking. 

It also introduces the constants `nonBlockingFileReadSupported`, `nonBlockingFileWriteSupported`, superseding the generic `nonBlockingFileIoSupported`: the reason is still related to #1579, where Windows-related concerns will be addressed; for now we ignore the issue on that platform. However, because the test is _not skipped_ on Windows, it looks like that platform is not affected (also verified on my Windows machine).
