### PR TITLE
wazevo(amd64): encode unaryRmR, not, neg, mulHi, shiftR

### DIFF
--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -880,7 +880,7 @@ func (s shiftROp) String() string {
 	case shiftROpShiftRightLogical:
 		return "shr"
 	case shiftROpShiftRightArithmetic:
-		return "shiftRightArithmetic"
+		return "sar"
 	default:
 		panic("BUG")
 	}

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -76,7 +76,11 @@ func (i *instruction) String() string {
 	case div:
 		panic("TODO")
 	case mulHi:
-		panic("TODO")
+		if i.u1 != 0 {
+			return fmt.Sprintf("imul %s", i.op1.format(i.b1))
+		} else {
+			return fmt.Sprintf("mul %s", i.op1.format(i.b1))
+		}
 	case checkedDivOrRemSeq:
 		panic("TODO")
 	case signExtendData:
@@ -710,6 +714,19 @@ func (i *instruction) asNeg(rm operand, _64 bool) *instruction {
 	i.kind = neg
 	i.op1 = rm
 	i.b1 = _64
+	return i
+}
+
+func (i *instruction) asMulHi(rm operand, signed, _64 bool) *instruction {
+	if rm.kind != operandKindReg && rm.kind != operandKindMem {
+		panic("BUG")
+	}
+	i.kind = mulHi
+	i.op1 = rm
+	i.b1 = _64
+	if signed {
+		i.u1 = 1
+	}
 	return i
 }
 

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -70,9 +70,9 @@ func (i *instruction) String() string {
 	case unaryRmR:
 		return fmt.Sprintf("%s %s, %s", unaryRmROpcode(i.u1), i.op1.format(i.b1), i.op2.format(i.b1))
 	case not:
-		panic("TODO")
+		return fmt.Sprintf("not %s", i.op1.format(i.b1))
 	case neg:
-		panic("TODO")
+		return fmt.Sprintf("neg %s", i.op1.format(i.b1))
 	case div:
 		panic("TODO")
 	case mulHi:
@@ -693,13 +693,22 @@ func (i *instruction) asMovRR(rm, rd regalloc.VReg, _64 bool) *instruction {
 	return i
 }
 
-func (i *instruction) asNot(rm operand, rd regalloc.VReg, _64 bool) *instruction {
+func (i *instruction) asNot(rm operand, _64 bool) *instruction {
 	if rm.kind != operandKindReg && rm.kind != operandKindMem {
 		panic("BUG")
 	}
 	i.kind = not
 	i.op1 = rm
-	i.op2 = newOperandReg(rd)
+	i.b1 = _64
+	return i
+}
+
+func (i *instruction) asNeg(rm operand, _64 bool) *instruction {
+	if rm.kind != operandKindReg && rm.kind != operandKindMem {
+		panic("BUG")
+	}
+	i.kind = neg
+	i.op1 = rm
 	i.b1 = _64
 	return i
 }

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -68,7 +68,7 @@ func (i *instruction) String() string {
 	case xmmUnaryRmR:
 		return fmt.Sprintf("%s %s, %s", sseOpcode(i.u1), i.op1.format(i.b1), i.op2.format(i.b1))
 	case unaryRmR:
-		panic("TODO")
+		return fmt.Sprintf("%s %s, %s", unaryRmROpcode(i.u1), i.op1.format(i.b1), i.op2.format(i.b1))
 	case not:
 		panic("TODO")
 	case neg:
@@ -693,6 +693,29 @@ func (i *instruction) asMovRR(rm, rd regalloc.VReg, _64 bool) *instruction {
 	return i
 }
 
+func (i *instruction) asNot(rm operand, rd regalloc.VReg, _64 bool) *instruction {
+	if rm.kind != operandKindReg && rm.kind != operandKindMem {
+		panic("BUG")
+	}
+	i.kind = not
+	i.op1 = rm
+	i.op2 = newOperandReg(rd)
+	i.b1 = _64
+	return i
+}
+
+func (i *instruction) asUnaryRmR(op unaryRmROpcode, rm operand, rd regalloc.VReg, _64 bool) *instruction {
+	if rm.kind != operandKindReg && rm.kind != operandKindMem {
+		panic("BUG")
+	}
+	i.kind = unaryRmR
+	i.op1 = rm
+	i.op2 = newOperandReg(rd)
+	i.u1 = uint64(op)
+	i.b1 = _64
+	return i
+}
+
 func (i *instruction) asXmmUnaryRmR(op sseOpcode, rm operand, rd regalloc.VReg, _64 bool) *instruction {
 	if rm.kind != operandKindReg && rm.kind != operandKindMem {
 		panic("BUG")
@@ -729,6 +752,33 @@ func (i *instruction) asPush64(op operand) *instruction {
 	i.kind = push64
 	i.op1 = op
 	return i
+}
+
+type unaryRmROpcode byte
+
+const (
+	unaryRmROpcodeBsr unaryRmROpcode = iota
+	unaryRmROpcodeBsf
+	unaryRmROpcodeLzcnt
+	unaryRmROpcodeTzcnt
+	unaryRmROpcodePopcnt
+)
+
+func (u unaryRmROpcode) String() string {
+	switch u {
+	case unaryRmROpcodeBsr:
+		return "bsr"
+	case unaryRmROpcodeBsf:
+		return "bsf"
+	case unaryRmROpcodeLzcnt:
+		return "lzcnt"
+	case unaryRmROpcodeTzcnt:
+		return "tzcnt"
+	case unaryRmROpcodePopcnt:
+		return "popcnt"
+	default:
+		panic("BUG")
+	}
 }
 
 type sseOpcode byte

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -68,7 +68,13 @@ func (i *instruction) String() string {
 	case xmmUnaryRmR:
 		return fmt.Sprintf("%s %s, %s", sseOpcode(i.u1), i.op1.format(i.b1), i.op2.format(i.b1))
 	case unaryRmR:
-		return fmt.Sprintf("%s %s, %s", unaryRmROpcode(i.u1), i.op1.format(i.b1), i.op2.format(i.b1))
+		var suffix string
+		if i.b1 {
+			suffix = "q"
+		} else {
+			suffix = "l"
+		}
+		return fmt.Sprintf("%s%s %s, %s", unaryRmROpcode(i.u1), suffix, i.op1.format(i.b1), i.op2.format(i.b1))
 	case not:
 		var op string
 		if i.b1 {

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -738,7 +738,7 @@ func (i *instruction) asNeg(rm operand, _64 bool) *instruction {
 }
 
 func (i *instruction) asMulHi(rm operand, signed, _64 bool) *instruction {
-	if rm.kind != operandKindReg && rm.kind != operandKindMem {
+	if rm.kind != operandKindReg && (rm.kind != operandKindMem || _64) {
 		panic("BUG")
 	}
 	i.kind = mulHi

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -872,9 +872,9 @@ const (
 func (s shiftROp) String() string {
 	switch s {
 	case shiftROpRotateLeft:
-		return "rotateLeft"
+		return "rol"
 	case shiftROpRotateRight:
-		return "rotateRight"
+		return "ror"
 	case shiftROpShiftLeft:
 		return "shl"
 	case shiftROpShiftRightLogical:

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -127,26 +127,12 @@ func (i *instruction) String() string {
 		}
 		return fmt.Sprintf("mov.%s %s, %s", suffix, i.op1.format(true), i.op2.format(true))
 	case shiftR:
-		_, _64 := i.u1 != 0, i.b1
-
 		var suffix string
-		if _64 {
+		if i.b1 {
 			suffix = "q"
 		} else {
 			suffix = "l"
 		}
-
-		//var op string
-		//switch {
-		//case signed && _64:
-		//	op = "sal"
-		//case !signed && _64:
-		//	op = "sar"
-		//case signed && !_64:
-		//	op = "shl"
-		//case !signed && !_64:
-		//	op = "shr"
-		//}
 		return fmt.Sprintf("%s%s %s, %s", shiftROp(i.u1), suffix, i.op1.format(false), i.op2.format(i.b1))
 	case xmmRmiReg:
 		panic("TODO")

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -878,7 +878,7 @@ func (s shiftROp) String() string {
 	case shiftROpShiftLeft:
 		return "shl"
 	case shiftROpShiftRightLogical:
-		return "shiftRightLogical"
+		return "shr"
 	case shiftROpShiftRightArithmetic:
 		return "shiftRightArithmetic"
 	default:

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -744,7 +744,7 @@ func (i *instruction) asNeg(rm operand, _64 bool) *instruction {
 }
 
 func (i *instruction) asMulHi(rm operand, signed, _64 bool) *instruction {
-	if rm.kind != operandKindReg && (rm.kind != operandKindMem || _64) {
+	if rm.kind != operandKindReg && (rm.kind != operandKindMem) {
 		panic("BUG")
 	}
 	i.kind = mulHi

--- a/internal/engine/wazevo/backend/isa/amd64/instr.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr.go
@@ -70,17 +70,37 @@ func (i *instruction) String() string {
 	case unaryRmR:
 		return fmt.Sprintf("%s %s, %s", unaryRmROpcode(i.u1), i.op1.format(i.b1), i.op2.format(i.b1))
 	case not:
-		return fmt.Sprintf("not %s", i.op1.format(i.b1))
+		var op string
+		if i.b1 {
+			op = "notq"
+		} else {
+			op = "notl"
+		}
+		return fmt.Sprintf("%s %s", op, i.op1.format(i.b1))
 	case neg:
-		return fmt.Sprintf("neg %s", i.op1.format(i.b1))
+		var op string
+		if i.b1 {
+			op = "negq"
+		} else {
+			op = "negl"
+		}
+		return fmt.Sprintf("%s %s", op, i.op1.format(i.b1))
 	case div:
 		panic("TODO")
 	case mulHi:
-		if i.u1 != 0 {
-			return fmt.Sprintf("imul %s", i.op1.format(i.b1))
-		} else {
-			return fmt.Sprintf("mul %s", i.op1.format(i.b1))
+		signed, _64 := i.u1 != 0, i.b1
+		var op string
+		switch {
+		case signed && _64:
+			op = "imulq"
+		case !signed && _64:
+			op = "mulq"
+		case signed && !_64:
+			op = "imull"
+		case !signed && !_64:
+			op = "mull"
 		}
+		return fmt.Sprintf("%s %s", op, i.op1.format(i.b1))
 	case checkedDivOrRemSeq:
 		panic("TODO")
 	case signExtendData:

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
@@ -493,21 +493,28 @@ func (i *instruction) encode(c backend.Compiler) (needsLabelResolution bool) {
 
 	case not:
 		var prefix legacyPrefixes
-		var opcode uint32
-
-		src, dst := regEncodings[i.op1.r.RealReg()], regEncodings[i.op2.r.RealReg()]
-
+		src := regEncodings[i.op1.r.RealReg()]
 		rex := rexInfo(0)
 		if i.b1 { // 64 bit.
 			rex = rexInfo(0).setW()
 		} else {
 			rex = rexInfo(0).clearW()
 		}
-
-		encodeRegReg(c, prefix, opcode, 1, src, dst, rex)
+		subopcode := regEnc(2)
+		encodeRegReg(c, prefix, 0xf7, 1, subopcode, src, rex)
 
 	case neg:
-		panic("TODO")
+		var prefix legacyPrefixes
+		src := regEncodings[i.op1.r.RealReg()]
+		rex := rexInfo(0)
+		if i.b1 { // 64 bit.
+			rex = rexInfo(0).setW()
+		} else {
+			rex = rexInfo(0).clearW()
+		}
+		subopcode := regEnc(3)
+		encodeRegReg(c, prefix, 0xf7, 1, subopcode, src, rex)
+
 	case div:
 		panic("TODO")
 	case mulHi:

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding.go
@@ -1061,7 +1061,7 @@ func (r regEnc) encoding() byte {
 }
 
 func regRexBit(r byte) byte {
-	return r >> 3 & 1
+	return r >> 3
 }
 
 func regEncoding(r byte) byte {

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -1903,6 +1903,34 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "48c1e780",
 			wantFormat: "shlq $128, %rdi",
 		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightLogical, newOperandReg(rcxVReg), rdiVReg, false)
+			},
+			want:       "d3ef",
+			wantFormat: "shrl %ecx, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightLogical, newOperandImm32(128), rdiVReg, false)
+			},
+			want:       "c1ef80",
+			wantFormat: "shrl $128, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightLogical, newOperandReg(rcxVReg), rdiVReg, true)
+			},
+			want:       "48d3ef",
+			wantFormat: "shrq %ecx, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightLogical, newOperandImm32(128), rdiVReg, true)
+			},
+			want:       "48c1ef80",
+			wantFormat: "shrq $128, %rdi",
+		},
 	} {
 		tc := tc
 		t.Run(tc.wantFormat, func(t *testing.T) {

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -100,6 +100,66 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "4d89dc",
 			wantFormat: "movq %r11, %r12",
 		},
+		// bsr
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, false) },
+			want:       "0fbdf8",
+			wantFormat: "bsr %eax, %edi",
+		},
+		// bsf
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsf, newOperandReg(raxVReg), rdiVReg, false) },
+			want:       "0fbcf8",
+			wantFormat: "bsf %eax, %edi",
+		},
+		// tzcnt
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeTzcnt, newOperandReg(raxVReg), rdiVReg, false) },
+			want:       "f30fbcf8",
+			wantFormat: "tzcnt %eax, %edi",
+		},
+		// lzcnt
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeLzcnt, newOperandReg(raxVReg), rdiVReg, false) },
+			want:       "f30fbdf8",
+			wantFormat: "lzcnt %eax, %edi",
+		},
+		// popcnt
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodePopcnt, newOperandReg(raxVReg), rdiVReg, false) },
+			want:       "f30fb8f8",
+			wantFormat: "popcnt %eax, %edi",
+		},
+		// bsr
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, true) },
+			want:       "480fbdf8",
+			wantFormat: "bsr %rax, %rdi",
+		},
+		// bsf
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsf, newOperandReg(raxVReg), rdiVReg, true) },
+			want:       "480fbcf8",
+			wantFormat: "bsf %rax, %rdi",
+		},
+		// tzcnt
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeTzcnt, newOperandReg(raxVReg), rdiVReg, true) },
+			want:       "f3480fbcf8",
+			wantFormat: "tzcnt %rax, %rdi",
+		},
+		// lzcnt
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeLzcnt, newOperandReg(raxVReg), rdiVReg, true) },
+			want:       "f3480fbdf8",
+			wantFormat: "lzcnt %rax, %rdi",
+		},
+		// popcnt
+		{
+			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodePopcnt, newOperandReg(raxVReg), rdiVReg, true) },
+			want:       "f3480fb8f8",
+			wantFormat: "popcnt %rax, %rdi",
+		},
 		// addss
 		{
 			setup:      func(i *instruction) { i.asXmmRmR(sseOpcodeAddss, newOperandReg(xmm1VReg), xmm0VReg, true) },

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -1875,6 +1875,34 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "66440f11797b",
 			wantFormat: "movupd %xmm15, 123(%rcx)",
 		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftLeft, newOperandReg(rcxVReg), rdiVReg, false)
