### PR TITLE
internal: skip platform-specific code when building with TinyGo

### DIFF
--- a/internal/engine/wazevo/entrypoint_amd64.go
+++ b/internal/engine/wazevo/entrypoint_amd64.go
@@ -1,3 +1,5 @@
+//go:build amd64 && !tinygo
+
 package wazevo
 
 import _ "unsafe"

--- a/internal/engine/wazevo/entrypoint_arm64.go
+++ b/internal/engine/wazevo/entrypoint_arm64.go
@@ -1,3 +1,5 @@
+//go:build arm64 && !tinygo
+
 package wazevo
 
 import _ "unsafe"

--- a/internal/engine/wazevo/entrypoint_others.go
+++ b/internal/engine/wazevo/entrypoint_others.go
@@ -1,4 +1,4 @@
-//go:build !arm64 && !amd64
+//go:build (!arm64 && !amd64) || tinygo
 
 package wazevo
 

--- a/internal/platform/cpuid_amd64.go
+++ b/internal/platform/cpuid_amd64.go
@@ -1,3 +1,5 @@
+//go:build amd64 && !tinygo
+
 package platform
 
 // CpuFeatures exposes the capabilities for this CPU, queried via the Has, HasExtra methods

--- a/internal/platform/cpuid_unsupported.go
+++ b/internal/platform/cpuid_unsupported.go
@@ -12,7 +12,3 @@ func (c *cpuFeatureFlags) Has(cpuFeature CpuFeature) bool { return false }
 
 // HasExtra implements the same method on the CpuFeatureFlags interface
 func (c *cpuFeatureFlags) HasExtra(cpuFeature CpuFeature) bool { return false }
-
-func cpuid(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32) {
-	panic("unsupported")
-}

--- a/internal/platform/cpuid_unsupported.go
+++ b/internal/platform/cpuid_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !amd64
+//go:build !amd64 || tinygo
 
 package platform
 
@@ -12,3 +12,7 @@ func (c *cpuFeatureFlags) Has(cpuFeature CpuFeature) bool { return false }
 
 // HasExtra implements the same method on the CpuFeatureFlags interface
 func (c *cpuFeatureFlags) HasExtra(cpuFeature CpuFeature) bool { return false }
+
+func cpuid(arg1, arg2 uint32) (eax, ebx, ecx, edx uint32) {
+	panic("unsupported")
+}

--- a/internal/platform/mmap_unix.go
+++ b/internal/platform/mmap_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux || freebsd
+//go:build (darwin || linux || freebsd) && !tinygo
 
 package platform
 

--- a/internal/platform/mmap_unsupported.go
+++ b/internal/platform/mmap_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || linux || freebsd || windows)
+//go:build !(darwin || linux || freebsd || windows) || tinygo
 
 package platform
 

--- a/internal/platform/mremap_other.go
+++ b/internal/platform/mremap_other.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || linux || freebsd)
+//go:build !(darwin || linux || freebsd) || tinygo
 
 package platform
 

--- a/internal/platform/mremap_unix.go
+++ b/internal/platform/mremap_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux || freebsd
+//go:build (darwin || linux || freebsd) && !tinygo
 
 package platform
 


### PR DESCRIPTION
Use build tags to skip some platform-specific Go code when building the project using TinyGo.

Together with my other recent PRs into the project, this one completes the set of changes required to build the project with TinyGo. When all of them are merged, I'll make sure to do one final check that it works as intended and then I'll add the TinyGo builds on CI.

Related open PRs: #2161 and #2160