### PR TITLE
Fix grammar in comment about peeking

### DIFF
--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -1088,7 +1088,7 @@ func (c *amd64Compiler) compileAdd(o *wazeroir.UnionOperation) error {
 		return err
 	}
 
-	x1 := c.locationStack.peek() // Note this is peek, pop!
+	x1 := c.locationStack.peek() // Note this is peek!
 	if err := c.compileEnsureOnRegister(x1); err != nil {
 		return err
 	}
@@ -1125,7 +1125,7 @@ func (c *amd64Compiler) compileSub(o *wazeroir.UnionOperation) error {
 		return err
 	}
 
-	x1 := c.locationStack.peek() // Note this is peek, pop!
+	x1 := c.locationStack.peek() // Note this is peek!
 	if err := c.compileEnsureOnRegister(x1); err != nil {
 		return err
 	}


### PR DESCRIPTION
Very minor just happened to notice while reading. I think this was meant to say `, not pop`, but looking through the file, there are far more comments just of the `Note this is peek!` form so aligned with that