### PR TITLE
wazevo: initial work on constant folding

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -1394,126 +1394,124 @@ L1 (SSA Block: blk0):
 L1 (SSA Block: blk0):
 	mov x130?, x2
 	mov v131?.8b, v0.8b
-	orr w289?, wzr, #0x1
-	madd w133?, w130?, w289?, wzr
-	orr w288?, wzr, #0x2
-	madd w135?, w130?, w288?, wzr
-	orr w287?, wzr, #0x3
-	madd w137?, w130?, w287?, wzr
-	orr w286?, wzr, #0x4
-	madd w139?, w130?, w286?, wzr
-	movz w285?, #0x5, lsl 0
-	madd w141?, w130?, w285?, wzr
-	orr w284?, wzr, #0x6
-	madd w143?, w130?, w284?, wzr
-	orr w283?, wzr, #0x7
-	madd w145?, w130?, w283?, wzr
-	orr w282?, wzr, #0x8
-	madd w147?, w130?, w282?, wzr
-	movz w281?, #0x9, lsl 0
-	madd w149?, w130?, w281?, wzr
-	movz w280?, #0xa, lsl 0
-	madd w151?, w130?, w280?, wzr
-	movz w279?, #0xb, lsl 0
-	madd w153?, w130?, w279?, wzr
-	orr w278?, wzr, #0xc
-	madd w155?, w130?, w278?, wzr
-	movz w277?, #0xd, lsl 0
-	madd w157?, w130?, w277?, wzr
-	orr w276?, wzr, #0xe
-	madd w159?, w130?, w276?, wzr
-	orr w275?, wzr, #0xf
-	madd w161?, w130?, w275?, wzr
-	orr w274?, wzr, #0x10
-	madd w163?, w130?, w274?, wzr
-	movz w273?, #0x11, lsl 0
-	madd w165?, w130?, w273?, wzr
-	movz w272?, #0x12, lsl 0
-	madd w167?, w130?, w272?, wzr
-	movz w271?, #0x13, lsl 0
-	madd w169?, w130?, w271?, wzr
-	movz w270?, #0x14, lsl 0
-	madd w171?, w130?, w270?, wzr
-	add w172?, w169?, w171?
-	add w173?, w167?, w172?
-	add w174?, w165?, w173?
-	add w175?, w163?, w174?
-	add w176?, w161?, w175?
-	add w177?, w159?, w176?
-	add w178?, w157?, w177?
-	add w179?, w155?, w178?
-	add w180?, w153?, w179?
-	add w181?, w151?, w180?
-	add w182?, w149?, w181?
-	add w183?, w147?, w182?
-	add w184?, w145?, w183?
-	add w185?, w143?, w184?
-	add w186?, w141?, w185?
-	add w187?, w139?, w186?
-	add w188?, w137?, w187?
-	add w189?, w135?, w188?
-	add w190?, w133?, w189?
-	ldr s269?, #8; b 8; data.f32 1.000000
-	fmul s192?, s131?, s269?
-	ldr s268?, #8; b 8; data.f32 2.000000
-	fmul s194?, s131?, s268?
-	ldr s267?, #8; b 8; data.f32 3.000000
-	fmul s196?, s131?, s267?
-	ldr s266?, #8; b 8; data.f32 4.000000
-	fmul s198?, s131?, s266?
-	ldr s265?, #8; b 8; data.f32 5.000000
-	fmul s200?, s131?, s265?
-	ldr s264?, #8; b 8; data.f32 6.000000
-	fmul s202?, s131?, s264?
-	ldr s263?, #8; b 8; data.f32 7.000000
-	fmul s204?, s131?, s263?
-	ldr s262?, #8; b 8; data.f32 8.000000
-	fmul s206?, s131?, s262?
-	ldr s261?, #8; b 8; data.f32 9.000000
-	fmul s208?, s131?, s261?
-	ldr s260?, #8; b 8; data.f32 10.000000
-	fmul s210?, s131?, s260?
-	ldr s259?, #8; b 8; data.f32 11.000000
-	fmul s212?, s131?, s259?
-	ldr s258?, #8; b 8; data.f32 12.000000
-	fmul s214?, s131?, s258?
-	ldr s257?, #8; b 8; data.f32 13.000000
-	fmul s216?, s131?, s257?
-	ldr s256?, #8; b 8; data.f32 14.000000
-	fmul s218?, s131?, s256?
-	ldr s255?, #8; b 8; data.f32 15.000000
-	fmul s220?, s131?, s255?
-	ldr s254?, #8; b 8; data.f32 16.000000
-	fmul s222?, s131?, s254?
-	ldr s253?, #8; b 8; data.f32 17.000000
-	fmul s224?, s131?, s253?
-	ldr s252?, #8; b 8; data.f32 18.000000
-	fmul s226?, s131?, s252?
-	ldr s251?, #8; b 8; data.f32 19.000000
-	fmul s228?, s131?, s251?
-	ldr s250?, #8; b 8; data.f32 20.000000
-	fmul s230?, s131?, s250?
-	fadd s231?, s228?, s230?
-	fadd s232?, s226?, s231?
-	fadd s233?, s224?, s232?
-	fadd s234?, s222?, s233?
-	fadd s235?, s220?, s234?
-	fadd s236?, s218?, s235?
-	fadd s237?, s216?, s236?
-	fadd s238?, s214?, s237?
-	fadd s239?, s212?, s238?
-	fadd s240?, s210?, s239?
-	fadd s241?, s208?, s240?
-	fadd s242?, s206?, s241?
-	fadd s243?, s204?, s242?
-	fadd s244?, s202?, s243?
-	fadd s245?, s200?, s244?
-	fadd s246?, s198?, s245?
-	fadd s247?, s196?, s246?
-	fadd s248?, s194?, s247?
-	fadd s249?, s192?, s248?
-	mov v0.8b, v249?.8b
-	mov x0, x190?
+	orr w286?, wzr, #0x2
+	madd w133?, w130?, w286?, wzr
+	orr w285?, wzr, #0x3
+	madd w135?, w130?, w285?, wzr
+	orr w284?, wzr, #0x4
+	madd w137?, w130?, w284?, wzr
+	movz w283?, #0x5, lsl 0
+	madd w139?, w130?, w283?, wzr
+	orr w282?, wzr, #0x6
+	madd w141?, w130?, w282?, wzr
+	orr w281?, wzr, #0x7
+	madd w143?, w130?, w281?, wzr
+	orr w280?, wzr, #0x8
+	madd w145?, w130?, w280?, wzr
+	movz w279?, #0x9, lsl 0
+	madd w147?, w130?, w279?, wzr
+	movz w278?, #0xa, lsl 0
+	madd w149?, w130?, w278?, wzr
+	movz w277?, #0xb, lsl 0
+	madd w151?, w130?, w277?, wzr
+	orr w276?, wzr, #0xc
+	madd w153?, w130?, w276?, wzr
+	movz w275?, #0xd, lsl 0
+	madd w155?, w130?, w275?, wzr
+	orr w274?, wzr, #0xe
+	madd w157?, w130?, w274?, wzr
+	orr w273?, wzr, #0xf
+	madd w159?, w130?, w273?, wzr
+	orr w272?, wzr, #0x10
+	madd w161?, w130?, w272?, wzr
+	movz w271?, #0x11, lsl 0
+	madd w163?, w130?, w271?, wzr
+	movz w270?, #0x12, lsl 0
+	madd w165?, w130?, w270?, wzr
+	movz w269?, #0x13, lsl 0
+	madd w167?, w130?, w269?, wzr
+	movz w268?, #0x14, lsl 0
+	madd w169?, w130?, w268?, wzr
+	add w170?, w167?, w169?
+	add w171?, w165?, w170?
+	add w172?, w163?, w171?
+	add w173?, w161?, w172?
+	add w174?, w159?, w173?
+	add w175?, w157?, w174?
+	add w176?, w155?, w175?
+	add w177?, w153?, w176?
+	add w178?, w151?, w177?
+	add w179?, w149?, w178?
+	add w180?, w147?, w179?
+	add w181?, w145?, w180?
+	add w182?, w143?, w181?
+	add w183?, w141?, w182?
+	add w184?, w139?, w183?
+	add w185?, w137?, w184?
+	add w186?, w135?, w185?
+	add w187?, w133?, w186?
+	add w188?, w130?, w187?
+	ldr s267?, #8; b 8; data.f32 1.000000
+	fmul s190?, s131?, s267?
+	ldr s266?, #8; b 8; data.f32 2.000000
+	fmul s192?, s131?, s266?
+	ldr s265?, #8; b 8; data.f32 3.000000
+	fmul s194?, s131?, s265?
+	ldr s264?, #8; b 8; data.f32 4.000000
+	fmul s196?, s131?, s264?
+	ldr s263?, #8; b 8; data.f32 5.000000
+	fmul s198?, s131?, s263?
+	ldr s262?, #8; b 8; data.f32 6.000000
+	fmul s200?, s131?, s262?
+	ldr s261?, #8; b 8; data.f32 7.000000
+	fmul s202?, s131?, s261?
+	ldr s260?, #8; b 8; data.f32 8.000000
+	fmul s204?, s131?, s260?
+	ldr s259?, #8; b 8; data.f32 9.000000
+	fmul s206?, s131?, s259?
+	ldr s258?, #8; b 8; data.f32 10.000000
+	fmul s208?, s131?, s258?
+	ldr s257?, #8; b 8; data.f32 11.000000
+	fmul s210?, s131?, s257?
+	ldr s256?, #8; b 8; data.f32 12.000000
+	fmul s212?, s131?, s256?
+	ldr s255?, #8; b 8; data.f32 13.000000
+	fmul s214?, s131?, s255?
+	ldr s254?, #8; b 8; data.f32 14.000000
+	fmul s216?, s131?, s254?
+	ldr s253?, #8; b 8; data.f32 15.000000
+	fmul s218?, s131?, s253?
+	ldr s252?, #8; b 8; data.f32 16.000000
+	fmul s220?, s131?, s252?
+	ldr s251?, #8; b 8; data.f32 17.000000
+	fmul s222?, s131?, s251?
+	ldr s250?, #8; b 8; data.f32 18.000000
+	fmul s224?, s131?, s250?
+	ldr s249?, #8; b 8; data.f32 19.000000
+	fmul s226?, s131?, s249?
+	ldr s248?, #8; b 8; data.f32 20.000000
+	fmul s228?, s131?, s248?
+	fadd s229?, s226?, s228?
+	fadd s230?, s224?, s229?
+	fadd s231?, s222?, s230?
+	fadd s232?, s220?, s231?
+	fadd s233?, s218?, s232?
+	fadd s234?, s216?, s233?
+	fadd s235?, s214?, s234?
+	fadd s236?, s212?, s235?
+	fadd s237?, s210?, s236?
+	fadd s238?, s208?, s237?
+	fadd s239?, s206?, s238?
+	fadd s240?, s204?, s239?
+	fadd s241?, s202?, s240?
+	fadd s242?, s200?, s241?
+	fadd s243?, s198?, s242?
+	fadd s244?, s196?, s243?
+	fadd s245?, s194?, s244?
+	fadd s246?, s192?, s245?
+	fadd s247?, s190?, s246?
+	mov v0.8b, v247?.8b
+	mov x0, x188?
 	ret
 `,
 			afterFinalizeARM64: `
