### PR TITLE
ci: fix WiX toolset path for release (msi build)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,9 +48,13 @@ jobs:
       # windows-2022 is missing osslsigncode (no issue, yet)
       - name: "Install osslsigncode, infozip; setup wix"
         run: |
+          # Find "C:\Program Files (x86)\WiX Toolset <version>\"
+          WIXDIR=`ls '/c/Program Files (x86)'|grep WiX`
+          WIXBIN="C:\\Program Files (x86)\\$WIXDIR\\bin"
+          echo WIXBIN=$WIXBIN
+          echo $WIXBIN >> $GITHUB_PATH
           choco install osslsigncode -y
           choco install zip -y
-          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
 
       - name: Download Windows code signing certificate
         env:


### PR DESCRIPTION
Do not hardcode the path to WiX toolset as it contains the version number. A recent GHA change updated 3.11 to 3.14 breaking the build.

Note for the future: when these issues arise I generally work on my own fork and use [`tmate` GHA](https://github.com/marketplace/actions/debugging-with-tmate) so that it is possible to SSH into a GHA worker and debug the issue interactively: life saver.