### PR TITLE
Upgrade floor Go version to 1.19 everywhere.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -22,7 +22,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the relevant information):**
-- Go version: [e.g. 1.18.1]
+- Go version: [e.g. 1.19.1]
 - wazero Version: [e.g. c815060196bbfaa2d0f66a6ddbe64ba026523944]
 - Host architecture: [e.g. amd64]
 - Runtime mode: [e.g. interpreter or compiler]

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -235,7 +235,7 @@ rt := wazero.NewRuntimeConfig() // initialized properly
 There are a few drawbacks to this, notably some work for maintainers.
 * Interfaces are decoupled from the structs implementing them, which means the signature has to be repeated twice.
 * Interfaces have to be documented and guarded at time of use, that 3rd party implementations aren't supported.
-* As of Golang 1.18, interfaces are still [not well supported](https://github.com/golang/go/issues/5860) in godoc.
+* As of Golang 1.21, interfaces are still [not well supported](https://github.com/golang/go/issues/5860) in godoc.
 
 ## Config
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -3495,7 +3495,7 @@ func Test_pathFilestatSetTimes(t *testing.T) {
 	}
 
 	if runtime.GOOS == "windows" && !platform.IsAtLeastGo120 {
-		// Windows 1.18 (possibly 1.19) returns ENOSYS on no_symlink_follow
+		// Windows 1.19 returns ENOSYS on no_symlink_follow
 		tests = tests[:len(tests)-1]
 	}
 

--- a/internal/filecache/file_cache_test.go
+++ b/internal/filecache/file_cache_test.go
@@ -1,4 +1,4 @@
-//go:build go1.18
+//go:build go1.19
 
 package filecache
 

--- a/internal/gojs/compiler_test.go
+++ b/internal/gojs/compiler_test.go
@@ -130,7 +130,7 @@ func TestMain(m *testing.M) {
 // compileJsWasm allows us to generate a binary with runtime.GOOS=js and
 // runtime.GOARCH=wasm. This intentionally does so on-demand, as it allows us
 // to test the user's current version of Go, as opposed to a specific one.
-// For example, this allows testing both Go 1.18 and 1.19 in CI.
+// For example, this allows testing both Go 1.19 and 1.20 in CI.
 func compileJsWasm(goBin string) error {
 	// Prepare the working directory.
 	workdir, err := os.MkdirTemp("", "example")

--- a/internal/integration_test/fuzz/go.mod
+++ b/internal/integration_test/fuzz/go.mod
@@ -1,7 +1,7 @@
 module github.com/tetratelabs/wazero/internal/integration_test/fuzz
 
-go 1.18
+go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.1
+require github.com/tetratelabs/wazero v0.0.0
 
 replace github.com/tetratelabs/wazero => ../../../

--- a/internal/integration_test/vs/time/go.mod
+++ b/internal/integration_test/vs/time/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/clock
 
-go 1.18
+go 1.19
 
 require golang.org/x/sys v0.1.0
 

--- a/internal/integration_test/vs/wasmedge/go.mod
+++ b/internal/integration_test/vs/wasmedge/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmedge
 
-go 1.18
+go 1.19
 
 require (
 	github.com/second-state/WasmEdge-go v0.12.1

--- a/internal/integration_test/vs/wasmtime/go.mod
+++ b/internal/integration_test/vs/wasmtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/vs/wasmtime
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bytecodealliance/wasmtime-go/v9 v9.0.0

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -27,6 +27,7 @@ func Test_isAtLeastGo120(t *testing.T) {
 		expected bool
 	}{
 		{input: "go1.18.10", expected: false},
+		{input: "go1.19.10", expected: false},
 		{input: "go1.20.5", expected: true},
 		{input: "devel go1.21-39c50707 Thu Jul 6 23:23:41 2023 +0000", expected: true},
 		{input: "go1.21rc2", expected: true},

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -214,14 +214,13 @@ func TestFileIno(t *testing.T) {
 
 // statSetsIno returns true if this will set sys.Stat_t Ino on stat. The
 // reverse doesn't mean it won't. Rather it is inconsistent. This is needed
-// because Windows on Go 1.18 sometimes, but not always returns non-zero inode.
+// because Windows on Go 1.19 sometimes, but not always returns non-zero inode.
 func statSetsIno() bool {
 	if runtime.GOOS != "windows" {
 		return true
 	} else {
 		// Go can read the inode via a Windows file handle, but it is
-		// inconsistent on Go 1.18.
-		// TODO: check on 1.19 can!
+		// inconsistent on Go 1.19.
 		return platform.IsAtLeastGo120
 	}
 }

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -170,7 +170,7 @@ func (f *osFile) Seek(offset int64, whence int) (newOffset int64, errno experime
 		errno = fileError(f, f.closed, errno)
 
 		// If the error was trying to rewind a directory, re-open it. Notably,
-		// seeking to zero on a directory doesn't work on Windows with Go 1.18.
+		// seeking to zero on a directory doesn't work on Windows with Go 1.19.
 		if errno == experimentalsys.EISDIR && offset == 0 && whence == io.SeekStart {
 			errno = 0
 			f.reopenDir = true

--- a/internal/sysfs/sync_windows.go
+++ b/internal/sysfs/sync_windows.go
@@ -11,7 +11,7 @@ func fsync(f *os.File) sys.Errno {
 	// Coerce error performing stat on a directory to 0, as it won't work
 	// on Windows.
 	switch errno {
-	case sys.EACCES /* Go 1.20 */, sys.EBADF /* Go 1.18 */ :
+	case sys.EACCES /* Go 1.20 */, sys.EBADF /* Go 1.19 */ :
 		if st, err := f.Stat(); err == nil && st.IsDir() {
 			errno = 0
 		}

--- a/internal/version/testdata/go.mod
+++ b/internal/version/testdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/version/testdata
 
-go 1.18
+go 1.19
 
 require github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1 // indirect
 


### PR DESCRIPTION
Sadly, this is mostly updating docs and comments (and some go.mod here and there), because the shortcomings of 1.18 are mostly still there with 1.19 😬 😅  