### PR TITLE
wazevo(frontend): stricter BCE

### DIFF
--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -206,7 +206,7 @@ func (c *Compiler) Init(idx, typIndex wasm.Index, typ *wasm.FunctionType, localT
 	c.wasmFunctionBody = body
 	c.wasmFunctionBodyOffsetInCodeSection = bodyOffsetInCodeSection
 	c.needListener = needListener
-	c.clearSafeBounds(true)
+	c.clearSafeBounds()
 }
 
 // Note: this assumes 64-bit platform (I believe we won't have 32-bit backend ;)).
@@ -440,22 +440,20 @@ func (c *Compiler) recordKnownSafeBound(v ssa.ValueID, safeBound uint64, absolut
 	}
 }
 
-// clearSafeBounds clears the known safe bounds. This must be called
-// after the compilation of each block.
-// If `hard` is true, it clears the bounds. Otherwise, it clears only the absolute addresses,
-// so that the constant bounds are still valid.
-func (c *Compiler) clearSafeBounds(hard bool) {
-	if hard {
-		for _, v := range c.knownSafeBoundsSet {
-			ptr := &c.knownSafeBounds[v]
-			ptr.bound = 0
-		}
-		c.knownSafeBoundsSet = c.knownSafeBoundsSet[:0]
-	} else {
-		for _, v := range c.knownSafeBoundsSet {
-			ptr := &c.knownSafeBounds[v]
-			ptr.absoluteAddr = ssa.ValueInvalid
-		}
+// clearSafeBounds clears the known safe bounds.
+func (c *Compiler) clearSafeBounds() {
+	for _, v := range c.knownSafeBoundsSet {
+		ptr := &c.knownSafeBounds[v]
+		ptr.bound = 0
+	}
+	c.knownSafeBoundsSet = c.knownSafeBoundsSet[:0]
+}
+
+// resetAbsoluteAddressInSafeBounds resets the absolute addresses recorded in the known safe bounds.
+func (c *Compiler) resetAbsoluteAddressInSafeBounds() {
+	for _, v := range c.knownSafeBoundsSet {
+		ptr := &c.knownSafeBounds[v]
+		ptr.absoluteAddr = ssa.ValueInvalid
 	}
 }
 

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -59,8 +59,11 @@ type Compiler struct {
 	execCtxPtrValue, moduleCtxPtrValue ssa.Value
 }
 
+// knownSafeBound represents a known safe bound for a value.
 type knownSafeBound struct {
-	bound        uint64
+	// bound is a constant upper bound for the value.
+	bound uint64
+	// absoluteAddr is the absolute address of the value.
 	absoluteAddr ssa.Value
 }
 
@@ -439,6 +442,8 @@ func (c *Compiler) recordKnownSafeBound(v ssa.ValueID, safeBound uint64, absolut
 
 // clearSafeBounds clears the known safe bounds. This must be called
 // after the compilation of each block.
+// If `hard` is true, it clears the bounds. Otherwise, it clears only the absolute addresses,
+// so that the constant bounds are still valid.
 func (c *Compiler) clearSafeBounds(hard bool) {
 	if hard {
 		for _, v := range c.knownSafeBoundsSet {

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -2996,36 +2996,35 @@ func TestCompiler_getKnownSafeBound(t *testing.T) {
 }
 
 func TestCompiler_clearSafeBounds(t *testing.T) {
-	t.Run("hard", func(t *testing.T) {
-		c := &Compiler{}
-		c.knownSafeBounds = []knownSafeBound{{bound: 1}, {}, {bound: 2}, {}, {}, {bound: 3}}
-		c.knownSafeBoundsSet = []ssa.ValueID{0, 2, 5}
-		c.clearSafeBounds(true)
-		require.Equal(t, 0, len(c.knownSafeBoundsSet))
-		require.Equal(t, []knownSafeBound{{}, {}, {}, {}, {}, {}}, c.knownSafeBounds)
-	})
-	t.Run("not hard", func(t *testing.T) {
-		c := &Compiler{}
-		c.knownSafeBounds = []knownSafeBound{
-			{bound: 1, absoluteAddr: ssa.Value(1)},
-			{},
-			{bound: 2, absoluteAddr: ssa.Value(2)},
-			{},
-			{},
-			{bound: 3, absoluteAddr: ssa.Value(3)},
-		}
-		c.knownSafeBoundsSet = []ssa.ValueID{0, 2, 5}
-		c.clearSafeBounds(false)
-		require.Equal(t, 3, len(c.knownSafeBoundsSet))
-		require.Equal(t, []knownSafeBound{
-			{bound: 1, absoluteAddr: ssa.ValueInvalid},
-			{},
-			{bound: 2, absoluteAddr: ssa.ValueInvalid},
-			{},
-			{},
-			{bound: 3, absoluteAddr: ssa.ValueInvalid},
-		}, c.knownSafeBounds)
-	})
+	c := &Compiler{}
+	c.knownSafeBounds = []knownSafeBound{{bound: 1}, {}, {bound: 2}, {}, {}, {bound: 3}}
+	c.knownSafeBoundsSet = []ssa.ValueID{0, 2, 5}
+	c.clearSafeBounds()
+	require.Equal(t, 0, len(c.knownSafeBoundsSet))
+	require.Equal(t, []knownSafeBound{{}, {}, {}, {}, {}, {}}, c.knownSafeBounds)
+}
+
+func TestCompiler_resetAbsoluteAddressInSafeBounds(t *testing.T) {
+	c := &Compiler{}
+	c.knownSafeBounds = []knownSafeBound{
+		{bound: 1, absoluteAddr: ssa.Value(1)},
+		{},
+		{bound: 2, absoluteAddr: ssa.Value(2)},
+		{},
+		{},
+		{bound: 3, absoluteAddr: ssa.Value(3)},
+	}
+	c.knownSafeBoundsSet = []ssa.ValueID{0, 2, 5}
+	c.resetAbsoluteAddressInSafeBounds()
+	require.Equal(t, 3, len(c.knownSafeBoundsSet))
+	require.Equal(t, []knownSafeBound{
+		{bound: 1, absoluteAddr: ssa.ValueInvalid},
+		{},
+		{bound: 2, absoluteAddr: ssa.ValueInvalid},
+		{},
+		{},
+		{bound: 3, absoluteAddr: ssa.ValueInvalid},
+	}, c.knownSafeBounds)
 }
 
 func TestKnownSafeBound_valid(t *testing.T) {

--- a/internal/engine/wazevo/frontend/frontend_test.go
+++ b/internal/engine/wazevo/frontend/frontend_test.go
@@ -2999,7 +2999,7 @@ func TestCompiler_clearSafeBounds(t *testing.T) {
 	c := &Compiler{}
 	c.knownSafeBounds = []knownSafeBound{{bound: 1}, {}, {bound: 2}, {}, {}, {bound: 3}}
 	c.knownSafeBoundsSet = []ssa.ValueID{0, 2, 5}
-	c.clearSafeBounds()
+	c.clearSafeBounds(true)
 	require.Equal(t, 0, len(c.knownSafeBoundsSet))
 	require.Equal(t, []knownSafeBound{{}, {}, {}, {}, {}, {}}, c.knownSafeBounds)
 }


### PR DESCRIPTION
## sqlite speedtest binary size
amd64: 8478767 bytes on main.
amd64: 8337167 bytes with predecessor check.
amd64: 8345407 bytes without predecessor check.

arm64: 8624468 on main.
arm64: 8465156 bytes with predecessor check.
arm64: 8474788 bytes without predecessor check.

### result
amd64: 8345407 - 8337167 = 141600 bytes: ~1.6% of 8.3MB
arm64: 8624468 - 8465156 = 159312 bytes: ~1.8% of 8.6MB

## zig stdlib binary size

amd64: 47128091 bytes on main.
amd64: 45244091 bytes with predecessor check.

arm64: 48182088 bytes on main.
arm64: 46195880 bytes with predecessor check.

### result
amd64: 47128091 - 45244091 = 1884000 bytes: ~4.0% of 47MB
arm64: 48182088 - 46195880 = 1986208 bytes: ~4.1% of 48MB
