### PR TITLE
wazevo: adds support for memory wait

### DIFF
--- a/internal/engine/wazevo/call_engine.go
+++ b/internal/engine/wazevo/call_engine.go
@@ -82,6 +82,8 @@ type (
 		memmoveAddress uintptr
 		// framePointerBeforeGoCall holds the frame pointer before calling a Go function. Note: only used in amd64.
 		framePointerBeforeGoCall uintptr
+		// memoryWaitAddress holds the address of memory wait trampoline function.
+		memoryWaitAddress *byte
 	}
 )
 

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -56,7 +56,11 @@ type (
 		// tableGrowExecutable is a compiled trampoline executable for table.grow builtin function.
 		tableGrowExecutable []byte
 		// refFuncExecutable is a compiled trampoline executable for ref.func builtin function.
-		refFuncExecutable         []byte
+		refFuncExecutable []byte
+		// memoryWait32Executable is a compiled trampoline executable for memory.wait32 builtin function
+		memoryWait32Executable []byte
+		// memoryWait64Executable is a compiled trampoline executable for memory.wait64 builtin function
+		memoryWait64Executable    []byte
 		listenerBeforeTrampolines map[*wasm.FunctionType][]byte
 		listenerAfterTrampolines  map[*wasm.FunctionType][]byte
 	}
@@ -639,6 +643,36 @@ func (e *engine) compileSharedFunctions() {
 		}
 	}
 
+	e.be.Init()
+	{
+		src := e.machine.CompileGoFunctionTrampoline(wazevoapi.ExitCodeMemoryWait32, &ssa.Signature{
+			// exec context, timeout, expected, addr
+			Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI64},
+			// Returns the status.
+			Results: []ssa.Type{ssa.TypeI32},
+		}, false)
+		e.sharedFunctions.memoryWait32Executable = mmapExecutable(src)
+		if wazevoapi.PerfMapEnabled {
+			exe := e.sharedFunctions.memoryWait32Executable
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "memory_wait32_trampoline")
+		}
+	}
+
+	e.be.Init()
+	{
+		src := e.machine.CompileGoFunctionTrampoline(wazevoapi.ExitCodeMemoryWait64, &ssa.Signature{
+			// exec context, timeout, expected, addr
+			Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI64},
+			// Returns the status.
+			Results: []ssa.Type{ssa.TypeI32},
+		}, false)
+		e.sharedFunctions.memoryWait64Executable = mmapExecutable(src)
+		if wazevoapi.PerfMapEnabled {
+			exe := e.sharedFunctions.memoryWait64Executable
+			wazevoapi.PerfMap.AddEntry(uintptr(unsafe.Pointer(&exe[0])), uint64(len(exe)), "memory_wait64_trampoline")
+		}
+	}
+
 	e.setFinalizer(e.sharedFunctions, sharedFunctionsFinalizer)
 }
 
