### PR TITLE
arm64: reduces the struct size of instructions

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/abi.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi.go
@@ -101,7 +101,8 @@ func (m *machine) LowerParams(args []ssa.Value) {
 			bits := arg.Type.Bits()
 			// At this point of compilation, we don't yet know how much space exist below the return address.
 			// So we instruct the address mode to add the `argStackOffset` to the offset at the later phase of compilation.
-			amode := addressMode{imm: arg.Offset, rn: spVReg, kind: addressModeKindArgStackSpace}
+			amode := m.amodePool.Allocate()
+			*amode = addressMode{imm: arg.Offset, rn: spVReg, kind: addressModeKindArgStackSpace}
 			load := m.allocateInstr()
 			switch arg.Type {
 			case ssa.TypeI32, ssa.TypeI64:
@@ -169,7 +170,8 @@ func (m *machine) LowerReturns(rets []ssa.Value) {
 
 			// At this point of compilation, we don't yet know how much space exist below the return address.
 			// So we instruct the address mode to add the `retStackOffset` to the offset at the later phase of compilation.
-			amode := addressMode{imm: r.Offset, rn: spVReg, kind: addressModeKindResultStackSpace}
+			amode := m.amodePool.Allocate()
+			*amode = addressMode{imm: r.Offset, rn: spVReg, kind: addressModeKindResultStackSpace}
 			store := m.allocateInstr()
 			store.asStore(operandNR(reg), amode, bits)
 			m.insert(store)
@@ -225,7 +227,7 @@ func (m *machine) callerGenFunctionReturnVReg(a *backend.FunctionABI, retIndex i
 	}
 }
 
-func (m *machine) resolveAddressModeForOffsetAndInsert(cur *instruction, offset int64, dstBits byte, rn regalloc.VReg, allowTmpRegUse bool) (*instruction, addressMode) {
+func (m *machine) resolveAddressModeForOffsetAndInsert(cur *instruction, offset int64, dstBits byte, rn regalloc.VReg, allowTmpRegUse bool) (*instruction, *addressMode) {
 	exct := m.executableContext
 	exct.PendingInstructions = exct.PendingInstructions[:0]
 	mode := m.resolveAddressModeForOffset(offset, dstBits, rn, allowTmpRegUse)
@@ -235,15 +237,15 @@ func (m *machine) resolveAddressModeForOffsetAndInsert(cur *instruction, offset 
 	return cur, mode
 }
 
-func (m *machine) resolveAddressModeForOffset(offset int64, dstBits byte, rn regalloc.VReg, allowTmpRegUse bool) addressMode {
+func (m *machine) resolveAddressModeForOffset(offset int64, dstBits byte, rn regalloc.VReg, allowTmpRegUse bool) *addressMode {
 	if rn.RegType() != regalloc.RegTypeInt {
 		panic("BUG: rn should be a pointer: " + formatVRegSized(rn, 64))
 	}
-	var amode addressMode
+	amode := m.amodePool.Allocate()
 	if offsetFitsInAddressModeKindRegUnsignedImm12(dstBits, offset) {
-		amode = addressMode{kind: addressModeKindRegUnsignedImm12, rn: rn, imm: offset}
+		*amode = addressMode{kind: addressModeKindRegUnsignedImm12, rn: rn, imm: offset}
 	} else if offsetFitsInAddressModeKindRegSignedImm9(offset) {
-		amode = addressMode{kind: addressModeKindRegSignedImm9, rn: rn, imm: offset}
+		*amode = addressMode{kind: addressModeKindRegSignedImm9, rn: rn, imm: offset}
 	} else {
 		var indexReg regalloc.VReg
 		if allowTmpRegUse {
@@ -253,7 +255,7 @@ func (m *machine) resolveAddressModeForOffset(offset int64, dstBits byte, rn reg
 			indexReg = m.compiler.AllocateVReg(ssa.TypeI64)
 			m.lowerConstantI64(indexReg, offset)
 		}
-		amode = addressMode{kind: addressModeKindRegReg, rn: rn, rm: indexReg, extOp: extendOpUXTX /* indicates index rm is 64-bit */}
+		*amode = addressMode{kind: addressModeKindRegReg, rn: rn, rm: indexReg, extOp: extendOpUXTX /* indicates index rm is 64-bit */}
 	}
 	return amode
 }

--- a/internal/engine/wazevo/backend/isa/arm64/abi.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi.go
@@ -105,9 +105,9 @@ func (m *machine) LowerParams(args []ssa.Value) {
 			load := m.allocateInstr()
 			switch arg.Type {
 			case ssa.TypeI32, ssa.TypeI64:
-				load.asULoad(operandNR(reg), amode, bits)
+				load.asULoad(reg, amode, bits)
 			case ssa.TypeF32, ssa.TypeF64, ssa.TypeV128:
-				load.asFpuLoad(operandNR(reg), amode, bits)
+				load.asFpuLoad(reg, amode, bits)
 			default:
 				panic("BUG")
 			}
@@ -215,9 +215,9 @@ func (m *machine) callerGenFunctionReturnVReg(a *backend.FunctionABI, retIndex i
 		ldr := m.allocateInstr()
 		switch r.Type {
 		case ssa.TypeI32, ssa.TypeI64:
-			ldr.asULoad(operandNR(reg), amode, r.Type.Bits())
+			ldr.asULoad(reg, amode, r.Type.Bits())
 		case ssa.TypeF32, ssa.TypeF64, ssa.TypeV128:
-			ldr.asFpuLoad(operandNR(reg), amode, r.Type.Bits())
+			ldr.asFpuLoad(reg, amode, r.Type.Bits())
 		default:
 			panic("BUG")
 		}
@@ -315,7 +315,7 @@ func (m *machine) insertAddOrSubStackPointer(rd regalloc.VReg, diff int64, add b
 		} else {
 			ao = aluOpSub
 		}
-		alu.asALU(ao, operandNR(rd), operandNR(spVReg), imm12Operand, true)
+		alu.asALU(ao, rd, operandNR(spVReg), imm12Operand, true)
 		m.insert(alu)
 	} else {
 		m.lowerConstantI64(tmpRegVReg, diff)
@@ -326,7 +326,7 @@ func (m *machine) insertAddOrSubStackPointer(rd regalloc.VReg, diff int64, add b
 		} else {
 			ao = aluOpSub
 		}
-		alu.asALU(ao, operandNR(rd), operandNR(spVReg), operandNR(tmpRegVReg), true)
+		alu.asALU(ao, rd, operandNR(spVReg), operandNR(tmpRegVReg), true)
 		m.insert(alu)
 	}
 }

--- a/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_entry_preamble.go
@@ -64,15 +64,15 @@ func (m *machine) goEntryPreamblePassArg(cur *instruction, paramSlicePtr regallo
 	instr := m.allocateInstr()
 	switch typ {
 	case ssa.TypeI32:
-		instr.asULoad(loadTargetReg, loadMode, 32)
+		instr.asULoad(loadTargetReg.reg(), loadMode, 32)
 	case ssa.TypeI64:
-		instr.asULoad(loadTargetReg, loadMode, 64)
+		instr.asULoad(loadTargetReg.reg(), loadMode, 64)
 	case ssa.TypeF32:
-		instr.asFpuLoad(loadTargetReg, loadMode, 32)
+		instr.asFpuLoad(loadTargetReg.reg(), loadMode, 32)
 	case ssa.TypeF64:
-		instr.asFpuLoad(loadTargetReg, loadMode, 64)
+		instr.asFpuLoad(loadTargetReg.reg(), loadMode, 64)
 	case ssa.TypeV128:
-		instr.asFpuLoad(loadTargetReg, loadMode, 128)
+		instr.asFpuLoad(loadTargetReg.reg(), loadMode, 128)
 	}
 	cur = linkInstr(cur, instr)
 
@@ -118,9 +118,9 @@ func (m *machine) goEntryPreamblePassResult(cur *instruction, resultSlicePtr reg
 		toReg := m.allocateInstr()
 		switch typ {
 		case ssa.TypeI32, ssa.TypeI64:
-			toReg.asULoad(storeTargetReg, loadMode, bits)
+			toReg.asULoad(storeTargetReg.reg(), loadMode, bits)
 		case ssa.TypeF32, ssa.TypeF64, ssa.TypeV128:
-			toReg.asFpuLoad(storeTargetReg, loadMode, bits)
+			toReg.asFpuLoad(storeTargetReg.reg(), loadMode, bits)
 		default:
 			panic("TODO?")
 		}
@@ -218,7 +218,7 @@ func (m *machine) loadOrStoreAtExecutionContext(d regalloc.VReg, offset wazevoap
 	if store {
 		instr.asStore(operandNR(d), mode, 64)
 	} else {
-		instr.asULoad(operandNR(d), mode, 64)
+		instr.asULoad(d, mode, 64)
 	}
 	return linkInstr(prev, instr)
 }

--- a/internal/engine/wazevo/backend/isa/arm64/abi_go_call.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi_go_call.go
@@ -87,7 +87,8 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 		// Module context is always the second argument.
 		moduleCtrPtr := x1VReg
 		store := m.allocateInstr()
-		amode := addressMode{kind: addressModeKindRegUnsignedImm12, rn: execCtrPtr, imm: offset}
+		amode := m.amodePool.Allocate()
+		*amode = addressMode{kind: addressModeKindRegUnsignedImm12, rn: execCtrPtr, imm: offset}
 		store.asStore(operandNR(moduleCtrPtr), amode, 64)
 		cur = linkInstr(cur, store)
 	}
@@ -120,11 +121,9 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 		} else {
 			sizeInBits = 64
 		}
-		store.asStore(operandNR(v),
-			addressMode{
-				kind: addressModeKindPostIndex,
-				rn:   arg0ret0AddrReg, imm: int64(sizeInBits / 8),
-			}, sizeInBits)
+		amode := m.amodePool.Allocate()
+		*amode = addressMode{kind: addressModeKindPostIndex, rn: arg0ret0AddrReg, imm: int64(sizeInBits / 8)}
+		store.asStore(operandNR(v), amode, sizeInBits)
 		cur = linkInstr(cur, store)
 	}
 
@@ -139,7 +138,7 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 		frameSizeReg = xzrVReg
 		sliceSizeReg = xzrVReg
 	}
-	_amode := addressModePreOrPostIndex(spVReg, -16, true)
+	_amode := addressModePreOrPostIndex(m, spVReg, -16, true)
 	storeP := m.allocateInstr()
 	storeP.asStorePair64(frameSizeReg, sliceSizeReg, _amode)
 	cur = linkInstr(cur, storeP)
@@ -165,8 +164,8 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 	cur = m.addsAddOrSubStackPointer(cur, spVReg, frameInfoSize+goCallStackSize, true)
 	ldr := m.allocateInstr()
 	// And load the return address.
-	ldr.asULoad(lrVReg,
-		addressModePreOrPostIndex(spVReg, 16 /* stack pointer must be 16-byte aligned. */, false /* increment after loads */), 64)
+	amode := addressModePreOrPostIndex(m, spVReg, 16 /* stack pointer must be 16-byte aligned. */, false /* increment after loads */)
+	ldr.asULoad(lrVReg, amode, 64)
 	cur = linkInstr(cur, ldr)
 
 	originalRet0Reg := x17VReg // Caller save, so we can use it for whatever we want.
@@ -183,7 +182,8 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 		r := &abi.Rets[i]
 		if r.Kind == backend.ABIArgKindReg {
 			loadIntoReg := m.allocateInstr()
-			mode := addressMode{kind: addressModeKindPostIndex, rn: arg0ret0AddrReg}
+			mode := m.amodePool.Allocate()
+			*mode = addressMode{kind: addressModeKindPostIndex, rn: arg0ret0AddrReg}
 			switch r.Type {
 			case ssa.TypeI32:
 				mode.imm = 8 // We use uint64 for all basic types, except SIMD v128.
@@ -208,7 +208,8 @@ func (m *machine) CompileGoFunctionTrampoline(exitCode wazevoapi.ExitCode, sig *
 			// First we need to load the value to a temporary just like ^^.
 			intTmp, floatTmp := x11VReg, v11VReg
 			loadIntoTmpReg := m.allocateInstr()
-			mode := addressMode{kind: addressModeKindPostIndex, rn: arg0ret0AddrReg}
+			mode := m.amodePool.Allocate()
+			*mode = addressMode{kind: addressModeKindPostIndex, rn: arg0ret0AddrReg}
 			var resultReg regalloc.VReg
 			switch r.Type {
 			case ssa.TypeI32:
@@ -258,12 +259,13 @@ func (m *machine) saveRegistersInExecutionContext(cur *instruction, regs []regal
 		case regalloc.RegTypeFloat:
 			sizeInBits = 128
 		}
-		store.asStore(operandNR(v),
-			addressMode{
-				kind: addressModeKindRegUnsignedImm12,
-				// Execution context is always the first argument.
-				rn: x0VReg, imm: offset,
-			}, sizeInBits)
+		mode := m.amodePool.Allocate()
+		*mode = addressMode{
+			kind: addressModeKindRegUnsignedImm12,
+			// Execution context is always the first argument.
+			rn: x0VReg, imm: offset,
+		}
+		store.asStore(operandNR(v), mode, sizeInBits)
 		store.prev = cur
 		cur.next = store
 		cur = store
@@ -276,7 +278,7 @@ func (m *machine) restoreRegistersInExecutionContext(cur *instruction, regs []re
 	offset := wazevoapi.ExecutionContextOffsetSavedRegistersBegin.I64()
 	for _, v := range regs {
 		load := m.allocateInstr()
-		var as func(dst regalloc.VReg, amode addressMode, sizeInBits byte)
+		var as func(dst regalloc.VReg, amode *addressMode, sizeInBits byte)
 		var sizeInBits byte
 		switch v.RegType() {
 		case regalloc.RegTypeInt:
@@ -286,12 +288,13 @@ func (m *machine) restoreRegistersInExecutionContext(cur *instruction, regs []re
 			as = load.asFpuLoad
 			sizeInBits = 128
 		}
-		as(v,
-			addressMode{
-				kind: addressModeKindRegUnsignedImm12,
-				// Execution context is always the first argument.
-				rn: x0VReg, imm: offset,
-			}, sizeInBits)
+		mode := m.amodePool.Allocate()
+		*mode = addressMode{
+			kind: addressModeKindRegUnsignedImm12,
+			// Execution context is always the first argument.
+			rn: x0VReg, imm: offset,
+		}
+		as(v, mode, sizeInBits)
 		cur = linkInstr(cur, load)
 		offset += 16 // Imm12 must be aligned 16 for vector regs, so we unconditionally load regs at the offset of multiple of 16.
 	}
@@ -324,11 +327,9 @@ func (m *machine) setExitCode(cur *instruction, execCtr regalloc.VReg, exitCode 
 
 	// Set the exit status on the execution context.
 	setExistStatus := m.allocateInstr()
-	setExistStatus.asStore(operandNR(constReg),
-		addressMode{
-			kind: addressModeKindRegUnsignedImm12,
-			rn:   execCtr, imm: wazevoapi.ExecutionContextOffsetExitCodeOffset.I64(),
-		}, 32)
+	mode := m.amodePool.Allocate()
+	*mode = addressMode{kind: addressModeKindRegUnsignedImm12, rn: execCtr, imm: wazevoapi.ExecutionContextOffsetExitCodeOffset.I64()}
+	setExistStatus.asStore(operandNR(constReg), mode, 32)
 	cur = linkInstr(cur, setExistStatus)
 	return cur
 }
@@ -340,12 +341,13 @@ func (m *machine) storeReturnAddressAndExit(cur *instruction) *instruction {
 	cur = linkInstr(cur, adr)
 
 	storeReturnAddr := m.allocateInstr()
-	storeReturnAddr.asStore(operandNR(tmpRegVReg),
-		addressMode{
-			kind: addressModeKindRegUnsignedImm12,
-			// Execution context is always the first argument.
-			rn: x0VReg, imm: wazevoapi.ExecutionContextOffsetGoCallReturnAddress.I64(),
-		}, 64)
+	mode := m.amodePool.Allocate()
+	*mode = addressMode{
+		kind: addressModeKindRegUnsignedImm12,
+		// Execution context is always the first argument.
+		rn: x0VReg, imm: wazevoapi.ExecutionContextOffsetGoCallReturnAddress.I64(),
+	}
+	storeReturnAddr.asStore(operandNR(tmpRegVReg), mode, 64)
 	cur = linkInstr(cur, storeReturnAddr)
 
 	// Exit the execution.
@@ -364,11 +366,12 @@ func (m *machine) saveCurrentStackPointer(cur *instruction, execCtr regalloc.VRe
 	cur = linkInstr(cur, movSp)
 
 	strSp := m.allocateInstr()
-	strSp.asStore(operandNR(tmpRegVReg),
-		addressMode{
-			kind: addressModeKindRegUnsignedImm12,
-			rn:   execCtr, imm: wazevoapi.ExecutionContextOffsetStackPointerBeforeGoCall.I64(),
-		}, 64)
+	mode := m.amodePool.Allocate()
+	*mode = addressMode{
+		kind: addressModeKindRegUnsignedImm12,
+		rn:   execCtr, imm: wazevoapi.ExecutionContextOffsetStackPointerBeforeGoCall.I64(),
+	}
+	strSp.asStore(operandNR(tmpRegVReg), mode, 64)
 	cur = linkInstr(cur, strSp)
 	return cur
 }
@@ -376,7 +379,8 @@ func (m *machine) saveCurrentStackPointer(cur *instruction, execCtr regalloc.VRe
 func (m *machine) goFunctionCallLoadStackArg(cur *instruction, originalArg0Reg regalloc.VReg, arg *backend.ABIArg, intVReg, floatVReg regalloc.VReg) (*instruction, regalloc.VReg) {
 	load := m.allocateInstr()
 	var result regalloc.VReg
-	mode := addressMode{kind: addressModeKindPostIndex, rn: originalArg0Reg}
+	mode := m.amodePool.Allocate()
+	*mode = addressMode{kind: addressModeKindPostIndex, rn: originalArg0Reg}
 	switch arg.Type {
 	case ssa.TypeI32:
 		mode.imm = 8 // We use uint64 for all basic types, except SIMD v128.
@@ -408,7 +412,8 @@ func (m *machine) goFunctionCallLoadStackArg(cur *instruction, originalArg0Reg r
 
 func (m *machine) goFunctionCallStoreStackResult(cur *instruction, originalRet0Reg regalloc.VReg, result *backend.ABIArg, resultVReg regalloc.VReg) *instruction {
 	store := m.allocateInstr()
-	mode := addressMode{kind: addressModeKindPostIndex, rn: originalRet0Reg}
+	mode := m.amodePool.Allocate()
+	*mode = addressMode{kind: addressModeKindPostIndex, rn: originalRet0Reg}
 	var sizeInBits byte
 	switch result.Type {
 	case ssa.TypeI32, ssa.TypeF32:

--- a/internal/engine/wazevo/backend/isa/arm64/instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr.go
@@ -23,7 +23,8 @@ type (
 	instruction struct {
 		prev, next          *instruction
 		u1, u2, u3          uint64
-		rd, rm, rn          operand
+		rd                  regalloc.VReg
+		rm, rn              operand
 		amode               addressMode
 		kind                instructionKind
 		addedBeforeRegAlloc bool
@@ -174,7 +175,7 @@ func (i *instruction) Defs(regs *[]regalloc.VReg) []regalloc.VReg {
 	switch defKinds[i.kind] {
 	case defKindNone:
 	case defKindRD:
-		*regs = append(*regs, i.rd.nr())
+		*regs = append(*regs, i.rd)
 	case defKindCall:
 		_, _, retIntRealRegs, retFloatRealRegs, _ := backend.ABIInfoFromUint64(i.u2)
 		for i := byte(0); i < retIntRealRegs; i++ {
@@ -194,7 +195,7 @@ func (i *instruction) AssignDef(reg regalloc.VReg) {
 	switch defKinds[i.kind] {
 	case defKindNone:
 	case defKindRD:
-		i.rd = i.rd.assignReg(reg)
+		i.rd = reg
 	case defKindCall:
 		panic("BUG: call instructions shouldn't be assigned")
 	default:
@@ -374,7 +375,7 @@ func (i *instruction) Uses(regs *[]regalloc.VReg) []regalloc.VReg {
 	case useKindRDRewrite:
 		*regs = append(*regs, i.rn.reg())
 		*regs = append(*regs, i.rm.reg())
-		*regs = append(*regs, i.rd.reg())
+		*regs = append(*regs, i.rd)
 	default:
 		panic(fmt.Sprintf("useKind for %v not defined", i))
 	}
@@ -408,8 +409,8 @@ func (i *instruction) AssignUse(index int, reg regalloc.VReg) {
 				i.rm = i.rm.assignReg(reg)
 			}
 		} else {
-			if rd := i.rd.reg(); rd.Valid() {
-				i.rd = i.rd.assignReg(reg)
+			if rd := i.rd; rd.Valid() {
+				i.rd = reg
 			}
 		}
 	case useKindRNRN1RM:
@@ -505,7 +506,7 @@ func (i *instruction) callFuncRef() ssa.FuncRef {
 // shift must be divided by 16 and must be in range 0-3 (if dst64bit is true) or 0-1 (if dst64bit is false)
 func (i *instruction) asMOVZ(dst regalloc.VReg, imm uint64, shift uint64, dst64bit bool) {
 	i.kind = movZ
-	i.rd = operandNR(dst)
+	i.rd = dst
 	i.u1 = imm
 	i.u2 = shift
 	if dst64bit {
@@ -516,7 +517,7 @@ func (i *instruction) asMOVZ(dst regalloc.VReg, imm uint64, shift uint64, dst64b
 // shift must be divided by 16 and must be in range 0-3 (if dst64bit is true) or 0-1 (if dst64bit is false)
 func (i *instruction) asMOVK(dst regalloc.VReg, imm uint64, shift uint64, dst64bit bool) {
 	i.kind = movK
-	i.rd = operandNR(dst)
+	i.rd = dst
 	i.u1 = imm
 	i.u2 = shift
 	if dst64bit {
@@ -527,7 +528,7 @@ func (i *instruction) asMOVK(dst regalloc.VReg, imm uint64, shift uint64, dst64b
 // shift must be divided by 16 and must be in range 0-3 (if dst64bit is true) or 0-1 (if dst64bit is false)
 func (i *instruction) asMOVN(dst regalloc.VReg, imm uint64, shift uint64, dst64bit bool) {
 	i.kind = movN
-	i.rd = operandNR(dst)
+	i.rd = dst
 	i.u1 = imm
 	i.u2 = shift
 	if dst64bit {
@@ -592,7 +593,7 @@ func (i *instruction) asStore(src operand, amode addressMode, sizeInBits byte) {
 	i.amode = amode
 }
 
-func (i *instruction) asSLoad(dst operand, amode addressMode, sizeInBits byte) {
+func (i *instruction) asSLoad(dst regalloc.VReg, amode addressMode, sizeInBits byte) {
 	switch sizeInBits {
 	case 8:
 		i.kind = sLoad8
@@ -607,7 +608,7 @@ func (i *instruction) asSLoad(dst operand, amode addressMode, sizeInBits byte) {
 	i.amode = amode
 }
 
-func (i *instruction) asULoad(dst operand, amode addressMode, sizeInBits byte) {
+func (i *instruction) asULoad(dst regalloc.VReg, amode addressMode, sizeInBits byte) {
 	switch sizeInBits {
 	case 8:
 		i.kind = uLoad8
@@ -622,7 +623,7 @@ func (i *instruction) asULoad(dst operand, amode addressMode, sizeInBits byte) {
 	i.amode = amode
 }
 
-func (i *instruction) asFpuLoad(dst operand, amode addressMode, sizeInBits byte) {
+func (i *instruction) asFpuLoad(dst regalloc.VReg, amode addressMode, sizeInBits byte) {
 	switch sizeInBits {
 	case 32:
 		i.kind = fpuLoad32
@@ -635,7 +636,7 @@ func (i *instruction) asFpuLoad(dst operand, amode addressMode, sizeInBits byte)
 	i.amode = amode
 }
 
-func (i *instruction) asVecLoad1R(rd, rn operand, arr vecArrangement) {
+func (i *instruction) asVecLoad1R(rd regalloc.VReg, rn operand, arr vecArrangement) {
 	// NOTE: currently only has support for no-offset loads, though it is suspicious that
 	// we would need to support offset load (that is only available for post-index).
 	i.kind = vecLoad1R
@@ -646,14 +647,14 @@ func (i *instruction) asVecLoad1R(rd, rn operand, arr vecArrangement) {
 
 func (i *instruction) asCSet(rd regalloc.VReg, mask bool, c condFlag) {
 	i.kind = cSet
-	i.rd = operandNR(rd)
+	i.rd = rd
 	i.u1 = uint64(c)
 	if mask {
 		i.u2 = 1
 	}
 }
 
-func (i *instruction) asCSel(rd, rn, rm operand, c condFlag, _64bit bool) {
+func (i *instruction) asCSel(rd regalloc.VReg, rn, rm operand, c condFlag, _64bit bool) {
 	i.kind = cSel
 	i.rd = rd
 	i.rn = rn
@@ -664,7 +665,7 @@ func (i *instruction) asCSel(rd, rn, rm operand, c condFlag, _64bit bool) {
 	}
 }
 
-func (i *instruction) asFpuCSel(rd, rn, rm operand, c condFlag, _64bit bool) {
+func (i *instruction) asFpuCSel(rd regalloc.VReg, rn, rm operand, c condFlag, _64bit bool) {
 	i.kind = fpuCSel
 	i.rd = rd
 	i.rn = rn
@@ -728,17 +729,17 @@ func (i *instruction) condBrLabel() label {
 
 // condBrOffsetResolve is called when the target label is resolved.
 func (i *instruction) condBrOffsetResolve(offset int64) {
-	i.rd.data = uint64(offset)
-	i.rd.data2 = 1 // indicate that the offset is resolved, for debugging.
+	i.rn.data = uint64(offset)
+	i.rn.data2 = 1 // indicate that the offset is resolved, for debugging.
 }
 
 // condBrOffsetResolved returns true if condBrOffsetResolve is already called.
 func (i *instruction) condBrOffsetResolved() bool {
-	return i.rd.data2 == 1
+	return i.rn.data2 == 1
 }
 
 func (i *instruction) condBrOffset() int64 {
-	return int64(i.rd.data)
+	return int64(i.rn.data)
 }
 
 func (i *instruction) condBrCond() cond {
@@ -752,20 +753,20 @@ func (i *instruction) condBr64bit() bool {
 func (i *instruction) asLoadFpuConst32(rd regalloc.VReg, raw uint64) {
 	i.kind = loadFpuConst32
 	i.u1 = raw
-	i.rd = operandNR(rd)
+	i.rd = rd
 }
 
 func (i *instruction) asLoadFpuConst64(rd regalloc.VReg, raw uint64) {
 	i.kind = loadFpuConst64
 	i.u1 = raw
-	i.rd = operandNR(rd)
+	i.rd = rd
 }
 
 func (i *instruction) asLoadFpuConst128(rd regalloc.VReg, lo, hi uint64) {
 	i.kind = loadFpuConst128
 	i.u1 = lo
 	i.u2 = hi
-	i.rd = operandNR(rd)
+	i.rd = rd
 }
 
 func (i *instruction) asFpuCmp(rn, rm operand, is64bit bool) {
@@ -788,7 +789,7 @@ func (i *instruction) asCCmpImm(rn operand, imm uint64, c condFlag, flag byte, i
 }
 
 // asALU setups a basic ALU instruction.
-func (i *instruction) asALU(aluOp aluOp, rd, rn, rm operand, dst64bit bool) {
+func (i *instruction) asALU(aluOp aluOp, rd regalloc.VReg, rn, rm operand, dst64bit bool) {
 	switch rm.kind {
 	case operandKindNR:
 		i.kind = aluRRR
@@ -809,7 +810,7 @@ func (i *instruction) asALU(aluOp aluOp, rd, rn, rm operand, dst64bit bool) {
 }
 
 // asALU setups a basic ALU instruction.
-func (i *instruction) asALURRRR(aluOp aluOp, rd, rn, rm operand, ra regalloc.VReg, dst64bit bool) {
+func (i *instruction) asALURRRR(aluOp aluOp, rd regalloc.VReg, rn, rm operand, ra regalloc.VReg, dst64bit bool) {
 	i.kind = aluRRRR
 	i.u1 = uint64(aluOp)
 	i.rd, i.rn, i.rm, i.u2 = rd, rn, rm, uint64(ra)
@@ -819,7 +820,7 @@ func (i *instruction) asALURRRR(aluOp aluOp, rd, rn, rm operand, ra regalloc.VRe
 }
 
 // asALUShift setups a shift based ALU instruction.
-func (i *instruction) asALUShift(aluOp aluOp, rd, rn, rm operand, dst64bit bool) {
+func (i *instruction) asALUShift(aluOp aluOp, rd regalloc.VReg, rn, rm operand, dst64bit bool) {
 	switch rm.kind {
 	case operandKindNR:
 		i.kind = aluRRR // If the shift amount op is a register, then the instruction is encoded as a normal ALU instruction with two register operands.
@@ -838,7 +839,7 @@ func (i *instruction) asALUShift(aluOp aluOp, rd, rn, rm operand, dst64bit bool)
 func (i *instruction) asALUBitmaskImm(aluOp aluOp, rd, rn regalloc.VReg, imm uint64, dst64bit bool) {
 	i.kind = aluRRBitmaskImm
 	i.u1 = uint64(aluOp)
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 	i.u2 = imm
 	if dst64bit {
 		i.u3 = 1
@@ -852,19 +853,19 @@ func (i *instruction) asMovToFPSR(rn regalloc.VReg) {
 
 func (i *instruction) asMovFromFPSR(rd regalloc.VReg) {
 	i.kind = movFromFPSR
-	i.rd = operandNR(rd)
+	i.rd = rd
 }
 
 func (i *instruction) asBitRR(bitOp bitOp, rd, rn regalloc.VReg, is64bit bool) {
 	i.kind = bitRR
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 	i.u1 = uint64(bitOp)
 	if is64bit {
 		i.u2 = 1
 	}
 }
 
-func (i *instruction) asFpuRRR(op fpuBinOp, rd, rn, rm operand, dst64bit bool) {
+func (i *instruction) asFpuRRR(op fpuBinOp, rd regalloc.VReg, rn, rm operand, dst64bit bool) {
 	i.kind = fpuRRR
 	i.u1 = uint64(op)
 	i.rd, i.rn, i.rm = rd, rn, rm
@@ -873,7 +874,7 @@ func (i *instruction) asFpuRRR(op fpuBinOp, rd, rn, rm operand, dst64bit bool) {
 	}
 }
 
-func (i *instruction) asFpuRR(op fpuUniOp, rd, rn operand, dst64bit bool) {
+func (i *instruction) asFpuRR(op fpuUniOp, rd regalloc.VReg, rn operand, dst64bit bool) {
 	i.kind = fpuRR
 	i.u1 = uint64(op)
 	i.rd, i.rn = rd, rn
@@ -884,7 +885,7 @@ func (i *instruction) asFpuRR(op fpuUniOp, rd, rn operand, dst64bit bool) {
 
 func (i *instruction) asExtend(rd, rn regalloc.VReg, fromBits, toBits byte, signed bool) {
 	i.kind = extend
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 	i.u1 = uint64(fromBits)
 	i.u2 = uint64(toBits)
 	if signed {
@@ -894,34 +895,34 @@ func (i *instruction) asExtend(rd, rn regalloc.VReg, fromBits, toBits byte, sign
 
 func (i *instruction) asMove32(rd, rn regalloc.VReg) {
 	i.kind = mov32
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 }
 
 func (i *instruction) asMove64(rd, rn regalloc.VReg) *instruction {
 	i.kind = mov64
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 	return i
 }
 
 func (i *instruction) asFpuMov64(rd, rn regalloc.VReg) {
 	i.kind = fpuMov64
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 }
 
 func (i *instruction) asFpuMov128(rd, rn regalloc.VReg) *instruction {
 	i.kind = fpuMov128
-	i.rn, i.rd = operandNR(rn), operandNR(rd)
+	i.rn, i.rd = operandNR(rn), rd
 	return i
 }
 
-func (i *instruction) asMovToVec(rd, rn operand, arr vecArrangement, index vecIndex) {
+func (i *instruction) asMovToVec(rd regalloc.VReg, rn operand, arr vecArrangement, index vecIndex) {
 	i.kind = movToVec
 	i.rd = rd
 	i.rn = rn
 	i.u1, i.u2 = uint64(arr), uint64(index)
 }
 
-func (i *instruction) asMovFromVec(rd, rn operand, arr vecArrangement, index vecIndex, signed bool) {
+func (i *instruction) asMovFromVec(rd regalloc.VReg, rn operand, arr vecArrangement, index vecIndex, signed bool) {
 	if signed {
 		i.kind = movFromVecSigned
 	} else {
@@ -932,48 +933,48 @@ func (i *instruction) asMovFromVec(rd, rn operand, arr vecArrangement, index vec
 	i.u1, i.u2 = uint64(arr), uint64(index)
 }
 
-func (i *instruction) asVecDup(rd, rn operand, arr vecArrangement) {
+func (i *instruction) asVecDup(rd regalloc.VReg, rn operand, arr vecArrangement) {
 	i.kind = vecDup
 	i.u1 = uint64(arr)
 	i.rn, i.rd = rn, rd
 }
 
-func (i *instruction) asVecDupElement(rd, rn operand, arr vecArrangement, index vecIndex) {
+func (i *instruction) asVecDupElement(rd regalloc.VReg, rn operand, arr vecArrangement, index vecIndex) {
 	i.kind = vecDupElement
 	i.u1 = uint64(arr)
 	i.rn, i.rd = rn, rd
 	i.u2 = uint64(index)
 }
 
-func (i *instruction) asVecExtract(rd, rn, rm operand, arr vecArrangement, index uint32) {
+func (i *instruction) asVecExtract(rd regalloc.VReg, rn, rm operand, arr vecArrangement, index uint32) {
 	i.kind = vecExtract
 	i.u1 = uint64(arr)
 	i.rn, i.rm, i.rd = rn, rm, rd
 	i.u2 = uint64(index)
 }
 
-func (i *instruction) asVecMovElement(rd, rn operand, arr vecArrangement, rdIndex, rnIndex vecIndex) {
+func (i *instruction) asVecMovElement(rd regalloc.VReg, rn operand, arr vecArrangement, rdIndex, rnIndex vecIndex) {
 	i.kind = vecMovElement
 	i.u1 = uint64(arr)
 	i.u2, i.u3 = uint64(rdIndex), uint64(rnIndex)
 	i.rn, i.rd = rn, rd
 }
 
-func (i *instruction) asVecMisc(op vecOp, rd, rn operand, arr vecArrangement) {
+func (i *instruction) asVecMisc(op vecOp, rd regalloc.VReg, rn operand, arr vecArrangement) {
 	i.kind = vecMisc
 	i.u1 = uint64(op)
 	i.rn, i.rd = rn, rd
 	i.u2 = uint64(arr)
 }
 
-func (i *instruction) asVecLanes(op vecOp, rd, rn operand, arr vecArrangement) {
+func (i *instruction) asVecLanes(op vecOp, rd regalloc.VReg, rn operand, arr vecArrangement) {
 	i.kind = vecLanes
 	i.u1 = uint64(op)
 	i.rn, i.rd = rn, rd
 	i.u2 = uint64(arr)
 }
 
-func (i *instruction) asVecShiftImm(op vecOp, rd, rn, rm operand, arr vecArrangement) *instruction {
+func (i *instruction) asVecShiftImm(op vecOp, rd regalloc.VReg, rn, rm operand, arr vecArrangement) *instruction {
 	i.kind = vecShiftImm
 	i.u1 = uint64(op)
 	i.rn, i.rm, i.rd = rn, rm, rd
@@ -981,7 +982,7 @@ func (i *instruction) asVecShiftImm(op vecOp, rd, rn, rm operand, arr vecArrange
 	return i
 }
 
-func (i *instruction) asVecTbl(nregs byte, rd, rn, rm operand, arr vecArrangement) {
+func (i *instruction) asVecTbl(nregs byte, rd regalloc.VReg, rn, rm operand, arr vecArrangement) {
 	switch nregs {
 	case 0, 1:
 		i.kind = vecTbl
@@ -1000,14 +1001,14 @@ func (i *instruction) asVecTbl(nregs byte, rd, rn, rm operand, arr vecArrangemen
 	i.u2 = uint64(arr)
 }
 
-func (i *instruction) asVecPermute(op vecOp, rd, rn, rm operand, arr vecArrangement) {
+func (i *instruction) asVecPermute(op vecOp, rd regalloc.VReg, rn, rm operand, arr vecArrangement) {
 	i.kind = vecPermute
 	i.u1 = uint64(op)
 	i.rn, i.rm, i.rd = rn, rm, rd
 	i.u2 = uint64(arr)
 }
 
-func (i *instruction) asVecRRR(op vecOp, rd, rn, rm operand, arr vecArrangement) *instruction {
+func (i *instruction) asVecRRR(op vecOp, rd regalloc.VReg, rn, rm operand, arr vecArrangement) *instruction {
 	i.kind = vecRRR
 	i.u1 = uint64(op)
 	i.rn, i.rd, i.rm = rn, rd, rm
@@ -1017,7 +1018,7 @@ func (i *instruction) asVecRRR(op vecOp, rd, rn, rm operand, arr vecArrangement)
 
 // asVecRRRRewrite encodes a vector instruction that rewrites the destination register.
 // IMPORTANT: the destination register must be already defined before this instruction.
-func (i *instruction) asVecRRRRewrite(op vecOp, rd, rn, rm operand, arr vecArrangement) {
+func (i *instruction) asVecRRRRewrite(op vecOp, rd regalloc.VReg, rn, rm operand, arr vecArrangement) {
 	i.kind = vecRRRRewrite
 	i.u1 = uint64(op)
 	i.rn, i.rd, i.rm = rn, rd, rm
@@ -1051,19 +1052,19 @@ func (i *instruction) String() (str string) {
 	case aluRRR:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %s", aluOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), size),
+			formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), size),
 			i.rm.format(size))
 	case aluRRRR:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %s, %s", aluOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), size), formatVRegSized(i.rm.nr(), size), formatVRegSized(regalloc.VReg(i.u2), size))
+			formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), size), formatVRegSized(i.rm.nr(), size), formatVRegSized(regalloc.VReg(i.u2), size))
 	case aluRRImm12:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %s", aluOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), size), i.rm.format(size))
+			formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), size), i.rm.format(size))
 	case aluRRBitmaskImm:
 		size := is64SizeBitToSize(i.u3)
-		rd, rn := formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), size)
+		rd, rn := formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), size)
 		if size == 32 {
 			str = fmt.Sprintf("%s %s, %s, #%#x", aluOp(i.u1).String(), rd, rn, uint32(i.u2))
 		} else {
@@ -1073,7 +1074,7 @@ func (i *instruction) String() (str string) {
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %#x",
 			aluOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size),
+			formatVRegSized(i.rd, size),
 			formatVRegSized(i.rn.nr(), size),
 			i.rm.shiftImm(),
 		)
@@ -1081,14 +1082,14 @@ func (i *instruction) String() (str string) {
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %s",
 			aluOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size),
+			formatVRegSized(i.rd, size),
 			formatVRegSized(i.rn.nr(), size),
 			i.rm.format(size),
 		)
 	case aluRRRExtend:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %s", aluOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size),
+			formatVRegSized(i.rd, size),
 			formatVRegSized(i.rn.nr(), size),
 			// Regardless of the source size, the register is formatted in 32-bit.
 			i.rm.format(32),
@@ -1097,23 +1098,23 @@ func (i *instruction) String() (str string) {
 		size := is64SizeBitToSize(i.u2)
 		str = fmt.Sprintf("%s %s, %s",
 			bitOp(i.u1),
-			formatVRegSized(i.rd.nr(), size),
+			formatVRegSized(i.rd, size),
 			formatVRegSized(i.rn.nr(), size),
 		)
 	case uLoad8:
-		str = fmt.Sprintf("ldrb %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldrb %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case sLoad8:
-		str = fmt.Sprintf("ldrsb %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldrsb %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case uLoad16:
-		str = fmt.Sprintf("ldrh %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldrh %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case sLoad16:
-		str = fmt.Sprintf("ldrsh %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldrsh %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case uLoad32:
-		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case sLoad32:
-		str = fmt.Sprintf("ldrs %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldrs %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case uLoad64:
-		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd.nr(), 64), i.amode.format(64))
+		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd, 64), i.amode.format(64))
 	case store8:
 		str = fmt.Sprintf("strb %s, %s", formatVRegSized(i.rn.nr(), 32), i.amode.format(8))
 	case store16:
@@ -1130,19 +1131,19 @@ func (i *instruction) String() (str string) {
 			formatVRegSized(i.rn.nr(), 64), formatVRegSized(i.rm.nr(), 64), i.amode.format(64))
 	case mov64:
 		str = fmt.Sprintf("mov %s, %s",
-			formatVRegSized(i.rd.nr(), 64),
+			formatVRegSized(i.rd, 64),
 			formatVRegSized(i.rn.nr(), 64))
 	case mov32:
-		str = fmt.Sprintf("mov %s, %s", formatVRegSized(i.rd.nr(), 32), formatVRegSized(i.rn.nr(), 32))
+		str = fmt.Sprintf("mov %s, %s", formatVRegSized(i.rd, 32), formatVRegSized(i.rn.nr(), 32))
 	case movZ:
 		size := is64SizeBitToSize(i.u3)
-		str = fmt.Sprintf("movz %s, #%#x, lsl %d", formatVRegSized(i.rd.nr(), size), uint16(i.u1), i.u2*16)
+		str = fmt.Sprintf("movz %s, #%#x, lsl %d", formatVRegSized(i.rd, size), uint16(i.u1), i.u2*16)
 	case movN:
 		size := is64SizeBitToSize(i.u3)
-		str = fmt.Sprintf("movn %s, #%#x, lsl %d", formatVRegSized(i.rd.nr(), size), uint16(i.u1), i.u2*16)
+		str = fmt.Sprintf("movn %s, #%#x, lsl %d", formatVRegSized(i.rd, size), uint16(i.u1), i.u2*16)
 	case movK:
 		size := is64SizeBitToSize(i.u3)
-		str = fmt.Sprintf("movk %s, #%#x, lsl %d", formatVRegSized(i.rd.nr(), size), uint16(i.u1), i.u2*16)
+		str = fmt.Sprintf("movk %s, #%#x, lsl %d", formatVRegSized(i.rd, size), uint16(i.u1), i.u2*16)
 	case extend:
 		fromBits, toBits := byte(i.u1), byte(i.u2)
 
@@ -1161,20 +1162,20 @@ func (i *instruction) String() (str string) {
 		case 32:
 			fromStr = "w"
 		}
-		str = fmt.Sprintf("%sxt%s %s, %s", signedStr, fromStr, formatVRegSized(i.rd.nr(), toBits), formatVRegSized(i.rn.nr(), 32))
+		str = fmt.Sprintf("%sxt%s %s, %s", signedStr, fromStr, formatVRegSized(i.rd, toBits), formatVRegSized(i.rn.nr(), 32))
 	case cSel:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("csel %s, %s, %s, %s",
-			formatVRegSized(i.rd.nr(), size),
+			formatVRegSized(i.rd, size),
 			formatVRegSized(i.rn.nr(), size),
 			formatVRegSized(i.rm.nr(), size),
 			condFlag(i.u1),
 		)
 	case cSet:
 		if i.u2 != 0 {
-			str = fmt.Sprintf("csetm %s, %s", formatVRegSized(i.rd.nr(), 64), condFlag(i.u1))
+			str = fmt.Sprintf("csetm %s, %s", formatVRegSized(i.rd, 64), condFlag(i.u1))
 		} else {
-			str = fmt.Sprintf("cset %s, %s", formatVRegSized(i.rd.nr(), 64), condFlag(i.u1))
+			str = fmt.Sprintf("cset %s, %s", formatVRegSized(i.rd, 64), condFlag(i.u1))
 		}
 	case cCmpImm:
 		size := is64SizeBitToSize(i.u3)
@@ -1184,11 +1185,11 @@ func (i *instruction) String() (str string) {
 			condFlag(i.u1))
 	case fpuMov64:
 		str = fmt.Sprintf("mov %s, %s",
-			formatVRegVec(i.rd.nr(), vecArrangement8B, vecIndexNone),
+			formatVRegVec(i.rd, vecArrangement8B, vecIndexNone),
 			formatVRegVec(i.rn.nr(), vecArrangement8B, vecIndexNone))
 	case fpuMov128:
 		str = fmt.Sprintf("mov %s, %s",
-			formatVRegVec(i.rd.nr(), vecArrangement16B, vecIndexNone),
+			formatVRegVec(i.rd, vecArrangement16B, vecIndexNone),
 			formatVRegVec(i.rn.nr(), vecArrangement16B, vecIndexNone))
 	case fpuMovFromVec:
 		panic("TODO")
@@ -1203,11 +1204,11 @@ func (i *instruction) String() (str string) {
 			srcSz = 64
 		}
 		str = fmt.Sprintf("%s %s, %s", op.String(),
-			formatVRegSized(i.rd.nr(), dstSz), formatVRegSized(i.rn.nr(), srcSz))
+			formatVRegSized(i.rd, dstSz), formatVRegSized(i.rn.nr(), srcSz))
 	case fpuRRR:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("%s %s, %s, %s", fpuBinOp(i.u1).String(),
-			formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), size), formatVRegSized(i.rm.nr(), size))
+			formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), size), formatVRegSized(i.rm.nr(), size))
 	case fpuRRI:
 		panic("TODO")
 	case fpuRRRR:
@@ -1217,24 +1218,24 @@ func (i *instruction) String() (str string) {
 		str = fmt.Sprintf("fcmp %s, %s",
 			formatVRegSized(i.rn.nr(), size), formatVRegSized(i.rm.nr(), size))
 	case fpuLoad32:
-		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd.nr(), 32), i.amode.format(32))
+		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd, 32), i.amode.format(32))
 	case fpuStore32:
 		str = fmt.Sprintf("str %s, %s", formatVRegSized(i.rn.nr(), 32), i.amode.format(64))
 	case fpuLoad64:
-		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd.nr(), 64), i.amode.format(64))
+		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd, 64), i.amode.format(64))
 	case fpuStore64:
 		str = fmt.Sprintf("str %s, %s", formatVRegSized(i.rn.nr(), 64), i.amode.format(64))
 	case fpuLoad128:
-		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd.nr(), 128), i.amode.format(64))
+		str = fmt.Sprintf("ldr %s, %s", formatVRegSized(i.rd, 128), i.amode.format(64))
 	case fpuStore128:
 		str = fmt.Sprintf("str %s, %s", formatVRegSized(i.rn.nr(), 128), i.amode.format(64))
 	case loadFpuConst32:
-		str = fmt.Sprintf("ldr %s, #8; b 8; data.f32 %f", formatVRegSized(i.rd.nr(), 32), math.Float32frombits(uint32(i.u1)))
+		str = fmt.Sprintf("ldr %s, #8; b 8; data.f32 %f", formatVRegSized(i.rd, 32), math.Float32frombits(uint32(i.u1)))
 	case loadFpuConst64:
-		str = fmt.Sprintf("ldr %s, #8; b 16; data.f64 %f", formatVRegSized(i.rd.nr(), 64), math.Float64frombits(i.u1))
+		str = fmt.Sprintf("ldr %s, #8; b 16; data.f64 %f", formatVRegSized(i.rd, 64), math.Float64frombits(i.u1))
 	case loadFpuConst128:
 		str = fmt.Sprintf("ldr %s, #8; b 32; data.v128  %016x %016x",
-			formatVRegSized(i.rd.nr(), 128), i.u1, i.u2)
+			formatVRegSized(i.rd, 128), i.u1, i.u2)
 	case fpuToInt:
 		var op, src, dst string
 		if signed := i.u1 == 1; signed {
@@ -1248,9 +1249,9 @@ func (i *instruction) String() (str string) {
 			src = formatVRegWidthVec(i.rn.nr(), vecArrangementS)
 		}
 		if dst64 := i.u3 == 1; dst64 {
-			dst = formatVRegSized(i.rd.nr(), 64)
+			dst = formatVRegSized(i.rd, 64)
 		} else {
-			dst = formatVRegSized(i.rd.nr(), 32)
+			dst = formatVRegSized(i.rd, 32)
 		}
 		str = fmt.Sprintf("%s %s, %s", op, dst, src)
 
@@ -1267,15 +1268,15 @@ func (i *instruction) String() (str string) {
 			src = formatVRegSized(i.rn.nr(), 32)
 		}
 		if dst64 := i.u3 == 1; dst64 {
-			dst = formatVRegWidthVec(i.rd.nr(), vecArrangementD)
+			dst = formatVRegWidthVec(i.rd, vecArrangementD)
 		} else {
-			dst = formatVRegWidthVec(i.rd.nr(), vecArrangementS)
+			dst = formatVRegWidthVec(i.rd, vecArrangementS)
 		}
 		str = fmt.Sprintf("%s %s, %s", op, dst, src)
 	case fpuCSel:
 		size := is64SizeBitToSize(i.u3)
 		str = fmt.Sprintf("fcsel %s, %s, %s, %s",
-			formatVRegSized(i.rd.nr(), size),
+			formatVRegSized(i.rd, size),
 			formatVRegSized(i.rn.nr(), size),
 			formatVRegSized(i.rm.nr(), size),
 			condFlag(i.u1),
@@ -1291,7 +1292,7 @@ func (i *instruction) String() (str string) {
 		default:
 			panic("unsupported arrangement " + arr.String())
 		}
-		str = fmt.Sprintf("ins %s, %s", formatVRegVec(i.rd.nr(), arr, vecIndex(i.u2)), formatVRegSized(i.rn.nr(), size))
+		str = fmt.Sprintf("ins %s, %s", formatVRegVec(i.rd, arr, vecIndex(i.u2)), formatVRegSized(i.rn.nr(), size))
 	case movFromVec, movFromVecSigned:
 		var size byte
 		var opcode string
@@ -1315,23 +1316,23 @@ func (i *instruction) String() (str string) {
 		default:
 			panic("unsupported arrangement " + arr.String())
 		}
-		str = fmt.Sprintf("%s %s, %s", opcode, formatVRegSized(i.rd.nr(), size), formatVRegVec(i.rn.nr(), arr, vecIndex(i.u2)))
+		str = fmt.Sprintf("%s %s, %s", opcode, formatVRegSized(i.rd, size), formatVRegVec(i.rn.nr(), arr, vecIndex(i.u2)))
 	case vecDup:
 		str = fmt.Sprintf("dup %s, %s",
-			formatVRegVec(i.rd.nr(), vecArrangement(i.u1), vecIndexNone),
+			formatVRegVec(i.rd, vecArrangement(i.u1), vecIndexNone),
 			formatVRegSized(i.rn.nr(), 64),
 		)
 	case vecDupElement:
 		arr := vecArrangement(i.u1)
 		str = fmt.Sprintf("dup %s, %s",
-			formatVRegVec(i.rd.nr(), arr, vecIndexNone),
+			formatVRegVec(i.rd, arr, vecIndexNone),
 			formatVRegVec(i.rn.nr(), arr, vecIndex(i.u2)),
 		)
 	case vecDupFromFpu:
 		panic("TODO")
 	case vecExtract:
 		str = fmt.Sprintf("ext %s, %s, %s, #%d",
-			formatVRegVec(i.rd.nr(), vecArrangement(i.u1), vecIndexNone),
+			formatVRegVec(i.rd, vecArrangement(i.u1), vecIndexNone),
 			formatVRegVec(i.rn.nr(), vecArrangement(i.u1), vecIndexNone),
 			formatVRegVec(i.rm.nr(), vecArrangement(i.u1), vecIndexNone),
 			uint32(i.u2),
@@ -1340,7 +1341,7 @@ func (i *instruction) String() (str string) {
 		panic("TODO")
 	case vecMovElement:
 		str = fmt.Sprintf("mov %s, %s",
-			formatVRegVec(i.rd.nr(), vecArrangement(i.u1), vecIndex(i.u2)),
+			formatVRegVec(i.rd, vecArrangement(i.u1), vecIndex(i.u2)),
 			formatVRegVec(i.rn.nr(), vecArrangement(i.u1), vecIndex(i.u3)),
 		)
 	case vecMiscNarrow:
@@ -1348,7 +1349,7 @@ func (i *instruction) String() (str string) {
 	case vecRRR, vecRRRRewrite:
 		str = fmt.Sprintf("%s %s, %s, %s",
 			vecOp(i.u1),
-			formatVRegVec(i.rd.nr(), vecArrangement(i.u2), vecIndexNone),
+			formatVRegVec(i.rd, vecArrangement(i.u2), vecIndexNone),
 			formatVRegVec(i.rn.nr(), vecArrangement(i.u2), vecIndexNone),
 			formatVRegVec(i.rm.nr(), vecArrangement(i.u2), vecIndexNone),
 		)
@@ -1356,12 +1357,12 @@ func (i *instruction) String() (str string) {
 		vop := vecOp(i.u1)
 		if vop == vecOpCmeq0 {
 			str = fmt.Sprintf("cmeq %s, %s, #0",
-				formatVRegVec(i.rd.nr(), vecArrangement(i.u2), vecIndexNone),
+				formatVRegVec(i.rd, vecArrangement(i.u2), vecIndexNone),
 				formatVRegVec(i.rn.nr(), vecArrangement(i.u2), vecIndexNone))
 		} else {
 			str = fmt.Sprintf("%s %s, %s",
 				vop,
-				formatVRegVec(i.rd.nr(), vecArrangement(i.u2), vecIndexNone),
+				formatVRegVec(i.rd, vecArrangement(i.u2), vecIndexNone),
 				formatVRegVec(i.rn.nr(), vecArrangement(i.u2), vecIndexNone))
 		}
 	case vecLanes:
@@ -1379,24 +1380,24 @@ func (i *instruction) String() (str string) {
 		}
 		str = fmt.Sprintf("%s %s, %s",
 			vecOp(i.u1),
-			formatVRegWidthVec(i.rd.nr(), destArr),
+			formatVRegWidthVec(i.rd, destArr),
 			formatVRegVec(i.rn.nr(), arr, vecIndexNone))
 	case vecShiftImm:
 		arr := vecArrangement(i.u2)
 		str = fmt.Sprintf("%s %s, %s, #%d",
 			vecOp(i.u1),
-			formatVRegVec(i.rd.nr(), arr, vecIndexNone),
+			formatVRegVec(i.rd, arr, vecIndexNone),
 			formatVRegVec(i.rn.nr(), arr, vecIndexNone),
 			i.rm.shiftImm())
 	case vecTbl:
 		arr := vecArrangement(i.u2)
 		str = fmt.Sprintf("tbl %s, { %s }, %s",
-			formatVRegVec(i.rd.nr(), arr, vecIndexNone),
+			formatVRegVec(i.rd, arr, vecIndexNone),
 			formatVRegVec(i.rn.nr(), vecArrangement16B, vecIndexNone),
 			formatVRegVec(i.rm.nr(), arr, vecIndexNone))
 	case vecTbl2:
 		arr := vecArrangement(i.u2)
-		rd, rn, rm := i.rd.nr(), i.rn.nr(), i.rm.nr()
+		rd, rn, rm := i.rd, i.rn.nr(), i.rm.nr()
 		rn1 := regalloc.FromRealReg(rn.RealReg()+1, rn.RegType())
 		str = fmt.Sprintf("tbl %s, { %s, %s }, %s",
 			formatVRegVec(rd, arr, vecIndexNone),
@@ -1407,13 +1408,13 @@ func (i *instruction) String() (str string) {
 		arr := vecArrangement(i.u2)
 		str = fmt.Sprintf("%s %s, %s, %s",
 			vecOp(i.u1),
-			formatVRegVec(i.rd.nr(), arr, vecIndexNone),
+			formatVRegVec(i.rd, arr, vecIndexNone),
 			formatVRegVec(i.rn.nr(), arr, vecIndexNone),
 			formatVRegVec(i.rm.nr(), arr, vecIndexNone))
 	case movToFPSR:
 		str = fmt.Sprintf("msr fpsr, %s", formatVRegSized(i.rn.nr(), 64))
 	case movFromFPSR:
-		str = fmt.Sprintf("mrs %s fpsr", formatVRegSized(i.rd.nr(), 64))
+		str = fmt.Sprintf("mrs %s fpsr", formatVRegSized(i.rd, 64))
 	case call:
 		str = fmt.Sprintf("bl %s", ssa.FuncRef(i.u1))
 	case callInd:
@@ -1456,7 +1457,7 @@ func (i *instruction) String() (str string) {
 			}
 		}
 	case adr:
-		str = fmt.Sprintf("adr %s, #%#x", formatVRegSized(i.rd.nr(), 64), int64(i.u1))
+		str = fmt.Sprintf("adr %s, #%#x", formatVRegSized(i.rd, 64), int64(i.u1))
 	case brTableSequence:
 		targetIndex := i.u1
 		str = fmt.Sprintf("br_table_sequence %s, table_index=%d", formatVRegSized(i.rn.nr(), 64), targetIndex)
@@ -1473,7 +1474,7 @@ func (i *instruction) String() (str string) {
 		case 1:
 			m = m + "b"
 		}
-		str = fmt.Sprintf("%s %s, %s, %s", m, formatVRegSized(i.rm.nr(), size), formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), 64))
+		str = fmt.Sprintf("%s %s, %s, %s", m, formatVRegSized(i.rm.nr(), size), formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), 64))
 	case atomicCas:
 		m := "casal"
 		size := byte(32)
@@ -1485,7 +1486,7 @@ func (i *instruction) String() (str string) {
 		case 1:
 			m = m + "b"
 		}
-		str = fmt.Sprintf("%s %s, %s, %s", m, formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rm.nr(), size), formatVRegSized(i.rn.nr(), 64))
+		str = fmt.Sprintf("%s %s, %s, %s", m, formatVRegSized(i.rd, size), formatVRegSized(i.rm.nr(), size), formatVRegSized(i.rn.nr(), 64))
 	case atomicLoad:
 		m := "ldar"
 		size := byte(32)
@@ -1497,7 +1498,7 @@ func (i *instruction) String() (str string) {
 		case 1:
 			m = m + "b"
 		}
-		str = fmt.Sprintf("%s %s, %s", m, formatVRegSized(i.rd.nr(), size), formatVRegSized(i.rn.nr(), 64))
+		str = fmt.Sprintf("%s %s, %s", m, formatVRegSized(i.rd, size), formatVRegSized(i.rn.nr(), 64))
 	case atomicStore:
 		m := "stlr"
 		size := byte(32)
@@ -1517,9 +1518,9 @@ func (i *instruction) String() (str string) {
 	case emitSourceOffsetInfo:
 		str = fmt.Sprintf("source_offset_info %d", ssa.SourceOffset(i.u1))
 	case vecLoad1R:
-		str = fmt.Sprintf("ld1r {%s}, [%s]", formatVRegVec(i.rd.nr(), vecArrangement(i.u1), vecIndexNone), formatVRegSized(i.rn.nr(), 64))
+		str = fmt.Sprintf("ld1r {%s}, [%s]", formatVRegVec(i.rd, vecArrangement(i.u1), vecIndexNone), formatVRegSized(i.rn.nr(), 64))
 	case loadConstBlockArg:
-		str = fmt.Sprintf("load_const_block_arg %s, %#x", formatVRegSized(i.rd.nr(), 64), i.u1)
+		str = fmt.Sprintf("load_const_block_arg %s, %#x", formatVRegSized(i.rd, 64), i.u1)
 	default:
 		panic(i.kind)
 	}
@@ -1528,26 +1529,26 @@ func (i *instruction) String() (str string) {
 
 func (i *instruction) asAdr(rd regalloc.VReg, offset int64) {
 	i.kind = adr
-	i.rd = operandNR(rd)
+	i.rd = rd
 	i.u1 = uint64(offset)
 }
 
-func (i *instruction) asAtomicRmw(op atomicRmwOp, rn, rs, rt operand, size uint64) {
+func (i *instruction) asAtomicRmw(op atomicRmwOp, rn, rs, rt regalloc.VReg, size uint64) {
 	i.kind = atomicRmw
-	i.rd, i.rn, i.rm = rt, rn, rs
+	i.rd, i.rn, i.rm = rt, operandNR(rn), operandNR(rs)
 	i.u1 = uint64(op)
 	i.u2 = size
 }
 
-func (i *instruction) asAtomicCas(rn, rs, rt operand, size uint64) {
+func (i *instruction) asAtomicCas(rn, rs, rt regalloc.VReg, size uint64) {
 	i.kind = atomicCas
-	i.rm, i.rn, i.rd = rt, rn, rs
+	i.rm, i.rn, i.rd = operandNR(rt), operandNR(rn), rs
 	i.u2 = size
 }
 
-func (i *instruction) asAtomicLoad(rn, rt operand, size uint64) {
+func (i *instruction) asAtomicLoad(rn, rt regalloc.VReg, size uint64) {
 	i.kind = atomicLoad
-	i.rn, i.rd = rn, rt
+	i.rn, i.rd = operandNR(rn), rt
 	i.u2 = size
 }
 
@@ -1755,12 +1756,12 @@ func (i *instruction) asLoadConstBlockArg(v uint64, typ ssa.Type, dst regalloc.V
 	i.kind = loadConstBlockArg
 	i.u1 = v
 	i.u2 = uint64(typ)
-	i.rd = operandNR(dst)
+	i.rd = dst
 	return i
 }
 
 func (i *instruction) loadConstBlockArgData() (v uint64, typ ssa.Type, dst regalloc.VReg) {
-	return i.u1, ssa.Type(i.u2), i.rd.nr()
+	return i.u1, ssa.Type(i.u2), i.rd
 }
 
 func (i *instruction) asEmitSourceOffsetInfo(l ssa.SourceOffset) *instruction {
@@ -1778,7 +1779,7 @@ func (i *instruction) asUDF() *instruction {
 	return i
 }
 
-func (i *instruction) asFpuToInt(rd, rn operand, rdSigned, src64bit, dst64bit bool) {
+func (i *instruction) asFpuToInt(rd regalloc.VReg, rn operand, rdSigned, src64bit, dst64bit bool) {
 	i.kind = fpuToInt
 	i.rn = rn
 	i.rd = rd
@@ -1793,7 +1794,7 @@ func (i *instruction) asFpuToInt(rd, rn operand, rdSigned, src64bit, dst64bit bo
 	}
 }
 
-func (i *instruction) asIntToFpu(rd, rn operand, rnSigned, src64bit, dst64bit bool) {
+func (i *instruction) asIntToFpu(rd regalloc.VReg, rn operand, rnSigned, src64bit, dst64bit bool) {
 	i.kind = intToFpu
 	i.rn = rn
 	i.rd = rd

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -44,9 +44,9 @@ func (i *instruction) encode(m *machine) {
 	case callInd:
 		c.Emit4Bytes(encodeUnconditionalBranchReg(regNumberInEncoding[i.rn.realReg()], true))
 	case store8, store16, store32, store64, fpuStore32, fpuStore64, fpuStore128:
-		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rn.realReg()], i.amode))
+		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rn.realReg()], *i.getAmode()))
 	case uLoad8, uLoad16, uLoad32, uLoad64, sLoad8, sLoad16, sLoad32, fpuLoad32, fpuLoad64, fpuLoad128:
-		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rd.RealReg()], i.amode))
+		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rd.RealReg()], *i.getAmode()))
 	case vecLoad1R:
 		c.Emit4Bytes(encodeVecLoad1R(
 			regNumberInEncoding[i.rd.RealReg()],
@@ -90,7 +90,7 @@ func (i *instruction) encode(m *machine) {
 		c.Emit4Bytes(encodeMov64(regNumberInEncoding[to], regNumberInEncoding[from], toIsSp, fromIsSp))
 	case loadP64, storeP64:
 		rt, rt2 := regNumberInEncoding[i.rn.realReg()], regNumberInEncoding[i.rm.realReg()]
-		amode := i.amode
+		amode := i.getAmode()
 		rn := regNumberInEncoding[amode.rn.RealReg()]
 		var pre bool
 		switch amode.kind {

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -46,10 +46,10 @@ func (i *instruction) encode(m *machine) {
 	case store8, store16, store32, store64, fpuStore32, fpuStore64, fpuStore128:
 		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rn.realReg()], i.amode))
 	case uLoad8, uLoad16, uLoad32, uLoad64, sLoad8, sLoad16, sLoad32, fpuLoad32, fpuLoad64, fpuLoad128:
-		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rd.realReg()], i.amode))
+		c.Emit4Bytes(encodeLoadOrStore(i.kind, regNumberInEncoding[i.rd.RealReg()], i.amode))
 	case vecLoad1R:
 		c.Emit4Bytes(encodeVecLoad1R(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(i.u1)))
 	case condBr:
@@ -75,16 +75,16 @@ func (i *instruction) encode(m *machine) {
 			panic("BUG")
 		}
 	case movN:
-		c.Emit4Bytes(encodeMoveWideImmediate(0b00, regNumberInEncoding[i.rd.realReg()], i.u1, i.u2, i.u3))
+		c.Emit4Bytes(encodeMoveWideImmediate(0b00, regNumberInEncoding[i.rd.RealReg()], i.u1, i.u2, i.u3))
 	case movZ:
-		c.Emit4Bytes(encodeMoveWideImmediate(0b10, regNumberInEncoding[i.rd.realReg()], i.u1, i.u2, i.u3))
+		c.Emit4Bytes(encodeMoveWideImmediate(0b10, regNumberInEncoding[i.rd.RealReg()], i.u1, i.u2, i.u3))
 	case movK:
-		c.Emit4Bytes(encodeMoveWideImmediate(0b11, regNumberInEncoding[i.rd.realReg()], i.u1, i.u2, i.u3))
+		c.Emit4Bytes(encodeMoveWideImmediate(0b11, regNumberInEncoding[i.rd.RealReg()], i.u1, i.u2, i.u3))
 	case mov32:
-		to, from := i.rd.realReg(), i.rn.realReg()
+		to, from := i.rd.RealReg(), i.rn.realReg()
 		c.Emit4Bytes(encodeAsMov32(regNumberInEncoding[from], regNumberInEncoding[to]))
 	case mov64:
-		to, from := i.rd.realReg(), i.rn.realReg()
+		to, from := i.rd.RealReg(), i.rn.realReg()
 		toIsSp := to == sp
 		fromIsSp := from == sp
 		c.Emit4Bytes(encodeMov64(regNumberInEncoding[to], regNumberInEncoding[from], toIsSp, fromIsSp))
@@ -102,21 +102,21 @@ func (i *instruction) encode(m *machine) {
 		}
 		c.Emit4Bytes(encodePreOrPostIndexLoadStorePair64(pre, kind == loadP64, rn, rt, rt2, amode.imm))
 	case loadFpuConst32:
-		rd := regNumberInEncoding[i.rd.realReg()]
+		rd := regNumberInEncoding[i.rd.RealReg()]
 		if i.u1 == 0 {
 			c.Emit4Bytes(encodeVecRRR(vecOpEOR, rd, rd, rd, vecArrangement8B))
 		} else {
 			encodeLoadFpuConst32(c, rd, i.u1)
 		}
 	case loadFpuConst64:
-		rd := regNumberInEncoding[i.rd.realReg()]
+		rd := regNumberInEncoding[i.rd.RealReg()]
 		if i.u1 == 0 {
 			c.Emit4Bytes(encodeVecRRR(vecOpEOR, rd, rd, rd, vecArrangement8B))
 		} else {
-			encodeLoadFpuConst64(c, regNumberInEncoding[i.rd.realReg()], i.u1)
+			encodeLoadFpuConst64(c, regNumberInEncoding[i.rd.RealReg()], i.u1)
 		}
 	case loadFpuConst128:
-		rd := regNumberInEncoding[i.rd.realReg()]
+		rd := regNumberInEncoding[i.rd.RealReg()]
 		lo, hi := i.u1, i.u2
 		if lo == 0 && hi == 0 {
 			c.Emit4Bytes(encodeVecRRR(vecOpEOR, rd, rd, rd, vecArrangement16B))
@@ -126,7 +126,7 @@ func (i *instruction) encode(m *machine) {
 	case aluRRRR:
 		c.Emit4Bytes(encodeAluRRRR(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			regNumberInEncoding[regalloc.VReg(i.u2).RealReg()],
@@ -135,7 +135,7 @@ func (i *instruction) encode(m *machine) {
 	case aluRRImmShift:
 		c.Emit4Bytes(encodeAluRRImm(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			uint32(i.rm.shiftImm()),
 			uint32(i.u3),
@@ -144,7 +144,7 @@ func (i *instruction) encode(m *machine) {
 		rn := i.rn.realReg()
 		c.Emit4Bytes(encodeAluRRR(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[rn],
 			regNumberInEncoding[i.rm.realReg()],
 			i.u3 == 1,
@@ -154,7 +154,7 @@ func (i *instruction) encode(m *machine) {
 		rm, exo, to := i.rm.er()
 		c.Emit4Bytes(encodeAluRRRExtend(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[rm.RealReg()],
 			exo,
@@ -164,7 +164,7 @@ func (i *instruction) encode(m *machine) {
 		r, amt, sop := i.rm.sr()
 		c.Emit4Bytes(encodeAluRRRShift(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[r.RealReg()],
 			uint32(amt),
@@ -174,7 +174,7 @@ func (i *instruction) encode(m *machine) {
 	case aluRRBitmaskImm:
 		c.Emit4Bytes(encodeAluBitmaskImmediate(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			i.u2,
 			i.u3 == 1,
@@ -182,7 +182,7 @@ func (i *instruction) encode(m *machine) {
 	case bitRR:
 		c.Emit4Bytes(encodeBitRR(
 			bitOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			uint32(i.u2)),
 		)
@@ -190,7 +190,7 @@ func (i *instruction) encode(m *machine) {
 		imm12, shift := i.rm.imm12()
 		c.Emit4Bytes(encodeAluRRImm12(
 			aluOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			imm12, shift,
 			i.u3 == 1,
@@ -198,14 +198,14 @@ func (i *instruction) encode(m *machine) {
 	case fpuRRR:
 		c.Emit4Bytes(encodeFpuRRR(
 			fpuBinOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			i.u3 == 1,
 		))
 	case fpuMov64, fpuMov128:
 		// https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/MOV--vector---Move-vector--an-alias-of-ORR--vector--register--
-		rd := regNumberInEncoding[i.rd.realReg()]
+		rd := regNumberInEncoding[i.rd.RealReg()]
 		rn := regNumberInEncoding[i.rn.realReg()]
 		var q uint32
 		if kind == fpuMov128 {
@@ -213,7 +213,7 @@ func (i *instruction) encode(m *machine) {
 		}
 		c.Emit4Bytes(q<<30 | 0b1110101<<21 | rn<<16 | 0b000111<<10 | rn<<5 | rd)
 	case cSet:
-		rd := regNumberInEncoding[i.rd.realReg()]
+		rd := regNumberInEncoding[i.rd.RealReg()]
 		cf := condFlag(i.u1)
 		if i.u2 == 1 {
 			// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/CSETM--Conditional-Set-Mask--an-alias-of-CSINV-
@@ -225,7 +225,7 @@ func (i *instruction) encode(m *machine) {
 			c.Emit4Bytes(0b1001101010011111<<16 | uint32(cf.invert())<<12 | 0b111111<<5 | rd)
 		}
 	case extend:
-		c.Emit4Bytes(encodeExtend(i.u3 == 1, byte(i.u1), byte(i.u2), regNumberInEncoding[i.rd.realReg()], regNumberInEncoding[i.rn.realReg()]))
+		c.Emit4Bytes(encodeExtend(i.u3 == 1, byte(i.u1), byte(i.u2), regNumberInEncoding[i.rd.RealReg()], regNumberInEncoding[i.rn.realReg()]))
 	case fpuCmp:
 		// https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/FCMP--Floating-point-quiet-Compare--scalar--?lang=en
 		rn, rm := regNumberInEncoding[i.rn.realReg()], regNumberInEncoding[i.rm.realReg()]
@@ -242,11 +242,11 @@ func (i *instruction) encode(m *machine) {
 			c.Emit4Bytes(0)
 		}
 	case adr:
-		c.Emit4Bytes(encodeAdr(regNumberInEncoding[i.rd.realReg()], uint32(i.u1)))
+		c.Emit4Bytes(encodeAdr(regNumberInEncoding[i.rd.RealReg()], uint32(i.u1)))
 	case cSel:
 		c.Emit4Bytes(encodeConditionalSelect(
 			kind,
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			condFlag(i.u1),
@@ -254,7 +254,7 @@ func (i *instruction) encode(m *machine) {
 		))
 	case fpuCSel:
 		c.Emit4Bytes(encodeFpuCSel(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			condFlag(i.u1),
@@ -262,14 +262,14 @@ func (i *instruction) encode(m *machine) {
 		))
 	case movToVec:
 		c.Emit4Bytes(encodeMoveToVec(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(byte(i.u1)),
 			vecIndex(i.u2),
 		))
 	case movFromVec, movFromVecSigned:
 		c.Emit4Bytes(encodeMoveFromVec(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(byte(i.u1)),
 			vecIndex(i.u2),
@@ -277,18 +277,18 @@ func (i *instruction) encode(m *machine) {
 		))
 	case vecDup:
 		c.Emit4Bytes(encodeVecDup(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(byte(i.u1))))
 	case vecDupElement:
 		c.Emit4Bytes(encodeVecDupElement(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(byte(i.u1)),
 			vecIndex(i.u2)))
 	case vecExtract:
 		c.Emit4Bytes(encodeVecExtract(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			vecArrangement(byte(i.u1)),
@@ -296,13 +296,13 @@ func (i *instruction) encode(m *machine) {
 	case vecPermute:
 		c.Emit4Bytes(encodeVecPermute(
 			vecOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			vecArrangement(byte(i.u2))))
 	case vecMovElement:
 		c.Emit4Bytes(encodeVecMovElement(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(i.u1),
 			uint32(i.u2), uint32(i.u3),
@@ -310,21 +310,21 @@ func (i *instruction) encode(m *machine) {
 	case vecMisc:
 		c.Emit4Bytes(encodeAdvancedSIMDTwoMisc(
 			vecOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(i.u2),
 		))
 	case vecLanes:
 		c.Emit4Bytes(encodeVecLanes(
 			vecOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			vecArrangement(i.u2),
 		))
 	case vecShiftImm:
 		c.Emit4Bytes(encodeVecShiftImm(
 			vecOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			uint32(i.rm.shiftImm()),
 			vecArrangement(i.u2),
@@ -332,7 +332,7 @@ func (i *instruction) encode(m *machine) {
 	case vecTbl:
 		c.Emit4Bytes(encodeVecTbl(
 			1,
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			vecArrangement(i.u2)),
@@ -340,7 +340,7 @@ func (i *instruction) encode(m *machine) {
 	case vecTbl2:
 		c.Emit4Bytes(encodeVecTbl(
 			2,
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			vecArrangement(i.u2)),
@@ -353,7 +353,7 @@ func (i *instruction) encode(m *machine) {
 	case fpuRR:
 		c.Emit4Bytes(encodeFloatDataOneSource(
 			fpuUniOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			i.u3 == 1,
 		))
@@ -365,7 +365,7 @@ func (i *instruction) encode(m *machine) {
 	case vecRRRRewrite:
 		c.Emit4Bytes(encodeVecRRR(
 			vecOp(i.u1),
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			vecArrangement(i.u2),
@@ -381,7 +381,7 @@ func (i *instruction) encode(m *machine) {
 			sf<<31 | 0b111101001<<22 | imm<<16 | cond<<12 | 0b1<<11 | rn<<5 | nzcv,
 		)
 	case movFromFPSR:
-		rt := regNumberInEncoding[i.rd.realReg()]
+		rt := regNumberInEncoding[i.rd.RealReg()]
 		c.Emit4Bytes(encodeSystemRegisterMove(rt, true))
 	case movToFPSR:
 		rt := regNumberInEncoding[i.rn.realReg()]
@@ -390,13 +390,13 @@ func (i *instruction) encode(m *machine) {
 		c.Emit4Bytes(encodeAtomicRmw(
 			atomicRmwOp(i.u1),
 			regNumberInEncoding[i.rm.realReg()],
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			uint32(i.u2),
 		))
 	case atomicCas:
 		c.Emit4Bytes(encodeAtomicCas(
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			regNumberInEncoding[i.rm.realReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			uint32(i.u2),
@@ -404,7 +404,7 @@ func (i *instruction) encode(m *machine) {
 	case atomicLoad:
 		c.Emit4Bytes(encodeAtomicLoadStore(
 			regNumberInEncoding[i.rn.realReg()],
-			regNumberInEncoding[i.rd.realReg()],
+			regNumberInEncoding[i.rd.RealReg()],
 			uint32(i.u2),
 			1,
 		))
@@ -810,7 +810,7 @@ func encodeFloatDataOneSource(op fpuUniOp, rd, rn uint32, dst64bit bool) uint32 
 // encodeCnvBetweenFloatInt encodes as "Conversion between floating-point and integer" in
 // https://developer.arm.com/documentation/ddi0596/2020-12/Index-by-Encoding/Data-Processing----Scalar-Floating-Point-and-Advanced-SIMD?lang=en
 func encodeCnvBetweenFloatInt(i *instruction) uint32 {
-	rd := regNumberInEncoding[i.rd.realReg()]
+	rd := regNumberInEncoding[i.rd.RealReg()]
 	rn := regNumberInEncoding[i.rn.realReg()]
 
 	var opcode uint32

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding.go
@@ -129,7 +129,7 @@ func (i *instruction) encode(m *machine) {
 			regNumberInEncoding[i.rd.realReg()],
 			regNumberInEncoding[i.rn.realReg()],
 			regNumberInEncoding[i.rm.realReg()],
-			regNumberInEncoding[i.ra.realReg()],
+			regNumberInEncoding[regalloc.VReg(i.u2).RealReg()],
 			uint32(i.u3),
 		))
 	case aluRRImmShift:

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -1093,16 +1093,16 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "101e306e", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0, 0) }},
 		{want: "5000009c05000014ffffffffffffffffaaaaaaaaaaaaaaaa", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0xffffffff_ffffffff, 0xaaaaaaaa_aaaaaaaa) }},
 		{want: "8220061b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), operandNR(x8VReg), false)
+			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, false)
 		}},
 		{want: "8220069b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), operandNR(x8VReg), true)
+			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, true)
 		}},
 		{want: "82a0061b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMSub, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), operandNR(x8VReg), false)
+			i.asALURRRR(aluOpMSub, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, false)
 		}},
 		{want: "82a0069b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMSub, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), operandNR(x8VReg), true)
+			i.asALURRRR(aluOpMSub, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, true)
 		}},
 		{want: "00213f1e", setup: func(i *instruction) { i.asFpuCmp(operandNR(v8VReg), operandNR(v31VReg), false) }},
 		{want: "00217f1e", setup: func(i *instruction) { i.asFpuCmp(operandNR(v8VReg), operandNR(v31VReg), true) }},

--- a/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_encoding_test.go
@@ -27,1058 +27,1058 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "21443bd5", setup: func(i *instruction) { i.asMovFromFPSR(x1VReg) }},
 		{want: "2f08417a", setup: func(i *instruction) { i.asCCmpImm(operandNR(x1VReg), 1, eq, 0b1111, false) }},
 		{want: "201841fa", setup: func(i *instruction) { i.asCCmpImm(operandNR(x1VReg), 1, ne, 0, true) }},
-		{want: "410c010e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B) }},
-		{want: "410c014e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B) }},
-		{want: "410c020e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H) }},
-		{want: "410c024e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H) }},
-		{want: "410c040e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S) }},
-		{want: "410c044e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S) }},
-		{want: "410c084e", setup: func(i *instruction) { i.asVecDup(operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D) }},
-		{want: "4104034e", setup: func(i *instruction) { i.asVecDupElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementB, 1) }},
-		{want: "4104064e", setup: func(i *instruction) { i.asVecDupElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementH, 1) }},
-		{want: "41040c4e", setup: func(i *instruction) { i.asVecDupElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementS, 1) }},
-		{want: "4104184e", setup: func(i *instruction) { i.asVecDupElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementD, 1) }},
+		{want: "410c010e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement8B) }},
+		{want: "410c014e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement16B) }},
+		{want: "410c020e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement4H) }},
+		{want: "410c024e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement8H) }},
+		{want: "410c040e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement2S) }},
+		{want: "410c044e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement4S) }},
+		{want: "410c084e", setup: func(i *instruction) { i.asVecDup(v1VReg, operandNR(v2VReg), vecArrangement2D) }},
+		{want: "4104034e", setup: func(i *instruction) { i.asVecDupElement(v1VReg, operandNR(v2VReg), vecArrangementB, 1) }},
+		{want: "4104064e", setup: func(i *instruction) { i.asVecDupElement(v1VReg, operandNR(v2VReg), vecArrangementH, 1) }},
+		{want: "41040c4e", setup: func(i *instruction) { i.asVecDupElement(v1VReg, operandNR(v2VReg), vecArrangementS, 1) }},
+		{want: "4104184e", setup: func(i *instruction) { i.asVecDupElement(v1VReg, operandNR(v2VReg), vecArrangementD, 1) }},
 		{want: "4138032e", setup: func(i *instruction) {
-			i.asVecExtract(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B, 7)
+			i.asVecExtract(v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B, 7)
 		}},
 		{want: "4138036e", setup: func(i *instruction) {
-			i.asVecExtract(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B, 7)
+			i.asVecExtract(v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B, 7)
 		}},
-		{want: "410c036e", setup: func(i *instruction) { i.asVecMovElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementB, 1, 1) }},
-		{want: "4114066e", setup: func(i *instruction) { i.asVecMovElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementH, 1, 1) }},
-		{want: "41240c6e", setup: func(i *instruction) { i.asVecMovElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementS, 1, 1) }},
-		{want: "4144186e", setup: func(i *instruction) { i.asVecMovElement(operandNR(v1VReg), operandNR(v2VReg), vecArrangementD, 1, 1) }},
+		{want: "410c036e", setup: func(i *instruction) { i.asVecMovElement(v1VReg, operandNR(v2VReg), vecArrangementB, 1, 1) }},
+		{want: "4114066e", setup: func(i *instruction) { i.asVecMovElement(v1VReg, operandNR(v2VReg), vecArrangementH, 1, 1) }},
+		{want: "41240c6e", setup: func(i *instruction) { i.asVecMovElement(v1VReg, operandNR(v2VReg), vecArrangementS, 1, 1) }},
+		{want: "4144186e", setup: func(i *instruction) { i.asVecMovElement(v1VReg, operandNR(v2VReg), vecArrangementD, 1, 1) }},
 		{want: "4104090f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement8B)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement8B)
 		}},
 		{want: "4104094f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement16B)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement16B)
 		}},
 		{want: "4104190f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement4H)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement4H)
 		}},
 		{want: "4104194f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement8H)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement8H)
 		}},
 		{want: "4104390f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement2S)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement2S)
 		}},
 		{want: "4104394f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement4S)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement4S)
 		}},
 		{want: "4104794f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(7), vecArrangement2D)
+			i.asVecShiftImm(vecOpSshr, v1VReg, operandNR(v2VReg), operandShiftImm(7), vecArrangement2D)
 		}},
 
 		{want: "41a40d0f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement8B)
+			i.asVecShiftImm(vecOpSshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement8B)
 		}},
 		{want: "41a40d4f", setup: func(i *instruction) { // sshll2
-			i.asVecShiftImm(vecOpSshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement16B)
+			i.asVecShiftImm(vecOpSshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement16B)
 		}},
 		{want: "41a41d0f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement4H)
+			i.asVecShiftImm(vecOpSshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement4H)
 		}},
 		{want: "41a41d4f", setup: func(i *instruction) { // sshll2
-			i.asVecShiftImm(vecOpSshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement8H)
+			i.asVecShiftImm(vecOpSshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement8H)
 		}},
 		{want: "41a43d0f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement2S)
+			i.asVecShiftImm(vecOpSshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement2S)
 		}},
 		{want: "41a43d4f", setup: func(i *instruction) { // sshll2
-			i.asVecShiftImm(vecOpSshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement4S)
+			i.asVecShiftImm(vecOpSshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement4S)
 		}},
 		{want: "41a40d2f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpUshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement8B)
+			i.asVecShiftImm(vecOpUshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement8B)
 		}},
 		{want: "41a40d6f", setup: func(i *instruction) { // ushll2
-			i.asVecShiftImm(vecOpUshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement16B)
+			i.asVecShiftImm(vecOpUshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement16B)
 		}},
 		{want: "41a41d2f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpUshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement4H)
+			i.asVecShiftImm(vecOpUshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement4H)
 		}},
 		{want: "41a41d6f", setup: func(i *instruction) { // ushll2
-			i.asVecShiftImm(vecOpUshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement8H)
+			i.asVecShiftImm(vecOpUshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement8H)
 		}},
 		{want: "41a43d2f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpUshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement2S)
+			i.asVecShiftImm(vecOpUshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement2S)
 		}},
 		{want: "41a43d6f", setup: func(i *instruction) { // ushll2
-			i.asVecShiftImm(vecOpUshll, operandNR(v1VReg), operandNR(v2VReg), operandShiftImm(3), vecArrangement4S)
+			i.asVecShiftImm(vecOpUshll, v1VReg, operandNR(v2VReg), operandShiftImm(3), vecArrangement4S)
 		}},
 		{want: "4100030e", setup: func(i *instruction) {
-			i.asVecTbl(1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecTbl(1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4100034e", setup: func(i *instruction) {
-			i.asVecTbl(1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecTbl(1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4120040e", setup: func(i *instruction) {
-			i.asVecTbl(2, operandNR(v1VReg), operandNR(v2VReg), operandNR(v4VReg), vecArrangement8B)
+			i.asVecTbl(2, v1VReg, operandNR(v2VReg), operandNR(v4VReg), vecArrangement8B)
 		}},
 		{want: "4120044e", setup: func(i *instruction) {
-			i.asVecTbl(2, operandNR(v1VReg), operandNR(v2VReg), operandNR(v4VReg), vecArrangement16B)
+			i.asVecTbl(2, v1VReg, operandNR(v2VReg), operandNR(v4VReg), vecArrangement16B)
 		}},
 		{want: "4138030e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4138034e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4138430e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4138434e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4138830e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4138834e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4138c34e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecPermute(vecOpZip1, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "411ca32e", setup: func(i *instruction) {
-			i.asVecRRRRewrite(vecOpBit, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRRRewrite(vecOpBit, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "411ca36e", setup: func(i *instruction) {
-			i.asVecRRRRewrite(vecOpBit, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRRRewrite(vecOpBit, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "411c236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpEOR, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpEOR, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "411c232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpEOR, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpEOR, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4184234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAdd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpAdd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4184a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAdd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpAdd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4184e34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAdd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpAdd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "410c230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "410c234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "410c630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "410c634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "410ca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "410ca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "410ce34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpSqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "410c232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "410c236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "410c632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "410c636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "410ca32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "410ca36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "410ce36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpUqadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "412c230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "412c234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "412c630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "412c634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "412ca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "412ca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "412ce34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpSqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "412c232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "412c236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "412c632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "412c636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "412ca32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "412ca36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "412ce36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUqsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpUqsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4184232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4184236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4184632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4184636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4184a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4184a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4184e36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpSub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41bc230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "41bc234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "41bc630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "41bc634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "41bca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41bca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41bce34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41bc230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAddp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpAddp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "41b8314e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecLanes(vecOpAddv, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "41b8710e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecLanes(vecOpAddv, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "41b8714e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecLanes(vecOpAddv, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "41b8b14e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpAddv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecLanes(vecOpAddv, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "416c230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "416c234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpSmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "416c630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "416c634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "416ca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "416ca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "416c232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "416c236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "416c632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "416c636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "416ca32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "416ca36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpUmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4164230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4164234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpSmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4164630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4164634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4164a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4164a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4164232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4164236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4164632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4164636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4164a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4164a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpUmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41a4232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUmaxp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "41a4236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUmaxp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "41a4632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUmaxp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "41a4636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUmaxp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "41a4a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUmaxp, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUmaxp, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41a8312e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecLanes(vecOpUminv, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "41a8316e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecLanes(vecOpUminv, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "41a8712e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecLanes(vecOpUminv, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "41a8716e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecLanes(vecOpUminv, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "41a8b16e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUminv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecLanes(vecOpUminv, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4114232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUrhadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4114236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUrhadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4114632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUrhadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4114636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUrhadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4114a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUrhadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4114a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUrhadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpUrhadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "419c230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpMul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "419c234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpMul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "419c630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpMul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "419c634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpMul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "419ca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpMul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "419ca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpMul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpMul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4198200e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "4198204e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "4198600e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "4198604e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "4198a00e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4198a04e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4198e04e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpCmeq0, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpCmeq0, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "418c232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "418c236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "418c632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "418c636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "418ca32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "418ca36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "418ce36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4134230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4134234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4134630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4134634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4134a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4134a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4134e34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4134232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4134236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4134632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4134636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4134a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4134a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4134e36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "413c230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "413c234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "413c630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "413c634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "413ca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "413ca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "413ce34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4134230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4134234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4134630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4134634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4134a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4134a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4134e34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4134232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4134236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4134632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4134636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4134a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4134a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "4134e36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhi, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmhi, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "413c232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "413c236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "413c632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "413c636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "413ca32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "413ca36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "413ce36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpCmhs, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpCmhs, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41f4230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41f4234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41f4634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmax, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFmax, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41f4a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41f4a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41f4e34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmin, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFmin, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41d4230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41d4234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41d4634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFadd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFadd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41d4a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41d4a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41d4e34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFsub, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFsub, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41dc232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFmul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41dc236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFmul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41dc636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFmul, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFmul, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41b4636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqrdmulh, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSqrdmulh, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "41b4632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqrdmulh, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSqrdmulh, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "41b4a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqrdmulh, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSqrdmulh, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41b4a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSqrdmulh, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSqrdmulh, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41fc232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFdiv, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFdiv, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41fc236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFdiv, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFdiv, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41fc636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFdiv, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFdiv, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41e4230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFcmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41e4234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFcmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41e4634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmeq, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFcmeq, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41e4a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFcmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41e4a36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFcmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41e4e36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmgt, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFcmgt, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "41e4232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpFcmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "41e4236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpFcmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41e4636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpFcmge, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpFcmge, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4198210e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintm, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFrintm, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4198214e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintm, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFrintm, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4198614e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintm, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFrintm, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "4188210e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFrintn, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4188214e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFrintn, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4188614e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFrintn, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "4188a10e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintp, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFrintp, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4188a14e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintp, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFrintp, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4188e14e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintp, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFrintp, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "4198a10e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintz, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFrintz, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4198a14e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintz, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFrintz, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4198e14e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFrintz, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFrintz, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "4178610e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtl, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFcvtl, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4178210e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtl, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpFcvtl, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "4168610e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFcvtn, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4168210e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpFcvtn, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "41b8a10e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtzs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFcvtzs, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41b8a14e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtzs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFcvtzs, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41b8e14e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtzs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFcvtzs, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41b8a12e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtzu, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFcvtzu, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41b8a16e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtzu, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFcvtzu, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41b8e16e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFcvtzu, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFcvtzu, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41d8210e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpScvtf, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpScvtf, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41d8214e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpScvtf, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpScvtf, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41d8614e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpScvtf, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpScvtf, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41d8212e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpUcvtf, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpUcvtf, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41d8216e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpUcvtf, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpUcvtf, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41d8616e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpUcvtf, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpUcvtf, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "4148210e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpSqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpSqxtn, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "4148214e", setup: func(i *instruction) { // sqxtn2
-			i.asVecMisc(vecOpSqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpSqxtn, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "4148610e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpSqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpSqxtn, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "4148614e", setup: func(i *instruction) { // sqxtn2
-			i.asVecMisc(vecOpSqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecMisc(vecOpSqxtn, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "4148a10e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpSqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpSqxtn, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4148a14e", setup: func(i *instruction) { // sqxtun2
-			i.asVecMisc(vecOpSqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpSqxtn, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4128212e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpSqxtun, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpSqxtun, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "4128216e", setup: func(i *instruction) { // uqxtun2
-			i.asVecMisc(vecOpSqxtun, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpSqxtun, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "4128612e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpSqxtun, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpSqxtun, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "4128616e", setup: func(i *instruction) { // sqxtun2
-			i.asVecMisc(vecOpSqxtun, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecMisc(vecOpSqxtun, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "4128a12e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpSqxtun, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpSqxtun, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4128a16e", setup: func(i *instruction) { // sqxtun2
-			i.asVecMisc(vecOpSqxtun, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpSqxtun, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "4148212e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpUqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpUqxtn, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "4148216e", setup: func(i *instruction) { // uqxtn2
-			i.asVecMisc(vecOpUqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpUqxtn, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "4148612e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpUqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpUqxtn, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "4148616e", setup: func(i *instruction) { // sqxtn2
-			i.asVecMisc(vecOpUqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecMisc(vecOpUqxtn, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "4148a12e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpUqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpUqxtn, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4148a16e", setup: func(i *instruction) { // sqxtn2
-			i.asVecMisc(vecOpUqxtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpUqxtn, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41b8200e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "41b8204e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "41b8600e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "41b8604e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "41b8a00e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41b8a04e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41b8e04e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpAbs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpAbs, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41f8a00e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFabs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFabs, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41f8a04e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFabs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFabs, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41f8e04e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFabs, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFabs, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41b8202e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "41b8206e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "41b8602e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "41b8606e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "41b8a02e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41b8a06e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41b8e06e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNeg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpNeg, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "4128a10e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpXtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpXtn, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "4128a10e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpXtn, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpXtn, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41f8a02e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFneg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFneg, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41f8a06e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFneg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFneg, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41f8e06e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFneg, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFneg, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
 		{want: "41f8a12e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFsqrt, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2S)
+			i.asVecMisc(vecOpFsqrt, v1VReg, operandNR(v2VReg), vecArrangement2S)
 		}},
 		{want: "41f8a16e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFsqrt, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecMisc(vecOpFsqrt, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41f8e16e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpFsqrt, operandNR(v1VReg), operandNR(v2VReg), vecArrangement2D)
+			i.asVecMisc(vecOpFsqrt, v1VReg, operandNR(v2VReg), vecArrangement2D)
 		}},
-		{want: "4100839a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), eq, true) }},
-		{want: "4110839a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), ne, true) }},
-		{want: "4100831a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), eq, false) }},
-		{want: "4110831a", setup: func(i *instruction) { i.asCSel(operandNR(x1VReg), operandNR(x2VReg), operandNR(x3VReg), ne, false) }},
-		{want: "41cc631e", setup: func(i *instruction) { i.asFpuCSel(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), gt, true) }},
-		{want: "41bc631e", setup: func(i *instruction) { i.asFpuCSel(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), lt, true) }},
-		{want: "41cc231e", setup: func(i *instruction) { i.asFpuCSel(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), gt, false) }},
-		{want: "41bc231e", setup: func(i *instruction) { i.asFpuCSel(operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), lt, false) }},
-		{want: "411c014e", setup: func(i *instruction) { i.asMovToVec(operandNR(v1VReg), operandNR(x2VReg), vecArrangementB, 0) }},
-		{want: "411c024e", setup: func(i *instruction) { i.asMovToVec(operandNR(v1VReg), operandNR(x2VReg), vecArrangementH, 0) }},
-		{want: "411c044e", setup: func(i *instruction) { i.asMovToVec(operandNR(v1VReg), operandNR(x2VReg), vecArrangementS, 0) }},
-		{want: "411c084e", setup: func(i *instruction) { i.asMovToVec(operandNR(v1VReg), operandNR(x2VReg), vecArrangementD, 0) }},
-		{want: "413c010e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementB, 0, false) }},
-		{want: "413c020e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementH, 0, false) }},
-		{want: "413c040e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementS, 0, false) }},
-		{want: "413c084e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementD, 0, false) }},
-		{want: "412c030e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementB, 1, true) }},
-		{want: "412c060e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementH, 1, true) }},
-		{want: "412c0c4e", setup: func(i *instruction) { i.asMovFromVec(operandNR(x1VReg), operandNR(v2VReg), vecArrangementS, 1, true) }},
-		{want: "410c084e", setup: func(i *instruction) { i.asVecDup(operandNR(x1VReg), operandNR(v2VReg), vecArrangement2D) }},
+		{want: "4100839a", setup: func(i *instruction) { i.asCSel(x1VReg, operandNR(x2VReg), operandNR(x3VReg), eq, true) }},
+		{want: "4110839a", setup: func(i *instruction) { i.asCSel(x1VReg, operandNR(x2VReg), operandNR(x3VReg), ne, true) }},
+		{want: "4100831a", setup: func(i *instruction) { i.asCSel(x1VReg, operandNR(x2VReg), operandNR(x3VReg), eq, false) }},
+		{want: "4110831a", setup: func(i *instruction) { i.asCSel(x1VReg, operandNR(x2VReg), operandNR(x3VReg), ne, false) }},
+		{want: "41cc631e", setup: func(i *instruction) { i.asFpuCSel(v1VReg, operandNR(v2VReg), operandNR(v3VReg), gt, true) }},
+		{want: "41bc631e", setup: func(i *instruction) { i.asFpuCSel(v1VReg, operandNR(v2VReg), operandNR(v3VReg), lt, true) }},
+		{want: "41cc231e", setup: func(i *instruction) { i.asFpuCSel(v1VReg, operandNR(v2VReg), operandNR(v3VReg), gt, false) }},
+		{want: "41bc231e", setup: func(i *instruction) { i.asFpuCSel(v1VReg, operandNR(v2VReg), operandNR(v3VReg), lt, false) }},
+		{want: "411c014e", setup: func(i *instruction) { i.asMovToVec(v1VReg, operandNR(x2VReg), vecArrangementB, 0) }},
+		{want: "411c024e", setup: func(i *instruction) { i.asMovToVec(v1VReg, operandNR(x2VReg), vecArrangementH, 0) }},
+		{want: "411c044e", setup: func(i *instruction) { i.asMovToVec(v1VReg, operandNR(x2VReg), vecArrangementS, 0) }},
+		{want: "411c084e", setup: func(i *instruction) { i.asMovToVec(v1VReg, operandNR(x2VReg), vecArrangementD, 0) }},
+		{want: "413c010e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementB, 0, false) }},
+		{want: "413c020e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementH, 0, false) }},
+		{want: "413c040e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementS, 0, false) }},
+		{want: "413c084e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementD, 0, false) }},
+		{want: "412c030e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementB, 1, true) }},
+		{want: "412c060e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementH, 1, true) }},
+		{want: "412c0c4e", setup: func(i *instruction) { i.asMovFromVec(x1VReg, operandNR(v2VReg), vecArrangementS, 1, true) }},
+		{want: "410c084e", setup: func(i *instruction) { i.asVecDup(x1VReg, operandNR(v2VReg), vecArrangement2D) }},
 		{want: "4140036e", setup: func(i *instruction) { // 4140036e
-			i.asVecExtract(operandNR(x1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B, 8)
+			i.asVecExtract(x1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B, 8)
 		}},
 		{want: "4138034e", setup: func(i *instruction) {
-			i.asVecPermute(vecOpZip1, operandNR(x1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecPermute(vecOpZip1, x1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4104214f", setup: func(i *instruction) {
-			i.asVecShiftImm(vecOpSshr, operandNR(x1VReg), operandNR(x2VReg), operandShiftImm(31), vecArrangement4S)
+			i.asVecShiftImm(vecOpSshr, x1VReg, operandNR(x2VReg), operandShiftImm(31), vecArrangement4S)
 		}},
 		{want: "5b28030b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
 		}},
 		{want: "5b28038b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
 		}},
 		{want: "5b28032b", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
+			i.asALU(aluOpAddS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
 		}},
 		{want: "5b2803ab", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
+			i.asALU(aluOpAddS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
 		}},
 		{want: "5b28430b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
 		}},
 		{want: "5b28438b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
 		}},
 		{want: "5b28432b", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
+			i.asALU(aluOpAddS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
 		}},
 		{want: "5b2843ab", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
+			i.asALU(aluOpAddS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
 		}},
 		{want: "5b28830b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
 		}},
 		{want: "5b28838b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
 		}},
 		{want: "5b28832b", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
+			i.asALU(aluOpAddS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
 		}},
 		{want: "5b2883ab", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
+			i.asALU(aluOpAddS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
 		}},
 		{want: "5b28034b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
 		}},
 		{want: "5b2803cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
 		}},
 		{want: "5b28036b", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
+			i.asALU(aluOpSubS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), false)
 		}},
 		{want: "5b2803eb", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
+			i.asALU(aluOpSubS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSL), true)
 		}},
 		{want: "5b28434b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
 		}},
 		{want: "5b2843cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
 		}},
 		{want: "5b28436b", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
+			i.asALU(aluOpSubS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), false)
 		}},
 		{want: "5b2843eb", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
+			i.asALU(aluOpSubS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpLSR), true)
 		}},
 		{want: "5b28834b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
 		}},
 		{want: "5b2883cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
 		}},
 		{want: "5b28836b", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
+			i.asALU(aluOpSubS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), false)
 		}},
 		{want: "5b2883eb", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(tmpRegVReg), operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
+			i.asALU(aluOpSubS, tmpRegVReg, operandNR(x2VReg), operandSR(x3VReg, 10, shiftOpASR), true)
 		}},
 		{want: "60033fd6", setup: func(i *instruction) {
 			i.asCallIndirect(tmpRegVReg, nil)
 		}},
 		{want: "fb633bcb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(spVReg), operandNR(tmpRegVReg), true)
+			i.asALU(aluOpSub, tmpRegVReg, operandNR(spVReg), operandNR(tmpRegVReg), true)
 		}},
 		{want: "fb633b8b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(tmpRegVReg), operandNR(spVReg), operandNR(tmpRegVReg), true)
+			i.asALU(aluOpAdd, tmpRegVReg, operandNR(spVReg), operandNR(tmpRegVReg), true)
 		}},
 		{want: "2000020a", setup: func(i *instruction) {
-			i.asALU(aluOpAnd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), false)
+			i.asALU(aluOpAnd, x0VReg, operandNR(x1VReg), operandNR(x2VReg), false)
 		}},
 		{want: "2000028a", setup: func(i *instruction) {
-			i.asALU(aluOpAnd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), true)
+			i.asALU(aluOpAnd, x0VReg, operandNR(x1VReg), operandNR(x2VReg), true)
 		}},
 		{want: "2010028a", setup: func(i *instruction) {
-			i.asALU(aluOpAnd, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
+			i.asALU(aluOpAnd, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
 		}},
 		{want: "2030428a", setup: func(i *instruction) {
-			i.asALU(aluOpAnd, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 12, shiftOpLSR), true)
+			i.asALU(aluOpAnd, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 12, shiftOpLSR), true)
 		}},
 		{want: "2000026a", setup: func(i *instruction) {
-			i.asALU(aluOpAnds, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), false)
+			i.asALU(aluOpAnds, x0VReg, operandNR(x1VReg), operandNR(x2VReg), false)
 		}},
 		{want: "200002ea", setup: func(i *instruction) {
-			i.asALU(aluOpAnds, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), true)
+			i.asALU(aluOpAnds, x0VReg, operandNR(x1VReg), operandNR(x2VReg), true)
 		}},
 		{want: "201002ea", setup: func(i *instruction) {
-			i.asALU(aluOpAnds, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
+			i.asALU(aluOpAnds, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
 		}},
 		{want: "203042ea", setup: func(i *instruction) {
-			i.asALU(aluOpAnds, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 12, shiftOpLSR), true)
+			i.asALU(aluOpAnds, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 12, shiftOpLSR), true)
 		}},
 		{want: "2000022a", setup: func(i *instruction) {
-			i.asALU(aluOpOrr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), false)
+			i.asALU(aluOpOrr, x0VReg, operandNR(x1VReg), operandNR(x2VReg), false)
 		}},
 		{want: "200002aa", setup: func(i *instruction) {
-			i.asALU(aluOpOrr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), true)
+			i.asALU(aluOpOrr, x0VReg, operandNR(x1VReg), operandNR(x2VReg), true)
 		}},
 		{want: "201002aa", setup: func(i *instruction) {
-			i.asALU(aluOpOrr, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
+			i.asALU(aluOpOrr, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
 		}},
 		{want: "201082aa", setup: func(i *instruction) {
-			i.asALU(aluOpOrr, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpASR), true)
+			i.asALU(aluOpOrr, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpASR), true)
 		}},
 		{want: "2000024a", setup: func(i *instruction) {
-			i.asALU(aluOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), false)
+			i.asALU(aluOpEor, x0VReg, operandNR(x1VReg), operandNR(x2VReg), false)
 		}},
 		{want: "200002ca", setup: func(i *instruction) {
-			i.asALU(aluOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), true)
+			i.asALU(aluOpEor, x0VReg, operandNR(x1VReg), operandNR(x2VReg), true)
 		}},
 		{want: "201002ca", setup: func(i *instruction) {
-			i.asALU(aluOpEor, operandNR(x0VReg), operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
+			i.asALU(aluOpEor, x0VReg, operandNR(x1VReg), operandSR(x2VReg, 4, shiftOpLSL), true)
 		}},
 		{want: "202cc21a", setup: func(i *instruction) {
-			i.asALU(aluOpRotR, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), false)
+			i.asALU(aluOpRotR, x0VReg, operandNR(x1VReg), operandNR(x2VReg), false)
 		}},
 		{want: "202cc29a", setup: func(i *instruction) {
-			i.asALU(aluOpRotR, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), true)
+			i.asALU(aluOpRotR, x0VReg, operandNR(x1VReg), operandNR(x2VReg), true)
 		}},
 		{want: "2000222a", setup: func(i *instruction) {
-			i.asALU(aluOpOrn, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), false)
+			i.asALU(aluOpOrn, x0VReg, operandNR(x1VReg), operandNR(x2VReg), false)
 		}},
 		{want: "200022aa", setup: func(i *instruction) {
-			i.asALU(aluOpOrn, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), true)
+			i.asALU(aluOpOrn, x0VReg, operandNR(x1VReg), operandNR(x2VReg), true)
 		}},
 		{want: "30000010", setup: func(i *instruction) { i.asAdr(v16VReg, 4) }},
 		{want: "50050030", setup: func(i *instruction) { i.asAdr(v16VReg, 169) }},
@@ -1093,16 +1093,16 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "101e306e", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0, 0) }},
 		{want: "5000009c05000014ffffffffffffffffaaaaaaaaaaaaaaaa", setup: func(i *instruction) { i.asLoadFpuConst128(v16VReg, 0xffffffff_ffffffff, 0xaaaaaaaa_aaaaaaaa) }},
 		{want: "8220061b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, false)
+			i.asALURRRR(aluOpMAdd, x2VReg, operandNR(x4VReg), operandNR(x6VReg), x8VReg, false)
 		}},
 		{want: "8220069b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMAdd, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, true)
+			i.asALURRRR(aluOpMAdd, x2VReg, operandNR(x4VReg), operandNR(x6VReg), x8VReg, true)
 		}},
 		{want: "82a0061b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMSub, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, false)
+			i.asALURRRR(aluOpMSub, x2VReg, operandNR(x4VReg), operandNR(x6VReg), x8VReg, false)
 		}},
 		{want: "82a0069b", setup: func(i *instruction) {
-			i.asALURRRR(aluOpMSub, operandNR(x2VReg), operandNR(x4VReg), operandNR(x6VReg), x8VReg, true)
+			i.asALURRRR(aluOpMSub, x2VReg, operandNR(x4VReg), operandNR(x6VReg), x8VReg, true)
 		}},
 		{want: "00213f1e", setup: func(i *instruction) { i.asFpuCmp(operandNR(v8VReg), operandNR(v31VReg), false) }},
 		{want: "00217f1e", setup: func(i *instruction) { i.asFpuCmp(operandNR(v8VReg), operandNR(v31VReg), true) }},
@@ -1200,76 +1200,76 @@ func TestInstruction_encode(t *testing.T) {
 		{want: "f21fbf0e", setup: func(i *instruction) { i.asFpuMov64(v18VReg, v31VReg) }},
 		{want: "f21fbf4e", setup: func(i *instruction) { i.asFpuMov128(v18VReg, v31VReg) }},
 		{want: "40a034ab", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTH, 64), false)
+			i.asALU(aluOpAddS, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTH, 64), false)
 		}},
 		{want: "4080348b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTB, 64), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTB, 64), false)
 		}},
 		{want: "40a0348b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTH, 64), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTH, 64), false)
 		}},
 		{want: "40c0348b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTW, 64), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTW, 64), false)
 		}},
 		{want: "4080340b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTB, 32), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTB, 32), false)
 		}},
 		{want: "40a0340b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTH, 32), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTH, 32), false)
 		}},
 		{want: "40c0340b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpSXTW, 32), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpSXTW, 32), false)
 		}},
 		{want: "400034eb", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTB, 64), false)
+			i.asALU(aluOpSubS, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTB, 64), false)
 		}},
 		{want: "400034cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTB, 64), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTB, 64), false)
 		}},
 		{want: "402034cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTH, 64), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTH, 64), false)
 		}},
 		{want: "404034cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTW, 64), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTW, 64), false)
 		}},
 		{want: "4000344b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTB, 32), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTB, 32), false)
 		}},
 		{want: "4020344b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTH, 32), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTH, 32), false)
 		}},
 		{want: "4040344b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandER(x20VReg, extendOpUXTW, 32), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandER(x20VReg, extendOpUXTW, 32), false)
 		}},
 		{want: "4000140b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "4000148b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "40001f8b", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x0VReg), operandNR(x2VReg), operandNR(xzrVReg), true)
+			i.asALU(aluOpAdd, x0VReg, operandNR(x2VReg), operandNR(xzrVReg), true)
 		}},
 		{want: "4000142b", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpAddS, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "400014ab", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpAddS, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "4000144b", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "400014cb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "40001fcb", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x0VReg), operandNR(x2VReg), operandNR(xzrVReg), true)
+			i.asALU(aluOpSub, x0VReg, operandNR(x2VReg), operandNR(xzrVReg), true)
 		}},
 		{want: "400014eb", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpSubS, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "40001feb", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x0VReg), operandNR(x2VReg), operandNR(xzrVReg), true)
+			i.asALU(aluOpSubS, x0VReg, operandNR(x2VReg), operandNR(xzrVReg), true)
 		}},
 		{want: "c0035fd6", setup: func(i *instruction) { i.asRet() }},
 		{want: "e303042a", setup: func(i *instruction) { i.asMove32(x3VReg, x4VReg) }},
@@ -1317,478 +1317,478 @@ func TestInstruction_encode(t *testing.T) {
 			i.condBrOffsetResolve(0x80)
 		}},
 		{want: "8328321e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpAdd, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), false)
+			i.asFpuRRR(fpuBinOpAdd, v3VReg, operandNR(v4VReg), operandNR(v18VReg), false)
 		}},
 		{want: "8328721e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpAdd, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), true)
+			i.asFpuRRR(fpuBinOpAdd, v3VReg, operandNR(v4VReg), operandNR(v18VReg), true)
 		}},
 		{want: "8338321e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpSub, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), false)
+			i.asFpuRRR(fpuBinOpSub, v3VReg, operandNR(v4VReg), operandNR(v18VReg), false)
 		}},
 		{want: "8338721e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpSub, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), true)
+			i.asFpuRRR(fpuBinOpSub, v3VReg, operandNR(v4VReg), operandNR(v18VReg), true)
 		}},
 		{want: "8308321e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpMul, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), false)
+			i.asFpuRRR(fpuBinOpMul, v3VReg, operandNR(v4VReg), operandNR(v18VReg), false)
 		}},
 		{want: "8308721e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpMul, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), true)
+			i.asFpuRRR(fpuBinOpMul, v3VReg, operandNR(v4VReg), operandNR(v18VReg), true)
 		}},
 		{want: "8318321e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpDiv, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), false)
+			i.asFpuRRR(fpuBinOpDiv, v3VReg, operandNR(v4VReg), operandNR(v18VReg), false)
 		}},
 		{want: "8318721e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpDiv, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), true)
+			i.asFpuRRR(fpuBinOpDiv, v3VReg, operandNR(v4VReg), operandNR(v18VReg), true)
 		}},
 		{want: "8348321e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpMax, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), false)
+			i.asFpuRRR(fpuBinOpMax, v3VReg, operandNR(v4VReg), operandNR(v18VReg), false)
 		}},
 		{want: "8348721e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpMax, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), true)
+			i.asFpuRRR(fpuBinOpMax, v3VReg, operandNR(v4VReg), operandNR(v18VReg), true)
 		}},
 		{want: "8358321e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpMin, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), false)
+			i.asFpuRRR(fpuBinOpMin, v3VReg, operandNR(v4VReg), operandNR(v18VReg), false)
 		}},
 		{want: "8358721e", setup: func(i *instruction) {
-			i.asFpuRRR(fpuBinOpMin, operandNR(v3VReg), operandNR(v4VReg), operandNR(v18VReg), true)
+			i.asFpuRRR(fpuBinOpMin, v3VReg, operandNR(v4VReg), operandNR(v18VReg), true)
 		}},
 		{want: "49fd7f11", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
+			i.asALU(aluOpAdd, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
 		}},
 		{want: "e9ff7f91", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x9VReg), operandNR(spVReg), operandImm12(0b111111111111, 0b1), true)
+			i.asALU(aluOpAdd, x9VReg, operandNR(spVReg), operandImm12(0b111111111111, 0b1), true)
 		}},
 		{want: "49fd3f11", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
+			i.asALU(aluOpAdd, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
 		}},
 		{want: "5ffd3f91", setup: func(i *instruction) {
-			i.asALU(aluOpAdd, operandNR(spVReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
+			i.asALU(aluOpAdd, spVReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
 		}},
 		{want: "49fd7f31", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
+			i.asALU(aluOpAddS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
 		}},
 		{want: "49fd7fb1", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b1), true)
+			i.asALU(aluOpAddS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b1), true)
 		}},
 		{want: "49fd3f31", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
+			i.asALU(aluOpAddS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
 		}},
 		{want: "49fd3fb1", setup: func(i *instruction) {
-			i.asALU(aluOpAddS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
+			i.asALU(aluOpAddS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
 		}},
 		{want: "49fd7f51", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
+			i.asALU(aluOpSub, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
 		}},
 		{want: "e9ff7fd1", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x9VReg), operandNR(spVReg), operandImm12(0b111111111111, 0b1), true)
+			i.asALU(aluOpSub, x9VReg, operandNR(spVReg), operandImm12(0b111111111111, 0b1), true)
 		}},
 		{want: "49fd3f51", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
+			i.asALU(aluOpSub, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
 		}},
 		{want: "5ffd3fd1", setup: func(i *instruction) {
-			i.asALU(aluOpSub, operandNR(spVReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
+			i.asALU(aluOpSub, spVReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
 		}},
 		{want: "49fd7f71", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
+			i.asALU(aluOpSubS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b1), false)
 		}},
 		{want: "49fd7ff1", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b1), true)
+			i.asALU(aluOpSubS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b1), true)
 		}},
 		{want: "49fd3f71", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
+			i.asALU(aluOpSubS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), false)
 		}},
 		{want: "49fd3ff1", setup: func(i *instruction) {
-			i.asALU(aluOpSubS, operandNR(x9VReg), operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
+			i.asALU(aluOpSubS, x9VReg, operandNR(x10VReg), operandImm12(0b111111111111, 0b0), true)
 		}},
 		{want: "4020d41a", setup: func(i *instruction) {
-			i.asALU(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpLsl, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "4020d49a", setup: func(i *instruction) {
-			i.asALU(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpLsl, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "4024d41a", setup: func(i *instruction) {
-			i.asALU(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpLsr, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "4024d49a", setup: func(i *instruction) {
-			i.asALU(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpLsr, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "4028d41a", setup: func(i *instruction) {
-			i.asALU(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpAsr, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "4028d49a", setup: func(i *instruction) {
-			i.asALU(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpAsr, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "400cd49a", setup: func(i *instruction) {
-			i.asALU(aluOpSDiv, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpSDiv, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "400cd41a", setup: func(i *instruction) {
-			i.asALU(aluOpSDiv, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpSDiv, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "4008d49a", setup: func(i *instruction) {
-			i.asALU(aluOpUDiv, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), true)
+			i.asALU(aluOpUDiv, x0VReg, operandNR(x2VReg), operandNR(x20VReg), true)
 		}},
 		{want: "4008d41a", setup: func(i *instruction) {
-			i.asALU(aluOpUDiv, operandNR(x0VReg), operandNR(x2VReg), operandNR(x20VReg), false)
+			i.asALU(aluOpUDiv, x0VReg, operandNR(x2VReg), operandNR(x20VReg), false)
 		}},
 		{want: "407c0013", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(0), false)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(0), false)
 		}},
 		{want: "40fc4093", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(0), true)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(0), true)
 		}},
 		{want: "407c0113", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(1), false)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(1), false)
 		}},
 		{want: "407c1f13", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(31), false)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(31), false)
 		}},
 		{want: "40fc4193", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(1), true)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(1), true)
 		}},
 		{want: "40fc5f93", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(31), true)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(31), true)
 		}},
 		{want: "40fc7f93", setup: func(i *instruction) {
-			i.asALUShift(aluOpAsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(63), true)
+			i.asALUShift(aluOpAsr, x0VReg, operandNR(x2VReg), operandShiftImm(63), true)
 		}},
 		{want: "407c0153", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(1), false)
+			i.asALUShift(aluOpLsr, x0VReg, operandNR(x2VReg), operandShiftImm(1), false)
 		}},
 		{want: "407c1f53", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(31), false)
+			i.asALUShift(aluOpLsr, x0VReg, operandNR(x2VReg), operandShiftImm(31), false)
 		}},
 		{want: "40fc41d3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(1), true)
+			i.asALUShift(aluOpLsr, x0VReg, operandNR(x2VReg), operandShiftImm(1), true)
 		}},
 		{want: "40fc5fd3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(31), true)
+			i.asALUShift(aluOpLsr, x0VReg, operandNR(x2VReg), operandShiftImm(31), true)
 		}},
 		{want: "40fc7fd3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsr, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(63), true)
+			i.asALUShift(aluOpLsr, x0VReg, operandNR(x2VReg), operandShiftImm(63), true)
 		}},
 		{want: "407c0053", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(0), false)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(0), false)
 		}},
 		{want: "40fc40d3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(0), true)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(0), true)
 		}},
 		{want: "40781f53", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(1), false)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(1), false)
 		}},
 		{want: "40000153", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(31), false)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(31), false)
 		}},
 		{want: "40f87fd3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(1), true)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(1), true)
 		}},
 		{want: "408061d3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(31), true)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(31), true)
 		}},
 		{want: "400041d3", setup: func(i *instruction) {
-			i.asALUShift(aluOpLsl, operandNR(x0VReg), operandNR(x2VReg), operandShiftImm(63), true)
+			i.asALUShift(aluOpLsl, x0VReg, operandNR(x2VReg), operandShiftImm(63), true)
 		}},
 		{want: "4000c05a", setup: func(i *instruction) { i.asBitRR(bitOpRbit, x0VReg, x2VReg, false) }},
 		{want: "4000c0da", setup: func(i *instruction) { i.asBitRR(bitOpRbit, x0VReg, x2VReg, true) }},
 		{want: "4010c05a", setup: func(i *instruction) { i.asBitRR(bitOpClz, x0VReg, x2VReg, false) }},
 		{want: "4010c0da", setup: func(i *instruction) { i.asBitRR(bitOpClz, x0VReg, x2VReg, true) }},
 		{want: "4138302e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUaddlv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecLanes(vecOpUaddlv, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "4138306e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUaddlv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecLanes(vecOpUaddlv, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "4138702e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUaddlv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4H)
+			i.asVecLanes(vecOpUaddlv, v1VReg, operandNR(v2VReg), vecArrangement4H)
 		}},
 		{want: "4138706e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUaddlv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8H)
+			i.asVecLanes(vecOpUaddlv, v1VReg, operandNR(v2VReg), vecArrangement8H)
 		}},
 		{want: "4138b06e", setup: func(i *instruction) {
-			i.asVecLanes(vecOpUaddlv, operandNR(v1VReg), operandNR(v2VReg), vecArrangement4S)
+			i.asVecLanes(vecOpUaddlv, v1VReg, operandNR(v2VReg), vecArrangement4S)
 		}},
 		{want: "41c0230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmull, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSmull, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "41c0630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmull, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSmull, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "41c0a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmull, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSmull, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "41c0234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmull2, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSmull2, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "41c0634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmull2, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSmull2, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "41c0a34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSmull2, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
+			i.asVecRRR(vecOpSmull2, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4S)
 		}},
 		{want: "411c630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpBic, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpBic, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "411c634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpBic, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpBic, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "411c632e", setup: func(i *instruction) {
-			i.asVecRRRRewrite(vecOpBsl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRRRewrite(vecOpBsl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "411c636e", setup: func(i *instruction) {
-			i.asVecRRRRewrite(vecOpBsl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRRRewrite(vecOpBsl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4158202e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNot, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B)
+			i.asVecMisc(vecOpNot, v1VReg, operandNR(v2VReg), vecArrangement8B)
 		}},
 		{want: "4158206e", setup: func(i *instruction) {
-			i.asVecMisc(vecOpNot, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B)
+			i.asVecMisc(vecOpNot, v1VReg, operandNR(v2VReg), vecArrangement16B)
 		}},
 		{want: "411c230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAnd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpAnd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "411c234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpAnd, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpAnd, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "411ca30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpOrr, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpOrr, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "411ca34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpOrr, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpOrr, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4144230e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4144234e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4144630e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4144634e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4144a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4144e34e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4144a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4144232e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
+			i.asVecRRR(vecOpUshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8B)
 		}},
 		{want: "4144236e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
+			i.asVecRRR(vecOpUshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement16B)
 		}},
 		{want: "4144632e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
+			i.asVecRRR(vecOpUshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement4H)
 		}},
 		{want: "4144636e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
+			i.asVecRRR(vecOpUshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement8H)
 		}},
 		{want: "4144a32e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpUshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
 		{want: "4144e36e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpUshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
+			i.asVecRRR(vecOpUshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2D)
 		}},
 		{want: "4144a30e", setup: func(i *instruction) {
-			i.asVecRRR(vecOpSshl, operandNR(v1VReg), operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
+			i.asVecRRR(vecOpSshl, v1VReg, operandNR(v2VReg), operandNR(v3VReg), vecArrangement2S)
 		}},
-		{want: "4158200e", setup: func(i *instruction) { i.asVecMisc(vecOpCnt, operandNR(v1VReg), operandNR(v2VReg), vecArrangement8B) }},
-		{want: "4158204e", setup: func(i *instruction) { i.asVecMisc(vecOpCnt, operandNR(v1VReg), operandNR(v2VReg), vecArrangement16B) }},
+		{want: "4158200e", setup: func(i *instruction) { i.asVecMisc(vecOpCnt, v1VReg, operandNR(v2VReg), vecArrangement8B) }},
+		{want: "4158204e", setup: func(i *instruction) { i.asVecMisc(vecOpCnt, v1VReg, operandNR(v2VReg), vecArrangement16B) }},
 		{want: "41c0221e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpCvt32To64, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpCvt32To64, v1VReg, operandNR(v2VReg), true)
 		}},
 		{want: "4140621e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpCvt64To32, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpCvt64To32, v1VReg, operandNR(v2VReg), true)
 		}},
 		{want: "4140211e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpNeg, operandNR(v1VReg), operandNR(v2VReg), false)
+			i.asFpuRR(fpuUniOpNeg, v1VReg, operandNR(v2VReg), false)
 		}},
 
 		{want: "41c0211e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpSqrt, operandNR(v1VReg), operandNR(v2VReg), false)
+			i.asFpuRR(fpuUniOpSqrt, v1VReg, operandNR(v2VReg), false)
 		}},
 		{want: "41c0611e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpSqrt, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpSqrt, v1VReg, operandNR(v2VReg), true)
 		}},
 		{want: "41c0241e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundPlus, operandNR(v1VReg), operandNR(v2VReg), false)
+			i.asFpuRR(fpuUniOpRoundPlus, v1VReg, operandNR(v2VReg), false)
 		}},
 		{want: "41c0641e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundPlus, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpRoundPlus, v1VReg, operandNR(v2VReg), true)
 		}},
 		{want: "4140251e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundMinus, operandNR(v1VReg), operandNR(v2VReg), false)
+			i.asFpuRR(fpuUniOpRoundMinus, v1VReg, operandNR(v2VReg), false)
 		}},
 		{want: "4140651e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundMinus, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpRoundMinus, v1VReg, operandNR(v2VReg), true)
 		}},
 		{want: "41c0251e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundZero, operandNR(v1VReg), operandNR(v2VReg), false)
+			i.asFpuRR(fpuUniOpRoundZero, v1VReg, operandNR(v2VReg), false)
 		}},
 		{want: "41c0651e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundZero, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpRoundZero, v1VReg, operandNR(v2VReg), true)
 		}},
 		{want: "4140241e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundNearest, operandNR(v1VReg), operandNR(v2VReg), false)
+			i.asFpuRR(fpuUniOpRoundNearest, v1VReg, operandNR(v2VReg), false)
 		}},
 		{want: "4140641e", setup: func(i *instruction) {
-			i.asFpuRR(fpuUniOpRoundNearest, operandNR(v1VReg), operandNR(v2VReg), true)
+			i.asFpuRR(fpuUniOpRoundNearest, v1VReg, operandNR(v2VReg), true)
 		}},
-		{want: "4140611e", setup: func(i *instruction) { i.asFpuRR(fpuUniOpNeg, operandNR(v1VReg), operandNR(v2VReg), true) }},
-		{want: "41c0404d", setup: func(i *instruction) { i.asVecLoad1R(operandNR(v1VReg), operandNR(x2VReg), vecArrangement16B) }},
-		{want: "41c4404d", setup: func(i *instruction) { i.asVecLoad1R(operandNR(v1VReg), operandNR(x2VReg), vecArrangement8H) }},
-		{want: "41c8404d", setup: func(i *instruction) { i.asVecLoad1R(operandNR(v1VReg), operandNR(x2VReg), vecArrangement4S) }},
-		{want: "41cc404d", setup: func(i *instruction) { i.asVecLoad1R(operandNR(v1VReg), operandNR(x2VReg), vecArrangement2D) }},
+		{want: "4140611e", setup: func(i *instruction) { i.asFpuRR(fpuUniOpNeg, v1VReg, operandNR(v2VReg), true) }},
+		{want: "41c0404d", setup: func(i *instruction) { i.asVecLoad1R(v1VReg, operandNR(x2VReg), vecArrangement16B) }},
+		{want: "41c4404d", setup: func(i *instruction) { i.asVecLoad1R(v1VReg, operandNR(x2VReg), vecArrangement8H) }},
+		{want: "41c8404d", setup: func(i *instruction) { i.asVecLoad1R(v1VReg, operandNR(x2VReg), vecArrangement4S) }},
+		{want: "41cc404d", setup: func(i *instruction) { i.asVecLoad1R(v1VReg, operandNR(x2VReg), vecArrangement2D) }},
 		{want: "0200e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0200e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0200e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0200e1f8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 8)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 8)
 		}},
 		{want: "0200e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0200e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0200e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpAdd, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpAdd, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0210e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0210e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0210e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0210e1f8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 8)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 8)
 		}},
 		{want: "0210e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0210e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0210e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpClr, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpClr, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0230e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0230e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0230e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0230e1f8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 8)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 8)
 		}},
 		{want: "0230e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0230e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0230e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSet, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpSet, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0220e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0220e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0220e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0220e1f8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 8)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 8)
 		}},
 		{want: "0220e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0220e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0220e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpEor, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpEor, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0280e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0280e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0280e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "0280e1f8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 8)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 8)
 		}},
 		{want: "0280e1b8", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "0280e178", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "0280e138", setup: func(i *instruction) {
-			i.asAtomicRmw(atomicRmwOpSwp, operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicRmw(atomicRmwOpSwp, x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "02fce188", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "02fce148", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "02fce108", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "02fce1c8", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 8)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 8)
 		}},
 		{want: "02fce188", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 4)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 4)
 		}},
 		{want: "02fce148", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 2)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 2)
 		}},
 		{want: "02fce108", setup: func(i *instruction) {
-			i.asAtomicCas(operandNR(x0VReg), operandNR(x1VReg), operandNR(x2VReg), 1)
+			i.asAtomicCas(x0VReg, x1VReg, x2VReg, 1)
 		}},
 		{want: "01fcdf88", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 4)
