### PR TITLE
compiler(arm64): fixes overflow in huge executable relocations

### DIFF
--- a/internal/engine/wazevo/backend/backend_test.go
+++ b/internal/engine/wazevo/backend/backend_test.go
@@ -2375,7 +2375,8 @@ L2 (SSA Block: blk2):
 				fmt.Println(be.Format())
 			}
 
-			be.Finalize(context.Background())
+			err = be.Finalize(context.Background())
+			require.NoError(t, err)
 			if verbose {
 				fmt.Println("============ finalization result ============")
 				fmt.Println(be.Format())

--- a/internal/engine/wazevo/backend/isa/amd64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi_go_call_test.go
@@ -370,10 +370,9 @@ L3:
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, m := newSetupWithMockContext()
 			m.CompileGoFunctionTrampoline(tc.exitCode, tc.sig, tc.needModuleContextPtr)
-
 			require.Equal(t, tc.exp, m.Format())
-
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 		})
 	}
 }
@@ -521,7 +520,8 @@ L2:
 			_, _, m := newSetupWithMockContext()
 			m.ectx.RootInstr = m.allocateNop()
 			m.insertStackBoundsCheck(tc.requiredStackSize, m.ectx.RootInstr)
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 			require.Equal(t, tc.exp, m.Format())
 		})
 	}

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -2058,7 +2058,7 @@ func (m *machine) Encode(ctx context.Context) {
 }
 
 // ResolveRelocations implements backend.Machine.
-func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []backend.RelocationInfo) {
+func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []backend.RelocationInfo, _ []int) {
 	for _, r := range relocations {
 		offset := r.Offset
 		calleeFnOffset := refToBinaryOffset[r.FuncRef]
@@ -2071,6 +2071,9 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 		callInstrOffsetBytes[3] = byte(diff >> 24)
 	}
 }
+
+// CallTrampolineIslandInfo implements backend.Machine CallTrampolineIslandInfo.
+func (m *machine) CallTrampolineIslandInfo(_ int) (_, _ int) { return }
 
 func (m *machine) lowerIcmpToFlag(xd, yd *backend.SSAValueDefinition, _64 bool) {
 	x := m.getOperand_Reg(xd)

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -1963,7 +1963,7 @@ func (m *machine) encodeWithoutSSA(root *instruction) {
 }
 
 // Encode implements backend.Machine Encode.
-func (m *machine) Encode(ctx context.Context) {
+func (m *machine) Encode(ctx context.Context) (err error) {
 	ectx := m.ectx
 	bufPtr := m.c.BufPtr()
 
@@ -2055,6 +2055,7 @@ func (m *machine) Encode(ctx context.Context) {
 			panic("BUG")
 		}
 	}
+	return
 }
 
 // ResolveRelocations implements backend.Machine.
@@ -2073,7 +2074,7 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 }
 
 // CallTrampolineIslandInfo implements backend.Machine CallTrampolineIslandInfo.
-func (m *machine) CallTrampolineIslandInfo(_ int) (_, _ int) { return }
+func (m *machine) CallTrampolineIslandInfo(_ int) (_, _ int, _ error) { return }
 
 func (m *machine) lowerIcmpToFlag(xd, yd *backend.SSAValueDefinition, _64 bool) {
 	x := m.getOperand_Reg(xd)

--- a/internal/engine/wazevo/backend/isa/amd64/machine_pro_epi_logue_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine_pro_epi_logue_test.go
@@ -77,7 +77,8 @@ func TestMachine_setupPrologue(t *testing.T) {
 
 			m.setupPrologue()
 			require.Equal(t, root, m.ectx.RootInstr)
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 			require.Equal(t, tc.exp, m.Format())
 		})
 	}
@@ -151,7 +152,8 @@ func TestMachine_postRegAlloc(t *testing.T) {
 			m.postRegAlloc()
 
 			require.Equal(t, root, m.ectx.RootInstr)
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 			require.Equal(t, tc.exp, m.Format())
 		})
 	}

