### PR TITLE
threads: don't use mmap for zero memory

### DIFF
--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -799,6 +799,41 @@ func BenchmarkWriteString(b *testing.B) {
 	}
 }
 
+func TestNewMemoryInstance_Shared(t *testing.T) {
+	tests := []struct {
+		name string
+		mem  *Memory
+		mmap bool
+	}{
+		{
+			name: "min 0, max 1",
+			mem:  &Memory{Min: 0, Max: 1, IsMaxEncoded: true, IsShared: true},
+			mmap: true,
+		},
+		{
+			name: "min 0, max 0",
+			mem:  &Memory{Min: 0, Max: 0, IsMaxEncoded: true, IsShared: true},
+			mmap: false, // Cannot mmap buffer of 0 size
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMemoryInstance(tc.mem)
+			defer m.Close()
+			require.Equal(t, tc.mem.Min, m.Min)
+			require.Equal(t, tc.mem.Max, m.Max)
+			require.True(t, m.Shared)
+			if tc.mmap {
+				require.NotNil(t, m.mmappedBuffer)
+			} else {
+				require.Nil(t, m.mmappedBuffer)
+			}
+		})
+	}
+}
+
 func TestMemoryInstance_WaitNotifyOnce(t *testing.T) {
 	reader := func(mem *MemoryInstance, offset uint32) uint32 {
 		val, _ := mem.ReadUint32Le(offset)


### PR DESCRIPTION
Also makes sure mmapped buffer is used for munmap, not sliced buffer. Technically sliced buffer is ok, but not if it's still empty `b[:0]` it seems.