### PR TITLE
wazevo: add nontrapping fp conversions (wasm v2)

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -1730,21 +1730,13 @@ L1 (SSA Block: blk0):
 			afterFinalizeARM64: `
 L1 (SSA Block: blk0):
 	str x30, [sp, #-0x10]!
-	msr fpsr, xzr
 	fcvtzs x0, d0
-	msr fpsr, xzr
 	fcvtzs x1, s1
-	msr fpsr, xzr
 	fcvtzs w2, d0
-	msr fpsr, xzr
 	fcvtzs w3, s1
-	msr fpsr, xzr
 	fcvtzu x4, d0
-	msr fpsr, xzr
 	fcvtzu x5, s1
-	msr fpsr, xzr
 	fcvtzu w6, d0
-	msr fpsr, xzr
 	fcvtzu w7, s1
 	ldr x30, [sp], #0x10
 	ret

--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -1727,37 +1727,6 @@ L1 (SSA Block: blk0):
 		{
 			name: "nontrapping_float_conversions",
 			m:    testcases.NonTrappingFloatConversions.Module,
-			afterLoweringARM64: `
-L1 (SSA Block: blk0):
-	mov x0?, x0
-	mov v2?.8b, v0.8b
-	mov v3?.8b, v1.8b
-	msr fpsr, xzr
-	fcvtzs x4?, d2?
-	msr fpsr, xzr
-	fcvtzs x5?, s3?
-	msr fpsr, xzr
-	fcvtzs w6?, d2?
-	msr fpsr, xzr
-	fcvtzs w7?, s3?
-	msr fpsr, xzr
-	fcvtzu x8?, d2?
-	msr fpsr, xzr
-	fcvtzu x9?, s3?
-	msr fpsr, xzr
-	fcvtzu w10?, d2?
-	msr fpsr, xzr
-	fcvtzu w11?, s3?
-	mov x7, x11?
-	mov x6, x10?
-	mov x5, x9?
-	mov x4, x8?
-	mov x3, x7?
-	mov x2, x6?
-	mov x1, x5?
-	mov x0, x4?
-	ret
-`,
 			afterFinalizeARM64: `
 L1 (SSA Block: blk0):
 	str x30, [sp, #-0x10]!

--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -1725,6 +1725,63 @@ L1 (SSA Block: blk0):
 `,
 		},
 		{
+			name: "nontrapping_float_conversions",
+			m:    testcases.NonTrappingFloatConversions.Module,
+			afterLoweringARM64: `
+L1 (SSA Block: blk0):
+	mov x0?, x0
+	mov v2?.8b, v0.8b
+	mov v3?.8b, v1.8b
+	msr fpsr, xzr
+	fcvtzs x4?, d2?
+	msr fpsr, xzr
+	fcvtzs x5?, s3?
+	msr fpsr, xzr
+	fcvtzs w6?, d2?
+	msr fpsr, xzr
+	fcvtzs w7?, s3?
+	msr fpsr, xzr
+	fcvtzu x8?, d2?
+	msr fpsr, xzr
+	fcvtzu x9?, s3?
+	msr fpsr, xzr
+	fcvtzu w10?, d2?
+	msr fpsr, xzr
+	fcvtzu w11?, s3?
+	mov x7, x11?
+	mov x6, x10?
+	mov x5, x9?
+	mov x4, x8?
+	mov x3, x7?
+	mov x2, x6?
+	mov x1, x5?
+	mov x0, x4?
+	ret
+`,
+			afterFinalizeARM64: `
+L1 (SSA Block: blk0):
+	str x30, [sp, #-0x10]!
+	msr fpsr, xzr
+	fcvtzs x0, d0
+	msr fpsr, xzr
+	fcvtzs x1, s1
+	msr fpsr, xzr
+	fcvtzs w2, d0
+	msr fpsr, xzr
+	fcvtzs w3, s1
+	msr fpsr, xzr
+	fcvtzu x4, d0
+	msr fpsr, xzr
+	fcvtzu x5, s1
+	msr fpsr, xzr
+	fcvtzu w6, d0
+	msr fpsr, xzr
+	fcvtzu w7, s1
+	ldr x30, [sp], #0x10
+	ret
+`,
+		},
+		{
 			name: "many_middle_values",
 			m:    testcases.ManyMiddleValues.Module,
 			afterLoweringARM64: `

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -205,20 +205,22 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x := instr.Arg()
 		result := instr.Return()
 		m.lowerPopcnt(x, result)
-	case ssa.OpcodeFcvtToSint:
+	case ssa.OpcodeFcvtToSint, ssa.OpcodeFcvtToSintSat:
 		x, ctx := instr.Arg2()
 		result := instr.Return()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rd := operandNR(m.compiler.VRegOf(result))
 		ctxVReg := m.compiler.VRegOf(ctx)
-		m.lowerFpuToInt(rd, rn, ctxVReg, true, x.Type() == ssa.TypeF64, result.Type().Bits() == 64)
-	case ssa.OpcodeFcvtToUint:
+		m.lowerFpuToInt(rd, rn, ctxVReg, true, x.Type() == ssa.TypeF64,
+			result.Type().Bits() == 64, op == ssa.OpcodeFcvtToSintSat)
+	case ssa.OpcodeFcvtToUint, ssa.OpcodeFcvtToUintSat:
 		x, ctx := instr.Arg2()
 		result := instr.Return()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rd := operandNR(m.compiler.VRegOf(result))
 		ctxVReg := m.compiler.VRegOf(ctx)
-		m.lowerFpuToInt(rd, rn, ctxVReg, false, x.Type() == ssa.TypeF64, result.Type().Bits() == 64)
+		m.lowerFpuToInt(rd, rn, ctxVReg, false, x.Type() == ssa.TypeF64,
+			result.Type().Bits() == 64, op == ssa.OpcodeFcvtToUintSat)
 	case ssa.OpcodeFcvtFromSint:
 		x := instr.Arg()
 		result := instr.Return()
@@ -427,7 +429,7 @@ func (m *machine) lowerFpuUniOp(op fpuUniOp, in, out ssa.Value) {
 	m.insert(neg)
 }
 
-func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64bit, dst64bit bool) {
+func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64bit, dst64bit, nonTrapping bool) {
 	// First of all, we have to clear the FPU flags.
 	flagClear := m.allocateInstr()
 	flagClear.asMovToFPSR(xzrVReg)
@@ -438,33 +440,35 @@ func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64
 	cvt.asFpuToInt(rd, rn, signed, src64bit, dst64bit)
 	m.insert(cvt)
 
-	// After the conversion, check the FPU flags.
-	getFlag := m.allocateInstr()
-	getFlag.asMovFromFPSR(tmpRegVReg)
-	m.insert(getFlag)
+	if !nonTrapping {
+		// After the conversion, check the FPU flags.
+		getFlag := m.allocateInstr()
+		getFlag.asMovFromFPSR(tmpRegVReg)
+		m.insert(getFlag)
 
-	// Check if the conversion was undefined by comparing the status with 1.
-	// See https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/FPSR--Floating-point-Status-Register
-	alu := m.allocateInstr()
-	alu.asALU(aluOpSubS, operandNR(xzrVReg), operandNR(tmpRegVReg), operandImm12(1, 0), true)
-	m.insert(alu)
+		// Check if the conversion was undefined by comparing the status with 1.
+		// See https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/FPSR--Floating-point-Status-Register
+		alu := m.allocateInstr()
+		alu.asALU(aluOpSubS, operandNR(xzrVReg), operandNR(tmpRegVReg), operandImm12(1, 0), true)
+		m.insert(alu)
 
-	// If it is not undefined, we can return the result.
-	ok := m.allocateInstr()
-	ok.asCondBr(ne.asCond(), invalidLabel, false /* ignored */)
-	ok.condBrOffsetResolve(4 /* fpuCmp */ + exitIfNotSequenceEncodingSize + exitWithCodeEncodingSize + 4)
-	m.insert(ok)
+		// If it is not undefined, we can return the result.
+		ok := m.allocateInstr()
+		ok.asCondBr(ne.asCond(), invalidLabel, false /* ignored */)
+		ok.condBrOffsetResolve(4 /* fpuCmp */ + exitIfNotSequenceEncodingSize + exitWithCodeEncodingSize + 4)
+		m.insert(ok)
 
-	// Otherwise, we have to choose the status depending on it is overflow or NaN conversion.
+		// Otherwise, we have to choose the status depending on it is overflow or NaN conversion.
 
-	// Comparing itself to check if it is a NaN.
-	fpuCmp := m.allocateInstr()
-	fpuCmp.asFpuCmp(rn, rn, src64bit)
-	m.insert(fpuCmp)
-	// If the VC flag is not set (== VS flag is set), it is a NaN.
-	m.exitIfNot(ctx, vc.asCond(), wazevoapi.ExitCodeInvalidConversionToInteger)
-	// Otherwise, it is an overflow.
-	m.lowerExitWithCode(ctx, wazevoapi.ExitCodeIntegerOverflow)
+		// Comparing itself to check if it is a NaN.
+		fpuCmp := m.allocateInstr()
+		fpuCmp.asFpuCmp(rn, rn, src64bit)
+		m.insert(fpuCmp)
+		// If the VC flag is not set (== VS flag is set), it is a NaN.
+		m.exitIfNot(ctx, vc.asCond(), wazevoapi.ExitCodeInvalidConversionToInteger)
+		// Otherwise, it is an overflow.
+		m.lowerExitWithCode(ctx, wazevoapi.ExitCodeIntegerOverflow)
+	}
 }
 
 func (m *machine) lowerIntToFpu(rd, rn operand, signed, src64bit, dst64bit bool) {

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -430,10 +430,12 @@ func (m *machine) lowerFpuUniOp(op fpuUniOp, in, out ssa.Value) {
 }
 
 func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64bit, dst64bit, nonTrapping bool) {
-	// First of all, we have to clear the FPU flags.
-	flagClear := m.allocateInstr()
-	flagClear.asMovToFPSR(xzrVReg)
-	m.insert(flagClear)
+	if !nonTrapping {
+		// First of all, we have to clear the FPU flags.
+		flagClear := m.allocateInstr()
+		flagClear.asMovToFPSR(xzrVReg)
+		m.insert(flagClear)
+	}
 
 	// Then, do the conversion which doesn't trap inherently.
 	cvt := m.allocateInstr()

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -394,10 +394,9 @@ exit_sequence x15
 			name:        "nontrapping",
 			nontrapping: true,
 			expectedAsm: `
-msr fpsr, xzr
 fcvtzu w1, s2
 `,
-			expectedBytes: "3f441bd54100391e",
+			expectedBytes: "4100391e",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -364,9 +364,16 @@ func Test_exitIfNotSequenceEncodingSize(t *testing.T) {
 }
 
 func TestMachine_lowerFpuToInt(t *testing.T) {
-	_, _, m := newSetupWithMockContext()
-	m.lowerFpuToInt(operandNR(x1VReg), operandNR(x2VReg), x15VReg, false, false, false)
-	require.Equal(t, `
+	for _, tc := range []struct {
+		name          string
+		nontrapping   bool
+		expectedAsm   string
+		expectedBytes string
+	}{
+		{
+			name:        "trapping",
+			nontrapping: false,
+			expectedAsm: `
 msr fpsr, xzr
 fcvtzu w1, s2
 mrs x27 fpsr
@@ -380,10 +387,28 @@ exit_sequence x15
 movz x27, #0xb, lsl 0
 str w27, [x15]
 exit_sequence x15
-`, "\n"+formatEmittedInstructionsInCurrentBlock(m)+"\n")
+`,
+			expectedBytes: "3f441bd54100391e3b443bd57f0700f1210200544020221e070100549b0180d2fb0100b9fd0940f9fb0d40f97f030091fe1140f9c0035fd67b0180d2fb0100b9fd0940f9fb0d40f97f030091fe1140f9c0035fd6",
+		},
+		{
+			name:        "nontrapping",
+			nontrapping: true,
+			expectedAsm: `
+msr fpsr, xzr
+fcvtzu w1, s2
+`,
+			expectedBytes: "3f441bd54100391e",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, m := newSetupWithMockContext()
+			m.lowerFpuToInt(operandNR(x1VReg), operandNR(x2VReg), x15VReg, false, false, false, tc.nontrapping)
+			require.Equal(t, tc.expectedAsm, "\n"+formatEmittedInstructionsInCurrentBlock(m)+"\n")
 
-	m.FlushPendingInstructions()
-	m.encode(m.perBlockHead)
-	buf := m.compiler.Buf()
-	require.Equal(t, "3f441bd54100391e3b443bd57f0700f1210200544020221e070100549b0180d2fb0100b9fd0940f9fb0d40f97f030091fe1140f9c0035fd67b0180d2fb0100b9fd0940f9fb0d40f97f030091fe1140f9c0035fd6", hex.EncodeToString(buf))
+			m.FlushPendingInstructions()
+			m.encode(m.perBlockHead)
+			buf := m.compiler.Buf()
+			require.Equal(t, tc.expectedBytes, hex.EncodeToString(buf))
+		})
+	}
 }

