### PR TITLE
Return err instead of nil in amd64 store impl

### DIFF
--- a/internal/engine/compiler/impl_amd64.go
+++ b/internal/engine/compiler/impl_amd64.go
@@ -3499,7 +3499,7 @@ func (c *amd64Compiler) compileStoreImpl(offsetConst uint32, inst asm.Instructio
 
 	reg, err := c.compileMemoryAccessCeilSetup(offsetConst, targetSizeInBytes)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	c.assembler.CompileRegisterToMemoryWithIndex(


### PR DESCRIPTION
Just noticed this when copy-pasting the block (and not the dozens of other correct ones XD). Wondering if anyone can help with backfilling a test for it?