### PR TITLE
sysfs: fix compile-time check on osFile

### DIFF
--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -92,7 +92,7 @@ func (f *osFile) SetAppend(enable bool) (errno experimentalsys.Errno) {
 }
 
 // compile-time check to ensure osFile.reopen implements reopenFile.
-var _ reopenFile = (*fsFile)(nil).reopen
+var _ reopenFile = (*osFile)(nil).reopen
 
 func (f *osFile) reopen() (errno experimentalsys.Errno) {
 	// Clear any create flag, as we are re-opening, not re-creating.


### PR DESCRIPTION
This is a tiny fix of a compile-time check on osFile.

It's not like it _matters_ all that much, as the missing method would be caught in other layers anyway, but when the check is there, it should be correct :)