+			i.asAtomicLoad(x0VReg, x1VReg, 4)
 		}},
 		{want: "01fcdf48", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 2)
+			i.asAtomicLoad(x0VReg, x1VReg, 2)
 		}},
 		{want: "01fcdf08", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 1)
+			i.asAtomicLoad(x0VReg, x1VReg, 1)
 		}},
 		{want: "01fcdfc8", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 8)
+			i.asAtomicLoad(x0VReg, x1VReg, 8)
 		}},
 		{want: "01fcdf88", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 4)
+			i.asAtomicLoad(x0VReg, x1VReg, 4)
 		}},
 		{want: "01fcdf48", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 2)
+			i.asAtomicLoad(x0VReg, x1VReg, 2)
 		}},
 		{want: "01fcdf08", setup: func(i *instruction) {
-			i.asAtomicLoad(operandNR(x0VReg), operandNR(x1VReg), 1)
+			i.asAtomicLoad(x0VReg, x1VReg, 1)
 		}},
 		{want: "01fc9f88", setup: func(i *instruction) {
 			i.asAtomicStore(operandNR(x0VReg), operandNR(x1VReg), 4)
@@ -1823,7 +1823,7 @@ func TestInstruction_encode(t *testing.T) {
 					for _, dst64bit := range trueFalse {
 						i := &instruction{prev: cur}
 						cur.next = i
-						i.asIntToFpu(operandNR(v2VReg), operandNR(x10VReg), rnSigned, src64bit, dst64bit)
+						i.asIntToFpu(v2VReg, operandNR(x10VReg), rnSigned, src64bit, dst64bit)
 						cur = i
 					}
 				}
@@ -1838,7 +1838,7 @@ func TestInstruction_encode(t *testing.T) {
 					for _, dst64bit := range trueFalse {
 						i := &instruction{prev: cur}
 						cur.next = i
-						i.asFpuToInt(operandNR(v2VReg), operandNR(x10VReg), rnSigned, src64bit, dst64bit)
+						i.asFpuToInt(v2VReg, operandNR(x10VReg), rnSigned, src64bit, dst64bit)
 						cur = i
 					}
 				}
@@ -2234,7 +2234,7 @@ func TestInstruction_encoding_store_encoding(t *testing.T) {
 			case store8, store16, store32, store64, fpuStore32, fpuStore64, fpuStore128:
 				i = &instruction{kind: tc.k, amode: tc.amode, rn: operandNR(tc.rn)}
 			case uLoad8, uLoad16, uLoad32, uLoad64, sLoad8, sLoad16, sLoad32, fpuLoad32, fpuLoad64, fpuLoad128:
-				i = &instruction{kind: tc.k, amode: tc.amode, rd: operandNR(tc.rn)}
+				i = &instruction{kind: tc.k, amode: tc.amode, rd: tc.rn}
 			default:
 				t.Fatalf("unknown kind: %v", tc.k)
 			}

--- a/internal/engine/wazevo/backend/isa/arm64/instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/instr_test.go
@@ -49,7 +49,7 @@ func TestInstruction_String(t *testing.T) {
 			i: &instruction{
 				kind: loadFpuConst32,
 				u1:   uint64(math.Float32bits(3.0)),
-				rd:   operandNR(regalloc.VReg(0).SetRegType(regalloc.RegTypeFloat)),
+				rd:   regalloc.VReg(0).SetRegType(regalloc.RegTypeFloat),
 			},
 			exp: "ldr s0?, #8; b 8; data.f32 3.000000",
 		},
@@ -57,7 +57,7 @@ func TestInstruction_String(t *testing.T) {
 			i: &instruction{
 				kind: loadFpuConst64,
 				u1:   math.Float64bits(12345.987491),
-				rd:   operandNR(regalloc.VReg(0).SetRegType(regalloc.RegTypeFloat)),
+				rd:   regalloc.VReg(0).SetRegType(regalloc.RegTypeFloat),
 			},
 			exp: "ldr d0?, #8; b 16; data.f64 12345.987491",
 		},

--- a/internal/engine/wazevo/backend/isa/arm64/lower_constant.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_constant.go
@@ -284,18 +284,18 @@ func (m *machine) load64bitConst(c int64, dst regalloc.VReg) {
 
 func (m *machine) insertMOVZ(dst regalloc.VReg, v uint64, shift int, dst64 bool) {
 	instr := m.allocateInstr()
-	instr.asMOVZ(dst, v, uint64(shift), dst64)
+	instr.asMOVZ(dst, v, uint32(shift), dst64)
 	m.insert(instr)
 }
 
 func (m *machine) insertMOVK(dst regalloc.VReg, v uint64, shift int, dst64 bool) {
 	instr := m.allocateInstr()
-	instr.asMOVK(dst, v, uint64(shift), dst64)
+	instr.asMOVK(dst, v, uint32(shift), dst64)
 	m.insert(instr)
 }
 
 func (m *machine) insertMOVN(dst regalloc.VReg, v uint64, shift int, dst64 bool) {
 	instr := m.allocateInstr()
-	instr.asMOVN(dst, v, uint64(shift), dst64)
+	instr.asMOVN(dst, v, uint32(shift), dst64)
 	m.insert(instr)
 }

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -351,7 +351,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
 		rd := operandNR(m.compiler.VRegOf(instr.Return()))
-		m.lowerIRem(ctxVReg, rd, rn, rm, x.Type() == ssa.TypeI64, op == ssa.OpcodeSrem)
+		m.lowerIRem(ctxVReg, rd, rn.nr(), rm, x.Type() == ssa.TypeI64, op == ssa.OpcodeSrem)
 	case ssa.OpcodeVconst:
 		result := m.compiler.VRegOf(instr.Return())
 		lo, hi := instr.VconstData()
@@ -1224,13 +1224,13 @@ func (m *machine) lowerVMinMaxPseudo(instr *ssa.Instruction, max bool) {
 	m.insert(mov2)
 }
 
-func (m *machine) lowerIRem(execCtxVReg regalloc.VReg, rd, rn, rm operand, _64bit, signed bool) {
+func (m *machine) lowerIRem(execCtxVReg regalloc.VReg, rd operand, rn regalloc.VReg, rm operand, _64bit, signed bool) {
 	div := m.allocateInstr()
 
 	if signed {
-		div.asALU(aluOpSDiv, rd, rn, rm, _64bit)
+		div.asALU(aluOpSDiv, rd, operandNR(rn), rm, _64bit)
 	} else {
-		div.asALU(aluOpUDiv, rd, rn, rm, _64bit)
+		div.asALU(aluOpUDiv, rd, operandNR(rn), rm, _64bit)
 	}
 	m.insert(div)
 
@@ -1797,7 +1797,7 @@ func (m *machine) lowerImul(x, y, result ssa.Value) {
 	// TODO: if this comes before Add/Sub, we could merge it by putting it into the place of xzrVReg.
 
 	mul := m.allocateInstr()
-	mul.asALURRRR(aluOpMAdd, operandNR(rd), rn, rm, operandNR(xzrVReg), x.Type().Bits() == 64)
+	mul.asALURRRR(aluOpMAdd, operandNR(rd), rn, rm, xzrVReg, x.Type().Bits() == 64)
 	m.insert(mul)
 }
 

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr.go
@@ -52,11 +52,11 @@ func (m *machine) lowerBrTable(i *ssa.Instruction) {
 	maxIndexReg := m.compiler.AllocateVReg(ssa.TypeI32)
 	m.lowerConstantI32(maxIndexReg, int32(len(targets)-1))
 	subs := m.allocateInstr()
-	subs.asALU(aluOpSubS, operandNR(xzrVReg), indexOperand, operandNR(maxIndexReg), false)
+	subs.asALU(aluOpSubS, xzrVReg, indexOperand, operandNR(maxIndexReg), false)
 	m.insert(subs)
 	csel := m.allocateInstr()
 	adjustedIndex := m.compiler.AllocateVReg(ssa.TypeI32)
-	csel.asCSel(operandNR(adjustedIndex), operandNR(maxIndexReg), indexOperand, hs, false)
+	csel.asCSel(adjustedIndex, operandNR(maxIndexReg), indexOperand, hs, false)
 	m.insert(csel)
 
 	brSequence := m.allocateInstr()
@@ -249,7 +249,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 			rc := m.getOperand_NR(m.compiler.ValueDefinition(c), extModeNone)
 			rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 			rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-			rd := operandNR(m.compiler.VRegOf(instr.Return()))
+			rd := m.compiler.VRegOf(instr.Return())
 			m.lowerSelectVec(rc, rn, rm, rd)
 		} else {
 			m.lowerSelect(c, x, y, instr.Return())
@@ -270,7 +270,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x, ctx := instr.Arg2()
 		result := instr.Return()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(result))
+		rd := m.compiler.VRegOf(result)
 		ctxVReg := m.compiler.VRegOf(ctx)
 		m.lowerFpuToInt(rd, rn, ctxVReg, true, x.Type() == ssa.TypeF64,
 			result.Type().Bits() == 64, op == ssa.OpcodeFcvtToSintSat)
@@ -278,7 +278,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x, ctx := instr.Arg2()
 		result := instr.Return()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(result))
+		rd := m.compiler.VRegOf(result)
 		ctxVReg := m.compiler.VRegOf(ctx)
 		m.lowerFpuToInt(rd, rn, ctxVReg, false, x.Type() == ssa.TypeF64,
 			result.Type().Bits() == 64, op == ssa.OpcodeFcvtToUintSat)
@@ -286,25 +286,25 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x := instr.Arg()
 		result := instr.Return()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(result))
+		rd := m.compiler.VRegOf(result)
 		m.lowerIntToFpu(rd, rn, true, x.Type() == ssa.TypeI64, result.Type().Bits() == 64)
 	case ssa.OpcodeFcvtFromUint:
 		x := instr.Arg()
 		result := instr.Return()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(result))
+		rd := m.compiler.VRegOf(result)
 		m.lowerIntToFpu(rd, rn, false, x.Type() == ssa.TypeI64, result.Type().Bits() == 64)
 	case ssa.OpcodeFdemote:
 		v := instr.Arg()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(v), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		cnt := m.allocateInstr()
 		cnt.asFpuRR(fpuUniOpCvt64To32, rd, rn, false)
 		m.insert(cnt)
 	case ssa.OpcodeFpromote:
 		v := instr.Arg()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(v), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		cnt := m.allocateInstr()
 		cnt.asFpuRR(fpuUniOpCvt32To64, rd, rn, true)
 		m.insert(cnt)
@@ -343,14 +343,14 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		ctxVReg := m.compiler.VRegOf(ctx)
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerIDiv(ctxVReg, rd, rn, rm, x.Type() == ssa.TypeI64, op == ssa.OpcodeSdiv)
 	case ssa.OpcodeSrem, ssa.OpcodeUrem:
 		x, y, ctx := instr.Arg3()
 		ctxVReg := m.compiler.VRegOf(ctx)
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerIRem(ctxVReg, rd, rn.nr(), rm, x.Type() == ssa.TypeI64, op == ssa.OpcodeSrem)
 	case ssa.OpcodeVconst:
 		result := m.compiler.VRegOf(instr.Return())
@@ -362,7 +362,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x := instr.Arg()
 		ins := m.allocateInstr()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		ins.asVecMisc(vecOpNot, rd, rn, vecArrangement16B)
 		m.insert(ins)
 	case ssa.OpcodeVbxor:
@@ -382,12 +382,12 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
 		creg := m.getOperand_NR(m.compiler.ValueDefinition(c), extModeNone)
-		tmp := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+		tmp := m.compiler.AllocateVReg(ssa.TypeV128)
 
 		// creg is overwritten by BSL, so we need to move it to the result register before the instruction
 		// in case when it is used somewhere else.
 		mov := m.allocateInstr()
-		mov.asFpuMov128(tmp.nr(), creg.nr())
+		mov.asFpuMov128(tmp, creg.nr())
 		m.insert(mov)
 
 		ins := m.allocateInstr()
@@ -396,7 +396,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 
 		mov2 := m.allocateInstr()
 		rd := m.compiler.VRegOf(instr.Return())
-		mov2.asFpuMov128(rd, tmp.nr())
+		mov2.asFpuMov128(rd, tmp)
 		m.insert(mov2)
 	case ssa.OpcodeVanyTrue, ssa.OpcodeVallTrue:
 		x, lane := instr.ArgWithLane()
@@ -405,12 +405,12 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 			arr = ssaLaneToArrangement(lane)
 		}
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerVcheckTrue(op, rm, rd, arr)
 	case ssa.OpcodeVhighBits:
 		x, lane := instr.ArgWithLane()
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		arr := ssaLaneToArrangement(lane)
 		m.lowerVhighBits(rm, rd, arr)
 	case ssa.OpcodeVIadd:
@@ -441,9 +441,9 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 			panic("unsupported lane " + lane.String())
 		}
 
