### PR TITLE
wazevo(regalloc): sort liveNodes by begin PC

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -2054,13 +2054,13 @@ L4 (SSA Block: blk3):
 	str x8, [x9, #0x8]
 	mov x0, x9
 	mov x1, x8
-	str x9, [sp]
-	str x8, [sp, #0x8]
-	str w11, [sp, #0x10]
+	str w11, [sp]
+	str x9, [sp, #0x4]
+	str x8, [sp, #0xc]
 	bl f0
-	ldr w11, [sp, #0x10]
-	ldr x8, [sp, #0x8]
-	ldr x9, [sp]
+	ldr x8, [sp, #0xc]
+	ldr x9, [sp, #0x4]
+	ldr w11, [sp]
 	mov x10, x0
 	sub w2, w11, #0x2
 	str x8, [x9, #0x8]

--- a/internal/engine/wazevo/backend/regalloc/assign_test.go
+++ b/internal/engine/wazevo/backend/regalloc/assign_test.go
@@ -70,8 +70,8 @@ func TestAllocator_activeNonRealVRegsAt(t *testing.T) {
 			name: "one live",
 			pc:   10,
 			lives: []liveNodeInBlock{
-				{n: &node{r: 1, v: 0xa, ranges: []liveRange{{begin: 100, end: 2000}}}},
 				{n: &node{r: 2, v: 0xf, ranges: []liveRange{{begin: 5, end: 20}}}},
+				{n: &node{r: 1, v: 0xa, ranges: []liveRange{{begin: 100, end: 2000}}}},
 			},
 			want: []VReg{0xf},
 		},
@@ -99,7 +99,7 @@ func TestAllocator_activeNonRealVRegsAt(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAllocator(&RegisterInfo{})
-			ans := a.activeNonRealVRegsAt(tc.pc, tc.lives)
+			ans := a.collectActiveNonRealVRegsAt(nil, tc.pc, tc.lives)
 
 			actual := make([]VReg, len(ans))
 			for i, n := range ans {


### PR DESCRIPTION
In preparation for passing "stack-page-guard" spectest,
this refactors a bit of regalloc logic.

#1496 