### PR TITLE
Changes ModuleID for listener existence per function

### DIFF
--- a/internal/wasm/host.go
+++ b/internal/wasm/host.go
@@ -72,7 +72,7 @@ func NewHostModule(
 	// compilation of host modules is not costly as it's merely small trampolines vs the real-world native Wasm binary.
 	// TODO: refactor engines so that we can properly cache compiled machine codes for host modules.
 	m.AssignModuleID([]byte(fmt.Sprintf("@@@@@@@@%p", m)), // @@@@@@@@ = any 8 bytes different from Wasm header.
-		false, false)
+		nil, false)
 	return
 }
 

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/ieee754"
 	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/wasmdebug"
@@ -198,13 +200,20 @@ const (
 
 // AssignModuleID calculates a sha256 checksum on `wasm` and other args, and set Module.ID to the result.
 // See the doc on Module.ID on what it's used for.
-func (m *Module) AssignModuleID(wasm []byte, withListener, withEnsureTermination bool) {
+func (m *Module) AssignModuleID(wasm []byte, listeners []experimental.FunctionListener, withEnsureTermination bool) {
 	h := sha256.New()
 	h.Write(wasm)
-	// Use the pre-allocated space on m.ID to append the booleans to sha256 hash.
-	m.ID[0] = boolToByte(withListener)
-	m.ID[1] = boolToByte(withEnsureTermination)
-	h.Write(m.ID[:2])
+	// Use the pre-allocated space backed by m.ID below.
+
+	// Write the existence of listeners to the checksum per function.
+	for i, l := range listeners {
+		binary.LittleEndian.PutUint32(m.ID[:], uint32(i))
+		m.ID[4] = boolToByte(l != nil)
+		h.Write(m.ID[:5])
+	}
+	// Write the flag of ensureTermination to the checksum.
+	m.ID[0] = boolToByte(withEnsureTermination)
+	h.Write(m.ID[:1])
 	// Get checksum by passing the slice underlying m.ID.
 	h.Sum(m.ID[:0])
 }

--- a/runtime.go
+++ b/runtime.go
@@ -233,7 +233,7 @@ func (r *runtime) CompileModule(ctx context.Context, binary []byte) (CompiledMod
 	if err != nil {
 		return nil, err
 	}
-	internal.AssignModuleID(binary, len(listeners) > 0, r.ensureTermination)
+	internal.AssignModuleID(binary, listeners, r.ensureTermination)
 	if err = r.store.Engine.CompileModule(ctx, internal, listeners, r.ensureTermination); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously the ModuleID only reflected the existence of listeners per module (i.e. len(listeners) >0 or not),
but that might be problematic if a user changes the listeners set before/after compilation. 

