### PR TITLE
fuzz: adds --no-trace-compares flag by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,14 +272,16 @@ clean: ## Ensure a clean build
 	@rm -rf dist build coverage.txt
 	@go clean -testcache
 
+fuzz_flags := --no-trace-compares --sanitizer=none -- -rss_limit_mb=8192
+
 fuzz_timeout_seconds ?= 10
 .PHONY: fuzz
 fuzz:
 	@cd internal/integration_test/fuzz && cargo test
-	@cd internal/integration_test/fuzz && cargo fuzz run logging_no_diff --sanitizer=none -- -rss_limit_mb=8192 -max_total_time=$(fuzz_timeout_seconds)
-	@cd internal/integration_test/fuzz && cargo fuzz run no_diff --sanitizer=none -- -rss_limit_mb=8192 -max_total_time=$(fuzz_timeout_seconds)
-	@cd internal/integration_test/fuzz && cargo fuzz run memory_no_diff --sanitizer=none -- -rss_limit_mb=8192 -max_total_time=$(fuzz_timeout_seconds)
-	@cd internal/integration_test/fuzz && cargo fuzz run validation --sanitizer=none -- -rss_limit_mb=8192 -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run logging_no_diff $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run no_diff $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run memory_no_diff $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run validation $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
 
 libsodium:
 	cd ./internal/integration_test/libsodium/testdata && \

--- a/Makefile
+++ b/Makefile
@@ -272,16 +272,16 @@ clean: ## Ensure a clean build
 	@rm -rf dist build coverage.txt
 	@go clean -testcache
 
-fuzz_flags := --no-trace-compares --sanitizer=none -- -rss_limit_mb=8192
+fuzz_default_flags := --no-trace-compares --sanitizer=none -- -rss_limit_mb=8192
 
 fuzz_timeout_seconds ?= 10
 .PHONY: fuzz
 fuzz:
 	@cd internal/integration_test/fuzz && cargo test
-	@cd internal/integration_test/fuzz && cargo fuzz run logging_no_diff $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
-	@cd internal/integration_test/fuzz && cargo fuzz run no_diff $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
-	@cd internal/integration_test/fuzz && cargo fuzz run memory_no_diff $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
-	@cd internal/integration_test/fuzz && cargo fuzz run validation $(fuzz_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run logging_no_diff $(fuzz_default_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run no_diff $(fuzz_default_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run memory_no_diff $(fuzz_default_flags) -max_total_time=$(fuzz_timeout_seconds)
+	@cd internal/integration_test/fuzz && cargo fuzz run validation $(fuzz_default_flags) -max_total_time=$(fuzz_timeout_seconds)
 
 libsodium:
 	cd ./internal/integration_test/libsodium/testdata && \

--- a/internal/integration_test/fuzz/README.md
+++ b/internal/integration_test/fuzz/README.md
@@ -41,16 +41,16 @@ See `cargo fuzz run --help` for the options. Especially, the following flags are
 
 ```
 # Running the `no_diff` target with 15 concurrent jobs with total runnig time with 2hrs and 8GB memory limit.
-$ cargo fuzz run no_diff --sanitizer=none -- -rss_limit_mb=8192 -max_len=5000000 -max_total_time=7200 -jobs=15
+$ cargo fuzz run no_diff --sanitizer=none --no-trace-compares -- -rss_limit_mb=8192 -max_len=5000000 -max_total_time=7200 -jobs=15
 
 # Running the `memory_no_diff` target with 15 concurrent jobs with timeout 2hrs and setting timeout per fuzz case to 30s.
-$ cargo fuzz run memory_no_diff --sanitizer=none -- -timeout=30 -max_total_time=7200 -jobs=15
+$ cargo fuzz run memory_no_diff --sanitizer=none --no-trace-compares -- -timeout=30 -max_total_time=7200 -jobs=15
 
 # Running the `validation` target with 4 concurrent jobs with timeout 2hrs and setting timeout per fuzz case to 30s.
-# cargo fuzz run validation --sanitizer=none -- -timeout=30 -max_total_time=7200 -jobs=4
+# cargo fuzz run validation --sanitizer=none --no-trace-compares -- -timeout=30 -max_total_time=7200 -jobs=4
 ```
 
-Note that `--sanitizer=none` is always recommended to use because the sanitizer is not useful for our use case plus this will speed up the fuzzing by like multiple times.
+Note that `--sanitizer=none` and `--no-trace-compares` are always recommended to use because the sanitizer is not useful for our use case plus this will speed up the fuzzing by like multiple times.
 
 ### Reproduce errors
 


### PR DESCRIPTION
This speeds up the fuzzing drastically at the cost of worse coverage (I think we don't care).