### PR TITLE
ci: builds spectests before check

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -53,9 +53,9 @@ jobs:
             ~/go/bin
           key: check-${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum', 'Makefile') }}
 
-      - run: make check
-
       - run: make build.spectest
+
+      - run: make check
 
   test_amd64:
     name: amd64, ${{ matrix.os }}, Go-${{ matrix.go-version }}


### PR DESCRIPTION
This should make drifts and unnecessary change in spectest dir fail on CI