@@ -658,6 +692,12 @@ func sharedFunctionsFinalizer(sf *sharedFunctions) {
 	if err := platform.MunmapCodeSegment(sf.refFuncExecutable); err != nil {
 		panic(err)
 	}
+	if err := platform.MunmapCodeSegment(sf.memoryWait32Executable); err != nil {
+		panic(err)
+	}
+	if err := platform.MunmapCodeSegment(sf.memoryWait64Executable); err != nil {
+		panic(err)
+	}
 	for _, f := range sf.listenerBeforeTrampolines {
 		if err := platform.MunmapCodeSegment(f); err != nil {
 			panic(err)
@@ -674,6 +714,8 @@ func sharedFunctionsFinalizer(sf *sharedFunctions) {
 	sf.stackGrowExecutable = nil
 	sf.tableGrowExecutable = nil
 	sf.refFuncExecutable = nil
+	sf.memoryWait32Executable = nil
+	sf.memoryWait64Executable = nil
 	sf.listenerBeforeTrampolines = nil
 	sf.listenerAfterTrampolines = nil
 }

--- a/internal/engine/wazevo/engine_test.go
+++ b/internal/engine/wazevo/engine_test.go
@@ -25,12 +25,18 @@ func Test_sharedFunctionsFinalizer(t *testing.T) {
 	require.NoError(t, err)
 	b7, err := platform.MmapCodeSegment(100)
 	require.NoError(t, err)
+	b8, err := platform.MmapCodeSegment(100)
+	require.NoError(t, err)
+	b9, err := platform.MmapCodeSegment(100)
+	require.NoError(t, err)
 
 	sf.memoryGrowExecutable = b1
 	sf.stackGrowExecutable = b2
 	sf.checkModuleExitCode = b3
 	sf.tableGrowExecutable = b6
 	sf.refFuncExecutable = b7
+	sf.memoryWait32Executable = b8
+	sf.memoryWait64Executable = b9
 
 	sharedFunctionsFinalizer(sf)
 	require.Nil(t, sf.memoryGrowExecutable)
@@ -38,6 +44,8 @@ func Test_sharedFunctionsFinalizer(t *testing.T) {
 	require.Nil(t, sf.checkModuleExitCode)
 	require.Nil(t, sf.tableGrowExecutable)
 	require.Nil(t, sf.refFuncExecutable)
+	require.Nil(t, sf.memoryWait32Executable)
+	require.Nil(t, sf.memoryWait64Executable)
 }
 
 func Test_executablesFinalizer(t *testing.T) {

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -21,6 +21,7 @@ type Compiler struct {
 	signatures             map[*wasm.FunctionType]*ssa.Signature
 	listenerSignatures     map[*wasm.FunctionType][2]*ssa.Signature
 	memoryGrowSig          ssa.Signature
+	memoryWaitSig          ssa.Signature
 	checkModuleExitCodeSig ssa.Signature
 	tableGrowSig           ssa.Signature
 	refFuncSig             ssa.Signature
@@ -142,6 +143,15 @@ func (c *Compiler) declareSignatures(listenerOn bool) {
 		Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32},
 	}
 	c.ssaBuilder.DeclareSignature(&c.memmoveSig)
+
+	c.memoryWaitSig = ssa.Signature{
+		ID: c.memmoveSig.ID + 1,
+		// module context, timeout, expected, address, size
+		Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI32},
+		// Returns the status.
+		Results: []ssa.Type{ssa.TypeI32},
+	}
+	c.ssaBuilder.DeclareSignature(&c.memoryWaitSig)
 }
 
 // SignatureForWasmFunctionType returns the ssa.Signature for the given wasm.FunctionType.

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -21,7 +21,8 @@ type Compiler struct {
 	signatures             map[*wasm.FunctionType]*ssa.Signature
 	listenerSignatures     map[*wasm.FunctionType][2]*ssa.Signature
 	memoryGrowSig          ssa.Signature
-	memoryWaitSig          ssa.Signature
+	memoryWait32Sig        ssa.Signature
+	memoryWait64Sig        ssa.Signature
 	checkModuleExitCodeSig ssa.Signature
 	tableGrowSig           ssa.Signature
 	refFuncSig             ssa.Signature
@@ -144,14 +145,23 @@ func (c *Compiler) declareSignatures(listenerOn bool) {
 	}
 	c.ssaBuilder.DeclareSignature(&c.memmoveSig)
 
-	c.memoryWaitSig = ssa.Signature{
+	c.memoryWait32Sig = ssa.Signature{
 		ID: c.memmoveSig.ID + 1,
-		// module context, timeout, expected, address, size
-		Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI32},
+		// exec context, timeout, expected, addr
+		Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI64},
 		// Returns the status.
 		Results: []ssa.Type{ssa.TypeI32},
 	}
-	c.ssaBuilder.DeclareSignature(&c.memoryWaitSig)
+	c.ssaBuilder.DeclareSignature(&c.memoryWait32Sig)
+
+	c.memoryWait64Sig = ssa.Signature{
+		ID: c.memoryWait32Sig.ID + 1,
+		// exec context, timeout, expected, addr
+		Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI64},
+		// Returns the status.
+		Results: []ssa.Type{ssa.TypeI32},
+	}
+	c.ssaBuilder.DeclareSignature(&c.memoryWait64Sig)
 }
 
 // SignatureForWasmFunctionType returns the ssa.Signature for the given wasm.FunctionType.

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -28,6 +28,7 @@ func TestCompiler_LowerToSSA(t *testing.T) {
 		exp string
 		// expAfterOpt is not empty when we want to check the result after optimization passes.
 		expAfterOpt string
+		features    api.CoreFeatures
 	}{
 		{
 			name: "empty", m: testcases.Empty.Module,
@@ -1617,8 +1618,9 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:v128, v3:v128)
 `,
 		},
 		{
-			name: "MemoryWait",
-			m:    testcases.MemoryWait.Module,
+			name:     "MemoryWait",
+			m:        testcases.MemoryWait.Module,
+			features: api.CoreFeaturesV2 | experimental.CoreFeaturesThreads,
 			exp: `
 blk0: (exec_ctx:i64, module_ctx:i64)
 	v2:i32 = Iconst_32 0x5
@@ -1651,7 +1653,11 @@ blk0: (exec_ctx:i64, module_ctx:i64)
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Just in case let's check the test module is valid.
-			err := tc.m.Validate(api.CoreFeaturesV2 | experimental.CoreFeaturesThreads)
+			features := tc.features
+			if features == 0 {
+				features = api.CoreFeaturesV2
+			}
+			err := tc.m.Validate(features)
 			require.NoError(t, err, "invalid test case module!")
 
 			b := ssa.NewBuilder()

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -1625,10 +1625,7 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:v128, v3:v128)
 signatures:
 	sig6: i64i64i32i64_i32
 
-blk0: (exec_ctx:i64, module_ctx:i64)
-	v2:i32 = Iconst_32 0x5
-	v3:i32 = Iconst_32 0x0
-	v4:i64 = Iconst_64 0xa
+blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i32, v4:i64)
 	v5:i64 = Iconst_64 0x4
 	v6:i64 = UExtend v2, 32->64
 	v7:i64 = Uload32 module_ctx, 0x10
