### PR TITLE
wasi: sockets, use WSAPoll and GetOverlappedResult on Windows

### DIFF
--- a/internal/sysfs/file_windows.go
+++ b/internal/sysfs/file_windows.go
@@ -81,7 +81,6 @@ func readSocket(h uintptr, buf []byte) (int, sys.Errno) {
 	//
 	// We are currently skipping checking if hFile was opened with FILE_FLAG_OVERLAPPED but using
 	// both lpOverlapped and lpNumberOfBytesRead.
-
 	var overlapped syscall.Overlapped
 
 	// Create an event to wait on.
@@ -98,12 +97,6 @@ func readSocket(h uintptr, buf []byte) (int, sys.Errno) {
 		if errno != nil {
 			return 0, sys.UnwrapOSError(errno) // This is a fatal error. CancelIo failed.
 		}
-		// // Temp Fix: This is to make sure that I/O is cancelled before we wait for it.
-		// // Otherwise, we may still see ERROR_IO_PENDING.
-		// //
-		// // Disabled: This is not a good fix since it does not address the root cause.
-		// // And the alleged bug cannot be reproduced in any test.
-		// time.Sleep(1 * time.Nanosecond)
 
 		done, errno = getOverlappedResult(syscall.Handle(h), &overlapped, true) // wait for I/O to complete(cancel or finish). Overwrite done and errno.
 		if errors.Is(errno, syscall.ERROR_OPERATION_ABORTED) {

--- a/internal/sysfs/sock_test.go
+++ b/internal/sysfs/sock_test.go
@@ -48,6 +48,8 @@ func TestTcpConnFile_Write(t *testing.T) {
 }
 
 func TestTcpConnFile_Read(t *testing.T) {
+	// Test #1: Read from a TCP connection with default synchrony
+	// (i.e., without explicitly setting the non-blocking flag).
 	listen, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listen.Close()
@@ -83,6 +85,51 @@ func TestTcpConnFile_Read(t *testing.T) {
 	require.Zero(t, errno)
 	require.NoError(t, err)
 	require.Equal(t, "waze", string(bytes))
+
+	// Test #2: Read from a TCP connection asynchronously (i.e., with
+	// the non-blocking flag set explicitly).
+	tcpAddr2, err := net.ResolveTCPAddr("tcp", listen.Addr().String())
+	require.NoError(t, err)
+	tcp2, err := net.DialTCP("tcp", nil, tcpAddr2)
+	require.NoError(t, err)
+	defer tcp.Close() //nolint
+
+	// use a goroutine to asynchronously write to the TCP connection
+	// with a delay that is visible to the test.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		n2, err := tcp2.Write([]byte("wazero"))
+		require.NoError(t, err)
+		require.NotEqual(t, 0, n2)
+	}()
+
+	conn2, err := listen.Accept()
+	require.NoError(t, err)
+	defer conn.Close()
+
+	bytes2 := make([]byte, 4)
+
+	require.NoError(t, err)
+	errno2 := sys.Errno(0)
+	file2 := newTcpConn(conn2.(*net.TCPConn))
+	errno2 = file2.(*tcpConnFile).SetNonblock(true)
+	require.Zero(t, errno2)
+
+	// Ensure we start by getting EAGAIN.
+	_, errno2 = file2.Read(bytes2)
+	require.Equal(t, sys.EAGAIN, errno2)
+
+	// Ensure we don't interrupt until we get a non-zero errno,
+	// and we retry on EAGAIN (i.e. when nonblocking is true).
+	for {
+		_, errno2 = file2.Read(bytes2)
+		if errno2 != sys.EAGAIN {
+			break
+		}
+	}
+	require.Zero(t, errno2)
+	require.NoError(t, err)
+	require.Equal(t, "waze", string(bytes2))
 }
 
 func TestTcpConnFile_Stat(t *testing.T) {

--- a/internal/sysfs/sock_test.go
+++ b/internal/sysfs/sock_test.go
@@ -94,7 +94,7 @@ func TestTcpConnFile_Read(t *testing.T) {
 	require.NoError(t, err)
 	defer tcp.Close() //nolint
 
-	// use a goroutine to asynchronously write to the TCP connection
+	// Use a goroutine to asynchronously write to the TCP connection
 	// with a delay that is visible to the test.
 	go func() {
 		time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
Current `readSocket` function for WASI sockets is implemented incorrectly on Windows and WASI polling an async socket for a long time will eventually get `ERROR_WORKING_SET_QUOTA` (1453):

```
Insufficient quota to complete the requested service.
```

A call to `GetOverlappedResult` is expected after each `ERROR_IO_PENDING` returned by `ReadFile` and that is what's missing in the current implementation. Besides that, `ReadFile` would create a background worker to keep on trying reading from the handle into the `buf`, which could result in data loss if we don't keep tracking of it. So we add a call to `WSAPoll` before calling `ReadFile` to observe how many bytes are ready to be read. 

In this pull request, we modify how `readSocket` in `internal/sysfs/file_windows.go` is implemented by adding the following changes: 
- [x] Call `WSAPoll` before calling `ReadFile`, abort if ~no bytes are available~ no fd is ready to be read. 
- [x] Call `GetOverlappedResult` if `ReadFile` returns `ERROR_IO_PENDING`. 
- [x] ~Limit the read buffer's size according to how many bytes are ready to be read (see review comments)~ 
- [x] Cancel the ongoing overlapped read if it cannot be completed immediately.