### PR TITLE
wazevo(backend): block arg as one instruction before regalloc

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -603,7 +603,7 @@ L4 (SSA Block: blk5):
 	ret
 L3 (SSA Block: blk4):
 L5 (SSA Block: blk3):
-	orr w131?, wzr, #0x1
+	load_const_block_arg x131?, 0x1
 	b L2
 `,
 			afterFinalizeARM64: `
@@ -619,6 +619,7 @@ L4 (SSA Block: blk5):
 	ret
 L3 (SSA Block: blk4):
 L5 (SSA Block: blk3):
+	load_const_block_arg x8, 0x1
 	orr w8, wzr, #0x1
 	mov x2, x8
 	b #-0x1c (L2)

--- a/internal/engine/wazevo/backend/compiler_lower.go
+++ b/internal/engine/wazevo/backend/compiler_lower.go
@@ -221,6 +221,6 @@ func (c *compiler) lowerBlockArguments(args []ssa.Value, succ ssa.BasicBlock) {
 	// Finally, move the constants.
 	for _, edge := range c.constEdges {
 		cInst, dst := edge.cInst, edge.dst
-		c.mach.InsertLoadConstant(cInst, dst)
+		c.mach.InsertLoadConstantBlockArg(cInst, dst)
 	}
 }

--- a/internal/engine/wazevo/backend/isa/amd64/abi.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi.go
@@ -136,7 +136,7 @@ func (m *machine) LowerReturn(ret ssa.Value, r *backend.ABIArg) {
 	if def := m.c.ValueDefinition(ret); def.IsFromInstr() {
 		// Constant instructions are inlined.
 		if inst := def.Instr; inst.Constant() {
-			m.InsertLoadConstant(inst, reg)
+			m.insertLoadConstant(inst, reg)
 		}
 	}
 	if r.Kind == backend.ABIArgKindReg {

--- a/internal/engine/wazevo/backend/isa/amd64/lower_constant.go
+++ b/internal/engine/wazevo/backend/isa/amd64/lower_constant.go
@@ -11,12 +11,16 @@ func (m *machine) lowerConstant(instr *ssa.Instruction) (vr regalloc.VReg) {
 	valType := val.Type()
 
 	vr = m.c.AllocateVReg(valType)
-	m.InsertLoadConstant(instr, vr)
+	m.insertLoadConstant(instr, vr)
 	return
 }
 
-// InsertLoadConstant implements backend.Machine.
-func (m *machine) InsertLoadConstant(instr *ssa.Instruction, vr regalloc.VReg) {
+// InsertLoadConstantBlockArg implements backend.Machine.
+func (m *machine) InsertLoadConstantBlockArg(instr *ssa.Instruction, vr regalloc.VReg) {
+	m.insertLoadConstant(instr, vr)
+}
+
+func (m *machine) insertLoadConstant(instr *ssa.Instruction, vr regalloc.VReg) {
 	val := instr.Return()
 	valType := val.Type()
 	v := instr.ConstantVal()

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -1642,7 +1642,7 @@ func (m *machine) callerGenVRegToFunctionArg(a *backend.FunctionABI, argIndex in
 	if def != nil && def.IsFromInstr() {
 		// Constant instructions are inlined.
 		if inst := def.Instr; inst.Constant() {
-			m.InsertLoadConstant(inst, reg)
+			m.insertLoadConstant(inst, reg)
 		}
 	}
 	if arg.Kind == backend.ABIArgKindReg {

--- a/internal/engine/wazevo/backend/isa/arm64/abi.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi.go
@@ -130,7 +130,10 @@ func (m *machine) LowerReturns(rets []ssa.Value) {
 		if def := m.compiler.ValueDefinition(ret); def.IsFromInstr() {
 			// Constant instructions are inlined.
 			if inst := def.Instr; inst.Constant() {
-				m.InsertLoadConstant(inst, reg)
+				val := inst.Return()
+				valType := val.Type()
+				v := inst.ConstantVal()
+				m.insertLoadConstant(v, valType, reg)
 			}
 		}
 		if r.Kind == backend.ABIArgKindReg {
@@ -182,7 +185,10 @@ func (m *machine) callerGenVRegToFunctionArg(a *backend.FunctionABI, argIndex in
 	if def != nil && def.IsFromInstr() {
 		// Constant instructions are inlined.
 		if inst := def.Instr; inst.Constant() {
-			m.InsertLoadConstant(inst, reg)
+			val := inst.Return()
+			valType := val.Type()
+			v := inst.ConstantVal()
+			m.insertLoadConstant(v, valType, reg)
 		}
 	}
 	if arg.Kind == backend.ABIArgKindReg {

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -24,7 +24,7 @@ func (m *machine) encode(root *instruction) {
 func (i *instruction) encode(m *machine) {
 	c := m.compiler
 	switch kind := i.kind; kind {
-	case nop0, emitSourceOffsetInfo:
+	case nop0, emitSourceOffsetInfo, loadConstBlockArg:
 	case exitSequence:
 		encodeExitSequence(c, i.rn.reg())
 	case ret:

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -45,8 +45,8 @@ type (
 		// InsertReturn inserts the return instruction to return from the current function.
 		InsertReturn()
 
-		// InsertLoadConstant inserts the instruction(s) to load the constant value into the given regalloc.VReg.
-		InsertLoadConstant(instr *ssa.Instruction, vr regalloc.VReg)
+		// InsertLoadConstantBlockArg inserts the instruction(s) to load the constant value into the given regalloc.VReg.
+		InsertLoadConstantBlockArg(instr *ssa.Instruction, vr regalloc.VReg)
 
 		// Format returns the string representation of the currently compiled machine code.
 		// This is only for testing purpose.

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -23,7 +23,6 @@ type mockMachine struct {
 	insertLoadConstant             func(instr *ssa.Instruction, vr regalloc.VReg)
 	format                         func() string
 	linkAdjacentBlocks             func(prev, next ssa.BasicBlock)
-	rinfo                          *regalloc.RegisterInfo
 }
 
 func (m mockMachine) ArgsResultsRegs() (argResultInts, argResultFloats []regalloc.RealReg) {

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -60,17 +60,6 @@ func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []Relocatio
 // PostRegAlloc implements Machine.SetupPrologue.
 func (m mockMachine) PostRegAlloc() {}
 
-// Function implements Machine.Function.
-func (m mockMachine) Function() (f regalloc.Function) { return }
-
-// RegisterInfo implements Machine.RegisterInfo.
-func (m mockMachine) RegisterInfo() *regalloc.RegisterInfo {
-	if m.rinfo != nil {
-		return m.rinfo
-	}
-	return &regalloc.RegisterInfo{}
-}
-
 // InsertReturn implements Machine.InsertReturn.
 func (m mockMachine) InsertReturn() { panic("TODO") }
 
@@ -131,8 +120,8 @@ func (m mockMachine) InsertMove(dst, src regalloc.VReg, typ ssa.Type) {
 	m.insertMove(dst, src)
 }
 
-// InsertLoadConstant implements Machine.InsertLoadConstant.
-func (m mockMachine) InsertLoadConstant(instr *ssa.Instruction, vr regalloc.VReg) {
+// InsertLoadConstantBlockArg implements Machine.InsertLoadConstantBlockArg.
+func (m mockMachine) InsertLoadConstantBlockArg(instr *ssa.Instruction, vr regalloc.VReg) {
 	m.insertLoadConstant(instr, vr)
 }
 


### PR DESCRIPTION
on arm64, constant block args were loaded via multiple instructions,
which makes it harder for me to optimize the regalloc's bottleneck.
Therefore, this introduces load_const_block_arg pseudo instruction,
which will be lowered at post-regalloc into multiple instructions when needed.