### PR TITLE
wazevo(frontend): allocation free initializeCurrentBlockKnownBounds

### DIFF
--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -4,7 +4,6 @@ package frontend
 import (
 	"bytes"
 	"math"
-	"slices"
 
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/wazevoapi"
@@ -507,9 +506,7 @@ func (c *Compiler) finalizeKnownSafeBoundsAtTheEndOfBlock(bID ssa.BasicBlockID) 
 	size := len(c.knownSafeBoundsSet)
 	allocated := c.varLengthKnownSafeBoundWithIDPool.Allocate(size)
 	// Sort the known safe bounds by the value ID so that we can use the intersection algorithm in initializeCurrentBlockKnownBounds.
-	slices.SortFunc(c.knownSafeBoundsSet, func(i, j ssa.ValueID) int {
-		return int(i) - int(j)
-	})
+	sortSSAValueIDs(c.knownSafeBoundsSet)
 	for _, vID := range c.knownSafeBoundsSet {
 		kb := c.knownSafeBounds[vID]
 		allocated = allocated.Append(p, knownSafeBoundWithID{

--- a/internal/engine/wazevo/frontend/sort_id.go
+++ b/internal/engine/wazevo/frontend/sort_id.go
@@ -1,0 +1,13 @@
+package frontend
+
+import (
+	"slices"
+
+	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
+)
+
+func sortSSAValueIDs(IDs []ssa.ValueID) {
+	slices.SortFunc(IDs, func(i, j ssa.ValueID) int {
+		return int(i) - int(j)
+	})
+}

--- a/internal/engine/wazevo/frontend/sort_id.go
+++ b/internal/engine/wazevo/frontend/sort_id.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 package frontend
 
 import (

--- a/internal/engine/wazevo/frontend/sort_id_old.go
+++ b/internal/engine/wazevo/frontend/sort_id_old.go
@@ -1,0 +1,15 @@
+//go:build !go1.21
+
+package frontend
+
+import (
+	"sort"
+
+	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
+)
+
+func sortSSAValueIDs(IDs []ssa.ValueID) {
+	sort.SliceStable(IDs, func(i, j int) bool {
+		return int(IDs[i]) < int(IDs[j])
+	})
+}

--- a/internal/engine/wazevo/frontend/sort_id_old.go
+++ b/internal/engine/wazevo/frontend/sort_id_old.go
@@ -1,5 +1,7 @@
 //go:build !go1.21
 
+// TODO: delete after the floor Go version is 1.21
+
 package frontend
 
 import (


### PR DESCRIPTION
``` 
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                             │  old.txt   │             new.txt              │
                             │   sec/op   │   sec/op    vs base              │
Zig/Compile/test-opt.wasm-10   4.749 ± 2%   4.732 ± 2%       ~ (p=1.000 n=7)
Zig/Compile/test.wasm-10       5.792 ± 2%   5.798 ± 2%       ~ (p=0.383 n=7)
geomean                        5.245        5.238       -0.13%

                             │   old.txt    │              new.txt               │
                             │     B/op     │     B/op      vs base              │
Zig/Compile/test-opt.wasm-10   454.9Mi ± 0%   448.1Mi ± 0%  -1.50% (p=0.001 n=7)
Zig/Compile/test.wasm-10       703.8Mi ± 0%   694.7Mi ± 0%  -1.29% (p=0.001 n=7)
geomean                        565.8Mi        557.9Mi       -1.40%

                             │   old.txt   │              new.txt               │
                             │  allocs/op  │  allocs/op   vs base               │
Zig/Compile/test-opt.wasm-10   436.5k ± 0%   389.0k ± 0%  -10.87% (p=0.001 n=7)
Zig/Compile/test.wasm-10       555.4k ± 0%   522.0k ± 0%   -6.01% (p=0.001 n=7)
geomean                        492.4k        450.6k        -8.47%

```