-		widenLo := m.allocateInstr().asVecShiftImm(widen, tmpLo, vv, operandShiftImm(0), loArr)
-		widenHi := m.allocateInstr().asVecShiftImm(widen, tmpHi, vv, operandShiftImm(0), hiArr)
-		addp := m.allocateInstr().asVecRRR(vecOpAddp, operandNR(m.compiler.VRegOf(instr.Return())), tmpLo, tmpHi, dstArr)
+		widenLo := m.allocateInstr().asVecShiftImm(widen, tmpLo.nr(), vv, operandShiftImm(0), loArr)
+		widenHi := m.allocateInstr().asVecShiftImm(widen, tmpHi.nr(), vv, operandShiftImm(0), hiArr)
+		addp := m.allocateInstr().asVecRRR(vecOpAddp, m.compiler.VRegOf(instr.Return()), tmpLo, tmpHi, dstArr)
 		m.insert(widenLo)
 		m.insert(widenHi)
 		m.insert(addp)
@@ -493,7 +493,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		arr := ssaLaneToArrangement(lane)
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerVIMul(rd, rn, rm, arr)
 	case ssa.OpcodeVIabs:
 		m.lowerVecMisc(vecOpAbs, instr)
@@ -507,7 +507,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		arr := ssaLaneToArrangement(lane)
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerVShift(op, rd, rn, rm, arr)
 	case ssa.OpcodeVSqrt:
 		m.lowerVecMisc(vecOpFsqrt, instr)