--- a/internal/engine/wazevo/backend/isa/amd64/util_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/util_test.go
@@ -67,11 +67,11 @@ func (m *mockCompiler) Buf() []byte { return m.buf }
 func (m *mockCompiler) TypeOf(v regalloc.VReg) (ret ssa.Type) {
 	return m.typeOf[v.ID()]
 }
-func (m *mockCompiler) Finalize(context.Context) {}
-func (m *mockCompiler) RegAlloc()                {}
-func (m *mockCompiler) Lower()                   {}
-func (m *mockCompiler) Format() string           { return "" }
-func (m *mockCompiler) Init()                    {}
+func (m *mockCompiler) Finalize(context.Context) (err error) { return }
+func (m *mockCompiler) RegAlloc()                            {}
+func (m *mockCompiler) Lower()                               {}
+func (m *mockCompiler) Format() string                       { return "" }
+func (m *mockCompiler) Init()                                {}
 
 func newMockCompilationContext() *mockCompiler { //nolint
 	return &mockCompiler{

--- a/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble_test.go
@@ -535,7 +535,8 @@ func TestMachine_goEntryPreamblePassArg(t *testing.T) {
 			m.executableContext.RootInstr = cur
 			m.goEntryPreamblePassArg(cur, paramSlicePtr, &tc.arg, tc.argSlotBeginOffsetFromSP)
 			require.Equal(t, tc.exp, m.Format())
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 		})
 	}
 }
@@ -688,7 +689,8 @@ func TestMachine_goEntryPreamblePassResult(t *testing.T) {
 			m.executableContext.RootInstr = cur
 			m.goEntryPreamblePassResult(cur, paramSlicePtr, &tc.arg, tc.retStart)
 			require.Equal(t, tc.exp, m.Format())
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call_test.go
@@ -451,7 +451,8 @@ func TestMachine_CompileGoFunctionTrampoline(t *testing.T) {
 
 			require.Equal(t, tc.exp, m.Format())
 
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 		})
 	}
 }
@@ -519,7 +520,8 @@ func Test_goFunctionCallLoadStackArg(t *testing.T) {
 				m.executableContext.RootInstr = nop
 
 				require.Equal(t, tc.exp, m.Format())
-				m.Encode(context.Background())
+				err := m.Encode(context.Background())
+				require.NoError(t, err)
 			})
 		})
 	}
@@ -585,7 +587,8 @@ func Test_goFunctionCallStoreStackResult(t *testing.T) {
 				m.executableContext.RootInstr = nop
 
 				require.Equal(t, tc.exp, m.Format())
-				m.Encode(context.Background())
+				err := m.Encode(context.Background())
+				require.NoError(t, err)
 			})
 		})
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -10,9 +10,13 @@ import (
 )
 
 // Encode implements backend.Machine Encode.
-func (m *machine) Encode(ctx context.Context) {
+func (m *machine) Encode(ctx context.Context) error {
 	m.resolveRelativeAddresses(ctx)
 	m.encode(m.executableContext.RootInstr)
+	if l := len(m.compiler.Buf()); l > maxFunctionExecutableSize {
+		return fmt.Errorf("function size exceeds the limit: %d > %d", l, maxFunctionExecutableSize)
+	}
+	return nil
 }
 
 func (m *machine) encode(root *instruction) {

--- a/internal/engine/wazevo/backend/isa/arm64/machine.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine.go
@@ -388,11 +388,11 @@ func (m *machine) resolveRelativeAddresses(ctx context.Context) {
 }
 
 const (
-	maxSignedInt26 int64 = 1<<25 - 1
-	minSignedInt26 int64 = -(1 << 25)
+	maxSignedInt26 = 1<<25 - 1
+	minSignedInt26 = -(1 << 25)
 
-	maxSignedInt19 int64 = 1<<19 - 1
-	minSignedInt19 int64 = -(1 << 19)
+	maxSignedInt19 = 1<<19 - 1
+	minSignedInt19 = -(1 << 19)
 )
 
 func (m *machine) insertConditionalJumpTrampoline(cbr *instruction, currentBlk *labelPosition, nextLabel label) {

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue_test.go
@@ -110,7 +110,8 @@ func TestMachine_setupPrologue(t *testing.T) {
 
 			m.setupPrologue()
 			require.Equal(t, root, m.executableContext.RootInstr)
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 			require.Equal(t, tc.exp, m.Format())
 		})
 	}
@@ -223,7 +224,8 @@ func TestMachine_postRegAlloc(t *testing.T) {
 			m.postRegAlloc()
 
 			require.Equal(t, root, m.executableContext.RootInstr)
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 			require.Equal(t, tc.exp, m.Format())
 		})
 	}
