### PR TITLE
wazevo: fixes accidental heap allocation in VarLengthPool.Allocate

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Run built test binaries
         run: |
           cd ${{ env.STDLIB_TESTS }}
-          go test -bench='BenchmarkZig' -timeout=20m
+          go test -bench='BenchmarkZig' -timeout=20m -benchtime=1x
 
   build_tinygo_test_binary:
     name: Build TinyGo test binary
@@ -213,7 +213,7 @@ jobs:
       - name: Run test binaries
         run: |
           cd ${{ env.STDLIB_TESTS }}
-          go test -bench='BenchmarkTinyGo' -timeout=20m
+          go test -bench='BenchmarkTinyGo' -timeout=20m -benchtime=1x
 
   wasi-testsuite:
     name: wasi-testsuite

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -347,7 +347,7 @@ jobs:
       - name: Run built test binaries
         run: |
           cd ${{ env.STDLIB_TESTS }}
-          go test -bench='BenchmarkWasip1' -timeout=20m
+          go test -bench='BenchmarkWasip1' -timeout=20m -benchtime=1x
 
   libsodium:
     name: libsodium (${{ matrix.os.name }}, ${{ matrix.os.arch }})
@@ -388,5 +388,4 @@ jobs:
         run: make libsodium
 
       - name: Run test binaries
-        #
         run: go test ./internal/integration_test/libsodium -bench=. -benchtime=1x

--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -478,13 +478,11 @@ func (k *knownSafeBound) valid() bool {
 	return k != nil && k.bound > 0
 }
 