@@ -547,18 +547,18 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x, lane := instr.ArgWithLane()
 		arr := ssaLaneToArrangement(lane)
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerVfpuToInt(rd, rn, arr, op == ssa.OpcodeVFcvtToSintSat)
 	case ssa.OpcodeVFcvtFromSint, ssa.OpcodeVFcvtFromUint:
 		x, lane := instr.ArgWithLane()
 		arr := ssaLaneToArrangement(lane)
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		m.lowerVfpuFromInt(rd, rn, arr, op == ssa.OpcodeVFcvtFromSint)
 	case ssa.OpcodeSwidenLow, ssa.OpcodeUwidenLow:
 		x, lane := instr.ArgWithLane()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
 		var arr vecArrangement
 		switch lane {
@@ -580,7 +580,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 	case ssa.OpcodeSwidenHigh, ssa.OpcodeUwidenHigh:
 		x, lane := instr.ArgWithLane()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
 		arr := ssaLaneToArrangement(lane)
 
@@ -607,9 +607,9 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		}
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
-		tmp := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+		tmp := m.compiler.AllocateVReg(ssa.TypeV128)
 
 		loQxtn := m.allocateInstr()
 		hiQxtn := m.allocateInstr()
@@ -628,7 +628,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		m.insert(hiQxtn)
 
 		mov := m.allocateInstr()
