### PR TITLE
wazevo: refactors calling Go convention

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
@@ -150,10 +150,10 @@ func (a *abiImpl) constructEntryPreamble() (root *instruction) {
 	//      mov tmp, sp ;; sp cannot be str'ed directly.
 	// 		str sp, [savedExecutionContextPtr, #OriginalStackPointer]
 	// 		str lr, [savedExecutionContextPtr, #GoReturnAddress]
-	cur = a.loadOrStoreAtExecutionContext(fpVReg, wazevoapi.ExecutionContextOffsets.OriginalFramePointer, true, cur)
+	cur = a.loadOrStoreAtExecutionContext(fpVReg, wazevoapi.ExecutionContextOffsetOriginalFramePointer, true, cur)
 	cur = a.move64(tmpRegVReg, spVReg, cur)
-	cur = a.loadOrStoreAtExecutionContext(tmpRegVReg, wazevoapi.ExecutionContextOffsets.OriginalStackPointer, true, cur)
-	cur = a.loadOrStoreAtExecutionContext(lrVReg, wazevoapi.ExecutionContextOffsets.GoReturnAddress, true, cur)
+	cur = a.loadOrStoreAtExecutionContext(tmpRegVReg, wazevoapi.ExecutionContextOffsetOriginalStackPointer, true, cur)
+	cur = a.loadOrStoreAtExecutionContext(lrVReg, wazevoapi.ExecutionContextOffsetGoReturnAddress, true, cur)
 
 	// Next, adjust the Go-allocated stack pointer to reserve the arg/result spaces.
 	// 		sub x28, x28, #stackSlotSize
@@ -208,10 +208,10 @@ func (a *abiImpl) constructEntryPreamble() (root *instruction) {
 	//      mov sp, tmp ;; sp cannot be str'ed directly.
 	// 		ldr lr, [savedExecutionContextPtr, #GoReturnAddress]
 	// 		ret ;; --> return to the Go code
-	cur = a.loadOrStoreAtExecutionContext(fpVReg, wazevoapi.ExecutionContextOffsets.OriginalFramePointer, false, cur)
-	cur = a.loadOrStoreAtExecutionContext(tmpRegVReg, wazevoapi.ExecutionContextOffsets.OriginalStackPointer, false, cur)
+	cur = a.loadOrStoreAtExecutionContext(fpVReg, wazevoapi.ExecutionContextOffsetOriginalFramePointer, false, cur)
+	cur = a.loadOrStoreAtExecutionContext(tmpRegVReg, wazevoapi.ExecutionContextOffsetOriginalStackPointer, false, cur)
 	cur = a.move64(spVReg, tmpRegVReg, cur)
-	cur = a.loadOrStoreAtExecutionContext(lrVReg, wazevoapi.ExecutionContextOffsets.GoReturnAddress, false, cur)
+	cur = a.loadOrStoreAtExecutionContext(lrVReg, wazevoapi.ExecutionContextOffsetGoReturnAddress, false, cur)
 	retInst := a.m.allocateInstr()
 	retInst.asRet(nil)
 	linkInstr(cur, retInst)

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
@@ -42,8 +42,15 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 			},
 			needModuleContextPtr: true,
 			exp: `
+	sub x27, sp, #0x40
+	ldr x11, [x0, #0x28]
+	subs xzr, x27, x11
+	b.ge #0x14
+	orr x27, xzr, #0x40
+	str x27, [x0, #0x40]
+	ldr x27, [x0, #0x50]
+	bl x27
 	stp x30, xzr, [sp, #-0x10]!
-	str xzr, [sp, #-0x10]!
 	str x19, [x0, #0x60]
 	str x20, [x0, #0x70]
 	str x21, [x0, #0x80]
@@ -69,8 +76,11 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	str q30, [x0, #0x1c0]
 	str q31, [x0, #0x1d0]
 	str x1, [x0, #0x460]
-	add x15, x0, #0x468
+	sub sp, sp, #0x20
+	mov x15, sp
 	str d0, [x15], #0x8
+	orr x27, xzr, #0x20
+	str x27, [sp, #-0x10]!
 	movz w17, #0x6406, lsl 0
 	str w17, [x0]
 	mov x27, sp
@@ -102,7 +112,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	ldr q29, [x0, #0x1b0]
 	ldr q30, [x0, #0x1c0]
 	ldr q31, [x0, #0x1d0]
-	add x15, x0, #0x468
+	add x15, sp, #0x10
 	ldr w27, [x15], #0x8
 	mov w0, w27
 	ldr x27, [x15], #0x8
@@ -111,7 +121,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	mov v0.8b, v17.8b
 	ldr d17, [x15], #0x8
 	mov v1.8b, v17.8b
-	add sp, sp, #0x20
+	add sp, sp, #0x40
 	ret
 `,
 		},
