### PR TITLE
wazevo(ssa): avoids allocation during natural order sort

### DIFF
--- a/internal/engine/wazevo/ssa/basic_block_sort.go
+++ b/internal/engine/wazevo/ssa/basic_block_sort.go
@@ -1,0 +1,23 @@
+//go:build go1.21
+
+package ssa
+
+import (
+	"slices"
+)
+
+func sortBlocks(blocks []*basicBlock) {
+	slices.SortFunc(blocks, func(i, j *basicBlock) int {
+		if j.ReturnBlock() {
+			return 1
+		}
+		if i.ReturnBlock() {
+			return -1
+		}
+		iRoot, jRoot := i.rootInstr, j.rootInstr
+		if iRoot == nil || jRoot == nil { // For testing.
+			return 1
+		}
+		return j.rootInstr.id - i.rootInstr.id
+	})
+}

--- a/internal/engine/wazevo/ssa/basic_block_sort.go
+++ b/internal/engine/wazevo/ssa/basic_block_sort.go
@@ -18,6 +18,6 @@ func sortBlocks(blocks []*basicBlock) {
 		if iRoot == nil || jRoot == nil { // For testing.
 			return 1
 		}
-		return j.rootInstr.id - i.rootInstr.id
+		return i.rootInstr.id - j.rootInstr.id
 	})
 }

--- a/internal/engine/wazevo/ssa/basic_block_sort_old.go
+++ b/internal/engine/wazevo/ssa/basic_block_sort_old.go
@@ -1,11 +1,12 @@
 //go:build !go1.21
 
+// TODO: delete after the floor Go version is 1.21
+
 package ssa
 
 import "sort"
 
 func sortBlocks(blocks []*basicBlock) {
-	// This function is a no-op in Go 1.21 and later.
 	sort.SliceStable(blocks, func(i, j int) bool {
 		iBlk, jBlk := blocks[i], blocks[j]
 		if jBlk.ReturnBlock() {

--- a/internal/engine/wazevo/ssa/basic_block_sort_old.go
+++ b/internal/engine/wazevo/ssa/basic_block_sort_old.go
@@ -1,0 +1,23 @@
+//go:build !go1.21
+
+package ssa
+
+import "sort"
+
+func sortBlocks(blocks []*basicBlock) {
+	// This function is a no-op in Go 1.21 and later.
+	sort.SliceStable(blocks, func(i, j int) bool {
+		iBlk, jBlk := blocks[i], blocks[j]
+		if jBlk.ReturnBlock() {
+			return true
+		}
+		if iBlk.ReturnBlock() {
+			return false
+		}
+		iRoot, jRoot := iBlk.rootInstr, jBlk.rootInstr
+		if iRoot == nil || jRoot == nil { // For testing.
+			return true
+		}
+		return iBlk.rootInstr.id < jBlk.rootInstr.id
+	})
+}

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -2,6 +2,7 @@ package ssa
 
 import (
 	"fmt"
+
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
 )
 

--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -2,8 +2,6 @@ package ssa
 
 import (
 	"fmt"
-	"sort"
-
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
 )
 
@@ -357,19 +355,6 @@ func passNopInstElimination(b *builder) {
 func passSortSuccessors(b *builder) {
 	for i := 0; i < b.basicBlocksPool.Allocated(); i++ {
 		blk := b.basicBlocksPool.View(i)
-		sort.SliceStable(blk.success, func(i, j int) bool {
-			iBlk, jBlk := blk.success[i], blk.success[j]
-			if jBlk.ReturnBlock() {
-				return true
-			}
-			if iBlk.ReturnBlock() {
-				return false
-			}
-			iRoot, jRoot := iBlk.rootInstr, jBlk.rootInstr
-			if iRoot == nil || jRoot == nil { // For testing.
-				return true
-			}
-			return iBlk.rootInstr.id < jBlk.rootInstr.id
-		})
+		sortBlocks(blk.success)
 	}
 }


### PR DESCRIPTION
This starts using `slices.SortFunc` (thanks to @achille-roussel) to avoid
allocations during `ssa.passSortSuccessors`. As a result for zig stdlib compilation,
huge amount of allocations has been eliminated.

```
                                        │    old.txt    │             new.txt              │
                                        │     B/op      │     B/op       vs base           │
Zig/optimizing/Compile/test-opt.wasm-10   513.2Mi ± ∞ ¹   506.6Mi ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                        │    old.txt    │             new.txt             │
                                        │   allocs/op   │  allocs/op    vs base           │
Zig/optimizing/Compile/test-opt.wasm-10   1201.3k ± ∞ ¹   781.8k ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

```