### PR TITLE
config: add support for cancellable Nanosleep

### DIFF
--- a/imports/wasi_snapshot_preview1/poll.go
+++ b/imports/wasi_snapshot_preview1/poll.go
@@ -49,7 +49,7 @@ type event struct {
 	errno     wasip1.Errno
 }
 
-func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno {
+func pollOneoffFn(ctx context.Context, mod api.Module, params []uint64) sys.Errno {
 	in := uint32(params[0])
 	out := uint32(params[1])
 	nsubscriptions := uint32(params[2])
@@ -166,7 +166,7 @@ func pollOneoffFn(_ context.Context, mod api.Module, params []uint64) sys.Errno 
 		// We only need to observe the timeout (nonzero if there are clock subscriptions)
 		// and return.
 		if timeout > 0 {
-			sysCtx.Nanosleep(int64(timeout))
+			sysCtx.Nanosleep(ctx, int64(timeout))
 		}
 		return 0
 	}

--- a/internal/platform/time.go
+++ b/internal/platform/time.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -35,7 +36,7 @@ func NewFakeNanotime() sys.Nanotime {
 }
 
 // FakeNanosleep implements sys.Nanosleep by returning without sleeping.
-var FakeNanosleep = sys.Nanosleep(func(int64) {})
+var FakeNanosleep = sys.CancellableNanosleep(func(context.Context, int64) {})
 
 // FakeOsyield implements sys.Osyield by returning without yielding.
 var FakeOsyield = sys.Osyield(func() {})
@@ -70,7 +71,10 @@ func Nanotime() int64 {
 	return nanotime()
 }
 
-// Nanosleep implements sys.Nanosleep with time.Sleep.
-func Nanosleep(ns int64) {
-	time.Sleep(time.Duration(ns))
+// CancellableNanosleep implements sys.CancellableNanosleep with time.Sleep.
+func CancellableNanosleep(ctx context.Context, ns int64) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Duration(ns)):
+	}
 }

--- a/internal/sys/sys.go
+++ b/internal/sys/sys.go
@@ -1,6 +1,7 @@
 package sys
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -22,7 +23,7 @@ type Context struct {
 	walltimeResolution sys.ClockResolution
 	nanotime           sys.Nanotime
 	nanotimeResolution sys.ClockResolution
-	nanosleep          sys.Nanosleep
+	nanosleep          sys.CancellableNanosleep
 	osyield            sys.Osyield
 	randSource         io.Reader
 	fsc                FSContext
@@ -89,8 +90,8 @@ func (c *Context) NanotimeResolution() sys.ClockResolution {
 }
 
 // Nanosleep implements sys.Nanosleep.
-func (c *Context) Nanosleep(ns int64) {
-	c.nanosleep(ns)
+func (c *Context) Nanosleep(ctx context.Context, ns int64) {
+	c.nanosleep(ctx, ns)
 }
 
 // Osyield implements sys.Osyield.
@@ -133,7 +134,7 @@ func NewContext(
 	walltimeResolution sys.ClockResolution,
 	nanotime sys.Nanotime,
 	nanotimeResolution sys.ClockResolution,
-	nanosleep sys.Nanosleep,
+	nanosleep sys.CancellableNanosleep,
 	osyield sys.Osyield,
 	fs []experimentalsys.FS, guestPaths []string,
 	tcpListeners []*net.TCPListener,

--- a/internal/sys/sys_test.go
+++ b/internal/sys/sys_test.go
@@ -2,6 +2,7 @@ package sys
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -259,7 +260,7 @@ func Test_clockResolutionInvalid(t *testing.T) {
 }
 
 func TestNewContext_Nanosleep(t *testing.T) {
-	var aNs sys.Nanosleep = func(int64) {}
+	var aNs sys.CancellableNanosleep = func(context.Context, int64) {}
 	sysCtx, err := NewContext(0, nil, nil, nil, nil, nil, nil, nil, 0, nil, 0, aNs, nil, nil, nil, nil)
 	require.Nil(t, err)
 	require.Equal(t, aNs, sysCtx.nanosleep)

--- a/sys/clock.go
+++ b/sys/clock.go
@@ -1,5 +1,7 @@
 package sys
 
+import "context"
+
 // ClockResolution is a positive granularity of clock precision in
 // nanoseconds. For example, if the resolution is 1us, this returns 1000.
 //
@@ -21,6 +23,10 @@ type Nanotime func() int64
 
 // Nanosleep puts the current goroutine to sleep for at least ns nanoseconds.
 type Nanosleep func(ns int64)
+
+// CancellableNanosleep puts the current goroutine to sleep for at least ns nanoseconds,
+// honoring the given context.Context.
+type CancellableNanosleep func(ctx context.Context, ns int64)
 
 // Osyield yields the processor, typically to implement spin-wait loops.
 type Osyield func()


### PR DESCRIPTION
It has been reported that in some cases (e.g. in `poll_oneoff`) the context is not honored on **sleep**. We introduce support for a configurable cancellable context, and we make it the default for `ModuleConfig.WithSysNanosleep()`.

We also introduce `WithCancellableNanosleep(sys.CancellableNanosleep)` alongside `WithNanosleep(sys.Nanosleep)` which should be a source-compatible change (advice welcome on whether this is a correct assumption).

Changing the default for `ModuleConfig.WithSysNanosleep()` is a behavioral change that should have no effect (it is actually a bug if you relied on the context not being cancellable), but it might be considered "breaking", so we can revert that if we'd rather keep the old default.

We can also deprecate `WithNanosleep(sys.Nanosleep)`, but for now I am just modifying the documentation to nudge users towards the new API.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