@@ -1644,7 +1641,7 @@ blk0: (exec_ctx:i64, module_ctx:i64)
 	ExitIfTrue v15, exec_ctx, unaligned_atomic
 	v16:i64 = Load exec_ctx, 0x488
 	v17:i32 = CallIndirect v16:sig6, exec_ctx, v4, v3, v11
-	Jump blk_ret
+	Jump blk_ret, v17
 `,
 		},
 		{
@@ -1655,10 +1652,7 @@ blk0: (exec_ctx:i64, module_ctx:i64)
 signatures:
 	sig7: i64i64i64i64_i32
 
-blk0: (exec_ctx:i64, module_ctx:i64)
-	v2:i32 = Iconst_32 0x5
-	v3:i64 = Iconst_64 0x0
-	v4:i64 = Iconst_64 0xa
+blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i64, v4:i64)
 	v5:i64 = Iconst_64 0x8
 	v6:i64 = UExtend v2, 32->64
 	v7:i64 = Uload32 module_ctx, 0x10
@@ -1674,7 +1668,7 @@ blk0: (exec_ctx:i64, module_ctx:i64)
 	ExitIfTrue v15, exec_ctx, unaligned_atomic
 	v16:i64 = Load exec_ctx, 0x490
 	v17:i32 = CallIndirect v16:sig7, exec_ctx, v4, v3, v11
-	Jump blk_ret
+	Jump blk_ret, v17
 `,
 		},
 	} {

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -1618,50 +1618,62 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:v128, v3:v128)
 `,
 		},
 		{
-			name:     "MemoryWait",
-			m:        testcases.MemoryWait.Module,
+			name:     "MemoryWait32",
+			m:        testcases.MemoryWait32.Module,
 			features: api.CoreFeaturesV2 | experimental.CoreFeaturesThreads,
 			exp: `
 signatures:
-	sig6: i64i64i64i32i32_i32
+	sig6: i64i64i32i64_i32
 
 blk0: (exec_ctx:i64, module_ctx:i64)
 	v2:i32 = Iconst_32 0x5
 	v3:i32 = Iconst_32 0x0
 	v4:i64 = Iconst_64 0xa
