### PR TITLE
Removes unnecessary mutex on Table/Memory Instance

### DIFF
--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -3,7 +3,6 @@ package wasm
 import (
 	"fmt"
 	"math"
-	"sync"
 
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/internal/leb128"
@@ -126,9 +125,6 @@ type TableInstance struct {
 
 	// Type is either RefTypeFuncref or RefTypeExternRef.
 	Type RefType
-
-	// mux is used to prevent overlapping calls to Grow.
-	mux sync.RWMutex
 }
 
 // ElementInstance represents an element instance in a module.
@@ -314,10 +310,6 @@ func (m *Module) verifyImportGlobalI32(sectionID SectionID, sectionIdx Index, id
 //
 // https://www.w3.org/TR/2022/WD-wasm-core-2-20220419/exec/instructions.html#xref-syntax-instructions-syntax-instr-table-mathsf-table-grow-x
 func (t *TableInstance) Grow(delta uint32, initialRef Reference) (currentLen uint32) {
-	// We take write-lock here as the following might result in a new slice
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
 	currentLen = uint32(len(t.References))
 	if delta == 0 {
 		return


### PR DESCRIPTION
This was _somehow_ introduced in the past, but the
reality is that the mutex only used during Grow doesn't
solve any concurrent issue at all and still could result in
crash when the module was accessed incorrectly concurrently.
The proper synchronization mechanism must be provided by
threads proposal, and this mutex usage can be removed.