### PR TITLE
Changes the type of Size() to uint64

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -563,7 +563,7 @@ type Memory interface {
 	// has 1 page: 65536
 	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
-	Size() uint32
+	Size() uint64
 
 	// Grow increases memory by the delta in pages (65536 bytes per page).
 	// The return val is the previous memory size in pages, or false if the

--- a/experimental/wazerotest/wazerotest.go
+++ b/experimental/wazerotest/wazerotest.go
@@ -507,8 +507,8 @@ func (m *Memory) Definition() api.MemoryDefinition {
 	return memoryDefinition{memory: m}
 }
 
-func (m *Memory) Size() uint32 {
-	return uint32(len(m.Bytes))
+func (m *Memory) Size() uint64 {
+	return uint64(len(m.Bytes))
 }
 
 func (m *Memory) Grow(deltaPages uint32) (previousPages uint32, ok bool) {
@@ -624,8 +624,10 @@ func (m *Memory) WriteString(offset uint32, value string) bool {
 	return true
 }
 
-func (m *Memory) isOutOfRange(offset, length uint32) bool {
-	size := m.Size()
+func (m *Memory) isOutOfRange(_offset, _length uint32) bool {
+	size := int64(m.Size())
+	offset := int64(_offset)
+	length := int64(_length)
 	return offset >= size || length > size || offset > (size-length)
 }
 

--- a/imports/wasi_snapshot_preview1/args_test.go
+++ b/imports/wasi_snapshot_preview1/args_test.go
@@ -41,7 +41,7 @@ func Test_argsGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithArgs("a", "bc"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 	validAddress := uint32(0) // arbitrary
 
 	tests := []struct {
@@ -133,7 +133,7 @@ func Test_argsSizesGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithArgs("a", "bc"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 	validAddress := uint32(0) // arbitrary valid address as arguments to args_sizes_get. We chose 0 here.
 
 	tests := []struct {

--- a/imports/wasi_snapshot_preview1/clock_test.go
+++ b/imports/wasi_snapshot_preview1/clock_test.go
@@ -259,7 +259,7 @@ func Test_clockTimeGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig())
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	tests := []struct {
 		name                     string

--- a/imports/wasi_snapshot_preview1/environ_test.go
+++ b/imports/wasi_snapshot_preview1/environ_test.go
@@ -44,7 +44,7 @@ func Test_environGet_Errors(t *testing.T) {
 		WithEnv("a", "bc").WithEnv("b", "cd"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 	validAddress := uint32(0) // arbitrary valid address as arguments to environ_get. We chose 0 here.
 
 	tests := []struct {
@@ -138,7 +138,7 @@ func Test_environSizesGet_Errors(t *testing.T) {
 		WithEnv("a", "b").WithEnv("b", "cd"))
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 	validAddress := uint32(0) // arbitrary
 
 	tests := []struct {

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -233,7 +233,7 @@ func Test_fdFdstatGet(t *testing.T) {
 	file, dir := "animals.txt", "sub"
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	// open both paths without using WASI
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
@@ -659,7 +659,7 @@ func Test_fdFilestatGet(t *testing.T) {
 	file, dir := "animals.txt", "sub"
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	// open both paths without using WASI
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
@@ -1397,7 +1397,7 @@ func Test_fdPrestatGet_Errors(t *testing.T) {
 	mod, dirFD, log, r := requireOpenFile(t, t.TempDir(), "tmp", nil, true)
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 	tests := []struct {
 		name          string
 		fd            int32
@@ -1477,7 +1477,7 @@ func Test_fdPrestatDirName_Errors(t *testing.T) {
 	mod, dirFD, log, r := requireOpenFile(t, t.TempDir(), "tmp", nil, true)
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 	maskMemory(t, mod, 10)
 
 	validAddress := uint32(0) // Arbitrary valid address as arguments to fd_prestat_dir_name. We chose 0 here.
@@ -2304,7 +2304,7 @@ func Test_fdReaddir_Rewind(t *testing.T) {
 func Test_fdReaddir_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
-	memLen := mod.Memory().Size()
+	memLen := uint32(mod.Memory().Size())
 
 	fsc := mod.(*wasm.ModuleInstance).Sys.FS()
 	preopen := fsc.RootFS()
@@ -2640,7 +2640,7 @@ func Test_fdSeek_Errors(t *testing.T) {
 	require.Zero(t, fsc.RootFS().Mkdir("dir", 0o0777))
 	dirFD := requireOpenFD(t, mod, "dir")
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	tests := []struct {
 		name                    string
@@ -2791,7 +2791,7 @@ func Test_fdTell_Errors(t *testing.T) {
 	mod, fd, log, r := requireOpenFile(t, t.TempDir(), "test_path", []byte("wazero"), true)
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	tests := []struct {
 		name            string
@@ -2888,7 +2888,7 @@ func Test_fdWrite_Errors(t *testing.T) {
 
 	// Setup valid test memory
 	iovsCount := uint32(1)
-	memSize := mod.Memory().Size()
+	memSize := uint32(mod.Memory().Size())
 
 	tests := []struct {
 		name                 string
@@ -3058,7 +3058,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 		{
 			name:          "out-of-memory reading path",
 			fd:            sys.FdPreopen,
-			path:          mod.Memory().Size(),
+			path:          uint32(mod.Memory().Size()),
 			pathLen:       1,
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
@@ -3070,7 +3070,7 @@ func Test_pathCreateDirectory_Errors(t *testing.T) {
 			name:          "out-of-memory reading pathLen",
 			fd:            sys.FdPreopen,
 			path:          0,
-			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
+			pathLen:       uint32(mod.Memory().Size()) + 1, // path is in the valid memory range, but pathLen is OOM for path
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_create_directory(fd=3,path=OOM(0,65537))
@@ -3126,7 +3126,7 @@ func Test_pathFilestatGet(t *testing.T) {
 
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig().WithFS(fstest.FS))
 	defer r.Close(testCtx)
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	fileFD := requireOpenFD(t, mod, file)
 
@@ -4078,7 +4078,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 		{
 			name:          "out-of-memory reading path",
 			fd:            sys.FdPreopen,
-			path:          mod.Memory().Size(),
+			path:          uint32(mod.Memory().Size()),
 			pathLen:       uint32(len(file)),
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
@@ -4090,7 +4090,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			name:          "out-of-memory reading pathLen",
 			fd:            sys.FdPreopen,
 			path:          0,
-			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
+			pathLen:       uint32(mod.Memory().Size()) + 1, // path is in the valid memory range, but pathLen is OOM for path
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=OOM(0,65537),oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
@@ -4163,7 +4163,7 @@ func Test_pathOpen_Errors(t *testing.T) {
 			pathName:       dir,
 			path:           0,
 			pathLen:        uint32(len(dir)),
-			resultOpenedFd: mod.Memory().Size(), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
+			resultOpenedFd: uint32(mod.Memory().Size()), // path and pathLen correctly point to the right path, but where to write the opened FD is outside memory.
 			expectedErrno:  wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=dir,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
@@ -4416,7 +4416,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 		{
 			name:          "out-of-memory reading path",
 			fd:            sys.FdPreopen,
-			path:          mod.Memory().Size(),
+			path:          uint32(mod.Memory().Size()),
 			pathLen:       1,
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
@@ -4428,7 +4428,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 			name:          "out-of-memory reading pathLen",
 			fd:            sys.FdPreopen,
 			path:          0,
-			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
+			pathLen:       uint32(mod.Memory().Size()) + 1, // path is in the valid memory range, but pathLen is OOM for path
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_remove_directory(fd=3,path=OOM(0,65537))
@@ -4682,7 +4682,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			name:          "out-of-memory reading old path",
 			oldFd:         sys.FdPreopen,
 			newFd:         sys.FdPreopen,
-			oldPath:       mod.Memory().Size(),
+			oldPath:       uint32(mod.Memory().Size()),
 			oldPathLen:    1,
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
@@ -4697,7 +4697,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			oldPath:       0,
 			oldPathName:   "a",
 			oldPathLen:    1,
-			newPath:       mod.Memory().Size(),
+			newPath:       uint32(mod.Memory().Size()),
 			newPathLen:    1,
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
@@ -4710,7 +4710,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			oldFd:         sys.FdPreopen,
 			newFd:         sys.FdPreopen,
 			oldPath:       0,
-			oldPathLen:    mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
+			oldPathLen:    uint32(mod.Memory().Size()) + 1, // path is in the valid memory range, but pathLen is OOM for path
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=OOM(0,65537),new_fd=3,new_path=)
@@ -4724,7 +4724,7 @@ func Test_pathRename_Errors(t *testing.T) {
 			oldPathName:   file,
 			oldPathLen:    uint32(len(file)),
 			newPath:       0,
-			newPathLen:    mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
+			newPathLen:    uint32(mod.Memory().Size()) + 1, // path is in the valid memory range, but pathLen is OOM for path
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_rename(fd=3,old_path=file,new_fd=3,new_path=OOM(0,65537))
@@ -4853,7 +4853,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 		{
 			name:          "out-of-memory reading path",
 			fd:            sys.FdPreopen,
-			path:          mod.Memory().Size(),
+			path:          uint32(mod.Memory().Size()),
 			pathLen:       1,
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
@@ -4865,7 +4865,7 @@ func Test_pathUnlinkFile_Errors(t *testing.T) {
 			name:          "out-of-memory reading pathLen",
 			fd:            sys.FdPreopen,
 			path:          0,
-			pathLen:       mod.Memory().Size() + 1, // path is in the valid memory range, but pathLen is OOM for path
+			pathLen:       uint32(mod.Memory().Size()) + 1, // path is in the valid memory range, but pathLen is OOM for path
 			expectedErrno: wasip1.ErrnoFault,
 			expectedLog: `
 ==> wasi_snapshot_preview1.path_unlink_file(fd=3,path=OOM(0,65537))

--- a/imports/wasi_snapshot_preview1/random_test.go
+++ b/imports/wasi_snapshot_preview1/random_test.go
@@ -43,7 +43,7 @@ func Test_randomGet_Errors(t *testing.T) {
 	mod, r, log := requireProxyModule(t, wazero.NewModuleConfig())
 	defer r.Close(testCtx)
 
-	memorySize := mod.Memory().Size()
+	memorySize := uint32(mod.Memory().Size())
 
 	tests := []struct {
 		name           string

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -4021,7 +4021,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance
 				panic(wasmruntime.ErrRuntimeUnalignedAtomic)
 			}
 			// Just a bounds check
-			if offset >= memoryInst.Size() {
+			if int(offset) >= len(memoryInst.Buffer) {
 				panic(wasmruntime.ErrRuntimeOutOfBoundsMemoryAccess)
 			}
 			res := memoryInst.Notify(offset, uint32(count))

--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -1150,7 +1150,7 @@ func TestE2E_reexported_memory(t *testing.T) {
 	mem := m1Inst.Memory()
 	require.Equal(t, mem, m3Inst.Memory())
 	require.Equal(t, mem, m2Inst.Memory())
-	require.Equal(t, uint32(11), mem.Size()/65536)
+	require.Equal(t, uint64(11), mem.Size()/65536)
 }
 
 func TestStackUnwind_panic_in_host(t *testing.T) {

--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -818,7 +818,7 @@ func testMemOps(t *testing.T, r wazero.Runtime) {
 	results, err = sizeFn.Call(testCtx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), results[0])        // 1 page
-	require.Equal(t, uint32(65536), memory.Size()) // 64KB
+	require.Equal(t, uint64(65536), memory.Size()) // 64KB
 
 	// Grow again so that the memory size matches memory capacity.
 	results, err = growFn.Call(testCtx, 1)

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -130,13 +130,13 @@ func (m *MemoryInstance) Definition() api.MemoryDefinition {
 }
 
 // Size implements the same method as documented on api.Memory.
-func (m *MemoryInstance) Size() uint32 {
-	return m.size()
+func (m *MemoryInstance) Size() uint64 {
+	return uint64(m.size())
 }
 
 // ReadByte implements the same method as documented on api.Memory.
 func (m *MemoryInstance) ReadByte(offset uint32) (byte, bool) {
-	if offset >= m.size() {
+	if int64(offset) >= int64(m.size()) {
 		return 0, false
 	}
 	return m.Buffer[offset], true
@@ -188,7 +188,7 @@ func (m *MemoryInstance) Read(offset, byteCount uint32) ([]byte, bool) {
 
 // WriteByte implements the same method as documented on api.Memory.
 func (m *MemoryInstance) WriteByte(offset uint32, v byte) bool {
-	if offset >= m.size() {
+	if int64(offset) >= m.size() {
 		return false
 	}
 	m.Buffer[offset] = v
@@ -309,8 +309,8 @@ func memoryBytesNumToPages(bytesNum uint64) (pages uint32) {
 }
 
 // size returns the size in bytes of the buffer.
-func (m *MemoryInstance) size() uint32 {
-	return uint32(len(m.Buffer)) // We don't lock here because size can't become smaller.
+func (m *MemoryInstance) size() int64 {
+	return int64(len(m.Buffer)) // We don't lock here because size can't become smaller.
 }
 
 // hasSize returns true if Len is sufficient for byteCount at the given offset.

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -151,7 +151,7 @@ func TestMemoryInstance_HasSize(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		offset      uint32
+		offset      uint64
 		sizeInBytes uint64
 		expected    bool
 	}{
@@ -197,7 +197,7 @@ func TestMemoryInstance_HasSize(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, memory.hasSize(tc.offset, tc.sizeInBytes))
+			require.Equal(t, tc.expected, memory.hasSize(uint32(tc.offset), tc.sizeInBytes))
 		})
 	}
 }
@@ -471,7 +471,7 @@ func TestMemoryInstance_WriteUint16Le(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		offset        uint32
+		offset        uint64
 		v             uint16
 		expectedOk    bool
 		expectedBytes []byte
@@ -509,7 +509,7 @@ func TestMemoryInstance_WriteUint16Le(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedOk, memory.WriteUint16Le(tc.offset, tc.v))
+			require.Equal(t, tc.expectedOk, memory.WriteUint16Le(uint32(tc.offset), tc.v))
 			if tc.expectedOk {
 				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+2]) // 2 is the size of uint16
 			}
@@ -522,7 +522,7 @@ func TestMemoryInstance_WriteUint32Le(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		offset        uint32
+		offset        uint64
 		v             uint32
 		expectedOk    bool
 		expectedBytes []byte
@@ -560,7 +560,7 @@ func TestMemoryInstance_WriteUint32Le(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedOk, memory.WriteUint32Le(tc.offset, tc.v))
+			require.Equal(t, tc.expectedOk, memory.WriteUint32Le(uint32(tc.offset), tc.v))
 			if tc.expectedOk {
 				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+4]) // 4 is the size of uint32
 			}
@@ -572,7 +572,7 @@ func TestMemoryInstance_WriteUint64Le(t *testing.T) {
 	memory := &MemoryInstance{Buffer: make([]byte, 100)}
 	tests := []struct {
 		name          string
-		offset        uint32
+		offset        uint64
 		v             uint64
 		expectedOk    bool
 		expectedBytes []byte
@@ -610,7 +610,7 @@ func TestMemoryInstance_WriteUint64Le(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedOk, memory.WriteUint64Le(tc.offset, tc.v))
+			require.Equal(t, tc.expectedOk, memory.WriteUint64Le(uint32(tc.offset), tc.v))
 			if tc.expectedOk {
 				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+8]) // 8 is the size of uint64
 			}
@@ -623,7 +623,7 @@ func TestMemoryInstance_WriteFloat32Le(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		offset        uint32
+		offset        uint64
 		v             float32
 		expectedOk    bool
 		expectedBytes []byte
@@ -661,7 +661,7 @@ func TestMemoryInstance_WriteFloat32Le(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedOk, memory.WriteFloat32Le(tc.offset, tc.v))
+			require.Equal(t, tc.expectedOk, memory.WriteFloat32Le(uint32(tc.offset), tc.v))
 			if tc.expectedOk {
 				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+4]) // 4 is the size of float32
 			}
@@ -673,7 +673,7 @@ func TestMemoryInstance_WriteFloat64Le(t *testing.T) {
 	memory := &MemoryInstance{Buffer: make([]byte, 100)}
 	tests := []struct {
 		name          string
-		offset        uint32
+		offset        uint64
 		v             float64
 		expectedOk    bool
 		expectedBytes []byte
@@ -711,7 +711,7 @@ func TestMemoryInstance_WriteFloat64Le(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectedOk, memory.WriteFloat64Le(tc.offset, tc.v))
+			require.Equal(t, tc.expectedOk, memory.WriteFloat64Le(uint32(tc.offset), tc.v))
 			if tc.expectedOk {
 				require.Equal(t, tc.expectedBytes, memory.Buffer[tc.offset:tc.offset+8]) // 8 is the size of float64
 			}

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -23,7 +23,7 @@ func TestModuleInstance_Memory(t *testing.T) {
 		name        string
 		input       *Module
 		expected    bool
-		expectedLen uint32
+		expectedLen uint64
 	}{
 		{
 			name:  "no memory",

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -192,7 +192,7 @@ func TestModule_Memory(t *testing.T) {
 		name        string
 		wasm        []byte
 		expected    bool
-		expectedLen uint32
+		expectedLen uint64
 	}{
 		{
 			name: "no memory",
@@ -226,7 +226,7 @@ func TestModule_Memory(t *testing.T) {
 				defs := module.ExportedMemoryDefinitions()
 				require.Equal(t, 1, len(defs))
 				def := defs["memory"]
-				require.Equal(t, tc.expectedLen>>16, def.Min())
+				require.Equal(t, tc.expectedLen>>16, uint64(def.Min()))
 			} else {
 				require.Nil(t, mem)
 				require.Zero(t, len(module.ExportedMemoryDefinitions()))


### PR DESCRIPTION
Fixes https://github.com/tetratelabs/wazero/issues/1852 by changing the signature of
api.Memory.Size to return 64bit int, rather than 32bit to avoid overflow.

This is _kind of_ breaking change but in anyway it should be almost harmless 
plus we are about to release 2.0 next month.