### PR TITLE
wazevo(regalloc): fixes phi node handlings

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -452,13 +452,13 @@ L4 (SSA Block: blk3):
 			afterFinalizeARM64: `
 L1 (SSA Block: blk0):
 	str x30, [sp, #-0x10]!
-	cbnz w2, #0x8 (L2)
+	cbnz w2, #0xc (L2)
 L3 (SSA Block: blk2):
+	mov x0, x3
 	b #0x8 (L4)
 L2 (SSA Block: blk1):
-	mov x3, x2
+	mov x0, x2
 L4 (SSA Block: blk3):
-	mov x0, x3
 	ldr x30, [sp], #0x10
 	ret
 `,

--- a/internal/engine/wazevo/backend/compiler_lower.go
+++ b/internal/engine/wazevo/backend/compiler_lower.go
@@ -152,9 +152,8 @@ func (c *compiler) lowerBlockArguments(args []ssa.Value, succ ssa.BasicBlock) {
 			}{cInst: srcDef.Instr, dst: dstReg})
 		} else {
 			srcReg := c.VRegOf(src)
-			if srcReg != dstReg { // Self-assignment can be no-op. This happens when, for example, passing a param as-is to the loop from the body.
-				c.varEdges = append(c.varEdges, [2]regalloc.VReg{srcReg, dstReg})
-			}
+			// Even when the src=dst, insert the move so that we can keep such registers keep-alive.
+			c.varEdges = append(c.varEdges, [2]regalloc.VReg{srcReg, dstReg})
 		}
 	}
 

