### PR TITLE
wazevo(backend): lowers call arguments in the reverse order

### DIFF
--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -1633,7 +1633,11 @@ func (m *machine) lowerCall(si *ssa.Instruction) {
 	// Note: See machine.SetupPrologue for the stack layout.
 	// The stack pointer decrease/increase will be inserted later in the compilation.
 
-	for i, arg := range args {
+	for i := range args {
+		// Lower in reverse order to avoid spilling the register-based arguments to load stack-based ones.
+		// This will emperically reduce the size of executable code highly likely due to the less-number of spills.
+		i := len(args) - 1 - i
+		arg := args[i]
 		reg := m.c.VRegOf(arg)
 		def := m.c.ValueDefinition(arg)
 		m.callerGenVRegToFunctionArg(calleeABI, i, reg, def, stackSlotSize)

--- a/internal/engine/wazevo/backend/isa/arm64/abi.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi.go
@@ -276,7 +276,11 @@ func (m *machine) lowerCall(si *ssa.Instruction) {
 		m.maxRequiredStackSizeForCalls = stackSlotSize + 16 // return address frame.
 	}
 
-	for i, arg := range args {
+	for i := range args {
+		// Lower in reverse order to avoid spilling the register-based arguments to load stack-based ones.
+		// This will emperically reduce the size of executable code highly likely due to the less-number of spills.
+		i := len(args) - 1 - i
+		arg := args[i]
 		reg := m.compiler.VRegOf(arg)
 		def := m.compiler.ValueDefinition(arg)
 		m.callerGenVRegToFunctionArg(calleeABI, i, reg, def, stackSlotSize)


### PR DESCRIPTION
For sqlite bench executable:

arm64: before=8632852, after=8630436 bytes
amd64: before=8485519, after=8432495 bytes