### PR TITLE
wazevo: fix side effect for OpcodeVbitselect

### DIFF
--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -875,7 +875,7 @@ var instructionSideEffects = [opcodeEnd]sideEffect{
 	OpcodeVband:              sideEffectNone,
 	OpcodeVbandnot:           sideEffectNone,
 	OpcodeVbnot:              sideEffectNone,
-	OpcodeVbitselect:         sideEffectTraps,
+	OpcodeVbitselect:         sideEffectNone,
 	OpcodeVanyTrue:           sideEffectNone,
 	OpcodeVallTrue:           sideEffectNone,
 	OpcodeVhighBits:          sideEffectNone,


### PR DESCRIPTION
erroneously merged #1715 without restoring `sideEffectNone` to `Vbitselect` (#1496)