@@ -1539,47 +1537,44 @@ L1 (SSA Block: blk0):
 	str q27, [sp, #-0x10]!
 	movz x27, #0x120, lsl 0
 	str x27, [sp, #-0x10]!
-	orr w8, wzr, #0x1
+	orr w8, wzr, #0x2
 	madd w8, w2, w8, wzr
-	orr w9, wzr, #0x2
+	orr w9, wzr, #0x3
 	madd w9, w2, w9, wzr
-	orr w10, wzr, #0x3
+	orr w10, wzr, #0x4
 	madd w10, w2, w10, wzr
-	orr w11, wzr, #0x4
+	movz w11, #0x5, lsl 0
 	madd w11, w2, w11, wzr
-	movz w12, #0x5, lsl 0
+	orr w12, wzr, #0x6
 	madd w12, w2, w12, wzr
-	orr w13, wzr, #0x6
+	orr w13, wzr, #0x7
 	madd w13, w2, w13, wzr
-	orr w14, wzr, #0x7
+	orr w14, wzr, #0x8
 	madd w14, w2, w14, wzr
-	orr w15, wzr, #0x8
+	movz w15, #0x9, lsl 0
 	madd w15, w2, w15, wzr
-	movz w16, #0x9, lsl 0
+	movz w16, #0xa, lsl 0
 	madd w16, w2, w16, wzr
-	movz w17, #0xa, lsl 0
+	movz w17, #0xb, lsl 0
 	madd w17, w2, w17, wzr
-	movz w19, #0xb, lsl 0
+	orr w19, wzr, #0xc
 	madd w19, w2, w19, wzr
-	orr w20, wzr, #0xc
+	movz w20, #0xd, lsl 0
 	madd w20, w2, w20, wzr
-	movz w21, #0xd, lsl 0
+	orr w21, wzr, #0xe
 	madd w21, w2, w21, wzr
-	orr w22, wzr, #0xe
+	orr w22, wzr, #0xf
 	madd w22, w2, w22, wzr
-	orr w23, wzr, #0xf
+	orr w23, wzr, #0x10
 	madd w23, w2, w23, wzr
-	orr w24, wzr, #0x10
+	movz w24, #0x11, lsl 0
 	madd w24, w2, w24, wzr
-	movz w25, #0x11, lsl 0
+	movz w25, #0x12, lsl 0
 	madd w25, w2, w25, wzr
-	movz w26, #0x12, lsl 0
+	movz w26, #0x13, lsl 0
 	madd w26, w2, w26, wzr
-	movz w29, #0x13, lsl 0
+	movz w29, #0x14, lsl 0
 	madd w29, w2, w29, wzr
-	movz w30, #0x14, lsl 0
-	madd w30, w2, w30, wzr
-	add w29, w29, w30
 	add w26, w26, w29
 	add w25, w25, w26
 	add w24, w24, w25
@@ -1598,6 +1593,7 @@ L1 (SSA Block: blk0):
 	add w10, w10, w11
 	add w9, w9, w10
 	add w8, w8, w9
+	add w8, w2, w8
 	ldr s8, #8; b 8; data.f32 1.000000
 	fmul s8, s0, s8
 	ldr s9, #8; b 8; data.f32 2.000000

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -95,8 +95,8 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i32)
 blk0: (exec_ctx:i64, module_ctx:i64)
 	v2:i32 = Iconst_32 0x0
 	v3:i64 = Iconst_64 0x0
-	v4:f32 = F32const 0.000000
-	v5:f64 = F64const 0.000000
+	v4:f32 = F32const 0
+	v5:f64 = F64const 0
 	Jump blk_ret
 `,
 			expAfterOpt: `
@@ -136,8 +136,8 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:i32)
 blk0: (exec_ctx:i64, module_ctx:i64, v2:i64, v3:f32, v4:f64)
 	v5:i32 = Iconst_32 0x0
 	v6:i64 = Iconst_64 0x0
