### PR TITLE
wazevo: adds `perfmap` build tag to write perf-map

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -2231,7 +2231,7 @@ L1 (SSA Block: blk0):
 				fmt.Println(be.Format())
 			}
 
-			be.Finalize()
+			be.Finalize(context.Background())
 			if verbose {
 				fmt.Println("============ finalization result ============")
 				fmt.Println(be.Format())

--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -50,7 +50,7 @@ type Compiler interface {
 	RegAlloc()
 
 	// Finalize performs the finalization of the compilation. This must be called after RegAlloc.
-	Finalize()
+	Finalize(ctx context.Context)
 
 	// Encode encodes the machine code to the buffer.
 	Encode()
@@ -163,7 +163,7 @@ func (c *compiler) Compile(ctx context.Context) ([]byte, []RelocationInfo, error
 	if wazevoapi.DeterministicCompilationVerifierEnabled {
 		wazevoapi.VerifyOrSetDeterministicCompilationContextValue(ctx, "After Register Allocation", c.Format())
 	}
-	c.Finalize()
+	c.Finalize(ctx)
 	if wazevoapi.PrintFinalizedMachineCode {
 		fmt.Printf("[[[after finalize for %s]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), c.Format())
 	}
@@ -184,10 +184,10 @@ func (c *compiler) RegAlloc() {
 }
 
 // Finalize implements Compiler.Finalize.
-func (c *compiler) Finalize() {
+func (c *compiler) Finalize(ctx context.Context) {
 	c.mach.SetupPrologue()
 	c.mach.SetupEpilogue()
-	c.mach.ResolveRelativeAddresses()
+	c.mach.ResolveRelativeAddresses(ctx)
 }
 
 // Encode implements Compiler.Encode.

--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -150,21 +150,21 @@ type SourceOffsetInfo struct {
 // Compile implements Compiler.Compile.
 func (c *compiler) Compile(ctx context.Context) ([]byte, []RelocationInfo, error) {
 	c.Lower()
-	if wazevoapi.PrintSSAToBackendIRLowering {
+	if wazevoapi.PrintSSAToBackendIRLowering && wazevoapi.PrintEnabledIndex(ctx) {
 		fmt.Printf("[[[after lowering for %s ]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), c.Format())
 	}
 	if wazevoapi.DeterministicCompilationVerifierEnabled {
 		wazevoapi.VerifyOrSetDeterministicCompilationContextValue(ctx, "After lowering to ISA specific IR", c.Format())
 	}
 	c.RegAlloc()
-	if wazevoapi.PrintRegisterAllocated {
+	if wazevoapi.PrintRegisterAllocated && wazevoapi.PrintEnabledIndex(ctx) {
 		fmt.Printf("[[[after regalloc for %s]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), c.Format())
 	}
 	if wazevoapi.DeterministicCompilationVerifierEnabled {
 		wazevoapi.VerifyOrSetDeterministicCompilationContextValue(ctx, "After Register Allocation", c.Format())
 	}
 	c.Finalize(ctx)
-	if wazevoapi.PrintFinalizedMachineCode {
+	if wazevoapi.PrintFinalizedMachineCode && wazevoapi.PrintEnabledIndex(ctx) {
 		fmt.Printf("[[[after finalize for %s]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), c.Format())
 	}
 	if wazevoapi.DeterministicCompilationVerifierEnabled {

--- a/internal/engine/wazevo/backend/isa/arm64/machine.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine.go
@@ -1,6 +1,7 @@
 package arm64
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -355,7 +356,7 @@ func (m *machine) resolveAddressingMode(arg0offset, ret0offset int64, i *instruc
 }
 
 // ResolveRelativeAddresses implements backend.Machine.
-func (m *machine) ResolveRelativeAddresses() {
+func (m *machine) ResolveRelativeAddresses(ctx context.Context) {
 	if len(m.unresolvedAddressModes) > 0 {
 		arg0offset, ret0offset := m.arg0OffsetFromSP(), m.ret0OffsetFromSP()
 		for _, i := range m.unresolvedAddressModes {
@@ -365,6 +366,16 @@ func (m *machine) ResolveRelativeAddresses() {
 
 	// Reuse the slice to gather the unresolved conditional branches.
 	cbrs := m.condBrRelocs[:0]
+
+	var fn string
+	var labelToSSABlockID map[label]ssa.BasicBlockID
+	if wazevoapi.PerfMapEnabled {
+		fn = wazevoapi.GetCurrentFunctionName(ctx)
+		labelToSSABlockID = make(map[label]ssa.BasicBlockID)
+		for i, l := range m.ssaBlockIDToLabels {
+			labelToSSABlockID[l] = ssa.BasicBlockID(i)
+		}
+	}
 
 	// Next, in order to determine the offsets of relative jumps, we have to calculate the size of each label.
 	var offset int64
@@ -397,6 +408,20 @@ func (m *machine) ResolveRelativeAddresses() {
 				break
 			}
 		}
+
+		if wazevoapi.PerfMapEnabled {
+			if size > 0 {
+				l := pos.l
+				var labelStr string
+				if blkID, ok := labelToSSABlockID[l]; ok {
+					labelStr = fmt.Sprintf("%s::SSA_Block[%s]", l, blkID)
+				} else {
+					labelStr = l.String()
+				}
+				wazevoapi.PerfMap.AddEntry(offset, uint64(size), fmt.Sprintf("%s:::::%s", fn, labelStr))
+			}
+		}
+
 		pos.binarySize = size
 		offset += size
 	}
@@ -421,12 +446,21 @@ func (m *machine) ResolveRelativeAddresses() {
 		}
 	}
 	if needRerun {
-		m.ResolveRelativeAddresses()
+		m.ResolveRelativeAddresses(ctx)
+		wazevoapi.PerfMap.Clear()
 		return
 	}
 
+	first := m.orderedBlockLabels[0].begin
+
 	var currentOffset int64
 	for cur := m.rootInstr; cur != nil; cur = cur.next {
+		if wazevoapi.PerfMapEnabled {
+			if first == cur {
+				wazevoapi.PerfMap.AddEntry(0, uint64(currentOffset), fmt.Sprintf("%s:::::prologue", fn))
+			}
+		}
+
 		switch cur.kind {
 		case br:
 			target := cur.brLabel()

--- a/internal/engine/wazevo/backend/isa/arm64/util_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/util_test.go
@@ -82,11 +82,11 @@ func (m *mockCompiler) Buf() []byte { return m.buf }
 func (m *mockCompiler) TypeOf(v regalloc.VReg) (ret ssa.Type) {
 	return m.typeOf[v.ID()]
 }
-func (m *mockCompiler) Finalize()      {}
-func (m *mockCompiler) RegAlloc()      {}
-func (m *mockCompiler) Lower()         {}
-func (m *mockCompiler) Format() string { return "" }
-func (m *mockCompiler) Init()          {}
+func (m *mockCompiler) Finalize(context.Context) {}
+func (m *mockCompiler) RegAlloc()                {}
+func (m *mockCompiler) Lower()                   {}
+func (m *mockCompiler) Format() string           { return "" }
+func (m *mockCompiler) Init()                    {}
 
 func newMockCompilationContext() *mockCompiler {
 	return &mockCompiler{

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
@@ -89,7 +90,7 @@ type (
 
 		// ResolveRelativeAddresses resolves the relative addresses after register allocations and prologue/epilogue setup.
 		// After this, the compiler is finally ready to emit machine code.
-		ResolveRelativeAddresses()
+		ResolveRelativeAddresses(ctx context.Context)
 
 		// ResolveRelocations resolves the relocations after emitting machine code.
 		ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []RelocationInfo)

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
@@ -50,7 +51,7 @@ func (m mockMachine) SetupPrologue() {}
 func (m mockMachine) SetupEpilogue() {}
 
 // ResolveRelativeAddresses implements Machine.ResolveRelativeAddresses.
-func (m mockMachine) ResolveRelativeAddresses() {}
+func (m mockMachine) ResolveRelativeAddresses(ctx context.Context) {}
 
 // Function implements Machine.Function.
 func (m mockMachine) Function() (f regalloc.Function) { return }

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -584,7 +584,7 @@ func (e *engine) compileSharedFunctions() {
 		e.sharedFunctions.memoryGrowExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.memoryGrowExecutable
-			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("memory_grow_trampoline"))
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "memory_grow_trampoline")
 		}
 	}
 
@@ -597,7 +597,7 @@ func (e *engine) compileSharedFunctions() {
 		e.sharedFunctions.tableGrowExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.tableGrowExecutable
-			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("table_grow_trampoline"))
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "table_grow_trampoline")
 		}
 	}
 
@@ -610,7 +610,7 @@ func (e *engine) compileSharedFunctions() {
 		e.sharedFunctions.checkModuleExitCode = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.checkModuleExitCode
-			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("check_module_exit_code_trampoline"))
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "check_module_exit_code_trampoline")
 		}
 	}
 
@@ -623,7 +623,7 @@ func (e *engine) compileSharedFunctions() {
 		e.sharedFunctions.refFuncExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.refFuncExecutable
-			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("ref_func_trampoline"))
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "ref_func_trampoline")
 		}
 	}
 
@@ -633,7 +633,7 @@ func (e *engine) compileSharedFunctions() {
 		e.sharedFunctions.stackGrowExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.stackGrowExecutable
-			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("stack_grow_trampoline"))
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "stack_grow_trampoline")
 		}
 	}
 

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -116,6 +116,11 @@ func NewEngine(ctx context.Context, _ api.CoreFeatures, fc filecache.Cache) wasm
 
 // CompileModule implements wasm.Engine.
 func (e *engine) CompileModule(ctx context.Context, module *wasm.Module, listeners []experimental.FunctionListener, ensureTermination bool) (err error) {
+	if wazevoapi.PerfMapEnabled {
+		wazevoapi.PerfMap.Lock()
+		defer wazevoapi.PerfMap.Unlock()
+	}
+
 	if _, ok, err := e.getCompiledModule(module, listeners, ensureTermination); ok { // cache hit!
 		return nil
 	} else if err != nil {
@@ -167,9 +172,8 @@ func (exec *executables) compileEntryPreambles(m *wasm.Module, machine backend.M
 		exec.entryPreambles[i] = executable
 
 		if wazevoapi.PerfMapEnabled {
-			wazevoapi.PerfMap.AddEntry(int64(uintptr(unsafe.Pointer(&executable[0]))),
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&executable[0])),
 				uint64(len(executable)), fmt.Sprintf("entry_preamble::type=%s", typ.String()))
-			wazevoapi.PerfMap.Flush(0)
 		}
 	}
 }
@@ -223,7 +227,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 			if len(def.ExportNames()) > 0 {
 				name = def.ExportNames()[0]
 			}
-			ctx = wazevoapi.SetCurrentFunctionName(ctx, fmt.Sprintf("[%d/%d]%s", i, len(module.CodeSection)-1, name))
+			ctx = wazevoapi.SetCurrentFunctionName(ctx, i, fmt.Sprintf("[%d/%d]%s", i, len(module.CodeSection)-1, name))
 		}
 
 		needListener := len(listeners) > 0 && listeners[i] != nil
@@ -278,8 +282,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 	}
 
 	if wazevoapi.PerfMapEnabled {
-		fmt.Println("PerfMapEnabled")
-		wazevoapi.PerfMap.Flush(uintptr(unsafe.Pointer(&executable[0])))
+		wazevoapi.PerfMap.Flush(uintptr(unsafe.Pointer(&executable[0])), cm.functionOffsets)
 	}
 
 	if needSourceInfo {
@@ -321,7 +324,7 @@ func (e *engine) compileLocalWasmFunction(
 
 	// Lower Wasm to SSA.
 	fe.LowerToSSA()
-	if wazevoapi.PrintSSA {
+	if wazevoapi.PrintSSA && wazevoapi.PrintEnabledIndex(ctx) {
 		fmt.Printf("[[[SSA for %s]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), ssaBuilder.Format())
 	}
 
@@ -332,7 +335,7 @@ func (e *engine) compileLocalWasmFunction(
 	// Run SSA-level optimization passes.
 	ssaBuilder.RunPasses()
 
-	if wazevoapi.PrintOptimizedSSA {
+	if wazevoapi.PrintOptimizedSSA && wazevoapi.PrintEnabledIndex(ctx) {
 		fmt.Printf("[[[Optimized SSA for %s]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), ssaBuilder.Format())
 	}
 
@@ -343,7 +346,7 @@ func (e *engine) compileLocalWasmFunction(
 	// Finalize the layout of SSA blocks which might use the optimization results.
 	ssaBuilder.LayoutBlocks()
 
-	if wazevoapi.PrintBlockLaidOutSSA {
+	if wazevoapi.PrintBlockLaidOutSSA && wazevoapi.PrintEnabledIndex(ctx) {
 		fmt.Printf("[[[Laidout SSA for %s]]]%s\n", wazevoapi.GetCurrentFunctionName(ctx), ssaBuilder.Format())
 	}
 
@@ -422,6 +425,14 @@ func (e *engine) compileHostModule(ctx context.Context, module *wasm.Module, lis
 		be.Encode()
 		body := be.Buf()
 
+		if wazevoapi.PerfMapEnabled {
+			name := module.FunctionDefinition(wasm.Index(i)).DebugName()
+			wazevoapi.PerfMap.AddModuleEntry(i,
+				int64(totalSize),
+				uint64(len(body)),
+				fmt.Sprintf("trampoline:%s", name))
+		}
+
 		// TODO: optimize as zero copy.
 		copied := make([]byte, len(body))
 		copy(copied, body)
@@ -439,6 +450,10 @@ func (e *engine) compileHostModule(ctx context.Context, module *wasm.Module, lis
 	for i, b := range bodies {
 		offset := cm.functionOffsets[i]
 		copy(executable[offset:], b)
+	}
+
+	if wazevoapi.PerfMapEnabled {
+		wazevoapi.PerfMap.Flush(uintptr(unsafe.Pointer(&executable[0])), cm.functionOffsets)
 	}
 
 	if runtime.GOARCH == "arm64" {
@@ -567,11 +582,9 @@ func (e *engine) compileSharedFunctions() {
 			Results: []ssa.Type{ssa.TypeI32},
 		}, false)
 		e.sharedFunctions.memoryGrowExecutable = mmapExecutable(src)
-
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.memoryGrowExecutable
-			wazevoapi.PerfMap.AddEntry(int64(uintptr(unsafe.Pointer(&exe[0]))), uint64(len(exe)), fmt.Sprintf("memory_grow_trampoline"))
-			wazevoapi.PerfMap.Flush(0)
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("memory_grow_trampoline"))
 		}
 	}
 
@@ -584,8 +597,7 @@ func (e *engine) compileSharedFunctions() {
 		e.sharedFunctions.tableGrowExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
 			exe := e.sharedFunctions.tableGrowExecutable
-			wazevoapi.PerfMap.AddEntry(int64(uintptr(unsafe.Pointer(&exe[0]))), uint64(len(exe)), fmt.Sprintf("table_grow_trampoline"))
-			wazevoapi.PerfMap.Flush(0)
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("table_grow_trampoline"))
 		}
 	}
 
@@ -597,10 +609,8 @@ func (e *engine) compileSharedFunctions() {
 		}, false)
 		e.sharedFunctions.checkModuleExitCode = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
-
 			exe := e.sharedFunctions.checkModuleExitCode
-			wazevoapi.PerfMap.AddEntry(int64(uintptr(unsafe.Pointer(&exe[0]))), uint64(len(exe)), fmt.Sprintf("check_module_exit_code_trampoline"))
-			wazevoapi.PerfMap.Flush(0)
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("check_module_exit_code_trampoline"))
 		}
 	}
 
@@ -612,10 +622,8 @@ func (e *engine) compileSharedFunctions() {
 		}, false)
 		e.sharedFunctions.refFuncExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
-
 			exe := e.sharedFunctions.refFuncExecutable
-			wazevoapi.PerfMap.AddEntry(int64(uintptr(unsafe.Pointer(&exe[0]))), uint64(len(exe)), fmt.Sprintf("ref_func_trampoline"))
-			wazevoapi.PerfMap.Flush(0)
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("ref_func_trampoline"))
 		}
 	}
 