@@ -268,7 +270,8 @@ func TestMachine_insertStackBoundsCheck(t *testing.T) {
 			m.executableContext.RootInstr = m.allocateInstr()
 			m.executableContext.RootInstr.asNop0()
 			m.insertStackBoundsCheck(tc.requiredStackSize, m.executableContext.RootInstr)
-			m.Encode(context.Background())
+			err := m.Encode(context.Background())
+			require.NoError(t, err)
 			require.Equal(t, tc.exp, m.Format())
 		})
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
@@ -56,9 +56,8 @@ func (m *machine) ResolveRelocations(
 				panic("BUG in trampoline placement")
 			}
 		}
-		imm26 = uint32(diff / 4)
-
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BL--Branch-with-Link-
+		imm26 = uint32(diff / 4)
 		brInstr[0] = byte(imm26)
 		brInstr[1] = byte(imm26 >> 8)
 		brInstr[2] = byte(imm26 >> 16)

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
@@ -1,27 +1,64 @@
 package arm64
 
 import (
-	"fmt"
+	"encoding/binary"
+	"math"
+	"sort"
 
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 )
 
+const (
+	trampolineCallSize = 4*4 + 4 // Four instructions + 32-bit immediate.
+
+	// Unconditional branch offset is encoded as divided by 4 in imm26.
+	// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/BL--Branch-with-Link-?lang=en
+
+	maxUnconditionalBranchOffset = maxSignedInt26 * 4
+	minUnconditionalBranchOffset = minSignedInt26 * 4
+)
+
+// CallTrampolineIslandInfo implements backend.Machine CallTrampolineIslandInfo.
+func (m *machine) CallTrampolineIslandInfo(numFunctions int) (interval, size int) {
+	// Always place trampoline in the middle of the range.
+	// TODO: precondition is that neither the trampoline size or a single function size is bigger than the range.
+	//	Add asserts to check this.
+	interval = int(maxUnconditionalBranchOffset) / 2
+	size = trampolineCallSize * numFunctions
+	return
+}
+
 // ResolveRelocations implements backend.Machine ResolveRelocations.
