### PR TITLE
wazevo(arm64): trampoline for far calls on relocation

### DIFF
--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -111,6 +111,7 @@ type Compiler interface {
 
 // RelocationInfo represents the relocation information for a call instruction.
 type RelocationInfo struct {
+	Caller ssa.FuncRef
 	// Offset represents the offset from the beginning of the machine code of either a function or the entire module.
 	Offset int64
 	// FuncRef is the target function of the call instruction.

--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -113,8 +113,10 @@ type Compiler interface {
 type RelocationInfo struct {
 	// Offset represents the offset from the beginning of the machine code of either a function or the entire module.
 	Offset int64
-	// Target is the target function of the call instruction.
+	// FuncRef is the target function of the call instruction.
 	FuncRef ssa.FuncRef
+	// TrampolineOffset is an optional offset to a trampoline if the call instruction is out of range.
+	TrampolineOffset int
 }
 
 // compiler implements Compiler.

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2072,6 +2072,11 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 	}
 }
 
+func (m *machine) UpdateRelocationInfo(r *backend.RelocationInfo, totalSize int, body []byte) []byte {
+	r.Offset += int64(totalSize)
+	return body
+}
+
 func (m *machine) lowerIcmpToFlag(xd, yd *backend.SSAValueDefinition, _64 bool) {
 	x := m.getOperand_Reg(xd)
 	y := m.getOperand_Mem_Imm32_Reg(yd)

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2072,9 +2072,9 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 	}
 }
 
-func (m *machine) UpdateRelocationInfo(r *backend.RelocationInfo, totalSize int, body []byte) []byte {
+func (m *machine) UpdateRelocationInfo(r backend.RelocationInfo, totalSize int, body []byte) (backend.RelocationInfo, []byte) {
 	r.Offset += int64(totalSize)
-	return body
+	return r, body
 }
 
 func (m *machine) lowerIcmpToFlag(xd, yd *backend.SSAValueDefinition, _64 bool) {

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2078,8 +2078,8 @@ func (m *machine) RelocationTrampolineSize(relocations []backend.RelocationInfo)
 }
 
 // UpdateRelocationInfo implements backend.Machine.
-func (m *machine) UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r backend.RelocationInfo) (backend.RelocationInfo, int) {
-	return r, 0
+func (m *machine) UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r *backend.RelocationInfo) int {
+	return 0
 }
 
 func (m *machine) lowerIcmpToFlag(xd, yd *backend.SSAValueDefinition, _64 bool) {

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2072,9 +2072,14 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 	}
 }
 
-func (m *machine) UpdateRelocationInfo(r backend.RelocationInfo, totalSize int, body []byte) (backend.RelocationInfo, []byte) {
-	r.Offset += int64(totalSize)
-	return r, body
+// RelocationTrampolineSize implements backend.Machine.
+func (m *machine) RelocationTrampolineSize(relocations []backend.RelocationInfo) int {
+	return 0
+}
+
+// UpdateRelocationInfo implements backend.Machine.
+func (m *machine) UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r backend.RelocationInfo) (backend.RelocationInfo, int) {
+	return r, 0
 }
 
 func (m *machine) lowerIcmpToFlag(xd, yd *backend.SSAValueDefinition, _64 bool) {

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
@@ -41,13 +41,13 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 	}
 }
 