--- a/internal/engine/wazevo/backend/regalloc/api.go
+++ b/internal/engine/wazevo/backend/regalloc/api.go
@@ -41,15 +41,17 @@ type (
 	Block interface {
 		// ID returns the unique identifier of this block.
 		ID() int
+		BlockParams() []VReg
 		// InstrIteratorBegin returns the first instruction in this block. Instructions added after lowering must be skipped.
 		// Note: multiple Instr(s) will not be held at the same time, so it's safe to use the same impl for the return Instr.
 		InstrIteratorBegin() Instr
 		// InstrIteratorNext returns the next instruction in this block. Instructions added after lowering must be skipped.
 		// Note: multiple Instr(s) will not be held at the same time, so it's safe to use the same impl for the return Instr.
 		InstrIteratorNext() Instr
-		// Preds returns the predecessors of this block in the CFG.
-		// Note: multiple returned []Block will not be used at the same time, so it's safe to use the same slice for []Block.
-		Preds() []Block
+		// Preds returns the number of predecessors of this block in the CFG.
+		Preds() int
+		// Pred returns the i-th predecessor of this block in the CFG.
+		Pred(i int) Block
 		// Entry returns true if the block is for the entry block.
 		Entry() bool
 	}

--- a/internal/engine/wazevo/backend/regalloc/api_test.go
+++ b/internal/engine/wazevo/backend/regalloc/api_test.go
@@ -194,10 +194,16 @@ func (m *mockBlock) InstrIteratorNext() Instr {
 	return ret
 }
 
-// Preds implements Instr.
-func (m *mockBlock) Preds() []Block {
-	return m._preds
+// Preds implements Block.
+func (m *mockBlock) Preds() int {
+	return len(m._preds)
 }
+
+// BlockParams implements Block.
+func (m *mockBlock) BlockParams() []VReg { return nil }
+
+// Pred implements Instr.
+func (m *mockBlock) Pred(i int) Block { return m._preds[i] }
 
 // Defs implements Instr.
 func (m *mockInstr) Defs() []VReg {

--- a/internal/engine/wazevo/backend/regalloc/coloring.go
+++ b/internal/engine/wazevo/backend/regalloc/coloring.go
@@ -24,8 +24,8 @@ func (a *Allocator) buildNeighborsByLiveNodes(lives []liveNodeInBlock) {
 	for i, src := range lives[:len(lives)-1] {
 		srcRange := &src.n.ranges[src.rangeIndex]
 		for _, dst := range lives[i+1:] {
-			if dst == src {
-				panic("BUG: dup entry in liveNodes")
+			if dst == src || dst.n == src.n {
+				panic(fmt.Sprintf("BUG: %s and %s are the same node", src.n.v, dst.n.v))
 			}
 			dstRange := &dst.n.ranges[dst.rangeIndex]
 			if src.n.v.RegType() == dst.n.v.RegType() && // Interfere only if they are the same type.
@@ -218,7 +218,7 @@ func (a *Allocator) coloringFor(allocatable []RealReg) {
 			}
 			for neighbor := range n.neighbors {
 				if n.r == neighbor.r {
-					panic("BUG color conflict")
+					panic(fmt.Sprintf("BUG color conflict: %s vs %s", n.v, neighbor.v))
 				}
 			}
 		}

--- a/internal/engine/wazevo/backend/regalloc/regalloc_test.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc_test.go
@@ -705,6 +705,12 @@ func initMapInInfo(info *blockInfo) {
 	if info.realRegDefs == nil {
 		info.realRegDefs = make(map[VReg][]programCounter)
 	}
+	if info.phiDefs == nil {
+		info.phiDefs = make(map[VReg]struct{})
+	}
+	if info.phiUses == nil {
+		info.phiUses = make(map[VReg]struct{})
+	}
 }
 
 func TestNode_assignedRealReg(t *testing.T) {

--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -32,8 +32,7 @@ func TestSpectestV1(t *testing.T) {
 	// Configure the new optimizing backend!
 	configureWazevo(config)
 
-	// TODO: adds incrementally one by one as we support more test cases. And eventually remove this
-	// and migrate to integration_test/spectest/v1/spec_test.go by the time when closing https://github.com/tetratelabs/wazero/issues/1496
+	// TODO: migrate to integration_test/spectest/v1/spec_test.go by the time when closing https://github.com/tetratelabs/wazero/issues/1496
 	for _, tc := range []struct {
 		name string
 	}{
@@ -82,7 +81,7 @@ func TestSpectestV1(t *testing.T) {
 		{name: "left-to-right"},
 		{name: "linking"},
 		{name: "load"},
-		//{name: "loop"},
+		{name: "loop"},
 		{name: "local_get"},
 		{name: "local_set"},
 		{name: "local_tee"},
@@ -315,6 +314,15 @@ func TestE2E(t *testing.T) {
 				// Out of range --> default.
 				{params: []uint64{6, 200}, expResults: []uint64{11 + 200}},
 				{params: []uint64{1000, 300}, expResults: []uint64{11 + 300}},
+			},
+		},
+		{
+			name: "multi_predecessor_local_ref",
+			m:    testcases.MultiPredecessorLocalRef.Module,
+			calls: []callCase{
+				{params: []uint64{0, 100}, expResults: []uint64{100}},
+				{params: []uint64{1, 100}, expResults: []uint64{1}},
+				{params: []uint64{1, 200}, expResults: []uint64{1}},
 			},
 		},
 	} {

--- a/internal/engine/wazevo/ssa/basic_block.go
+++ b/internal/engine/wazevo/ssa/basic_block.go
@@ -58,6 +58,8 @@ type BasicBlock interface {
 	NextPredIterator() BasicBlock
 	// Preds returns the number of predecessors of this block.
 	Preds() int
+	// Pred returns the i-th predecessor of this block.
+	Pred(i int) BasicBlock
 }
 
 type (
@@ -225,6 +227,11 @@ func (bb *basicBlock) NextPredIterator() BasicBlock {
 // Preds implements BasicBlock.Preds.
 func (bb *basicBlock) Preds() int {
 	return len(bb.preds)
+}
+
+// Pred implements BasicBlock.Pred.
+func (bb *basicBlock) Pred(i int) BasicBlock {
+	return bb.preds[i].blk
 }
 
 // Root implements BasicBlock.Root.


### PR DESCRIPTION
This fixes the handling of phi nodes (in our terminology SSA block arguments)
in the register allocation especially by implementing the missing logic in the
liveness analysis. 

As a result, wazevo, our new optimizing compiler #1496, finally has started passing 
all the WebAssembly v1 specification tests on AArch64.

