### PR TITLE
ci: always use the same command to upload artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,12 +181,6 @@ jobs:
           ls dist
           tag="${GITHUB_REF#refs/tags/}"
           ./.github/workflows/release_notes.sh ${tag} > release-notes.txt
-          if [[ $VERSION =~ -[a-z]+\. ]]; then
-            # If it is a pre-release (e.g. it contains `-pre.`) create release notes without artifacts.
-            gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/}
-          else
-            # Otherwise upload artifacts.
-            gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/} ./dist/*
-          fi
+          gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/} ./dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Partially reverts the change in #2143 because the alternative command uploads the artifacts anyway. The rest of #2143 fixes the version number for MSI artifacts, which is still required.