@@ -124,8 +134,15 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 			},
 			needModuleContextPtr: true,
 			exp: `
+	sub x27, sp, #0x40
+	ldr x11, [x0, #0x28]
+	subs xzr, x27, x11
+	b.ge #0x14
+	orr x27, xzr, #0x40
+	str x27, [x0, #0x40]
+	ldr x27, [x0, #0x50]
+	bl x27
 	stp x30, xzr, [sp, #-0x10]!
-	str xzr, [sp, #-0x10]!
 	str x19, [x0, #0x60]
 	str x20, [x0, #0x70]
 	str x21, [x0, #0x80]
@@ -151,11 +168,14 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	str q30, [x0, #0x1c0]
 	str q31, [x0, #0x1d0]
 	str x1, [x0, #0x460]
-	add x15, x0, #0x468
+	sub sp, sp, #0x20
+	mov x15, sp
 	str d0, [x15], #0x8
 	str d1, [x15], #0x8
 	str x2, [x15], #0x8
 	str x3, [x15], #0x8
+	orr x27, xzr, #0x20
+	str x27, [sp, #-0x10]!
 	movz w17, #0x6406, lsl 0
 	str w17, [x0]
 	mov x27, sp
@@ -187,8 +207,7 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	ldr q29, [x0, #0x1b0]
 	ldr q30, [x0, #0x1c0]
 	ldr q31, [x0, #0x1d0]
-	add x15, x0, #0x468
-	add sp, sp, #0x20
+	add sp, sp, #0x40
 	ret
 `,
 		},
@@ -200,8 +219,15 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 				Results: []ssa.Type{ssa.TypeI32},
 			},
 			exp: `
+	sub x27, sp, #0x30
+	ldr x11, [x0, #0x28]
+	subs xzr, x27, x11
+	b.ge #0x14
+	orr x27, xzr, #0x30
+	str x27, [x0, #0x40]
+	ldr x27, [x0, #0x50]
+	bl x27
 	stp x30, xzr, [sp, #-0x10]!
-	str xzr, [sp, #-0x10]!
 	str x19, [x0, #0x60]
 	str x20, [x0, #0x70]
 	str x21, [x0, #0x80]
@@ -226,8 +252,11 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	str q29, [x0, #0x1b0]
 	str q30, [x0, #0x1c0]
 	str q31, [x0, #0x1d0]
-	add x15, x0, #0x468
+	sub sp, sp, #0x10
+	mov x15, sp
 	str x1, [x15], #0x8
+	orr x27, xzr, #0x10
+	str x27, [sp, #-0x10]!
 	orr w17, wzr, #0x2
 	str w17, [x0]
 	mov x27, sp
@@ -259,10 +288,10 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 	ldr q29, [x0, #0x1b0]
 	ldr q30, [x0, #0x1c0]
 	ldr q31, [x0, #0x1d0]
-	add x15, x0, #0x468
+	add x15, sp, #0x10
 	ldr w27, [x15], #0x8
 	mov w0, w27
-	add sp, sp, #0x20
+	add sp, sp, #0x30
 	ret
 `,
 		},
@@ -276,6 +305,53 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 
 			m.Encode()
 			fmt.Println(hex.EncodeToString(m.compiler.Buf()))
