### PR TITLE
wazevo(regalloc): specifies the VReg in swapping

### DIFF
--- a/internal/engine/wazevo/backend/regalloc/regalloc.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc.go
@@ -833,8 +833,8 @@ func (a *Allocator) reconcileEdge(f Function,
 			)
 		}
 		f.SwapAtEndOfBlock(
-			FromRealReg(r, typ),
-			FromRealReg(er, typ),
+			currentVReg.SetRealReg(r),
+			desiredVReg.SetRealReg(er),
 			freeReg,
 			pred,
 		)


### PR DESCRIPTION
#1496 