--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -130,7 +130,7 @@ func TestSpectestV2(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 	}{
-		// {"conversions"}, includes non-trapping conversions.
+		{"conversions"}, // includes non-trapping conversions.
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			spectest.RunCase(t, v2.Testcases, tc.name, context.Background(), config,

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -680,6 +680,21 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:f64, v3:f32)
 `,
 		},
 		{
+			name: "non-trapping float conversions", m: testcases.NonTrappingFloatConversions.Module,
+			exp: `
+blk0: (exec_ctx:i64, module_ctx:i64, v2:f64, v3:f32)
+	v4:i64 = FcvtToSintSat v2
+	v5:i64 = FcvtToSintSat v3
+	v6:i32 = FcvtToSintSat v2
+	v7:i32 = FcvtToSintSat v3
+	v8:i64 = FcvtToUintSat v2
+	v9:i64 = FcvtToUintSat v3
+	v10:i32 = FcvtToUintSat v2
+	v11:i32 = FcvtToUintSat v3
+	Jump blk_ret, v4, v5, v6, v7, v8, v9, v10, v11
+`,
+		},
+		{
 			name: "loop with param and results", m: testcases.LoopBrWithParamResults.Module,
 			exp: `
 blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i32)

--- a/internal/engine/wazevo/testcases/testcases.go
+++ b/internal/engine/wazevo/testcases/testcases.go
@@ -895,6 +895,39 @@ var (
 			wasm.OpcodeEnd,
 		}, []wasm.ValueType{}),
 	}