-func (m *machine) UpdateRelocationInfo(r *backend.RelocationInfo, totalSize int, body []byte) []byte {
+func (m *machine) UpdateRelocationInfo(r backend.RelocationInfo, totalSize int, body []byte) (backend.RelocationInfo, []byte) {
 	// FIXME: this should add padding conditionally based on refToBinaryOffset[r.FuncRef].
 	// But when we invoke this method the refToBinaryOffset is not set for all funcRefs.
 	r.Offset += int64(totalSize)
 	r.TrampolineOffset = totalSize + len(body)
 	body = append(body, make([]byte, 4*6)...)
-	return body
+	return r, body
 }
 
 func encodeTrampoline(addr uint, binary []byte, instrOffset int, returnOffset int64) {

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
@@ -1,7 +1,7 @@
 package arm64
 
 import (
-	"fmt"
+	"unsafe"
 
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
@@ -11,6 +11,7 @@ import (
 //
 // TODO: unit test!
 func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []backend.RelocationInfo) {
+	base := uintptr(unsafe.Pointer(&binary[0]))
 	for _, r := range relocations {
 		instrOffset := r.Offset
 		calleeFnOffset := refToBinaryOffset[r.FuncRef]
@@ -18,7 +19,14 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 		diff := int64(calleeFnOffset) - (instrOffset)
 		// Check if the diff is within the range of the branch instruction.
 		if diff < -(1<<25)*4 || diff > ((1<<25)-1)*4 {
-			panic(fmt.Sprintf("TODO: too large binary where branch target is out of the supported range +/-128MB: %#x", diff))
+			// If the diff is out of range, we need to use a trampoline.
+			diff = int64(r.TrampolineOffset) - instrOffset
+			// The trampoline invokes the function using the BLR instruction
+			// using the absolute address of the callee function.
+			absoluteCalleeFnAddress := uint(base) + uint(calleeFnOffset)
+			// The trampoline should return to the next instruction after the branch instruction.
+			returnOffset := -diff + 8
+			encodeTrampoline(absoluteCalleeFnAddress, binary, r.TrampolineOffset, returnOffset)
 		}
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BL--Branch-with-Link-
 		imm26 := diff / 4
@@ -30,5 +38,40 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 		} else {
 			brInstr[3] = (byte(imm26 >> 24 & 0b000000_01)) | 0b100101_00 // No sign bit.
 		}
+	}
+}
+
+func (m *machine) UpdateRelocationInfo(r *backend.RelocationInfo, totalSize int, body []byte) []byte {
+	// FIXME: this should add padding conditionally based on refToBinaryOffset[r.FuncRef].
+	// But when we invoke this method the refToBinaryOffset is not set for all funcRefs.
+	r.Offset += int64(totalSize)
+	r.TrampolineOffset = totalSize + len(body)
+	body = append(body, make([]byte, 4*6)...)
+	return body
+}
+
+func encodeTrampoline(addr uint, binary []byte, instrOffset int, returnOffset int64) {
+	// The tmpReg is safe to overwrite.
+	tmpReg := regNumberInEncoding[tmp]
+
+	const movzOp = uint32(0b10)
+	const movkOp = uint32(0b11)
+	// Note: for our purposes the 64-bit width of the reg should be enough.
+	//       however, larger values could be written to and loaded from a constant pool (see encodeBrTableSequence).
+	instrs := []uint32{
+		encodeMoveWideImmediate(movzOp, tmpReg, uint64(uint16(addr)), 0, 1),
+		encodeMoveWideImmediate(movkOp, tmpReg, uint64(uint16(addr>>16)), 1, 1),
+		encodeMoveWideImmediate(movkOp, tmpReg, uint64(uint16(addr>>32)), 2, 1),
+		encodeMoveWideImmediate(movkOp, tmpReg, uint64(uint16(addr>>48)), 3, 1),
+		encodeUnconditionalBranchReg(tmpReg, true),
+		encodeUnconditionalBranch(false, returnOffset-6*4),
+	}
+
+	for i, inst := range instrs {
+		instrBytes := binary[instrOffset+i*4 : instrOffset+(i+1)*4]
+		instrBytes[0] = byte(inst)
+		instrBytes[1] = byte(inst >> 8)
+		instrBytes[2] = byte(inst >> 16)
+		instrBytes[3] = byte(inst >> 24)
 	}
 }

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation_test.go
@@ -1,0 +1,188 @@
+package arm64
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend"
+	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestMachine_ResolveRelocations(t *testing.T) {
+	// ResolveRelocations takes the address of the "body" function
+	// so we pre-allocate a buffer here to reuse so that the value
+	// will be stable across executions.
+	// When we test we just copy over data to the buffer
+	// before encoding.
+
+	buf := make([]byte, 128)
+	base := uint(uintptr(unsafe.Pointer(&buf[0])))
+
+	tests := []struct {
+		name string
+
+		refToBinaryOffset map[ssa.FuncRef]int
+		relocations       []backend.RelocationInfo
+
+		expBinary func() []byte
+	}{
+		{
+			name:        "no trampolines",
+			relocations: []backend.RelocationInfo{{Caller: 1, Offset: 8, TrampolineOffset: 0, FuncRef: 3}},
+			expBinary: func() []byte {
+				copy(buf[8:16], []byte{0xfe, 0xff, 0xff, 0x97})
+				return append([]byte{}, buf...)
+			},
+		},
+		{
+			name: "1 trampoline",
+			refToBinaryOffset: map[ssa.FuncRef]int{
+				3: (1<<25)*4 + 100,
+			},
+			relocations: []backend.RelocationInfo{{Offset: 8, TrampolineOffset: 16, FuncRef: 3}},
+			expBinary: func() []byte {
+				prefix := []byte{
+					0, 0, 0, 0,
+					0, 0, 0, 0,
+					0x2, 0x0, 0x0, 0x94,
+					0, 0, 0, 0,
+				}
+				copy(buf, prefix)
+				encodeTrampoline(base+uint(1<<25)*4+100, buf, 16)
+				return append([]byte{}, buf...)
+			},
+		},
+		{
+			name: "multiple trampolines",
+
+			relocations: []backend.RelocationInfo{
+				{Caller: 1, Offset: 8, TrampolineOffset: 16 + relocationTrampolineSize, FuncRef: 3},
+				{Caller: 1, Offset: 12, TrampolineOffset: 16 + 2*relocationTrampolineSize, FuncRef: 4},
+			},
+			refToBinaryOffset: map[ssa.FuncRef]int{
+				1: 500,
+				3: (1<<25)*4 + 100,
+				4: -(1<<25)*4 - 100,
+			},
+			expBinary: func() []byte {
+				prefix := []byte{
+					0, 0, 0, 0,
+					0, 0, 0, 0,
+					0x7, 0x0, 0x0, 0x94,
+					0xb, 0x0, 0x0, 0x94,
+				}
+				copy(buf, prefix)
+				addr1 := base + (1<<25)*4 + 100
+				addr2 := base - (1<<25)*4 - 100
+				encodeTrampoline(addr1, buf, 16+relocationTrampolineSize)
+				encodeTrampoline(addr2, buf, 16+2*relocationTrampolineSize)
+				return append([]byte{}, buf...)
+			},
+		},
+		{
+			name: "mixed trampolines + within range",
+			relocations: []backend.RelocationInfo{
+				{Caller: 1, Offset: 4, FuncRef: 3},
+				{Caller: 1, Offset: 8, TrampolineOffset: 20 + relocationTrampolineSize, FuncRef: 4},
+				{Caller: 1, Offset: 12, TrampolineOffset: 20 + 2*relocationTrampolineSize, FuncRef: 5},
+			},
+			refToBinaryOffset: map[ssa.FuncRef]int{
+				1: 500,
+				3: 400,
+				4: (1<<25)*4 + 100,
+				5: -(1<<25)*4 - 300,
+			},
+			expBinary: func() []byte {
+				prefix := []byte{
+					0, 0, 0, 0,
+					0x63, 0x0, 0x0, 0x94,
+					0x8, 0x0, 0x0, 0x94,
+					0xc, 0, 0, 0x94,
+				}
+				copy(buf, prefix)
+				addr1 := base + (1<<25)*4 + 100
+				addr2 := base - (1<<25)*4 - 300
+				encodeTrampoline(addr1, buf, 20+relocationTrampolineSize)
+				encodeTrampoline(addr2, buf, 20+2*relocationTrampolineSize)
+				return append([]byte{}, buf...)
+			},
+		},
+		{
+			name: "mixed trampolines + within range",
+			relocations: []backend.RelocationInfo{
+				{Caller: 1, Offset: 4, FuncRef: 3},
+				{Caller: 1, Offset: 8, TrampolineOffset: 20 + relocationTrampolineSize, FuncRef: 4},
+				{Caller: 1, Offset: 12, TrampolineOffset: 20 + 2*relocationTrampolineSize, FuncRef: 5},
+			},
+			refToBinaryOffset: map[ssa.FuncRef]int{
+				1: 500,
+				3: 400,
+				4: (1<<25)*4 + 100,
+				5: -(1<<25)*4 - 300,
+			},
+			expBinary: func() []byte {
+				prefix := []byte{
+					0, 0, 0, 0,
+					0x63, 0x0, 0x0, 0x94,
+					0x8, 0x0, 0x0, 0x94,
+					0xc, 0, 0, 0x94,
+				}
+				copy(buf, prefix)
+				addr1 := base + (1<<25)*4 + 100
+				addr2 := base - (1<<25)*4 - 300
+				encodeTrampoline(addr1, buf, 20+relocationTrampolineSize)
+				encodeTrampoline(addr2, buf, 20+2*relocationTrampolineSize)
+				return append([]byte{}, buf...)
+			},
+		},
+		{
+			name: "extra rel entries + mixed trampolines + within range on arm64",
+			refToBinaryOffset: map[ssa.FuncRef]int{
+				1: 400,
+				2: 500,
+				3: 600,
+				4: (1<<25)*4 + 1000,
+				5: -(1<<25)*4 - 300,
+			},
+			relocations: []backend.RelocationInfo{
+				{Caller: 1, Offset: 4, FuncRef: 3},
+				{Caller: 2, Offset: 8, FuncRef: 1},
+				{Caller: 3, Offset: 12, FuncRef: 2},
+				{Caller: 10, Offset: 80, FuncRef: 3},
+				{Caller: 10, Offset: 84, TrampolineOffset: 20 + relocationTrampolineSize, FuncRef: 4},
+				{Caller: 10, Offset: 88, TrampolineOffset: 20 + 2*relocationTrampolineSize, FuncRef: 5},
+				{Caller: 12, Offset: 120, FuncRef: 2},
+			},
+			expBinary: func() []byte {
+				prefix := []byte{
+					0, 0, 0, 0,
+					0x95, 0x0, 0x0, 0x94,
+					0x62, 0x0, 0x0, 0x94,
+					0x7a, 0, 0, 0x94,
+				}
+				copy(buf, prefix)
+				addr1 := base + (1<<25)*4 + 1000
+				addr2 := base - (1<<25)*4 - 300
+				encodeTrampoline(addr1, buf, 20+relocationTrampolineSize)
+				encodeTrampoline(addr2, buf, 20+2*relocationTrampolineSize)
+				return append([]byte{}, buf...)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &machine{}
+			buf = buf[0:]
+			m.ResolveRelocations(tt.refToBinaryOffset, buf, tt.relocations)
+			result := append([]byte{}, buf...)
+			buf = buf[0:]
+			expBinary := tt.expBinary()
+			require.Equal(t, expBinary, result)
+
+			for i := 0; i < len(expBinary); i++ {
+				require.Equal(t, expBinary[i], result[i], i)
+			}
+		})
+	}
+}

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -61,6 +61,10 @@ type (
 		// ResolveRelocations resolves the relocations after emitting machine code.
 		ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []RelocationInfo)
 
+		// UpdateRelocationInfo recomputes the relocation info after emitting machine code and pads the body
+		// to accommodate trampolines if necessary.
+		UpdateRelocationInfo(r *RelocationInfo, totalSize int, body []byte) []byte
+
 		// Encode encodes the machine instructions to the Compiler.
 		Encode(ctx context.Context)
 

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -63,7 +63,7 @@ type (
 
 		// UpdateRelocationInfo recomputes the RelocationInfo after emitting machine code and returns the updated
 		// RelocationInfo and the size of the trampoline if necessary.
-		UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r RelocationInfo) (res RelocationInfo, trampolineSize int)
+		UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r *RelocationInfo) (trampolineSize int)
 
 		RelocationTrampolineSize(relocations []RelocationInfo) int
 

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -65,6 +65,8 @@ type (
 		// RelocationInfo and the size of the trampoline if necessary.
 		UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r *RelocationInfo) (trampolineSize int)
 
+		// RelocationTrampolineSize returns the size of the trampoline section at the end of a function
+		// for the given relocation info.
 		RelocationTrampolineSize(relocations []RelocationInfo) int
 
 		// Encode encodes the machine instructions to the Compiler.

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -63,7 +63,7 @@ type (
 
 		// UpdateRelocationInfo recomputes the relocation info after emitting machine code and pads the body
 		// to accommodate trampolines if necessary.
-		UpdateRelocationInfo(r *RelocationInfo, totalSize int, body []byte) []byte
+		UpdateRelocationInfo(r RelocationInfo, totalSize int, body []byte) (RelocationInfo, []byte)
 
 		// Encode encodes the machine instructions to the Compiler.
 		Encode(ctx context.Context)

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -61,9 +61,11 @@ type (
 		// ResolveRelocations resolves the relocations after emitting machine code.
 		ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []RelocationInfo)
 
-		// UpdateRelocationInfo recomputes the relocation info after emitting machine code and pads the body
-		// to accommodate trampolines if necessary.
-		UpdateRelocationInfo(r RelocationInfo, totalSize int, body []byte) (RelocationInfo, []byte)
+		// UpdateRelocationInfo recomputes the RelocationInfo after emitting machine code and returns the updated
+		// RelocationInfo and the size of the trampoline if necessary.
+		UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r RelocationInfo) (res RelocationInfo, trampolineSize int)
+
+		RelocationTrampolineSize(relocations []RelocationInfo) int
 
 		// Encode encodes the machine instructions to the Compiler.
 		Encode(ctx context.Context)

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -57,8 +57,8 @@ func (m mockMachine) Encode(ctx context.Context) {}
 func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo) {}
 
 // UpdateRelocationInfo implements Machine.UpdateRelocationInfo.
