### PR TITLE
wazevo(arm64): relocations for large conditional branches

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -647,9 +647,13 @@ func (i *instruction) brLabel() label {
 }
 
 // brOffsetResolved is called when the target label is resolved.
-func (i *instruction) brOffsetResolved(offset int64) {
+func (i *instruction) brOffsetResolve(offset int64) {
 	i.u2 = uint64(offset)
 	i.u3 = 1 // indicate that the offset is resolved, for debugging.
+}
+
+func (i *instruction) brOffsetResolved() bool {
+	return i.u3 == 1
 }
 
 func (i *instruction) brOffset() int64 {
@@ -664,6 +668,10 @@ func (i *instruction) asCondBr(c cond, target label, is64bit bool) {
 	if is64bit {
 		i.u3 = 1
 	}
+}
+
+func (i *instruction) setCondBrTargets(target label) {
+	i.u2 = uint64(target)
 }
 
 func (i *instruction) condBrLabel() label {

--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -652,10 +652,6 @@ func (i *instruction) brOffsetResolve(offset int64) {
 	i.u3 = 1 // indicate that the offset is resolved, for debugging.
 }
 
-func (i *instruction) brOffsetResolved() bool {
-	return i.u3 == 1
-}
-
 func (i *instruction) brOffset() int64 {
 	return int64(i.u2)
 }

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -1280,7 +1280,7 @@ func TestInstruction_encode(t *testing.T) {
 		}},
 		{want: "20000014", setup: func(i *instruction) {
 			i.asBr(dummyLabel)
-			i.brOffsetResolved(0x80)
+			i.brOffsetResolve(0x80)
 		}},
 		{want: "01040034", setup: func(i *instruction) {
 			i.asCondBr(registerAsRegZeroCond(x1VReg), dummyLabel, false)

--- a/internal/engine/wazevo/backend/isa/arm64/machine_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_test.go
@@ -1,7 +1,6 @@
 package arm64
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc"
@@ -209,15 +208,15 @@ L200:
 			m.labelPositions[originLabelNext] = originNextLabelPos
 
 			m.rootInstr = cbr
-			fmt.Println(originLabelPos.begin.String())
 			require.Equal(t, tc.expBefore, m.Format())
 
 			m.nextLabel = 9999999
 			m.insertConditionalJumpTrampoline(cbr, originLabelPos, originLabelNext)
 
-			fmt.Println(originLabelPos.begin.String())
-
 			require.Equal(t, tc.expAfter, m.Format())
+
+			// The original label position should be updated to the unconditional jump to the original target destination.
+			require.Equal(t, "b L12345", originLabelPos.end.String())
 		})
 	}
 }


### PR DESCRIPTION
This allows the optimizing compiler to pass all GOOS=wasip1 tests.

```
>> wazero run -optimizing-compiler -mount=/:/ -env PWD=$PWD ./reflect.test -- -test.short
PASS
```