+			},
+			want:       "d3e7",
+			wantFormat: "shll %ecx, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftLeft, newOperandImm32(128), rdiVReg, false)
+			},
+			want:       "c1e780",
+			wantFormat: "shll $128, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftLeft, newOperandReg(rcxVReg), rdiVReg, true)
+			},
+			want:       "48d3e7",
+			wantFormat: "shlq %ecx, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftLeft, newOperandImm32(128), rdiVReg, true)
+			},
+			want:       "48c1e780",
+			wantFormat: "shlq $128, %rdi",
+		},
 	} {
 		tc := tc
 		t.Run(tc.wantFormat, func(t *testing.T) {

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -100,6 +100,26 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "4d89dc",
 			wantFormat: "movq %r11, %r12",
 		},
+		{
+			setup:      func(i *instruction) { i.asNot(newOperandReg(raxVReg), false) },
+			want:       "f7d0",
+			wantFormat: "not %eax",
+		},
+		{
+			setup:      func(i *instruction) { i.asNot(newOperandReg(raxVReg), true) },
+			want:       "48f7d0",
+			wantFormat: "not %rax",
+		},
+		{
+			setup:      func(i *instruction) { i.asNeg(newOperandReg(raxVReg), false) },
+			want:       "f7d8",
+			wantFormat: "neg %eax",
+		},
+		{
+			setup:      func(i *instruction) { i.asNeg(newOperandReg(raxVReg), true) },
+			want:       "48f7d8",
+			wantFormat: "neg %rax",
+		},
 		// bsr
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, false) },

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -103,62 +103,62 @@ func TestInstruction_format_encode(t *testing.T) {
 		{
 			setup:      func(i *instruction) { i.asNot(newOperandReg(raxVReg), false) },
 			want:       "f7d0",
-			wantFormat: "not %eax",
+			wantFormat: "notl %eax",
 		},
 		{
 			setup:      func(i *instruction) { i.asNot(newOperandReg(raxVReg), true) },
 			want:       "48f7d0",
-			wantFormat: "not %rax",
+			wantFormat: "notq %rax",
 		},
 		{
 			setup:      func(i *instruction) { i.asNeg(newOperandReg(raxVReg), false) },
 			want:       "f7d8",
-			wantFormat: "neg %eax",
+			wantFormat: "negl %eax",
 		},
 		{
 			setup:      func(i *instruction) { i.asNeg(newOperandReg(raxVReg), true) },
 			want:       "48f7d8",
-			wantFormat: "neg %rax",
+			wantFormat: "negq %rax",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandReg(rsiVReg), true, false) },
 			want:       "f7ee",
