### PR TITLE
wazevo(ssa): introduce trappable side effect

### DIFF
--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -100,6 +100,7 @@ func TestSpectestV1(t *testing.T) {
 		{name: "switch"},
 		{name: "token"},
 		{name: "type"},
+		//{name: "traps"},
 		{name: "unreachable"},
 		{name: "unreached-invalid"},
 		{name: "unwind"},

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -179,9 +179,13 @@ func passDeadCodeEliminationOpt(b *builder) {
 	for blk := b.blockIteratorBegin(); blk != nil; blk = b.blockIteratorNext() {
 		for cur := blk.rootInstr; cur != nil; cur = cur.next {
 			cur.gid = gid
-			if cur.HasSideEffects() {
+			switch cur.sideEffect() {
+			case sideEffectTraps:
+				// The trappable should always be alive.
 				liveInstructions = append(liveInstructions, cur)
-				// Side effects create different instruction groups.
+			case sideEffectStrict:
+				liveInstructions = append(liveInstructions, cur)
+				// The strict side effect should create different instruction groups.
 				gid++
 			}
 


### PR DESCRIPTION
this refactors a bit around side effect, and introduces the "trappable" side effect
which represents an instruction that shouldn't be optimized out regardless of whether 
the result is used or not.