### PR TITLE
wazevo(regalloc): prioritizes rematerializable values first

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -140,7 +140,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		m.lowerSubOrAdd(instr, op == ssa.OpcodeIadd)
 	case ssa.OpcodeFadd, ssa.OpcodeFsub, ssa.OpcodeFmul, ssa.OpcodeFdiv, ssa.OpcodeFmax, ssa.OpcodeFmin:
 		m.lowerFpuBinOp(instr)
-	case ssa.OpcodeIconst, ssa.OpcodeF32const, ssa.OpcodeF64const: // Constant instructions are inlined.
+	case ssa.OpcodeIconst, ssa.OpcodeF32const, ssa.OpcodeF64const, ssa.OpcodeVconst: // Constant instructions are inlined.
 	case ssa.OpcodeExitWithCode:
 		execCtx, code := instr.ExitWithCodeData()
 		m.lowerExitWithCode(m.compiler.VRegOf(execCtx), code)
@@ -328,12 +328,6 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
 		rd := operandNR(m.compiler.VRegOf(instr.Return()))
 		m.lowerIRem(ctxVReg, rd, rn, rm, x.Type() == ssa.TypeI64, op == ssa.OpcodeSrem)
-	case ssa.OpcodeVconst:
-		result := m.compiler.VRegOf(instr.Return())
-		lo, hi := instr.VconstData()
-		v := m.allocateInstr()
-		v.asLoadFpuConst128(result, lo, hi)
-		m.insert(v)
 	case ssa.OpcodeVbnot:
 		x := instr.Arg()
 		ins := m.allocateInstr()

--- a/internal/engine/wazevo/backend/regalloc/reg.go
+++ b/internal/engine/wazevo/backend/regalloc/reg.go
@@ -35,7 +35,7 @@ func FromRealReg(r RealReg, typ RegType) VReg {
 
 // SetRealReg sets the RealReg of this VReg and returns the updated VReg.
 func (v VReg) SetRealReg(r RealReg) VReg {
-	return VReg(r)<<32 | (v & 0xff_00_ffffffff)
+	return VReg(r)<<32 | (v & 0xffffff00_ffffffff)
 }
 
 // RegType returns the RegType of this VReg.
@@ -45,7 +45,18 @@ func (v VReg) RegType() RegType {
 
 // SetRegType sets the RegType of this VReg and returns the updated VReg.
 func (v VReg) SetRegType(t RegType) VReg {
-	return VReg(t)<<40 | (v & 0x00_ff_ffffffff)
+	return VReg(t)<<40 | (v & 0xffff00ff_ffffffff)
+}
+
+// MarkRematerializable marks this VReg as rematerializable.
+func (v VReg) MarkRematerializable() VReg {
+	v |= 1 << 48
+	return v
+}
+
+// Rematerializable returns true if this VReg is rematerializable.
+func (v VReg) Rematerializable() bool {
+	return v&(1<<48) != 0
 }
 
 // ID returns the VRegID of this VReg.

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -2514,7 +2514,7 @@ func (i *Instruction) addArgumentBranchInst(v Value) {
 // Constant returns true if this instruction is a constant instruction.
 func (i *Instruction) Constant() bool {
 	switch i.opcode {
-	case OpcodeIconst, OpcodeF32const, OpcodeF64const:
+	case OpcodeIconst, OpcodeF32const, OpcodeF64const, OpcodeVconst:
 		return true
 	}
 	return false
@@ -2527,7 +2527,8 @@ func (i *Instruction) ConstantVal() (ret uint64) {
 	case OpcodeIconst, OpcodeF32const, OpcodeF64const:
 		ret = i.u1
 	default:
-		panic("TODO")
+		// OpcodeVconst must be handled via VconstData.
+		panic("BUG: ConstantVal only available for OpcodeIconst, OpcodeF32const, OpcodeF64const")
 	}
 	return
 }


### PR DESCRIPTION
This didn't make noticeable difference as-is as only 10-20 values out of the entire Zig stdlib tests turned out to be the targets. Just opened here for the future reference. 