### PR TITLE
compiler: fix compiledModule leak

### DIFF
--- a/internal/engine/compiler/compiler_controlflow_test.go
+++ b/internal/engine/compiler/compiler_controlflow_test.go
@@ -822,7 +822,7 @@ func TestCompiler_callIndirect_largeTypeIndex(t *testing.T) {
 
 		makeExecutable(code1.Bytes())
 		f := function{
-			parent:             &compiledFunction{parent: &compiledModule{executable: code1}},
+			parent:             &compiledFunction{parent: &compiledCode{executable: code1}},
 			codeInitialAddress: uintptr(unsafe.Pointer(&code1.Bytes()[0])),
 			moduleInstance:     env.moduleInstance,
 		}
@@ -896,7 +896,7 @@ func TestCompiler_compileCall(t *testing.T) {
 
 		makeExecutable(code.Bytes())
 		me.functions = append(me.functions, function{
-			parent:             &compiledFunction{parent: &compiledModule{executable: code}},
+			parent:             &compiledFunction{parent: &compiledCode{executable: code}},
 			codeInitialAddress: uintptr(unsafe.Pointer(&code.Bytes()[0])),
 			moduleInstance:     env.moduleInstance,
 		})

--- a/internal/engine/compiler/compiler_test.go
+++ b/internal/engine/compiler/compiler_test.go
@@ -202,7 +202,7 @@ func (j *compilerEnv) callEngine() *callEngine {
 }
 
 func (j *compilerEnv) exec(machineCode []byte) {
-	cm := new(compiledModule)
+	cm := &compiledModule{compiledCode: &compiledCode{}}
 	if err := cm.executable.Map(len(machineCode)); err != nil {
 		panic(err)
 	}
@@ -211,7 +211,7 @@ func (j *compilerEnv) exec(machineCode []byte) {
 	makeExecutable(executable)
 
 	f := &function{
-		parent:             &compiledFunction{parent: cm},
+		parent:             &compiledFunction{parent: cm.compiledCode},
 		codeInitialAddress: uintptr(unsafe.Pointer(&executable[0])),
 		moduleInstance:     j.moduleInstance,
 	}
@@ -268,7 +268,7 @@ func newCompilerEnvironment() *compilerEnv {
 			Globals:        []*wasm.GlobalInstance{},
 			Engine:         me,
 		},
-		ce: me.newCallEngine(initialStackSize, &function{parent: &compiledFunction{parent: &compiledModule{}}}),
+		ce: me.newCallEngine(initialStackSize, &function{parent: &compiledFunction{parent: &compiledCode{}}}),
 	}
 }
 

--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -759,6 +759,8 @@ func (ce *callEngine) call(ctx context.Context, params, results []uint64) (_ []u
 			// If the module closed during the call, and the call didn't err for another reason, set an ExitError.
 			err = m.FailIfClosed()
 		}
+		// Ensure that the compiled module will never be GC'd before this method returns.
+		runtime.KeepAlive(ce.module)
 	}()
 
 	ft := ce.initialFn.funcType
@@ -778,9 +780,6 @@ func (ce *callEngine) call(ctx context.Context, params, results []uint64) (_ []u
 		results = make([]uint64, ft.ResultNumInUint64)
 	}
 	copy(results, ce.stack)
-
-	// Ensure that the compiled module will never be GC'd before this method returns.
-	runtime.KeepAlive(ce.module)
 	return results, nil
 }
 

--- a/internal/engine/compiler/engine_bench_test.go
+++ b/internal/engine/compiler/engine_bench_test.go
@@ -20,7 +20,7 @@ func BenchmarkCallEngine_builtinFunctionFunctionListener(b *testing.B) {
 				},
 			},
 			index: 0,
