### PR TITLE
Enables Zig/wasip1 stdlib trests for wazevo on amd64

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -104,6 +104,12 @@ jobs:
               name: macOS
             compiler: optimizing
             arch:     "arm64"
+          - os:
+              version: ubuntu-22.04
+              name: Ubuntu
+            compiler:   optimizing
+            arch:       "amd64"
+            go-version: "1.21"
 
     steps:
       - name: Checkout wazero
@@ -345,6 +351,13 @@ jobs:
             compiler:   optimizing
             arch:       "arm64"
             go-version: "1.21"
+          - os:
+              version: ubuntu-22.04
+              name: Ubuntu
+            compiler:   optimizing
+            arch:       "amd64"
+            go-version: "1.21"
+
     steps:
       - id: setup-go
         uses: actions/setup-go@v4

--- a/internal/integration_test/stdlibs/bench_test.go
+++ b/internal/integration_test/stdlibs/bench_test.go
@@ -18,12 +18,10 @@ import (
 )
 
 func BenchmarkZig(b *testing.B) {
-	if runtime.GOARCH == "arm64" {
-		b.Run("optimizing", func(b *testing.B) {
-			c := opt.NewRuntimeConfigOptimizingCompiler()
-			runtBenches(b, context.Background(), c, zigTestCase)
-		})
-	}
+	b.Run("optimizing", func(b *testing.B) {
+		c := opt.NewRuntimeConfigOptimizingCompiler()
+		runtBenches(b, context.Background(), c, zigTestCase)
+	})
 	b.Run("baseline", func(b *testing.B) {
 		c := wazero.NewRuntimeConfigCompiler()
 		runtBenches(b, context.Background(), c, zigTestCase)
@@ -44,12 +42,10 @@ func BenchmarkTinyGo(b *testing.B) {
 }
 
 func BenchmarkWasip1(b *testing.B) {
-	if runtime.GOARCH == "arm64" {
-		b.Run("optimizing", func(b *testing.B) {
-			c := opt.NewRuntimeConfigOptimizingCompiler()
-			runtBenches(b, context.Background(), c, wasip1TestCase)
-		})
-	}
+	b.Run("optimizing", func(b *testing.B) {
+		c := opt.NewRuntimeConfigOptimizingCompiler()
+		runtBenches(b, context.Background(), c, wasip1TestCase)
+	})
 	b.Run("baseline", func(b *testing.B) {
 		c := wazero.NewRuntimeConfigCompiler()
 		runtBenches(b, context.Background(), c, wasip1TestCase)


### PR DESCRIPTION
somehow tinygo is still not passing yet