### PR TITLE
wazevo: fix simd bit shift test temp reg usage

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -586,10 +586,6 @@ func (m *machine) lowerVShift(op ssa.Opcode, rd, rn, rm operand, arr vecArrangem
 
 	tmp := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeFloat))
 
-	mov := m.allocateInstr()
-	mov.asFpuMov128(tmp.nr(), rm.nr())
-	m.insert(mov)
-
 	and := m.allocateInstr()
 	and.asALUBitmaskImm(aluOpAnd, rm.nr(), tmp.nr(), uint64(modulo), false)
 	m.insert(and)
@@ -603,7 +599,7 @@ func (m *machine) lowerVShift(op ssa.Opcode, rd, rn, rm operand, arr vecArrangem
 
 	// Copy the shift amount into a vector register as sshl/ushl requires it to be there.
 	dup := m.allocateInstr()
-	dup.asVecDup(rd, rm, arr)
+	dup.asVecDup(rd, tmp, arr)
 	m.insert(dup)
 
 	if op == ssa.OpcodeVIshl || op == ssa.OpcodeVSshr {

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -739,38 +739,35 @@ func TestMachine_lowerVShift(t *testing.T) {
 			op:          ssa.OpcodeVIshl,
 			arrangement: vecArrangement16B,
 			expectedAsm: `
-mov v1?.16b, x15.16b
 and s1?, w15, #0x7
-dup x1.16b, x15
+dup x1.16b, d1?
 sshl x1.16b, x2.16b, x1.16b
 `,
-			expectedBytes: "e01daf4ee0090012e10d014e4144214e",
+			expectedBytes: "e0090012010c014e4144214e",
 		},
 		{
 			name:        "VSshr",
 			op:          ssa.OpcodeVSshr,
 			arrangement: vecArrangement16B,
 			expectedAsm: `
-mov v1?.16b, x15.16b
 and s1?, w15, #0x7
 sub s1?, wzr, s1?
-dup x1.16b, x15
+dup x1.16b, d1?
 sshl x1.16b, x2.16b, x1.16b
 `,
-			expectedBytes: "e01daf4ee0090012e003004be10d014e4144214e",
+			expectedBytes: "e0090012e003004b010c014e4144214e",
 		},
 		{
 			name:        "VUshr",
 			op:          ssa.OpcodeVUshr,
 			arrangement: vecArrangement16B,
 			expectedAsm: `
-mov v1?.16b, x15.16b
 and s1?, w15, #0x7
 sub s1?, wzr, s1?
-dup x1.16b, x15
+dup x1.16b, d1?
 ushl x1.16b, x2.16b, x1.16b
 `,
-			expectedBytes: "e01daf4ee0090012e003004be10d014e4144216e",
+			expectedBytes: "e0090012e003004b010c014e4144216e",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
- continues #1496 
- addresses an incorrect usage of registers in #1738, removes useless instruction