### PR TITLE
Fix TestErrorBuilderGoRuntimeError

### DIFF
--- a/internal/wasmdebug/debug_test.go
+++ b/internal/wasmdebug/debug_test.go
@@ -144,7 +144,7 @@ wasm stack trace:
 	x.y()`)
 	require.Contains(t, errStr, "Go runtime stack trace:")
 	require.Contains(t, errStr, "goroutine ")
-	require.Contains(t, errStr, "wazero/internal/wasmdebug/debug_test.go")
+	require.Contains(t, errStr, "/internal/wasmdebug/debug_test.go")
 }
 
 // compile-time check to ensure testRuntimeErr implements runtime.Error.


### PR DESCRIPTION
The `TestErrorBuilderGoRuntimeError` test fails if the directory with the repository is named anything but `wazero`. The PR removes this assumption.