### PR TITLE
wazevo: passes simd_boolean spec tests

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -1138,10 +1138,17 @@ func (i *instruction) String() (str string) {
 			formatVRegVec(i.rm.nr(), vecArrangement(i.u2), vecIndexNone),
 		)
 	case vecMisc:
-		str = fmt.Sprintf("%s %s, %s",
-			vecOp(i.u1),
-			formatVRegVec(i.rd.nr(), vecArrangement(i.u2), vecIndexNone),
-			formatVRegVec(i.rn.nr(), vecArrangement(i.u2), vecIndexNone))
+		vop := vecOp(i.u1)
+		if vop == vecOpCmeq0 {
+			str = fmt.Sprintf("cmeq %s, %s, #0",
+				formatVRegVec(i.rd.nr(), vecArrangement(i.u2), vecIndexNone),
+				formatVRegVec(i.rn.nr(), vecArrangement(i.u2), vecIndexNone))
+		} else {
+			str = fmt.Sprintf("%s %s, %s",
+				vop,
+				formatVRegVec(i.rd.nr(), vecArrangement(i.u2), vecIndexNone),
+				formatVRegVec(i.rn.nr(), vecArrangement(i.u2), vecIndexNone))
+		}
 	case vecLanes:
 		arr := vecArrangement(i.u2)
 		var destArr vecArrangement