-		mov.asFpuMov128(rd.nr(), tmp.nr())
+		mov.asFpuMov128(rd, tmp)
 		m.insert(mov)
 	case ssa.OpcodeFvpromoteLow:
 		x, lane := instr.ArgWithLane()
@@ -637,7 +637,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		}
 		ins := m.allocateInstr()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		ins.asVecMisc(vecOpFcvtl, rd, rn, vecArrangement2S)
 		m.insert(ins)
 	case ssa.OpcodeFvdemote:
@@ -647,14 +647,14 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		}
 		ins := m.allocateInstr()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 		ins.asVecMisc(vecOpFcvtn, rd, rn, vecArrangement2S)
 		m.insert(ins)
 	case ssa.OpcodeExtractlane:
 		x, index, signed, lane := instr.ExtractlaneData()
 
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
 		mov := m.allocateInstr()
 		switch lane {
@@ -680,12 +680,12 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x, y, index, lane := instr.InsertlaneData()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
-		tmpReg := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+		rd := m.compiler.VRegOf(instr.Return())
+		tmpReg := m.compiler.AllocateVReg(ssa.TypeV128)
 
 		// Initially mov rn to tmp.
 		mov1 := m.allocateInstr()
-		mov1.asFpuMov128(tmpReg.nr(), rn.nr())
+		mov1.asFpuMov128(tmpReg, rn.nr())
 		m.insert(mov1)
 
 		// movToVec and vecMovElement do not clear the remaining bits to zero,
@@ -709,14 +709,14 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 
 		// Finally mov tmp to rd.
 		mov3 := m.allocateInstr()
-		mov3.asFpuMov128(rd.nr(), tmpReg.nr())
+		mov3.asFpuMov128(rd, tmpReg)
 		m.insert(mov3)
 
 	case ssa.OpcodeSwizzle:
 		x, y, lane := instr.Arg2WithLane()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
 		arr := ssaLaneToArrangement(lane)
 
@@ -729,14 +729,14 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		x, y, lane1, lane2 := instr.ShuffleData()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 		rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
 		m.lowerShuffle(rd, rn, rm, lane1, lane2)
 
 	case ssa.OpcodeSplat:
 		x, lane := instr.ArgWithLane()
 		rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
+		rd := m.compiler.VRegOf(instr.Return())
 
 		dup := m.allocateInstr()
 		switch lane {
@@ -760,12 +760,12 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		xx, yy := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone),
 			m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
 		tmp, tmp2 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128)), operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