-func (c *Compiler) allocateVarLengthValues(vs ...ssa.Value) ssa.Values {
+func (c *Compiler) allocateVarLengthValues(_cap int, vs ...ssa.Value) ssa.Values {
 	builder := c.ssaBuilder
 	pool := builder.VarLengthPool()
-	args := pool.Allocate(len(vs))
-	for _, v := range vs {
-		args = args.Append(builder.VarLengthPool(), v)
-	}
+	args := pool.Allocate(_cap)
+	args = args.Append(builder.VarLengthPool(), vs...)
 	return args
 }
 

--- a/internal/engine/wazevo/ssa/pass_blk_layouts_test.go
+++ b/internal/engine/wazevo/ssa/pass_blk_layouts_test.go
@@ -277,9 +277,7 @@ func TestBuilder_LayoutBlocks(t *testing.T) {
 		b.SetCurrentBlock(src)
 		jump := b.AllocateInstruction()
 		args := b.varLengthPool.Allocate(len(vs))
-		for _, v := range vs {
-			args = args.Append(&b.varLengthPool, v)
-		}
+		args = args.Append(&b.varLengthPool, vs...)
 		jump.AsJump(args, dst)
 		b.InsertInstruction(jump)
 	}
@@ -290,9 +288,7 @@ func TestBuilder_LayoutBlocks(t *testing.T) {
 		b.InsertInstruction(vinst)
 		brz := b.AllocateInstruction()
 		args := b.varLengthPool.Allocate(len(vs))
-		for _, v := range vs {
-			args = args.Append(&b.varLengthPool, v)
-		}
+		args = args.Append(&b.varLengthPool, vs...)
 		brz.AsBrz(condVal, args, dst)
 		b.InsertInstruction(brz)
 	}

--- a/internal/engine/wazevo/wazevoapi/pool.go
+++ b/internal/engine/wazevo/wazevoapi/pool.go
@@ -154,21 +154,21 @@ func (p *VarLengthPool[T]) Reset() {
 }
 
 // Append appends an item to the backing slice.
-func (i VarLength[T]) Append(p *VarLengthPool[T], item T) VarLength[T] {
+func (i VarLength[T]) Append(p *VarLengthPool[T], items ...T) VarLength[T] {
 	if i.backing == nil {
 		arr := p.arrayPool.Allocate()[:0]
 		i.backing = &arr
 	}
 
-	if len(*i.backing)+1 <= arraySize {
-		*i.backing = append(*i.backing, item)
+	if len(*i.backing)+len(items) <= arraySize {
+		*i.backing = append(*i.backing, items...)
 		return i
 	} else if len(*i.backing) == arraySize {
 		slc := p.slicePool.Allocate()
 		// Copy the array to the slice.
 		*slc = append(*slc, *i.backing...)
 	}
-	*i.backing = append(*i.backing, item)
+	*i.backing = append(*i.backing, items...)
 	return i
 }
 

--- a/internal/engine/wazevo/wazevoapi/pool.go
+++ b/internal/engine/wazevo/wazevoapi/pool.go
@@ -108,23 +108,35 @@ func (p *IDedPool[T]) MaxIDEncountered() int {
 	return p.maxIDEncountered
 }
 
-const arraySize = 20
+// arraySize is the size of the array used in VarLengthPool's arrayPool.
+// This is chosen to be 8, which is empirically a good number among 8, 12, 16 and 20.
+const arraySize = 8
 
 // VarLengthPool is a pool of VarLength[T] that can be allocated and reset.
-type VarLengthPool[T any] struct {
-	arrayPool Pool[[arraySize]T]
-	slicePool Pool[[]T]
-}
+type (
+	VarLengthPool[T any] struct {
+		arrayPool Pool[varLengthPoolArray[T]]
+		slicePool Pool[[]T]
+	}
+	// varLengthPoolArray wraps an array and keeps track of the next index to be used to avoid the heap allocation.
+	varLengthPoolArray[T any] struct {
+		arr  [arraySize]T
+		next int
+	}
+)
 
 // VarLength is a variable length array that can be reused via a pool.
 type VarLength[T any] struct {
-	backing *[]T
+	arr *varLengthPoolArray[T]
+	slc *[]T
 }
 
 // NewVarLengthPool returns a new VarLengthPool.
 func NewVarLengthPool[T any]() VarLengthPool[T] {
 	return VarLengthPool[T]{
-		arrayPool: NewPool[[arraySize]T](nil),
+		arrayPool: NewPool[varLengthPoolArray[T]](func(v *varLengthPoolArray[T]) {
+			v.next = 0
+		}),
 		slicePool: NewPool[[]T](func(i *[]T) {
 			*i = (*i)[:0]
 		}),
@@ -133,18 +145,17 @@ func NewVarLengthPool[T any]() VarLengthPool[T] {
 
 // NewNilVarLength returns a new VarLength[T] with a nil backing.
 func NewNilVarLength[T any]() VarLength[T] {
-	var v *[]T = nil
-	return VarLength[T]{backing: v}
+	return VarLength[T]{}
 }
 
 // Allocate allocates a new VarLength[T] from the pool.
 func (p *VarLengthPool[T]) Allocate(knownMin int) VarLength[T] {
 	if knownMin <= arraySize {
-		arr := p.arrayPool.Allocate()[:0]
-		return VarLength[T]{backing: &arr}
+		arr := p.arrayPool.Allocate()
+		return VarLength[T]{arr: arr}
 	}
 	slc := p.slicePool.Allocate()
-	return VarLength[T]{backing: slc}
+	return VarLength[T]{slc: slc}
 }
 
 // Reset resets the pool.
@@ -153,35 +164,52 @@ func (p *VarLengthPool[T]) Reset() {
 	p.slicePool.Reset()
 }
 
-// Append appends an item to the backing slice.
+// Append appends items to the backing slice just like the `append` builtin function in Go.
 func (i VarLength[T]) Append(p *VarLengthPool[T], items ...T) VarLength[T] {
-	if i.backing == nil {
-		arr := p.arrayPool.Allocate()[:0]
-		i.backing = &arr
+	if i.slc != nil {
+		*i.slc = append(*i.slc, items...)
+		return i
 	}
 
-	if len(*i.backing)+len(items) <= arraySize {
-		*i.backing = append(*i.backing, items...)
-		return i
-	} else if len(*i.backing) == arraySize {
+	if i.arr == nil {
+		i.arr = p.arrayPool.Allocate()
+	}
+
+	arr := i.arr
+	if arr.next+len(items) <= arraySize {
+		for _, item := range items {
+			arr.arr[arr.next] = item
+			arr.next++
+		}
+	} else {
 		slc := p.slicePool.Allocate()
 		// Copy the array to the slice.
-		*slc = append(*slc, *i.backing...)
+		for ptr := 0; ptr < arr.next; ptr++ {
+			*slc = append(*slc, arr.arr[ptr])
+		}
+		i.slc = slc
+		*i.slc = append(*i.slc, items...)
 	}
-	*i.backing = append(*i.backing, items...)
 	return i
 }
 
 // View returns the backing slice.
 func (i VarLength[T]) View() []T {
-	if i.backing == nil {
-		return nil
+	if i.slc != nil {
+		return *i.slc
+	} else if i.arr != nil {
+		arr := i.arr
+		return arr.arr[:arr.next]
 	}
-	return *i.backing
+	return nil
 }
 
 // Cut cuts the backing slice to the given length.
 // Precondition: n <= len(i.backing).
 func (i VarLength[T]) Cut(n int) {
-	*i.backing = (*i.backing)[:n]
+	if i.slc != nil {
+		*i.slc = (*i.slc)[:n]
+	} else if i.arr != nil {
+		i.arr.next = n
+	}
 }

--- a/internal/engine/wazevo/wazevoapi/pool_test.go
+++ b/internal/engine/wazevo/wazevoapi/pool_test.go
@@ -17,34 +17,34 @@ func TestNewNilVarLength(t *testing.T) {
 func TestAllocate(t *testing.T) {
 	pool := NewVarLengthPool[uint64]()
 	// Array:
-	v := pool.Allocate(10)
-	require.NotNil(t, v.backing)
-	require.Equal(t, 0, len(*v.backing))
-	require.Equal(t, arraySize, cap(*v.backing))
+	v := pool.Allocate(5)
+	require.NotNil(t, v.arr)
+	require.Equal(t, 0, v.arr.next)
+	require.Equal(t, arraySize, cap(v.arr.arr))
 
 	// Slice backed:
 	v = pool.Allocate(25)
-	require.NotNil(t, v.backing)
-	require.Equal(t, 0, len(*v.backing))
+	require.NotNil(t, v.slc)
+	require.Equal(t, 0, len(*v.slc))
 	v.Append(&pool, 1)
-	require.NotNil(t, v.backing)
-	require.Equal(t, 1, len(*v.backing))
+	require.NotNil(t, v.slc)
+	require.Equal(t, 1, len(*v.slc))
 	v.Append(&pool, 2)
-	require.NotNil(t, v.backing)
-	require.Equal(t, 2, len(*v.backing))
-	capacity := cap(*v.backing)
+	require.NotNil(t, v.slc)
+	require.Equal(t, 2, len(*v.slc))
+	capacity := cap(*v.slc)
 
 	// Reset the pool and ensure the backing slice is reused.
 	pool.Reset()
 
-	v = pool.Allocate(10)
-	require.NotNil(t, v.backing)
-	require.Equal(t, 0, len(*v.backing))
-	require.Equal(t, arraySize, cap(*v.backing))
+	v = pool.Allocate(5)
+	require.NotNil(t, v.arr)
+	require.Equal(t, 0, v.arr.next)
+	require.Equal(t, arraySize, cap(v.arr.arr))
 	v = pool.Allocate(25)
-	require.NotNil(t, v.backing)
-	require.Equal(t, 0, len(*v.backing))
-	require.Equal(t, capacity, cap(*v.backing))
+	require.NotNil(t, v.slc)
+	require.Equal(t, 0, len(*v.slc))
+	require.Equal(t, capacity, cap(*v.slc))
 }
 
 func TestAppendAndView(t *testing.T) {

--- a/internal/integration_test/stdlibs/bench_test.go
+++ b/internal/integration_test/stdlibs/bench_test.go
@@ -129,7 +129,7 @@ func runtBenches(b *testing.B, ctx context.Context, rc wazero.RuntimeConfig, tc 
 			continue
 		}
 
-		for _, compile := range []bool{false, true} {
+		for _, compile := range []bool{true} {
 			if compile {
 				b.Run("Compile/"+fname, func(b *testing.B) {
 					b.ResetTimer()


### PR DESCRIPTION
```
>> benchstat old.txt new8.txt
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                             │   old.txt   │              new8.txt               │
                             │   sec/op    │   sec/op     vs base                │
Zig/Compile/test-opt.wasm-10   4.750 ± ∞ ¹   4.842 ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Compile/test.wasm-10       5.931 ± ∞ ¹   5.899 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                        5.308         5.345        +0.69%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                             │    old.txt    │               new8.txt                │
                             │     B/op      │     B/op       vs base                │
Zig/Compile/test-opt.wasm-10   464.0Mi ± ∞ ¹   455.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Compile/test.wasm-10       717.8Mi ± ∞ ¹   703.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                        577.1Mi         565.9Mi        -1.94%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                             │    old.txt    │               new8.txt                │
                             │   allocs/op   │  allocs/op    vs base                 │
Zig/Compile/test-opt.wasm-10    953.9k ± ∞ ¹   436.8k ± ∞ ¹        ~ (p=1.000 n=1) ²
Zig/Compile/test.wasm-10       1137.6k ± ∞ ¹   555.1k ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                         1.042M         492.4k        -52.73%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```