### PR TITLE
Emulates AT_SYMLINK_NOFOLLOW instead of sometimes implementing it

### DIFF
--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -3494,6 +3494,11 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 		},
 	}
 
+	if runtime.GOOS == "windows" && !platform.IsAtLeastGo120 {
+		// Windows 1.18 (possibly 1.19) returns ENOSYS on no_symlink_follow
+		tests = tests[:len(tests)-1]
+	}
+
 	for _, tt := range tests {
 		tc := tt
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strings"
 	"testing"
 	gofstest "testing/fstest"
 	"time"
@@ -3500,11 +3499,6 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			defer log.Reset()
-
-			if tc.flags == 0 && !sysfs.SupportsSymlinkNoFollow {
-				tc.expectedErrno = wasip1.ErrnoNosys
-				tc.expectedLog = strings.ReplaceAll(tc.expectedLog, "ESUCCESS", "ENOSYS")
-			}
 
 			pathName := tc.pathName
 			if pathName == "" {

--- a/internal/fsapi/fs.go
+++ b/internal/fsapi/fs.go
@@ -275,7 +275,8 @@ type FS interface {
 	// The `times` parameter includes the access and modification timestamps to
 	// assign. Special syscall.Timespec NSec values UTIME_NOW and UTIME_OMIT
 	// may be specified instead of real timestamps. A nil `times` parameter
-	// behaves the same as if both were set to UTIME_NOW.
+	// behaves the same as if both were set to UTIME_NOW. If the path is a
+	// symbolic link, the target of expanding that link is updated.
 	//
 	// # Errors
 	//

--- a/internal/fsapi/fs.go
+++ b/internal/fsapi/fs.go
@@ -277,9 +277,6 @@ type FS interface {
 	// may be specified instead of real timestamps. A nil `times` parameter
 	// behaves the same as if both were set to UTIME_NOW.
 	//
-	// When the `symlinkFollow` parameter is true and the path is a symbolic link,
-	// the target of expanding that link is updated.
-	//
 	// # Errors
 	//
 	// A zero Errno is success. The below are expected otherwise:
@@ -292,7 +289,7 @@ type FS interface {
 	//
 	//   - This is like syscall.UtimesNano and `utimensat` with `AT_FDCWD` in
 	//     POSIX. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
-	Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) experimentalsys.Errno
+	Utimens(path string, times *[2]syscall.Timespec) experimentalsys.Errno
 	// TODO: change impl to not use syscall package,
 	// possibly by being just a pair of int64s..
 }

--- a/internal/fsapi/unimplemented.go
+++ b/internal/fsapi/unimplemented.go
@@ -79,7 +79,7 @@ func (UnimplementedFS) Unlink(path string) experimentalsys.Errno {
 }
 
 // Utimens implements FS.Utimens
-func (UnimplementedFS) Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) experimentalsys.Errno {
+func (UnimplementedFS) Utimens(path string, times *[2]syscall.Timespec) experimentalsys.Errno {
 	return experimentalsys.ENOSYS
 }
 

--- a/internal/gojs/fs.go
+++ b/internal/gojs/fs.go
@@ -435,7 +435,7 @@ func (u *jsfsUtimes) invoke(ctx context.Context, mod api.Module, args ...interfa
 	times := [2]syscall.Timespec{
 		syscall.NsecToTimespec(atimeSec * 1e9), syscall.NsecToTimespec(mtimeSec * 1e9),
 	}
-	errno := fsc.RootFS().Utimens(path, &times, true)
+	errno := fsc.RootFS().Utimens(path, &times)
 
 	return jsfsInvoke(ctx, mod, callback, errno)
 }

--- a/internal/sysfs/adapter_test.go
+++ b/internal/sysfs/adapter_test.go
@@ -90,7 +90,7 @@ func TestAdapt_UtimesNano(t *testing.T) {
 	realPath := joinPath(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
-	err := testFS.Utimens(path, nil, true)
+	err := testFS.Utimens(path, nil)
 	require.EqualErrno(t, experimentalsys.ENOSYS, err)
 }
 

--- a/internal/sysfs/dirfs.go
+++ b/internal/sysfs/dirfs.go
@@ -116,8 +116,8 @@ func (d *dirFS) Symlink(oldName, link string) experimentalsys.Errno {
 }
 
 // Utimens implements the same method as documented on fsapi.FS
-func (d *dirFS) Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) experimentalsys.Errno {
-	return Utimens(d.join(path), times, symlinkFollow)
+func (d *dirFS) Utimens(path string, times *[2]syscall.Timespec) experimentalsys.Errno {
+	return Utimens(d.join(path), times)
 }
 
 func (d *dirFS) join(path string) string {

--- a/internal/sysfs/futimens.go
+++ b/internal/sysfs/futimens.go
@@ -28,10 +28,8 @@ const (
 // The `times` parameter includes the access and modification timestamps to
 // assign. Special syscall.Timespec NSec values UTIME_NOW and UTIME_OMIT may be
 // specified instead of real timestamps. A nil `times` parameter behaves the
-// same as if both were set to UTIME_NOW.
-//
-// When the `symlinkFollow` parameter is true and the path is a symbolic link,
-// the target of expanding that link is updated.
+// same as if both were set to UTIME_NOW. If the path is a symbolic link, the
+// target of expanding that link is updated.
 //
 // # Errors
 //
@@ -45,8 +43,8 @@ const (
 //
 //   - This is like syscall.UtimesNano and `utimensat` with `AT_FDCWD` in
 //     POSIX. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
-func Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) experimentalsys.Errno {
-	err := utimens(path, times, symlinkFollow)
+func Utimens(path string, times *[2]syscall.Timespec) experimentalsys.Errno {
+	err := utimens(path, times)
 	return experimentalsys.UnwrapOSError(err)
 }
 
@@ -57,11 +55,7 @@ func timesToPtr(times *[2]syscall.Timespec) unsafe.Pointer { //nolint:unused
 	return unsafe.Pointer(nil)
 }
 
-func utimensPortable(path string, times *[2]syscall.Timespec, symlinkFollow bool) error { //nolint:unused
-	if !symlinkFollow {
-		return experimentalsys.ENOSYS
-	}
-
+func utimensPortable(path string, times *[2]syscall.Timespec) error { //nolint:unused
 	// Handle when both inputs are current system time.
 	if times == nil || times[0].Nsec == UTIME_NOW && times[1].Nsec == UTIME_NOW {
 		ts := nowTimespec()

--- a/internal/sysfs/futimens_darwin.go
+++ b/internal/sysfs/futimens_darwin.go
@@ -6,22 +6,18 @@ import (
 )
 
 const (
-	_AT_FDCWD               = -0x2
-	_AT_SYMLINK_NOFOLLOW    = 0x0020
-	_UTIME_NOW              = -1
-	_UTIME_OMIT             = -2
-	SupportsSymlinkNoFollow = true
+	_AT_FDCWD            = -0x2
+	_AT_SYMLINK_NOFOLLOW = 0x0020
+	_UTIME_NOW           = -1
+	_UTIME_OMIT          = -2
 )
 
 //go:noescape
 //go:linkname utimensat syscall.utimensat
 func utimensat(dirfd int, path string, times *[2]syscall.Timespec, flags int) error
 
-func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) error {
+func utimens(path string, times *[2]syscall.Timespec) error {
 	var flags int
-	if !symlinkFollow {
-		flags = _AT_SYMLINK_NOFOLLOW
-	}
 	return utimensat(_AT_FDCWD, path, times, flags)
 }
 

--- a/internal/sysfs/futimens_linux.go
+++ b/internal/sysfs/futimens_linux.go
@@ -7,19 +7,13 @@ import (
 )
 
 const (
-	_AT_FDCWD               = -0x64
-	_AT_SYMLINK_NOFOLLOW    = 0x100
-	_UTIME_NOW              = (1 << 30) - 1
-	_UTIME_OMIT             = (1 << 30) - 2
-	SupportsSymlinkNoFollow = true
+	_AT_FDCWD   = -0x64
+	_UTIME_NOW  = (1 << 30) - 1
+	_UTIME_OMIT = (1 << 30) - 2
 )
 
-func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) (err error) {
+func utimens(path string, times *[2]syscall.Timespec) (err error) {
 	var flags int
-	if !symlinkFollow {
-		flags = _AT_SYMLINK_NOFOLLOW
-	}
-
 	var _p0 *byte
 	_p0, err = syscall.BytePtrFromString(path)
 	if err != nil {

--- a/internal/sysfs/futimens_unsupported.go
+++ b/internal/sysfs/futimens_unsupported.go
@@ -10,13 +10,12 @@ import (
 
 // Define values even if not used except as sentinels.
 const (
-	_UTIME_NOW              = -1
-	_UTIME_OMIT             = -2
-	SupportsSymlinkNoFollow = false
+	_UTIME_NOW  = -1
+	_UTIME_OMIT = -2
 )
 
-func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) error {
-	return utimensPortable(path, times, symlinkFollow)
+func utimens(path string, times *[2]syscall.Timespec) error {
+	return utimensPortable(path, times)
 }
 
 func futimens(fd uintptr, times *[2]syscall.Timespec) error {

--- a/internal/sysfs/futimens_windows.go
+++ b/internal/sysfs/futimens_windows.go
@@ -15,8 +15,8 @@ const (
 	SupportsSymlinkNoFollow = false
 )
 
-func utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) error {
-	return utimensPortable(path, times, symlinkFollow)
+func utimens(path string, times *[2]syscall.Timespec) error {
+	return utimensPortable(path, times)
 }
 
 func futimens(fd uintptr, times *[2]syscall.Timespec) error {

--- a/internal/sysfs/readfs.go
+++ b/internal/sysfs/readfs.go
@@ -98,7 +98,7 @@ func (r *readFS) Unlink(path string) experimentalsys.Errno {
 }
 
 // Utimens implements the same method as documented on fsapi.FS
-func (r *readFS) Utimens(path string, times *[2]syscall.Timespec, symlinkFollow bool) experimentalsys.Errno {
+func (r *readFS) Utimens(path string, times *[2]syscall.Timespec) experimentalsys.Errno {
 	return experimentalsys.EROFS
 }
 

--- a/internal/sysfs/readfs_test.go
+++ b/internal/sysfs/readfs_test.go
@@ -114,7 +114,7 @@ func TestReadFS_UtimesNano(t *testing.T) {
 	realPath := joinPath(tmpDir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
-	err := testFS.Utimens(path, nil, true)
+	err := testFS.Utimens(path, nil)
 	require.EqualErrno(t, sys.EROFS, err)
 }
 


### PR DESCRIPTION
futimes `AT_SYMLINK_NOFOLLOW` isn't universally supported. Before, we attempted to support it, but it was a bit hairy. It is better to take the hit of opening the file in the case we need to *not* follow symlinks than deal with something not very portable by default.