### PR TITLE
wazevo: adds initial support for SIMD vectors

### DIFF
--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -135,6 +135,7 @@ type compiler struct {
 	alreadyLowered map[*ssa.Instruction]bool
 	regAlloc       regalloc.Allocator
 	varEdges       [][2]regalloc.VReg
+	varEdgeTypes   []ssa.Type
 	constEdges     []struct {
 		cInst *ssa.Instruction
 		dst   regalloc.VReg

--- a/internal/engine/wazevo/backend/isa/arm64/abi.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi.go
@@ -153,7 +153,7 @@ func (a *abiImpl) CalleeGenFunctionArgsToVRegs(args []ssa.Value) {
 		reg := a.m.compiler.VRegOf(ssaArg)
 		arg := &a.args[i]
 		if arg.Kind == backend.ABIArgKindReg {
-			a.m.InsertMove(reg, arg.Reg)
+			a.m.InsertMove(reg, arg.Reg, arg.Type)
 		} else {
 			// TODO: we could use pair load if there's consecutive loads for the same type.
 			//
@@ -214,7 +214,7 @@ func (a *abiImpl) CalleeGenVRegsToFunctionReturns(rets []ssa.Value) {
 			}
 		}
 		if r.Kind == backend.ABIArgKindReg {
-			a.m.InsertMove(r.Reg, reg)
+			a.m.InsertMove(r.Reg, reg, ret.Type())
 		} else {
 			// TODO: we could use pair store if there's consecutive stores for the same type.
 			//
@@ -267,7 +267,7 @@ func (a *abiImpl) callerGenVRegToFunctionArg(argIndex int, reg regalloc.VReg, de
 		}
 	}
 	if arg.Kind == backend.ABIArgKindReg {
-		a.m.InsertMove(arg.Reg, reg)
+		a.m.InsertMove(arg.Reg, reg, arg.Type)
 	} else {
 		// TODO: we could use pair store if there's consecutive stores for the same type.
 		//
@@ -283,7 +283,7 @@ func (a *abiImpl) callerGenVRegToFunctionArg(argIndex int, reg regalloc.VReg, de
 func (a *abiImpl) callerGenFunctionReturnVReg(retIndex int, reg regalloc.VReg) {
 	r := &a.rets[retIndex]
 	if r.Kind == backend.ABIArgKindReg {
-		a.m.InsertMove(reg, r.Reg)
+		a.m.InsertMove(reg, r.Reg, r.Type)
 	} else {
 		// TODO: we could use pair load if there's consecutive loads for the same type.
 		amode := a.m.resolveAddressModeForOffset(r.Offset, r.Type.Bits(), spVReg)

--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -1789,7 +1789,7 @@ func (i *instruction) size() int64 {
 		if i.u1 == 0 && i.u2 == 0 {
 			return 4 // zero loading can be encoded as a single instruction.
 		}
-		return 4 + 4 + 12
+		return 4 + 4 + 16
 	case brTableSequence:
 		return 4*4 + int64(len(i.targets))*4
 	default:

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -358,9 +358,24 @@ func encodeVecRRR(op vecOp, rd, rn, rm uint32, arr vecArrangement) uint32 {
 		}
 		return encodeAdvancedSIMDThreeSame(rd, rn, rm, 0b00011, 0b00, 0b1, q)
 	case vecOpAdd:
-		return encodeAdvancedSIMDThreeSame(rd, rn, rm, 0b10000, 0b00, 0b1, 0)
+		return encodeAdvancedSIMDThreeSame(rd, rn, rm, 0b10000, arrToSizeEncoded(arr), 0b0, 1 /* we always use the full-width */)
 	default:
 		panic("TODO")
+	}
+}
+
+func arrToSizeEncoded(arr vecArrangement) uint32 {
+	switch arr {
+	case vecArrangement8B, vecArrangement16B:
+		return 0b00
+	case vecArrangement4H, vecArrangement8H:
+		return 0b01
+	case vecArrangement2S, vecArrangement4S:
+		return 0b10
+	case vecArrangement1D, vecArrangement2D:
+		return 0b11
+	default:
+		panic("BUG")
 	}
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -337,7 +337,7 @@ func encodeVecRRR(op vecOp, rd, rn, rm uint32, arr vecArrangement) uint32 {
 	switch op {
 	case vecOpBit:
 		_, q := arrToSizeQEncoded(arr)
-		return encodeAdvancedSIMDThreeSame(rd, rn, rm, 0b00011, 0b10 /* always has size 0b10*/, 0b1, q)
+		return encodeAdvancedSIMDThreeSame(rd, rn, rm, 0b00011, 0b10 /* always has size 0b10 */, 0b1, q)
 	case vecOpEOR:
 		size, q := arrToSizeQEncoded(arr)
 		return encodeAdvancedSIMDThreeSame(rd, rn, rm, 0b00011, size, 0b1, q)

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -186,6 +186,9 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "5000005c03000014000000000000f03f", setup: func(i *instruction) {
 			i.asLoadFpuConst64(v16VReg, math.Float64bits(1.0))
 		}},
+		{want: "101e306e", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0, 0) }},
+		{want: "101e306e", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0xffffffff_ffffffff, 0xaaaaaaaa_aaaaaaaa) }},
+
 		{want: "8220061b", setup: func(i *instruction) {
 			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), operandNR(x8VReg), false)
 		}},

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -40,6 +40,15 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "411c232e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpEOR, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
+		{want: "4184234e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpAdd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+		}},
+		{want: "4184a34e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpAdd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+		}},
+		{want: "4184e34e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpAdd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+		}},
 		{want: "4100839a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), eq, true) }},
 		{want: "4110839a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), ne, true) }},
 		{want: "4100831a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), eq, false) }},
@@ -187,8 +196,7 @@ func TestInstruction_encode(t *testing.T) {
 			i.asLoadFpuConst64(v16VReg, math.Float64bits(1.0))
 		}},
 		{want: "101e306e", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0, 0) }},
-		{want: "101e306e", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0xffffffff_ffffffff, 0xaaaaaaaa_aaaaaaaa) }},
-
+		{want: "5000009c05000014ffffffffffffffffaaaaaaaaaaaaaaaa", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0xffffffff_ffffffff, 0xaaaaaaaa_aaaaaaaa) }},
 		{want: "8220061b", setup: func(i *instruction) {
 			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), operandNR(x8VReg), false)
 		}},