-	v7:f32 = F32const 0.000000
-	v8:f64 = F64const 0.000000
+	v7:f32 = F32const 0
+	v8:f64 = F64const 0
 	v9:i64 = Iadd v2, v2
 	v10:i64 = Isub v9, v2
 	v11:f32 = Fadd v3, v3
@@ -204,8 +204,8 @@ blk1: () <-- (blk0)
 blk0: (exec_ctx:i64, module_ctx:i64)
 	v2:i32 = Iconst_32 0x0
 	v3:i64 = Iconst_64 0x0
-	v4:f32 = F32const 0.000000
-	v5:f64 = F64const 0.000000
+	v4:f32 = F32const 0
+	v5:f64 = F64const 0
 	Jump blk1
 
 blk1: () <-- (blk0)
@@ -311,8 +311,8 @@ blk3: () <-- (blk1)
 blk0: (exec_ctx:i64, module_ctx:i64)
 	v2:i32 = Iconst_32 0x0
 	v3:i64 = Iconst_64 0x0
-	v4:f32 = F32const 0.000000
-	v5:f64 = F64const 0.000000
+	v4:f32 = F32const 0
+	v5:f64 = F64const 0
 	Jump blk1
 
 blk1: () <-- (blk0)
@@ -885,45 +885,45 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:f32)
 	v60:i32 = Iadd v9, v59
 	v61:i32 = Iadd v7, v60
 	v62:i32 = Iadd v5, v61