@@ -624,10 +632,8 @@ func (e *engine) compileSharedFunctions() {
 		src := e.machine.CompileStackGrowCallSequence()
 		e.sharedFunctions.stackGrowExecutable = mmapExecutable(src)
 		if wazevoapi.PerfMapEnabled {
-
 			exe := e.sharedFunctions.stackGrowExecutable
-			wazevoapi.PerfMap.AddEntry(int64(uintptr(unsafe.Pointer(&exe[0]))), uint64(len(exe)), fmt.Sprintf("stack_grow_trampoline"))
-			wazevoapi.PerfMap.Flush(0)
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), fmt.Sprintf("stack_grow_trampoline"))
 		}
 	}
 

--- a/internal/engine/wazevo/wazevoapi/debug_options.go
+++ b/internal/engine/wazevo/wazevoapi/debug_options.go
@@ -162,7 +162,8 @@ const NeedFunctionNameInContext = PrintSSA ||
 	PrintRegisterAllocated ||
 	PrintFinalizedMachineCode ||
 	PrintMachineCodeHexPerFunction ||
-	DeterministicCompilationVerifierEnabled
+	DeterministicCompilationVerifierEnabled ||
+	PerfMapEnabled
 
 // SetCurrentFunctionName sets the current function name to the given `functionName`.
 func SetCurrentFunctionName(ctx context.Context, functionName string) context.Context {

--- a/internal/engine/wazevo/wazevoapi/debug_options.go
+++ b/internal/engine/wazevo/wazevoapi/debug_options.go
@@ -46,6 +46,9 @@ const printTarget = -1
 
 // PrintEnabledIndex returns true if the current function index is the print target.
 func PrintEnabledIndex(ctx context.Context) bool {
+	if printTarget == -1 {
+		return true
+	}
 	return GetCurrentFunctionIndex(ctx) == printTarget
 }
 

--- a/internal/engine/wazevo/wazevoapi/debug_options.go
+++ b/internal/engine/wazevo/wazevoapi/debug_options.go
@@ -27,11 +27,11 @@ const (
 
 const (
 	PrintSSA                                 = false
-	PrintOptimizedSSA                        = false
+	PrintOptimizedSSA                        = true
 	PrintBlockLaidOutSSA                     = false
-	PrintSSAToBackendIRLowering              = false
-	PrintRegisterAllocated                   = false
-	PrintFinalizedMachineCode                = false
+	PrintSSAToBackendIRLowering              = true
+	PrintRegisterAllocated                   = true
+	PrintFinalizedMachineCode                = true
 	PrintMachineCodeHexPerFunction           = printMachineCodeHexPerFunctionUnmodified || PrintMachineCodeHexPerFunctionDisassemblable //nolint
 	printMachineCodeHexPerFunctionUnmodified = false
 	// PrintMachineCodeHexPerFunctionDisassemblable prints the machine code while modifying the actual result
@@ -39,6 +39,15 @@ const (
 	// When this is enabled, functions must not be called.
 	PrintMachineCodeHexPerFunctionDisassemblable = false
 )
+
+// printTarget is the function index to print the machine code. This is used for debugging to print the machine code
+// of a specific function.
+const printTarget = 23231
+
+// PrintEnabledIndex returns true if the current function index is the print target.
+func PrintEnabledIndex(ctx context.Context) bool {
+	return GetCurrentFunctionIndex(ctx) == printTarget
+}
 
 // ----- Validations -----
 const (
@@ -84,6 +93,7 @@ type (
 	}
 	verifierStateContextKey struct{}
 	currentFunctionNameKey  struct{}
+	currentFunctionIndexKey struct{}
 )
 
 // NewDeterministicCompilationVerifierContext creates a new context with the deterministic compilation verifier used per wasm.Module.
@@ -166,13 +176,22 @@ const NeedFunctionNameInContext = PrintSSA ||
 	PerfMapEnabled
 
 // SetCurrentFunctionName sets the current function name to the given `functionName`.
-func SetCurrentFunctionName(ctx context.Context, functionName string) context.Context {
-	return context.WithValue(ctx, currentFunctionNameKey{}, functionName)
+func SetCurrentFunctionName(ctx context.Context, index int, functionName string) context.Context {
+	ctx = context.WithValue(ctx, currentFunctionNameKey{}, functionName)
+	ctx = context.WithValue(ctx, currentFunctionIndexKey{}, index)
+	return ctx
 }
 
 // GetCurrentFunctionName returns the current function name.
 func GetCurrentFunctionName(ctx context.Context) string {
-	return ctx.Value(currentFunctionNameKey{}).(string)
+	ret, _ := ctx.Value(currentFunctionNameKey{}).(string)
+	return ret
+}
+
+// GetCurrentFunctionIndex returns the current function index.
+func GetCurrentFunctionIndex(ctx context.Context) int {
+	ret, _ := ctx.Value(currentFunctionIndexKey{}).(int)
+	return ret
 }
 
 // ----- High Register Pressure -----

--- a/internal/engine/wazevo/wazevoapi/debug_options.go
+++ b/internal/engine/wazevo/wazevoapi/debug_options.go
@@ -27,11 +27,11 @@ const (
 
 const (
 	PrintSSA                                 = false
-	PrintOptimizedSSA                        = true
+	PrintOptimizedSSA                        = false
 	PrintBlockLaidOutSSA                     = false
-	PrintSSAToBackendIRLowering              = true
-	PrintRegisterAllocated                   = true
-	PrintFinalizedMachineCode                = true
+	PrintSSAToBackendIRLowering              = false
+	PrintRegisterAllocated                   = false
+	PrintFinalizedMachineCode                = false
 	PrintMachineCodeHexPerFunction           = printMachineCodeHexPerFunctionUnmodified || PrintMachineCodeHexPerFunctionDisassemblable //nolint
 	printMachineCodeHexPerFunctionUnmodified = false
 	// PrintMachineCodeHexPerFunctionDisassemblable prints the machine code while modifying the actual result
@@ -42,7 +42,7 @@ const (
 
 // printTarget is the function index to print the machine code. This is used for debugging to print the machine code
 // of a specific function.
-const printTarget = 23231
+const printTarget = -1
 
 // PrintEnabledIndex returns true if the current function index is the print target.
 func PrintEnabledIndex(ctx context.Context) bool {

--- a/internal/engine/wazevo/wazevoapi/perfmap.go
+++ b/internal/engine/wazevo/wazevoapi/perfmap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 )
 
 var PerfMap *Perfmap
@@ -25,19 +26,33 @@ func init() {
 // Perfmap holds perfmap entries to be flushed into a perfmap file.
 type Perfmap struct {
 	entries []entry
+	mux     sync.Mutex
 	fh      *os.File
 }
 
 type entry struct {
-	addr int64
-	size uint64
-	name string
+	index  int
+	offset int64
+	size   uint64
+	name   string
 }
 
-// AddEntry adds a new entry to the perfmap. Each entry contains the address,
-// the size and the name of the function.
-func (f *Perfmap) AddEntry(addr int64, size uint64, name string) {
-	e := entry{addr, size, name}
+func (f *Perfmap) Lock() {
+	f.mux.Lock()
+}
+
+func (f *Perfmap) Unlock() {
+	f.mux.Unlock()
+}
+
+// AddModuleEntry adds a perfmap entry into the perfmap file.
+// index is the index of the function in the module, offset is the offset of the function in the module,
+// size is the size of the function, and name is the name of the function.
+//
+// Note that the entries are not flushed into the perfmap file until Flush is called,
+// and the entries are module-scoped; Perfmap must be locked until Flush is called.
+func (f *Perfmap) AddModuleEntry(index int, offset int64, size uint64, name string) {
+	e := entry{index: index, offset: offset, size: size, name: name}
 	if f.entries == nil {
 		f.entries = []entry{e}
 		return
@@ -45,20 +60,32 @@ func (f *Perfmap) AddEntry(addr int64, size uint64, name string) {
 	f.entries = append(f.entries, e)
 }
 
-func (f *Perfmap) Clear() {
-	f.entries = f.entries[:0]
-}
-
-func (f *Perfmap) Flush(offset uintptr) {
+// Flush writes the perfmap entries into the perfmap file where the entries are adjusted by the given `addr` and `functionOffsets`.
+func (f *Perfmap) Flush(addr uintptr, functionOffsets []int) {
 	defer func() {
 		_ = f.fh.Sync()
 	}()
 
 	for _, e := range f.entries {
 		f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
-			uintptr(e.addr)+offset,
+			uintptr(e.offset)+addr+uintptr(functionOffsets[e.index]),
 			strconv.FormatUint(e.size, 16),
 			e.name,
 		))
 	}
+	f.entries = f.entries[:0]
+}
+
+// Clear clears the perfmap entries not yet flushed.
+func (f *Perfmap) Clear() {
+	f.entries = f.entries[:0]
+}
+
+// AddEntry writes a perfmap entry directly into the perfmap file, not using the entries.
+func (f *Perfmap) AddEntry(addr uintptr, size uint64, name string) {
+	f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
+		addr,
+		strconv.FormatUint(size, 16),
+		name,
+	))
 }

--- a/internal/engine/wazevo/wazevoapi/perfmap.go
+++ b/internal/engine/wazevo/wazevoapi/perfmap.go
@@ -14,7 +14,7 @@ func init() {
 		pid := os.Getpid()
 		filename := "/tmp/perf-" + strconv.Itoa(pid) + ".map"
 
-		fh, err := os.OpenFile(filename, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0644)
+		fh, err := os.OpenFile(filename, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0o644)
 		if err != nil {
 			panic(err)
 		}
@@ -67,11 +67,13 @@ func (f *Perfmap) Flush(addr uintptr, functionOffsets []int) {
 	}()
 
 	for _, e := range f.entries {
-		f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
+		if _, err := f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
 			uintptr(e.offset)+addr+uintptr(functionOffsets[e.index]),
 			strconv.FormatUint(e.size, 16),
 			e.name,
-		))
+		)); err != nil {
+			panic(err)
+		}
 	}
 	f.entries = f.entries[:0]
 }
@@ -83,9 +85,12 @@ func (f *Perfmap) Clear() {
 
 // AddEntry writes a perfmap entry directly into the perfmap file, not using the entries.
 func (f *Perfmap) AddEntry(addr uintptr, size uint64, name string) {
-	f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
+	_, err := f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
 		addr,
 		strconv.FormatUint(size, 16),
 		name,
 	))
+	if err != nil {
+		panic(err)
+	}
 }

--- a/internal/engine/wazevo/wazevoapi/perfmap.go
+++ b/internal/engine/wazevo/wazevoapi/perfmap.go
@@ -1,0 +1,64 @@
+package wazevoapi
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var PerfMap *Perfmap
+
+func init() {
+	if PerfMapEnabled {
+		pid := os.Getpid()
+		filename := "/tmp/perf-" + strconv.Itoa(pid) + ".map"
+
+		fh, err := os.OpenFile(filename, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0644)
+		if err != nil {
+			panic(err)
+		}
+
+		PerfMap = &Perfmap{fh: fh}
+	}
+}
+
+// Perfmap holds perfmap entries to be flushed into a perfmap file.
+type Perfmap struct {
+	entries []entry
+	fh      *os.File
+}
+
+type entry struct {
+	addr int64
+	size uint64
+	name string
+}
+
+// AddEntry adds a new entry to the perfmap. Each entry contains the address,
+// the size and the name of the function.
+func (f *Perfmap) AddEntry(addr int64, size uint64, name string) {
+	e := entry{addr, size, name}
+	if f.entries == nil {
+		f.entries = []entry{e}
+		return
+	}
+	f.entries = append(f.entries, e)
+}
+
+func (f *Perfmap) Clear() {
+	f.entries = f.entries[:0]
+}
+
+func (f *Perfmap) Flush(offset uintptr) {
+	defer func() {
+		_ = f.fh.Sync()
+	}()
+
+	for _, e := range f.entries {
+		f.fh.WriteString(fmt.Sprintf("%x %s %s\n",
+			uintptr(e.addr)+offset,
+			strconv.FormatUint(e.size, 16),
+			e.name,
+		))
+	}
+}

--- a/internal/engine/wazevo/wazevoapi/perfmap_disabled.go
+++ b/internal/engine/wazevo/wazevoapi/perfmap_disabled.go
@@ -1,0 +1,5 @@
+//go:build !perfmap
+
+package wazevoapi
+
+const PerfMapEnabled = false

--- a/internal/engine/wazevo/wazevoapi/perfmap_enabled.go
+++ b/internal/engine/wazevo/wazevoapi/perfmap_enabled.go
@@ -1,0 +1,5 @@
+//go:build perfmap
+
+package wazevoapi
+
+const PerfMapEnabled = true


### PR DESCRIPTION
This allows us to check per-basic block based hot paths perf like the below:
![image](https://github.com/tetratelabs/wazero/assets/13513977/498a0a2f-6beb-4a9c-a60b-ceca10febdc1)

