### PR TITLE
Moves UTIME constants to fsapi package

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/fsapi"
 	socketapi "github.com/tetratelabs/wazero/internal/sock"
 	"github.com/tetratelabs/wazero/internal/sys"
-	"github.com/tetratelabs/wazero/internal/sysfs"
 	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
 	sysapi "github.com/tetratelabs/wazero/sys"
@@ -530,9 +529,9 @@ func toTimes(atim, mtime int64, fstFlags uint16) (times [2]syscall.Timespec, err
 	} else if set {
 		times[0] = syscall.NsecToTimespec(atim)
 	} else if now {
-		times[0].Nsec = sysfs.UTIME_NOW
+		times[0].Nsec = fsapi.UTIME_NOW
 	} else {
-		times[0].Nsec = sysfs.UTIME_OMIT
+		times[0].Nsec = fsapi.UTIME_OMIT
 	}
 
 	// coerce mtim into a timespec
@@ -542,9 +541,9 @@ func toTimes(atim, mtime int64, fstFlags uint16) (times [2]syscall.Timespec, err
 	} else if set {
 		times[1] = syscall.NsecToTimespec(mtime)
 	} else if now {
-		times[1].Nsec = sysfs.UTIME_NOW
+		times[1].Nsec = fsapi.UTIME_NOW
 	} else {
-		times[1].Nsec = sysfs.UTIME_OMIT
+		times[1].Nsec = fsapi.UTIME_OMIT
 	}
 	return
 }

--- a/internal/fsapi/time.go
+++ b/internal/fsapi/time.go
@@ -1,0 +1,16 @@
+package fsapi
+
+// The following constants make it possible to portably handle utimes, at the
+// cost of making it impossible to set a time one or two nanoseconds before
+// epoch.
+
+const (
+	// UTIME_NOW is a special syscall.Timespec NSec value used to set the
+	// file's timestamp to a value close to, but not greater than the current
+	// system time.
+	UTIME_NOW = -1
+
+	// UTIME_OMIT is a special syscall.Timespec NSec value used to avoid
+	// setting the file's timestamp.
+	UTIME_OMIT = -2
+)

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -555,35 +555,35 @@ func TestDirFS_Utimesns(t *testing.T) {
 		{
 			name: "a=omit,m=omit",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_OMIT},
-				{Sec: 123, Nsec: UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
 			},
 		},
 		{
 			name: "a=now,m=omit",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_NOW},
-				{Sec: 123, Nsec: UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
 			},
 		},
 		{
 			name: "a=omit,m=now",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_OMIT},
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 			},
 		},
 		{
 			name: "a=now,m=now",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_NOW},
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 			},
 		},
 		{
 			name: "a=now,m=set",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 				{Sec: 123, Nsec: 4 * 1e3},
 			},
 		},