-func (m mockMachine) UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r RelocationInfo) (RelocationInfo, int) {
-	return r, 0
+func (m mockMachine) UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r *RelocationInfo) int {
+	return 0
 }
 
 // RelocationTrampolineSize implements Machine.RelocationTrampolineSize.

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -57,9 +57,13 @@ func (m mockMachine) Encode(ctx context.Context) {}
 func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo) {}
 
 // UpdateRelocationInfo implements Machine.UpdateRelocationInfo.
-func (m mockMachine) UpdateRelocationInfo(r RelocationInfo, totalSize int, body []byte) (RelocationInfo, []byte) {
-	r.Offset += int64(totalSize)
-	return r, body
+func (m mockMachine) UpdateRelocationInfo(refToBinaryOffset map[ssa.FuncRef]int, trampolineOffset int, r RelocationInfo) (RelocationInfo, int) {
+	return r, 0
+}
+
+// RelocationTrampolineSize implements Machine.RelocationTrampolineSize.
+func (m mockMachine) RelocationTrampolineSize(rels []RelocationInfo) int {
+	return 0
 }
 
 // PostRegAlloc implements Machine.SetupPrologue.

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -56,6 +56,12 @@ func (m mockMachine) Encode(ctx context.Context) {}
 // ResolveRelocations implements Machine.ResolveRelocations.
 func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo) {}
 