-			wantFormat: "imul %esi",
+			wantFormat: "imull %esi",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandReg(r14VReg), false, false) },
 			want:       "41f7e6",
-			wantFormat: "mul %r14d",
+			wantFormat: "mull %r14d",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandReg(r15VReg), true, true) },
 			want:       "49f7ef",
-			wantFormat: "imul %r15",
+			wantFormat: "imulq %r15",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandReg(rdiVReg), false, true) },
 			want:       "48f7e7",
-			wantFormat: "mul %rdi",
+			wantFormat: "mulq %rdi",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, false) },
 			want:       "f76f7b",
-			wantFormat: "imul 123(%edi)",
+			wantFormat: "imull 123(%rdi)",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, false) },
 			want:       "f7677b",
-			wantFormat: "mul 123(%edi)",
+			wantFormat: "mull 123(%rdi)",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, true) },
 			want:       "48f76f7b",
-			wantFormat: "imul 123(%rdi)",
+			wantFormat: "imulq 123(%rdi)",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, true) },
 			want:       "48f7677b",
-			wantFormat: "mul 123(%rdi)",
+			wantFormat: "mulq 123(%rdi)",
 		},
 		// bsr
 		{

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -1877,6 +1877,62 @@ func TestInstruction_format_encode(t *testing.T) {
 		},
 		{
 			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateLeft, newOperandReg(rcxVReg), rdiVReg, false)
+			},
+			want:       "d3c7",
+			wantFormat: "roll %ecx, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateLeft, newOperandImm32(128), rdiVReg, false)
+			},
+			want:       "c1c780",
+			wantFormat: "roll $128, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateLeft, newOperandReg(rcxVReg), rdiVReg, true)
+			},
+			want:       "48d3c7",
+			wantFormat: "rolq %ecx, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateLeft, newOperandImm32(128), rdiVReg, true)
+			},
+			want:       "48c1c780",
+			wantFormat: "rolq $128, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateRight, newOperandReg(rcxVReg), rdiVReg, false)
+			},
+			want:       "d3cf",
+			wantFormat: "rorl %ecx, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateRight, newOperandImm32(128), rdiVReg, false)
+			},
+			want:       "c1cf80",
+			wantFormat: "rorl $128, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateRight, newOperandReg(rcxVReg), rdiVReg, true)
+			},
+			want:       "48d3cf",
+			wantFormat: "rorq %ecx, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpRotateRight, newOperandImm32(128), rdiVReg, true)
+			},
+			want:       "48c1cf80",
+			wantFormat: "rorq $128, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
 				i.asShiftR(shiftROpShiftLeft, newOperandReg(rcxVReg), rdiVReg, false)
 			},
 			want:       "d3e7",

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -140,26 +140,6 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "48f7e7",
 			wantFormat: "mulq %rdi",
 		},
