### PR TITLE
fsapi: migrates PollRead to Poll with Pflag

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -712,8 +712,8 @@ head-of-line blocking, even when emulated.
 The main use case of multi-poll are bidirectional network services, something
 not used in `GOOS=wasip1` standard libraries, but could be in the future.
 Moving forward without a multi-poller allows wazero to expose its file system
-abstraction instead of continuing to hold back the file system abstraction.
-We'll continue discussion below regardless, as rationale was requested.
+abstraction instead of continuing to hold back it back for edge cases. We'll
+continue discussion below regardless, as rationale was requested.
 
 You can loop through multiple `sys.File`, using `File.Poll` to see if an event
 is ready, but there is a head-of-line blocking problem. If a long timeout is

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -174,7 +175,7 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 			return sys.EBADF
 		}
 		// Wait for the timeout to expire, or for some data to become available on Stdin.
-		stdinReady, errno := stdin.File.PollRead(int32(timeout.Milliseconds()))
+		stdinReady, errno := stdin.File.Poll(fsapi.POLLIN, int32(timeout.Milliseconds()))
 		if errno != 0 {
 			return errno
 		}

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -554,8 +554,11 @@ type neverReadyTtyStdinFile struct {
 	ttyStat
 }
 
-// PollRead implements the same method as documented on fsapi.File
-func (neverReadyTtyStdinFile) PollRead(timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+// Poll implements the same method as documented on fsapi.File
+func (neverReadyTtyStdinFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	if flag != fsapi.POLLIN {
+		return false, experimentalsys.ENOTSUP
+	}
 	switch {
 	case timeoutMillis <= 0:
 		return
@@ -570,7 +573,10 @@ type pollStdinFile struct {
 	ready bool
 }
 
-// PollRead implements the same method as documented on fsapi.File
-func (p *pollStdinFile) PollRead(int32) (ready bool, errno experimentalsys.Errno) {
+// Poll implements the same method as documented on fsapi.File
+func (p *pollStdinFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	if flag != fsapi.POLLIN {
+		return false, experimentalsys.ENOTSUP
+	}
 	return p.ready, 0
 }

--- a/internal/fsapi/dir.go
+++ b/internal/fsapi/dir.go
@@ -87,8 +87,8 @@ func (DirFile) Pread([]byte, int64) (int, experimentalsys.Errno) {
 	return 0, experimentalsys.EISDIR
 }
 
-// PollRead implements File.PollRead
-func (DirFile) PollRead(int32) (ready bool, errno experimentalsys.Errno) {
+// Poll implements File.Poll
+func (DirFile) Poll(Pflag, int32) (ready bool, errno experimentalsys.Errno) {
 	return false, experimentalsys.ENOSYS
 }
 

--- a/internal/fsapi/file.go
+++ b/internal/fsapi/file.go
@@ -205,22 +205,26 @@ type File interface {
 	//     of io.Seeker. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fseek.html
 	Seek(offset int64, whence int) (newOffset int64, errno experimentalsys.Errno)
 
-	// PollRead returns if the file has data ready to be read or an error.
+	// Poll returns if the file has data ready to be read or written.
 	//
 	// # Parameters
 	//
-	// The `timeoutMillis` parameter is how long to block for data to become
-	// readable, or interrupted, in milliseconds. There are two special values:
+	// The `flag` parameter determines which event to await, such as POLLIN,
+	// POLLOUT, or a combination like `POLLIN|POLLOUT`.
+	//
+	// The `timeoutMillis` parameter is how long to block for an event, or
+	// interrupted, in milliseconds. There are two special values:
 	//   - zero returns immediately
 	//   - any negative value blocks any amount of time
 	//
 	// # Results
 	//
-	// `ready` means there was data ready to read or false if not or when
-	// `errno` is not zero.
+	// `ready` means there was data ready to read or written. False can mean no
+	// event was ready or `errno` is not zero.
 	//
 	// A zero `errno` is success. The below are expected otherwise:
 	//   - sys.ENOSYS: the implementation does not support this function.
+	//   - sys.ENOTSUP: the implementation does not the flag combination.
 	//   - sys.EINTR: the call was interrupted prior to an event.
 	//
 	// # Notes
@@ -228,9 +232,9 @@ type File interface {
 	//   - This is like `poll` in POSIX, for a single file.
 	//     See https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
 	//   - No-op files, such as those which read from /dev/null, should return
-	//     immediately true, as data will never become readable.
+	//     immediately true, as data will never become available.
 	//   - See /RATIONALE.md for detailed notes including impact of blocking.
-	PollRead(timeoutMillis int32) (ready bool, errno experimentalsys.Errno)
+	Poll(flag Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno)
 
 	// Readdir reads the contents of the directory associated with file and
 	// returns a slice of up to n Dirent values in an arbitrary order. This is

--- a/internal/fsapi/poll.go
+++ b/internal/fsapi/poll.go
@@ -1,0 +1,20 @@
+package fsapi
+
+// Pflag are bit flags used for File.Poll. Values, including zero, should not
+// be interpreted numerically. Instead, use by constants prefixed with 'POLL'.
+//
+// # Notes
+//
+//   - This is like `pollfd.events` flags for `poll` in POSIX. See
+//     https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/poll.h.html
+type Pflag uint32
+
+// Only define bitflags we support and are needed by `poll_oneoff` in wasip1
+// See https://github.com/WebAssembly/WASI/blob/snapshot-01/phases/snapshot/docs.md#eventrwflags
+const (
+	// POLLIN is a read event.
+	POLLIN Pflag = 1 << iota
+
+	// POLLOUT is a write event.
+	POLLOUT
+)

--- a/internal/fsapi/unimplemented.go
+++ b/internal/fsapi/unimplemented.go
@@ -153,8 +153,8 @@ func (UnimplementedFile) Readdir(int) (dirents []Dirent, errno experimentalsys.E
 	return nil, experimentalsys.ENOSYS
 }
 
-// PollRead implements File.PollRead
-func (UnimplementedFile) PollRead(int32) (ready bool, errno experimentalsys.Errno) {
+// Poll implements File.Poll
+func (UnimplementedFile) Poll(Pflag, int32) (ready bool, errno experimentalsys.Errno) {
 	return false, experimentalsys.ENOSYS
 }
 

--- a/internal/sys/stdio.go
+++ b/internal/sys/stdio.go
@@ -48,8 +48,11 @@ func (noopStdinFile) Read([]byte) (int, experimentalsys.Errno) {
 	return 0, 0 // Always EOF
 }
 
-// PollRead implements the same method as documented on fsapi.File
-func (noopStdinFile) PollRead(int32) (ready bool, errno experimentalsys.Errno) {
+// Poll implements the same method as documented on fsapi.File
+func (noopStdinFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	if flag != fsapi.POLLIN {
+		return false, experimentalsys.ENOTSUP
+	}
 	return true, 0 // always ready to read nothing
 }
 

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -180,9 +180,9 @@ func (f *osFile) Seek(offset int64, whence int) (newOffset int64, errno experime
 	return
 }
 
-// PollRead implements the same method as documented on fsapi.File
-func (f *osFile) PollRead(timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
-	return pollRead(f.fd, timeoutMillis)
+// Poll implements the same method as documented on fsapi.File
+func (f *osFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	return poll(f.fd, flag, timeoutMillis)
 }
 
 // Readdir implements File.Readdir. Notably, this uses "Readdir", not

--- a/internal/sysfs/poll.go
+++ b/internal/sysfs/poll.go
@@ -2,12 +2,17 @@
 
 package sysfs
 
-import "github.com/tetratelabs/wazero/experimental/sys"
+import (
+	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
+)
 
-// pollRead implements `PollRead` as documented on fsapi.File via a file
-// descriptor.
-func pollRead(fd uintptr, timeoutMillis int32) (ready bool, errno sys.Errno) {
+// poll implements `Poll` as documented on fsapi.File via a file descriptor.
+func poll(fd uintptr, flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno sys.Errno) {
+	if flag != fsapi.POLLIN {
+		return false, sys.ENOTSUP
+	}
 	fds := []pollFd{newPollFd(fd, _POLLIN, 0)}
-	count, errno := poll(fds, timeoutMillis)
+	count, errno := _poll(fds, timeoutMillis)
 	return count > 0, errno
 }

--- a/internal/sysfs/poll_darwin.go
+++ b/internal/sysfs/poll_darwin.go
@@ -24,8 +24,8 @@ func newPollFd(fd uintptr, events, revents int16) pollFd {
 // _POLLIN subscribes a notification when any readable data is available.
 const _POLLIN = 0x0001
 
-// poll implements poll on Darwin via the corresponding libc function.
-func poll(fds []pollFd, timeoutMillis int32) (n int, errno sys.Errno) {
+// _poll implements poll on Darwin via the corresponding libc function.
+func _poll(fds []pollFd, timeoutMillis int32) (n int, errno sys.Errno) {
 	var fdptr *pollFd
 	nfds := len(fds)
 	if nfds > 0 {

--- a/internal/sysfs/poll_linux.go
+++ b/internal/sysfs/poll_linux.go
@@ -26,8 +26,8 @@ func newPollFd(fd uintptr, events, revents int16) pollFd {
 // _POLLIN subscribes a notification when any readable data is available.
 const _POLLIN = 0x0001
 
-// poll implements poll on Linux via ppoll.
-func poll(fds []pollFd, timeoutMillis int32) (n int, errno sys.Errno) {
+// _poll implements poll on Linux via ppoll.
+func _poll(fds []pollFd, timeoutMillis int32) (n int, errno sys.Errno) {
 	var ts syscall.Timespec
 	if timeoutMillis >= 0 {
 		ts = syscall.NsecToTimespec(int64(time.Duration(timeoutMillis) * time.Millisecond))

--- a/internal/sysfs/poll_test.go
+++ b/internal/sysfs/poll_test.go
@@ -1,3 +1,5 @@
+//go:build windows || linux || darwin
+
 package sysfs
 
 import (
@@ -9,9 +11,9 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func TestPoll(t *testing.T) {
+func Test_poll(t *testing.T) {
 	t.Run("should return immediately with no fds and duration 0", func(t *testing.T) {
-		n, err := poll([]pollFd{}, 0)
+		n, err := _poll([]pollFd{}, 0)
 		require.EqualErrno(t, 0, err)
 		require.Equal(t, 0, n)
 	})
@@ -23,7 +25,7 @@ func TestPoll(t *testing.T) {
 		// updated by select(2). We are not accounting for this
 		// in our implementation.
 		start := time.Now()
-		n, err := poll([]pollFd{}, dur)
+		n, err := _poll([]pollFd{}, dur)
 		took = time.Since(start)
 		require.EqualErrno(t, 0, err)
 		require.Equal(t, 0, n)
@@ -53,7 +55,7 @@ func TestPoll(t *testing.T) {
 		require.NoError(t, err)
 
 		fds := []pollFd{newPollFd(rr.Fd(), _POLLIN, 0)}
-		n, err := poll(fds, 0)
+		n, err := _poll(fds, 0)
 		require.EqualErrno(t, 0, err)
 		require.Equal(t, 1, n)
 	})

--- a/internal/sysfs/poll_unsupported.go
+++ b/internal/sysfs/poll_unsupported.go
@@ -2,10 +2,12 @@
 
 package sysfs
 
-import "github.com/tetratelabs/wazero/experimental/sys"
+import (
+	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
+)
 
-// pollRead implements `PollRead` as documented on fsapi.File via a file
-// descriptor.
-func pollRead(fd uintptr, timeoutMillis int32) (ready bool, errno sys.Errno) {
+// poll implements `Poll` as documented on fsapi.File via a file descriptor.
+func poll(fd uintptr, flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno sys.Errno) {
 	return false, sys.ENOSYS
 }

--- a/internal/sysfs/poll_windows.go
+++ b/internal/sysfs/poll_windows.go
@@ -40,7 +40,7 @@ func newPollFd(fd uintptr, events, revents int16) pollFd {
 // pollInterval is the interval between each calls to peekNamedPipe in selectAllHandles
 const pollInterval = 100 * time.Millisecond
 
-// poll implements poll on Windows, for a subset of cases.
+// _poll implements poll on Windows, for a subset of cases.
 //
 // pollWithContext emulates the behavior of POSIX poll(2) on Windows, for a subset of cases,
 // and it supports context cancellation.
@@ -58,7 +58,7 @@ const pollInterval = 100 * time.Millisecond
 //
 // The duration may be negative, in which case it will wait indefinitely. The given ctx is
 // used to allow for cancellation, and it is currently used only in tests.
-func poll(fds []pollFd, timeoutMillis int32) (n int, errno sys.Errno) {
+func _poll(fds []pollFd, timeoutMillis int32) (n int, errno sys.Errno) {
 	if fds == nil {
 		return -1, sys.ENOSYS
 	}

--- a/internal/sysfs/poll_windows_test.go
+++ b/internal/sysfs/poll_windows_test.go
@@ -20,13 +20,13 @@ func TestPoll_Windows(t *testing.T) {
 	pollToChannel := func(fd uintptr, timeoutMillis int32, ch chan result) {
 		r := result{}
 		fds := []pollFd{{fd: fd, events: _POLLIN}}
-		r.n, r.err = poll(fds, timeoutMillis)
+		r.n, r.err = _poll(fds, timeoutMillis)
 		ch <- r
 		close(ch)
 	}
 
 	t.Run("poll returns sys.ENOSYS when n == 0 and timeoutMillis is negative", func(t *testing.T) {
-		n, errno := poll(nil, -1)
+		n, errno := _poll(nil, -1)
 		require.Equal(t, -1, n)
 		require.EqualErrno(t, sys.ENOSYS, errno)
 	})
@@ -73,7 +73,7 @@ func TestPoll_Windows(t *testing.T) {
 
 		fds := []pollFd{{fd: f.Fd()}}
 
-		n, errno := poll(fds, 0)
+		n, errno := _poll(fds, 0)
 		require.Zero(t, errno)
 		require.Equal(t, 1, n)
 	})
@@ -135,7 +135,7 @@ func TestPoll_Windows(t *testing.T) {
 		r, _, err := os.Pipe()
 		require.NoError(t, err)
 		fds := []pollFd{{fd: r.Fd(), events: _POLLIN}}
-		n, err := poll(fds, 0)
+		n, err := _poll(fds, 0)
 		require.Zero(t, err)
 		require.Zero(t, n)
 	})
@@ -153,7 +153,7 @@ func TestPoll_Windows(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify that the write is reported.
-		n, err := poll(fds, 0)
+		n, err := _poll(fds, 0)
 		require.Zero(t, err)
 		require.Equal(t, 1, n)
 	})
@@ -269,7 +269,7 @@ func TestPoll_Windows(t *testing.T) {
 		defer f.Close()
 		require.NoError(t, err)
 		fds := []pollFd{{fd: f.Fd(), events: _POLLIN}}
-		n, errno := poll(fds, 0)
+		n, errno := _poll(fds, 0)
 		require.Zero(t, errno)
 		require.Equal(t, 1, n)
 	})

--- a/internal/sysfs/sock_windows.go
+++ b/internal/sysfs/sock_windows.go
@@ -118,7 +118,7 @@ type winTcpListenerFile struct {
 func (f *winTcpListenerFile) Accept() (socketapi.TCPConn, sys.Errno) {
 	// Ensure we have an incoming connection using winsock_select.
 	n, errno := syscallConnControl(f.tl, func(fd uintptr) (int, sys.Errno) {
-		return poll([]pollFd{newPollFd(fd, _POLLIN, 0)}, 0)
+		return _poll([]pollFd{newPollFd(fd, _POLLIN, 0)}, 0)
 	})
 
 	// Otherwise return immediately.


### PR DESCRIPTION
This migrates PollRead to Poll so that it can support read, write or a combination via flags. This should allow `poll_oneoff` to be implemented even if internally it may need to use a deadline decrementing approach to cycle through each file instead of via multiple at the same time.

The benefit of doing things this way is we don't need to top-level a concept of file descriptor, which complicates the design of `fsapi.FS` which is far easier to implement if there are no "multi-file" apis on it.

This intentionally doesn't implement the approach at the same time, as the goal is to create the api to implement. Doing so also puts a lot less pressure on the task to complete migration off syscall types.