### PR TITLE
compiler: add munmap finalizer on cache hits to avoid memory leak

### DIFF
--- a/internal/engine/compiler/engine_cache.go
+++ b/internal/engine/compiler/engine_cache.go
@@ -46,6 +46,9 @@ func (e *engine) getCompiledModule(module *wasm.Module, listeners []experimental
 				cm.functions[i].listener = listeners[i]
 			}
 		}
+
+		// As this uses mmap, we need to munmap on the compiled machine code when it's GCed.
+		e.setFinalizer(cm, releaseCompiledModule)
 	}
 	return
 }


### PR DESCRIPTION
Not sure how this was never noticed, trying to run the same thing over and over in response to request with cache enabled would OOM very quickly…

![Screenshot from 2023-10-23 19-08-13](https://github.com/tetratelabs/wazero/assets/208340/c6a04faf-438d-4979-b76c-3ef32ad8f99e)