### PR TITLE
wazevo(ssa): eliminates no-op shifts by constant zeros

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -35,7 +35,7 @@ func newMachine() backend.Machine {
 }
 
 func TestE2E(t *testing.T) {
-	const verbose = true
+	const verbose = false
 
 	type testCase struct {
 		name                                   string

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -1715,6 +1715,9 @@ func encodeMoveWideImmediate(opc uint32, rd uint32, imm, shift, _64bit uint64) (
 // encodeAluRRImm encodes as "Bitfield" in
 // https://developer.arm.com/documentation/ddi0596/2020-12/Index-by-Encoding/Data-Processing----Immediate?lang=en#log_imm
 func encodeAluRRImm(op aluOp, rd, rn, amount, _64bit uint32) uint32 {
+	if amount == 0 {
+		panic("Shifting by 0 is not allowed; must be optimized out")
+	}
 	var opc uint32
 	var immr, imms uint32
 	switch op {

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -1,7 +1,6 @@
 package frontend
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/tetratelabs/wazero/api"
@@ -1809,13 +1808,11 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:v128, v3:v128)
 			fc.LowerToSSA()
 
 			actual := fc.formatBuilder()
-			fmt.Println(actual)
 			require.Equal(t, tc.exp, actual)
 
 			b.RunPasses()
 			if expAfterOpt := tc.expAfterOpt; expAfterOpt != "" {
 				actualAfterOpt := fc.formatBuilder()
-				fmt.Println(actualAfterOpt)
 				require.Equal(t, expAfterOpt, actualAfterOpt)
 			}
 

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -1769,11 +1769,12 @@ func (i *Instruction) AsVUshr(x, amount Value, lane VecLane) *Instruction {
 }
 
 // AsSshr initializes this instruction as an integer signed shift right (arithmetic shift right) instruction with OpcodeSshr.
-func (i *Instruction) AsSshr(x, amount Value) {
+func (i *Instruction) AsSshr(x, amount Value) *Instruction {
 	i.opcode = OpcodeSshr
 	i.v = x
 	i.v2 = amount
 	i.typ = x.Type()
+	return i
 }
 
 // AsVSshr initializes this instruction as an integer signed shift right (arithmetic shift right) instruction with OpcodeVSshr on vector.


### PR DESCRIPTION
detected by the fuzzer that immediate shift with zero cannot be encoded in arm64.

#1496 