-	v63:f32 = F32const 1.000000
+	v63:f32 = F32const 1
 	v64:f32 = Fmul v3, v63
-	v65:f32 = F32const 2.000000
+	v65:f32 = F32const 2
 	v66:f32 = Fmul v3, v65
-	v67:f32 = F32const 3.000000
+	v67:f32 = F32const 3
 	v68:f32 = Fmul v3, v67
-	v69:f32 = F32const 4.000000
+	v69:f32 = F32const 4
 	v70:f32 = Fmul v3, v69
-	v71:f32 = F32const 5.000000
+	v71:f32 = F32const 5
 	v72:f32 = Fmul v3, v71
-	v73:f32 = F32const 6.000000
+	v73:f32 = F32const 6
 	v74:f32 = Fmul v3, v73
-	v75:f32 = F32const 7.000000
+	v75:f32 = F32const 7
 	v76:f32 = Fmul v3, v75
-	v77:f32 = F32const 8.000000
+	v77:f32 = F32const 8
 	v78:f32 = Fmul v3, v77
-	v79:f32 = F32const 9.000000
+	v79:f32 = F32const 9
 	v80:f32 = Fmul v3, v79
-	v81:f32 = F32const 10.000000
+	v81:f32 = F32const 10
 	v82:f32 = Fmul v3, v81
-	v83:f32 = F32const 11.000000
+	v83:f32 = F32const 11
 	v84:f32 = Fmul v3, v83
-	v85:f32 = F32const 12.000000
+	v85:f32 = F32const 12
 	v86:f32 = Fmul v3, v85
-	v87:f32 = F32const 13.000000
+	v87:f32 = F32const 13
 	v88:f32 = Fmul v3, v87
-	v89:f32 = F32const 14.000000
+	v89:f32 = F32const 14
 	v90:f32 = Fmul v3, v89
-	v91:f32 = F32const 15.000000
+	v91:f32 = F32const 15
 	v92:f32 = Fmul v3, v91
-	v93:f32 = F32const 16.000000
+	v93:f32 = F32const 16
 	v94:f32 = Fmul v3, v93
-	v95:f32 = F32const 17.000000
+	v95:f32 = F32const 17
 	v96:f32 = Fmul v3, v95
-	v97:f32 = F32const 18.000000
+	v97:f32 = F32const 18
 	v98:f32 = Fmul v3, v97
-	v99:f32 = F32const 19.000000
+	v99:f32 = F32const 19
 	v100:f32 = Fmul v3, v99
-	v101:f32 = F32const 20.000000
+	v101:f32 = F32const 20
 	v102:f32 = Fmul v3, v101
 	v103:f32 = Fadd v100, v102
 	v104:f32 = Fadd v98, v103
@@ -1356,10 +1356,10 @@ blk0: (exec_ctx:i64, module_ctx:i64)
 	v4:i64 = Iconst_64 0x2
 	v5:i64 = Load module_ctx, 0x10
 	Store v4, v5, 0x8
-	v6:f32 = F32const 3.000000
+	v6:f32 = F32const 3
 	v7:i64 = Load module_ctx, 0x18
 	Store v6, v7, 0x8
