### PR TITLE
emscripten: explicitly checks if an api.Function is not nil

### DIFF
--- a/internal/emscripten/emscripten.go
+++ b/internal/emscripten/emscripten.go
@@ -170,8 +170,8 @@ func (v *InvokeFunc) Call(ctx context.Context, mod api.Module, stack []uint64) {
 // potentially nil interface can be fatal on some platforms due to a bug? in Go/QEMU.
 // See https://github.com/tetratelabs/wazero/issues/1621
 func callOrPanic(ctx context.Context, m api.Module, name string, stack []uint64) {
-	if srf := m.ExportedFunction(name); srf != nil {
-		err := srf.CallWithStack(ctx, stack)
+	if f := m.ExportedFunction(name); f != nil {
+		err := f.CallWithStack(ctx, stack)
 		if err != nil {
 			panic(err)
 		}

--- a/internal/emscripten/emscripten_test.go
+++ b/internal/emscripten/emscripten_test.go
@@ -1,0 +1,26 @@
+package emscripten
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental/wazerotest"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func Test_callOnPanic(t *testing.T) {
+	const exists = "f"
+	var called bool
+	f := wazerotest.NewFunction(func(context.Context, api.Module) { called = true })
+	f.ExportNames = []string{exists}
+	m := wazerotest.NewModule(nil, f)
+	t.Run("exists", func(t *testing.T) {
+		callOrPanic(context.Background(), m, exists, nil)
+		require.True(t, called)
+	})
+	t.Run("not exist", func(t *testing.T) {
+		err := require.CapturePanic(func() { callOrPanic(context.Background(), m, "not-exist", nil) })
+		require.EqualError(t, err, "not-exist not exported")
+	})
+}


### PR DESCRIPTION
Fixes #1621 (at least for us in terms of flaky tests)