-			parent: &compiledModule{
+			parent: &compiledCode{
 				source: &wasm.Module{
 					TypeSection:     []wasm.FunctionType{{}},
 					FunctionSection: []wasm.Index{0},

--- a/internal/engine/compiler/engine_cache.go
+++ b/internal/engine/compiler/engine_cache.go
@@ -17,6 +17,11 @@ import (
 func (e *engine) deleteCompiledModule(module *wasm.Module) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
+
+	cm := e.codes[module.ID]
+	for j := range cm.functions {
+		cm.functions[j].parent = nil
+	}
 	delete(e.codes, module.ID)
 
 	// Note: we do not call e.Cache.Delete, as the lifetime of

--- a/internal/engine/compiler/engine_cache.go
+++ b/internal/engine/compiler/engine_cache.go
@@ -160,10 +160,9 @@ func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser, modul
 	ensureTermination := header[cachedVersionEnd] != 0
 	functionsNum := binary.LittleEndian.Uint32(header[len(header)-4:])
 	cm = &compiledModule{
-		compiledCode: &compiledCode{
-			ensureTermination: ensureTermination,
-		},
-		functions: make([]compiledFunction, functionsNum),
+		compiledCode:      new(compiledCode),
+		functions:         make([]compiledFunction, functionsNum),
+		ensureTermination: ensureTermination,
 	}
 
 	imported := module.ImportFunctionCount

--- a/internal/engine/compiler/engine_cache.go
+++ b/internal/engine/compiler/engine_cache.go
@@ -18,10 +18,6 @@ func (e *engine) deleteCompiledModule(module *wasm.Module) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
 
-	cm := e.codes[module.ID]
-	for j := range cm.functions {
-		cm.functions[j].parent = nil
-	}
 	delete(e.codes, module.ID)
 
 	// Note: we do not call e.Cache.Delete, as the lifetime of
@@ -163,14 +159,19 @@ func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser, modul
 
 	ensureTermination := header[cachedVersionEnd] != 0
 	functionsNum := binary.LittleEndian.Uint32(header[len(header)-4:])
-	cm = &compiledModule{functions: make([]compiledFunction, functionsNum), ensureTermination: ensureTermination}
+	cm = &compiledModule{
+		compiledCode: &compiledCode{
+			ensureTermination: ensureTermination,
+		},
+		functions: make([]compiledFunction, functionsNum),
+	}
 
 	imported := module.ImportFunctionCount
 
 	var eightBytes [8]byte
 	for i := uint32(0); i < functionsNum; i++ {
 		f := &cm.functions[i]
-		f.parent = cm
+		f.parent = cm.compiledCode
 
 		// Read the stack pointer ceil.
 		if f.stackPointerCeil, err = readUint64(reader, &eightBytes); err != nil {

--- a/internal/engine/compiler/engine_cache_test.go
+++ b/internal/engine/compiler/engine_cache_test.go
@@ -60,12 +60,12 @@ func TestSerializeCompiledModule(t *testing.T) {
 		{
 			in: &compiledModule{
 				compiledCode: &compiledCode{
-					ensureTermination: true,
-					executable:        makeCodeSegment(1, 2, 3, 4, 5),
+					executable: makeCodeSegment(1, 2, 3, 4, 5),
 				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
+				ensureTermination: true,
 			},
 			exp: concat(
 				[]byte(wazeroMagic),
@@ -82,13 +82,13 @@ func TestSerializeCompiledModule(t *testing.T) {
 		{
 			in: &compiledModule{
 				compiledCode: &compiledCode{
-					ensureTermination: true,
-					executable:        makeCodeSegment(1, 2, 3, 4, 5, 1, 2, 3),
+					executable: makeCodeSegment(1, 2, 3, 4, 5, 1, 2, 3),
 				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 					{executableOffset: 5, stackPointerCeil: 0xffffffff},
 				},
+				ensureTermination: true,
 			},
 			exp: concat(
 				[]byte(wazeroMagic),
@@ -190,10 +190,10 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			),
 			expCompiledModule: &compiledModule{
 				compiledCode: &compiledCode{
-					ensureTermination: true,
-					executable:        makeCodeSegment(1, 2, 3, 4, 5),
+					executable: makeCodeSegment(1, 2, 3, 4, 5),
 				},
-				functions: []compiledFunction{{executableOffset: 0, stackPointerCeil: 12345, index: 0}},
+				functions:         []compiledFunction{{executableOffset: 0, stackPointerCeil: 12345, index: 0}},
+				ensureTermination: true,
 			},
 			expStaleCache: false,
 			expErr:        "",

--- a/internal/engine/compiler/engine_cache_test.go
+++ b/internal/engine/compiler/engine_cache_test.go
@@ -38,7 +38,9 @@ func TestSerializeCompiledModule(t *testing.T) {
 	}{
 		{
 			in: &compiledModule{
-				executable: makeCodeSegment(1, 2, 3, 4, 5),
+				compiledCode: &compiledCode{
+					executable: makeCodeSegment(1, 2, 3, 4, 5),
+				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
@@ -57,8 +59,10 @@ func TestSerializeCompiledModule(t *testing.T) {
 		},
 		{
 			in: &compiledModule{
-				ensureTermination: true,
-				executable:        makeCodeSegment(1, 2, 3, 4, 5),
+				compiledCode: &compiledCode{
+					ensureTermination: true,
+					executable:        makeCodeSegment(1, 2, 3, 4, 5),
+				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 				},
@@ -77,8 +81,10 @@ func TestSerializeCompiledModule(t *testing.T) {
 		},
 		{
 			in: &compiledModule{
-				ensureTermination: true,
-				executable:        makeCodeSegment(1, 2, 3, 4, 5, 1, 2, 3),
+				compiledCode: &compiledCode{
+					ensureTermination: true,
+					executable:        makeCodeSegment(1, 2, 3, 4, 5, 1, 2, 3),
+				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345},
 					{executableOffset: 5, stackPointerCeil: 0xffffffff},
@@ -159,7 +165,9 @@ func TestDeserializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5}, // machine code.
 			),
 			expCompiledModule: &compiledModule{
-				executable: makeCodeSegment(1, 2, 3, 4, 5),
+				compiledCode: &compiledCode{
+					executable: makeCodeSegment(1, 2, 3, 4, 5),
+				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345, index: 0},
 				},
@@ -181,9 +189,11 @@ func TestDeserializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5}, // code.
 			),
 			expCompiledModule: &compiledModule{
-				ensureTermination: true,
-				executable:        makeCodeSegment(1, 2, 3, 4, 5),
-				functions:         []compiledFunction{{executableOffset: 0, stackPointerCeil: 12345, index: 0}},
+				compiledCode: &compiledCode{
+					ensureTermination: true,
+					executable:        makeCodeSegment(1, 2, 3, 4, 5),
+				},
+				functions: []compiledFunction{{executableOffset: 0, stackPointerCeil: 12345, index: 0}},
 			},
 			expStaleCache: false,
 			expErr:        "",
@@ -208,7 +218,9 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			),
 			importedFunctionCount: 1,
 			expCompiledModule: &compiledModule{
-				executable: makeCodeSegment(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+				compiledCode: &compiledCode{
+					executable: makeCodeSegment(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+				},
 				functions: []compiledFunction{
 					{executableOffset: 0, stackPointerCeil: 12345, index: 1},
 					{executableOffset: 7, stackPointerCeil: 0xffffffff, index: 2},
@@ -279,8 +291,8 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			if tc.expCompiledModule != nil {
 				require.Equal(t, len(tc.expCompiledModule.functions), len(cm.functions))
 				for i := 0; i < len(cm.functions); i++ {
-					require.Equal(t, cm, cm.functions[i].parent)
-					tc.expCompiledModule.functions[i].parent = cm
+					require.Equal(t, cm.compiledCode, cm.functions[i].parent)
+					tc.expCompiledModule.functions[i].parent = cm.compiledCode
 				}
 			}
 
@@ -361,13 +373,13 @@ func TestEngine_getCompiledModuleFromCache(t *testing.T) {
 			},
 			expHit: true,
 			expCompiledModule: &compiledModule{
-				executable: makeCodeSegment(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+				compiledCode: &compiledCode{
+					executable: makeCodeSegment(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+				},
 				functions: []compiledFunction{
 					{stackPointerCeil: 12345, executableOffset: 0, index: 0},
 					{stackPointerCeil: 0xffffffff, executableOffset: 5, index: 1},
 				},
-				source:            nil,
-				ensureTermination: false,
 			},
 		},
 	}
@@ -379,7 +391,7 @@ func TestEngine_getCompiledModuleFromCache(t *testing.T) {
 			if exp := tc.expCompiledModule; exp != nil {
 				exp.source = m
 				for i := range tc.expCompiledModule.functions {
-					tc.expCompiledModule.functions[i].parent = exp
+					tc.expCompiledModule.functions[i].parent = exp.compiledCode
 				}
 			}
 
@@ -422,8 +434,10 @@ func TestEngine_addCompiledModuleToCache(t *testing.T) {
 		tc := filecache.New(t.TempDir())
 		e := engine{fileCache: tc}
 		cm := &compiledModule{
-			executable: makeCodeSegment(1, 2, 3),
-			functions:  []compiledFunction{{stackPointerCeil: 123}},
+			compiledCode: &compiledCode{
+				executable: makeCodeSegment(1, 2, 3),
+			},
+			functions: []compiledFunction{{stackPointerCeil: 123}},
 		}
 		m := &wasm.Module{ID: sha256.Sum256(nil), IsHostModule: true} // Host module!
 		err := e.addCompiledModuleToCache(m, cm)
@@ -438,8 +452,10 @@ func TestEngine_addCompiledModuleToCache(t *testing.T) {
 		e := engine{fileCache: tc}
 		m := &wasm.Module{}
 		cm := &compiledModule{
-			executable: makeCodeSegment(1, 2, 3),
-			functions:  []compiledFunction{{stackPointerCeil: 123}},
+			compiledCode: &compiledCode{
+				executable: makeCodeSegment(1, 2, 3),
+			},
+			functions: []compiledFunction{{stackPointerCeil: 123}},
 		}
 		err := e.addCompiledModuleToCache(m, cm)
 		require.NoError(t, err)

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -234,7 +234,9 @@ func TestCompiler_CompileModule(t *testing.T) {
 func TestCompiler_Releasecode_Panic(t *testing.T) {
 	captured := require.CapturePanic(func() {
 		releaseCompiledModule(&compiledModule{
-			executable: makeCodeSegment(1, 2),
+			compiledCode: &compiledCode{
+				executable: makeCodeSegment(1, 2),
+			},
 		})
 	})
 	require.Contains(t, captured.Error(), "compiler: failed to munmap code segment")
@@ -392,15 +394,15 @@ func TestCallEngine_deferredOnCall(t *testing.T) {
 	}
 	f1 := &function{
 		funcType: &wasm.FunctionType{ParamNumInUint64: 2},
-		parent:   &compiledFunction{parent: &compiledModule{source: s}, index: 0},
+		parent:   &compiledFunction{parent: &compiledCode{source: s}, index: 0},
 	}
 	f2 := &function{
 		funcType: &wasm.FunctionType{ParamNumInUint64: 2, ResultNumInUint64: 3},
-		parent:   &compiledFunction{parent: &compiledModule{source: s}, index: 1},
+		parent:   &compiledFunction{parent: &compiledCode{source: s}, index: 1},
 	}
 	f3 := &function{
 		funcType: &wasm.FunctionType{ResultNumInUint64: 1},
-		parent:   &compiledFunction{parent: &compiledModule{source: s}, index: 2},
+		parent:   &compiledFunction{parent: &compiledCode{source: s}, index: 2},
 	}
 
 	ce := &callEngine{
@@ -598,7 +600,7 @@ func TestCallEngine_builtinFunctionFunctionListenerBefore(t *testing.T) {
 				},
 			},
 			index: 0,
-			parent: &compiledModule{source: &wasm.Module{
+			parent: &compiledCode{source: &wasm.Module{
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []wasm.Code{{}},
 				TypeSection:     []wasm.FunctionType{{}},
@@ -624,7 +626,7 @@ func TestCallEngine_builtinFunctionFunctionListenerAfter(t *testing.T) {
 				},
 			},
 			index: 0,
-			parent: &compiledModule{source: &wasm.Module{
+			parent: &compiledCode{source: &wasm.Module{
 				FunctionSection: []wasm.Index{0},
 				CodeSection:     []wasm.Code{{}},
 				TypeSection:     []wasm.FunctionType{{}},

--- a/internal/engine/compiler/impl_amd64_test.go
+++ b/internal/engine/compiler/impl_amd64_test.go
@@ -44,7 +44,7 @@ func TestAmd64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		makeExecutable(executable)
 
 		f := function{
-			parent:             &compiledFunction{parent: &compiledModule{executable: code}},
+			parent:             &compiledFunction{parent: &compiledCode{executable: code}},
 			codeInitialAddress: code.Addr(),
 			moduleInstance:     env.moduleInstance,
 			typeID:             0,

--- a/internal/engine/compiler/impl_arm64_test.go
+++ b/internal/engine/compiler/impl_arm64_test.go
@@ -42,7 +42,7 @@ func TestArm64Compiler_indirectCallWithTargetOnCallingConvReg(t *testing.T) {
 		makeExecutable(executable)
 
 		f := function{
-			parent:             &compiledFunction{parent: &compiledModule{executable: code}},
+			parent:             &compiledFunction{parent: &compiledCode{executable: code}},
 			codeInitialAddress: code.Addr(),
 			moduleInstance:     env.moduleInstance,
 		}

--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -83,7 +83,7 @@ var (
 
 func TestMain(m *testing.M) {
 	// For some reason, windows and freebsd fail to compile with exit status 1.
-	if o := runtime.GOOS; o != "linux" {
+	if o := runtime.GOOS; o != "darwin" && o != "linux" {
 		log.Println("gojs: skipping due to not yet supported OS:", o)
 		os.Exit(0)
 	}

--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -83,7 +83,7 @@ var (
 
 func TestMain(m *testing.M) {
 	// For some reason, windows and freebsd fail to compile with exit status 1.
-	if o := runtime.GOOS; o != "darwin" && o != "linux" {
+	if o := runtime.GOOS; o != "linux" {
 		log.Println("gojs: skipping due to not yet supported OS:", o)
 		os.Exit(0)
 	}

--- a/internal/integration_test/engine/memleak_test.go
+++ b/internal/integration_test/engine/memleak_test.go
@@ -1,0 +1,51 @@
+package adhoc
+
+import (
+	"context"
+	"log"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/tetratelabs/wazero"
+)
+
+func TestMemoryLeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping memory leak test in short mode.")
+	}
+
+	duration := 5 * time.Second
+	t.Logf("running memory leak test for %s", duration)
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	for ctx.Err() == nil {
+		if err := testMemoryLeakInstantiateRuntimeAndModule(); err != nil {
+			log.Panicln(err)
+		}
+	}
+
+	var stats runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&stats)
+
+	if stats.Alloc > (100 * 1024 * 1024) {
+		t.Errorf("wazero used more than 100 MiB after running the test for %s (alloc=%d)", duration, stats.Alloc)
+	}
+}
+
+func testMemoryLeakInstantiateRuntimeAndModule() error {
+	ctx := context.Background()
+
+	runtime := wazero.NewRuntime(ctx)
+	defer runtime.Close(ctx)
+
+	mod, err := runtime.InstantiateWithConfig(ctx, memoryWasm,
+		wazero.NewModuleConfig().WithStartFunctions())
+	if err != nil {
+		return err
+	}
+	return mod.Close(ctx)
+}


### PR DESCRIPTION
Fixes #1600.

I'm not 100% sure why this is needed, but it's being done as well in:
https://github.com/tetratelabs/wazero/blob/1f8c908f1c61c964192c731af495caf1d720418c/internal/engine/compiler/engine.go#L495-L508

Somehow, not doing this prevents the `releaseCompiledModule` finalizer from running.