-	v8:f64 = F64const 4.000000
+	v8:f64 = F64const 4
 	v9:i64 = Load module_ctx, 0x20
 	Store v8, v9, 0x8
 	Jump blk_ret, v2, v4, v6, v8

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -2394,9 +2394,9 @@ func (i *Instruction) Format(b Builder) string {
 	case OpcodeVconst:
 		instSuffix = fmt.Sprintf(" %016x %016x", i.u1, i.u2)
 	case OpcodeF32const:
-		instSuffix = fmt.Sprintf(" %f", math.Float32frombits(uint32(i.u1)))
+		instSuffix = fmt.Sprintf(" %g", math.Float32frombits(uint32(i.u1)))
 	case OpcodeF64const:
-		instSuffix = fmt.Sprintf(" %f", math.Float64frombits(i.u1))
+		instSuffix = fmt.Sprintf(" %g", math.Float64frombits(i.u1))
 	case OpcodeReturn:
 		if len(i.vs) == 0 {
 			break

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -1732,27 +1732,30 @@ func (i *Instruction) InsertlaneData() (x, y Value, index byte, l VecLane) {
 }
 
 // AsFadd initializes this instruction as a floating-point addition instruction with OpcodeFadd.
-func (i *Instruction) AsFadd(x, y Value) {
+func (i *Instruction) AsFadd(x, y Value) *Instruction {
 	i.opcode = OpcodeFadd
 	i.v = x
 	i.v2 = y
 	i.typ = x.Type()
+	return i
 }
 
 // AsFsub initializes this instruction as a floating-point subtraction instruction with OpcodeFsub.
-func (i *Instruction) AsFsub(x, y Value) {
+func (i *Instruction) AsFsub(x, y Value) *Instruction {
 	i.opcode = OpcodeFsub
 	i.v = x
 	i.v2 = y
 	i.typ = x.Type()
+	return i
 }
 
 // AsFmul initializes this instruction as a floating-point multiplication instruction with OpcodeFmul.
-func (i *Instruction) AsFmul(x, y Value) {
+func (i *Instruction) AsFmul(x, y Value) *Instruction {
 	i.opcode = OpcodeFmul
 	i.v = x
 	i.v2 = y
 	i.typ = x.Type()
+	return i
 }
 
 // AsFdiv initializes this instruction as a floating-point division instruction with OpcodeFdiv.

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -361,8 +361,6 @@ func passNopInstElimination(b *builder) {
 }
 
 func ensureValueIdToInstructionInit(b *builder) {
-	b.valueIDToInstruction = b.valueIDToInstruction[:0]
-
 	if int(b.nextValueID) >= len(b.valueIDToInstruction) {
 		b.valueIDToInstruction = append(b.valueIDToInstruction, make([]*Instruction, b.nextValueID)...)
 	}

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -20,6 +20,8 @@ func (b *builder) RunPasses() {
 	passRedundantPhiEliminationOpt(b)
 	// The result of passCalculateImmediateDominators will be used by various passes below.
 	passCalculateImmediateDominators(b)
+
+	passCollectValueIdToInstructionMapping(b)
 	passNopInstElimination(b)
 
 	// TODO: implement either conversion of irreducible CFG into reducible one, or irreducible CFG detection where we panic.
@@ -312,8 +314,6 @@ func (b *builder) clearBlkVisited() {
 
 // passNopInstElimination eliminates the instructions which is essentially a no-op.
 func passNopInstElimination(b *builder) {
-	ensureValueIdToInstructionInit(b)
-
 	for blk := b.blockIteratorBegin(); blk != nil; blk = b.blockIteratorNext() {
 		for cur := blk.rootInstr; cur != nil; cur = cur.next {
 			op := cur.Opcode()
@@ -361,7 +361,7 @@ func passNopInstElimination(b *builder) {
 	}
 }
 
-func ensureValueIdToInstructionInit(b *builder) {
+func passCollectValueIdToInstructionMapping(b *builder) {
 	if int(b.nextValueID) >= len(b.valueIDToInstruction) {
 		b.valueIDToInstruction = append(b.valueIDToInstruction, make([]*Instruction, b.nextValueID)...)
 	}
@@ -382,8 +382,6 @@ func ensureValueIdToInstructionInit(b *builder) {
 // passConstFoldingOpt scans all instructions for arithmetic operations over constants,
 // and replaces them with a const of their result.
 func passConstFoldingOpt(b *builder) {
-	ensureValueIdToInstructionInit(b)
-
 	isFixedPoint := false
 	for !isFixedPoint {
 		isFixedPoint = true

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -399,14 +399,26 @@ func passConstFoldingOpt(b *builder) {
 						// Clear the references to operands.
 						cur.v, cur.v2 = ValueInvalid, ValueInvalid
 						// We assume all the types are consistent.
-						xc, yc := xDef.ConstantVal(), yDef.ConstantVal()
-						switch op {
-						case OpcodeIadd:
-							cur.u1 = xc + yc
-						case OpcodeIsub:
-							cur.u1 = xc - yc
-						case OpcodeImul:
-							cur.u1 = xc * yc
+						if x.Type().Bits() == 64 {
+							xc, yc := int64(xDef.ConstantVal()), int64(yDef.ConstantVal())
+							switch op {
+							case OpcodeIadd:
+								cur.u1 = uint64(xc + yc)
+							case OpcodeIsub:
+								cur.u1 = uint64(xc - yc)
+							case OpcodeImul:
+								cur.u1 = uint64(xc * yc)
+							}
+						} else {
+							xc, yc := int32(xDef.ConstantVal()), int32(yDef.ConstantVal())
+							switch op {
+							case OpcodeIadd:
+								cur.u1 = uint64(xc + yc)
+							case OpcodeIsub:
+								cur.u1 = uint64(xc - yc)
+							case OpcodeImul:
+								cur.u1 = uint64(xc * yc)
+							}
 						}
 					}
 				case OpcodeFadd, OpcodeFsub, OpcodeFmul:

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -405,6 +405,11 @@ func passConstFoldingOpt(b *builder) {
 
 						yc := yDef.ConstantVal()
 						xc := xDef.ConstantVal()
+
+						// Clear the references to operands.
+						cur.v = ValueInvalid
+						cur.v2 = ValueInvalid
+
 						// Mutate the instruction to an Iconst.
 						cur.opcode = OpcodeIconst
 						switch op {
@@ -413,10 +418,6 @@ func passConstFoldingOpt(b *builder) {
 						case OpcodeIsub:
 							cur.u1 = xc - yc
 						}
-						cur.u2 = 0
-						// Clear the references to operands.
-						cur.v = 0
-						cur.v2 = 0
 					}
 				}
 			}

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -382,7 +382,7 @@ func ensureValueIdToInstructionInit(b *builder) {
 	}
 }
 
-// passNopInstElimination eliminates the instructions which is essentially a no-op.
+// passConstFoldingOpt folds constant arithmetic ops into constant ops.
 func passConstFoldingOpt(b *builder) {
 	ensureValueIdToInstructionInit(b)
 
@@ -397,7 +397,6 @@ func passConstFoldingOpt(b *builder) {
 				// Y := Const yc
 				// - (Iadd X, Y) => Const (xc + yc)
 				case OpcodeIadd, OpcodeIsub:
-					isFixedPoint = false
 					x, y := cur.Arg2()
 					xDef := b.valueIDToInstruction[x.ID()]
 					yDef := b.valueIDToInstruction[y.ID()]
@@ -405,7 +404,9 @@ func passConstFoldingOpt(b *builder) {
 						// If we are adding some parameter, ignore.
 						continue
 					}
-					if xDef.Constant() || yDef.Constant() {
+					if xDef.Constant() && yDef.Constant() {
+						isFixedPoint = false
+
 						yc := yDef.ConstantVal()
 						xc := xDef.ConstantVal()
 						// Mutate the instruction to an Iconst.

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -38,8 +38,6 @@ func (b *builder) RunPasses() {
 	passConstFoldingOpt(b)
 	passNopInstElimination(b)
 
-	passCollectValueIdToInstructionMapping(b)
-
 	// passDeadCodeEliminationOpt could be more accurate if we do this after other optimizations.
 	passDeadCodeEliminationOpt(b)
 	b.donePasses = true

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -361,9 +361,7 @@ func passNopInstElimination(b *builder) {
 }
 
 func ensureValueIdToInstructionInit(b *builder) {
-	if len(b.valueIDToInstruction) != 0 {
-		return
-	}
+	b.valueIDToInstruction = b.valueIDToInstruction[:0]
 
 	if int(b.nextValueID) >= len(b.valueIDToInstruction) {
 		b.valueIDToInstruction = append(b.valueIDToInstruction, make([]*Instruction, b.nextValueID)...)

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -179,9 +179,6 @@ func passDeadCodeEliminationOpt(b *builder) {
 	if nvid >= len(b.valueRefCounts) {
 		b.valueRefCounts = append(b.valueRefCounts, make([]int, b.nextValueID)...)
 	}
-	if nvid >= len(b.valueIDToInstruction) {
-		b.valueIDToInstruction = append(b.valueIDToInstruction, make([]*Instruction, b.nextValueID)...)
-	}
 
 	// First, we gather all the instructions with side effects.
 	liveInstructions := b.instStack[:0]
@@ -199,14 +196,6 @@ func passDeadCodeEliminationOpt(b *builder) {
 				liveInstructions = append(liveInstructions, cur)
 				// The strict side effect should create different instruction groups.
 				gid++
-			}
-
-			r1, rs := cur.Returns()
-			if r1.Valid() {
-				b.valueIDToInstruction[r1.ID()] = cur
-			}
-			for _, r := range rs {
-				b.valueIDToInstruction[r.ID()] = cur
 			}
 		}
 	}

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -194,7 +194,10 @@ blk2: () <-- (blk1)
 		},
 		{
 			name: "dead code",
-			pass: passDeadCodeEliminationOpt,
+			pass: func(b *builder) {
+				passCollectValueIdToInstructionMapping(b)
+				passDeadCodeEliminationOpt(b)
+			},
 			setup: func(b *builder) func(*testing.T) {
 				entry, end := b.AllocateBasicBlock(), b.AllocateBasicBlock()
 

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -285,8 +285,11 @@ blk1: () <-- (blk0)
 `,
 		},
 		{
-			name:     "nop elimination",
-			pass:     passNopInstElimination,
+			name: "nop elimination",
+			pass: func(b *builder) {
+				passCollectValueIdToInstructionMapping(b)
+				passNopInstElimination(b)
+			},
 			postPass: passDeadCodeEliminationOpt,
 			setup: func(b *builder) (verifier func(t *testing.T)) {
 				entry := b.AllocateBasicBlock()
@@ -361,8 +364,11 @@ blk0: (v0:i32, v1:i64)
 `,
 		},
 		{
-			name:     "const folding",
-			pass:     passConstFoldingOpt,
+			name: "const folding",
+			pass: func(b *builder) {
+				passCollectValueIdToInstructionMapping(b)
+				passConstFoldingOpt(b)
+			},
 			postPass: passDeadCodeEliminationOpt,
 			setup: func(b *builder) (verifier func(t *testing.T)) {
 				entry := b.AllocateBasicBlock()

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -472,20 +472,20 @@ blk0: ()
 	v13:i64 = Iconst_64 0x4
 	v14:i64 = Isub v13, v12
 	v15:i64 = Imul v14, v14
-	v16:f32 = F32const 1.000000
-	v17:f32 = F32const 2.000000
+	v16:f32 = F32const 1
+	v17:f32 = F32const 2
 	v18:f32 = Fadd v16, v17
-	v19:f32 = F32const 3.000000
+	v19:f32 = F32const 3
 	v20:f32 = Fadd v18, v19
-	v21:f32 = F32const 4.000000
+	v21:f32 = F32const 4
 	v22:f32 = Fsub v21, v20
 	v23:f32 = Fmul v22, v22
-	v24:f64 = F64const 1.000000
-	v25:f64 = F64const 2.000000
+	v24:f64 = F64const 1
+	v25:f64 = F64const 2
 	v26:f64 = Fadd v24, v25
-	v27:f64 = F64const 3.000000
+	v27:f64 = F64const 3
 	v28:f64 = Fadd v26, v27
-	v29:f64 = F64const 4.000000
+	v29:f64 = F64const 4
 	v30:f64 = Fsub v29, v28
 	v31:f64 = Fmul v30, v30
 	Return v7, v14, v15, v22, v23, v26, v30, v31
@@ -495,11 +495,11 @@ blk0: ()
 	v7:i32 = Iconst_32 0x4
 	v14:i64 = Iconst_64 0xfffffffffffffffe
 	v15:i64 = Iconst_64 0x4
-	v22:f32 = F32const -2.000000
-	v23:f32 = F32const 4.000000
-	v26:f64 = F64const 3.000000
-	v30:f64 = F64const -2.000000
-	v31:f64 = F64const 4.000000
+	v22:f32 = F32const -2
+	v23:f32 = F32const 4
+	v26:f64 = F64const 3
+	v30:f64 = F64const -2
+	v31:f64 = F64const 4
 	Return v7, v14, v15, v22, v23, v26, v30, v31
 `,
 		},

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -400,7 +400,6 @@ blk0: ()
 			// FIXME: the first `Iconst_32 0x1` should be dead code, and should not be present in the output.
 			after: `
 blk0: ()
-	v0:i32 = Iconst_32 0x1
 	v6:i32 = Iconst_32 0xfffffffe
 	Return v6
 `,

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -528,6 +528,7 @@ blk0: ()
 				oneI64 := b.AllocateInstruction().AsIconst64(1).Insert(b).Return()
 				// Iadd MaxInt64, 1 overflows and wraps around to 0x8000000000000000 (min representable Int64)
 				wrapI64 := b.AllocateInstruction().AsIadd(maxI64, oneI64).Insert(b).Return()
+				// Imul MaxInt64, MaxInt64 overflows and wraps around to 0x1.
 				mulI64 := b.AllocateInstruction().AsImul(maxI64, maxI64).Insert(b).Return()
 
 				// Explicitly using the constant because math.MinInt64 is not representable.

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -310,8 +310,20 @@ blk1: () <-- (blk0)
 				nonZeroI64 := b.AllocateInstruction().AsIconst64(64*245 + 1).Insert(b).Return()
 				nonZeroSshr := b.AllocateInstruction().AsSshr(i64Param, nonZeroI64).Insert(b).Return()
 
+				// Iadd32.
+				zero32 := b.AllocateInstruction().AsIconst32(0).Insert(b).Return()
+				nopIadd32 := b.AllocateInstruction().AsIadd(i32Param, zero32).Insert(b).Return()
+
+				// Iadd32.
+				zero32_2 := b.AllocateInstruction().AsIconst32(0).Insert(b).Return()
+				nopIadd32_2 := b.AllocateInstruction().AsIadd(zero32_2, i32Param).Insert(b).Return()
+
+				// Iadd64.
+				zero64 := b.AllocateInstruction().AsIconst64(0).Insert(b).Return()
+				nopIadd64 := b.AllocateInstruction().AsIadd(i64Param, zero64).Insert(b).Return()
+
 				ret := b.AllocateInstruction()
-				ret.AsReturn([]Value{nopIshl, nopUshr, nonZeroIshl, nonZeroSshr})
+				ret.AsReturn([]Value{nopIshl, nopUshr, nonZeroIshl, nonZeroSshr, nopIadd32, nopIadd32_2, nopIadd64})
 				b.InsertInstruction(ret)
 				return nil
 			},
@@ -325,7 +337,13 @@ blk0: (v0:i32, v1:i64)
 	v7:i32 = Ishl v0, v6
 	v8:i64 = Iconst_64 0x3d41
 	v9:i64 = Sshr v1, v8
-	Return v3, v5, v7, v9
+	v10:i32 = Iconst_32 0x0
+	v11:i32 = Iadd v0, v10
+	v12:i32 = Iconst_32 0x0
+	v13:i32 = Iadd v12, v0
+	v14:i64 = Iconst_64 0x0
+	v15:i64 = Iadd v1, v14
+	Return v3, v5, v7, v9, v11, v13, v15
 `,
 			after: `
 blk0: (v0:i32, v1:i64)
@@ -333,7 +351,7 @@ blk0: (v0:i32, v1:i64)
 	v7:i32 = Ishl v0, v6
 	v8:i64 = Iconst_64 0x3d41
 	v9:i64 = Sshr v1, v8
-	Return v0, v1, v7, v9
+	Return v0, v1, v7, v9, v0, v0, v1
 `,
 		},
 	} {

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -639,54 +639,6 @@ blk0: ()
 	Return v2, v3, v5, v8, v9, v11, v14, v15, v16, v18, v19, v20, v23, v24, v25, v27, v28, v29
 `,
 		},
-		{
-			name:     "algebraic simplification",
-			prePass:  passCollectValueIdToInstructionMapping,
-			pass:     passAlgebraicSimplification,
-			postPass: passDeadCodeEliminationOpt,
-			setup: func(b *builder) (verifier func(t *testing.T)) {
-				entry := b.AllocateBasicBlock()
-				b.SetCurrentBlock(entry)
-
-				i32Param := entry.AddParam(b, TypeI32)
-				i64Param := entry.AddParam(b, TypeI64)
-
-				oneI32 := b.AllocateInstruction().AsIconst32(1).Insert(b).Return()
-				twoI32 := b.AllocateInstruction().AsIconst32(2).Insert(b).Return()
-				res1I32 := b.AllocateInstruction().AsIadd(i32Param, oneI32).Insert(b).Return()
-				res2I32 := b.AllocateInstruction().AsIadd(res1I32, twoI32).Insert(b).Return()
-
-				oneI64 := b.AllocateInstruction().AsIconst64(1).Insert(b).Return()
-				twoI64 := b.AllocateInstruction().AsIconst64(2).Insert(b).Return()
-				res1I64 := b.AllocateInstruction().AsIadd(i64Param, oneI64).Insert(b).Return()
-				res2I64 := b.AllocateInstruction().AsIadd(res1I64, twoI64).Insert(b).Return()
-
-				ret := b.AllocateInstruction()
-				ret.AsReturn([]Value{res2I32, res2I64})
-				b.InsertInstruction(ret)
-				return nil
-			},
-			before: `
-blk0: (v0:i32, v1:i64)
-	v2:i32 = Iconst_32 0x1
-	v3:i32 = Iconst_32 0x2
-	v4:i32 = Iadd v0, v2
-	v5:i32 = Iadd v4, v3
-	v6:i64 = Iconst_64 0x1
-	v7:i64 = Iconst_64 0x2
-	v8:i64 = Iadd v1, v6
-	v9:i64 = Iadd v8, v7
-	Return v5, v9
-`,
-			after: `
-blk0: (v0:i32, v1:i64)
-	v10:i32 = Iconst_32 0x3
-	v5:i32 = Iadd v0, v10
-	v11:i64 = Iconst_64 0x3
-	v9:i64 = Iadd v1, v11
-	Return v5, v9
-`,
-		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/integration_test/fuzz/wazerolib/nodiff.go
+++ b/internal/integration_test/fuzz/wazerolib/nodiff.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"unsafe"
 
@@ -275,8 +276,16 @@ const valueTypeVector = 0x7b
 func ensureInvocationResultMatch(compiledMod, interpreterMod api.Module, exportedFunctions map[string]api.FunctionDefinition) (err error) {
 	ctx := context.Background()
 
+	// In order to do the deterministic execution, we need to sort the exported functions.
+	var names []string
+	for f := range exportedFunctions {
+		names = append(names, f)
+	}
+	sort.Strings(names)
+
 outer:
-	for name, def := range exportedFunctions {
+	for _, name := range names {
+		def := exportedFunctions[name]
 		resultTypes := def.ResultTypes()
 		for _, rt := range resultTypes {
 			switch rt {


### PR DESCRIPTION
#1496 

This implements an initial, simple constant folding pass for add/sub/mul for i32/i64/f32/f64.
It also implements a new case for `passNopInstElimination` where one of the args is const 0.

- is it ok to mutate instructions in-place that way?
- do we need to add checks for integer underflow/overflow? the behavior right now is essentially whatever Go does (i.e. let integers wrap, let floats go to ±inf)
- todo: add a few more test cases