+		})
+	}
+}
+
+func Test_goFunctionCallRequiredStackSize(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sig      *ssa.Signature
+		argBegin int
+		exp      int64
+	}{
+		{
+			name: "no param",
+			sig:  &ssa.Signature{},
+			exp:  0,
+		},
+		{
+			name: "only param",
+			sig:  &ssa.Signature{Params: []ssa.Type{ssa.TypeI64, ssa.TypeV128}},
+			exp:  32,
+		},
+		{
+			name: "only result",
+			sig:  &ssa.Signature{Results: []ssa.Type{ssa.TypeI64, ssa.TypeV128, ssa.TypeI32}},
+			exp:  32,
+		},
+		{
+			name: "param < result",
+			sig:  &ssa.Signature{Params: []ssa.Type{ssa.TypeI64, ssa.TypeV128}, Results: []ssa.Type{ssa.TypeI64, ssa.TypeV128, ssa.TypeI32}},
+			exp:  32,
+		},
+		{
+			name: "param > result",
+			sig:  &ssa.Signature{Params: []ssa.Type{ssa.TypeI64, ssa.TypeV128, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64, ssa.TypeV128}},
+			exp:  32,
+		},
+		{
+			name:     "param < result / argBegin=2",
+			argBegin: 2,
+			sig:      &ssa.Signature{Params: []ssa.Type{ssa.TypeI64, ssa.TypeV128, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64, ssa.TypeV128}},
+			exp:      32,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			requiredSize := goFunctionCallRequiredStackSize(tc.sig, tc.argBegin)
+			require.Equal(t, tc.exp, requiredSize)
 		})
 	}
 }

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -1538,7 +1538,7 @@ func encodeExitSequence(c backend.Compiler, ctxReg regalloc.VReg) {
 		addressMode{
 			kind: addressModeKindRegUnsignedImm12,
 			rn:   ctxReg,
-			imm:  wazevoapi.ExecutionContextOffsets.GoReturnAddress.I64(),
+			imm:  wazevoapi.ExecutionContextOffsetGoReturnAddress.I64(),
 		},
 	)
 
@@ -1548,7 +1548,7 @@ func encodeExitSequence(c backend.Compiler, ctxReg regalloc.VReg) {
 		addressMode{
 			kind: addressModeKindRegUnsignedImm12,
 			rn:   ctxReg,
-			imm:  wazevoapi.ExecutionContextOffsets.OriginalFramePointer.I64(),
+			imm:  wazevoapi.ExecutionContextOffsetOriginalFramePointer.I64(),
 		},
 	)
 
