### PR TITLE
wazevo(arm64): fixes Fcopysign instruction order

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -1157,7 +1157,7 @@ func (m *machine) lowerFcopysign(x, y, ret ssa.Value) {
 	tmpF := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeFloat))
 	tmpI := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeInt))
 	rd := m.compiler.VRegOf(ret)
-	m.lowerFcopysignImpl(operandNR(rd), rn, rm, tmpI, tmpF, x.Type() == ssa.TypeF32)
+	m.lowerFcopysignImpl(operandNR(rd), rn, rm, tmpI, tmpF, x.Type() == ssa.TypeF64)
 }
 
 func (m *machine) lowerFcopysignImpl(rd, rn, rm, tmpI, tmpF operand, _64bit bool) {

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -853,7 +853,6 @@ bsl v4?.16b, v2?.16b, v3?.16b
 }
 
 func TestMachine_lowerFcopysign(t *testing.T) {
-
 	for _, tc := range []struct {
 		_64bit bool
 		exp    string

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -851,3 +851,48 @@ dup v4?.2d, x5?
 bsl v4?.16b, v2?.16b, v3?.16b
 `, "\n"+formatEmittedInstructionsInCurrentBlock(m)+"\n")
 }
+
+func TestMachine_lowerFcopysign(t *testing.T) {
+
+	for _, tc := range []struct {
+		_64bit bool
+		exp    string
+	}{
+		{
+			_64bit: false,
+			exp: `
+movz w1?, #0x8000, lsl 16
+ins v2?.s[0], w1?
+mov v5?.8b, v3?.8b
+bit v5?.8b, v4?.8b, v2?.8b
+`,
+		},
+		{
+			_64bit: true,
+			exp: `
+movz x1?, #0x8000, lsl 48
+ins v2?.d[0], x1?
+mov v5?.8b, v3?.8b
+bit v5?.8b, v4?.8b, v2?.8b
+`,
+		},
+	} {
+		t.Run(fmt.Sprintf("64bit=%v", tc._64bit), func(t *testing.T) {
+			_, _, m := newSetupWithMockContext()
+			tmpI := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeInt))
+			tmpF := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeFloat))
+			rn := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeFloat))
+			rm := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeFloat))
+			rd := operandNR(m.compiler.AllocateVReg(regalloc.RegTypeFloat))
+
+			require.Equal(t, 1, int(tmpI.reg().ID()))
+			require.Equal(t, 2, int(tmpF.reg().ID()))
+			require.Equal(t, 3, int(rn.reg().ID()))
+			require.Equal(t, 4, int(rm.reg().ID()))
+			require.Equal(t, 5, int(rd.reg().ID()))
+
+			m.lowerFcopysignImpl(rd, rn, rm, tmpI, tmpF, tc._64bit)
+			require.Equal(t, tc.exp, "\n"+formatEmittedInstructionsInCurrentBlock(m)+"\n")
+		})
+	}
+}

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -87,7 +87,7 @@ func (c *callEngine) requiredInitialStackSize() int {
 	const initialStackSizeDefault = 512
 	stackSize := initialStackSizeDefault
 	paramResultInBytes := c.sizeOfParamResultSlice * 8 * 2 // * 8 because uint64 is 8 bytes, and *2 because we need both separated param/result slots.
-	required := paramResultInBytes + 32 + 16               // 32 is enough to accommodate the call frame info, and 16 is just in case when []byte is aligned to 16 bytes.
+	required := paramResultInBytes + 32 + 16               // 32 is enough to accommodate the call frame info, and 16 exists just in case when []byte is not aligned to 16 bytes.
 	if required > stackSize {
 		stackSize = required
 	}

--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -87,7 +87,7 @@ func (c *callEngine) requiredInitialStackSize() int {
 	const initialStackSizeDefault = 512
 	stackSize := initialStackSizeDefault
 	paramResultInBytes := c.sizeOfParamResultSlice * 8 * 2 // * 8 because uint64 is 8 bytes, and *2 because we need both separated param/result slots.
-	required := paramResultInBytes + 32                    // 32 is enough to accommodate the call frame info.
+	required := paramResultInBytes + 32 + 16               // 32 is enough to accommodate the call frame info, and 16 is just in case when []byte is aligned to 16 bytes.
 	if required > stackSize {
 		stackSize = required
 	}

--- a/internal/engine/wazevo/call_engine_test.go
+++ b/internal/engine/wazevo/call_engine_test.go
@@ -61,5 +61,5 @@ func TestCallEngine_requiredInitialStackSize(t *testing.T) {
 	c.sizeOfParamResultSlice = 10
 	require.Equal(t, 512, c.requiredInitialStackSize())
 	c.sizeOfParamResultSlice = 120
-	require.Equal(t, 120*16+32, c.requiredInitialStackSize())
+	require.Equal(t, 120*16+32+16, c.requiredInitialStackSize())
 }


### PR DESCRIPTION
detected by the fuzzer

#1496 