### PR TITLE
Re-introduces internal fsapi.File with non-blocking methods

### DIFF
--- a/experimental/sys/dir.go
+++ b/experimental/sys/dir.go
@@ -61,16 +61,6 @@ func (DirFile) SetAppend(bool) Errno {
 	return EISDIR
 }
 
-// IsNonblock implements File.IsNonblock
-func (DirFile) IsNonblock() bool {
-	return false
-}
-
-// SetNonblock implements File.SetNonblock
-func (DirFile) SetNonblock(bool) Errno {
-	return EISDIR
-}
-
 // IsDir implements File.IsDir
 func (DirFile) IsDir() (bool, Errno) {
 	return true, 0
@@ -84,11 +74,6 @@ func (DirFile) Read([]byte) (int, Errno) {
 // Pread implements File.Pread
 func (DirFile) Pread([]byte, int64) (int, Errno) {
 	return 0, EISDIR
-}
-
-// Poll implements File.Poll
-func (DirFile) Poll(Pflag, int32) (ready bool, errno Errno) {
-	return false, ENOSYS
 }
 
 // Write implements File.Write

--- a/experimental/sys/file.go
+++ b/experimental/sys/file.go
@@ -67,29 +67,6 @@ type File interface {
 	//   - Implementations should cache this result.
 	IsDir() (bool, Errno)
 
-	// IsNonblock returns true if the file was opened with O_NONBLOCK, or
-	// SetNonblock was successfully enabled on this file.
-	//
-	// # Notes
-	//
-	//   - This might not match the underlying state of the file descriptor if
-	//     the file was not opened via OpenFile.
-	IsNonblock() bool
-
-	// SetNonblock toggles the non-blocking mode (O_NONBLOCK) of this file.
-	//
-	// # Errors
-	//
-	// A zero Errno is success. The below are expected otherwise:
-	//   - ENOSYS: the implementation does not support this function.
-	//   - EBADF: the file or directory was closed.
-	//
-	// # Notes
-	//
-	//   - This is like syscall.SetNonblock and `fcntl` with O_NONBLOCK in
-	//     POSIX. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html
-	SetNonblock(enable bool) Errno
-
 	// IsAppend returns true if the file was opened with O_APPEND, or
 	// SetAppend was successfully enabled on this file.
 	//
@@ -199,37 +176,6 @@ type File interface {
 	//   - This is like io.Seeker and `fseek` in POSIX, preferring semantics
 	//     of io.Seeker. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fseek.html
 	Seek(offset int64, whence int) (newOffset int64, errno Errno)
-
-	// Poll returns if the file has data ready to be read or written.
-	//
-	// # Parameters
-	//
-	// The `flag` parameter determines which event to await, such as POLLIN,
-	// POLLOUT, or a combination like `POLLIN|POLLOUT`.
-	//
-	// The `timeoutMillis` parameter is how long to block for an event, or
-	// interrupted, in milliseconds. There are two special values:
-	//   - zero returns immediately
-	//   - any negative value blocks any amount of time
-	//
-	// # Results
-	//
-	// `ready` means there was data ready to read or written. False can mean no
-	// event was ready or `errno` is not zero.
-	//
-	// A zero `errno` is success. The below are expected otherwise:
-	//   - ENOSYS: the implementation does not support this function.
-	//   - ENOTSUP: the implementation does not the flag combination.
-	//   - EINTR: the call was interrupted prior to an event.
-	//
-	// # Notes
-	//
-	//   - This is like `poll` in POSIX, for a single file.
-	//     See https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
-	//   - No-op files, such as those which read from /dev/null, should return
-	//     immediately true, as data will never become available.
-	//   - See /RATIONALE.md for detailed notes including impact of blocking.
-	Poll(flag Pflag, timeoutMillis int32) (ready bool, errno Errno)
 
 	// Readdir reads the contents of the directory associated with file and
 	// returns a slice of up to n Dirent values in an arbitrary order. This is

--- a/experimental/sys/unimplemented.go
+++ b/experimental/sys/unimplemented.go
@@ -101,16 +101,6 @@ func (UnimplementedFile) SetAppend(bool) Errno {
 	return ENOSYS
 }
 
-// IsNonblock implements File.IsNonblock
-func (UnimplementedFile) IsNonblock() bool {
-	return false
-}
-
-// SetNonblock implements File.SetNonblock
-func (UnimplementedFile) SetNonblock(bool) Errno {
-	return ENOSYS
-}
-
 // Stat implements File.Stat
 func (UnimplementedFile) Stat() (sys.Stat_t, Errno) {
 	return sys.Stat_t{}, ENOSYS
@@ -134,11 +124,6 @@ func (UnimplementedFile) Seek(int64, int) (int64, Errno) {
 // Readdir implements File.Readdir
 func (UnimplementedFile) Readdir(int) (dirents []Dirent, errno Errno) {
 	return nil, ENOSYS
-}
-
-// Poll implements File.Poll
-func (UnimplementedFile) Poll(Pflag, int32) (ready bool, errno Errno) {
-	return false, ENOSYS
 }
 
 // Write implements File.Write

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/fstest"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/sys"
@@ -247,7 +248,7 @@ func Test_fdFdstatGet(t *testing.T) {
 	}}}).OpenFile("stdin", 0, 0)
 	require.EqualErrno(t, 0, errno)
 
-	stdin.File = stdinFile
+	stdin.File = fsapi.Adapt(stdinFile)
 
 	// Make this file writeable, to ensure flags read-back correctly.
 	fileFD, errno := fsc.OpenFile(preopen, file, experimentalsys.O_RDWR, 0)

--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/wasip1"
 	"github.com/tetratelabs/wazero/internal/wasm"
@@ -177,7 +178,7 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 	}
 	// Wait for the timeout to expire, or for some data to become available on Stdin.
 
-	if stdinReady, errno := stdin.File.Poll(sys.POLLIN, int32(timeout.Milliseconds())); errno != 0 {
+	if stdinReady, errno := stdin.File.Poll(fsapi.POLLIN, int32(timeout.Milliseconds())); errno != 0 {
 		return errno
 	} else if stdinReady {
 		// stdin has data ready to for reading, write back all the events

--- a/imports/wasi_snapshot_preview1/poll_test.go
+++ b/imports/wasi_snapshot_preview1/poll_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/wasip1"
@@ -161,7 +162,7 @@ func Test_pollOneoff_Stdin(t *testing.T) {
 		name                                   string
 		in, out, nsubscriptions, resultNevents uint32
 		mem                                    []byte // at offset in
-		stdin                                  experimentalsys.File
+		stdin                                  fsapi.File
 		expectedErrno                          wasip1.Errno
 		expectedMem                            []byte // at offset out
 		expectedLog                            string
@@ -442,7 +443,7 @@ func Test_pollOneoff_Stdin(t *testing.T) {
 	}
 }
 
-func setStdin(t *testing.T, mod api.Module, stdin experimentalsys.File) {
+func setStdin(t *testing.T, mod api.Module, stdin fsapi.File) {
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	f, ok := fsc.LookupFile(sys.FdStdin)
 	require.True(t, ok)
@@ -613,8 +614,8 @@ type neverReadyTtyStdinFile struct {
 }
 
 // Poll implements the same method as documented on sys.File
-func (neverReadyTtyStdinFile) Poll(flag experimentalsys.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
-	if flag != experimentalsys.POLLIN {
+func (neverReadyTtyStdinFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	if flag != fsapi.POLLIN {
 		return false, experimentalsys.ENOTSUP
 	}
 	switch {
@@ -632,8 +633,8 @@ type pollStdinFile struct {
 }
 
 // Poll implements the same method as documented on sys.File
-func (p *pollStdinFile) Poll(flag experimentalsys.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
-	if flag != experimentalsys.POLLIN {
+func (p *pollStdinFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	if flag != fsapi.POLLIN {
 		return false, experimentalsys.ENOTSUP
 	}
 	return p.ready, 0

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	experimentalsock "github.com/tetratelabs/wazero/experimental/sock"
-	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/fstest"
 	internalsys "github.com/tetratelabs/wazero/internal/sys"
 	"github.com/tetratelabs/wazero/internal/testing/require"
@@ -329,7 +329,7 @@ func Test_Poll(t *testing.T) {
 	tests := []struct {
 		name            string
 		args            []string
-		stdin           experimentalsys.File
+		stdin           fsapi.File
 		expectedOutput  string
 		expectedTimeout time.Duration
 	}{

--- a/internal/fsapi/file.go
+++ b/internal/fsapi/file.go
@@ -1,0 +1,69 @@
+package fsapi
+
+import experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+
+// File includes methods not yet ready to document for end users, notably
+// non-blocking functionality.
+//
+// Particularly, Poll is subject to debate. For example, whether a user should
+// be able to choose how to implement timeout or not. Currently, this interface
+// allows the user to choose to sleep or use native polling, and which choice
+// they make impacts thread behavior as summarized here:
+// https://github.com/tetratelabs/wazero/pull/1606#issuecomment-1665475516
+type File interface {
+	experimentalsys.File
+
+	// IsNonblock returns true if the file was opened with O_NONBLOCK, or
+	// SetNonblock was successfully enabled on this file.
+	//
+	// # Notes
+	//
+	//   - This might not match the underlying state of the file descriptor if
+	//     the file was not opened via OpenFile.
+	IsNonblock() bool
+
+	// SetNonblock toggles the non-blocking mode (O_NONBLOCK) of this file.
+	//
+	// # Errors
+	//
+	// A zero Errno is success. The below are expected otherwise:
+	//   - ENOSYS: the implementation does not support this function.
+	//   - EBADF: the file or directory was closed.
+	//
+	// # Notes
+	//
+	//   - This is like syscall.SetNonblock and `fcntl` with O_NONBLOCK in
+	//     POSIX. See https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html
+	SetNonblock(enable bool) experimentalsys.Errno
+
+	// Poll returns if the file has data ready to be read or written.
+	//
+	// # Parameters
+	//
+	// The `flag` parameter determines which event to await, such as POLLIN,
+	// POLLOUT, or a combination like `POLLIN|POLLOUT`.
+	//
+	// The `timeoutMillis` parameter is how long to block for an event, or
+	// interrupted, in milliseconds. There are two special values:
+	//   - zero returns immediately
+	//   - any negative value blocks any amount of time
+	//
+	// # Results
+	//
+	// `ready` means there was data ready to read or written. False can mean no
+	// event was ready or `errno` is not zero.
+	//
+	// A zero `errno` is success. The below are expected otherwise:
+	//   - ENOSYS: the implementation does not support this function.
+	//   - ENOTSUP: the implementation does not the flag combination.
+	//   - EINTR: the call was interrupted prior to an event.
+	//
+	// # Notes
+	//
+	//   - This is like `poll` in POSIX, for a single file.
+	//     See https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
+	//   - No-op files, such as those which read from /dev/null, should return
+	//     immediately true, as data will never become available.
+	//   - See /RATIONALE.md for detailed notes including impact of blocking.
+	Poll(flag Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno)
+}

--- a/internal/fsapi/poll.go
+++ b/internal/fsapi/poll.go
@@ -1,4 +1,4 @@
-package sys
+package fsapi
 
 // Pflag are bit flags used for File.Poll. Values, including zero, should not
 // be interpreted numerically. Instead, use by constants prefixed with 'POLL'.

--- a/internal/fsapi/unimplemented.go
+++ b/internal/fsapi/unimplemented.go
@@ -1,0 +1,27 @@
+package fsapi
+
+import experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+
+func Adapt(f experimentalsys.File) File {
+	if f, ok := f.(File); ok {
+		return f
+	}
+	return unimplementedFile{f}
+}
+
+type unimplementedFile struct{ experimentalsys.File }
+
+// IsNonblock implements File.IsNonblock
+func (unimplementedFile) IsNonblock() bool {
+	return false
+}
+
+// SetNonblock implements File.SetNonblock
+func (unimplementedFile) SetNonblock(bool) experimentalsys.Errno {
+	return experimentalsys.ENOSYS
+}
+
+// Poll implements File.Poll
+func (unimplementedFile) Poll(Pflag, int32) (ready bool, errno experimentalsys.Errno) {
+	return false, experimentalsys.ENOSYS
+}

--- a/internal/sys/stdio.go
+++ b/internal/sys/stdio.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/sysfs"
 	"github.com/tetratelabs/wazero/sys"
 )
@@ -47,9 +48,9 @@ func (noopStdinFile) Read([]byte) (int, experimentalsys.Errno) {
 	return 0, 0 // Always EOF
 }
 
-// Poll implements the same method as documented on sys.File
-func (noopStdinFile) Poll(flag experimentalsys.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
-	if flag != experimentalsys.POLLIN {
+// Poll implements the same method as documented on fsapi.File
+func (noopStdinFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+	if flag != fsapi.POLLIN {
 		return false, experimentalsys.ENOTSUP
 	}
 	return true, 0 // always ready to read nothing
@@ -82,6 +83,21 @@ func (noopStdioFile) IsDir() (bool, experimentalsys.Errno) {
 
 // Close implements the same method as documented on sys.File
 func (noopStdioFile) Close() (errno experimentalsys.Errno) { return }
+
+// IsNonblock implements the same method as documented on fsapi.File
+func (noopStdioFile) IsNonblock() bool {
+	return false
+}
+
+// SetNonblock implements the same method as documented on fsapi.File
+func (noopStdioFile) SetNonblock(bool) experimentalsys.Errno {
+	return experimentalsys.ENOSYS
+}
+
+// Poll implements the same method as documented on fsapi.File
+func (noopStdioFile) Poll(fsapi.Pflag, int32) (ready bool, errno experimentalsys.Errno) {
+	return false, experimentalsys.ENOSYS
+}
 
 func stdinFileEntry(r io.Reader) (*FileEntry, error) {
 	if r == nil {

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -11,6 +11,7 @@ import (
 	gofstest "testing/fstest"
 
 	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/platform"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/sys"
@@ -319,7 +320,7 @@ func TestFileReadAndPread(t *testing.T) {
 }
 
 func TestFilePoll_POLLIN(t *testing.T) {
-	pflag := experimentalsys.POLLIN
+	pflag := fsapi.POLLIN
 
 	// Test using os.Pipe as it is known to support poll.
 	r, w, err := os.Pipe()
@@ -355,7 +356,7 @@ func TestFilePoll_POLLIN(t *testing.T) {
 }
 
 func TestFilePoll_POLLOUT(t *testing.T) {
-	pflag := experimentalsys.POLLOUT
+	pflag := fsapi.POLLOUT
 
 	// Test using os.Pipe as it is known to support poll.
 	r, w, err := os.Pipe()

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -7,10 +7,11 @@ import (
 	"runtime"
 
 	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/sys"
 )
 
-func newOsFile(path string, flag experimentalsys.Oflag, perm fs.FileMode, f *os.File) experimentalsys.File {
+func newOsFile(path string, flag experimentalsys.Oflag, perm fs.FileMode, f *os.File) fsapi.File {
 	// Windows cannot read files written to a directory after it was opened.
 	// This was noticed in #1087 in zig tests. Use a flag instead of a
 	// different type.
@@ -102,12 +103,12 @@ func (f *osFile) reopen() (errno experimentalsys.Errno) {
 	return
 }
 
-// IsNonblock implements the same method as documented on sys.File
+// IsNonblock implements the same method as documented on fsapi.File
 func (f *osFile) IsNonblock() bool {
 	return isNonblock(f)
 }
 
-// SetNonblock implements the same method as documented on sys.File
+// SetNonblock implements the same method as documented on fsapi.File
 func (f *osFile) SetNonblock(enable bool) (errno experimentalsys.Errno) {
 	if enable {
 		f.flag |= experimentalsys.O_NONBLOCK
@@ -178,8 +179,8 @@ func (f *osFile) Seek(offset int64, whence int) (newOffset int64, errno experime
 	return
 }
 
-// Poll implements the same method as documented on sys.File
-func (f *osFile) Poll(flag experimentalsys.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
+// Poll implements the same method as documented on fsapi.File
+func (f *osFile) Poll(flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno experimentalsys.Errno) {
 	return poll(f.fd, flag, timeoutMillis)
 }
 

--- a/internal/sysfs/poll.go
+++ b/internal/sysfs/poll.go
@@ -4,11 +4,12 @@ package sysfs
 
 import (
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 )
 
 // poll implements `Poll` as documented on sys.File via a file descriptor.
-func poll(fd uintptr, flag sys.Pflag, timeoutMillis int32) (ready bool, errno sys.Errno) {
-	if flag != sys.POLLIN {
+func poll(fd uintptr, flag fsapi.Pflag, timeoutMillis int32) (ready bool, errno sys.Errno) {
+	if flag != fsapi.POLLIN {
 		return false, sys.ENOTSUP
 	}
 	fds := []pollFd{newPollFd(fd, _POLLIN, 0)}

--- a/internal/sysfs/poll_unsupported.go
+++ b/internal/sysfs/poll_unsupported.go
@@ -4,9 +4,10 @@ package sysfs
 
 import (
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 )
 
-// poll implements `Poll` as documented on sys.File via a file descriptor.
-func poll(fd uintptr, flag sys.Pflag, timeoutMillis int32) (ready bool, errno sys.Errno) {
+// poll implements `Poll` as documented on fsapi.File via a file descriptor.
+func poll(uintptr, fsapi.Pflag, int32) (bool, sys.Errno) {
 	return false, sys.ENOSYS
 }

--- a/internal/sysfs/sock_test.go
+++ b/internal/sysfs/sock_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tetratelabs/wazero/experimental/sys"
+	"github.com/tetratelabs/wazero/internal/fsapi"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
@@ -117,15 +118,16 @@ func TestTcpConnFile_SetNonblock(t *testing.T) {
 	require.NoError(t, err)
 	defer tcp.Close() //nolint
 
-	errno := lf.SetNonblock(true)
+	nblf := fsapi.Adapt(lf)
+	errno := nblf.SetNonblock(true)
 	require.EqualErrno(t, 0, errno)
-	require.True(t, lf.IsNonblock())
+	require.True(t, nblf.IsNonblock())
 
 	conn, errno := lf.Accept()
 	require.EqualErrno(t, 0, errno)
 	defer conn.Close()
 
-	file := newTcpConn(tcp)
+	file := fsapi.Adapt(newTcpConn(tcp))
 	errno = file.SetNonblock(true)
 	require.EqualErrno(t, 0, errno)
 	require.True(t, file.IsNonblock())


### PR DESCRIPTION
Folks aren't currently on the same page on whether or not users should be able to implement the timeout parameter on `File.Poll` or whether it should always be externally controlled via a sleep loop which uses poll (immediate). Until we are sure internally, we shouldn't expose this for implementation, as it would be confusing for the same reason.

This migrates the non-blocking functionality back into the internal package.

One future way out could be to allow the user to decide if the backend is allowed to use the timeout parameter or not. Just as they control the FS, they could control a poller, which would then be able to span across both normal files and sockets. One could then be able to choose in the case of a single file and a specific known wasm, simply use the native timeout. In other words, since there are valid alternate answers, even though Go doesn't support custom pollers we could, if we decide that native polling is basically not allowed. Alternatively, we could force it to never be allowed by removing the timeout parameter (making it a poll immediate). Anyway, I will leave that decision up to @ncruces and @evacchi who will take responsibility of whichever decision is made.