@@ -591,7 +591,7 @@ func TestDirFS_Utimesns(t *testing.T) {
 			name: "a=set,m=now",
 			times: &[2]syscall.Timespec{
 				{Sec: 123, Nsec: 4 * 1e3},
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 			},
 		},
 		{
@@ -657,9 +657,9 @@ func TestDirFS_Utimesns(t *testing.T) {
 				require.EqualErrno(t, 0, errno)
 
 				if platform.CompilerSupported() {
-					if tc.times != nil && tc.times[0].Nsec == UTIME_OMIT {
+					if tc.times != nil && tc.times[0].Nsec == fsapi.UTIME_OMIT {
 						require.Equal(t, oldSt.Atim, newSt.Atim)
-					} else if tc.times == nil || tc.times[0].Nsec == UTIME_NOW {
+					} else if tc.times == nil || tc.times[0].Nsec == fsapi.UTIME_NOW {
 						now := time.Now().UnixNano()
 						require.True(t, newSt.Atim <= now, "expected atim %d <= now %d", newSt.Atim, now)
 					} else {
@@ -668,9 +668,9 @@ func TestDirFS_Utimesns(t *testing.T) {
 				}
 
 				// When compiler isn't supported, we can still check mtim.
-				if tc.times != nil && tc.times[1].Nsec == UTIME_OMIT {
+				if tc.times != nil && tc.times[1].Nsec == fsapi.UTIME_OMIT {
 					require.Equal(t, oldSt.Mtim, newSt.Mtim)
-				} else if tc.times == nil || tc.times[1].Nsec == UTIME_NOW {
+				} else if tc.times == nil || tc.times[1].Nsec == fsapi.UTIME_NOW {
 					now := time.Now().UnixNano()
 					require.True(t, newSt.Mtim <= now, "expected mtim %d <= now %d", newSt.Mtim, now)
 				} else {

--- a/internal/sysfs/futimens_darwin.go
+++ b/internal/sysfs/futimens_darwin.go
@@ -8,8 +8,6 @@ import (
 const (
 	_AT_FDCWD               = -0x2
 	_AT_SYMLINK_NOFOLLOW    = 0x0020
-	_UTIME_NOW              = -1
-	_UTIME_OMIT             = -2
 	SupportsSymlinkNoFollow = true
 )
 

--- a/internal/sysfs/futimens_test.go
+++ b/internal/sysfs/futimens_test.go
@@ -44,35 +44,35 @@ func testUtimens(t *testing.T, futimes bool) {
 		{
 			name: "a=omit,m=omit",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_OMIT},
-				{Sec: 123, Nsec: UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
 			},
 		},
 		{
 			name: "a=now,m=omit",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_NOW},
-				{Sec: 123, Nsec: UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
 			},
 		},
 		{
 			name: "a=omit,m=now",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_OMIT},
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 			},
 		},
 		{
 			name: "a=now,m=now",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_NOW},
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 			},
 		},
 		{
 			name: "a=now,m=set",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 				{Sec: 123, Nsec: 4 * 1e3},
 			},
 		},
@@ -80,20 +80,20 @@ func testUtimens(t *testing.T, futimes bool) {
 			name: "a=set,m=now",
 			times: &[2]syscall.Timespec{
 				{Sec: 123, Nsec: 4 * 1e3},
-				{Sec: 123, Nsec: UTIME_NOW},
+				{Sec: 123, Nsec: fsapi.UTIME_NOW},
 			},
 		},
 		{
 			name: "a=set,m=omit",
 			times: &[2]syscall.Timespec{
 				{Sec: 123, Nsec: 4 * 1e3},
-				{Sec: 123, Nsec: UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
 			},
 		},
 		{
 			name: "a=omit,m=set",
 			times: &[2]syscall.Timespec{
-				{Sec: 123, Nsec: UTIME_OMIT},
+				{Sec: 123, Nsec: fsapi.UTIME_OMIT},
 				{Sec: 123, Nsec: 4 * 1e3},
 			},
 		},
@@ -181,9 +181,9 @@ func testUtimens(t *testing.T, futimes bool) {
 				require.EqualErrno(t, 0, errno)
 
 				if platform.CompilerSupported() {
-					if tc.times != nil && tc.times[0].Nsec == UTIME_OMIT {
+					if tc.times != nil && tc.times[0].Nsec == fsapi.UTIME_OMIT {
 						require.Equal(t, oldSt.Atim, newSt.Atim)
-					} else if tc.times == nil || tc.times[0].Nsec == UTIME_NOW {
+					} else if tc.times == nil || tc.times[0].Nsec == fsapi.UTIME_NOW {
 						now := time.Now().UnixNano()
 						require.True(t, newSt.Atim <= now, "expected atim %d <= now %d", newSt.Atim, now)
 					} else {
@@ -192,9 +192,9 @@ func testUtimens(t *testing.T, futimes bool) {
 				}
 
 				// When compiler isn't supported, we can still check mtim.
-				if tc.times != nil && tc.times[1].Nsec == UTIME_OMIT {
+				if tc.times != nil && tc.times[1].Nsec == fsapi.UTIME_OMIT {
 					require.Equal(t, oldSt.Mtim, newSt.Mtim)
-				} else if tc.times == nil || tc.times[1].Nsec == UTIME_NOW {
+				} else if tc.times == nil || tc.times[1].Nsec == fsapi.UTIME_NOW {
 					now := time.Now().UnixNano()
 					require.True(t, newSt.Mtim <= now, "expected mtim %d <= now %d", newSt.Mtim, now)
 				} else {

--- a/internal/sysfs/futimens_unsupported.go
+++ b/internal/sysfs/futimens_unsupported.go
@@ -9,11 +9,7 @@ import (
 )
 
 // Define values even if not used except as sentinels.
-const (
-	_UTIME_NOW              = -1
-	_UTIME_OMIT             = -2
-	SupportsSymlinkNoFollow = false
-)
+const SupportsSymlinkNoFollow = false
 
 func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) error {
 	return utimensPortable(path, times, symlinkFollow)

--- a/internal/sysfs/futimens_windows.go
+++ b/internal/sysfs/futimens_windows.go
@@ -5,15 +5,11 @@ import (
 	"time"
 
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 )
 
-// Define values even if not used except as sentinels.
-const (
-	_UTIME_NOW              = -1
-	_UTIME_OMIT             = -2
-	SupportsSymlinkNoFollow = false
-)
+const SupportsSymlinkNoFollow = false
 
 func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) error {
 	return utimensPortable(path, times, symlinkFollow)
@@ -44,7 +40,7 @@ func futimens(fd uintptr, times *[2]syscall.Timespec) error {
 
 func timespecToFiletime(times *[2]syscall.Timespec) (a, w *syscall.Filetime) {
 	// Handle when both inputs are current system time.
-	if times == nil || times[0].Nsec == UTIME_NOW && times[1].Nsec == UTIME_NOW {
+	if times == nil || times[0].Nsec == fsapi.UTIME_NOW && times[1].Nsec == fsapi.UTIME_NOW {
 		now := time.Now().UnixNano()
 		ft := syscall.NsecToFiletime(now)
 		return &ft, &ft
@@ -58,12 +54,12 @@ func timespecToFiletime(times *[2]syscall.Timespec) (a, w *syscall.Filetime) {
 }
 
 func timespecToFileTime(times *[2]syscall.Timespec, i int) *syscall.Filetime {
-	if times[i].Nsec == UTIME_OMIT {
+	if times[i].Nsec == fsapi.UTIME_OMIT {
 		return nil
 	}
 
 	var nsec int64
-	if times[i].Nsec == UTIME_NOW {
+	if times[i].Nsec == fsapi.UTIME_NOW {
 		nsec = time.Now().UnixNano()
 	} else {
 		nsec = syscall.TimespecToNsec(times[i])


### PR DESCRIPTION
This begins, but doesn't complete, syscall package decoupling around times. The first step is to move the constants `UTIME_NOW` and `UTIME_OMIT` to the fsapi package. While the real values vary a bit, at the cost of banishing updates to exclude one or two nanoseconds before epoch, we can portably handle unknown operating systems without codebase updates.