+// UpdateRelocationInfo implements Machine.UpdateRelocationInfo.
+func (m mockMachine) UpdateRelocationInfo(r *RelocationInfo, totalSize int, body []byte) []byte {
+	r.Offset += int64(totalSize)
+	return body
+}
+
 // PostRegAlloc implements Machine.SetupPrologue.
 func (m mockMachine) PostRegAlloc() {}
 

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -57,9 +57,9 @@ func (m mockMachine) Encode(ctx context.Context) {}
 func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo) {}
 
 // UpdateRelocationInfo implements Machine.UpdateRelocationInfo.
-func (m mockMachine) UpdateRelocationInfo(r *RelocationInfo, totalSize int, body []byte) []byte {
+func (m mockMachine) UpdateRelocationInfo(r RelocationInfo, totalSize int, body []byte) (RelocationInfo, []byte) {
 	r.Offset += int64(totalSize)
-	return body
+	return r, body
 }
 
 // PostRegAlloc implements Machine.SetupPrologue.

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -264,7 +264,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 		// At this point, relocation offsets are relative to the start of the function body,
 		// so we adjust it to the start of the executable.
 		for _, r := range rels {
-			body = e.machine.UpdateRelocationInfo(&r, totalSize, body)
+			r, body = e.machine.UpdateRelocationInfo(r, totalSize, body)
 			e.rels = append(e.rels, r)
 		}
 

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -342,13 +342,11 @@ func (e *engine) updateRelocationInfos(currentOffset int, offsetDelta int64, fre
 	trampolineSectionSize := 0
 	// Loop while there are RelocationInfos left and the given RelocationInfo relates to the current function.
 	for ; currentRelIdx < len(e.rels) && e.rels[currentRelIdx].Caller == fref; currentRelIdx++ {
-		r := e.rels[currentRelIdx]
+		r := &e.rels[currentRelIdx]
 		// Update the offset and compute the offset to the trampoline at the end of the function.
 		r.Offset += offsetDelta
 		trampolineOffset := currentOffset + bodySize + trampolineSectionSize
-		r, l := e.machine.UpdateRelocationInfo(e.refToBinaryOffset, trampolineOffset, r)
-		e.rels[currentRelIdx] = r
-		trampolineSectionSize += l
+		trampolineSectionSize += e.machine.UpdateRelocationInfo(e.refToBinaryOffset, trampolineOffset, r)
 	}
 	return currentRelIdx, bodySize + trampolineSectionSize
 }

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -264,7 +264,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 		// At this point, relocation offsets are relative to the start of the function body,
 		// so we adjust it to the start of the executable.
 		for _, r := range rels {
-			r.Offset += int64(totalSize)
+			body = e.machine.UpdateRelocationInfo(&r, totalSize, body)
 			e.rels = append(e.rels, r)
 		}
 

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -291,7 +291,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 				totalSize, offsetDelta, fref, len(bodies[i]), relIdx)
 
 			if needSourceInfo {
-				updateSourceMap(cm, totalSize, module.CodeSection[i], sourceOffsets, i)
+				updateSourceMap(cm, totalSize, module.CodeSection[i], sourceOffsets[i])
 			}
 
 			totalSize = totalSize + updatedBodySize
