### PR TITLE
wasi: Handle EFBIG from OS on`fd_filestat_set_size`

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -464,7 +464,7 @@ var fdFilestatSetSize = newHostFunc(wasip1.FdFilestatSetSizeName, fdFilestatSetS
 
 func fdFilestatSetSizeFn(_ context.Context, mod api.Module, params []uint64) experimentalsys.Errno {
 	fd := int32(params[0])
-	size := uint32(params[1])
+	size := int64(params[1])
 
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 
@@ -472,7 +472,7 @@ func fdFilestatSetSizeFn(_ context.Context, mod api.Module, params []uint64) exp
 	if f, ok := fsc.LookupFile(fd); !ok {
 		return experimentalsys.EBADF
 	} else {
-		return f.File.Truncate(int64(size))
+		return f.File.Truncate(size)
 	}
 }
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -835,7 +835,7 @@ func Test_fdFilestatSetSize(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		size                     uint32
+		size                     uint64
 		content, expectedContent []byte
 		expectedLog              string
 		expectedErrno            wasip1.Errno
@@ -881,6 +881,17 @@ func Test_fdFilestatSetSize(t *testing.T) {
 			expectedLog: `
 ==> wasi_snapshot_preview1.fd_filestat_set_size(fd=4,size=106)
 <== errno=ESUCCESS
+`,
+		},
+		{
+			name:            "large size",
+			content:         []byte(""),
+			expectedContent: []byte(""),
+			size:            math.MaxUint64,
+			expectedErrno:   wasip1.ErrnoInval,
+			expectedLog: `
+==> wasi_snapshot_preview1.fd_filestat_set_size(fd=4,size=-1)
+<== errno=EINVAL
 `,
 		},
 	}


### PR DESCRIPTION
This commit handles potential `EFBIG` returned from the OS and maps it to WASI's `fbig`.  It also fixes an integer truncation bug in the `fd_filestat_set_size` handler.

fixes https://github.com/tetratelabs/wazero/issues/1870