-	v5:i32 = Iconst_32 0x4
-	v6:i64 = Iconst_64 0x4
-	v7:i64 = UExtend v2, 32->64
-	v8:i64 = Uload32 module_ctx, 0x10
-	v9:i64 = Iadd v7, v6
-	v10:i32 = Icmp lt_u, v8, v9
-	ExitIfTrue v10, exec_ctx, memory_out_of_bounds
-	v11:i64 = Load module_ctx, 0x8
-	v12:i64 = Iadd v11, v7
-	v13:i64 = Iconst_64 0x3
-	v14:i64 = Band v12, v13
-	v15:i64 = Iconst_64 0x0
-	v16:i32 = Icmp neq, v14, v15
-	ExitIfTrue v16, exec_ctx, unaligned_atomic
-	v17:i64 = Load exec_ctx, 0x488
-	v18:i32 = CallIndirect v17:sig6, module_ctx, v4, v3, v12, v5
-	v19:i32 = Iconst_32 0x5
-	v20:i64 = Iconst_64 0x0
-	v21:i64 = Iconst_64 0xa
-	v22:i32 = Iconst_32 0x8
-	v23:i64 = Iconst_64 0x8
-	v24:i64 = UExtend v19, 32->64
-	v25:i64 = Iadd v24, v23
-	v26:i32 = Icmp lt_u, v8, v25
-	ExitIfTrue v26, exec_ctx, memory_out_of_bounds
-	v27:i64 = Iadd v11, v24
-	v28:i64 = Iconst_64 0x7
-	v29:i64 = Band v27, v28
-	v30:i64 = Iconst_64 0x0
-	v31:i32 = Icmp neq, v29, v30
-	ExitIfTrue v31, exec_ctx, unaligned_atomic
-	v32:i64 = Load exec_ctx, 0x488
-	v33:i32 = CallIndirect v32:sig6, module_ctx, v21, v20, v27, v22
+	v5:i64 = Iconst_64 0x4
+	v6:i64 = UExtend v2, 32->64
+	v7:i64 = Uload32 module_ctx, 0x10
+	v8:i64 = Iadd v6, v5
+	v9:i32 = Icmp lt_u, v7, v8
+	ExitIfTrue v9, exec_ctx, memory_out_of_bounds
+	v10:i64 = Load module_ctx, 0x8
+	v11:i64 = Iadd v10, v6
+	v12:i64 = Iconst_64 0x3
+	v13:i64 = Band v11, v12
+	v14:i64 = Iconst_64 0x0
+	v15:i32 = Icmp neq, v13, v14
+	ExitIfTrue v15, exec_ctx, unaligned_atomic
+	v16:i64 = Load exec_ctx, 0x488
+	v17:i32 = CallIndirect v16:sig6, exec_ctx, v4, v3, v11
+	Jump blk_ret
+`,
+		},
+		{
+			name:     "MemoryWait64",
+			m:        testcases.MemoryWait64.Module,
+			features: api.CoreFeaturesV2 | experimental.CoreFeaturesThreads,
+			exp: `
+signatures:
+	sig7: i64i64i64i64_i32
+
+blk0: (exec_ctx:i64, module_ctx:i64)
+	v2:i32 = Iconst_32 0x5
+	v3:i64 = Iconst_64 0x0
+	v4:i64 = Iconst_64 0xa
+	v5:i64 = Iconst_64 0x8
+	v6:i64 = UExtend v2, 32->64
+	v7:i64 = Uload32 module_ctx, 0x10
+	v8:i64 = Iadd v6, v5
+	v9:i32 = Icmp lt_u, v7, v8
+	ExitIfTrue v9, exec_ctx, memory_out_of_bounds
+	v10:i64 = Load module_ctx, 0x8
+	v11:i64 = Iadd v10, v6
+	v12:i64 = Iconst_64 0x7
+	v13:i64 = Band v11, v12
+	v14:i64 = Iconst_64 0x0
+	v15:i32 = Icmp neq, v13, v14
+	ExitIfTrue v15, exec_ctx, unaligned_atomic
+	v16:i64 = Load exec_ctx, 0x490
+	v17:i32 = CallIndirect v16:sig7, exec_ctx, v4, v3, v11
 	Jump blk_ret
 `,
 		},
@@ -1771,7 +1783,8 @@ func TestCompiler_declareSignatures(t *testing.T) {
 			{ID: 6, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32, ssa.TypeI32, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
 			{ID: 7, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64}},
 			{ID: 8, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32}},
-			{ID: 9, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}},
+			{ID: 9, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
+			{ID: 10, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
 		}
 
 		require.Equal(t, len(expected), len(declaredSigs))
@@ -1808,7 +1821,8 @@ func TestCompiler_declareSignatures(t *testing.T) {
 			{ID: 14, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32, ssa.TypeI32, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
 			{ID: 15, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64}},
 			{ID: 16, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32}},
-			{ID: 17, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}},
+			{ID: 17, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
+			{ID: 18, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
 		}
 		require.Equal(t, len(expected), len(declaredSigs))
 		for i := 0; i < len(declaredSigs); i++ {

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -1626,6 +1626,7 @@ signatures:
 	sig6: i64i64i32i64_i32
 
 blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i32, v4:i64)
+	Store module_ctx, exec_ctx, 0x8
 	v5:i64 = Iconst_64 0x4
 	v6:i64 = UExtend v2, 32->64
 	v7:i64 = Uload32 module_ctx, 0x10
@@ -1653,6 +1654,7 @@ signatures:
 	sig7: i64i64i64i64_i32
 
 blk0: (exec_ctx:i64, module_ctx:i64, v2:i32, v3:i64, v4:i64)
+	Store module_ctx, exec_ctx, 0x8
 	v5:i64 = Iconst_64 0x8
 	v6:i64 = UExtend v2, 32->64
 	v7:i64 = Uload32 module_ctx, 0x10

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -1638,24 +1638,30 @@ blk0: (exec_ctx:i64, module_ctx:i64)
 	ExitIfTrue v10, exec_ctx, memory_out_of_bounds
 	v11:i64 = Load module_ctx, 0x8
 	v12:i64 = Iadd v11, v7
-	IandsImm v12, 0x3
-	ExitIfCond eq, exec_ctx, unaligned_atomic
-	v13:i64 = Load exec_ctx, 0x488
-	v14:i32 = CallIndirect v13:sig6, module_ctx, v4, v3, v12, v5
-	v15:i32 = Iconst_32 0x5
-	v16:i64 = Iconst_64 0x0
-	v17:i64 = Iconst_64 0xa
-	v18:i32 = Iconst_32 0x8
-	v19:i64 = Iconst_64 0x8
-	v20:i64 = UExtend v15, 32->64
-	v21:i64 = Iadd v20, v19
-	v22:i32 = Icmp lt_u, v8, v21
-	ExitIfTrue v22, exec_ctx, memory_out_of_bounds
-	v23:i64 = Iadd v11, v20
-	IandsImm v23, 0x7
-	ExitIfCond eq, exec_ctx, unaligned_atomic
-	v24:i64 = Load exec_ctx, 0x488
-	v25:i32 = CallIndirect v24:sig6, module_ctx, v17, v16, v23, v18
+	v13:i64 = Iconst_64 0x3
+	v14:i64 = Band v12, v13
+	v15:i64 = Iconst_64 0x0
+	v16:i32 = Icmp neq, v14, v15
+	ExitIfTrue v16, exec_ctx, unaligned_atomic
+	v17:i64 = Load exec_ctx, 0x488
+	v18:i32 = CallIndirect v17:sig6, module_ctx, v4, v3, v12, v5
+	v19:i32 = Iconst_32 0x5
+	v20:i64 = Iconst_64 0x0
+	v21:i64 = Iconst_64 0xa
+	v22:i32 = Iconst_32 0x8
+	v23:i64 = Iconst_64 0x8
+	v24:i64 = UExtend v19, 32->64
+	v25:i64 = Iadd v24, v23
+	v26:i32 = Icmp lt_u, v8, v25
+	ExitIfTrue v26, exec_ctx, memory_out_of_bounds
+	v27:i64 = Iadd v11, v24
+	v28:i64 = Iconst_64 0x7
+	v29:i64 = Band v27, v28
+	v30:i64 = Iconst_64 0x0
+	v31:i32 = Icmp neq, v29, v30
+	ExitIfTrue v31, exec_ctx, unaligned_atomic
+	v32:i64 = Load exec_ctx, 0x488
+	v33:i32 = CallIndirect v32:sig6, module_ctx, v21, v20, v27, v22
 	Jump blk_ret
 `,
 		},

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -1622,29 +1622,40 @@ blk0: (exec_ctx:i64, module_ctx:i64, v2:v128, v3:v128)
 			m:        testcases.MemoryWait.Module,
 			features: api.CoreFeaturesV2 | experimental.CoreFeaturesThreads,
 			exp: `
+signatures:
+	sig6: i64i64i64i32i32_i32
+
 blk0: (exec_ctx:i64, module_ctx:i64)
 	v2:i32 = Iconst_32 0x5
 	v3:i32 = Iconst_32 0x0
 	v4:i64 = Iconst_64 0xa
-	v5:i64 = Iconst_64 0x4
-	v6:i64 = UExtend v2, 32->64
-	v7:i64 = Uload32 module_ctx, 0x10
-	v8:i64 = Iadd v6, v5
-	v9:i32 = Icmp lt_u, v7, v8
-	ExitIfTrue v9, exec_ctx, memory_out_of_bounds
-	v10:i64 = Load module_ctx, 0x8
-	v11:i64 = Iadd v10, v6
-	v12:i32 = MemoryWait_i32, v4, v3, v11
-	v13:i32 = Iconst_32 0x5
-	v14:i64 = Iconst_64 0x0
-	v15:i64 = Iconst_64 0xa
-	v16:i64 = Iconst_64 0x8
-	v17:i64 = UExtend v13, 32->64
-	v18:i64 = Iadd v17, v16
-	v19:i32 = Icmp lt_u, v7, v18
-	ExitIfTrue v19, exec_ctx, memory_out_of_bounds
-	v20:i64 = Iadd v10, v17
-	v21:i32 = MemoryWait_i64, v15, v14, v20
+	v5:i32 = Iconst_32 0x4
+	v6:i64 = Iconst_64 0x4
+	v7:i64 = UExtend v2, 32->64
+	v8:i64 = Uload32 module_ctx, 0x10
+	v9:i64 = Iadd v7, v6
+	v10:i32 = Icmp lt_u, v8, v9
+	ExitIfTrue v10, exec_ctx, memory_out_of_bounds
+	v11:i64 = Load module_ctx, 0x8
+	v12:i64 = Iadd v11, v7
+	IandsImm v12, 0x3
+	ExitIfCond eq, exec_ctx, unaligned_atomic
+	v13:i64 = Load exec_ctx, 0x488
+	v14:i32 = CallIndirect v13:sig6, module_ctx, v4, v3, v12, v5
+	v15:i32 = Iconst_32 0x5
+	v16:i64 = Iconst_64 0x0
+	v17:i64 = Iconst_64 0xa
+	v18:i32 = Iconst_32 0x8
+	v19:i64 = Iconst_64 0x8
+	v20:i64 = UExtend v15, 32->64
+	v21:i64 = Iadd v20, v19
+	v22:i32 = Icmp lt_u, v8, v21
+	ExitIfTrue v22, exec_ctx, memory_out_of_bounds
+	v23:i64 = Iadd v11, v20
+	IandsImm v23, 0x7
+	ExitIfCond eq, exec_ctx, unaligned_atomic
+	v24:i64 = Load exec_ctx, 0x488
+	v25:i32 = CallIndirect v24:sig6, module_ctx, v17, v16, v23, v18
 	Jump blk_ret
 `,
 		},