-		{
-			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, false) },
-			want:       "f76f7b",
-			wantFormat: "imull 123(%edi)",
-		},
-		{
-			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, false) },
-			want:       "f7677b",
-			wantFormat: "mull 123(%edi)",
-		},
-		{
-			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, true) },
-			want:       "48f76f7b",
-			wantFormat: "imulq 123(%rdi)",
-		},
-		{
-			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, true) },
-			want:       "48f7677b",
-			wantFormat: "mulq 123(%rdi)",
-		},
 		// bsr
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, false) },

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -140,6 +140,26 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "48f7e7",
 			wantFormat: "mulq %rdi",
 		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, raxVReg)), true, false) },
+			want:       "f7687b",
+			wantFormat: "imull 123(%rax)",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, raxVReg)), false, false) },
+			want:       "f7607b",
+			wantFormat: "mull 123(%rax)",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, raxVReg)), true, true) },
+			want:       "48f7687b",
+			wantFormat: "imulq 123(%rax)",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, raxVReg)), false, true) },
+			want:       "48f7607b",
+			wantFormat: "mulq 123(%rax)",
+		},
 		// bsr
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, false) },

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -164,61 +164,131 @@ func TestInstruction_format_encode(t *testing.T) {
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, false) },
 			want:       "0fbdf8",
