### PR TITLE
wazevo: optimize regalloc block info memory

### DIFF
--- a/internal/engine/wazevo/backend/regalloc/regalloc_test.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc_test.go
@@ -519,7 +519,7 @@ func TestAllocator_livenessAnalysis(t *testing.T) {
 			a := NewAllocator(&RegisterInfo{})
 			a.livenessAnalysis(f)
 			for blockID := range a.blockInfos {
-				actual := &a.blockInfos[blockID]
+				actual := a.blockInfos[blockID]
 				exp := tc.exp[blockID]
 				initMapInInfo(exp)
 				saved := actual.intervalMng


### PR DESCRIPTION
Building on #1804, this PR modifies how block info values are tracked to reduce the memory footprint.

On the compilation of Python, the change reduces by 3.8GB the amount of memory allocated and allocates 61% fewer objects:

```
Type: alloc_space
Time: Oct 19, 2023 at 11:35am (PDT)
Showing nodes accounting for -3827.23MB, 18.33% of 20878.78MB total
Dropped 143 nodes (cum <= 104.39MB)
      flat  flat%   sum%        cum   cum%
-2373.80MB 11.37% 11.37% -2362.30MB 11.31%  github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi.(*Pool[go.shape.struct { github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.id github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.BasicBlockID; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.rootInstr *github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Instruction; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.currentInstr *github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Instruction; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.params []github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.blockParam; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.predIter int; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.preds []github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.basicBlockPredecessorInfo; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.success []*github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.basicBlock; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.singlePred *github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.basicBlock; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.lastDefinitions map[github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Variable]github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Value; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.unknownValues map[github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Variable]github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Value; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.invalid bool; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.sealed bool; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.loopHeader bool; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.reversePostOrder int }]).Allocate
 -731.21MB  3.50% 14.87%  -727.71MB  3.49%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*intervalManager).build
 -257.57MB  1.23% 16.11%  -475.67MB  2.28%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).livenessAnalysis
 -189.44MB  0.91% 17.01% -2586.05MB 12.39%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*intervalManager).insert
  -78.37MB  0.38% 17.39%   -66.28MB  0.32%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*VRegTypeTable).Insert
  -52.73MB  0.25% 17.64%   -99.31MB  0.48%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).allocateBlockInfo
  -49.01MB  0.23% 17.88%   -49.01MB  0.23%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).upAndMarkStack
     -41MB   0.2% 18.07%      -41MB   0.2%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.newIntervalManager (inline)
     -41MB   0.2% 18.27%   -82.01MB  0.39%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).initBlockInfo
  -18.04MB 0.086% 18.35% -2593.07MB 12.42%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).buildLiveRangesForNonReals
    4.93MB 0.024% 18.33% -3833.07MB 18.36%  github.com/tetratelabs/wazero/internal/engine/wazevo.(*engine).compileModule
```

```
Type: alloc_objects
Time: Oct 19, 2023 at 11:35am (PDT)
Showing nodes accounting for -33337301, 61.54% of 54174929 total
Dropped 141 nodes (cum <= 270874)
      flat  flat%   sum%        cum   cum%
 -20295578 37.46% 37.46%  -20180886 37.25%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*intervalManager).build
  -8329025 15.37% 52.84%   -8832208 16.30%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*intervalManager).insert
  -1250106  2.31% 55.14%   -3626896  6.69%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).livenessAnalysis
   -895698  1.65% 56.80%   -1469178  2.71%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).initBlockInfo
   -671876  1.24% 58.04%   -9640691 17.80%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).buildLiveRangesForNonReals
   -617958  1.14% 59.18%    -617958  1.14%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).upAndMarkStack
   -573480  1.06% 60.24%    -573480  1.06%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.newIntervalManager (inline)
   -502879  0.93% 61.17%    -251647  0.46%  github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi.(*Pool[go.shape.struct { github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.id github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.BasicBlockID; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.rootInstr *github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Instruction; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.currentInstr *github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Instruction; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.params []github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.blockParam; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.predIter int; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.preds []github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.basicBlockPredecessorInfo; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.success []*github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.basicBlock; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.singlePred *github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.basicBlock; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.lastDefinitions map[github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Variable]github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Value; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.unknownValues map[github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Variable]github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.Value; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.invalid bool; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.sealed bool; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.loopHeader bool; github.com/tetratelabs/wazero/internal/engine/wazevo/ssa.reversePostOrder int }]).Allocate
   -442222  0.82% 61.98%    -442222  0.82%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*blockInfo).addRealRegUsage (inline)
    240309  0.44% 61.54%     240309  0.44%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*intervalManager).reset (inline)
      1201 0.0022% 61.54%  -33473953 61.79%  github.com/tetratelabs/wazero/internal/engine/wazevo.(*engine).compileModule
        11 2e-05% 61.54%   -1228829  2.27%  github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc.(*Allocator).allocateBlockInfo
```