@@ -1754,6 +1765,7 @@ func TestCompiler_declareSignatures(t *testing.T) {
 			{ID: 6, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32, ssa.TypeI32, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
 			{ID: 7, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64}},
 			{ID: 8, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32}},
+			{ID: 9, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}},
 		}
 
 		require.Equal(t, len(expected), len(declaredSigs))
@@ -1790,6 +1802,7 @@ func TestCompiler_declareSignatures(t *testing.T) {
 			{ID: 14, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32, ssa.TypeI32, ssa.TypeI64}, Results: []ssa.Type{ssa.TypeI32}},
 			{ID: 15, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI64}},
 			{ID: 16, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI32}},
+			{ID: 17, Params: []ssa.Type{ssa.TypeI64, ssa.TypeI64, ssa.TypeI64, ssa.TypeI32, ssa.TypeI32}, Results: []ssa.Type{ssa.TypeI32}},
 		}
 		require.Equal(t, len(expected), len(declaredSigs))
 		for i := 0; i < len(declaredSigs); i++ {

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -3476,7 +3476,7 @@ func (c *Compiler) memAlignmentCheck(addr ssa.Value, operationSizeInBytes uint64
 	}
 
 	builder := c.ssaBuilder
-	builder.AllocateInstruction().AsIandImm(addr, checkBits).Insert(builder)
+	builder.AllocateInstruction().AsIandsImm(addr, checkBits).Insert(builder)
 	builder.AllocateInstruction().AsExitIfCondWithCode(c.execCtxPtrValue, ssa.IntegerCmpCondEqual, wazevoapi.ExitCodeUnalignedAtomic).
 		Insert(builder)
 }

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -3160,6 +3160,9 @@ func (c *Compiler) lowerCurrentOpcode() {
 			if state.unreachable {
 				break
 			}
+
+			c.storeCallerModuleContext()
+
 			var opSize uint64
 			var trampoline wazevoapi.Offset
 			var sig *ssa.Signature

--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -183,6 +183,8 @@ func (m *moduleEngine) NewFunction(index wasm.Index) api.Function {
 	ce.execCtx.checkModuleExitCodeTrampolineAddress = &m.parent.sharedFunctions.checkModuleExitCode[0]
 	ce.execCtx.tableGrowTrampolineAddress = &m.parent.sharedFunctions.tableGrowExecutable[0]
 	ce.execCtx.refFuncTrampolineAddress = &m.parent.sharedFunctions.refFuncExecutable[0]
+	ce.execCtx.memoryWait32TrampolineAddress = &m.parent.sharedFunctions.memoryWait32Executable[0]
+	ce.execCtx.memoryWait64TrampolineAddress = &m.parent.sharedFunctions.memoryWait64Executable[0]
 	ce.execCtx.memmoveAddress = memmovPtr
 	ce.init()
 	return ce

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -326,7 +326,7 @@ const (
 	// OpcodeIcmpImm compares an integer value with the immediate value on the given condition: `v = icmp_imm Cond, x, Y`.
 	OpcodeIcmpImm
 
-	// OpcodeIaddImm performs a bitwise AND with the immediate value and updates condition flags.
+	// OpcodeIandsImm performs a bitwise AND with the immediate value and updates condition flags.
 	OpcodeIandsImm
 
 	// OpcodeIadd performs an integer addition: `v = Iadd x, y`.
@@ -1112,8 +1112,8 @@ func (i *Instruction) AsIconst32(v uint32) *Instruction {
 	return i
 }
 
-// AsIaddImm initializes this instruction as an integer bitwise and instruction with OpcodeIandImm.
-func (i *Instruction) AsIandImm(x Value, y uint64) *Instruction {
+// AsIaddImm initializes this instruction as an integer bitwise and instruction with OpcodeIandsImm.
+func (i *Instruction) AsIandsImm(x Value, y uint64) *Instruction {
 	i.opcode = OpcodeIandsImm
 	i.v = x
 	i.u1 = y

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -1962,7 +1962,7 @@ func (i *Instruction) AsExitIfTrueWithCode(ctx, c Value, code wazevoapi.ExitCode
 	return i
 }
 
-// AsExitIfTrueWithCode initializes this instruction as a trap instruction with OpcodeExitIfTrueWithCode.
+// AsExitIfTrueWithCode initializes this instruction as a trap instruction with OpcodeExitIfCondWithCode.
 func (i *Instruction) AsExitIfCondWithCode(ctx Value, cond IntegerCmpCond, code wazevoapi.ExitCode) *Instruction {
 	i.opcode = OpcodeExitIfCondWithCode
 	i.v = ctx

--- a/internal/engine/wazevo/testcases/testcases.go
+++ b/internal/engine/wazevo/testcases/testcases.go
@@ -1687,16 +1687,15 @@ var (
 	MemoryWait32 = TestCase{
 		Name: "memory_wait32",
 		Module: &wasm.Module{
-			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
+			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{i32, i32, i64}, Results: []wasm.ValueType{i32}}},
 			ExportSection:   []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 0}},
 			MemorySection:   &wasm.Memory{Min: 1, Max: 1, IsMaxEncoded: true, IsShared: true},
 			FunctionSection: []wasm.Index{0},
 			CodeSection: []wasm.Code{{Body: []byte{
-				wasm.OpcodeI32Const, 5,
-				wasm.OpcodeI32Const, 0,
-				wasm.OpcodeI64Const, 10,
+				wasm.OpcodeLocalGet, 0,
+				wasm.OpcodeLocalGet, 1,
+				wasm.OpcodeLocalGet, 2,
 				wasm.OpcodeAtomicPrefix, wasm.OpcodeAtomicMemoryWait32, 0x1, 0,
-				wasm.OpcodeDrop,
 				wasm.OpcodeEnd,
 			}}},
 		},
@@ -1705,16 +1704,15 @@ var (
 	MemoryWait64 = TestCase{
 		Name: "memory_wait64",
 		Module: &wasm.Module{
-			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
+			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{i32, i64, i64}, Results: []wasm.ValueType{i32}}},
 			ExportSection:   []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 0}},
 			MemorySection:   &wasm.Memory{Min: 1, Max: 1, IsMaxEncoded: true, IsShared: true},
 			FunctionSection: []wasm.Index{0},
 			CodeSection: []wasm.Code{{Body: []byte{
-				wasm.OpcodeI32Const, 5,
-				wasm.OpcodeI64Const, 0,
-				wasm.OpcodeI64Const, 10,
+				wasm.OpcodeLocalGet, 0,
+				wasm.OpcodeLocalGet, 1,
+				wasm.OpcodeLocalGet, 2,
 				wasm.OpcodeAtomicPrefix, wasm.OpcodeAtomicMemoryWait64, 0x2, 0,
-				wasm.OpcodeDrop,
 				wasm.OpcodeEnd,
 			}}},
 		},

--- a/internal/engine/wazevo/testcases/testcases.go
+++ b/internal/engine/wazevo/testcases/testcases.go
@@ -1683,6 +1683,29 @@ var (
 		Name:   "shuffle",
 		Module: VecShuffleWithLane(0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31),
 	}
+
+	MemoryWait = TestCase{
+		Name: "memory_wait",
+		Module: &wasm.Module{
+			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
+			ExportSection:   []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 0}},
+			MemorySection:   &wasm.Memory{Min: 1, Max: 1, IsMaxEncoded: true, IsShared: true},
+			FunctionSection: []wasm.Index{0},
+			CodeSection: []wasm.Code{{Body: []byte{
+				wasm.OpcodeI32Const, 5,
+				wasm.OpcodeI32Const, 0,
+				wasm.OpcodeI64Const, 10,
+				wasm.OpcodeAtomicPrefix, wasm.OpcodeAtomicMemoryWait32, 0x1, 0,
+				wasm.OpcodeDrop,
+				wasm.OpcodeI32Const, 5,
+				wasm.OpcodeI64Const, 0,
+				wasm.OpcodeI64Const, 10,
+				wasm.OpcodeAtomicPrefix, wasm.OpcodeAtomicMemoryWait64, 0x2, 0,
+				wasm.OpcodeDrop,
+				wasm.OpcodeEnd,
+			}}},
+		},
+	}
 )
 
 // VecShuffleWithLane returns a VecShuffle test with a custom 16-bytes immediate (lane indexes).

