### PR TITLE
fix: workaround Memory.Size() overflow with 4GB memory

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -559,11 +559,19 @@ type Memory interface {
 	// Definition is metadata about this memory from its defining module.
 	Definition() MemoryDefinition
 
-	// Size returns the size in bytes available. e.g. If the underlying memory
-	// has 1 page: 65536
+	// Size returns the memory size in bytes available.
+	// e.g. If the underlying memory has 1 page: 65536
+	//
+	// # Notes
+	//
+	//   - This overflows (returns zero) if the memory has the maximum 65536 pages.
+	//   - Use PageSize() to handle this corner case.
 	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
 	Size() uint32
+
+	// Size returns the memory size in pages available.
+	PageSize() (pages uint32)
 
 	// Grow increases memory by the delta in pages (65536 bytes per page).
 	// The return val is the previous memory size in pages, or false if the
@@ -572,7 +580,7 @@ type Memory interface {
 	// # Notes
 	//
 	//   - This is the same as the "memory.grow" instruction defined in the
-	//	  WebAssembly Core Specification, except returns false instead of -1.
+	//	   WebAssembly Core Specification, except returns false instead of -1.
 	//   - When this returns true, any shared views via Read must be refreshed.
 	//
 	// See MemorySizer Read and https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#grow-mem

--- a/experimental/wazerotest/wazerotest.go
+++ b/experimental/wazerotest/wazerotest.go
@@ -511,8 +511,12 @@ func (m *Memory) Size() uint32 {
 	return uint32(len(m.Bytes))
 }
 
+func (m *Memory) PageSize() uint32 {
+	return uint32(len(m.Bytes) / PageSize)
+}
+
 func (m *Memory) Grow(deltaPages uint32) (previousPages uint32, ok bool) {
-	previousPages = uint32(len(m.Bytes) / PageSize)
+	previousPages = m.PageSize()
 	numPages := previousPages + deltaPages
 	if m.Max != 0 && numPages > m.Max {
 		return previousPages, false

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -213,7 +213,7 @@ func MemoryPagesToBytesNum(pages uint32) (bytesNum uint64) {
 
 // Grow implements the same method as documented on api.Memory.
 func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
-	currentPages := memoryBytesNumToPages(uint64(len(m.Buffer)))
+	currentPages := m.PageSize()
 	if delta == 0 {
 		return currentPages, true
 	}


### PR DESCRIPTION
Fixes #1852.