@@ -352,13 +352,13 @@ func (e *engine) updateRelocationInfos(currentOffset int, offsetDelta int64, fre
 }
 
 // updateSourceMap Update the source maps for the current offset.
-func updateSourceMap(cm *compiledModule, totalSize int, codeSection wasm.Code, sourceOffsets [][]backend.SourceOffsetInfo, i int) {
+func updateSourceMap(cm *compiledModule, totalSize int, codeSection wasm.Code, sourceOffsets []backend.SourceOffsetInfo) {
 	// At the beginning of the function, we add the offset of the function body so that
 	// we can resolve the source location of the call site of before listener call.
 	cm.sourceMap.executableOffsets = append(cm.sourceMap.executableOffsets, uintptr(totalSize))
 	cm.sourceMap.wasmBinaryOffsets = append(cm.sourceMap.wasmBinaryOffsets, codeSection.BodyOffsetInCodeSection)
 
-	for _, info := range sourceOffsets[i] {
+	for _, info := range sourceOffsets {
 		cm.sourceMap.executableOffsets = append(cm.sourceMap.executableOffsets, uintptr(totalSize)+uintptr(info.ExecutableOffset))
 		cm.sourceMap.wasmBinaryOffsets = append(cm.sourceMap.wasmBinaryOffsets, uint64(info.SourceOffset))
 	}


### PR DESCRIPTION
Fixes #2158, follows up to #2167. 

Draft for feedback on the approach; also needs tests.

- Essentially, this adds some padding (`r.TrampolineOffset`) at the end of a function to accommodate a trampoline for far jumps (using BRL).
- The trampoline will be written **if** the relative jump is outside the accepted range. 
- When such an invalid relative jump is detected, instead of jumping to the function we jump to the trampoline:
   * 64-bit mov to `tmp` reg -- movz/movk/movk/movk 
   * BRL to `tmp`
   * unconditional branch back to the origin
- Note: This is currently adding such a padding for _all_ relocated calls, so obviously it is not optimal (will continue working on it later then undraft. I think it should be doable with some minor refactoring); however there is only waste of space: we use the trampoline only for far jumps.
- Also note: this is using a BLR. In other places (e.g. `resolveRelativeAddress`) we use relative jumps but at that time 1) we don't know the absolute address yet and 2) we can inject instruction at any point within the function because we are resolving the addresses before encoding.

Moreover, BRL's 64-bit addressing should obviously be comfortable enough to reach any point in the executable.

This was manually tested against the reproducers (top post and others in the comments) in #2158 and verified to work, but I will add proper tests. 


Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
