### PR TITLE
deps: bump golangci-lint to v1.55.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 gofumpt       := mvdan.cc/gofumpt@v0.5.0
 gosimports    := github.com/rinchsan/gosimports/cmd/gosimports@v0.3.8
-golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
+golangci_lint := github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 asmfmt        := github.com/klauspost/asmfmt/cmd/asmfmt@v1.3.2
 # sync this with netlify.toml!
 hugo          := github.com/gohugoio/hugo@v0.115.2


### PR DESCRIPTION
Upgrading to go 1.21.5 causes the following `golangci-lint` error in the source tree `(`max()` new pseudo-function unrecognized):

```
❯ make format lint
../../../../sdk/go/src/net/http/internal/chunked.go:79:14: undefined: max (typecheck)
	cr.excess = max(cr.excess, 0)
	            ^
make: *** [lint] Error 1
```

Upgrading to the latest version of `golangci-lint` fixes the problem.

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
