### PR TITLE
Use setup-go output for standard library test key

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -335,7 +335,8 @@ jobs:
           - "1.21"  # Current Go version && The only version that supports wasip1.
 
     steps:
-      - uses: actions/setup-go@v4
+      - id: setup-go
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -344,7 +345,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/tests
-          key: go-wasip1-binaries-${{ matrix.os }}-${{ matrix.go-version }}
+          # Use precise Go version from setup-go as patch version differences can effect tests.
+          key: go-wasip1-binaries-${{ matrix.os }}-${{ steps.setup-go.outputs.go-version }}
 
       - if: ${{ steps.cache-go-test-binaries.outputs.cache-hit != 'true' }}
         name: Build Test Binaries


### PR DESCRIPTION
Allows respecting patch version

Interestingly, it seems that based on the randomly selected runner, the go version can be different

https://github.com/tetratelabs/wazero/actions/runs/6180785720/job/16777777783?pr=1709
https://github.com/tetratelabs/wazero/actions/runs/6180785720/job/16778006464?pr=1709

One way to not have this happen is `check-latest`. It's funny how they recommend `false` for stability :P

https://github.com/actions/setup-go#check-latest-version