### PR TITLE
Renames PageSize -> Pages

### DIFF
--- a/api/wasm.go
+++ b/api/wasm.go
@@ -565,13 +565,16 @@ type Memory interface {
 	// # Notes
 	//
 	//   - This overflows (returns zero) if the memory has the maximum 65536 pages.
-	//   - Use PageSize() to handle this corner case.
+	//   - Use Pages() to handle this corner case.
 	//
 	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#-hrefsyntax-instr-memorymathsfmemorysize%E2%91%A0
 	Size() uint32
 
-	// Size returns the memory size in pages available.
-	PageSize() (pages uint32)
+	// Pages returns the number of pages in the memory. 1 Page corresponds to 65536 bytes,
+	// which is called "Page Size" in WebAssembly.
+	//
+	// See https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#memory-instances%E2%91%A0
+	Pages() (pages uint32)
 
 	// Grow increases memory by the delta in pages (65536 bytes per page).
 	// The return val is the previous memory size in pages, or false if the

--- a/experimental/wazerotest/wazerotest.go
+++ b/experimental/wazerotest/wazerotest.go
@@ -511,12 +511,12 @@ func (m *Memory) Size() uint32 {
 	return uint32(len(m.Bytes))
 }
 
-func (m *Memory) PageSize() uint32 {
+func (m *Memory) Pages() uint32 {
 	return uint32(len(m.Bytes) / PageSize)
 }
 
 func (m *Memory) Grow(deltaPages uint32) (previousPages uint32, ok bool) {
-	previousPages = m.PageSize()
+	previousPages = m.Pages()
 	numPages := previousPages + deltaPages
 	if m.Max != 0 && numPages > m.Max {
 		return previousPages, false

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -926,7 +926,7 @@ func (ce *callEngine) callNativeFunc(ctx context.Context, m *wasm.ModuleInstance
 			}
 			frame.pc++
 		case wazeroir.OperationKindMemorySize:
-			ce.pushValue(uint64(memoryInst.PageSize()))
+			ce.pushValue(uint64(memoryInst.Pages()))
 			frame.pc++
 		case wazeroir.OperationKindMemoryGrow:
 			n := ce.popValue()

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -213,7 +213,7 @@ func MemoryPagesToBytesNum(pages uint32) (bytesNum uint64) {
 
 // Grow implements the same method as documented on api.Memory.
 func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
-	currentPages := m.PageSize()
+	currentPages := m.Pages()
 	if delta == 0 {
 		return currentPages, true
 	}
@@ -241,8 +241,8 @@ func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 	}
 }
 
-// PageSize returns the current memory buffer size in pages.
-func (m *MemoryInstance) PageSize() (result uint32) {
+// Pages implements the same method as documented on api.Memory.
+func (m *MemoryInstance) Pages() (result uint32) {
 	return memoryBytesNumToPages(uint64(len(m.Buffer)))
 }
 

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -55,18 +55,18 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 			res, ok := m.Grow(5)
 			require.True(t, ok)
 			require.Equal(t, uint32(0), res)
-			require.Equal(t, uint32(5), m.PageSize())
+			require.Equal(t, uint32(5), m.Pages())
 
 			// Zero page grow is well-defined, should return the current page correctly.
 			res, ok = m.Grow(0)
 			require.True(t, ok)
 			require.Equal(t, uint32(5), res)
-			require.Equal(t, uint32(5), m.PageSize())
+			require.Equal(t, uint32(5), m.Pages())
 
 			res, ok = m.Grow(4)
 			require.True(t, ok)
 			require.Equal(t, uint32(5), res)
-			require.Equal(t, uint32(9), m.PageSize())
+			require.Equal(t, uint32(9), m.Pages())
 
 			// At this point, the page size equal 9,
 			// so trying to grow two pages should result in failure.

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -72,7 +72,7 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 			// so trying to grow two pages should result in failure.
 			_, ok = m.Grow(2)
 			require.False(t, ok)
-			require.Equal(t, uint32(9), m.PageSize())
+			require.Equal(t, uint32(9), m.Pages())
 
 			// But growing one page is still permitted.
 			res, ok = m.Grow(1)
@@ -80,7 +80,7 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 			require.Equal(t, uint32(9), res)
 
 			// Ensure that the current page size equals the max.
-			require.Equal(t, max, m.PageSize())
+			require.Equal(t, max, m.Pages())
 
 			if tc.capEqualsMax { // Ensure the capacity isn't more than max.
 				require.Equal(t, maxBytes, uint64(cap(m.Buffer)))


### PR DESCRIPTION
@ncruces  `PageSize` is not appropriate name as it's defined in the spec as 65536 bytes.