@@ -1567,8 +1574,8 @@ func (b vecOp) String() string {
 	switch b {
 	case vecOpCnt:
 		return "cnt"
-	case vecOpCmeqZero:
-		return "cmeqZero"
+	case vecOpCmeq0:
+		return "cmeq0"
 	case vecOpUaddlv:
 		return "uaddlv"
 	case vecOpBit:
@@ -1629,7 +1636,7 @@ func (b vecOp) String() string {
 
 const (
 	vecOpCnt vecOp = iota
-	vecOpCmeqZero
+	vecOpCmeq0
 	vecOpUaddlv
 	vecOpBit
 	vecOpBic

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -773,6 +773,7 @@ func encodeVecDup(rd, rn uint32, arr vecArrangement) uint32 {
 // encodeVecExtract encodes as "Advanced SIMD extract."
 // Currently only `ext` is defined.
 // https://developer.arm.com/documentation/ddi0602/2023-06/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en#simd-dp
+// https://developer.arm.com/documentation/ddi0602/2023-06/SIMD-FP-Instructions/EXT--Extract-vector-from-pair-of-vectors-?lang=en
 func encodeVecExtract(rd, rn, rm uint32, arr vecArrangement, index uint32) uint32 {
 	var q, imm4 uint32
 	switch arr {
@@ -780,6 +781,8 @@ func encodeVecExtract(rd, rn, rm uint32, arr vecArrangement, index uint32) uint3
 		q, imm4 = 0, 0b0111&uint32(index)
 	case vecArrangement16B:
 		q, imm4 = 1, 0b1111&uint32(index)
+	default:
+		panic("Unsupported arrangement " + arr.String())
 	}
 	return q<<30 | 0b101110000<<21 | rm<<16 | imm4<<11 | rn<<5 | rd
 }
@@ -1603,7 +1606,7 @@ func encodeAdvancedSIMDTwoMisc(op vecOp, rd, rn uint32, arr vecArrangement) uint
 		default:
 			panic("unsupported arrangement: " + arr.String())
 		}
-	case vecOpCmeqZero:
+	case vecOpCmeq0:
 		if arr == vecArrangement1D {
 			panic("unsupported arrangement: " + arr.String())
 		}

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -246,6 +246,12 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "4164a36e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
+		{want: "41a4236e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+		}},
+		{want: "41a8316e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+		}},
 		{want: "4114232e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
@@ -281,6 +287,9 @@ func TestInstruction_encode(t *testing.T) {
 		}},
 		{want: "419ca34e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+		}},
+		{want: "4198200e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeqZero, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "41b8200e", setup: func(i *instruction) {
 			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
@@ -346,6 +355,16 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "413c020e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementH, 0) }},
 		{want: "413c040e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementS, 0) }},
 		{want: "413c084e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementD, 0) }},
+		{want: "410c084e", setup: func(i *instruction) { i.asVecDup(operandNR(x1VReg), operandNR(v2VReg), vecArrangement2D) }},
+		{want: "4140036e", setup: func(i *instruction) { // 4140036e
+			i.asVecExtract(operandNR(x1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B, 8)
+		}},
+		{want: "4138034e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(x1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+		}},
+		{want: "4104214f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(x1VReg), operandNR(x2VReg), operandShiftImm(31), vecArrangement4S)
+		}},
 		{want: "5b28030b", setup: func(i *instruction) {
 			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
 		}},

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -27,6 +27,61 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "21443bd5", setup: func(i *instruction) { i.asMovFromFPSR(x1VReg) }},
 		{want: "2f08417a", setup: func(i *instruction) { i.asCCmpImm(operandNR(x1VReg), 1, eq, 0b1111, false) }},
 		{want: "201841fa", setup: func(i *instruction) { i.asCCmpImm(operandNR(x1VReg), 1, ne, 0, true) }},
+		{want: "410c010e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B) }},
+		{want: "410c014e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B) }},
+		{want: "410c020e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H) }},
+		{want: "410c024e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H) }},
+		{want: "410c040e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S) }},
+		{want: "410c044e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S) }},
+		{want: "410c084e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D) }},
+		{want: "4138032e", setup: func(i *instruction) {
+			i.asVecExtract(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B, 7)
+		}},
+		{want: "4138036e", setup: func(i *instruction) {
+			i.asVecExtract(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B, 7)
+		}},
+		{want: "4104090f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement8B)
+		}},
+		{want: "4104094f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement16B)
+		}},
+		{want: "4104190f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement4H)
+		}},
+		{want: "4104194f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement8H)
+		}},
+		{want: "4104390f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement2S)
+		}},
+		{want: "4104394f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement4S)
+		}},
+		{want: "4104794f", setup: func(i *instruction) {
+			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement2D)
+		}},
+		{want: "4138030e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+		}},
+		{want: "4138034e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+		}},
+		{want: "4138430e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+		}},
+		{want: "4138434e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+		}},
+		{want: "4138830e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+		}},
+		{want: "4138834e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+		}},
+		{want: "4138c34e", setup: func(i *instruction) {
+			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+		}},
 		{want: "411ca32e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpBit, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
@@ -174,6 +229,21 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "41bce34e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
+		{want: "41bc230e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+		}},
+		{want: "41b8314e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+		}},
+		{want: "41b8710e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+		}},
+		{want: "41b8714e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+		}},
+		{want: "41b8b14e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+		}},
 		{want: "416c230e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
@@ -246,11 +316,35 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "4164a36e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
+		{want: "41a4232e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+		}},
 		{want: "41a4236e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
+		{want: "41a4632e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+		}},
+		{want: "41a4636e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+		}},
+		{want: "41a4a32e", setup: func(i *instruction) {
+			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+		}},
+		{want: "41a8312e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+		}},
 		{want: "41a8316e", setup: func(i *instruction) {
 			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+		}},
+		{want: "41a8712e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+		}},
+		{want: "41a8716e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+		}},
+		{want: "41a8b16e", setup: func(i *instruction) {
+			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4114232e", setup: func(i *instruction) {
 			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
@@ -289,7 +383,25 @@ func TestInstruction_encode(t *testing.T) {
 			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4198200e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeqZero, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+		}},
+		{want: "4198204e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+		}},
+		{want: "4198600e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+		}},
+		{want: "4198604e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+		}},
+		{want: "4198a00e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+		}},
+		{want: "4198a04e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+		}},
+		{want: "4198e04e", setup: func(i *instruction) {
+			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41b8200e", setup: func(i *instruction) {
 			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -492,12 +492,13 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(7), vecArrangement16B)
 		m.insert(sshr)
 
-		// Load the bit mask into vecTmp.
+		// Load the bit mask into r0.
 		m.insertMOVZ(r0.nr(), 0x0201, 0, true)
 		m.insertMOVK(r0.nr(), 0x0804, 1, true)
 		m.insertMOVK(r0.nr(), 0x2010, 2, true)
 		m.insertMOVK(r0.nr(), 0x8040, 3, true)
 
+		// dup r0 to v0.
 		dup := m.allocateInstr()
 		dup.asVecDup(v0, r0, vecArrangement2D)
 		m.insert(dup)
@@ -629,7 +630,6 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		movfv := m.allocateInstr()
 		movfv.asMovFromVec(rd, v0, vecArrangementS, vecIndex(0))
 		m.insert(movfv)
-
 	case ssa.VecLaneI64x2:
 		// 	mov d3?, v2?.d[0]
 		//	mov x4?, v2?.d[1]

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -408,7 +408,7 @@ func (m *machine) lowerVcheckTrue(instr *ssa.Instruction) {
 
 	if instr.Opcode() == ssa.OpcodeVallTrue && lane == ssa.VecLaneI64x2 {
 		ins := m.allocateInstr()
-		ins.asVecMisc(vecOpCmeqZero, rd, rm, vecArrangement2D)
+		ins.asVecMisc(vecOpCmeq0, rd, rm, vecArrangement2D)
 		m.insert(ins)
 
 		addp := m.allocateInstr()

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -406,7 +406,13 @@ func (m *machine) lowerVcheckTrue(instr *ssa.Instruction) {
 	rd := operandNR(m.compiler.VRegOf(instr.Return()))
 	tmp := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeOf(ssa.TypeV128)))
 
+	// Special case VallTrue for i64x2.
 	if instr.Opcode() == ssa.OpcodeVallTrue && lane == ssa.VecLaneI64x2 {
+		// 	cmeq v3?.2d, v2?.2d, #0
+		//	addp v3?.2d, v3?.2d, v3?.2d
+		//	fcmp x3?, x3?
+		//	cset x3?, eq
+
 		ins := m.allocateInstr()
 		ins.asVecMisc(vecOpCmeq0, rd, rm, vecArrangement2D)
 		m.insert(ins)
@@ -426,17 +432,22 @@ func (m *machine) lowerVcheckTrue(instr *ssa.Instruction) {
 		return
 	}
 
-	ins := m.allocateInstr()
-
 	// Create a scalar value with umaxp or uminv, then compare it against zero.
+	ins := m.allocateInstr()
 	if instr.Opcode() == ssa.OpcodeVanyTrue {
+		// 	umaxp v4?.16b, v2?.16b, v2?.16b
 		ins.asVecRRR(vecOpUmaxp, tmp, rm, rm, vecArrangement16B)
 	} else {
+		// 	uminv d4?, v2?.4s
 		arr := ssaLaneToArrangement(lane)
 		ins.asVecLanes(vecOpUminv, tmp, rm, arr)
 	}
-
 	m.insert(ins)
+
+	//	mov x3?, v4?.d[0]
+	//	ccmp x3?, #0x0, #0x0, al
+	//	cset x3?, ne
+	//	mov x0, x3?
 
 	movv := m.allocateInstr()
 	movv.asMovFromVec(rd, tmp, vecArrangementD, vecIndex(0))
@@ -463,11 +474,25 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 	switch lane {
 
 	case ssa.VecLaneI8x16:
+		//	sshr v6?.16b, v2?.16b, #7
+		//	movz x4?, #0x201, lsl 0
+		//	movk x4?, #0x804, lsl 16
+		//	movk x4?, #0x2010, lsl 32
+		//	movk x4?, #0x8040, lsl 48
+		//	dup v5?.2d, x4?
+		//	and v6?.16b, v6?.16b, v5?.16b
+		//	ext v5?.16b, v6?.16b, v6?.16b, #8
+		//	zip1 v5?.16b, v6?.16b, v5?.16b
+		//	addv s5?, v5?.8h
+		//	umov s3?, v5?.h[0]
+
+		// Right arithmetic shift on the original vector and store the result into vecTmp. So we have:
+		// v[i] = 0xff if vi<0, 0 otherwise.
 		sshr := m.allocateInstr()
 		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(7), vecArrangement16B)
 		m.insert(sshr)
 
-		// m.lowerConstantI64(r0.nr(), 0x0008000400020001)
+		// Load the bit mask into vecTmp.
 		m.insertMOVZ(r0.nr(), 0x0201, 0, true)
 		m.insertMOVK(r0.nr(), 0x0804, 1, true)
 		m.insertMOVK(r0.nr(), 0x2010, 2, true)
@@ -477,30 +502,55 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		dup.asVecDup(v0, r0, vecArrangement2D)
 		m.insert(dup)
 
+		// Lane-wise logical AND with i8x16BitmaskConst, meaning that we have
+		// v[i] = (1 << i) if vi<0, 0 otherwise.
+		//
+		// Below, we use the following notation:
+		// wi := (1 << i) if vi<0, 0 otherwise.
 		and := m.allocateInstr()
 		and.asVecRRR(vecOpAnd, v1, v1, v0, vecArrangement16B)
 		m.insert(and)
 
+		// Swap the lower and higher 8 byte elements, and write it into vecTmp, meaning that we have
+		// vecTmp[i] = w(i+8) if i < 8, w(i-8) otherwise.
 		ext := m.allocateInstr()
 		ext.asVecExtract(v0, v1, v1, vecArrangement16B, uint32(8))
 		m.insert(ext)
 
+		// v = [w0, w8, ..., w7, w15]
 		zip1 := m.allocateInstr()
 		zip1.asVecPermute(vecOpZip1, v0, v1, v0, vecArrangement16B)
 		m.insert(zip1)
 
+		// v.h[0] = w0 + ... + w15
 		addv := m.allocateInstr()
 		addv.asVecLanes(vecOpAddv, v0, v0, vecArrangement8H)
 		m.insert(addv)
 
+		// Extract the v.h[0] as the result.
 		movfv := m.allocateInstr()
 		movfv.asMovFromVec(rd, v0, vecArrangementH, vecIndex(0))
 		m.insert(movfv)
 	case ssa.VecLaneI16x8:
+		//	sshr v6?.8h, v2?.8h, #15
+		//	movz x4?, #0x1, lsl 0
+		//	movk x4?, #0x2, lsl 16
+		//	movk x4?, #0x4, lsl 32
+		//	movk x4?, #0x8, lsl 48
+		//	dup v5?.2d, x4?
+		//	lsl x4?, x4?, 0x4
+		//	ins v5?.d[1], x4?
+		//	and v5?.16b, v6?.16b, v5?.16b
+		//	addv s5?, v5?.8h
+		//	umov s3?, v5?.h[0]
+
+		// Right arithmetic shift on the original vector and store the result into vecTmp. So we have:
+		// v[i] = 0xffff if vi<0, 0 otherwise.
 		sshr := m.allocateInstr()
 		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(15), vecArrangement8H)
 		m.insert(sshr)
 
+		// Load the bit mask into vecTmp.
 		m.lowerConstantI64(r0.nr(), 0x0008000400020001)
 
 		dup := m.allocateInstr()
@@ -515,6 +565,9 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		movv.asMovToVec(v0, r0, vecArrangementD, vecIndex(1))
 		m.insert(movv)
 
+		// Lane-wise logical AND with i16x8BitmaskConst, meaning that we have
+		// v[i] = (1 << i)     if vi<0, 0 otherwise for i=0..3
+		//      = (1 << (i+4)) if vi<0, 0 otherwise for i=3..7
 		and := m.allocateInstr()
 		and.asVecRRR(vecOpAnd, v0, v1, v0, vecArrangement16B)
 		m.insert(and)
@@ -527,10 +580,25 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		movfv.asMovFromVec(rd, v0, vecArrangementH, vecIndex(0))
 		m.insert(movfv)
 	case ssa.VecLaneI32x4:
+		// 	sshr v6?.8h, v2?.8h, #15
+		//	movz x4?, #0x1, lsl 0
+		//	movk x4?, #0x2, lsl 16
+		//	movk x4?, #0x4, lsl 32
+		//	movk x4?, #0x8, lsl 48
+		//	dup v5?.2d, x4?
+		//	lsl x4?, x4?, 0x4
+		//	ins v5?.d[1], x4?
+		//	and v5?.16b, v6?.16b, v5?.16b
+		//	addv s5?, v5?.8h
+		//	umov s3?, v5?.h[0]
+
+		// Right arithmetic shift on the original vector and store the result into vecTmp. So we have:
+		// v[i] = 0xffffffff if vi<0, 0 otherwise.
 		sshr := m.allocateInstr()
 		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(31), vecArrangement4S)
 		m.insert(sshr)
 
+		// Load the bit mask into vecTmp.
 		m.lowerConstantI64(r0.nr(), 0x0000000200000001)
 
 		dup := m.allocateInstr()
@@ -545,6 +613,9 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		movv.asMovToVec(v0, r0, vecArrangementD, vecIndex(1))
 		m.insert(movv)
 
+		// Lane-wise logical AND with i16x8BitmaskConst, meaning that we have
+		// v[i] = (1 << i)     if vi<0, 0 otherwise for i in [0, 1]
+		//      = (1 << (i+4)) if vi<0, 0 otherwise for i in [2, 3]
 		and := m.allocateInstr()
 		and.asVecRRR(vecOpAnd, v0, v1, v0, vecArrangement16B)
 		m.insert(and)
@@ -558,14 +629,23 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		m.insert(movfv)
 
 	case ssa.VecLaneI64x2:
+		// 	mov d3?, v2?.d[0]
+		//	mov x4?, v2?.d[1]
+		//	lsr x4?, x4?, 0x3f
+		//	lsr d3?, d3?, 0x3f
+		//	add s3?, s3?, w4?, lsl #1
+
+		// Move the lower 64-bit int into result,
 		movv0 := m.allocateInstr()
 		movv0.asMovFromVec(rd, rm, vecArrangementD, vecIndex(0))
 		m.insert(movv0)
 
+		// Move the higher 64-bit int into arm64ReservedRegisterForTemporary.
 		movv1 := m.allocateInstr()
 		movv1.asMovFromVec(r0, rm, vecArrangementD, vecIndex(1))
 		m.insert(movv1)
 
+		// Move the sign bit into the least significant bit.
 		lsr1 := m.allocateInstr()
 		lsr1.asALUShift(aluOpLsr, r0, r0, operandShiftImm(63), true)
 		m.insert(lsr1)
@@ -574,6 +654,7 @@ func (m *machine) lowerVhighBits(instr *ssa.Instruction) {
 		lsr2.asALUShift(aluOpLsr, rd, rd, operandShiftImm(63), true)
 		m.insert(lsr2)
 
+		// result = (arm64ReservedRegisterForTemporary<<1) | result
 		lsl := m.allocateInstr()
 		lsl.asALU(aluOpAdd, rd, rd, operandSR(r0.nr(), 1, shiftOpLSL), false)
 		m.insert(lsl)

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -555,7 +555,6 @@ cset x15, ne
 `,
 			expectedBytes: "20a4216e0f3c084ee0e940faef079f9a",
 		},
-
 		{
 			name:        "allTrue 2D",
 			op:          ssa.OpcodeVallTrue,
@@ -632,6 +631,91 @@ cset x15, ne
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, m := newSetupWithMockContext()
 			m.lowerVcheckTrue(tc.op, operandNR(x1VReg), operandNR(x15VReg), tc.arrangement)
+			require.Equal(t, tc.expectedAsm, "\n"+formatEmittedInstructionsInCurrentBlock(m)+"\n")
+
+			m.FlushPendingInstructions()
+			m.encode(m.perBlockHead)
+			buf := m.compiler.Buf()
+			require.Equal(t, tc.expectedBytes, hex.EncodeToString(buf))
+		})
+	}
+}
+
+func TestMachine_lowerVhighBits(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		expectedAsm   string
+		arrangement   vecArrangement
+		expectedBytes string
+	}{
+		{
+			name:        "16B",
+			arrangement: vecArrangement16B,
+			expectedAsm: `
+sshr v3?.16b, x1.16b, #7
+movz x1?, #0x201, lsl 0
+movk x1?, #0x804, lsl 16
+movk x1?, #0x2010, lsl 32
+movk x1?, #0x8040, lsl 48
+dup v2?.2d, x1?
+and v3?.16b, v3?.16b, v2?.16b
+ext v2?.16b, v3?.16b, v3?.16b, #8
+zip1 v2?.16b, v3?.16b, v2?.16b
+addv s2?, v2?.8h
+umov w15, v2?.h[0]
+`,
+			expectedBytes: "2004094f204080d28000a1f20002c4f20008f0f2000c084e001c204e0040006e0038004e00b8714e0f3c020e",
+		},
+		{
+			name:        "8H",
+			arrangement: vecArrangement8H,
+			expectedAsm: `
+sshr v3?.8h, x1.8h, #15
+movz x1?, #0x1, lsl 0
+movk x1?, #0x2, lsl 16
+movk x1?, #0x4, lsl 32
+movk x1?, #0x8, lsl 48
+dup v2?.2d, x1?
+lsl x1?, x1?, 0x4
+ins v2?.d[1], x1?
+and v2?.16b, v3?.16b, v2?.16b
+addv s2?, v2?.8h
+umov w15, v2?.h[0]
+`,
+			expectedBytes: "2004114f200080d24000a0f28000c0f20001e0f2000c084e00ec7cd3001c184e001c204e00b8714e0f3c020e",
+		},
+		{
+			name:        "4S",
+			arrangement: vecArrangement4S,
+			expectedAsm: `
+sshr v3?.4s, x1.4s, #31
+movz x1?, #0x1, lsl 0
+movk x1?, #0x2, lsl 32
+dup v2?.2d, x1?
+lsl x1?, x1?, 0x2
+ins v2?.d[1], x1?
+and v2?.16b, v3?.16b, v2?.16b
+addv d2?, v2?.4s
+umov w15, v2?.s[0]
+`,
+			expectedBytes: "2004214f200080d24000c0f2000c084e00f47ed3001c184e001c204e00b8b14e0f3c040e",
+		},
+		{
+			name:        "2D",
+			arrangement: vecArrangement2D,
+			expectedAsm: `
+mov x15, x1.d[0]
+mov x1?, x1.d[1]
+lsr x1?, x1?, 0x3f
+lsr x15, x15, 0x3f
+add w15, w15, w1?, lsl #1
+`,
+			expectedBytes: "2f3c084e203c184e00fc7fd3effd7fd3ef05000b",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, m := newSetupWithMockContext()
+			m.lowerVhighBits(operandNR(x1VReg), operandNR(x15VReg), tc.arrangement)
 			require.Equal(t, tc.expectedAsm, "\n"+formatEmittedInstructionsInCurrentBlock(m)+"\n")
 
 			m.FlushPendingInstructions()

--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -141,6 +141,7 @@ func TestSpectestV2(t *testing.T) {
 		{"conversions"},
 		{"if"},
 		{"loop"},
+		{"simd_boolean"},
 		{"simd_bitwise"},
 		{"simd_const"},
 		{"simd_i8x16_arith"},

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -1414,6 +1414,49 @@ func (c *Compiler) lowerCurrentOpcode() {
 			v1 := state.pop()
 			ret := builder.AllocateInstruction().AsVbitselect(c, v1, v2).Insert(builder).Return()
 			state.push(ret)
+		case wasm.OpcodeVecV128AnyTrue:
+			if state.unreachable {
+				break
+			}
+			v1 := state.pop()
+			ret := builder.AllocateInstruction().AsVanyTrue(v1).Insert(builder).Return()
+			state.push(ret)
+		case wasm.OpcodeVecI8x16AllTrue, wasm.OpcodeVecI16x8AllTrue, wasm.OpcodeVecI32x4AllTrue, wasm.OpcodeVecI64x2AllTrue:
+			if state.unreachable {
+				break
+			}
+			var lane ssa.VecLane
+			switch vecOp {
+			case wasm.OpcodeVecI8x16AllTrue:
+				lane = ssa.VecLaneI8x16
+			case wasm.OpcodeVecI16x8AllTrue:
+				lane = ssa.VecLaneI16x8
+			case wasm.OpcodeVecI32x4AllTrue:
+				lane = ssa.VecLaneI32x4
+			case wasm.OpcodeVecI64x2AllTrue:
+				lane = ssa.VecLaneI64x2
+			}
+			v1 := state.pop()
+			ret := builder.AllocateInstruction().AsVallTrue(v1, lane).Insert(builder).Return()
+			state.push(ret)
+		case wasm.OpcodeVecI8x16BitMask, wasm.OpcodeVecI16x8BitMask, wasm.OpcodeVecI32x4BitMask, wasm.OpcodeVecI64x2BitMask:
+			if state.unreachable {
+				break
+			}
+			var lane ssa.VecLane
+			switch vecOp {
+			case wasm.OpcodeVecI8x16BitMask:
+				lane = ssa.VecLaneI8x16
+			case wasm.OpcodeVecI16x8BitMask:
+				lane = ssa.VecLaneI16x8
+			case wasm.OpcodeVecI32x4BitMask:
+				lane = ssa.VecLaneI32x4
+			case wasm.OpcodeVecI64x2BitMask:
+				lane = ssa.VecLaneI64x2
+			}
+			v1 := state.pop()
+			ret := builder.AllocateInstruction().AsVhighBits(v1, lane).Insert(builder).Return()
+			state.push(ret)
 		case wasm.OpcodeVecI8x16Abs, wasm.OpcodeVecI16x8Abs, wasm.OpcodeVecI32x4Abs, wasm.OpcodeVecI64x2Abs:
 			if state.unreachable {
 				break

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -913,8 +913,8 @@ var instructionReturnTypes = [opcodeEnd]returnTypesFn{
 	OpcodeVbnot:      returnTypesFnV128,
 	OpcodeVbandnot:   returnTypesFnV128,
 	OpcodeVbitselect: returnTypesFnV128,
-	OpcodeVanyTrue:   returnTypesFnV128,
-	OpcodeVallTrue:   returnTypesFnV128,
+	OpcodeVanyTrue:   returnTypesFnSingle,
+	OpcodeVallTrue:   returnTypesFnSingle,
 	OpcodeVhighBits:  returnTypesFnV128,
 	OpcodeVIadd:      returnTypesFnV128,
 	OpcodeVSaddSat:   returnTypesFnV128,
@@ -1553,6 +1553,32 @@ func (i *Instruction) AsVbitselect(c, x, y Value) *Instruction {
 	i.v = c
 	i.v2 = x
 	i.v3 = y
+	return i
+}
+
+// AsVanyTrue initializes this instruction as an anyTrue vector instruction with OpcodeVanyTrue.
+func (i *Instruction) AsVanyTrue(x Value) *Instruction {
+	i.opcode = OpcodeVanyTrue
+	i.typ = TypeI32
+	i.v = x
+	return i
+}
+
+// AsVallTrue initializes this instruction as an allTrue vector instruction with OpcodeVallTrue.
+func (i *Instruction) AsVallTrue(x Value, lane VecLane) *Instruction {
+	i.opcode = OpcodeVallTrue
+	i.typ = TypeI32
+	i.v = x
+	i.u1 = uint64(lane)
+	return i
+}
+
+// AsVhighBits initializes this instruction as a highBits vector instruction with OpcodeVhighBits.
+func (i *Instruction) AsVhighBits(x Value, lane VecLane) *Instruction {
+	i.opcode = OpcodeVhighBits
+	i.typ = TypeI32
+	i.v = x
+	i.u1 = uint64(lane)
 	return i
 }
 

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -913,8 +913,8 @@ var instructionReturnTypes = [opcodeEnd]returnTypesFn{
 	OpcodeVbnot:      returnTypesFnV128,
 	OpcodeVbandnot:   returnTypesFnV128,
 	OpcodeVbitselect: returnTypesFnV128,
-	OpcodeVanyTrue:   returnTypesFnSingle,
-	OpcodeVallTrue:   returnTypesFnSingle,
+	OpcodeVanyTrue:   returnTypesFnI32,
+	OpcodeVallTrue:   returnTypesFnI32,
 	OpcodeVhighBits:  returnTypesFnV128,
 	OpcodeVIadd:      returnTypesFnV128,
 	OpcodeVSaddSat:   returnTypesFnV128,
@@ -2067,7 +2067,7 @@ func (i *Instruction) Format(b Builder) string {
 		OpcodeCeil, OpcodeFloor, OpcodeTrunc, OpcodeNearest:
 		instSuffix = " " + i.v.Format(b)
 	case OpcodeVIadd, OpcodeVSaddSat, OpcodeVUaddSat, OpcodeVIsub, OpcodeVSsubSat, OpcodeVUsubSat,
-		OpcodeVImin, OpcodeVUmin, OpcodeVImax, OpcodeVUmax, OpcodeVImul:
+		OpcodeVImin, OpcodeVUmin, OpcodeVImax, OpcodeVUmax, OpcodeVImul, OpcodeVAvgRound:
 		instSuffix = fmt.Sprintf(".%s %s, %s", VecLane(i.u1), i.v.Format(b), i.v2.Format(b))
 	case OpcodeVIabs, OpcodeVIneg, OpcodeVIpopcnt, OpcodeVhighBits, OpcodeVallTrue, OpcodeVanyTrue:
 		instSuffix = fmt.Sprintf(".%s %s", VecLane(i.u1), i.v.Format(b))
@@ -2463,6 +2463,8 @@ func (o Opcode) String() (ret string) {
 		return "VSsubSat"
 	case OpcodeVUsubSat:
 		return "VUsubSat"
+	case OpcodeVAvgRound:
+		return "OpcodeVAvgRound"
 	case OpcodeVIsub:
 		return "VIsub"
 	case OpcodeVImin:


### PR DESCRIPTION
continues #1496

passes `simd_boolean` spec tests, adds related instructions: `addv`, `uminv`, `umaxp` `dup`, `ext`, `zip`, `sshr`, `cmeq(zero)`