@@ -1558,7 +1558,7 @@ func encodeExitSequence(c backend.Compiler, ctxReg regalloc.VReg) {
 		addressMode{
 			kind: addressModeKindRegUnsignedImm12,
 			rn:   ctxReg,
-			imm:  wazevoapi.ExecutionContextOffsets.OriginalStackPointer.I64(),
+			imm:  wazevoapi.ExecutionContextOffsetOriginalStackPointer.I64(),
 		},
 	)
 

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -854,7 +854,7 @@ func (m *machine) lowerExitWithCode(execCtxVReg regalloc.VReg, code wazevoapi.Ex
 	setExitCode.asStore(operandNR(tmpReg1),
 		addressMode{
 			kind: addressModeKindRegUnsignedImm12,
-			rn:   execCtxVReg, imm: wazevoapi.ExecutionContextOffsets.ExitCodeOffset.I64(),
+			rn:   execCtxVReg, imm: wazevoapi.ExecutionContextOffsetExitCodeOffset.I64(),
 		}, 32)
 
 	// In order to unwind the stack, we also need to push the current stack pointer:
@@ -865,7 +865,7 @@ func (m *machine) lowerExitWithCode(execCtxVReg regalloc.VReg, code wazevoapi.Ex
 	strSpToExecCtx.asStore(operandNR(tmp2),
 		addressMode{
 			kind: addressModeKindRegUnsignedImm12,
-			rn:   execCtxVReg, imm: wazevoapi.ExecutionContextOffsets.StackPointerBeforeGoCall.I64(),
+			rn:   execCtxVReg, imm: wazevoapi.ExecutionContextOffsetStackPointerBeforeGoCall.I64(),
 		}, 64)
 	// Also the address of this exit.
 	tmp3 := m.compiler.AllocateVReg(regalloc.RegTypeInt)
@@ -875,7 +875,7 @@ func (m *machine) lowerExitWithCode(execCtxVReg regalloc.VReg, code wazevoapi.Ex
 	storeCurrentAddrToExecCtx.asStore(operandNR(tmp3),
 		addressMode{
 			kind: addressModeKindRegUnsignedImm12,
-			rn:   execCtxVReg, imm: wazevoapi.ExecutionContextOffsets.GoCallReturnAddress.I64(),
+			rn:   execCtxVReg, imm: wazevoapi.ExecutionContextOffsetGoCallReturnAddress.I64(),
 		}, 64)
 
 	exitSeq := m.allocateInstr()

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
@@ -141,7 +141,7 @@ func (m *machine) SetupPrologue() {
 	//                                            +-----------------+ <---- SP
 	//            (low address)
 	//
-	cur = m.createFrameSizeSlot(cur)
+	cur = m.createFrameSizeSlot(cur, m.frameSize())
 
 	linkInstr(cur, prevInitInst)
 }
@@ -163,9 +163,9 @@ func (m *machine) createReturnAddrAndSizeOfArgRetSlot(cur *instruction) *instruc
 	return cur
 }
 
-func (m *machine) createFrameSizeSlot(cur *instruction) *instruction {
+func (m *machine) createFrameSizeSlot(cur *instruction, s int64) *instruction {
 	var frameSizeReg regalloc.VReg
-	if s := m.frameSize(); s > 0 {
+	if s > 0 {
 		cur = m.lowerConstantI64AndInsert(cur, tmpRegVReg, s)
 		frameSizeReg = tmpRegVReg
 	} else {
@@ -343,7 +343,7 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 	ldr.asULoad(operandNR(tmp2), addressMode{
 		kind: addressModeKindRegUnsignedImm12,
 		rn:   x0VReg, // execution context is always the first argument.
-		imm:  wazevoapi.ExecutionContextOffsets.StackBottomPtr.I64(),
+		imm:  wazevoapi.ExecutionContextOffsetStackBottomPtr.I64(),
 	}, 64)
 	cur = linkInstr(cur, ldr)
 
@@ -366,7 +366,7 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 			addressMode{
 				kind: addressModeKindRegUnsignedImm12,
 				// Execution context is always the first argument.
-				rn: x0VReg, imm: wazevoapi.ExecutionContextOffsets.StackGrowRequiredSize.I64(),
+				rn: x0VReg, imm: wazevoapi.ExecutionContextOffsetStackGrowRequiredSize.I64(),
 			}, 64)
 
 		cur = linkInstr(cur, setRequiredStackSize)
@@ -376,7 +376,7 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 	ldrAddress.asULoad(operandNR(tmpRegVReg), addressMode{
 		kind: addressModeKindRegUnsignedImm12,
 		rn:   x0VReg, // execution context is always the first argument
-		imm:  wazevoapi.ExecutionContextOffsets.StackGrowCallTrampolineAddress.I64(),
+		imm:  wazevoapi.ExecutionContextOffsetStackGrowCallTrampolineAddress.I64(),
 	}, 64)
 	cur = linkInstr(cur, ldrAddress)
 

--- a/internal/engine/wazevo/backend/isa/arm64/unwind_stack.go
+++ b/internal/engine/wazevo/backend/isa/arm64/unwind_stack.go
@@ -59,3 +59,27 @@ func UnwindStack(sp, top uintptr) (returnAddresses []uintptr) {
 	}
 	return
 }
+
+// GoCallStackView is a function to get a view of the stack before a Go call, which
+// is the view of the stack allocated in CompileGoFunctionTrampoline.
+func GoCallStackView(stackPointerBeforeGoCall *uint64) []uint64 {
+	//                (high address)
+	//         ^  +-----------------+ <----+
+	//         |  |  arg[N]/ret[M]  |      |
+	//   view  |  |  ............   |      | frame_size
+	//         |  |  arg[1]/ret[1]  |      |
+	//         v  |  arg[0]/ret[0]  | <----+
+	//            |     xxxxxx      |  ;; unused space to make it 16-byte aligned.
+	//            |   frame_size    |
+	//            +-----------------+ <---- stackPointerBeforeGoCall
+	//               (low address)
+	size := *stackPointerBeforeGoCall
+	var view []uint64
+	{
+		sh := (*reflect.SliceHeader)(unsafe.Pointer(&view))
+		sh.Data = uintptr(unsafe.Pointer(stackPointerBeforeGoCall)) + 16 // skips the (frame_size, xxxxx).
+		sh.Len = int(size)
+		sh.Cap = int(size)
+	}
+	return view
+}

--- a/internal/engine/wazevo/call_engine_test.go
+++ b/internal/engine/wazevo/call_engine_test.go
@@ -32,7 +32,7 @@ func TestCallEngine_growStack(t *testing.T) {
 			stackTop: uintptr(unsafe.Pointer(&s[15])),
 			execCtx: executionContext{
 				stackGrowRequiredSize:    160,
-				stackPointerBeforeGoCall: uintptr(unsafe.Pointer(&s[10])),
+				stackPointerBeforeGoCall: (*uint64)(unsafe.Pointer(&s[10])),
 			},
 		}
 		newSP, err := c.growStack()

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -289,10 +289,6 @@ func (e *engine) compileHostModule(ctx context.Context, module *wasm.Module) (*c
 
 		typIndex := module.FunctionSection[i]
 		typ := &module.TypeSection[typIndex]
-		if typ.ParamNumInUint64 >= goFunctionCallStackSize || typ.ResultNumInUint64 >= goFunctionCallStackSize {
-			return nil, fmt.Errorf("too many params or results for a host function (maximum %d): %v",
-				goFunctionCallStackSize, typ)
-		}
 
 		// We can relax until the index fits together in ExitCode as we do in wazevoapi.ExitCodeCallGoModuleFunctionWithIndex.
 		// However, 1 << 16 should be large enough for a real use case.

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -823,7 +823,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 		pages := state.pop()
 		loadPtr := builder.AllocateInstruction().
 			AsLoad(c.execCtxPtrValue,
-				wazevoapi.ExecutionContextOffsets.MemoryGrowTrampolineAddress.U32(),
+				wazevoapi.ExecutionContextOffsetMemoryGrowTrampolineAddress.U32(),
 				ssa.TypeI64,
 			).Insert(builder).Return()
 
@@ -1015,7 +1015,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 		if c.ensureTermination {
 			checkModuleExitCodePtr := builder.AllocateInstruction().
 				AsLoad(c.execCtxPtrValue,
-					wazevoapi.ExecutionContextOffsets.CheckModuleExitCodeTrampolineAddress.U32(),
+					wazevoapi.ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress.U32(),
 					ssa.TypeI64,
 				).Insert(builder).Return()
 
@@ -1932,7 +1932,7 @@ func (c *Compiler) storeCallerModuleContext() {
 	execCtx := c.execCtxPtrValue
 	store := builder.AllocateInstruction()
 	store.AsStore(ssa.OpcodeStore,
-		c.moduleCtxPtrValue, execCtx, wazevoapi.ExecutionContextOffsets.CallerModuleContextPtr.U32())
+		c.moduleCtxPtrValue, execCtx, wazevoapi.ExecutionContextOffsetCallerModuleContextPtr.U32())
 	builder.InsertInstruction(store)
 }
 

--- a/internal/engine/wazevo/machine.go
+++ b/internal/engine/wazevo/machine.go
@@ -24,3 +24,12 @@ func unwindStack(sp, top uintptr) (returnAddresses []uintptr) {
 		panic("unsupported architecture")
 	}
 }
+
+func goCallStackView(stackPointerBeforeGoCall *uint64) []uint64 {
+	switch runtime.GOARCH {
+	case "arm64":
+		return arm64.GoCallStackView(stackPointerBeforeGoCall)
+	default:
+		panic("unsupported architecture")
+	}
+}

--- a/internal/engine/wazevo/wazevo_test.go
+++ b/internal/engine/wazevo/wazevo_test.go
@@ -46,23 +46,20 @@ func TestEngine_DeleteCompiledModule(t *testing.T) {
 }
 
 func Test_ExecutionContextOffsets(t *testing.T) {
-	offsets := wazevoapi.ExecutionContextOffsets
-
 	var execCtx executionContext
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.exitCode)), offsets.ExitCodeOffset)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.callerModuleContextPtr)), offsets.CallerModuleContextPtr)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.originalFramePointer)), offsets.OriginalFramePointer)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.originalStackPointer)), offsets.OriginalStackPointer)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goReturnAddress)), offsets.GoReturnAddress)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goCallReturnAddress)), offsets.GoCallReturnAddress)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.stackPointerBeforeGoCall)), offsets.StackPointerBeforeGoCall)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.stackGrowRequiredSize)), offsets.StackGrowRequiredSize)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.memoryGrowTrampolineAddress)), offsets.MemoryGrowTrampolineAddress)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.stackGrowCallTrampolineAddress)), offsets.StackGrowCallTrampolineAddress)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.checkModuleExitCodeTrampolineAddress)), offsets.CheckModuleExitCodeTrampolineAddress)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.exitCode)), wazevoapi.ExecutionContextOffsetExitCodeOffset)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.callerModuleContextPtr)), wazevoapi.ExecutionContextOffsetCallerModuleContextPtr)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.originalFramePointer)), wazevoapi.ExecutionContextOffsetOriginalFramePointer)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.originalStackPointer)), wazevoapi.ExecutionContextOffsetOriginalStackPointer)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goReturnAddress)), wazevoapi.ExecutionContextOffsetGoReturnAddress)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goCallReturnAddress)), wazevoapi.ExecutionContextOffsetGoCallReturnAddress)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.stackPointerBeforeGoCall)), wazevoapi.ExecutionContextOffsetStackPointerBeforeGoCall)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.stackGrowRequiredSize)), wazevoapi.ExecutionContextOffsetStackGrowRequiredSize)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.memoryGrowTrampolineAddress)), wazevoapi.ExecutionContextOffsetMemoryGrowTrampolineAddress)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.stackGrowCallTrampolineAddress)), wazevoapi.ExecutionContextOffsetStackGrowCallTrampolineAddress)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.checkModuleExitCodeTrampolineAddress)), wazevoapi.ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.savedRegisters))%16, wazevoapi.Offset(0),
 		"SavedRegistersBegin must be aligned to 16 bytes")
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.savedRegisters)), offsets.SavedRegistersBegin)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goFunctionCallCalleeModuleContextOpaque)), offsets.GoFunctionCallCalleeModuleContextOpaque)
-	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goFunctionCallStack)), offsets.GoFunctionCallStackBegin)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.savedRegisters)), wazevoapi.ExecutionContextOffsetSavedRegistersBegin)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.goFunctionCallCalleeModuleContextOpaque)), wazevoapi.ExecutionContextOffsetGoFunctionCallCalleeModuleContextOpaque)
 }

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -1,6 +1,8 @@
 package wazevoapi
 