+	NonTrappingFloatConversions = TestCase{
+		Name: "float_conversions",
+		Module: SingleFunctionModule(wasm.FunctionType{
+			Params:  []wasm.ValueType{f64, f32},
+			Results: []wasm.ValueType{i64, i64, i32, i32, i64, i64, i32, i32},
+		}, []byte{
+			wasm.OpcodeLocalGet, 0,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI64TruncSatF64S,
+
+			wasm.OpcodeLocalGet, 1,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI64TruncSatF32S,
+
+			wasm.OpcodeLocalGet, 0,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI32TruncSatF64S,
+
+			wasm.OpcodeLocalGet, 1,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI32TruncSatF32S,
+
+			wasm.OpcodeLocalGet, 0,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI64TruncSatF64U,
+
+			wasm.OpcodeLocalGet, 1,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI64TruncSatF32U,
+
+			wasm.OpcodeLocalGet, 0,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI32TruncSatF64U,
+
+			wasm.OpcodeLocalGet, 1,
+			wasm.OpcodeMiscPrefix, wasm.OpcodeMiscI32TruncSatF32U,
+
+			wasm.OpcodeEnd,
+		}, []wasm.ValueType{}),
+	}
 	FibonacciRecursive = TestCase{
 		Name: "recursive_fibonacci",
 		Module: SingleFunctionModule(i32_i32, []byte{


### PR DESCRIPTION
moves forward #1496 with support for non-trapping floating point conversions to integer.

This also changes the signature of `lowerOpcode(op)` to `lowerCurrentOpcode()`. In order to parse `wasm.OpcodeMisc*TruncSat*` etc. it is necessary to parse `wasm.OpcodeMiscPrefix` first, and then advance to the next opcode, which will be in the range `[0x00..0x07]` They cannot be parsed otherwise, because then these opcodes would be mismatched in the `switch` statement for other unrelated opcodes.

Now `lowerCurrentOpcode()` instead moves `pc`itself; for this reason, all the related logic such as the debugging statements are now moved to this procedure, and  `return` statements had had to be changed to `break`s, otherwise the final `pc++` would be skipped in many cases.
