### PR TITLE
wasi: resets offsets in reopen

### DIFF
--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -147,6 +147,9 @@ func TestFileSetAppend(t *testing.T) {
 	require.EqualErrno(t, 0, f.SetAppend(false))
 	require.False(t, f.IsAppend())
 
+	_, errno = f.Seek(0, 0)
+	require.EqualErrno(t, 0, errno)
+
 	// without O_APPEND flag, the data writes at offset zero
 	_, errno = f.Write([]byte("wazero"))
 	require.EqualErrno(t, 0, errno)


### PR DESCRIPTION
This commit fixes `fd_fdstat_set_flags` resetting the fd offset due to it reopening the file every time.  This fix gets the current offset before reopening and restore the offset with seek. This addresses https://github.com/tetratelabs/wazero/issues/1865.

NB: A couple of existing tests are actually spec'd wrong. To fix, I introduced addition `Seek` calls before checking removing append flag.