-			wantFormat: "bsr %eax, %edi",
+			wantFormat: "bsrl %eax, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeBsr, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, false)
+			},
+			want:       "0fbd787b",
+			wantFormat: "bsrl 123(%rax), %edi",
 		},
 		// bsf
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsf, newOperandReg(raxVReg), rdiVReg, false) },
 			want:       "0fbcf8",
-			wantFormat: "bsf %eax, %edi",
+			wantFormat: "bsfl %eax, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeBsf, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, false)
+			},
+			want:       "0fbc787b",
+			wantFormat: "bsfl 123(%rax), %edi",
 		},
 		// tzcnt
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeTzcnt, newOperandReg(raxVReg), rdiVReg, false) },
 			want:       "f30fbcf8",
-			wantFormat: "tzcnt %eax, %edi",
+			wantFormat: "tzcntl %eax, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeTzcnt, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, false)
+			},
+			want:       "f30fbc787b",
+			wantFormat: "tzcntl 123(%rax), %edi",
 		},
 		// lzcnt
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeLzcnt, newOperandReg(raxVReg), rdiVReg, false) },
 			want:       "f30fbdf8",
-			wantFormat: "lzcnt %eax, %edi",
+			wantFormat: "lzcntl %eax, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeLzcnt, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, false)
+			},
+			want:       "f30fbd787b",
+			wantFormat: "lzcntl 123(%rax), %edi",
 		},
 		// popcnt
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodePopcnt, newOperandReg(raxVReg), rdiVReg, false) },
 			want:       "f30fb8f8",
