### PR TITLE
docs: replace relative path

### DIFF
--- a/cmd/wazero/README.md
+++ b/cmd/wazero/README.md
@@ -30,6 +30,6 @@ example [Dockerfile](Dockerfile). It should amount to about 4.5MB total.
 # build the image
 $ docker build -t wazero:latest -f Dockerfile .
 # volume mount wasi or GOOS=js wasm you are interested in, and run it.
-$ docker run -v ./testdata/:/wasm wazero:latest /wasm/wasi_arg.wasm 1 2 3
+$ docker run -v $PWD/testdata/:/wasm wazero:latest /wasm/wasi_arg.wasm 1 2 3
 wasi_arg.wasm123
 ```


### PR DESCRIPTION
If you run the example of trying the wazero CLI via Docker as is, it will fail.
```
docker: Error response from daemon: create ./testdata/: "./testdata/" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'
```
This is because relative paths cannot be specified for docker volumes.
Specifying the `$PWD` environment variable allows the reader to try it out smoothly.