### PR TITLE
spectest: ensure compiled functions can outlive module

### DIFF
--- a/internal/engine/compiler/engine.go
+++ b/internal/engine/compiler/engine.go
@@ -498,9 +498,9 @@ func (s nativeCallStatusCode) String() (ret string) {
 	return
 }
 
-// releaseCompiledModule is a runtime.SetFinalizer function that munmaps the compiledModule.executable.
-func releaseCompiledModule(cm *compiledModule) {
-	if err := cm.executable.Unmap(); err != nil {
+// releaseCompiledCode is a runtime.SetFinalizer function that munmaps the compiledCode.executable.
+func releaseCompiledCode(code *compiledCode) {
+	if err := code.executable.Unmap(); err != nil {
 		// munmap failure cannot recover, and happen asynchronously on the
 		// finalizer thread. While finalizer functions can return errors,
 		// they are ignored.
@@ -555,7 +555,7 @@ func (e *engine) CompileModule(_ context.Context, module *wasm.Module, listeners
 	}
 
 	// As this uses mmap, we need to munmap on the compiled machine code when it's GCed.
-	e.setFinalizer(cm, releaseCompiledModule)
+	e.setFinalizer(cm.compiledCode, releaseCompiledCode)
 	ln := len(listeners)
 	cmp := newCompiler()
 	asmNodes := new(asmNodes)

--- a/internal/engine/compiler/engine_cache.go
+++ b/internal/engine/compiler/engine_cache.go
@@ -51,7 +51,7 @@ func (e *engine) getCompiledModule(module *wasm.Module, listeners []experimental
 		}
 
 		// As this uses mmap, we need to munmap on the compiled machine code when it's GCed.
-		e.setFinalizer(cm, releaseCompiledModule)
+		e.setFinalizer(cm.compiledCode, releaseCompiledCode)
 	}
 	return
 }

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -95,10 +95,8 @@ func TestCompiler_CompileModule(t *testing.T) {
 
 func TestCompiler_Releasecode_Panic(t *testing.T) {
 	captured := require.CapturePanic(func() {
-		releaseCompiledModule(&compiledModule{
-			compiledCode: &compiledCode{
-				executable: makeCodeSegment(1, 2),
-			},
+		releaseCompiledCode(&compiledCode{
+			executable: makeCodeSegment(1, 2),
 		})
 	})
 	require.Contains(t, captured.Error(), "compiler: failed to munmap code segment")

--- a/internal/engine/compiler/engine_test.go
+++ b/internal/engine/compiler/engine_test.go
@@ -26,14 +26,14 @@ func requireSupportedOSArch(t *testing.T) {
 	}
 }
 
-type fakeFinalizer map[*compiledModule]func(module *compiledModule)
+type fakeFinalizer map[*compiledCode]func(code *compiledCode)
 
 func (f fakeFinalizer) setFinalizer(obj interface{}, finalizer interface{}) {
-	cf := obj.(*compiledModule)
+	cf := obj.(*compiledCode)
 	if _, ok := f[cf]; ok { // easier than adding a field for testing.T
 		panic(fmt.Sprintf("BUG: %v already had its finalizer set", cf))
 	}
-	f[cf] = finalizer.(func(*compiledModule))
+	f[cf] = finalizer.(func(*compiledCode))
 }
 
 func TestCompiler_CompileModule(t *testing.T) {


### PR DESCRIPTION
Tentative fix for #2039 for the `compiler`, not `wazevo`.

In [`linking.wast`](https://github.com/tetratelabs/wazero/blob/0b0a23c28f52ee16d102d14453af3a4e4316f98c/internal/integration_test/spectest/v2/testdata/linking.wast#L421-L453) we have:
- a module `A` that exports its memory and table
- a module `B` that imports both
  - it initializes the (shared) memory, and 
  - it initializes the (shared) table, setting entry zero to one of its functions
  - then it fails while running `main`

The test then verifies that initializing the memory and the table _both_ succeeded _before_ main failed. It does so by reading from the memory, and **indirect calling** the function in the table.

Both the memory and table are owned by `A`, so still exist. But the function, or rather the compiled code (and `mmap`ed memory) for the function is/was owned by `B` and can be GCed, because we `SetFinalizer` on an object owned by `B`.

This change makes it so that the finalizer is set on the `compiledCode` rather than on the `compiledModule`. Since the [resolved function import](https://github.com/tetratelabs/wazero/blob/0b0a23c28f52ee16d102d14453af3a4e4316f98c/internal/engine/compiler/engine.go#L659-L663) is a `function`, and that owns a `compiledFunction`, which owns the `compiledCode`, this should fix the issue.