@@ -629,6 +637,12 @@ func TestInstruction_encode(t *testing.T) {
 			// require.NoError(t, err, hex.EncodeToString(m.buf))
 			// fmt.Println(inst.String())
 			require.Equal(t, tc.want, hex.EncodeToString(mc.buf))
+
+			var actualSize int
+			for cur := i; cur != nil; cur = cur.next {
+				actualSize += int(cur.size())
+			}
+			require.Equal(t, len(tc.want)/2, actualSize)
 		})
 	}
 }

--- a/internal/engine/wazevo/backend/isa/arm64/lower_constant.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_constant.go
@@ -36,13 +36,13 @@ func (m *machine) InsertLoadConstant(instr *ssa.Instruction, vr regalloc.VReg) {
 		m.insert(loadF)
 	case ssa.TypeI32:
 		if v == 0 {
-			m.InsertMove(vr, xzrVReg)
+			m.InsertMove(vr, xzrVReg, ssa.TypeI32)
 		} else {
 			m.lowerConstantI32(vr, int32(v))
 		}
 	case ssa.TypeI64:
 		if v == 0 {
-			m.InsertMove(vr, xzrVReg)
+			m.InsertMove(vr, xzrVReg, ssa.TypeI64)
 		} else {
 			m.lowerConstantI64(vr, int64(v))
 		}

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -549,13 +549,15 @@ func (m *machine) lowerSubOrAdd(si *ssa.Instruction, add bool) {
 }
 
 // InsertMove implements backend.Machine.
-func (m *machine) InsertMove(dst, src regalloc.VReg) {
+func (m *machine) InsertMove(dst, src regalloc.VReg, typ ssa.Type) {
 	instr := m.allocateInstr()
-	switch src.RegType() {
-	case regalloc.RegTypeInt:
+	switch typ {
+	case ssa.TypeI32, ssa.TypeI64:
 		instr.asMove64(dst, src)
-	case regalloc.RegTypeFloat:
+	case ssa.TypeF32, ssa.TypeF64:
 		instr.asFpuMov64(dst, src)
+	case ssa.TypeV128:
+		instr.asFpuMov128(dst, src)
 	default:
 		panic("TODO")
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -291,6 +291,21 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
 		rd := operandNR(m.compiler.VRegOf(instr.Return()))
 		m.lowerIRem(ctxVReg, rd, rn, rm, x.Type() == ssa.TypeI64, op == ssa.OpcodeSrem)
+	case ssa.OpcodeVconst:
+		result := m.compiler.VRegOf(instr.Return())
+		lo, hi := instr.VconstData()
+		v := m.allocateInstr()
+		v.asLoadFpuConst128(result, lo, hi)
+		m.insert(v)
+	case ssa.OpcodeVIadd:
+		x, y, lane := instr.Arg2WithLane()
+		arr := ssaLeneToArrangement(lane)
+		add := m.allocateInstr()
+		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
+		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
+		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		add.asVecRRR(vecOpAdd, rd, rn, rm, arr)
+		m.insert(add)
 	default:
 		panic("TODO: lowering " + op.String())
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -256,6 +256,7 @@ func TestMachine_InsertMove(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		src, dst    regalloc.VReg
+		typ         ssa.Type
 		instruction string
 	}{
 		{
@@ -263,17 +264,26 @@ func TestMachine_InsertMove(t *testing.T) {
 			src:         regalloc.VReg(1).SetRegType(regalloc.RegTypeInt),
 			dst:         regalloc.VReg(2).SetRegType(regalloc.RegTypeInt),
 			instruction: "mov x1?, x2?",
+			typ:         ssa.TypeI64,
 		},
 		{
 			name:        "float",
 			src:         regalloc.VReg(1).SetRegType(regalloc.RegTypeFloat),
 			dst:         regalloc.VReg(2).SetRegType(regalloc.RegTypeFloat),
 			instruction: "mov v1?.8b, v2?.8b",
+			typ:         ssa.TypeF64,
+		},
+		{
+			name:        "vector",
+			src:         regalloc.VReg(1).SetRegType(regalloc.RegTypeFloat),
+			dst:         regalloc.VReg(2).SetRegType(regalloc.RegTypeFloat),
+			instruction: "mov v1?.16b, v2?.16b",
+			typ:         ssa.TypeV128,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, m := newSetupWithMockContext()
-			m.InsertMove(tc.src, tc.dst)
+			m.InsertMove(tc.src, tc.dst, tc.typ)
 			require.Equal(t, tc.instruction, formatEmittedInstructionsInCurrentBlock(m))
 		})
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/lower_mem.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_mem.go
@@ -219,6 +219,8 @@ func (m *machine) lowerLoad(si *ssa.Instruction) {
 		load.asULoad(operandNR(dst), amode, typ.Bits())
 	case ssa.TypeF32, ssa.TypeF64:
 		load.asFpuLoad(operandNR(dst), amode, typ.Bits())
+	case ssa.TypeV128:
+		load.asFpuLoad(operandNR(dst), amode, 128)
 	default:
 		panic("TODO")
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/machine_regalloc.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_regalloc.go
@@ -322,6 +322,8 @@ func (m *machine) reloadRegister(v regalloc.VReg, instr *instruction, after bool
 		load.asULoad(operandNR(v), admode, typ.Bits())
 	case ssa.TypeF32, ssa.TypeF64:
 		load.asFpuLoad(operandNR(v), admode, typ.Bits())
+	case ssa.TypeV128:
+		load.asFpuLoad(operandNR(v), admode, 128)
 	default:
 		panic("TODO")
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/reg.go
+++ b/internal/engine/wazevo/backend/isa/arm64/reg.go
@@ -286,8 +286,7 @@ func formatVRegSized(r regalloc.VReg, size byte) (ret string) {
 				panic("BUG: invalid register size")
 			}
 		default:
-			fmt.Println(r)
-			panic("BUG: invalid register type")
+			panic(fmt.Sprintf("BUG: invalid register type: %d fro %s", r.RegType(), r))
 		}
 	}
 	return

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -67,7 +67,7 @@ type (
 		FlushPendingInstructions()
 
 		// InsertMove inserts a move instruction from src to dst.
-		InsertMove(dst, src regalloc.VReg)
+		InsertMove(dst, src regalloc.VReg, typ ssa.Type)
 
 		// InsertReturn inserts the return instruction to return from the current function.
 		InsertReturn()

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -66,7 +66,7 @@ type (
 		// This will be called after the lowering of each SSA Instruction.
 		FlushPendingInstructions()
 
-		// InsertMove inserts a move instruction from src to dst.
+		// InsertMove inserts a move instruction from src to dst whose type is typ.
 		InsertMove(dst, src regalloc.VReg, typ ssa.Type)
 
 		// InsertReturn inserts the return instruction to return from the current function.

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -118,7 +118,7 @@ func (m mockMachine) Reset() {
 func (m mockMachine) FlushPendingInstructions() {}
 
 // InsertMove implements Machine.InsertMove.
-func (m mockMachine) InsertMove(dst, src regalloc.VReg) {
+func (m mockMachine) InsertMove(dst, src regalloc.VReg, typ ssa.Type) {
 	m.insertMove(dst, src)
 }
 

--- a/internal/engine/wazevo/backend/regalloc/reg.go
+++ b/internal/engine/wazevo/backend/regalloc/reg.go
@@ -117,7 +117,7 @@ func RegTypeOf(p ssa.Type) RegType {
 	switch p {
 	case ssa.TypeI32, ssa.TypeI64:
 		return RegTypeInt
-	case ssa.TypeF32, ssa.TypeF64:
+	case ssa.TypeF32, ssa.TypeF64, ssa.TypeV128:
 		return RegTypeFloat
 	default:
 		panic("invalid type")

--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -129,6 +129,7 @@ func TestSpectestV2(t *testing.T) {
 		name string
 	}{
 		{"conversions"}, // includes non-trapping conversions.
+		{"simd_const"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			spectest.RunCase(t, v2.Testcases, tc.name, context.Background(), config,

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -170,6 +170,8 @@ func (c *Compiler) declareWasmLocals(entry ssa.BasicBlock) {
 			zeroInst.AsF32const(0)
 		case ssa.TypeF64:
 			zeroInst.AsF64const(0)
+		case ssa.TypeV128:
+			zeroInst.AsVconst(0, 0)
 		default:
 			panic("TODO: " + wasm.ValueTypeName(typ))
 		}
@@ -215,6 +217,8 @@ func (c *Compiler) declareWasmGlobal(typ wasm.ValueType, mutable bool) {
 		st = ssa.TypeF32
 	case wasm.ValueTypeF64:
 		st = ssa.TypeF64
+	case wasm.ValueTypeV128:
+		st = ssa.TypeV128
 	default:
 		panic("TODO: " + wasm.ValueTypeName(typ))
 	}
@@ -238,6 +242,8 @@ func WasmTypeToSSAType(vt wasm.ValueType) ssa.Type {
 		return ssa.TypeF32
 	case wasm.ValueTypeF64:
 		return ssa.TypeF64
+	case wasm.ValueTypeV128:
+		return ssa.TypeV128
 	default:
 		panic("TODO: " + wasm.ValueTypeName(vt))
 	}

--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -121,8 +121,8 @@ func (m *moduleEngine) NewFunction(index wasm.Index) api.Function {
 
 	src := m.module.Source
 	typ := src.TypeSection[src.FunctionSection[localIndex]]
-	sizeOfParamResultSlice := len(typ.Results)
-	if ps := len(typ.Params); ps > sizeOfParamResultSlice {
+	sizeOfParamResultSlice := typ.ResultNumInUint64
+	if ps := typ.ParamNumInUint64; ps > sizeOfParamResultSlice {
 		sizeOfParamResultSlice = ps
 	}
 	p := m.parent

--- a/internal/engine/wazevo/ssa/type.go
+++ b/internal/engine/wazevo/ssa/type.go
@@ -19,7 +19,8 @@ const (
 	// TypeF64 represents 64-bit floats in the IEEE 754.
 	TypeF64
 
-	// TODO: SIMD, ref types!
+	// TypeV128 represents 128-bit SIMD vectors.
+	TypeV128
 )
 
 // String implements fmt.Stringer.
@@ -35,6 +36,8 @@ func (t Type) String() (ret string) {
 		return "f32"
 	case TypeF64:
 		return "f64"
+	case TypeV128:
+		return "v128"
 	default:
 		panic(int(t))
 	}
@@ -52,6 +55,8 @@ func (t Type) Bits() byte {
 		return 32
 	case TypeI64, TypeF64:
 		return 64
+	case TypeV128:
+		return 128
 	default:
 		panic(int(t))
 	}
@@ -64,4 +69,39 @@ func (t Type) Size() byte {
 
 func (t Type) invalid() bool {
 	return t == typeInvalid
+}
+
+// VecLane represents a lane in a SIMD vector.
+type VecLane byte
+
+const (
+	VecLaneInvalid VecLane = 1 + iota
+	VecLaneI8x16
+	VecLaneI16x8
+	VecLaneI32x4
+	VecLaneI64x2
+	VecLaneF32x4
+	VecLaneF64x2
+)
+
+// String implements fmt.Stringer.
+func (vl VecLane) String() (ret string) {
+	switch vl {
+	case VecLaneInvalid:
+		return "invalid"
+	case VecLaneI8x16:
+		return "i8x16"
+	case VecLaneI16x8:
+		return "i16x8"
+	case VecLaneI32x4:
+		return "i32x4"
+	case VecLaneI64x2:
+		return "i64x2"
+	case VecLaneF32x4:
+		return "f32x4"
+	case VecLaneF64x2:
+		return "f64x2"
+	default:
+		panic(int(vl))
+	}
 }


### PR DESCRIPTION
This makes wazevo pass the simd_const spectest.

#1496 