### PR TITLE
filecache: use os.CreateTemp to create files

### DIFF
--- a/internal/filecache/file_cache.go
+++ b/internal/filecache/file_cache.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sync"
 )
 
 // New returns a new Cache implemented by fileCache.
@@ -24,12 +23,6 @@ func newFileCache(dir string) *fileCache {
 // Note: this can be expanded to do binary signing/verification, set TTL on each entry, etc.
 type fileCache struct {
 	dirPath string
-	mux     sync.RWMutex
-}
-
-type fileReadCloser struct {
-	*os.File
-	fc *fileCache
 }
 
 func (fc *fileCache) path(key Key) string {
@@ -37,40 +30,17 @@ func (fc *fileCache) path(key Key) string {
 }
 
 func (fc *fileCache) Get(key Key) (content io.ReadCloser, ok bool, err error) {
-	// TODO: take lock per key for more efficiency vs the complexity of impl.
-	fc.mux.RLock()
-	unlock := fc.mux.RUnlock
-	defer func() {
-		if unlock != nil {
-			unlock()
-		}
-	}()
-
 	f, err := os.Open(fc.path(key))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, false, nil
 	} else if err != nil {
 		return nil, false, err
 	} else {
-		// Unlock is done inside the content.Close() at the call site.
-		unlock = nil
-		return &fileReadCloser{File: f, fc: fc}, true, nil
+		return f, true, nil
 	}
 }
 
-// Close wraps the os.File Close to release the read lock on fileCache.
-func (f *fileReadCloser) Close() (err error) {
-	defer f.fc.mux.RUnlock()
-	err = f.File.Close()
-	return
-}
-
 func (fc *fileCache) Add(key Key, content io.Reader) (err error) {
-	// TODO: take lock per key for more efficiency vs the complexity of impl.
-	fc.mux.Lock()
-	defer fc.mux.Unlock()
-
-	// Use rename for an atomic write
 	path := fc.path(key)
 	dirPath, fileName := filepath.Split(path)
 
@@ -98,10 +68,6 @@ func (fc *fileCache) Add(key Key, content io.Reader) (err error) {
 }
 
 func (fc *fileCache) Delete(key Key) (err error) {
-	// TODO: take lock per key for more efficiency vs the complexity of impl.
-	fc.mux.Lock()
-	defer fc.mux.Unlock()
-
 	err = os.Remove(fc.path(key))
 	if errors.Is(err, os.ErrNotExist) {
 		err = nil

--- a/internal/filecache/file_cache.go
+++ b/internal/filecache/file_cache.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 )
 
@@ -71,7 +72,9 @@ func (fc *fileCache) Add(key Key, content io.Reader) (err error) {
 
 	// Use rename for an atomic write
 	path := fc.path(key)
-	file, err := os.Create(path + ".tmp")
+	dirPath, fileName := filepath.Split(path)
+
+	file, err := os.CreateTemp(dirPath, fileName+".*.tmp")
 	if err != nil {
 		return
 	}

--- a/internal/filecache/file_cache.go
+++ b/internal/filecache/file_cache.go
@@ -49,11 +49,11 @@ func (fc *fileCache) Add(key Key, content io.Reader) (err error) {
 		return
 	}
 	defer func() {
+		file.Close()
 		if err != nil {
 			_ = os.Remove(file.Name())
 		}
 	}()
-	defer file.Close()
 	if _, err = io.Copy(file, content); err != nil {
 		return
 	}

--- a/internal/filecache/file_cache_test.go
+++ b/internal/filecache/file_cache_test.go
@@ -9,25 +9,6 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
-func TestFileReadCloser_Close(t *testing.T) {
-	fc := newFileCache(t.TempDir())
-	key := Key{1, 2, 3}
-
-	err := fc.Add(key, bytes.NewReader([]byte{1, 2, 3, 4}))
-	require.NoError(t, err)
-
-	c, ok, err := fc.Get(key)
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	// At this point, file is not closed, therefore TryLock should fail.
-	require.False(t, fc.mux.TryLock())
-
-	// Close, and then TryLock should succeed this time.
-	require.NoError(t, c.Close())
-	require.True(t, fc.mux.TryLock())
-}
-
 func TestFileCache_Add(t *testing.T) {
 	fc := newFileCache(t.TempDir())
 


### PR DESCRIPTION
This might be a fix for #2039 

Since https://github.com/tetratelabs/wazero/pull/1816, the file cache appended `.tmp` to the file path name to avoid leaving incomplete files in the cache when an error occurs. However, this is the definition of `os.Create`:

```go
func Create(name string) (*File, error) {
	return OpenFile(name, O_RDWR|O_CREATE|O_TRUNC, 0666)
}
```

File creation does not include the `O_EXCL` flag, which means that when the file already exists, it is opened and truncated.

This PR changes the file cache to use `os.CreateTemp` instead, which guarantees that the file name will be unique by injecting a random string in the file name and opening the file with `O_EXCL` to prevent racing calls that would accidentally use the same name from both suceeding:

```go
func CreateTemp(dir, pattern string) (*File, error) {
	if dir == "" {
		dir = TempDir()
	}

	prefix, suffix, err := prefixAndSuffix(pattern)
	if err != nil {
		return nil, &PathError{Op: "createtemp", Path: pattern, Err: err}
	}
	prefix = joinPath(dir, prefix)

	try := 0
	for {
		name := prefix + nextRandom() + suffix
		f, err := OpenFile(name, O_RDWR|O_CREATE|O_EXCL, 0600)
		if IsExist(err) {
			if try++; try < 10000 {
				continue
			}
			return nil, &PathError{Op: "createtemp", Path: prefix + "*" + suffix, Err: ErrExist}
		}
		return f, err
	}
}
```

In #2039, we observe errors where the memory mapping containing the code was getting corrupted somehow. We first assumed that it was caused by a lifecycle issue on the compiled modules that hold these memory segments. The hypothesis I'm making with this change is that concurrent calls to `os.Create` for the same compiled module race each other; when the second call occurs, it truncates the content that was being written by the first call. After that, the program cannot rely on the content of the file anymore.

I don't have a test to verify the hypothesis, but regardless, I believe this change is useful to make because it addresses a potential race condition that will manifest sooner or later.