### PR TITLE
testing: pass N, P into Run of hammer

### DIFF
--- a/internal/integration_test/engine/hammer_test.go
+++ b/internal/integration_test/engine/hammer_test.go
@@ -97,7 +97,7 @@ func closeModuleWhileInUse(t *testing.T, r wazero.Runtime, closeFn func(imported
 
 	// As this is a blocking function call, only run 1 per goroutine.
 	i := importing // pin the module used inside goroutines
-	hammer.NewHammer(t, P, 1).Run(func(name string) {
+	hammer.NewHammer(t, P, 1).Run(func(p, n int) {
 		// In all cases, the importing module is closed, so the error should have that as its module name.
 		requireFunctionCallExits(t, i.ExportedFunction("call_return_input"))
 	}, func() { // When all functions are in-flight, re-assign the modules.

--- a/internal/testing/hammer/hammer.go
+++ b/internal/testing/hammer/hammer.go
@@ -1,7 +1,6 @@
 package hammer
 
 import (
-	"fmt"
 	"runtime"
 	"sync"
 	"testing"
@@ -38,7 +37,7 @@ type Hammer interface {
 	//	if t.Failed() {
 	//		return
 	//	}
-	Run(test func(name string), onRunning func())
+	Run(test func(p, n int), onRunning func())
 }
 
 // NewHammer returns a Hammer initialized to indicated count of goroutines (P) and iterations per goroutine (N).
@@ -58,7 +57,7 @@ type hammer struct {
 }
 
 // Run implements Hammer.Run
-func (h *hammer) Run(test func(name string), onRunning func()) {
+func (h *hammer) Run(test func(p, n int), onRunning func()) {
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(h.P / 2)) // Ensure goroutines have to switch cores.
 
 	// running track
@@ -84,7 +83,7 @@ func (h *hammer) Run(test func(name string), onRunning func()) {
 
 			unblocked.Wait()           // Wait to be unblocked
 			for n := 0; n < h.N; n++ { // Invoke one test
-				test(fmt.Sprintf("%s:%d-%d", h.t.Name(), p, n))
+				test(p, n)
 			}
 		}()
 	}

--- a/internal/wasm/function_definition_test.go
+++ b/internal/wasm/function_definition_test.go
@@ -269,7 +269,7 @@ func TestModule_BuildFunctionDefinitions(t *testing.T) {
 		testName := tc.name + " (concurrent)"
 		t.Run(testName, func(t *testing.T) {
 			hammer.NewHammer(t, nGoroutines, nIterations).
-				Run(func(name string) {
+				Run(func(p, n int) {
 					tc.m.buildFunctionDefinitions()
 				}, nil)
 

--- a/internal/wasm/module_instance_test.go
+++ b/internal/wasm/module_instance_test.go
@@ -127,7 +127,7 @@ func TestModuleInstance_Close(t *testing.T) {
 		require.True(t, ok, "sysCtx.openedFiles was empty")
 
 		// Closing should not err even when concurrently closed.
-		hammer.NewHammer(t, 100, 10).Run(func(name string) {
+		hammer.NewHammer(t, 100, 10).Run(func(p, n int) {
 			require.NoError(t, m.Close(testCtx))
 			// closeWithExitCode is the one called during Store.CloseWithExitCode.
 			require.NoError(t, m.closeWithExitCode(testCtx, 0))

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -220,8 +220,8 @@ func TestStore_hammer(t *testing.T) {
 		P = 4
 		N = 100
 	}
-	hammer.NewHammer(t, P, N).Run(func(name string) {
-		mod, instantiateErr := s.Instantiate(testCtx, importingModule, name, sys.DefaultContext(nil), []FunctionTypeID{0})
+	hammer.NewHammer(t, P, N).Run(func(p, n int) {
+		mod, instantiateErr := s.Instantiate(testCtx, importingModule, fmt.Sprintf("%d:%d", p, n), sys.DefaultContext(nil), []FunctionTypeID{0})
 		require.NoError(t, instantiateErr)
 		require.NoError(t, mod.Close(testCtx))
 	}, nil)
@@ -279,7 +279,7 @@ func TestStore_hammer_close(t *testing.T) {
 		instances[i] = mod
 	}
 
-	hammer.NewHammer(t, 100, 2).Run(func(name string) {
+	hammer.NewHammer(t, 100, 2).Run(func(p, n int) {
 		for i := 0; i < instCount; i++ {
 			if i == instCount/2 {
 				// Close store concurrently as well.

--- a/internal/wasmdebug/dwarf_test.go
+++ b/internal/wasmdebug/dwarf_test.go
@@ -61,7 +61,7 @@ func TestDWARFLines_Line_Zig(t *testing.T) {
 		tc := tc
 		t.Run(fmt.Sprintf("%#x/%s", tc.offset, tc.exp), func(t *testing.T) {
 			// Ensures that DWARFLines.Line is goroutine-safe.
-			hammer.NewHammer(t, 100, 5).Run(func(name string) {
+			hammer.NewHammer(t, 100, 5).Run(func(p, n int) {
 				actual := mod.DWARFLines.Line(tc.offset)
 				require.Equal(t, len(tc.exp), len(actual))
 				for i := range tc.exp {


### PR DESCRIPTION
This reduces the testing time drastically for the `TestThreadsCompiler_hammer`