-		m.insert(m.allocateInstr().asVecRRR(vecOpSmull, tmp, xx, yy, vecArrangement8H))
-		m.insert(m.allocateInstr().asVecRRR(vecOpSmull2, tmp2, xx, yy, vecArrangement8H))
-		m.insert(m.allocateInstr().asVecRRR(vecOpAddp, tmp, tmp, tmp2, vecArrangement4S))
+		m.insert(m.allocateInstr().asVecRRR(vecOpSmull, tmp.nr(), xx, yy, vecArrangement8H))
+		m.insert(m.allocateInstr().asVecRRR(vecOpSmull2, tmp2.nr(), xx, yy, vecArrangement8H))
+		m.insert(m.allocateInstr().asVecRRR(vecOpAddp, tmp.nr(), tmp, tmp2, vecArrangement4S))
 
-		rd := operandNR(m.compiler.VRegOf(instr.Return()))
-		m.insert(m.allocateInstr().asFpuMov128(rd.nr(), tmp.nr()))
+		rd := m.compiler.VRegOf(instr.Return())
+		m.insert(m.allocateInstr().asFpuMov128(rd, tmp.nr()))
 
 	case ssa.OpcodeLoadSplat:
 		ptr, offset, lane := instr.LoadSplatData()
@@ -794,7 +794,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 	m.executableContext.FlushPendingInstructions()
 }
 
