### PR TITLE
wazevo(arm64): do not optimize out Ireduce

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -835,7 +835,9 @@ func (i *instruction) asVecRRR(op vecOp, rd, rn, rm operand, arr vecArrangement)
 
 func (i *instruction) isCopy() bool {
 	op := i.kind
-	return op == mov64 || op == mov32 || op == fpuMov64 || op == fpuMov128
+	// We do not include mov32 as it is not a copy instruction in the sense that it does not preserve the upper 32 bits,
+	// and it is only used in the translation of IReduce, not the actual copy indeed.
+	return op == mov64 || op == fpuMov64 || op == fpuMov128
 }
 
 // String implements fmt.Stringer.

--- a/internal/engine/wazevo/backend/isa/arm64/instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_test.go
@@ -67,3 +67,10 @@ func TestInstruction_String(t *testing.T) {
 		t.Run(tc.exp, func(t *testing.T) { require.Equal(t, tc.exp, tc.i.String()) })
 	}
 }
+
+func TestInstruction_isCopy(t *testing.T) {
+	require.False(t, (&instruction{kind: mov32}).isCopy())
+	require.True(t, (&instruction{kind: mov64}).isCopy())
+	require.True(t, (&instruction{kind: fpuMov64}).isCopy())
+	require.True(t, (&instruction{kind: fpuMov128}).isCopy())
+}


### PR DESCRIPTION
pointed out by the fuzzer

#1496 