--- a/internal/engine/wazevo/testcases/testcases.go
+++ b/internal/engine/wazevo/testcases/testcases.go
@@ -1684,8 +1684,8 @@ var (
 		Module: VecShuffleWithLane(0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31),
 	}
 
-	MemoryWait = TestCase{
-		Name: "memory_wait",
+	MemoryWait32 = TestCase{
+		Name: "memory_wait32",
 		Module: &wasm.Module{
 			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
 			ExportSection:   []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 0}},
@@ -1697,6 +1697,19 @@ var (
 				wasm.OpcodeI64Const, 10,
 				wasm.OpcodeAtomicPrefix, wasm.OpcodeAtomicMemoryWait32, 0x1, 0,
 				wasm.OpcodeDrop,
+				wasm.OpcodeEnd,
+			}}},
+		},
+	}
+
+	MemoryWait64 = TestCase{
+		Name: "memory_wait64",
+		Module: &wasm.Module{
+			TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{}, Results: []wasm.ValueType{}}},
+			ExportSection:   []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 0}},
+			MemorySection:   &wasm.Memory{Min: 1, Max: 1, IsMaxEncoded: true, IsShared: true},
+			FunctionSection: []wasm.Index{0},
+			CodeSection: []wasm.Code{{Body: []byte{
 				wasm.OpcodeI32Const, 5,
 				wasm.OpcodeI64Const, 0,
 				wasm.OpcodeI64Const, 10,

--- a/internal/engine/wazevo/wazevo_test.go
+++ b/internal/engine/wazevo/wazevo_test.go
@@ -79,4 +79,6 @@ func Test_ExecutionContextOffsets(t *testing.T) {
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.refFuncTrampolineAddress)), wazevoapi.ExecutionContextOffsetRefFuncTrampolineAddress)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.memmoveAddress)), wazevoapi.ExecutionContextOffsetMemmoveAddress)
 	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.framePointerBeforeGoCall)), wazevoapi.ExecutionContextOffsetFramePointerBeforeGoCall)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.memoryWait32TrampolineAddress)), wazevoapi.ExecutionContextOffsetMemoryWait32TrampolineAddress)
