### PR TITLE
wazevo: introduces the deterministic compilation verifier

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/util_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/util_test.go
@@ -1,6 +1,7 @@
 package arm64
 
 import (
+	"context"
 	"strings"
 
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend"
@@ -143,6 +144,6 @@ func (m *mockCompiler) MatchInstrOneOf(def *backend.SSAValueDefinition, opcodes 
 }
 
 // Compile implements backend.Compiler.
-func (m *mockCompiler) Compile() (_ []byte, _ []backend.RelocationInfo, goPreambleSize int, _ error) {
+func (m *mockCompiler) Compile(context.Context) (_ []byte, _ []backend.RelocationInfo, goPreambleSize int, _ error) {
 	return
 }

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -141,8 +141,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 			needGoEntryPreamble = true
 		}
 
-		body, rels, goPreambleSize, err :=
-			e.compileLocalWasmFunction(ctx, module, wasm.Index(i), fidx, needGoEntryPreamble, fe, ssaBuilder, be, listeners, ensureTermination)
+		body, rels, goPreambleSize, err := e.compileLocalWasmFunction(ctx, module, wasm.Index(i), fidx, needGoEntryPreamble, fe, ssaBuilder, be, listeners, ensureTermination)
 		if err != nil {
 			return nil, fmt.Errorf("compile function %d/%d: %v", i, len(module.CodeSection)-1, err)
 		}

--- a/internal/engine/wazevo/wazevoapi/debug_consts.go
+++ b/internal/engine/wazevo/wazevoapi/debug_consts.go
@@ -52,8 +52,8 @@ const (
 const (
 	// DeterministicCompilationVerifierEnabled enables the deterministic compilation verifier. This is disabled by default
 	// since the operation is expensive. But when in doubt, enable this to make sure the compilation is deterministic.
-	DeterministicCompilationVerifierEnabled = true
-	DeterministicCompilationVerifyingIter   = 5
+	DeterministicCompilationVerifierEnabled = false
+	DeterministicCompilationVerifyingIter   = 20
 )
 
 type (


### PR DESCRIPTION
this introduces the new debugging option to ensure that the compilation pipeline is deterministic. This is disabled by default but can be enabled when debugging.

#1496 