### PR TITLE
wasi: uses the shared compilation cache in tests

### DIFF
--- a/imports/wasi_snapshot_preview1/wasi_snapshot_preview1_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_snapshot_preview1_test.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/tetratelabs/wazero"
 )
 
 func TestMain(m *testing.M) {
@@ -17,6 +19,9 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(m.Run())
 }
+
+// runtimeCfg is a shared runtime configuration for tests within this package to reduce the compilation time of the binary.
+var runtimeCfg = wazero.NewRuntimeConfig().WithCompilationCache(wazero.NewCompilationCache())
 
 // compileWasip1Wasm allows us to generate a binary with runtime.GOOS=wasip1
 // and runtime.GOARCH=wasm. This intentionally does so on-demand, because the
@@ -32,8 +37,8 @@ func compileWasip1Wasm() ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	bin := path.Join(workdir, "wasi.wasm")
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", bin, ".") //nolint:gosec
+	binPath := path.Join(workdir, "wasi.wasm")
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, ".") //nolint:gosec
 	cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
 	cmd.Dir = "testdata/go"
 	out, err := cmd.CombinedOutput()
@@ -41,5 +46,14 @@ func compileWasip1Wasm() ([]byte, error) {
 		return nil, fmt.Errorf("couldn't compile %s: %w", string(out), err)
 	}
 
-	return os.ReadFile(bin) //nolint:gosec
+	bin, err := os.ReadFile(binPath) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+
+	// Proactively compile the binary to reduce the test time.
+	r := wazero.NewRuntimeWithConfig(context.Background(), runtimeCfg)
+	defer r.Close(context.Background())
+	_, err = r.CompileModule(context.Background(), bin)
+	return bin, err
 }


### PR DESCRIPTION
😠 