-func (m *machine) lowerShuffle(rd, rn, rm operand, lane1, lane2 uint64) {
+func (m *machine) lowerShuffle(rd regalloc.VReg, rn, rm operand, lane1, lane2 uint64) {
 	// `tbl2` requires 2 consecutive registers, so we arbitrarily pick v29, v30.
 	vReg, wReg := v29VReg, v30VReg
 
@@ -822,7 +822,7 @@ func (m *machine) lowerShuffle(rd, rn, rm operand, lane1, lane2 uint64) {
 	m.insert(tbl2)
 }
 
-func (m *machine) lowerVShift(op ssa.Opcode, rd, rn, rm operand, arr vecArrangement) {
+func (m *machine) lowerVShift(op ssa.Opcode, rd regalloc.VReg, rn, rm operand, arr vecArrangement) {
 	var modulo byte
 	switch arr {
 	case vecArrangement16B:
@@ -847,13 +847,13 @@ func (m *machine) lowerVShift(op ssa.Opcode, rd, rn, rm operand, arr vecArrangem
 	if op != ssa.OpcodeVIshl {
 		// Negate the amount to make this as right shift.
 		neg := m.allocateInstr()
-		neg.asALU(aluOpSub, rtmp, operandNR(xzrVReg), rtmp, true)
+		neg.asALU(aluOpSub, rtmp.nr(), operandNR(xzrVReg), rtmp, true)
 		m.insert(neg)
 	}
 
 	// Copy the shift amount into a vector register as sshl/ushl requires it to be there.
 	dup := m.allocateInstr()
-	dup.asVecDup(vtmp, rtmp, arr)
+	dup.asVecDup(vtmp.nr(), rtmp, arr)
 	m.insert(dup)
 
 	if op == ssa.OpcodeVIshl || op == ssa.OpcodeVSshr {
@@ -867,7 +867,7 @@ func (m *machine) lowerVShift(op ssa.Opcode, rd, rn, rm operand, arr vecArrangem
 	}
 }
 
-func (m *machine) lowerVcheckTrue(op ssa.Opcode, rm, rd operand, arr vecArrangement) {
+func (m *machine) lowerVcheckTrue(op ssa.Opcode, rm operand, rd regalloc.VReg, arr vecArrangement) {
 	tmp := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
 
 	// Special case VallTrue for i64x2.
@@ -878,11 +878,11 @@ func (m *machine) lowerVcheckTrue(op ssa.Opcode, rm, rd operand, arr vecArrangem
 		//	cset dst, eq
 
 		ins := m.allocateInstr()
-		ins.asVecMisc(vecOpCmeq0, tmp, rm, vecArrangement2D)
+		ins.asVecMisc(vecOpCmeq0, tmp.nr(), rm, vecArrangement2D)
 		m.insert(ins)
 
 		addp := m.allocateInstr()
-		addp.asVecRRR(vecOpAddp, tmp, tmp, tmp, vecArrangement2D)
+		addp.asVecRRR(vecOpAddp, tmp.nr(), tmp, tmp, vecArrangement2D)
 		m.insert(addp)
 
 		fcmp := m.allocateInstr()
@@ -890,7 +890,7 @@ func (m *machine) lowerVcheckTrue(op ssa.Opcode, rm, rd operand, arr vecArrangem
 		m.insert(fcmp)
 
 		cset := m.allocateInstr()
-		cset.asCSet(rd.nr(), false, eq)
+		cset.asCSet(rd, false, eq)
 		m.insert(cset)
 
 		return
@@ -900,10 +900,10 @@ func (m *machine) lowerVcheckTrue(op ssa.Opcode, rm, rd operand, arr vecArrangem
 	ins := m.allocateInstr()
 	if op == ssa.OpcodeVanyTrue {
 		// 	umaxp v4?.16b, v2?.16b, v2?.16b
-		ins.asVecRRR(vecOpUmaxp, tmp, rm, rm, vecArrangement16B)
+		ins.asVecRRR(vecOpUmaxp, tmp.nr(), rm, rm, vecArrangement16B)
 	} else {
 		// 	uminv d4?, v2?.4s
-		ins.asVecLanes(vecOpUminv, tmp, rm, arr)
+		ins.asVecLanes(vecOpUminv, tmp.nr(), rm, arr)
 	}
 	m.insert(ins)
 
@@ -917,15 +917,15 @@ func (m *machine) lowerVcheckTrue(op ssa.Opcode, rm, rd operand, arr vecArrangem
 	m.insert(movv)
 
 	fc := m.allocateInstr()
-	fc.asCCmpImm(rd, uint64(0), al, 0, true)
+	fc.asCCmpImm(operandNR(rd), uint64(0), al, 0, true)
 	m.insert(fc)
 
 	cset := m.allocateInstr()
-	cset.asCSet(rd.nr(), false, ne)
+	cset.asCSet(rd, false, ne)
 	m.insert(cset)
 }
 
-func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
+func (m *machine) lowerVhighBits(rm operand, rd regalloc.VReg, arr vecArrangement) {
 	r0 := operandNR(m.compiler.AllocateVReg(ssa.TypeI64))
 	v0 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
 	v1 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
@@ -947,7 +947,7 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 		// Right arithmetic shift on the original vector and store the result into v1. So we have:
 		// v1[i] = 0xff if vi<0, 0 otherwise.
 		sshr := m.allocateInstr()
-		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(7), vecArrangement16B)
+		sshr.asVecShiftImm(vecOpSshr, v1.nr(), rm, operandShiftImm(7), vecArrangement16B)
 		m.insert(sshr)
 
 		// Load the bit mask into r0.
@@ -958,7 +958,7 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 
 		// dup r0 to v0.
 		dup := m.allocateInstr()
-		dup.asVecDup(v0, r0, vecArrangement2D)
+		dup.asVecDup(v0.nr(), r0, vecArrangement2D)
 		m.insert(dup)
 
 		// Lane-wise logical AND with the bit mask, meaning that we have
@@ -967,23 +967,23 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 		// Below, we use the following notation:
 		// wi := (1 << i) if vi<0, 0 otherwise.
 		and := m.allocateInstr()
-		and.asVecRRR(vecOpAnd, v1, v1, v0, vecArrangement16B)
+		and.asVecRRR(vecOpAnd, v1.nr(), v1, v0, vecArrangement16B)
 		m.insert(and)
 
 		// Swap the lower and higher 8 byte elements, and write it into v0, meaning that we have
 		// v0[i] = w(i+8) if i < 8, w(i-8) otherwise.
 		ext := m.allocateInstr()
-		ext.asVecExtract(v0, v1, v1, vecArrangement16B, uint32(8))
+		ext.asVecExtract(v0.nr(), v1, v1, vecArrangement16B, uint32(8))
 		m.insert(ext)
 
 		// v = [w0, w8, ..., w7, w15]
 		zip1 := m.allocateInstr()
-		zip1.asVecPermute(vecOpZip1, v0, v1, v0, vecArrangement16B)
+		zip1.asVecPermute(vecOpZip1, v0.nr(), v1, v0, vecArrangement16B)
 		m.insert(zip1)
 
 		// v.h[0] = w0 + ... + w15
 		addv := m.allocateInstr()
-		addv.asVecLanes(vecOpAddv, v0, v0, vecArrangement8H)
+		addv.asVecLanes(vecOpAddv, v0.nr(), v0, vecArrangement8H)
 		m.insert(addv)
 
 		// Extract the v.h[0] as the result.
@@ -1006,7 +1006,7 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 		// Right arithmetic shift on the original vector and store the result into v1. So we have:
 		// v[i] = 0xffff if vi<0, 0 otherwise.
 		sshr := m.allocateInstr()
-		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(15), vecArrangement8H)
+		sshr.asVecShiftImm(vecOpSshr, v1.nr(), rm, operandShiftImm(15), vecArrangement8H)
 		m.insert(sshr)
 
 		// Load the bit mask into r0.
@@ -1014,26 +1014,26 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 
 		// dup r0 to vector v0.
 		dup := m.allocateInstr()
-		dup.asVecDup(v0, r0, vecArrangement2D)
+		dup.asVecDup(v0.nr(), r0, vecArrangement2D)
 		m.insert(dup)
 
 		lsl := m.allocateInstr()
-		lsl.asALUShift(aluOpLsl, r0, r0, operandShiftImm(4), true)
+		lsl.asALUShift(aluOpLsl, r0.nr(), r0, operandShiftImm(4), true)
 		m.insert(lsl)
 
 		movv := m.allocateInstr()
-		movv.asMovToVec(v0, r0, vecArrangementD, vecIndex(1))
+		movv.asMovToVec(v0.nr(), r0, vecArrangementD, vecIndex(1))
 		m.insert(movv)
 
 		// Lane-wise logical AND with the bitmask, meaning that we have
 		// v[i] = (1 << i)     if vi<0, 0 otherwise for i=0..3
 		//      = (1 << (i+4)) if vi<0, 0 otherwise for i=3..7
 		and := m.allocateInstr()
-		and.asVecRRR(vecOpAnd, v0, v1, v0, vecArrangement16B)
+		and.asVecRRR(vecOpAnd, v0.nr(), v1, v0, vecArrangement16B)
 		m.insert(and)
 
 		addv := m.allocateInstr()
-		addv.asVecLanes(vecOpAddv, v0, v0, vecArrangement8H)
+		addv.asVecLanes(vecOpAddv, v0.nr(), v0, vecArrangement8H)
 		m.insert(addv)
 
 		movfv := m.allocateInstr()
@@ -1055,7 +1055,7 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 		// Right arithmetic shift on the original vector and store the result into v1. So we have:
 		// v[i] = 0xffffffff if vi<0, 0 otherwise.
 		sshr := m.allocateInstr()
-		sshr.asVecShiftImm(vecOpSshr, v1, rm, operandShiftImm(31), vecArrangement4S)
+		sshr.asVecShiftImm(vecOpSshr, v1.nr(), rm, operandShiftImm(31), vecArrangement4S)
 		m.insert(sshr)
 
 		// Load the bit mask into r0.
@@ -1063,26 +1063,26 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 
 		// dup r0 to vector v0.
 		dup := m.allocateInstr()
-		dup.asVecDup(v0, r0, vecArrangement2D)
+		dup.asVecDup(v0.nr(), r0, vecArrangement2D)
 		m.insert(dup)
 
 		lsl := m.allocateInstr()
-		lsl.asALUShift(aluOpLsl, r0, r0, operandShiftImm(2), true)
+		lsl.asALUShift(aluOpLsl, r0.nr(), r0, operandShiftImm(2), true)
 		m.insert(lsl)
 
 		movv := m.allocateInstr()
-		movv.asMovToVec(v0, r0, vecArrangementD, vecIndex(1))
+		movv.asMovToVec(v0.nr(), r0, vecArrangementD, vecIndex(1))
 		m.insert(movv)
 
 		// Lane-wise logical AND with the bitmask, meaning that we have
 		// v[i] = (1 << i)     if vi<0, 0 otherwise for i in [0, 1]
 		//      = (1 << (i+4)) if vi<0, 0 otherwise for i in [2, 3]
 		and := m.allocateInstr()
-		and.asVecRRR(vecOpAnd, v0, v1, v0, vecArrangement16B)
+		and.asVecRRR(vecOpAnd, v0.nr(), v1, v0, vecArrangement16B)
 		m.insert(and)
 
 		addv := m.allocateInstr()
-		addv.asVecLanes(vecOpAddv, v0, v0, vecArrangement4S)
+		addv.asVecLanes(vecOpAddv, v0.nr(), v0, vecArrangement4S)
 		m.insert(addv)
 
 		movfv := m.allocateInstr()
@@ -1102,21 +1102,21 @@ func (m *machine) lowerVhighBits(rm, rd operand, arr vecArrangement) {
 
 		// Move the higher 64-bit int into r0.
 		movv1 := m.allocateInstr()
-		movv1.asMovFromVec(r0, rm, vecArrangementD, vecIndex(1), false)
+		movv1.asMovFromVec(r0.nr(), rm, vecArrangementD, vecIndex(1), false)
 		m.insert(movv1)
 
 		// Move the sign bit into the least significant bit.
 		lsr1 := m.allocateInstr()
-		lsr1.asALUShift(aluOpLsr, r0, r0, operandShiftImm(63), true)
+		lsr1.asALUShift(aluOpLsr, r0.nr(), r0, operandShiftImm(63), true)
 		m.insert(lsr1)
 
 		lsr2 := m.allocateInstr()
-		lsr2.asALUShift(aluOpLsr, rd, rd, operandShiftImm(63), true)
+		lsr2.asALUShift(aluOpLsr, rd, operandNR(rd), operandShiftImm(63), true)
 		m.insert(lsr2)
 
 		// rd = (r0<<1) | rd
 		lsl := m.allocateInstr()
-		lsl.asALU(aluOpAdd, rd, rd, operandSR(r0.nr(), 1, shiftOpLSL), false)
+		lsl.asALU(aluOpAdd, rd, operandNR(rd), operandSR(r0.nr(), 1, shiftOpLSL), false)
 		m.insert(lsl)
 	default:
 		panic("Unsupported " + arr.String())
@@ -1128,7 +1128,7 @@ func (m *machine) lowerVecMisc(op vecOp, instr *ssa.Instruction) {
 	arr := ssaLaneToArrangement(lane)
 	ins := m.allocateInstr()
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
-	rd := operandNR(m.compiler.VRegOf(instr.Return()))
+	rd := m.compiler.VRegOf(instr.Return())
 	ins.asVecMisc(op, rd, rn, arr)
 	m.insert(ins)
 }
@@ -1137,22 +1137,22 @@ func (m *machine) lowerVecRRR(op vecOp, x, y, ret ssa.Value, arr vecArrangement)
 	ins := m.allocateInstr()
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 	rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-	rd := operandNR(m.compiler.VRegOf(ret))
+	rd := m.compiler.VRegOf(ret)
 	ins.asVecRRR(op, rd, rn, rm, arr)
 	m.insert(ins)
 }
 
-func (m *machine) lowerVIMul(rd, rn, rm operand, arr vecArrangement) {
+func (m *machine) lowerVIMul(rd regalloc.VReg, rn, rm operand, arr vecArrangement) {
 	if arr != vecArrangement2D {
 		mul := m.allocateInstr()
 		mul.asVecRRR(vecOpMul, rd, rn, rm, arr)
 		m.insert(mul)
 	} else {
-		tmp1 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
-		tmp2 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
-		tmp3 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+		tmp1 := m.compiler.AllocateVReg(ssa.TypeV128)
+		tmp2 := m.compiler.AllocateVReg(ssa.TypeV128)
+		tmp3 := m.compiler.AllocateVReg(ssa.TypeV128)
 
-		tmpRes := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+		tmpRes := m.compiler.AllocateVReg(ssa.TypeV128)
 
 		// Following the algorithm in https://chromium-review.googlesource.com/c/v8/v8/+/1781696
 		rev64 := m.allocateInstr()
@@ -1160,7 +1160,7 @@ func (m *machine) lowerVIMul(rd, rn, rm operand, arr vecArrangement) {
 		m.insert(rev64)
 
 		mul := m.allocateInstr()
-		mul.asVecRRR(vecOpMul, tmp2, tmp2, rn, vecArrangement4S)
+		mul.asVecRRR(vecOpMul, tmp2, operandNR(tmp2), rn, vecArrangement4S)
 		m.insert(mul)
 
 		xtn1 := m.allocateInstr()
@@ -1168,7 +1168,7 @@ func (m *machine) lowerVIMul(rd, rn, rm operand, arr vecArrangement) {
 		m.insert(xtn1)
 
 		addp := m.allocateInstr()
-		addp.asVecRRR(vecOpAddp, tmp2, tmp2, tmp2, vecArrangement4S)
+		addp.asVecRRR(vecOpAddp, tmp2, operandNR(tmp2), operandNR(tmp2), vecArrangement4S)
 		m.insert(addp)
 
 		xtn2 := m.allocateInstr()
@@ -1179,15 +1179,15 @@ func (m *machine) lowerVIMul(rd, rn, rm operand, arr vecArrangement) {
 		// In short, in UMLAL instruction, the result register is also one of the source register, and
 		// the value on the result register is significant.
 		shll := m.allocateInstr()
-		shll.asVecMisc(vecOpShll, tmpRes, tmp2, vecArrangement2S)
+		shll.asVecMisc(vecOpShll, tmpRes, operandNR(tmp2), vecArrangement2S)
 		m.insert(shll)
 
 		umlal := m.allocateInstr()
-		umlal.asVecRRRRewrite(vecOpUmlal, tmpRes, tmp3, tmp1, vecArrangement2S)
+		umlal.asVecRRRRewrite(vecOpUmlal, tmpRes, operandNR(tmp3), operandNR(tmp1), vecArrangement2S)
 		m.insert(umlal)
 
 		mov := m.allocateInstr()
-		mov.asFpuMov128(rd.nr(), tmpRes.nr())
+		mov.asFpuMov128(rd, tmpRes)
 		m.insert(mov)
 	}
 }
@@ -1203,7 +1203,7 @@ func (m *machine) lowerVMinMaxPseudo(instr *ssa.Instruction, max bool) {
 	// BSL modifies the destination register, so we need to use a temporary register so that
 	// the actual definition of the destination register happens *after* the BSL instruction.
 	// That way, we can force the spill instruction to be inserted after the BSL instruction.
-	tmp := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+	tmp := m.compiler.AllocateVReg(ssa.TypeV128)
 
 	fcmgt := m.allocateInstr()
 	if max {
@@ -1220,11 +1220,11 @@ func (m *machine) lowerVMinMaxPseudo(instr *ssa.Instruction, max bool) {
 
 	res := operandNR(m.compiler.VRegOf(instr.Return()))
 	mov2 := m.allocateInstr()
-	mov2.asFpuMov128(res.nr(), tmp.nr())
+	mov2.asFpuMov128(res.nr(), tmp)
 	m.insert(mov2)
 }
 
-func (m *machine) lowerIRem(execCtxVReg regalloc.VReg, rd operand, rn regalloc.VReg, rm operand, _64bit, signed bool) {
+func (m *machine) lowerIRem(execCtxVReg regalloc.VReg, rd, rn regalloc.VReg, rm operand, _64bit, signed bool) {
 	div := m.allocateInstr()
 
 	if signed {
@@ -1239,11 +1239,11 @@ func (m *machine) lowerIRem(execCtxVReg regalloc.VReg, rd operand, rn regalloc.V
 
 	// rd = rn-rd*rm by MSUB instruction.
 	msub := m.allocateInstr()
-	msub.asALURRRR(aluOpMSub, rd, rd, rm, rn, _64bit)
+	msub.asALURRRR(aluOpMSub, rd, operandNR(rd), rm, rn, _64bit)
 	m.insert(msub)
 }
 
-func (m *machine) lowerIDiv(execCtxVReg regalloc.VReg, rd, rn, rm operand, _64bit, signed bool) {
+func (m *machine) lowerIDiv(execCtxVReg, rd regalloc.VReg, rn, rm operand, _64bit, signed bool) {
 	div := m.allocateInstr()
 
 	if signed {
@@ -1260,7 +1260,7 @@ func (m *machine) lowerIDiv(execCtxVReg regalloc.VReg, rd, rn, rm operand, _64bi
 		// We need to check the signed overflow which happens iff "math.MinInt{32,64} / -1"
 		minusOneCheck := m.allocateInstr()
 		// Sets eq condition if rm == -1.
-		minusOneCheck.asALU(aluOpAddS, operandNR(xzrVReg), rm, operandImm12(1, 0), _64bit)
+		minusOneCheck.asALU(aluOpAddS, xzrVReg, rm, operandImm12(1, 0), _64bit)
 		m.insert(minusOneCheck)
 
 		ccmp := m.allocateInstr()
@@ -1290,20 +1290,20 @@ func (m *machine) exitIfNot(execCtxVReg regalloc.VReg, c cond, cond64bit bool, c
 func (m *machine) lowerFcopysign(x, y, ret ssa.Value) {
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 	rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-	var tmpI, tmpF operand
+	var tmpI, tmpF regalloc.VReg
 	_64 := x.Type() == ssa.TypeF64
 	if _64 {
-		tmpF = operandNR(m.compiler.AllocateVReg(ssa.TypeF64))
-		tmpI = operandNR(m.compiler.AllocateVReg(ssa.TypeI64))
+		tmpF = m.compiler.AllocateVReg(ssa.TypeF64)
+		tmpI = m.compiler.AllocateVReg(ssa.TypeI64)
 	} else {
-		tmpF = operandNR(m.compiler.AllocateVReg(ssa.TypeF32))
-		tmpI = operandNR(m.compiler.AllocateVReg(ssa.TypeI32))
+		tmpF = m.compiler.AllocateVReg(ssa.TypeF32)
+		tmpI = m.compiler.AllocateVReg(ssa.TypeI32)
 	}
 	rd := m.compiler.VRegOf(ret)
-	m.lowerFcopysignImpl(operandNR(rd), rn, rm, tmpI, tmpF, _64)
+	m.lowerFcopysignImpl(rd, rn, rm, tmpI, tmpF, _64)
 }
 
-func (m *machine) lowerFcopysignImpl(rd, rn, rm, tmpI, tmpF operand, _64bit bool) {
+func (m *machine) lowerFcopysignImpl(rd regalloc.VReg, rn, rm operand, tmpI, tmpF regalloc.VReg, _64bit bool) {
 	// This is exactly the same code emitted by GCC for "__builtin_copysign":
 	//
 	//    mov     x0, -9223372036854775808
@@ -1313,26 +1313,26 @@ func (m *machine) lowerFcopysignImpl(rd, rn, rm, tmpI, tmpF operand, _64bit bool
 
 	setMSB := m.allocateInstr()
 	if _64bit {
-		m.lowerConstantI64(tmpI.nr(), math.MinInt64)
-		setMSB.asMovToVec(tmpF, tmpI, vecArrangementD, vecIndex(0))
+		m.lowerConstantI64(tmpI, math.MinInt64)
+		setMSB.asMovToVec(tmpF, operandNR(tmpI), vecArrangementD, vecIndex(0))
 	} else {
-		m.lowerConstantI32(tmpI.nr(), math.MinInt32)
-		setMSB.asMovToVec(tmpF, tmpI, vecArrangementS, vecIndex(0))
+		m.lowerConstantI32(tmpI, math.MinInt32)
+		setMSB.asMovToVec(tmpF, operandNR(tmpI), vecArrangementS, vecIndex(0))
 	}
 	m.insert(setMSB)
 
-	tmpReg := operandNR(m.compiler.AllocateVReg(ssa.TypeF64))
+	tmpReg := m.compiler.AllocateVReg(ssa.TypeF64)
 
 	mov := m.allocateInstr()
-	mov.asFpuMov64(tmpReg.nr(), rn.nr())
+	mov.asFpuMov64(tmpReg, rn.nr())
 	m.insert(mov)
 
 	vbit := m.allocateInstr()
-	vbit.asVecRRRRewrite(vecOpBit, tmpReg, rm, tmpF, vecArrangement8B)
+	vbit.asVecRRRRewrite(vecOpBit, tmpReg, rm, operandNR(tmpF), vecArrangement8B)
 	m.insert(vbit)
 
 	movDst := m.allocateInstr()
-	movDst.asFpuMov64(rd.nr(), tmpReg.nr())
+	movDst.asFpuMov64(rd, tmpReg)
 	m.insert(movDst)
 }
 
@@ -1340,7 +1340,7 @@ func (m *machine) lowerBitcast(instr *ssa.Instruction) {
 	v, dstType := instr.BitcastData()
 	srcType := v.Type()
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(v), extModeNone)
-	rd := operandNR(m.compiler.VRegOf(instr.Return()))
+	rd := m.compiler.VRegOf(instr.Return())
 	srcInt := srcType.IsInt()
 	dstInt := dstType.IsInt()
 	switch {
@@ -1371,14 +1371,14 @@ func (m *machine) lowerBitcast(instr *ssa.Instruction) {
 
 func (m *machine) lowerFpuUniOp(op fpuUniOp, in, out ssa.Value) {
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(in), extModeNone)
-	rd := operandNR(m.compiler.VRegOf(out))
+	rd := m.compiler.VRegOf(out)
 
 	neg := m.allocateInstr()
 	neg.asFpuRR(op, rd, rn, in.Type().Bits() == 64)
 	m.insert(neg)
 }
 
-func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64bit, dst64bit, nonTrapping bool) {
+func (m *machine) lowerFpuToInt(rd regalloc.VReg, rn operand, ctx regalloc.VReg, signed, src64bit, dst64bit, nonTrapping bool) {
 	if !nonTrapping {
 		// First of all, we have to clear the FPU flags.
 		flagClear := m.allocateInstr()
@@ -1405,7 +1405,7 @@ func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64
 		// Check if the conversion was undefined by comparing the status with 1.
 		// See https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/FPSR--Floating-point-Status-Register
 		alu := m.allocateInstr()
-		alu.asALU(aluOpSubS, operandNR(xzrVReg), operandNR(tmpReg), operandImm12(1, 0), true)
+		alu.asALU(aluOpSubS, xzrVReg, operandNR(tmpReg), operandImm12(1, 0), true)
 		m.insert(alu)
 
 		// If it is not undefined, we can return the result.
@@ -1429,7 +1429,7 @@ func (m *machine) lowerFpuToInt(rd, rn operand, ctx regalloc.VReg, signed, src64
 	}
 }
 
-func (m *machine) lowerIntToFpu(rd, rn operand, signed, src64bit, dst64bit bool) {
+func (m *machine) lowerIntToFpu(rd regalloc.VReg, rn operand, signed, src64bit, dst64bit bool) {
 	cvt := m.allocateInstr()
 	cvt.asIntToFpu(rd, rn, signed, src64bit, dst64bit)
 	m.insert(cvt)
@@ -1456,7 +1456,7 @@ func (m *machine) lowerFpuBinOp(si *ssa.Instruction) {
 	xDef, yDef := m.compiler.ValueDefinition(x), m.compiler.ValueDefinition(y)
 	rn := m.getOperand_NR(xDef, extModeNone)
 	rm := m.getOperand_NR(yDef, extModeNone)
-	rd := operandNR(m.compiler.VRegOf(si.Return()))
+	rd := m.compiler.VRegOf(si.Return())
 	instr.asFpuRRR(op, rd, rn, rm, x.Type().Bits() == 64)
 	m.insert(instr)
 }
@@ -1482,7 +1482,7 @@ func (m *machine) lowerSubOrAdd(si *ssa.Instruction, add bool) {
 	case !add && yNegated: // rn+rm = x-(-y) = x-y
 		aop = aluOpAdd
 	}
-	rd := operandNR(m.compiler.VRegOf(si.Return()))
+	rd := m.compiler.VRegOf(si.Return())
 	alu := m.allocateInstr()
 	alu.asALU(aop, rd, rn, rm, x.Type().Bits() == 64)
 	m.insert(alu)
@@ -1527,7 +1527,7 @@ func (m *machine) lowerIcmp(si *ssa.Instruction) {
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), ext)
 	rm := m.getOperand_Imm12_ER_SR_NR(m.compiler.ValueDefinition(y), ext)
 	alu := m.allocateInstr()
-	alu.asALU(aluOpSubS, operandNR(xzrVReg), rn, rm, in64bit)
+	alu.asALU(aluOpSubS, xzrVReg, rn, rm, in64bit)
 	m.insert(alu)
 
 	cset := m.allocateInstr()
@@ -1542,7 +1542,7 @@ func (m *machine) lowerVIcmp(si *ssa.Instruction) {
 
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 	rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-	rd := operandNR(m.compiler.VRegOf(si.Return()))
+	rd := m.compiler.VRegOf(si.Return())
 
 	switch flag {
 	case eq:
@@ -1554,7 +1554,7 @@ func (m *machine) lowerVIcmp(si *ssa.Instruction) {
 		cmp.asVecRRR(vecOpCmeq, rd, rn, rm, arr)
 		m.insert(cmp)
 		not := m.allocateInstr()
-		not.asVecMisc(vecOpNot, rd, rd, vecArrangement16B)
+		not.asVecMisc(vecOpNot, rd, operandNR(rd), vecArrangement16B)
 		m.insert(not)
 	case ge:
 		cmp := m.allocateInstr()
@@ -1598,7 +1598,7 @@ func (m *machine) lowerVFcmp(si *ssa.Instruction) {
 
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 	rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-	rd := operandNR(m.compiler.VRegOf(si.Return()))
+	rd := m.compiler.VRegOf(si.Return())
 
 	switch flag {
 	case eq:
@@ -1610,7 +1610,7 @@ func (m *machine) lowerVFcmp(si *ssa.Instruction) {
 		cmp.asVecRRR(vecOpFcmeq, rd, rn, rm, arr)
 		m.insert(cmp)
 		not := m.allocateInstr()
-		not.asVecMisc(vecOpNot, rd, rd, vecArrangement16B)
+		not.asVecMisc(vecOpNot, rd, operandNR(rd), vecArrangement16B)
 		m.insert(not)
 	case ge:
 		cmp := m.allocateInstr()
@@ -1631,7 +1631,7 @@ func (m *machine) lowerVFcmp(si *ssa.Instruction) {
 	}
 }
 
-func (m *machine) lowerVfpuToInt(rd, rn operand, arr vecArrangement, signed bool) {
+func (m *machine) lowerVfpuToInt(rd regalloc.VReg, rn operand, arr vecArrangement, signed bool) {
 	cvt := m.allocateInstr()
 	if signed {
 		cvt.asVecMisc(vecOpFcvtzs, rd, rn, arr)
@@ -1643,15 +1643,15 @@ func (m *machine) lowerVfpuToInt(rd, rn operand, arr vecArrangement, signed bool
 	if arr == vecArrangement2D {
 		narrow := m.allocateInstr()
 		if signed {
-			narrow.asVecMisc(vecOpSqxtn, rd, rd, vecArrangement2S)
+			narrow.asVecMisc(vecOpSqxtn, rd, operandNR(rd), vecArrangement2S)
 		} else {
-			narrow.asVecMisc(vecOpUqxtn, rd, rd, vecArrangement2S)
+			narrow.asVecMisc(vecOpUqxtn, rd, operandNR(rd), vecArrangement2S)
 		}
 		m.insert(narrow)
 	}
 }
 
-func (m *machine) lowerVfpuFromInt(rd, rn operand, arr vecArrangement, signed bool) {
+func (m *machine) lowerVfpuFromInt(rd regalloc.VReg, rn operand, arr vecArrangement, signed bool) {
 	cvt := m.allocateInstr()
 	if signed {
 		cvt.asVecMisc(vecOpScvtf, rd, rn, arr)
@@ -1665,7 +1665,7 @@ func (m *machine) lowerShifts(si *ssa.Instruction, ext extMode, aluOp aluOp) {
 	x, amount := si.Arg2()
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), ext)
 	rm := m.getOperand_ShiftImm_NR(m.compiler.ValueDefinition(amount), ext, x.Type().Bits())
-	rd := operandNR(m.compiler.VRegOf(si.Return()))
+	rd := m.compiler.VRegOf(si.Return())
 
 	alu := m.allocateInstr()
 	alu.asALUShift(aluOp, rd, rn, rm, x.Type().Bits() == 64)
@@ -1678,11 +1678,11 @@ func (m *machine) lowerBitwiseAluOp(si *ssa.Instruction, op aluOp, ignoreResult 
 	xDef, yDef := m.compiler.ValueDefinition(x), m.compiler.ValueDefinition(y)
 	rn := m.getOperand_NR(xDef, extModeNone)
 
-	var rd operand
+	var rd regalloc.VReg
 	if ignoreResult {
-		rd = operandNR(xzrVReg)
+		rd = xzrVReg
 	} else {
-		rd = operandNR(m.compiler.VRegOf(si.Return()))
+		rd = m.compiler.VRegOf(si.Return())
 	}
 
 	_64 := x.Type().Bits() == 64
@@ -1691,7 +1691,7 @@ func (m *machine) lowerBitwiseAluOp(si *ssa.Instruction, op aluOp, ignoreResult 
 		c := instr.ConstantVal()
 		if isBitMaskImmediate(c, _64) {
 			// Constant bit wise operations can be lowered to a single instruction.
-			alu.asALUBitmaskImm(op, rd.nr(), rn.nr(), c, _64)
+			alu.asALUBitmaskImm(op, rd, rn.nr(), c, _64)
 			m.insert(alu)
 			return
 		}
@@ -1709,25 +1709,25 @@ func (m *machine) lowerRotl(si *ssa.Instruction) {
 
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 	rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
-	var tmp operand
+	var tmp regalloc.VReg
 	if _64 {
-		tmp = operandNR(m.compiler.AllocateVReg(ssa.TypeI64))
+		tmp = m.compiler.AllocateVReg(ssa.TypeI64)
 	} else {
-		tmp = operandNR(m.compiler.AllocateVReg(ssa.TypeI32))
+		tmp = m.compiler.AllocateVReg(ssa.TypeI32)
 	}
-	rd := operandNR(m.compiler.VRegOf(r))
+	rd := m.compiler.VRegOf(r)
 
 	// Encode rotl as neg + rotr: neg is a sub against the zero-reg.
 	m.lowerRotlImpl(rd, rn, rm, tmp, _64)
 }
 
-func (m *machine) lowerRotlImpl(rd, rn, rm, tmp operand, is64bit bool) {
+func (m *machine) lowerRotlImpl(rd regalloc.VReg, rn, rm operand, tmp regalloc.VReg, is64bit bool) {
 	// Encode rotl as neg + rotr: neg is a sub against the zero-reg.
 	neg := m.allocateInstr()
 	neg.asALU(aluOpSub, tmp, operandNR(xzrVReg), rm, is64bit)
 	m.insert(neg)
 	alu := m.allocateInstr()
-	alu.asALU(aluOpRotR, rd, rn, tmp, is64bit)
+	alu.asALU(aluOpRotR, rd, rn, operandNR(tmp), is64bit)
 	m.insert(alu)
 }
 
@@ -1737,7 +1737,7 @@ func (m *machine) lowerRotr(si *ssa.Instruction) {
 	xDef, yDef := m.compiler.ValueDefinition(x), m.compiler.ValueDefinition(y)
 	rn := m.getOperand_NR(xDef, extModeNone)
 	rm := m.getOperand_NR(yDef, extModeNone)
-	rd := operandNR(m.compiler.VRegOf(si.Return()))
+	rd := m.compiler.VRegOf(si.Return())
 
 	alu := m.allocateInstr()
 	alu.asALU(aluOpRotR, rd, rn, rm, si.Return().Type().Bits() == 64)
@@ -1797,7 +1797,7 @@ func (m *machine) lowerImul(x, y, result ssa.Value) {
 	// TODO: if this comes before Add/Sub, we could merge it by putting it into the place of xzrVReg.
 
 	mul := m.allocateInstr()
-	mul.asALURRRR(aluOpMAdd, operandNR(rd), rn, rm, xzrVReg, x.Type().Bits() == 64)
+	mul.asALURRRR(aluOpMAdd, rd, rn, rm, xzrVReg, x.Type().Bits() == 64)
 	m.insert(mul)
 }
 
@@ -1849,22 +1849,22 @@ func (m *machine) lowerPopcnt(x, result ssa.Value) {
 	//    mov x5, v0.d[0]     ;; finally we mov the result back to a GPR
 	//
 
-	rd := operandNR(m.compiler.VRegOf(result))
+	rd := m.compiler.VRegOf(result)
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 
 	rf1 := operandNR(m.compiler.AllocateVReg(ssa.TypeF64))
 	ins := m.allocateInstr()
-	ins.asMovToVec(rf1, rn, vecArrangementD, vecIndex(0))
+	ins.asMovToVec(rf1.nr(), rn, vecArrangementD, vecIndex(0))
 	m.insert(ins)
 
 	rf2 := operandNR(m.compiler.AllocateVReg(ssa.TypeF64))
 	cnt := m.allocateInstr()
-	cnt.asVecMisc(vecOpCnt, rf2, rf1, vecArrangement16B)
+	cnt.asVecMisc(vecOpCnt, rf2.nr(), rf1, vecArrangement16B)
 	m.insert(cnt)
 
 	rf3 := operandNR(m.compiler.AllocateVReg(ssa.TypeF64))
 	uaddlv := m.allocateInstr()
-	uaddlv.asVecLanes(vecOpUaddlv, rf3, rf2, vecArrangement8B)
+	uaddlv.asVecLanes(vecOpUaddlv, rf3.nr(), rf2, vecArrangement8B)
 	m.insert(uaddlv)
 
 	mov := m.allocateInstr()
@@ -1937,7 +1937,7 @@ func (m *machine) lowerIcmpToFlag(x, y ssa.Value, signed bool) {
 	alu.asALU(
 		aluOpSubS,
 		// We don't need the result, just need to set flags.
-		operandNR(xzrVReg),
+		xzrVReg,
 		rn,
 		rm,
 		x.Type().Bits() == 64,
@@ -2012,7 +2012,7 @@ func (m *machine) lowerSelect(c, x, y, result ssa.Value) {
 		alu.asALU(
 			aluOpSubS,
 			// We don't need the result, just need to set flags.
-			operandNR(xzrVReg),
+			xzrVReg,
 			rn,
 			operandNR(xzrVReg),
 			c.Type().Bits() == 64,
@@ -2024,7 +2024,7 @@ func (m *machine) lowerSelect(c, x, y, result ssa.Value) {
 	rn := m.getOperand_NR(m.compiler.ValueDefinition(x), extModeNone)
 	rm := m.getOperand_NR(m.compiler.ValueDefinition(y), extModeNone)
 
-	rd := operandNR(m.compiler.VRegOf(result))
+	rd := m.compiler.VRegOf(result)
 	switch x.Type() {
 	case ssa.TypeI32, ssa.TypeI64:
 		// csel rd, rn, rm, cc
@@ -2041,10 +2041,10 @@ func (m *machine) lowerSelect(c, x, y, result ssa.Value) {
 	}
 }
 
-func (m *machine) lowerSelectVec(rc, rn, rm, rd operand) {
+func (m *machine) lowerSelectVec(rc, rn, rm operand, rd regalloc.VReg) {
 	// First check if `rc` is zero or not.
 	checkZero := m.allocateInstr()
-	checkZero.asALU(aluOpSubS, operandNR(xzrVReg), rc, operandNR(xzrVReg), false)
+	checkZero.asALU(aluOpSubS, xzrVReg, rc, operandNR(xzrVReg), false)
 	m.insert(checkZero)
 
 	// Then use CSETM to set all bits to one if `rc` is zero.
@@ -2054,7 +2054,7 @@ func (m *machine) lowerSelectVec(rc, rn, rm, rd operand) {
 	m.insert(cset)
 
 	// Then move the bits to the result vector register.
-	tmp2 := operandNR(m.compiler.AllocateVReg(ssa.TypeV128))
+	tmp2 := m.compiler.AllocateVReg(ssa.TypeV128)
 	dup := m.allocateInstr()
 	dup.asVecDup(tmp2, operandNR(allOnesOrZero), vecArrangement2D)
 	m.insert(dup)
@@ -2067,7 +2067,7 @@ func (m *machine) lowerSelectVec(rc, rn, rm, rd operand) {
 
 	// Finally, move the result to the destination register.
 	mov2 := m.allocateInstr()
-	mov2.asFpuMov128(rd.nr(), tmp2.nr())
+	mov2.asFpuMov128(rd, tmp2)
 	m.insert(mov2)
 }
 
@@ -2099,28 +2099,28 @@ func (m *machine) lowerAtomicRmw(si *ssa.Instruction) {
 	addr, val := si.Arg2()
 	addrDef, valDef := m.compiler.ValueDefinition(addr), m.compiler.ValueDefinition(val)
 	rn := m.getOperand_NR(addrDef, extModeNone)
-	rt := operandNR(m.compiler.VRegOf(si.Return()))
+	rt := m.compiler.VRegOf(si.Return())
 	rs := m.getOperand_NR(valDef, extModeNone)
 
 	_64 := si.Return().Type().Bits() == 64
-	var tmp operand
+	var tmp regalloc.VReg
 	if _64 {
-		tmp = operandNR(m.compiler.AllocateVReg(ssa.TypeI64))
+		tmp = m.compiler.AllocateVReg(ssa.TypeI64)
 	} else {
-		tmp = operandNR(m.compiler.AllocateVReg(ssa.TypeI32))
+		tmp = m.compiler.AllocateVReg(ssa.TypeI32)
 	}
-	m.lowerAtomicRmwImpl(op, rn, rs, rt, tmp, size, negateArg, flipArg, _64)
+	m.lowerAtomicRmwImpl(op, rn.nr(), rs.nr(), rt, tmp, size, negateArg, flipArg, _64)
 }
 
-func (m *machine) lowerAtomicRmwImpl(op atomicRmwOp, rn, rs, rt, tmp operand, size uint64, negateArg, flipArg, dst64bit bool) {
+func (m *machine) lowerAtomicRmwImpl(op atomicRmwOp, rn, rs, rt, tmp regalloc.VReg, size uint64, negateArg, flipArg, dst64bit bool) {
 	switch {
 	case negateArg:
 		neg := m.allocateInstr()
-		neg.asALU(aluOpSub, tmp, operandNR(xzrVReg), rs, dst64bit)
+		neg.asALU(aluOpSub, tmp, operandNR(xzrVReg), operandNR(rs), dst64bit)
 		m.insert(neg)
 	case flipArg:
 		flip := m.allocateInstr()
-		flip.asALU(aluOpOrn, tmp, operandNR(xzrVReg), rs, dst64bit)
+		flip.asALU(aluOpOrn, tmp, operandNR(xzrVReg), operandNR(rs), dst64bit)
 		m.insert(flip)
 	default:
 		tmp = rs
@@ -2139,32 +2139,32 @@ func (m *machine) lowerAtomicCas(si *ssa.Instruction) {
 	rn := m.getOperand_NR(addrDef, extModeNone)
 	rt := m.getOperand_NR(replDef, extModeNone)
 	rs := m.getOperand_NR(expDef, extModeNone)
-	tmp := operandNR(m.compiler.AllocateVReg(si.Return().Type()))
+	tmp := m.compiler.AllocateVReg(si.Return().Type())
 
 	_64 := si.Return().Type().Bits() == 64
 	// rs is overwritten by CAS, so we need to move it to the result register before the instruction
 	// in case when it is used somewhere else.
 	mov := m.allocateInstr()
 	if _64 {
-		mov.asMove64(tmp.nr(), rs.nr())
+		mov.asMove64(tmp, rs.nr())
 	} else {
-		mov.asMove32(tmp.nr(), rs.nr())
+		mov.asMove32(tmp, rs.nr())
 	}
 	m.insert(mov)
 
-	m.lowerAtomicCasImpl(rn, tmp, rt, size)
+	m.lowerAtomicCasImpl(rn.nr(), tmp, rt.nr(), size)
 
 	mov2 := m.allocateInstr()
 	rd := m.compiler.VRegOf(si.Return())
 	if _64 {
-		mov2.asMove64(rd, tmp.nr())
+		mov2.asMove64(rd, tmp)
 	} else {
-		mov2.asMove32(rd, tmp.nr())
+		mov2.asMove32(rd, tmp)
 	}
 	m.insert(mov2)
 }
 
-func (m *machine) lowerAtomicCasImpl(rn, rs, rt operand, size uint64) {
+func (m *machine) lowerAtomicCasImpl(rn, rs, rt regalloc.VReg, size uint64) {
 	cas := m.allocateInstr()
 	cas.asAtomicCas(rn, rs, rt, size)
 	m.insert(cas)
@@ -2176,12 +2176,12 @@ func (m *machine) lowerAtomicLoad(si *ssa.Instruction) {
 
 	addrDef := m.compiler.ValueDefinition(addr)
 	rn := m.getOperand_NR(addrDef, extModeNone)
-	rt := operandNR(m.compiler.VRegOf(si.Return()))
+	rt := m.compiler.VRegOf(si.Return())
 
-	m.lowerAtomicLoadImpl(rn, rt, size)
+	m.lowerAtomicLoadImpl(rn.nr(), rt, size)
 }
 
-func (m *machine) lowerAtomicLoadImpl(rn, rt operand, size uint64) {
+func (m *machine) lowerAtomicLoadImpl(rn, rt regalloc.VReg, size uint64) {
 	ld := m.allocateInstr()
 	ld.asAtomicLoad(rn, rt, size)
 	m.insert(ld)

--- a/internal/engine/wazevo/backend/isa/arm64/lower_mem_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_mem_test.go
@@ -807,7 +807,7 @@ func TestMachine_lowerToAddressModeFromAddends(t *testing.T) {
 			}
 			actual := m.lowerToAddressModeFromAddends(&a32s, &a64s, tc.dstSizeInBits, tc.offset)
 			require.Equal(t, strings.Join(tc.insts, "\n"), formatEmittedInstructionsInCurrentBlock(m))
-			require.Equal(t, tc.exp, actual, actual.format(tc.dstSizeInBits))
+			require.Equal(t, &tc.exp, actual, actual.format(tc.dstSizeInBits))
 		})
 	}
 }

--- a/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_pro_epi_logue.go
@@ -159,7 +159,7 @@ func (m *machine) createReturnAddrAndSizeOfArgRetSlot(cur *instruction) *instruc
 		sizeOfArgRetReg = tmpRegVReg
 
 		subSp := m.allocateInstr()
-		subSp.asALU(aluOpSub, operandNR(spVReg), operandNR(spVReg), operandNR(sizeOfArgRetReg), true)
+		subSp.asALU(aluOpSub, spVReg, operandNR(spVReg), operandNR(sizeOfArgRetReg), true)
 		cur = linkInstr(cur, subSp)
 	} else {
 		sizeOfArgRetReg = xzrVReg
@@ -213,7 +213,7 @@ func (m *machine) postRegAlloc() {
 			m.executableContext.PendingInstructions = m.executableContext.PendingInstructions[:0]
 		default:
 			// Removes the redundant copy instruction.
-			if cur.IsCopy() && cur.rn.realReg() == cur.rd.realReg() {
+			if cur.IsCopy() && cur.rn.realReg() == cur.rd.RealReg() {
 				prev, next := cur.prev, cur.next
 				// Remove the copy instruction.
 				prev.next = next
@@ -293,9 +293,9 @@ func (m *machine) setupEpilogueAfter(cur *instruction) {
 			// TODO: pair loads to reduce the number of instructions.
 			switch regTypeToRegisterSizeInBits(vr.RegType()) {
 			case 64: // save int reg.
-				load.asULoad(operandNR(vr), amode, 64)
+				load.asULoad(vr, amode, 64)
 			case 128: // save vector reg.
-				load.asFpuLoad(operandNR(vr), amode, 128)
+				load.asFpuLoad(vr, amode, 128)
 			}
 			cur = linkInstr(cur, load)
 		}
@@ -317,7 +317,7 @@ func (m *machine) setupEpilogueAfter(cur *instruction) {
 	//    SP----> +-----------------+
 
 	ldr := m.allocateInstr()
-	ldr.asULoad(operandNR(lrVReg),
+	ldr.asULoad(lrVReg,
 		addressModePreOrPostIndex(spVReg, 16 /* stack pointer must be 16-byte aligned. */, false /* increment after loads */), 64)
 	cur = linkInstr(cur, ldr)
 
@@ -351,14 +351,14 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 	if immm12op, ok := asImm12Operand(uint64(requiredStackSize)); ok {
 		// sub tmp, sp, #requiredStackSize
 		sub := m.allocateInstr()
-		sub.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(spVReg), immm12op, true)
+		sub.asALU(aluOpSub, tmpRegVReg, operandNR(spVReg), immm12op, true)
 		cur = linkInstr(cur, sub)
 	} else {
 		// This case, we first load the requiredStackSize into the temporary register,
 		cur = m.lowerConstantI64AndInsert(cur, tmpRegVReg, requiredStackSize)
 		// Then subtract it.
 		sub := m.allocateInstr()
-		sub.asALU(aluOpSub, operandNR(tmpRegVReg), operandNR(spVReg), operandNR(tmpRegVReg), true)
+		sub.asALU(aluOpSub, tmpRegVReg, operandNR(spVReg), operandNR(tmpRegVReg), true)
 		cur = linkInstr(cur, sub)
 	}
 
@@ -366,7 +366,7 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 
 	// ldr tmp2, [executionContext #StackBottomPtr]
 	ldr := m.allocateInstr()
-	ldr.asULoad(operandNR(tmp2), addressMode{
+	ldr.asULoad(tmp2, addressMode{
 		kind: addressModeKindRegUnsignedImm12,
 		rn:   x0VReg, // execution context is always the first argument.
 		imm:  wazevoapi.ExecutionContextOffsetStackBottomPtr.I64(),
@@ -375,7 +375,7 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 
 	// subs xzr, tmp, tmp2
 	subs := m.allocateInstr()
-	subs.asALU(aluOpSubS, operandNR(xzrVReg), operandNR(tmpRegVReg), operandNR(tmp2), true)
+	subs.asALU(aluOpSubS, xzrVReg, operandNR(tmpRegVReg), operandNR(tmp2), true)
 	cur = linkInstr(cur, subs)
 
 	// b.ge #imm
@@ -399,7 +399,7 @@ func (m *machine) insertStackBoundsCheck(requiredStackSize int64, cur *instructi
 	}
 
 	ldrAddress := m.allocateInstr()
-	ldrAddress.asULoad(operandNR(tmpRegVReg), addressMode{
+	ldrAddress.asULoad(tmpRegVReg, addressMode{
 		kind: addressModeKindRegUnsignedImm12,
 		rn:   x0VReg, // execution context is always the first argument
 		imm:  wazevoapi.ExecutionContextOffsetStackGrowCallTrampolineAddress.I64(),

--- a/internal/engine/wazevo/backend/isa/arm64/machine_regalloc.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_regalloc.go
@@ -121,11 +121,11 @@ func (m *machine) InsertReloadRegisterAt(v regalloc.VReg, instr *instruction, af
 	load := m.allocateInstr()
 	switch typ {
 	case ssa.TypeI32, ssa.TypeI64:
-		load.asULoad(operandNR(v), amode, typ.Bits())
+		load.asULoad(v, amode, typ.Bits())
 	case ssa.TypeF32, ssa.TypeF64:
-		load.asFpuLoad(operandNR(v), amode, typ.Bits())
+		load.asFpuLoad(v, amode, typ.Bits())
 	case ssa.TypeV128:
-		load.asFpuLoad(operandNR(v), amode, 128)
+		load.asFpuLoad(v, amode, 128)
 	default:
 		panic("TODO")
 	}

--- a/internal/engine/wazevo/backend/isa/arm64/machine_regalloc.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_regalloc.go
@@ -91,7 +91,7 @@ func (m *machine) InsertStoreRegisterAt(v regalloc.VReg, instr *instruction, aft
 	}
 
 	offsetFromSP := m.getVRegSpillSlotOffsetFromSP(v.ID(), typ.Size())
-	var amode addressMode
+	var amode *addressMode
 	cur, amode = m.resolveAddressModeForOffsetAndInsert(cur, offsetFromSP, typ.Bits(), spVReg, true)
 	store := m.allocateInstr()
 	store.asStore(operandNR(v), amode, typ.Bits())
@@ -116,7 +116,7 @@ func (m *machine) InsertReloadRegisterAt(v regalloc.VReg, instr *instruction, af
 	}
 
 	offsetFromSP := m.getVRegSpillSlotOffsetFromSP(v.ID(), typ.Size())
-	var amode addressMode
+	var amode *addressMode
 	cur, amode = m.resolveAddressModeForOffsetAndInsert(cur, offsetFromSP, typ.Bits(), spVReg, true)
 	load := m.allocateInstr()
 	switch typ {

--- a/internal/engine/wazevo/backend/isa/arm64/machine_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_test.go
@@ -9,39 +9,43 @@ import (
 )
 
 func TestMachine_resolveAddressingMode(t *testing.T) {
+	m := NewBackend().(*machine)
 	t.Run("imm12/arg", func(t *testing.T) {
-		m := &machine{}
 		i := &instruction{}
-		i.asULoad(x17VReg, addressMode{
+		amode := m.amodePool.Allocate()
+		*amode = addressMode{
 			kind: addressModeKindArgStackSpace,
 			rn:   spVReg,
 			imm:  128,
-		}, 64)
+		}
+		i.asULoad(x17VReg, amode, 64)
 		m.resolveAddressingMode(1024, 0, i)
-		require.Equal(t, addressModeKindRegUnsignedImm12, i.amode.kind)
-		require.Equal(t, int64(128+1024), i.amode.imm)
+		require.Equal(t, addressModeKindRegUnsignedImm12, i.getAmode().kind)
+		require.Equal(t, int64(128+1024), i.getAmode().imm)
 	})
 	t.Run("imm12/result", func(t *testing.T) {
-		m := &machine{}
 		i := &instruction{}
-		i.asULoad(x17VReg, addressMode{
+		amode := m.amodePool.Allocate()
+		*amode = addressMode{
 			kind: addressModeKindResultStackSpace,
 			rn:   spVReg,
 			imm:  128,
-		}, 64)
+		}
+		i.asULoad(x17VReg, amode, 64)
 		m.resolveAddressingMode(0, 256, i)
-		require.Equal(t, addressModeKindRegUnsignedImm12, i.amode.kind)
-		require.Equal(t, int64(128+256), i.amode.imm)
+		require.Equal(t, addressModeKindRegUnsignedImm12, i.getAmode().kind)
+		require.Equal(t, int64(128+256), i.getAmode().imm)
 	})
 
 	t.Run("tmp reg", func(t *testing.T) {
-		m := &machine{executableContext: newExecutableContext()}
 		root := &instruction{kind: udf}
 		i := &instruction{prev: root}
-		i.asULoad(x17VReg, addressMode{
+		amode := m.amodePool.Allocate()
+		*amode = addressMode{
 			kind: addressModeKindResultStackSpace,
 			rn:   spVReg,
-		}, 64)
+		}
+		i.asULoad(x17VReg, amode, 64)
 		m.resolveAddressingMode(0, 0x40000001, i)
 
 		m.executableContext.RootInstr = root

--- a/internal/engine/wazevo/backend/isa/arm64/machine_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine_test.go
@@ -12,7 +12,7 @@ func TestMachine_resolveAddressingMode(t *testing.T) {
 	t.Run("imm12/arg", func(t *testing.T) {
 		m := &machine{}
 		i := &instruction{}
-		i.asULoad(operandNR(x17VReg), addressMode{
+		i.asULoad(x17VReg, addressMode{
 			kind: addressModeKindArgStackSpace,
 			rn:   spVReg,
 			imm:  128,
@@ -24,7 +24,7 @@ func TestMachine_resolveAddressingMode(t *testing.T) {
 	t.Run("imm12/result", func(t *testing.T) {
 		m := &machine{}
 		i := &instruction{}
-		i.asULoad(operandNR(x17VReg), addressMode{
+		i.asULoad(x17VReg, addressMode{
 			kind: addressModeKindResultStackSpace,
 			rn:   spVReg,
 			imm:  128,
@@ -38,7 +38,7 @@ func TestMachine_resolveAddressingMode(t *testing.T) {
 		m := &machine{executableContext: newExecutableContext()}
 		root := &instruction{kind: udf}
 		i := &instruction{prev: root}
-		i.asULoad(operandNR(x17VReg), addressMode{
+		i.asULoad(x17VReg, addressMode{
 			kind: addressModeKindResultStackSpace,
 			rn:   spVReg,
 		}, 64)


### PR DESCRIPTION
This makes arm64's instruction data structure smaller, and 
makes it more aligned with amd64. As a result, the compilation 
gets slightly faster and uses 10% less memory space for 
compiling wazero itself.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │  old.txt   │             new.txt              │
               │   sec/op   │   sec/op    vs base              │
Compilation-10   3.444 ± 2%   3.315 ± 1%  -3.75% (p=0.001 n=7)

               │   old.txt    │              new.txt               │
               │     B/op     │     B/op      vs base              │
Compilation-10   391.2Mi ± 0%   354.7Mi ± 0%  -9.35% (p=0.001 n=7)

               │   old.txt   │              new.txt              │
               │  allocs/op  │  allocs/op   vs base              │
Compilation-10   693.3k ± 0%   695.3k ± 0%  +0.28% (p=0.001 n=7)
```