+	require.Equal(t, wazevoapi.Offset(unsafe.Offsetof(execCtx.memoryWait64TrampolineAddress)), wazevoapi.ExecutionContextOffsetMemoryWait64TrampolineAddress)
 }

--- a/internal/engine/wazevo/wazevoapi/exitcode.go
+++ b/internal/engine/wazevo/wazevoapi/exitcode.go
@@ -26,6 +26,7 @@ const (
 	ExitCodeCallGoFunctionWithListener
 	ExitCodeTableGrow
 	ExitCodeRefFunc
+	ExitCodeUnalignedAtomic
 	exitCodeMax
 )
 
@@ -46,6 +47,8 @@ func (e ExitCode) String() string {
 		return "unreachable"
 	case ExitCodeMemoryOutOfBounds:
 		return "memory_out_of_bounds"
+	case ExitCodeUnalignedAtomic:
+		return "unaligned_atomic"
 	case ExitCodeTableOutOfBounds:
 		return "table_out_of_bounds"
 	case ExitCodeIndirectCallNullPointer:

--- a/internal/engine/wazevo/wazevoapi/exitcode.go
+++ b/internal/engine/wazevo/wazevoapi/exitcode.go
@@ -26,6 +26,8 @@ const (
 	ExitCodeCallGoFunctionWithListener
 	ExitCodeTableGrow
 	ExitCodeRefFunc
+	ExitCodeMemoryWait32
+	ExitCodeMemoryWait64
 	ExitCodeUnalignedAtomic
 	exitCodeMax
 )
@@ -77,6 +79,10 @@ func (e ExitCode) String() string {
 		return "table_grow"
 	case ExitCodeRefFunc:
 		return "ref_func"
+	case ExitCodeMemoryWait32:
+		return "memory_wait32"
+	case ExitCodeMemoryWait64:
+		return "memory_wait64"
 	}
 	panic("TODO")
 }

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -47,10 +47,11 @@ const (
 	// ExecutionContextOffsetTableGrowTrampolineAddress is an offset of `tableGrowTrampolineAddress` field in wazevo.executionContext
 	ExecutionContextOffsetTableGrowTrampolineAddress Offset = 1128
 	// ExecutionContextOffsetRefFuncTrampolineAddress is an offset of `refFuncTrampolineAddress` field in wazevo.executionContext
-	ExecutionContextOffsetRefFuncTrampolineAddress Offset = 1136
-	ExecutionContextOffsetMemmoveAddress           Offset = 1144
-	ExecutionContextOffsetFramePointerBeforeGoCall Offset = 1152
-	ExecutionContextOffsetMemoryWaitAddress        Offset = 1160
+	ExecutionContextOffsetRefFuncTrampolineAddress      Offset = 1136
+	ExecutionContextOffsetMemmoveAddress                Offset = 1144
+	ExecutionContextOffsetFramePointerBeforeGoCall      Offset = 1152
+	ExecutionContextOffsetMemoryWait32TrampolineAddress Offset = 1160
+	ExecutionContextOffsetMemoryWait64TrampolineAddress Offset = 1168
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,

--- a/internal/engine/wazevo/wazevoapi/offsetdata.go
+++ b/internal/engine/wazevo/wazevoapi/offsetdata.go
@@ -50,6 +50,7 @@ const (
 	ExecutionContextOffsetRefFuncTrampolineAddress Offset = 1136
 	ExecutionContextOffsetMemmoveAddress           Offset = 1144
 	ExecutionContextOffsetFramePointerBeforeGoCall Offset = 1152
+	ExecutionContextOffsetMemoryWaitAddress        Offset = 1160
 )
 
 // ModuleContextOffsetData allows the compilers to get the information about offsets to the fields of wazevo.moduleContextOpaque,


### PR DESCRIPTION
Not too sure what I'm doing so sending out lowering of one atomic op to understand the pattern, hopefully it will be enough to do the rest in the later PR.

I'm trying to compare to wasmtime but not sure if I'm doing something wrong. For this wat file

```
(module
  (import "console" "log" (func $log (param i32)))
  (func
    (i32.const 5)
    (i32.const 0)
    (i64.const 10)
    memory.atomic.wait32
    (call $log)
  )
  (memory 1 1 shared)
  (export "" (func 0))
)
```

I get

```
❯ target/debug/clif-util wasm --target aarch64-apple-darwin test.wat -p -t
function u0:1(i64 vmctx) fast {
    gv0 = vmctx
    gv1 = load.i64 notrap aligned readonly gv0
    sig0 = (i32, i64 vmctx) fast
    fn0 = u0:0 sig0

                                block0(v0: i64):
@0038                               v1 = iconst.i32 5
@003a                               v2 = iconst.i32 0
@003c                               v3 = iconst.i64 10
@003e                               v4 = iconst.i32 0xffff_ffff
@0042                               call fn0(v4, v0)  ; v4 = 0xffff_ffff
@0044                               jump block1

                                block1:
@0044                               return
}
```

I initially used the same wat as my test case but thought some optimization may be happening so tried adding the `call $log`, but still somehow it is just `v4 = iconst.i32 0xffff_ffff`. Any idea what I'm doing wrong?