-			wantFormat: "popcnt %eax, %edi",
+			wantFormat: "popcntl %eax, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodePopcnt, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, false)
+			},
+			want:       "f30fb8787b",
+			wantFormat: "popcntl 123(%rax), %edi",
 		},
 		// bsr
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, true) },
 			want:       "480fbdf8",
-			wantFormat: "bsr %rax, %rdi",
+			wantFormat: "bsrq %rax, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeBsr, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, true)
+			},
+			want:       "480fbd787b",
+			wantFormat: "bsrq 123(%rax), %rdi",
 		},
 		// bsf
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsf, newOperandReg(raxVReg), rdiVReg, true) },
 			want:       "480fbcf8",
-			wantFormat: "bsf %rax, %rdi",
+			wantFormat: "bsfq %rax, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeBsf, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, true)
+			},
+			want:       "480fbc787b",
+			wantFormat: "bsfq 123(%rax), %rdi",
 		},
 		// tzcnt
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeTzcnt, newOperandReg(raxVReg), rdiVReg, true) },
 			want:       "f3480fbcf8",
-			wantFormat: "tzcnt %rax, %rdi",
+			wantFormat: "tzcntq %rax, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeTzcnt, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, true)
+			},
+			want:       "f3480fbc787b",
+			wantFormat: "tzcntq 123(%rax), %rdi",
 		},
 		// lzcnt
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeLzcnt, newOperandReg(raxVReg), rdiVReg, true) },
 			want:       "f3480fbdf8",
