### PR TITLE
wazevo: adds bit count instructions clz, ctz

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -1418,6 +1418,37 @@ L1 (SSA Block: blk0):
 `,
 		},
 		{
+			name: "integer bit counts", m: testcases.IntegerBitCounts.Module,
+			afterLoweringARM64: `
+L1 (SSA Block: blk0):
+	mov x2?, x2
+	mov x3?, x3
+	clz w4?, w2?
+	rbit w5?, w2?
+	clz w5?, w5?
+	clz x6?, x3?
+	rbit x7?, x3?
+	clz x7?, x7?
+	mov x3, x7?
+	mov x2, x6?
+	mov x1, x5?
+	mov x0, x4?
+	ret
+`,
+			afterFinalizeARM64: `
+L1 (SSA Block: blk0):
+	str x30, [sp, #-0x10]!
+	clz w0, w2
+	rbit w1, w2
+	clz w1, w1
+	clz x2, x3
+	rbit x3, x3
+	clz x3, x3
+	ldr x30, [sp], #0x10
+	ret
+`,
+		},
+		{
 			name: "float_comparisons",
 			m:    testcases.FloatComparisons.Module,
 			afterLoweringARM64: `

--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -735,7 +735,7 @@ func (i *instruction) String() (str string) {
 	case bitRR:
 		size := is64SizeBitToSize(i.u2)
 		str = fmt.Sprintf("%s %s, %s",
-			bitOp(i.u1).String(),
+			bitOp(i.u1),
 			formatVRegSized(i.rd.nr(), size),
 			formatVRegSized(i.rn.nr(), size),
 		)
@@ -1255,6 +1255,7 @@ const (
 // bitOpRbit and bitOpClz would use this type.
 type bitOp int
 
+// String implements fmt.Stringer.
 func (b bitOp) String() string {
 	switch b {
 	case bitOpRbit:

--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -1266,8 +1266,9 @@ func (b bitOp) String() string {
 }
 
 const (
-	// 32/64-bit Clz.
+	// 32/64-bit Rbit.
 	bitOpRbit bitOp = iota
+	// 32/64-bit Clz.
 	bitOpClz
 )
 

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -328,7 +328,6 @@ func encodeBitRR(op bitOp, rd, rn, _64bit uint32) uint32 {
 	default:
 		panic("TODO/BUG")
 	}
-	_, _ = opcode2, opcode
 	return _64bit<<31 | 0b1_0_11010110<<21 | opcode2<<15 | opcode<<10 | rn<<5 | rd
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -157,6 +157,13 @@ func (i *instruction) encode(c backend.Compiler) {
 			i.u2,
 			i.u3 == 1,
 		))
+	case bitRR:
+		c.Emit4Bytes(encodeBitRR(
+			bitOp(i.u1),
+			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rn.realReg()],
+			uint32(i.u2)),
+		)
 	case aluRRImm12:
 		imm12, shift := i.rm.imm12()
 		c.Emit4Bytes(encodeAluRRImm12(
@@ -307,6 +314,22 @@ func encodeAluRRRR(op aluOp, rd, rn, rm, ra, _64bit uint32) uint32 {
 		panic("TODO/BUG")
 	}
 	return _64bit<<31 | 0b11011<<24 | op31<<21 | rm<<16 | oO<<15 | ra<<10 | rn<<5 | rd
+}
+
+// encodeBitRR encodes as Data-processing (1 source) in
+// https://developer.arm.com/documentation/ddi0596/2020-12/Index-by-Encoding/Data-Processing----Register?lang=en
+func encodeBitRR(op bitOp, rd, rn, _64bit uint32) uint32 {
+	var opcode2, opcode uint32
+	switch op {
+	case bitOpRbit:
+		opcode2, opcode = 0b00000, 0b000000
+	case bitOpClz:
+		opcode2, opcode = 0b00000, 0b000100
+	default:
+		panic("TODO/BUG")
+	}
+	_, _ = opcode2, opcode
+	return _64bit<<31 | 0b1_0_11010110<<21 | opcode2<<15 | opcode<<10 | rn<<5 | rd
 }
 
 func encodeAsMov32(rn, rd uint32) uint32 {

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -434,6 +434,8 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "400041d3", setup: func(i *instruction) {
 			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(63), true)
 		}},
+		{want: "4010c05a", setup: func(i *instruction) { i.asBitRR(bitOpClz, x0VReg, x2VReg, false) }},
+		{want: "4010c0da", setup: func(i *instruction) { i.asBitRR(bitOpClz, x0VReg, x2VReg, true) }},
 	} {
 		tc := tc
 		t.Run(tc.want, func(t *testing.T) {

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -434,6 +434,8 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "400041d3", setup: func(i *instruction) {
 			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(63), true)
 		}},
+		{want: "4000c05a", setup: func(i *instruction) { i.asBitRR(bitOpRbit, x0VReg, x2VReg, false) }},
+		{want: "4000c0da", setup: func(i *instruction) { i.asBitRR(bitOpRbit, x0VReg, x2VReg, true) }},
 		{want: "4010c05a", setup: func(i *instruction) { i.asBitRR(bitOpClz, x0VReg, x2VReg, false) }},
 		{want: "4010c0da", setup: func(i *instruction) { i.asBitRR(bitOpClz, x0VReg, x2VReg, true) }},
 	} {

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -147,6 +147,14 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 	case ssa.OpcodeSelect:
 		c, x, y := instr.SelectData()
 		m.lowerSelect(c, x, y, instr.Return())
+	case ssa.OpcodeClz:
+		x := instr.UnaryData()
+		result := instr.Return()
+		m.lowerClz(x, result)
+	case ssa.OpcodeCtz:
+		x := instr.UnaryData()
+		result := instr.Return()
+		m.lowerCtz(x, result)
 	default:
 		panic("TODO: lowering " + instr.Opcode().String())
 	}
@@ -293,6 +301,26 @@ func (m *machine) lowerImul(x, y, result ssa.Value) {
 	mul := m.allocateInstr()
 	mul.asALURRRR(aluOpMAdd, operandNR(rd), rn, rm, operandNR(xzrVReg), x.Type().Bits() == 64)
 	m.insert(mul)
+}
+
+func (m *machine) lowerClz(x, result ssa.Value) {
+	rd := m.compiler.VRegOf(result)
+	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
+	clz := m.allocateInstr()
+	clz.asBitRR(bitOpClz, rd, rn.nr(), x.Type().Bits() == 64)
+	m.insert(clz)
+}
+
+func (m *machine) lowerCtz(x, result ssa.Value) {
+	rd := m.compiler.VRegOf(result)
+	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
+	rbit := m.allocateInstr()
+	rbit.asBitRR(bitOpRbit, rd, rn.nr(), x.Type().Bits() == 64)
+	m.insert(rbit)
+
+	clz := m.allocateInstr()
+	clz.asBitRR(bitOpClz, rd, rd, x.Type().Bits() == 64)
+	m.insert(clz)
 }
 
 const exitWithCodeEncodingSize = exitSequenceSize + 8

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -612,6 +612,17 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i64)
 `,
 		},
 		{
+			name: "integer bit counts", m: testcases.IntegerBitCounts.Module,
+			exp: `
+blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i64)
+	v4:i32 = Clz v2
+	v5:i32 = Ctz v2
+	v6:i64 = Clz v3
+	v7:i64 = Ctz v3
+	Jump blk_ret, v4, v5, v6, v7
+`,
+		},
+		{
 			name: "float comparisons", m: testcases.FloatComparisons.Module,
 			exp: `
 blk0: (exec_ctx:i64, module_ctx:i64, v2:f32, v3:f32, v4:f64, v5:f64)

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -427,6 +427,26 @@ func (c *Compiler) lowerOpcode(op wasm.Opcode) {
 		builder.InsertInstruction(ishl)
 		value := ishl.Return()
 		state.push(value)
+	case wasm.OpcodeI32Clz, wasm.OpcodeI64Clz:
+		if state.unreachable {
+			return
+		}
+		x := state.pop()
+		clz := builder.AllocateInstruction()
+		clz.AsClz(x)
+		builder.InsertInstruction(clz)
+		value := clz.Return()
+		state.push(value)
+	case wasm.OpcodeI32Ctz, wasm.OpcodeI64Ctz:
+		if state.unreachable {
+			return
+		}
+		x := state.pop()
+		ctz := builder.AllocateInstruction()
+		ctz.AsCtz(x)
+		builder.InsertInstruction(ctz)
+		value := ctz.Return()
+		state.push(value)
 	case wasm.OpcodeGlobalGet:
 		index := c.readI32u()
 		if state.unreachable {

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -836,6 +836,8 @@ var instructionSideEffects = [opcodeEnd]sideEffect{
 	OpcodeIcmp:               sideEffectFalse,
 	OpcodeFcmp:               sideEffectFalse,
 	OpcodeFadd:               sideEffectFalse,
+	OpcodeClz:                sideEffectFalse,
+	OpcodeCtz:                sideEffectFalse,
 	OpcodeLoad:               sideEffectFalse,
 	OpcodeUload8:             sideEffectFalse,
 	OpcodeUload16:            sideEffectFalse,
@@ -933,6 +935,8 @@ var instructionReturnTypes = [opcodeEnd]returnTypesFn{
 	OpcodeFmin:               returnTypesFnSingle,
 	OpcodeF32const:           returnTypesFnF32,
 	OpcodeF64const:           returnTypesFnF64,
+	OpcodeClz:                returnTypesFnSingle,
+	OpcodeCtz:                returnTypesFnSingle,
 	OpcodeStore:              returnTypesFnNoReturns,
 	OpcodeIstore8:            returnTypesFnNoReturns,
 	OpcodeIstore16:           returnTypesFnNoReturns,
@@ -1302,6 +1306,32 @@ func (i *Instruction) CallIndirectData() (funcPtr Value, sigID SignatureID, args
 	return
 }
 
+// AsClz initializes this instruction as a Count Leading Zeroes instruction with OpcodeClz.
+func (i *Instruction) AsClz(x Value) {
+	i.opcode = OpcodeClz
+	i.v = x
+	i.typ = x.Type()
+}
+
+// AsCtz initializes this instruction as a Count Trailing Zeroes instruction with OpcodeCtz.
+func (i *Instruction) AsCtz(x Value) {
+	i.opcode = OpcodeCtz
+	i.v = x
+	i.typ = x.Type()
+}
+
+// AsPopcnt initializes this instruction as an Integer Population Count instruction with OpcodePopcnt.
+func (i *Instruction) AsPopcnt(x Value) {
+	i.opcode = OpcodePopcnt
+	i.v = x
+	i.typ = x.Type()
+}
+
+// UnaryData return the operand for a unary instruction.
+func (i *Instruction) UnaryData() Value {
+	return i.v
+}
+
 // AsSExtend initializes this instruction as a sign extension instruction with OpcodeSExtend.
 func (i *Instruction) AsSExtend(v Value, from, to byte) {
 	i.opcode = OpcodeSExtend
@@ -1438,6 +1468,8 @@ func (i *Instruction) Format(b Builder) string {
 	case OpcodeIshl, OpcodeSshr, OpcodeUshr:
 		instSuffix = fmt.Sprintf(" %s, %s", i.v.Format(b), i.v2.Format(b))
 	case OpcodeUndefined:
+	case OpcodeClz, OpcodeCtz, OpcodePopcnt:
+		instSuffix = " " + i.v.Format(b)
 	default:
 		panic(fmt.Sprintf("TODO: format for %s", i.opcode))
 	}

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -1320,13 +1320,6 @@ func (i *Instruction) AsCtz(x Value) {
 	i.typ = x.Type()
 }
 
-// AsPopcnt initializes this instruction as an Integer Population Count instruction with OpcodePopcnt.
-func (i *Instruction) AsPopcnt(x Value) {
-	i.opcode = OpcodePopcnt
-	i.v = x
-	i.typ = x.Type()
-}
-
 // UnaryData return the operand for a unary instruction.
 func (i *Instruction) UnaryData() Value {
 	return i.v
@@ -1468,7 +1461,7 @@ func (i *Instruction) Format(b Builder) string {
 	case OpcodeIshl, OpcodeSshr, OpcodeUshr:
 		instSuffix = fmt.Sprintf(" %s, %s", i.v.Format(b), i.v2.Format(b))
 	case OpcodeUndefined:
-	case OpcodeClz, OpcodeCtz, OpcodePopcnt:
+	case OpcodeClz, OpcodeCtz:
 		instSuffix = " " + i.v.Format(b)
 	default:
 		panic(fmt.Sprintf("TODO: format for %s", i.opcode))

--- a/internal/engine/wazevo/testcases/testcases.go
+++ b/internal/engine/wazevo/testcases/testcases.go
@@ -731,6 +731,27 @@ var (
 			wasm.OpcodeEnd,
 		}, []wasm.ValueType{}),
 	}
+	IntegerBitCounts = TestCase{
+		Name: "integer_bit_counts",
+		Module: SingleFunctionModule(wasm.FunctionType{
+			Params:  []wasm.ValueType{i32, i64},
+			Results: []wasm.ValueType{i32, i32, i64, i64},
+		}, []byte{
+			wasm.OpcodeLocalGet, 0,
+			wasm.OpcodeI32Clz,
+
+			wasm.OpcodeLocalGet, 0,
+			wasm.OpcodeI32Ctz,
+
+			wasm.OpcodeLocalGet, 1,
+			wasm.OpcodeI64Clz,
+
+			wasm.OpcodeLocalGet, 1,
+			wasm.OpcodeI64Ctz,
+
+			wasm.OpcodeEnd,
+		}, []wasm.ValueType{}),
+	}
 	FloatComparisons = TestCase{
 		Name: "float_comparisons",
 		Module: SingleFunctionModule(wasm.FunctionType{


### PR DESCRIPTION
Continues #1496.

This introduces the front-end and back-end for clz, ctz (in terms of rbit+clz).

It originally also introduced popcnt for the front-end, but this requires 
VCNT in the backend, which is probably worth its own separate PR.

Contextually, this also introduces a partial implementation for bitRR.

First PR to wazevo, so I am not entirely sure that the generated
code for the SSA and the backend is correct, let me know if there are errors,
I am really figuring out a lot of stuff, including the framework :)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
