### PR TITLE
wazevo(frontend): BCE should not propagate the memory address to unsealed blocks

### DIFF
--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -524,7 +524,13 @@ func (c *Compiler) initializeCurrentBlockKnownBounds() {
 	case 1:
 		pred := currentBlk.Pred(0).ID()
 		for _, kb := range c.getKnownSafeBoundsAtTheEndOfBlocks(pred).View() {
-			c.recordKnownSafeBound(kb.id, kb.bound, kb.absoluteAddr)
+			// Unless the block is sealed, we cannot assume the absolute address is valid:
+			// later we might add another predecessor that has no visibility of that value.
+			addr := ssa.ValueInvalid
+			if currentBlk.Sealed() {
+				addr = kb.absoluteAddr
+			}
+			c.recordKnownSafeBound(kb.id, kb.bound, addr)
 		}
 	default:
 		c.pointers = c.pointers[:0]

--- a/internal/engine/wazevo/ssa/basic_block.go
+++ b/internal/engine/wazevo/ssa/basic_block.go
@@ -55,6 +55,9 @@ type BasicBlock interface {
 	// Valid is true if this block is still valid even after optimizations.
 	Valid() bool
 
+	// Sealed is true if this block has been sealed.
+	Sealed() bool
+
 	// BeginPredIterator returns the first predecessor of this block.
 	BeginPredIterator() BasicBlock
 
@@ -210,6 +213,11 @@ func (bb *basicBlock) Param(i int) Value {
 // Valid implements BasicBlock.Valid.
 func (bb *basicBlock) Valid() bool {
 	return !bb.invalid
+}
+
+// Sealed implements BasicBlock.Sealed.
+func (bb *basicBlock) Sealed() bool {
+	return bb.sealed
 }
 
 // InsertInstruction implements BasicBlock.InsertInstruction.


### PR DESCRIPTION
tl;dr: I propose to propagate the memory address only for **sealed** blocks, where we know that no predecessors will be added at a later time.

This originated from an issue raised by @jerbob92 for go-pdfium.

Essentially, it looks like block 4 of function `5011` (local ID = 4960) in go-pdfium references some values that *may* not be visibile on by some of its predecessors.

We are propagating known bounds _while_ we are creating basic blocks; which means that, at a give time, we _might not know_ all of the possible predecessors to a given block. In the case of that block 4, the SSA dump shows:

```
blk4: (v305:i32,v341:i32) <-- (blk3,blk62)
```

which means that one of the predecessors in `blk62`. However, when we enter function `initializeCurrentBlockKnownBounds()` we enter `case 1` because there is only one predecessor (`blk3`) at that time. 

When blocks have more than 1 predecessor, we should enter the `default` case instead: this never propagates `kb.bound` AND `kb.address`, but it always propagates `kb.bound` and `ssa.ValueInvalid` because it cannot assume that the address will be valid on all paths.

This small change, as opposed to other earlier attempts, where I was unconditionally propagating `ssa.ValueInvalid` in all cases (see the Slack threads), does not affect codegen in a lot of cases (e.g. test case `TestCompiler_LowerToSSA/bounds check in if-else` is left unaffected)