-			wantFormat: "lzcnt %rax, %rdi",
+			wantFormat: "lzcntq %rax, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodeLzcnt, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, true)
+			},
+			want:       "f3480fbd787b",
+			wantFormat: "lzcntq 123(%rax), %rdi",
 		},
 		// popcnt
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodePopcnt, newOperandReg(raxVReg), rdiVReg, true) },
 			want:       "f3480fb8f8",
-			wantFormat: "popcnt %rax, %rdi",
+			wantFormat: "popcntq %rax, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asUnaryRmR(unaryRmROpcodePopcnt, newOperandMem(newAmodeImmReg(123, raxVReg)), rdiVReg, true)
+			},
+			want:       "f3480fb8787b",
+			wantFormat: "popcntq 123(%rax), %rdi",
 		},
 		// addss
 		{

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -1931,6 +1931,34 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "48c1ef80",
 			wantFormat: "shrq $128, %rdi",
 		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightArithmetic, newOperandReg(rcxVReg), rdiVReg, false)
+			},
+			want:       "d3ff",
+			wantFormat: "sarl %ecx, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightArithmetic, newOperandImm32(128), rdiVReg, false)
+			},
+			want:       "c1ff80",
+			wantFormat: "sarl $128, %edi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightArithmetic, newOperandReg(rcxVReg), rdiVReg, true)
+			},
+			want:       "48d3ff",
+			wantFormat: "sarq %ecx, %rdi",
+		},
+		{
+			setup: func(i *instruction) {
+				i.asShiftR(shiftROpShiftRightArithmetic, newOperandImm32(128), rdiVReg, true)
+			},
+			want:       "48c1ff80",
+			wantFormat: "sarq $128, %rdi",
+		},
 	} {
 		tc := tc
 		t.Run(tc.wantFormat, func(t *testing.T) {

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -120,6 +120,46 @@ func TestInstruction_format_encode(t *testing.T) {
 			want:       "48f7d8",
 			wantFormat: "neg %rax",
 		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandReg(rsiVReg), true, false) },
+			want:       "f7ee",
+			wantFormat: "imul %esi",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandReg(r14VReg), false, false) },
+			want:       "41f7e6",
+			wantFormat: "mul %r14d",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandReg(r15VReg), true, true) },
+			want:       "49f7ef",
+			wantFormat: "imul %r15",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandReg(rdiVReg), false, true) },
+			want:       "48f7e7",
+			wantFormat: "mul %rdi",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, false) },
+			want:       "f76f7b",
+			wantFormat: "imul 123(%edi)",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, false) },
+			want:       "f7677b",
+			wantFormat: "mul 123(%edi)",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, true) },
+			want:       "48f76f7b",
+			wantFormat: "imul 123(%rdi)",
+		},
+		{
+			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, true) },
+			want:       "48f7677b",
+			wantFormat: "mul 123(%rdi)",
+		},
 		// bsr
 		{
 			setup:      func(i *instruction) { i.asUnaryRmR(unaryRmROpcodeBsr, newOperandReg(raxVReg), rdiVReg, false) },

--- a/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/instr_encoding_test.go
@@ -143,12 +143,12 @@ func TestInstruction_format_encode(t *testing.T) {
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, false) },
 			want:       "f76f7b",
-			wantFormat: "imull 123(%rdi)",
+			wantFormat: "imull 123(%edi)",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), false, false) },
 			want:       "f7677b",