-import "github.com/tetratelabs/wazero/internal/wasm"
+import (
+	"github.com/tetratelabs/wazero/internal/wasm"
+)
 
 const (
 	// FunctionInstanceSize is the size of wazevo.functionInstance.
@@ -13,58 +15,36 @@ const (
 	FunctionInstanceTypeIDOffset = 16
 )
 
-var ExecutionContextOffsets = ExecutionContextOffsetData{
-	ExitCodeOffset:                          0,
-	CallerModuleContextPtr:                  8,
-	OriginalFramePointer:                    16,
-	OriginalStackPointer:                    24,
-	GoReturnAddress:                         32,
-	StackBottomPtr:                          40,
-	GoCallReturnAddress:                     48,
-	StackPointerBeforeGoCall:                56,
-	StackGrowRequiredSize:                   64,
-	MemoryGrowTrampolineAddress:             72,
-	StackGrowCallTrampolineAddress:          80,
-	CheckModuleExitCodeTrampolineAddress:    88,
-	SavedRegistersBegin:                     96,
-	GoFunctionCallCalleeModuleContextOpaque: 1120,
-	GoFunctionCallStackBegin:                1128,
-}
-
-// ExecutionContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.executionContext,
-// which are necessary for compiling various instructions. This is globally unique.
-type ExecutionContextOffsetData struct {
-	// ExitCodeOffset is an offset of `exitCode` field in wazevo.executionContext
-	ExitCodeOffset Offset
-	// CallerModuleContextPtr is an offset of `callerModuleContextPtr` field in wazevo.executionContext
-	CallerModuleContextPtr Offset
-	// CallerModuleContextPtr is an offset of `originalFramePointer` field in wazevo.executionContext
-	OriginalFramePointer Offset
-	// OriginalStackPointer is an offset of `originalStackPointer` field in wazevo.executionContext
-	OriginalStackPointer Offset
-	// GoReturnAddress is an offset of `goReturnAddress` field in wazevo.executionContext
-	GoReturnAddress Offset
-	// StackBottomPtr is an offset of `stackBottomPtr` field in wazevo.executionContext
-	StackBottomPtr Offset
-	// GoCallReturnAddress is an offset of `goCallReturnAddress` field in wazevo.executionContext
-	GoCallReturnAddress Offset
-	// StackPointerBeforeGoCall is an offset of `StackPointerBeforeGoCall` field in wazevo.executionContext
-	StackPointerBeforeGoCall Offset
-	// StackGrowRequiredSize is an offset of `stackGrowRequiredSize` field in wazevo.executionContext
-	StackGrowRequiredSize Offset
-	// MemoryGrowTrampolineAddress is an offset of `memoryGrowTrampolineAddress` field in wazevo.executionContext
-	MemoryGrowTrampolineAddress Offset
-	// stackGrowCallTrampolineAddress is an offset of `stackGrowCallTrampolineAddress` field in wazevo.executionContext.
-	StackGrowCallTrampolineAddress Offset
-	// CheckModuleExitCodeTrampolineAddress is an offset of `checkModuleExitCodeTrampolineAddress` field in wazevo.executionContext.
-	CheckModuleExitCodeTrampolineAddress Offset
-	// GoCallReturnAddress is an offset of the first element of `savedRegisters` field in wazevo.executionContext
-	SavedRegistersBegin Offset
-	// GoFunctionCallCalleeModuleContextOpaque is an offset of `goFunctionCallCalleeModuleContextOpaque` field in wazevo.executionContext
-	GoFunctionCallCalleeModuleContextOpaque Offset
-	// GoFunctionCallStackBegin is an offset of the first element of `goFunctionCallStack` field in wazevo.executionContext
-	GoFunctionCallStackBegin Offset
-}
+const (
+	// ExecutionContextOffsetExitCodeOffset is an offset of `exitCode` field in wazevo.executionContext
+	ExecutionContextOffsetExitCodeOffset Offset = 0
+	// ExecutionContextOffsetCallerModuleContextPtr is an offset of `callerModuleContextPtr` field in wazevo.executionContext
+	ExecutionContextOffsetCallerModuleContextPtr Offset = 8
+	// ExecutionContextOffsetOriginalFramePointer is an offset of `originalFramePointer` field in wazevo.executionContext
+	ExecutionContextOffsetOriginalFramePointer Offset = 16
+	// ExecutionContextOffsetOriginalStackPointer is an offset of `originalStackPointer` field in wazevo.executionContext
+	ExecutionContextOffsetOriginalStackPointer Offset = 24
+	// ExecutionContextOffsetGoReturnAddress is an offset of `goReturnAddress` field in wazevo.executionContext
+	ExecutionContextOffsetGoReturnAddress Offset = 32
+	// ExecutionContextOffsetStackBottomPtr is an offset of `stackBottomPtr` field in wazevo.executionContext
+	ExecutionContextOffsetStackBottomPtr Offset = 40
+	// ExecutionContextOffsetGoCallReturnAddress is an offset of `goCallReturnAddress` field in wazevo.executionContext
+	ExecutionContextOffsetGoCallReturnAddress Offset = 48
+	// ExecutionContextOffsetStackPointerBeforeGoCall is an offset of `StackPointerBeforeGoCall` field in wazevo.executionContext
+	ExecutionContextOffsetStackPointerBeforeGoCall Offset = 56
+	// ExecutionContextOffsetStackGrowRequiredSize is an offset of `stackGrowRequiredSize` field in wazevo.executionContext
+	ExecutionContextOffsetStackGrowRequiredSize Offset = 64
+	// ExecutionContextOffsetMemoryGrowTrampolineAddress is an offset of `memoryGrowTrampolineAddress` field in wazevo.executionContext
+	ExecutionContextOffsetMemoryGrowTrampolineAddress Offset = 72
+	// ExecutionContextOffsetStackGrowCallTrampolineAddress is an offset of `stackGrowCallTrampolineAddress` field in wazevo.executionContext.
+	ExecutionContextOffsetStackGrowCallTrampolineAddress Offset = 80
+	// ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress is an offset of `checkModuleExitCodeTrampolineAddress` field in wazevo.executionContext.
+	ExecutionContextOffsetCheckModuleExitCodeTrampolineAddress Offset = 88
+	// ExecutionContextOffsetSavedRegistersBegin is an offset of the first element of `savedRegisters` field in wazevo.executionContext
+	ExecutionContextOffsetSavedRegistersBegin Offset = 96
+	// ExecutionContextOffsetGoFunctionCallCalleeModuleContextOpaque is an offset of `goFunctionCallCalleeModuleContextOpaque` field in wazevo.executionContext
+	ExecutionContextOffsetGoFunctionCallCalleeModuleContextOpaque Offset = 1120
+)
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,
 // This is unique per module.


### PR DESCRIPTION
this makes it possible to call Go functions for any length of parameters,
and this enables the function listeners impl in the subsequent PR.

#1496 