### PR TITLE
Fix `fd_fdstat_set_flags` truncating with O_TRUNC

### DIFF
--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -83,8 +83,8 @@ func (f *osFile) SetAppend(enable bool) (errno experimentalsys.Errno) {
 		f.flag &= ^experimentalsys.O_APPEND
 	}
 
-	// Clear any create flag, as we are re-opening, not re-creating.
-	f.flag &= ^experimentalsys.O_CREAT
+	// Clear any create or trunc flag, as we are re-opening, not re-creating.
+	f.flag &= ^(experimentalsys.O_CREAT | experimentalsys.O_TRUNC)
 
 	// appendMode (bool) cannot be changed later, so we have to re-open the
 	// file. https://github.com/golang/go/blob/go1.20/src/os/file_unix.go#L60


### PR DESCRIPTION
This commit fixes a buf when `fd_fdstat_set_flags` would erroneously truncate an open file if it is opened with the O_TRUNC flag.  This happens because the O_TRUNC flag causes the file to be truncated when it is opened.

This fixes https://github.com/tetratelabs/wazero/issues/1862