-			wantFormat: "mull 123(%rdi)",
+			wantFormat: "mull 123(%edi)",
 		},
 		{
 			setup:      func(i *instruction) { i.asMulHi(newOperandMem(newAmodeImmReg(123, rdiVReg)), true, true) },

--- a/internal/engine/wazevo/backend/isa/amd64/operands.go
+++ b/internal/engine/wazevo/backend/isa/amd64/operands.go
@@ -52,7 +52,7 @@ func (o *operand) format(_64 bool) string {
 	case operandKindReg:
 		return formatVRegSized(o.r, _64)
 	case operandKindMem:
-		return o.amode.String()
+		return o.amode.format(_64)
 	case operandKindImm32:
 		return fmt.Sprintf("$%d", int32(o.imm32))
 	case operandKindLabel:
@@ -171,22 +171,22 @@ func newAmodeRipRelative(label backend.Label) amode {
 }
 
 // String implements fmt.Stringer.
-func (a *amode) String() string {
+func (a *amode) format(_64 bool) string {
 	switch a.kind {
 	case amodeImmReg:
 		if a.imm32 == 0 {
-			return fmt.Sprintf("(%s)", formatVRegSized(a.base, true))
+			return fmt.Sprintf("(%s)", formatVRegSized(a.base, _64))
 		}
-		return fmt.Sprintf("%d(%s)", int32(a.imm32), formatVRegSized(a.base, true))
+		return fmt.Sprintf("%d(%s)", int32(a.imm32), formatVRegSized(a.base, _64))
 	case amodeRegRegShift:
 		if a.imm32 == 0 {
 			return fmt.Sprintf(
 				"(%s,%s,%d)",
-				formatVRegSized(a.base, true), formatVRegSized(a.index, true), 1<<a.shift)
+				formatVRegSized(a.base, true), formatVRegSized(a.index, _64), 1<<a.shift)
 		}
 		return fmt.Sprintf(
 			"%d(%s,%s,%d)",
-			int32(a.imm32), formatVRegSized(a.base, true), formatVRegSized(a.index, true), 1<<a.shift)
+			int32(a.imm32), formatVRegSized(a.base, _64), formatVRegSized(a.index, _64), 1<<a.shift)
 	case amodeRipRelative:
 		if a.label != backend.LabelInvalid {
 			return fmt.Sprintf("%s(%%rip)", a.label)

--- a/internal/engine/wazevo/backend/isa/amd64/operands.go
+++ b/internal/engine/wazevo/backend/isa/amd64/operands.go
@@ -52,7 +52,7 @@ func (o *operand) format(_64 bool) string {
 	case operandKindReg:
 		return formatVRegSized(o.r, _64)
 	case operandKindMem:
-		return o.amode.format(_64)
+		return o.amode.String()
 	case operandKindImm32:
 		return fmt.Sprintf("$%d", int32(o.imm32))
 	case operandKindLabel:
@@ -171,22 +171,22 @@ func newAmodeRipRelative(label backend.Label) amode {
 }
 
 // String implements fmt.Stringer.
-func (a *amode) format(_64 bool) string {
+func (a *amode) String() string {
 	switch a.kind {
 	case amodeImmReg:
 		if a.imm32 == 0 {
-			return fmt.Sprintf("(%s)", formatVRegSized(a.base, _64))
+			return fmt.Sprintf("(%s)", formatVRegSized(a.base, true))
 		}
-		return fmt.Sprintf("%d(%s)", int32(a.imm32), formatVRegSized(a.base, _64))
+		return fmt.Sprintf("%d(%s)", int32(a.imm32), formatVRegSized(a.base, true))
 	case amodeRegRegShift:
 		if a.imm32 == 0 {
 			return fmt.Sprintf(
 				"(%s,%s,%d)",
-				formatVRegSized(a.base, true), formatVRegSized(a.index, _64), 1<<a.shift)
+				formatVRegSized(a.base, true), formatVRegSized(a.index, true), 1<<a.shift)
 		}
 		return fmt.Sprintf(
 			"%d(%s,%s,%d)",
-			int32(a.imm32), formatVRegSized(a.base, _64), formatVRegSized(a.index, _64), 1<<a.shift)
+			int32(a.imm32), formatVRegSized(a.base, true), formatVRegSized(a.index, true), 1<<a.shift)
 	case amodeRipRelative:
 		if a.label != backend.LabelInvalid {
 			return fmt.Sprintf("%s(%%rip)", a.label)


### PR DESCRIPTION
- arm64: encode unaryRmR
- amd64: encode not,neg
- amd64: introduce encodeEncEnc, rexInfo.encode() accepts arbitrary uint8
- amd64: mulHi, fix formatting for amode + _64

some refactoring as well. E.g. introduce encodeEncEnc and encodeEncMem, which are generalized versions of, respectively encodeRegReg and encodeRegMem, where instead of a `regEnc` a `uint8` is accepted. 

Notice that in some cases it is still necessary to treat the uint8 as registers; instead of arbitrarily casting I have added accessors `regEncoding(uint8)` and `regRexBit(uint8)`; open to suggestions if this makes no sense / alternative approaches are preferred.

