### PR TITLE
docs: adds issue links on TinyGo TODO

### DIFF
--- a/imports/wasi_snapshot_preview1/testdata/tinygo/wasi.go
+++ b/imports/wasi_snapshot_preview1/testdata/tinygo/wasi.go
@@ -29,8 +29,10 @@ func main() {
 		}
 	case "sock":
 		// TODO: undefined: net.FileListener
+		// See https://github.com/tinygo-org/tinygo/pull/2748
 	case "nonblock":
 		// TODO: undefined: syscall.SetNonblock
+		// See https://github.com/tinygo-org/tinygo/issues/3840
 	}
 }
 


### PR DESCRIPTION
there are a couple places we can't test TinyGo due to compilation fail.