### PR TITLE
experimental: configure custom memory allocator

### DIFF
--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -18,6 +18,8 @@ type MemoryBuffer interface {
 	// Return the backing []byte for the memory buffer.
 	Buffer() []byte
 	// Grow the backing memory buffer to size bytes in length.
+	// To back a shared memory, Grow can't change the address
+	// of the backing []byte (only its length/capacity may change).
 	Grow(size uint64) []byte
 	// Free the backing memory buffer.
 	Free()

--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -8,7 +8,7 @@ import (
 
 // MemoryAllocator is a memory allocation hook which is invoked
 // to create a new MemoryBuffer, with the given specification:
-// min is the initial and minimum length of the backing []byte,
+// min is the initial and minimum length (in bytes) of the backing []byte,
 // cap a suggested initial capacity, and max the maximum length
 // that will ever be requested.
 type MemoryAllocator func(min, cap, max uint64) MemoryBuffer

--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -8,8 +8,8 @@ import (
 
 type MemoryAllocator interface {
 	Make(min, cap, max uint64) []byte
-	Grow(old []byte, more uint64) []byte
-	Free([]byte)
+	Grow(uint64) []byte
+	Free()
 }
 
 func WithMemoryAllocator(ctx context.Context, allocator MemoryAllocator) context.Context {

--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -6,18 +6,20 @@ import (
 	"github.com/tetratelabs/wazero/internal/ctxkey"
 )
 
-// MemoryAllocator is a memory allocation hook.
-type MemoryAllocator interface {
-	// Make is invoked to create a new memory, with the given specification.
-	// Implementations must return a []byte min bytes in length,
-	// should return a []byte with at least cap capacity,
-	// and be prepared to allocate up to max bytes of memory.
-	Make(min, cap, max uint64) []byte
+// MemoryAllocator is a memory allocation hook which is invoked
+// to create a new MemoryBuffer, with the given specification:
+// min is the initial and minimum length of the backing []byte,
+// cap a suggested initial capacity, and max the maximum length
+// that will ever be requested.
+type MemoryAllocator func(min, cap, max uint64) MemoryBuffer
 
-	// Grow is invoked to grow the memory to size bytes in length.
+// MemoryBuffer is a memory buffer that backs a Wasm memory.
+type MemoryBuffer interface {
+	// Return the backing []byte for the memory buffer.
+	Buffer() []byte
+	// Grow the backing memory buffer to size bytes in length.
 	Grow(size uint64) []byte
-
-	// Free is invoked to free the memory.
+	// Free the backing memory buffer.
 	Free()
 }
 

--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -6,12 +6,23 @@ import (
 	"github.com/tetratelabs/wazero/internal/ctxkey"
 )
 
+// MemoryAllocator is a memory allocation hook.
 type MemoryAllocator interface {
+	// Make is invoked to create a new memory, with the given specification.
+	// Implementations must return a []byte min bytes in length,
+	// should return a []byte with at least cap capacity,
+	// and be prepared to allocate up to max bytes of memory.
 	Make(min, cap, max uint64) []byte
-	Grow(uint64) []byte
+
+	// Grow is invoked to grow the memory to size bytes in length.
+	Grow(size uint64) []byte
+
+	// Free is invoked to free the memory.
 	Free()
 }
 
+// WithMemoryAllocator registers the given MemoryAllocator into the given
+// context.Context.
 func WithMemoryAllocator(ctx context.Context, allocator MemoryAllocator) context.Context {
 	if allocator != nil {
 		return context.WithValue(ctx, ctxkey.MemoryAllocatorKey{}, allocator)

--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -9,6 +9,7 @@ import (
 type MemoryAllocator interface {
 	Make(min, cap, max uint64) []byte
 	Grow(old []byte, more uint64) []byte
+	Free([]byte)
 }
 
 func WithMemoryAllocator(ctx context.Context, allocator MemoryAllocator) context.Context {

--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -1,0 +1,19 @@
+package experimental
+
+import (
+	"context"
+
+	"github.com/tetratelabs/wazero/internal/ctxkey"
+)
+
+type MemoryAllocator interface {
+	Make(min, cap, max uint64) []byte
+	Grow(old []byte, more uint64) []byte
+}
+
+func WithMemoryAllocator(ctx context.Context, allocator MemoryAllocator) context.Context {
+	if allocator != nil {
+		return context.WithValue(ctx, ctxkey.MemoryAllocatorKey{}, allocator)
+	}
+	return ctx
+}

--- a/imports/assemblyscript/assemblyscript_test.go
+++ b/imports/assemblyscript/assemblyscript_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	. "github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/experimental/logging"
+	"github.com/tetratelabs/wazero/experimental/wazerotest"
 	. "github.com/tetratelabs/wazero/internal/assemblyscript"
 	"github.com/tetratelabs/wazero/internal/testing/proxy"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 	"github.com/tetratelabs/wazero/internal/u64"
-	"github.com/tetratelabs/wazero/internal/wasm"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -376,7 +376,7 @@ func Test_readAssemblyScriptString(t *testing.T) {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {
-			mem := wasm.NewMemoryInstance(&wasm.Memory{Min: 1, Cap: 1, Max: 1})
+			mem := wazerotest.NewFixedMemory(wazerotest.PageSize)
 			tc.memory(mem)
 
 			s, ok := readAssemblyScriptString(mem, uint32(tc.offset))

--- a/internal/ctxkey/memory.go
+++ b/internal/ctxkey/memory.go
@@ -1,0 +1,3 @@
+package ctxkey
+
+type MemoryAllocatorKey struct{}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -59,19 +59,19 @@ type MemoryInstance struct {
 	// with a fixed weight of 1 and no spurious notifications.
 	waiters sync.Map
 
-	allocator experimental.MemoryBuffer
+	expBuffer experimental.MemoryBuffer
 }
 
 // NewMemoryInstance creates a new instance based on the parameters in the SectionIDMemory.
 func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator) *MemoryInstance {
-	min := MemoryPagesToBytesNum(memSec.Min)
-	cur := MemoryPagesToBytesNum(memSec.Cap)
-	max := MemoryPagesToBytesNum(memSec.Max)
+	minBytes := MemoryPagesToBytesNum(memSec.Min)
+	capBytes := MemoryPagesToBytesNum(memSec.Cap)
+	maxBytes := MemoryPagesToBytesNum(memSec.Max)
 
 	var buffer []byte
 	var alloc experimental.MemoryBuffer
 	if allocator != nil {
-		alloc = allocator(min, cur, max)
+		alloc = allocator(minBytes, capBytes, maxBytes)
 		buffer = alloc.Buffer()
 	} else if memSec.IsShared {
 		// Shared memory needs a fixed buffer, so allocate with the maximum size.
@@ -84,9 +84,9 @@ func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator) *
 		// the memory buffer allocation here is virtual and doesn't consume physical memory until it's used.
 		// 	* https://github.com/golang/go/blob/8121604559035734c9677d5281bbdac8b1c17a1e/src/runtime/malloc.go#L1059
 		//	* https://github.com/golang/go/blob/8121604559035734c9677d5281bbdac8b1c17a1e/src/runtime/malloc.go#L1165
-		buffer = make([]byte, min, max)
+		buffer = make([]byte, minBytes, maxBytes)
 	} else {
-		buffer = make([]byte, min, cur)
+		buffer = make([]byte, minBytes, capBytes)
 	}
 	return &MemoryInstance{
 		Buffer:    buffer,
@@ -94,7 +94,7 @@ func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator) *
 		Cap:       memoryBytesNumToPages(uint64(cap(buffer))),
 		Max:       memSec.Max,
 		Shared:    memSec.IsShared,
-		allocator: alloc,
+		expBuffer: alloc,
 	}
 }
 
@@ -232,14 +232,16 @@ func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 	newPages := currentPages + delta
 	if newPages > m.Max || int32(delta) < 0 {
 		return 0, false
-	} else if m.allocator != nil {
-		buffer := m.allocator.Grow(MemoryPagesToBytesNum(newPages))
+	} else if m.expBuffer != nil {
+		buffer := m.expBuffer.Grow(MemoryPagesToBytesNum(newPages))
 		if m.Shared {
 			if unsafe.SliceData(buffer) != unsafe.SliceData(m.Buffer) {
 				panic("shared memory cannot move")
 			}
-			// Use atomic to ensure maximum length is visible across threads.
-			atomicGrowLength(&m.Buffer, uintptr(len(buffer)))
+			// We assume grow is called under a guest lock.
+			// But the memory length is accessed elsewhere,
+			// Use atomic to make the new length visible across threads.
+			atomicStoreLength(&m.Buffer, uintptr(len(buffer)))
 			m.Cap = memoryBytesNumToPages(uint64(cap(buffer)))
 		} else {
 			m.Buffer = buffer
@@ -255,8 +257,10 @@ func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 		return currentPages, true
 	} else { // We already have the capacity we need.
 		if m.Shared {
-			// Use atomic to ensure maximum length is visible across threads.
-			atomicGrowLength(&m.Buffer, uintptr(MemoryPagesToBytesNum(newPages)))
+			// We assume grow is called under a guest lock.
+			// But the memory length is accessed elsewhere,
+			// Use atomic to make the new length visible across threads.
+			atomicStoreLength(&m.Buffer, uintptr(MemoryPagesToBytesNum(newPages)))
 		} else {
 			m.Buffer = m.Buffer[:MemoryPagesToBytesNum(newPages)]
 		}
@@ -290,20 +294,11 @@ func PagesToUnitOfBytes(pages uint32) string {
 
 // Below are raw functions used to implement the api.Memory API:
 
-// Uses atomic to set the length of the buf slice to the maximum
-// of the previous and new lengths.
-func atomicGrowLength(buf *[]byte, length uintptr) {
-	slicePtr := (*reflect.SliceHeader)(unsafe.Pointer(buf))
+// Uses atomic write to update the length of a slice.
+func atomicStoreLength(slice *[]byte, length uintptr) {
+	slicePtr := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
 	lenPtr := (*uintptr)(unsafe.Pointer(&slicePtr.Len))
-	for {
-		if old := atomic.LoadUintptr(lenPtr); old >= length {
-			// Was already greater or equal.
-			break
-		} else if atomic.CompareAndSwapUintptr(lenPtr, old, length) {
-			// Successfully updated.
-			break
-		}
-	}
+	atomic.StoreUintptr(lenPtr, length)
 }
 
 // memoryBytesNumToPages converts the given number of bytes into the number of pages.

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -236,7 +236,7 @@ func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 			panic("shared memory cannot be grown, this is a bug in wazero")
 		}
 		if m.allocator != nil {
-			m.Buffer = m.allocator.Grow(m.Buffer, MemoryPagesToBytesNum(delta))
+			m.Buffer = m.allocator.Grow(MemoryPagesToBytesNum(delta))
 		} else {
 			m.Buffer = append(m.Buffer, make([]byte, MemoryPagesToBytesNum(delta))...)
 		}

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -296,8 +296,8 @@ func atomicGrowLength(buf *[]byte, length uintptr) {
 	slicePtr := (*reflect.SliceHeader)(unsafe.Pointer(buf))
 	lenPtr := (*uintptr)(unsafe.Pointer(&slicePtr.Len))
 	for {
-		if old := atomic.LoadUintptr(lenPtr); old > length {
-			// Was already greater.
+		if old := atomic.LoadUintptr(lenPtr); old >= length {
+			// Was already greater or equal.
 			break
 		} else if atomic.CompareAndSwapUintptr(lenPtr, old, length) {
 			// Successfully updated.

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -231,15 +231,15 @@ func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 	newPages := currentPages + delta
 	if newPages > m.Max || int32(delta) < 0 {
 		return 0, false
+	} else if m.allocator != nil {
+		m.Buffer = m.allocator.Grow(MemoryPagesToBytesNum(newPages))
+		m.Cap = newPages
+		return currentPages, true
 	} else if newPages > m.Cap { // grow the memory.
 		if m.Shared {
 			panic("shared memory cannot be grown, this is a bug in wazero")
 		}
-		if m.allocator != nil {
-			m.Buffer = m.allocator.Grow(MemoryPagesToBytesNum(delta))
-		} else {
-			m.Buffer = append(m.Buffer, make([]byte, MemoryPagesToBytesNum(delta))...)
-		}
+		m.Buffer = append(m.Buffer, make([]byte, MemoryPagesToBytesNum(delta))...)
 		m.Cap = newPages
 		return currentPages, true
 	} else { // We already have the capacity we need.

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -832,7 +832,7 @@ func TestNewMemoryInstance_Shared(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			m := NewMemoryInstance(tc.mem)
+			m := NewMemoryInstance(tc.mem, nil)
 			require.Equal(t, tc.mem.Min, m.Min)
 			require.Equal(t, tc.mem.Max, m.Max)
 			require.True(t, m.Shared)

--- a/internal/wasm/memory_test.go
+++ b/internal/wasm/memory_test.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
@@ -34,9 +35,11 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 	tests := []struct {
 		name         string
 		capEqualsMax bool
+		expAllocator bool
 	}{
 		{name: ""},
 		{name: "capEqualsMax", capEqualsMax: true},
+		{name: "expAllocator", expAllocator: true},
 	}
 
 	for _, tt := range tests {
@@ -46,10 +49,14 @@ func TestMemoryInstance_Grow_Size(t *testing.T) {
 			max := uint32(10)
 			maxBytes := MemoryPagesToBytesNum(max)
 			var m *MemoryInstance
-			if tc.capEqualsMax {
-				m = &MemoryInstance{Cap: max, Max: max, Buffer: make([]byte, 0, maxBytes)}
-			} else {
+			switch {
+			default:
 				m = &MemoryInstance{Max: max, Buffer: make([]byte, 0)}
+			case tc.capEqualsMax:
+				m = &MemoryInstance{Cap: max, Max: max, Buffer: make([]byte, 0, maxBytes)}
+			case tc.expAllocator:
+				expBuffer := sliceAllocator(0, 0, maxBytes)
+				m = &MemoryInstance{Max: max, Buffer: expBuffer.Buffer(), expBuffer: expBuffer}
 			}
 
 			res, ok := m.Grow(5)
@@ -814,6 +821,13 @@ func BenchmarkWriteString(b *testing.B) {
 	}
 }
 
+func Test_atomicStoreLength(t *testing.T) {
+	// Doesn't verify atomicity, but at least we're updating the correct thing.
+	slice := make([]byte, 10, 20)
+	atomicStoreLength(&slice, 15)
+	require.Equal(t, 15, len(slice))
+}
+
 func TestNewMemoryInstance_Shared(t *testing.T) {
 	tests := []struct {
 		name string
@@ -978,4 +992,26 @@ func requireChannelEmpty(t *testing.T, ch chan string) {
 	default:
 		// fallthrough
 	}
+}
+
+func sliceAllocator(min, cap, max uint64) experimental.MemoryBuffer {
+	return &sliceBuffer{make([]byte, min, cap), max}
+}
+
+type sliceBuffer struct {
+	buf []byte
+	max uint64
+}
+
+func (b *sliceBuffer) Free() {}
+
+func (b *sliceBuffer) Buffer() []byte { return b.buf }
+
+func (b *sliceBuffer) Grow(size uint64) []byte {
+	if cap := uint64(cap(b.buf)); size > cap {
+		b.buf = append(b.buf[:cap], make([]byte, size-cap)...)
+	} else {
+		b.buf = b.buf[:size]
+	}
+	return b.buf
 }

--- a/internal/wasm/module.go
+++ b/internal/wasm/module.go
@@ -652,10 +652,10 @@ func paramNames(localNames IndirectNameMap, funcIdx uint32, paramLen int) []stri
 	return nil
 }
 
-func (m *ModuleInstance) buildMemory(module *Module) {
+func (m *ModuleInstance) buildMemory(module *Module, allocator experimental.MemoryAllocator) {
 	memSec := module.MemorySection
 	if memSec != nil {
-		m.MemoryInstance = NewMemoryInstance(memSec)
+		m.MemoryInstance = NewMemoryInstance(memSec, allocator)
 		m.MemoryInstance.definition = &module.MemoryDefinitionSection[0]
 	}
 }

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -127,7 +127,7 @@ func (m *ModuleInstance) closeWithExitCode(ctx context.Context, exitCode uint32)
 	}
 	if mem := m.MemoryInstance; mem != nil {
 		if allocator, ok := ctx.Value(ctxkey.MemoryAllocatorKey{}).(experimental.MemoryAllocator); ok {
-			allocator.Free(mem.Buffer)
+			allocator.Free()
 		}
 	}
 	return m.ensureResourcesClosed(ctx)

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -123,11 +123,6 @@ func (m *ModuleInstance) closeWithExitCode(ctx context.Context, exitCode uint32)
 	if !m.setExitCode(exitCode, exitCodeFlagResourceClosed) {
 		return nil // not an error to have already closed
 	}
-	if mem := m.MemoryInstance; mem != nil {
-		if mem.allocator != nil {
-			mem.allocator.Free()
-		}
-	}
 	return m.ensureResourcesClosed(ctx)
 }
 
@@ -160,6 +155,13 @@ func (m *ModuleInstance) ensureResourcesClosed(ctx context.Context) (err error) 
 			return err
 		}
 		m.Sys = nil
+	}
+
+	if mem := m.MemoryInstance; mem != nil {
+		if mem.allocator != nil {
+			mem.allocator.Free()
+			mem.allocator = nil
+		}
 	}
 
 	if m.CodeCloser == nil {

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/experimental"
-	"github.com/tetratelabs/wazero/internal/ctxkey"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -126,8 +124,8 @@ func (m *ModuleInstance) closeWithExitCode(ctx context.Context, exitCode uint32)
 		return nil // not an error to have already closed
 	}
 	if mem := m.MemoryInstance; mem != nil {
-		if allocator, ok := ctx.Value(ctxkey.MemoryAllocatorKey{}).(experimental.MemoryAllocator); ok {
-			allocator.Free()
+		if mem.allocator != nil {
+			mem.allocator.Free()
 		}
 	}
 	return m.ensureResourcesClosed(ctx)

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/internal/ctxkey"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -122,6 +124,10 @@ func (m *ModuleInstance) closeWithExitCodeWithoutClosingResource(exitCode uint32
 func (m *ModuleInstance) closeWithExitCode(ctx context.Context, exitCode uint32) (err error) {
 	if !m.setExitCode(exitCode, exitCodeFlagResourceClosed) {
 		return nil // not an error to have already closed
+	}
+	if mem := m.MemoryInstance; mem != nil {
+		allocator, _ := ctx.Value(ctxkey.MemoryAllocatorKey{}).(experimental.MemoryAllocator)
+		allocator.Free(mem.Buffer)
 	}
 	return m.ensureResourcesClosed(ctx)
 }

--- a/internal/wasm/module_instance.go
+++ b/internal/wasm/module_instance.go
@@ -126,8 +126,9 @@ func (m *ModuleInstance) closeWithExitCode(ctx context.Context, exitCode uint32)
 		return nil // not an error to have already closed
 	}
 	if mem := m.MemoryInstance; mem != nil {
-		allocator, _ := ctx.Value(ctxkey.MemoryAllocatorKey{}).(experimental.MemoryAllocator)
-		allocator.Free(mem.Buffer)
+		if allocator, ok := ctx.Value(ctxkey.MemoryAllocatorKey{}).(experimental.MemoryAllocator); ok {
+			allocator.Free(mem.Buffer)
+		}
 	}
 	return m.ensureResourcesClosed(ctx)
 }

--- a/internal/wasm/module_test.go
+++ b/internal/wasm/module_test.go
@@ -839,7 +839,7 @@ func TestModule_buildGlobals(t *testing.T) {
 func TestModule_buildMemoryInstance(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		m := ModuleInstance{}
-		m.buildMemory(&Module{})
+		m.buildMemory(&Module{}, nil)
 		require.Nil(t, m.MemoryInstance)
 	})
 	t.Run("non-nil", func(t *testing.T) {
@@ -850,7 +850,7 @@ func TestModule_buildMemoryInstance(t *testing.T) {
 		m.buildMemory(&Module{
 			MemorySection:           &Memory{Min: min, Cap: min, Max: max},
 			MemoryDefinitionSection: []MemoryDefinition{mDef},
-		})
+		}, nil)
 		mem := m.MemoryInstance
 		require.Equal(t, min, mem.Min)
 		require.Equal(t, max, mem.Max)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/internal/ctxkey"
 	"github.com/tetratelabs/wazero/internal/internalapi"
 	"github.com/tetratelabs/wazero/internal/leb128"
@@ -362,8 +363,13 @@ func (s *Store) instantiate(
 		return nil, err
 	}
 
+	var allocator experimental.MemoryAllocator
+	if ctx != nil {
+		allocator, _ = ctx.Value(ctxkey.MemoryAllocatorKey{}).(experimental.MemoryAllocator)
+	}
+
 	m.buildGlobals(module, m.Engine.FunctionInstanceReference)
-	m.buildMemory(module)
+	m.buildMemory(module, allocator)
 	m.Exports = module.Exports
 	for _, exp := range m.Exports {
 		if exp.Type == ExternTypeTable {


### PR DESCRIPTION
Still draft, missing tests, but you can see it put to good use in https://github.com/ncruces/go-sqlite3/pull/71.
It passes extensive tests on Linux (`amd64` native, `arm64` emulated) and macOS (`amd64`/`arm64` native), and solves a long standing issue with SQLite (on those platforms).

Happy to redesign the API, putting the PR up precisely to collect early feedback!