-//
-// TODO: unit test!
-func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []backend.RelocationInfo) {
+func (m *machine) ResolveRelocations(
+	refToBinaryOffset map[ssa.FuncRef]int,
+	executable []byte,
+	relocations []backend.RelocationInfo,
+	callTrampolineIslandOffsets []int,
+) {
+	for _, islandOffset := range callTrampolineIslandOffsets {
+		encodeCallTrampolineIsland(refToBinaryOffset, islandOffset, executable)
+	}
+
 	for _, r := range relocations {
 		instrOffset := r.Offset
 		calleeFnOffset := refToBinaryOffset[r.FuncRef]
-		brInstr := binary[instrOffset : instrOffset+4]
+		brInstr := executable[instrOffset : instrOffset+4]
 		diff := int64(calleeFnOffset) - (instrOffset)
 		// Check if the diff is within the range of the branch instruction.
-		if diff < -(1<<25)*4 || diff > ((1<<25)-1)*4 {
-			panic(fmt.Sprintf("TODO: too large binary where branch target is out of the supported range +/-128MB: %#x", diff))
+		var imm26 uint32
+		if diff < minUnconditionalBranchOffset || diff > maxUnconditionalBranchOffset {
+			// Find the nearest trampoline island from callTrampolineIslandOffsets.
+			islandOffset := findNearestTrampolineIsland(callTrampolineIslandOffsets, int(instrOffset))
+			islandTargetOffset := islandOffset + trampolineCallSize*int(r.FuncRef)
+			diff = int64(islandTargetOffset) - (instrOffset)
+			if diff < minUnconditionalBranchOffset || diff > maxUnconditionalBranchOffset {
+				panic("BUG in trampoline placement")
+			}
 		}
+		imm26 = uint32(diff / 4)
+
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BL--Branch-with-Link-
-		imm26 := diff / 4
 		brInstr[0] = byte(imm26)
 		brInstr[1] = byte(imm26 >> 8)
 		brInstr[2] = byte(imm26 >> 16)
@@ -31,4 +68,50 @@ func (m *machine) ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, bina
 			brInstr[3] = (byte(imm26 >> 24 & 0b000000_01)) | 0b100101_00 // No sign bit.
 		}
 	}
+}
+
+// encodeCallTrampolineIsland encodes a trampoline island for the given functions.
+// Each island consists of a trampoline instruction sequence for each function.
+// Each trampoline instruction sequence consists of 4 instructions + 32-bit immediate.
+func encodeCallTrampolineIsland(refToBinaryOffset map[ssa.FuncRef]int, islandOffset int, executable []byte) {
+	for i := 0; i < len(refToBinaryOffset); i++ {
+		trampolineOffset := islandOffset + trampolineCallSize*i
+
+		fnOffset := refToBinaryOffset[ssa.FuncRef(i)]
+		diff := fnOffset - (trampolineOffset + 16)
+		if diff > math.MaxInt32 || diff < math.MinInt32 {
+			// This case even amd64 can't handle. 4GB is too big.
+			panic("too big binary")
+		}
+
+		// The tmpReg, tmpReg2 is safe to overwrite (in fact any caller-saved register is safe to use).
+		tmpReg, tmpReg2 := regNumberInEncoding[tmpRegVReg.RealReg()], regNumberInEncoding[x11]
+
+		// adr tmpReg, PC+16: load the address of #diff into tmpReg.
+		binary.LittleEndian.PutUint32(executable[trampolineOffset:], encodeAdr(tmpReg, 16))
+		// ldrsw tmpReg2, [tmpReg]: Load #diff into tmpReg2.
+		binary.LittleEndian.PutUint32(executable[trampolineOffset+4:],
+			encodeLoadOrStore(sLoad32, tmpReg2, addressMode{kind: addressModeKindRegUnsignedImm12, rn: tmpRegVReg}))
+		// add tmpReg, tmpReg2, tmpReg: add #diff to the address of #diff, getting the absolute address of the function.
+		binary.LittleEndian.PutUint32(executable[trampolineOffset+8:],
+			encodeAluRRR(aluOpAdd, tmpReg, tmpReg, tmpReg2, true, false))
+		// br tmpReg: branch to the function without overwriting the link register.
+		binary.LittleEndian.PutUint32(executable[trampolineOffset+12:], encodeUnconditionalBranchReg(tmpReg, false))
+		// #diff
+		binary.LittleEndian.PutUint32(executable[trampolineOffset+16:], uint32(diff))
+	}
+}
+
+// findNearestTrampolineIsland finds the nearest trampoline island from callTrampolineIslandOffsets.
+// precondition: callTrampolineIslandOffsets is sorted in ascending order.
+func findNearestTrampolineIsland(callTrampolineIslandOffsets []int, offset int) int {
+	// Find the nearest trampoline island from callTrampolineIslandOffsets.
+	l := len(callTrampolineIslandOffsets)
+	n := sort.Search(l, func(i int) bool {
+		return callTrampolineIslandOffsets[i] >= offset
+	})
+	if n == l {
+		n = l - 1
+	}
+	return callTrampolineIslandOffsets[n]
 }

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation.go
@@ -46,7 +46,6 @@ func (m *machine) ResolveRelocations(
 		brInstr := executable[instrOffset : instrOffset+4]
 		diff := int64(calleeFnOffset) - (instrOffset)
 		// Check if the diff is within the range of the branch instruction.
-		var imm26 uint32
 		if diff < minUnconditionalBranchOffset || diff > maxUnconditionalBranchOffset {
 			// Find the nearest trampoline island from callTrampolineIslandOffsets.
 			islandOffset := findNearestTrampolineIsland(callTrampolineIslandOffsets, int(instrOffset))
@@ -57,7 +56,7 @@ func (m *machine) ResolveRelocations(
 			}
 		}
 		// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BL--Branch-with-Link-
-		imm26 = uint32(diff / 4)
+		imm26 := uint32(diff / 4)
 		brInstr[0] = byte(imm26)
 		brInstr[1] = byte(imm26 >> 8)
 		brInstr[2] = byte(imm26 >> 16)

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
+func Test_maxNumFunctions(t *testing.T) {
+	// Ensures that trampoline island is small enough to fit in the interval.
+	require.True(t, maxNumFunctions*trampolineCallSize < trampolineIslandInterval/2) //nolint:gomnd
+	// Ensures that each function is small enough to fit in the interval.
+	require.True(t, maxFunctionExecutableSize < trampolineIslandInterval/2) //nolint:gomnd
+}
+
 func Test_encodeCallTrampolineIsland(t *testing.T) {
 	executable := make([]byte, 16*1000)
 	islandOffset := 160
@@ -22,4 +29,14 @@ func Test_encodeCallTrampolineIsland(t *testing.T) {
 		imm := binary.LittleEndian.Uint32(executable[offset+trampolineCallSize-4:])
 		require.Equal(t, uint32(refToBinaryOffset[ssa.FuncRef(i)]-(offset+16)), imm)
 	}
+}
+
+func Test_searchTrampolineIsland(t *testing.T) {
+	offsets := []int{16, 32, 48}
+	require.Equal(t, 32, searchTrampolineIsland(offsets, 30))
+	require.Equal(t, 32, searchTrampolineIsland(offsets, 17))
+	require.Equal(t, 16, searchTrampolineIsland(offsets, 16))
+	require.Equal(t, 48, searchTrampolineIsland(offsets, 48))
+	require.Equal(t, 48, searchTrampolineIsland(offsets, 56))
+	require.Equal(t, 16, searchTrampolineIsland(offsets, 1))
 }

--- a/internal/engine/wazevo/backend/isa/arm64/machine_relocation_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_relocation_test.go
@@ -1,0 +1,25 @@
+package arm64
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func Test_encodeCallTrampolineIsland(t *testing.T) {
+	executable := make([]byte, 16*1000)
+	islandOffset := 160
+	refToBinaryOffset := map[ssa.FuncRef]int{0: 0, 1: 16, 2: 1600, 3: 16000}
+	encodeCallTrampolineIsland(refToBinaryOffset, islandOffset, executable)
+	for i := 0; i < len(refToBinaryOffset); i++ {
+		offset := islandOffset + trampolineCallSize*i
+		instrs := executable[offset : offset+trampolineCallSize-4]
+		// Instructions are always the same except for the last immediate.
+		require.Equal(t, "9b0000106b0380b97b030b8b60031fd6", hex.EncodeToString(instrs))
+		imm := binary.LittleEndian.Uint32(executable[offset+trampolineCallSize-4:])
+		require.Equal(t, uint32(refToBinaryOffset[ssa.FuncRef(i)]-(offset+16)), imm)
+	}
+}

--- a/internal/engine/wazevo/backend/isa/arm64/util_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/util_test.go
@@ -97,11 +97,11 @@ func (m *mockCompiler) Buf() []byte { return m.buf }
 func (m *mockCompiler) TypeOf(v regalloc.VReg) (ret ssa.Type) {
 	return m.typeOf[v.ID()]
 }
-func (m *mockCompiler) Finalize(context.Context) {}
-func (m *mockCompiler) RegAlloc()                {}
-func (m *mockCompiler) Lower()                   {}
-func (m *mockCompiler) Format() string           { return "" }
-func (m *mockCompiler) Init()                    {}
+func (m *mockCompiler) Finalize(context.Context) (err error) { return }
+func (m *mockCompiler) RegAlloc()                            {}
+func (m *mockCompiler) Lower()                               {}
+func (m *mockCompiler) Format() string                       { return "" }
+func (m *mockCompiler) Init()                                {}
 
 func newMockCompilationContext() *mockCompiler {
 	return &mockCompiler{

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -59,7 +59,16 @@ type (
 		PostRegAlloc()
 
 		// ResolveRelocations resolves the relocations after emitting machine code.
-		ResolveRelocations(refToBinaryOffset map[ssa.FuncRef]int, binary []byte, relocations []RelocationInfo)
+		//  * refToBinaryOffset: the map from the function reference to the executable offset.
+		//  * executable: the binary to resolve the relocations.
+		//  * relocations: the relocations to resolve.
+		//  * callTrampolineIslandOffsets: the offsets of the trampoline islands in the executable.
+		ResolveRelocations(
+			refToBinaryOffset map[ssa.FuncRef]int,
+			executable []byte,
+			relocations []RelocationInfo,
+			callTrampolineIslandOffsets []int,
+		)
 
 		// Encode encodes the machine instructions to the Compiler.
 		Encode(ctx context.Context)
@@ -83,5 +92,9 @@ type (
 
 		// ArgsResultsRegs returns the registers used for arguments and return values.
 		ArgsResultsRegs() (argResultInts, argResultFloats []regalloc.RealReg)
+
+		// CallTrampolineIslandInfo returns the interval of the offset where the trampoline island is placed, and
+		// the size of the trampoline island. If islandSize is zero, the trampoline island is not used on this machine.
+		CallTrampolineIslandInfo(numFunctions int) (interval, islandSize int)
 	}
 )

--- a/internal/engine/wazevo/backend/machine.go
+++ b/internal/engine/wazevo/backend/machine.go
@@ -71,7 +71,7 @@ type (
 		)
 
 		// Encode encodes the machine instructions to the Compiler.
-		Encode(ctx context.Context)
+		Encode(ctx context.Context) error
 
 		// CompileGoFunctionTrampoline compiles the trampoline function  to call a Go function of the given exit code and signature.
 		CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *ssa.Signature, needModuleContextPtr bool) []byte
@@ -95,6 +95,6 @@ type (
 
 		// CallTrampolineIslandInfo returns the interval of the offset where the trampoline island is placed, and
 		// the size of the trampoline island. If islandSize is zero, the trampoline island is not used on this machine.
-		CallTrampolineIslandInfo(numFunctions int) (interval, islandSize int)
+		CallTrampolineIslandInfo(numFunctions int) (interval, islandSize int, err error)
 	}
 )

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -25,6 +25,11 @@ type mockMachine struct {
 	linkAdjacentBlocks             func(prev, next ssa.BasicBlock)
 }
 
+func (m mockMachine) CallTrampolineIslandInfo(_ int) (_, _ int) {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (m mockMachine) ArgsResultsRegs() (argResultInts, argResultFloats []regalloc.RealReg) {
 	return m.argResultInts, m.argResultFloats
 }
@@ -54,7 +59,7 @@ func (m mockMachine) CompileGoFunctionTrampoline(wazevoapi.ExitCode, *ssa.Signat
 func (m mockMachine) Encode(ctx context.Context) {}
 
 // ResolveRelocations implements Machine.ResolveRelocations.
-func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo) {}
+func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo, []int) {}
 
 // PostRegAlloc implements Machine.SetupPrologue.
 func (m mockMachine) PostRegAlloc() {}

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -25,7 +25,7 @@ type mockMachine struct {
 	linkAdjacentBlocks             func(prev, next ssa.BasicBlock)
 }
 
-func (m mockMachine) CallTrampolineIslandInfo(_ int) (_, _ int) { panic("implement me") }
+func (m mockMachine) CallTrampolineIslandInfo(_ int) (_, _ int, _ error) { panic("implement me") }
 
 func (m mockMachine) ArgsResultsRegs() (argResultInts, argResultFloats []regalloc.RealReg) {
 	return m.argResultInts, m.argResultFloats
@@ -53,7 +53,7 @@ func (m mockMachine) CompileGoFunctionTrampoline(wazevoapi.ExitCode, *ssa.Signat
 }
 
 // Encode implements Machine.Encode.
-func (m mockMachine) Encode(ctx context.Context) {}
+func (m mockMachine) Encode(context.Context) (err error) { return }
 
 // ResolveRelocations implements Machine.ResolveRelocations.
 func (m mockMachine) ResolveRelocations(map[ssa.FuncRef]int, []byte, []RelocationInfo, []int) {}

--- a/internal/engine/wazevo/backend/machine_test.go
+++ b/internal/engine/wazevo/backend/machine_test.go
@@ -25,10 +25,7 @@ type mockMachine struct {
 	linkAdjacentBlocks             func(prev, next ssa.BasicBlock)
 }
 
-func (m mockMachine) CallTrampolineIslandInfo(_ int) (_, _ int) {
-	// TODO implement me
-	panic("implement me")
-}
+func (m mockMachine) CallTrampolineIslandInfo(_ int) (_, _ int) { panic("implement me") }
 
 func (m mockMachine) ArgsResultsRegs() (argResultInts, argResultFloats []regalloc.RealReg) {
 	return m.argResultInts, m.argResultFloats

--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -220,6 +220,12 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 	totalSize := 0 // Total binary size of the executable.
 	cm.functionOffsets = make([]int, localFns)
 	bodies := make([][]byte, localFns)
+
+	// Trampoline relocation related variables.
+	trampolineInterval, callTrampolineIslandSize := machine.CallTrampolineIslandInfo(localFns)
+	needCallTrampoline := callTrampolineIslandSize > 0
+	var callTrampolineIslandOffsets []int
+
 	for i := range module.CodeSection {
 		if wazevoapi.DeterministicCompilationVerifierEnabled {
 			i = wazevoapi.DeterministicCompilationVerifierGetRandomizedLocalFunctionIndex(ctx, i)
@@ -240,6 +246,13 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 		body, rels, err := e.compileLocalWasmFunction(ctx, module, wasm.Index(i), fe, ssaBuilder, be, needListener)
 		if err != nil {
 			return nil, fmt.Errorf("compile function %d/%d: %v", i, len(module.CodeSection)-1, err)
+		}
+
+		if needCallTrampoline {
+			if totalSize/trampolineInterval > len(callTrampolineIslandOffsets) {
+				callTrampolineIslandOffsets = append(callTrampolineIslandOffsets, totalSize)
+				totalSize += callTrampolineIslandSize
+			}
 		}
 
 		// Align 16-bytes boundary.
@@ -299,7 +312,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 
 	// Resolve relocations for local function calls.
 	if len(e.rels) > 0 {
-		machine.ResolveRelocations(e.refToBinaryOffset, executable, e.rels)
+		machine.ResolveRelocations(e.refToBinaryOffset, executable, e.rels, callTrampolineIslandOffsets)
 	}
 
 	if runtime.GOARCH == "arm64" {


### PR DESCRIPTION
Obviates https://github.com/tetratelabs/wazero/pull/2169 and fixes #2158 