### PR TITLE
ssa: empericially faster passRedundantPhiEliminationOpt

### DIFF
--- a/internal/engine/wazevo/ssa/pass.go
+++ b/internal/engine/wazevo/ssa/pass.go
@@ -22,9 +22,9 @@ func (b *builder) RunPasses() {
 func (b *builder) runPreBlockLayoutPasses() {
 	passSortSuccessors(b)
 	passDeadBlockEliminationOpt(b)
-	passRedundantPhiEliminationOpt(b)
 	// The result of passCalculateImmediateDominators will be used by various passes below.
 	passCalculateImmediateDominators(b)
+	passRedundantPhiEliminationOpt(b)
 	passNopInstElimination(b)
 
 	// TODO: implement either conversion of irreducible CFG into reducible one, or irreducible CFG detection where we panic.
@@ -120,9 +120,9 @@ func passRedundantPhiEliminationOpt(b *builder) {
 	//  complexity here is O(BlockNum * Iterations) at the worst case where BlockNum might be the order of thousands.
 	for {
 		changed := false
-		_ = b.blockIteratorBegin() // skip entry block!
+		_ = b.blockIteratorReversePostOrderBegin() // skip entry block!
 		// Below, we intentionally use the named iteration variable name, as this comes with inevitable nested for loops!
-		for blk := b.blockIteratorNext(); blk != nil; blk = b.blockIteratorNext() {
+		for blk := b.blockIteratorReversePostOrderNext(); blk != nil; blk = b.blockIteratorReversePostOrderNext() {
 			paramNum := len(blk.params)
 
 			for paramIndex := 0; paramIndex < paramNum; paramIndex++ {

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -167,6 +167,8 @@ blk3: () <-- (blk1,blk2)
 					ret.AsReturn(ValuesNil)
 					b.InsertInstruction(ret)
 				}
+
+				b.reversePostOrderedBasicBlocks = []*basicBlock{entry.(*basicBlock), loopHeader.(*basicBlock), end.(*basicBlock)}
 				return nil
 			},
 			before: `


### PR DESCRIPTION


## Stdlibs 

### wasip1

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                                            │ old_wasip1.txt │             new_wasip1.txt              │
                                            │     sec/op     │     sec/op      vs base                 │
Wasip1/Compile/src_archive_tar.test-10         3.114 ±  2%      2.335 ±  7%    -25.02% (p=0.001 n=7)
Wasip1/Run/src_archive_tar.test-10            399.7m ±  3%     399.9m ±  2%          ~ (p=0.456 n=7)
Wasip1/Compile/src_bufio.test-10               1.874 ±  1%      1.574 ±  1%    -16.00% (p=0.001 n=7)
Wasip1/Run/src_bufio.test-10                  122.9m ± 13%     125.6m ±  4%          ~ (p=0.620 n=7)
Wasip1/Compile/src_bytes.test-10               1.987 ±  1%      1.639 ±  1%    -17.50% (p=0.001 n=7)
Wasip1/Run/src_bytes.test-10                  471.4m ±  0%     470.4m ±  0%          ~ (p=0.456 n=7)
Wasip1/Compile/src_context.test-10             2.086 ±  1%      1.752 ±  3%    -16.02% (p=0.001 n=7)
Wasip1/Run/src_context.test-10                31.78m ±  9%     30.91m ±  2%     -2.74% (p=0.038 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10    1.727 ±  3%      1.407 ±  1%    -18.54% (p=0.001 n=7)
Wasip1/Run/src_encoding_ascii85.test-10       7.536m ±  3%     7.530m ±  1%          ~ (p=1.000 n=7)
Wasip1/Compile/src_encoding_asn1.test-10       1.948 ±  1%      1.637 ±  1%    -15.99% (p=0.001 n=7)
Wasip1/Run/src_encoding_asn1.test-10          8.542m ±  6%     8.425m ±  2%          ~ (p=0.128 n=7)
Wasip1/Compile/src_encoding_base32.test-10     1.790 ±  1%      1.462 ±  1%    -18.32% (p=0.001 n=7)
Wasip1/Run/src_encoding_base32.test-10        28.82m ±  3%     27.81m ±  1%     -3.53% (p=0.002 n=7)
Wasip1/Compile/src_encoding_base64.test-10     1.817 ±  1%      1.472 ±  0%    -19.00% (p=0.001 n=7)
Wasip1/Run/src_encoding_base64.test-10        12.31m ±  2%     12.17m ±  2%          ~ (p=0.209 n=7)
Wasip1/Compile/src_encoding_binary.test-10     1.843 ±  2%      1.651 ± 14%    -10.38% (p=0.026 n=7)
Wasip1/Run/src_encoding_binary.test-10        9.444m ±  4%     9.583m ±  4%     +1.46% (p=0.038 n=7)
Wasip1/Compile/src_encoding_csv.test-10        1.789 ±  1%      1.500 ±  1%    -16.17% (p=0.001 n=7)
Wasip1/Run/src_encoding_csv.test-10           19.99m ±   ∞ ¹   20.85m ±  4%          ~ (p=0.250 n=1+7)
Wasip1/Compile/src_encoding_gob.test-10                         2.165 ±  1%
geomean                                       264.3m           314.9m           -9.16%

                                            │ old_wasip1.txt │             new_wasip1.txt             │
                                            │      B/op      │      B/op       vs base                │
Wasip1/Compile/src_archive_tar.test-10        104.2Mi ± 0%     104.2Mi ± 0%         ~ (p=0.073 n=7)
Wasip1/Run/src_archive_tar.test-10            286.0Mi ± 0%     286.0Mi ± 0%         ~ (p=0.401 n=7)
Wasip1/Compile/src_bufio.test-10              81.91Mi ± 0%     81.90Mi ± 0%         ~ (p=0.456 n=7)
Wasip1/Run/src_bufio.test-10                  105.3Mi ± 0%     105.3Mi ± 0%         ~ (p=0.674 n=7)
Wasip1/Compile/src_bytes.test-10              83.43Mi ± 0%     83.43Mi ± 0%         ~ (p=0.902 n=7)
Wasip1/Run/src_bytes.test-10                  605.0Mi ± 0%     605.0Mi ± 0%         ~ (p=0.274 n=7)
Wasip1/Compile/src_context.test-10            86.57Mi ± 0%     86.57Mi ± 0%         ~ (p=0.710 n=7)
Wasip1/Run/src_context.test-10                71.52Mi ± 0%     71.52Mi ± 0%         ~ (p=0.076 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10   77.77Mi ± 0%     77.78Mi ± 0%    +0.02% (p=0.002 n=7)
Wasip1/Run/src_encoding_ascii85.test-10       69.21Mi ± 0%     69.21Mi ± 0%         ~ (p=0.381 n=7)
Wasip1/Compile/src_encoding_asn1.test-10      84.43Mi ± 0%     84.44Mi ± 0%         ~ (p=0.165 n=7)
Wasip1/Run/src_encoding_asn1.test-10          70.30Mi ± 0%     70.30Mi ± 0%         ~ (p=0.073 n=7)
Wasip1/Compile/src_encoding_base32.test-10    79.55Mi ± 0%     79.55Mi ± 0%         ~ (p=0.073 n=7)
Wasip1/Run/src_encoding_base32.test-10        104.4Mi ± 0%     104.4Mi ± 0%    -0.00% (p=0.011 n=7)
Wasip1/Compile/src_encoding_base64.test-10    79.99Mi ± 0%     79.99Mi ± 0%         ~ (p=0.620 n=7)
Wasip1/Run/src_encoding_base64.test-10        69.50Mi ± 0%     69.50Mi ± 0%         ~ (p=0.535 n=7)
Wasip1/Compile/src_encoding_binary.test-10    80.86Mi ± 0%     80.86Mi ± 0%         ~ (p=0.259 n=7)
Wasip1/Run/src_encoding_binary.test-10        69.78Mi ± 0%     69.78Mi ± 0%         ~ (p=0.154 n=7)
Wasip1/Compile/src_encoding_csv.test-10       79.88Mi ± 0%     79.89Mi ± 0%         ~ (p=0.302 n=7)
Wasip1/Run/src_encoding_csv.test-10           69.51Mi ±  ∞ ¹   69.51Mi ± 0%         ~ (p=0.250 n=1+7)
Wasip1/Compile/src_encoding_gob.test-10                        93.47Mi ± 0%
geomean                                       95.17Mi          113.7Mi         +0.00%

                                            │ old_wasip1.txt │            new_wasip1.txt             │
                                            │   allocs/op    │   allocs/op    vs base                │
Wasip1/Compile/src_archive_tar.test-10         335.0k ± 0%     335.3k ± 0%         ~ (p=0.097 n=7)
Wasip1/Run/src_archive_tar.test-10             7.836k ± 0%     7.837k ± 0%         ~ (p=0.592 n=7)
Wasip1/Compile/src_bufio.test-10               243.5k ± 0%     243.6k ± 0%         ~ (p=0.456 n=7)
Wasip1/Run/src_bufio.test-10                   3.728k ± 2%     3.728k ± 2%         ~ (p=1.000 n=7)
Wasip1/Compile/src_bytes.test-10               254.4k ± 0%     254.3k ± 0%         ~ (p=1.000 n=7)
Wasip1/Run/src_bytes.test-10                   6.377k ± 0%     6.378k ± 0%         ~ (p=0.070 n=7)
Wasip1/Compile/src_context.test-10             274.4k ± 0%     274.4k ± 0%         ~ (p=0.710 n=7)
Wasip1/Run/src_context.test-10                 3.801k ± 1%     3.780k ± 0%         ~ (p=0.062 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10    227.8k ± 0%     228.2k ± 0%    +0.16% (p=0.001 n=7)
Wasip1/Run/src_encoding_ascii85.test-10        2.707k ± 0%     2.707k ± 0%         ~ (p=1.000 n=7)
Wasip1/Compile/src_encoding_asn1.test-10       254.6k ± 0%     254.9k ± 0%         ~ (p=0.053 n=7)
Wasip1/Run/src_encoding_asn1.test-10           2.991k ± 0%     2.990k ± 0%         ~ (p=0.217 n=7)
Wasip1/Compile/src_encoding_base32.test-10     233.5k ± 0%     233.6k ± 0%         ~ (p=0.053 n=7)
Wasip1/Run/src_encoding_base32.test-10         2.972k ± 0%     2.972k ± 0%         ~ (p=0.122 n=7)
Wasip1/Compile/src_encoding_base64.test-10     235.7k ± 0%     235.7k ± 0%         ~ (p=0.535 n=7)
Wasip1/Run/src_encoding_base64.test-10         2.913k ± 0%     2.912k ± 0%         ~ (p=0.583 n=7)
Wasip1/Compile/src_encoding_binary.test-10     240.8k ± 0%     241.1k ± 0%         ~ (p=0.209 n=7)
Wasip1/Run/src_encoding_binary.test-10         3.070k ± 0%     3.071k ± 0%         ~ (p=0.117 n=7)
Wasip1/Compile/src_encoding_csv.test-10        236.1k ± 0%     236.4k ± 0%         ~ (p=0.245 n=7)
Wasip1/Run/src_encoding_csv.test-10            2.937k ±  ∞ ¹   2.941k ± 0%         ~ (p=0.250 n=1+7)
Wasip1/Compile/src_encoding_gob.test-10                        287.3k ± 0%
geomean                                        30.43k          32.13k         +0.01%
```

### TinyGo

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                                        │ old_tinygo.txt │            new_tinygo.txt             │
                                        │     sec/op     │    sec/op     vs base                 │
TinyGo/Compile/container_heap.test-10     668.8m ±  2%     445.6m ±  9%  -33.38% (p=0.001 n=7)
TinyGo/Run/container_heap.test-10         14.42m ± 11%     14.53m ±  7%        ~ (p=0.318 n=7)
TinyGo/Compile/container_list.test-10     663.8m ±  1%     433.9m ±  2%  -34.64% (p=0.001 n=7)
TinyGo/Run/container_list.test-10         14.26m ± 10%     14.17m ±  7%        ~ (p=0.318 n=7)
TinyGo/Compile/container_ring.test-10     665.9m ±  1%     435.6m ±  4%  -34.58% (p=0.001 n=7)
TinyGo/Run/container_ring.test-10         14.24m ± 12%     14.49m ±  2%        ~ (p=0.259 n=7)
TinyGo/Compile/crypto_des.test-10         692.5m ±  4%     452.5m ±  9%  -34.66% (p=0.001 n=7)
TinyGo/Run/crypto_des.test-10             18.32m ±  4%     18.14m ±  3%        ~ (p=0.128 n=7)
TinyGo/Compile/crypto_md5.test-10         681.3m ±  3%     450.5m ±  4%  -33.88% (p=0.001 n=7)
TinyGo/Run/crypto_md5.test-10             20.90m ±  4%     20.80m ±  8%        ~ (p=1.000 n=7)
TinyGo/Compile/crypto_rc4.test-10         673.2m ±  4%     429.0m ±  3%  -36.28% (p=0.001 n=7)
TinyGo/Run/crypto_rc4.test-10             162.7m ±  1%     162.7m ±  1%        ~ (p=0.902 n=7)
TinyGo/Compile/crypto_sha1.test-10        679.4m ±  3%     437.5m ±  3%  -35.61% (p=0.001 n=7)
TinyGo/Run/crypto_sha1.test-10            16.02m ±  6%     16.33m ±  3%        ~ (p=0.535 n=7)
TinyGo/Compile/crypto_sha256.test-10      697.0m ±  4%     445.0m ±  0%  -36.15% (p=0.001 n=7)
TinyGo/Run/crypto_sha256.test-10          16.10m ±  7%     15.91m ±  1%   -1.13% (p=0.017 n=7)
TinyGo/Compile/crypto_sha512.test-10      698.2m ±  3%     450.0m ±  2%  -35.56% (p=0.001 n=7)
TinyGo/Run/crypto_sha512.test-10          20.26m ±  7%     18.76m ±  1%   -7.41% (p=0.017 n=7)
TinyGo/Compile/encoding_ascii85.test-10   681.4m ±  4%     435.9m ±  1%  -36.03% (p=0.001 n=7)
TinyGo/Run/encoding_ascii85.test-10       14.88m ±  1%     14.93m ± 12%        ~ (p=0.318 n=7)
TinyGo/Compile/encoding_base32.test-10     1.645 ±  4%      1.165 ±  4%  -29.19% (p=0.001 n=7)
TinyGo/Run/encoding_base32.test-10        86.46m ±  4%     88.18m ±  5%        ~ (p=0.209 n=7)
TinyGo/Compile/encoding_csv.test-10       734.2m ±  1%     483.1m ±  5%  -34.20% (p=0.001 n=7)
TinyGo/Run/encoding_csv.test-10           22.85m ±  6%     22.86m ±  0%        ~ (p=1.000 n=7)
TinyGo/Compile/encoding_hex.test-10       699.8m ±  5%     455.9m ±  2%  -34.86% (p=0.001 n=7)
TinyGo/Run/encoding_hex.test-10           10.23m ±  4%     10.23m ±  5%        ~ (p=0.805 n=7)
TinyGo/Compile/go_scanner.test-10         752.3m ±  3%     485.0m ±  1%  -35.53% (p=0.001 n=7)
TinyGo/Run/go_scanner.test-10             16.70m ±  5%     16.62m ±  8%        ~ (p=0.620 n=7)
TinyGo/Compile/hash.test-10               948.3m ±  2%     690.5m ±  1%  -27.19% (p=0.001 n=7)
TinyGo/Run/hash.test-10                   16.19m ±  5%     16.14m ±  5%        ~ (p=0.902 n=7)
TinyGo/Compile/hash_adler32.test-10       663.8m ±  3%     423.4m ±  3%  -36.22% (p=0.001 n=7)
TinyGo/Run/hash_adler32.test-10           24.75m ±  8%     24.62m ±  1%        ~ (p=0.535 n=7)
TinyGo/Compile/hash_crc64.test-10         887.8m ±  3%     653.2m ±  1%  -26.43% (p=0.001 n=7)
TinyGo/Run/hash_crc64.test-10             17.27m ±  1%     17.53m ±  5%   +1.48% (p=0.017 n=7)
TinyGo/Compile/hash_fnv.test-10           685.6m ±  7%     443.7m ±  4%  -35.28% (p=0.001 n=7)
TinyGo/Run/hash_fnv.test-10               15.49m ±  4%     14.59m ±  4%   -5.85% (p=0.002 n=7)
TinyGo/Compile/html.test-10                2.476 ±  5%      2.188 ±  1%  -11.63% (p=0.001 n=7)
TinyGo/Compile/internal_itoa.test-10                       417.6m ±  1%
geomean                                   127.6m           108.0m        -18.34%

                                        │ old_tinygo.txt │            new_tinygo.txt            │
                                        │      B/op      │     B/op      vs base                │
TinyGo/Compile/container_heap.test-10     53.28Mi ± 0%     53.27Mi ± 0%       ~ (p=0.165 n=7)
TinyGo/Run/container_heap.test-10         16.63Mi ± 0%     16.63Mi ± 0%       ~ (p=0.259 n=7)
TinyGo/Compile/container_list.test-10     53.23Mi ± 0%     53.23Mi ± 0%       ~ (p=1.000 n=7)
TinyGo/Run/container_list.test-10         16.40Mi ± 0%     16.40Mi ± 0%       ~ (p=0.620 n=7)
TinyGo/Compile/container_ring.test-10     52.47Mi ± 0%     52.47Mi ± 0%       ~ (p=0.259 n=7)
TinyGo/Run/container_ring.test-10         16.30Mi ± 0%     16.30Mi ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/crypto_des.test-10         53.43Mi ± 0%     53.42Mi ± 0%       ~ (p=0.383 n=7)
TinyGo/Run/crypto_des.test-10             16.76Mi ± 0%     16.76Mi ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/crypto_md5.test-10         53.56Mi ± 0%     53.55Mi ± 0%       ~ (p=0.383 n=7)
TinyGo/Run/crypto_md5.test-10             44.97Mi ± 0%     44.97Mi ± 0%       ~ (p=0.223 n=7)
TinyGo/Compile/crypto_rc4.test-10         52.46Mi ± 0%     52.46Mi ± 0%       ~ (p=0.902 n=7)
TinyGo/Run/crypto_rc4.test-10             29.28Mi ± 0%     29.28Mi ± 0%       ~ (p=0.402 n=7)
TinyGo/Compile/crypto_sha1.test-10        53.76Mi ± 0%     53.76Mi ± 0%       ~ (p=0.805 n=7)
TinyGo/Run/crypto_sha1.test-10            17.44Mi ± 0%     17.44Mi ± 0%       ~ (p=0.383 n=7)
TinyGo/Compile/crypto_sha256.test-10      53.60Mi ± 0%     53.60Mi ± 0%       ~ (p=1.000 n=7)
TinyGo/Run/crypto_sha256.test-10          17.53Mi ± 0%     17.53Mi ± 0%       ~ (p=0.477 n=7)
TinyGo/Compile/crypto_sha512.test-10      53.58Mi ± 0%     53.59Mi ± 0%       ~ (p=0.805 n=7)
TinyGo/Run/crypto_sha512.test-10          17.82Mi ± 0%     17.82Mi ± 0%       ~ (p=0.073 n=7)
TinyGo/Compile/encoding_ascii85.test-10   53.38Mi ± 0%     53.39Mi ± 0%       ~ (p=0.710 n=7)
TinyGo/Run/encoding_ascii85.test-10       16.54Mi ± 0%     16.54Mi ± 0%       ~ (p=0.259 n=7)
TinyGo/Compile/encoding_base32.test-10    60.78Mi ± 0%     60.77Mi ± 0%       ~ (p=0.902 n=7)
TinyGo/Run/encoding_base32.test-10        23.75Mi ± 0%     23.75Mi ± 0%       ~ (p=0.383 n=7)
TinyGo/Compile/encoding_csv.test-10       54.35Mi ± 0%     54.35Mi ± 0%       ~ (p=0.902 n=7)
TinyGo/Run/encoding_csv.test-10           11.71Mi ± 0%     11.71Mi ± 0%       ~ (p=0.244 n=7)
TinyGo/Compile/encoding_hex.test-10       53.78Mi ± 0%     53.78Mi ± 0%       ~ (p=0.620 n=7)
TinyGo/Run/encoding_hex.test-10           8.264Mi ± 0%     8.264Mi ± 0%       ~ (p=0.128 n=7)
TinyGo/Compile/go_scanner.test-10         55.27Mi ± 0%     55.27Mi ± 0%  -0.01% (p=0.011 n=7)
TinyGo/Run/go_scanner.test-10             18.52Mi ± 0%     18.52Mi ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/hash.test-10               58.10Mi ± 0%     58.11Mi ± 0%       ~ (p=0.620 n=7)
TinyGo/Run/hash.test-10                   18.22Mi ± 0%     18.22Mi ± 0%       ~ (p=0.383 n=7)
TinyGo/Compile/hash_adler32.test-10       52.85Mi ± 0%     52.84Mi ± 0%       ~ (p=0.073 n=7)
TinyGo/Run/hash_adler32.test-10           21.36Mi ± 0%     21.36Mi ± 0%       ~ (p=0.902 n=7)
TinyGo/Compile/hash_crc64.test-10         57.29Mi ± 0%     57.30Mi ± 0%       ~ (p=0.318 n=7)
TinyGo/Run/hash_crc64.test-10             16.47Mi ± 0%     16.47Mi ± 0%       ~ (p=0.209 n=7)
TinyGo/Compile/hash_fnv.test-10           53.50Mi ± 0%     53.49Mi ± 0%       ~ (p=0.535 n=7)
TinyGo/Run/hash_fnv.test-10               16.69Mi ± 0%     16.69Mi ± 0%       ~ (p=0.902 n=7)
TinyGo/Compile/html.test-10               163.8Mi ± 0%     163.8Mi ± 0%       ~ (p=0.710 n=7)
TinyGo/Compile/internal_itoa.test-10                       52.37Mi ± 0%
geomean                                   32.24Mi          32.65Mi       -0.00%

                                        │ old_tinygo.txt │           new_tinygo.txt            │
                                        │   allocs/op    │  allocs/op   vs base                │
TinyGo/Compile/container_heap.test-10      110.3k ± 0%     110.1k ± 0%       ~ (p=0.318 n=7)
TinyGo/Run/container_heap.test-10          374.9k ± 0%     374.9k ± 0%       ~ (p=0.627 n=7)
TinyGo/Compile/container_list.test-10      109.9k ± 0%     109.9k ± 0%       ~ (p=0.805 n=7)
TinyGo/Run/container_list.test-10          370.0k ± 0%     370.0k ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/container_ring.test-10      109.6k ± 0%     109.5k ± 0%       ~ (p=0.510 n=7)
TinyGo/Run/container_ring.test-10          367.6k ± 0%     367.6k ± 0%       ~ (p=0.540 n=7)
TinyGo/Compile/crypto_des.test-10          110.5k ± 0%     110.4k ± 0%       ~ (p=0.383 n=7)
TinyGo/Run/crypto_des.test-10              378.1k ± 0%     378.1k ± 0%       ~ (p=0.592 n=7)
TinyGo/Compile/crypto_md5.test-10          110.9k ± 0%     110.8k ± 0%       ~ (p=0.128 n=7)
TinyGo/Run/crypto_md5.test-10              393.3k ± 0%     393.3k ± 0%       ~ (p=0.706 n=7)
TinyGo/Compile/crypto_rc4.test-10          109.8k ± 0%     109.7k ± 0%       ~ (p=0.646 n=7)
TinyGo/Run/crypto_rc4.test-10              367.1k ± 0%     367.1k ± 0%       ~ (p=0.364 n=7)
TinyGo/Compile/crypto_sha1.test-10         110.8k ± 0%     110.8k ± 0%       ~ (p=1.000 n=7)
TinyGo/Run/crypto_sha1.test-10             392.7k ± 0%     392.7k ± 0%       ~ (p=0.249 n=7)
TinyGo/Compile/crypto_sha256.test-10       110.7k ± 0%     110.7k ± 0%       ~ (p=0.641 n=7)
TinyGo/Run/crypto_sha256.test-10           394.5k ± 0%     394.5k ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/crypto_sha512.test-10       110.8k ± 0%     110.7k ± 0%       ~ (p=0.456 n=7)
TinyGo/Run/crypto_sha512.test-10           397.2k ± 0%     397.2k ± 0%       ~ (p=0.767 n=7)
TinyGo/Compile/encoding_ascii85.test-10    110.4k ± 0%     110.5k ± 0%       ~ (p=0.805 n=7)
TinyGo/Run/encoding_ascii85.test-10        373.0k ± 0%     373.0k ± 0%       ~ (p=0.494 n=7)
TinyGo/Compile/encoding_base32.test-10     116.4k ± 0%     116.4k ± 0%       ~ (p=0.805 n=7)
TinyGo/Run/encoding_base32.test-10         397.6k ± 0%     397.6k ± 0%       ~ (p=0.450 n=7)
TinyGo/Compile/encoding_csv.test-10        113.7k ± 0%     113.7k ± 0%       ~ (p=0.259 n=7)
TinyGo/Run/encoding_csv.test-10            213.4k ± 0%     213.4k ± 0%       ~ (p=0.592 n=7)
TinyGo/Compile/encoding_hex.test-10        111.7k ± 0%     111.6k ± 0%       ~ (p=0.274 n=7)
TinyGo/Run/encoding_hex.test-10            178.4k ± 0%     178.4k ± 0%       ~ (p=0.266 n=7)
TinyGo/Compile/go_scanner.test-10          114.4k ± 0%     114.2k ± 0%  -0.16% (p=0.038 n=7)
TinyGo/Run/go_scanner.test-10              420.7k ± 0%     420.7k ± 0%       ~ (p=0.392 n=7)
TinyGo/Compile/hash.test-10                118.2k ± 0%     118.2k ± 0%       ~ (p=0.735 n=7)
TinyGo/Run/hash.test-10                    410.7k ± 0%     410.7k ± 0%       ~ (p=0.507 n=7)
TinyGo/Compile/hash_adler32.test-10        109.7k ± 0%     109.6k ± 0%       ~ (p=0.128 n=7)
TinyGo/Run/hash_adler32.test-10            368.6k ± 0%     368.6k ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/hash_crc64.test-10          113.5k ± 0%     113.6k ± 0%       ~ (p=0.383 n=7)
TinyGo/Run/hash_crc64.test-10              371.1k ± 0%     371.1k ± 0%       ~ (p=0.225 n=7)
TinyGo/Compile/hash_fnv.test-10            110.8k ± 0%     110.7k ± 0%       ~ (p=0.456 n=7)
TinyGo/Run/hash_fnv.test-10                376.0k ± 0%     376.0k ± 0%       ~ (p=1.000 n=7)
TinyGo/Compile/html.test-10                328.0k ± 0%     328.0k ± 0%       ~ (p=0.902 n=7)
TinyGo/Compile/internal_itoa.test-10                       109.3k ± 0%
geomean                                    206.1k          202.8k       -0.02%
```

### Zig
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                             │ old_zig.txt │           new_zig.txt            │
                             │   sec/op    │   sec/op    vs base              │
Zig/Compile/test-opt.wasm-10    4.577 ± 1%   4.697 ± 4%  +2.63% (p=0.038 n=7)
Zig/Run/test-opt.wasm-10        18.91 ± 4%   18.96 ± 2%       ~ (p=0.902 n=7)
Zig/Compile/test.wasm-10        5.710 ± 0%   5.707 ± 0%       ~ (p=0.456 n=7)
Zig/Run/test.wasm-10            19.39 ± 1%   19.08 ± 2%  -1.60% (p=0.011 n=7)
geomean                         9.894        9.924       +0.30%

                             │ old_zig.txt  │            new_zig.txt             │
                             │     B/op     │     B/op      vs base              │
Zig/Compile/test-opt.wasm-10   400.3Mi ± 0%   400.4Mi ± 0%       ~ (p=0.805 n=7)
Zig/Run/test-opt.wasm-10       741.7Mi ± 0%   741.7Mi ± 0%       ~ (p=0.828 n=7)
Zig/Compile/test.wasm-10       672.8Mi ± 0%   672.8Mi ± 0%       ~ (p=0.383 n=7)
Zig/Run/test.wasm-10           1.296Gi ± 0%   1.296Gi ± 0%       ~ (p=0.683 n=7)
geomean                        717.6Mi        717.6Mi       -0.00%

                             │ old_zig.txt │            new_zig.txt            │
                             │  allocs/op  │  allocs/op   vs base              │
Zig/Compile/test-opt.wasm-10   387.1k ± 0%   387.1k ± 0%       ~ (p=0.902 n=7)
Zig/Run/test-opt.wasm-10       51.58k ± 0%   51.58k ± 0%       ~ (p=1.000 n=7)
Zig/Compile/test.wasm-10       521.3k ± 0%   520.9k ± 0%       ~ (p=0.710 n=7)
Zig/Run/test.wasm-10           2.156M ± 0%   2.156M ± 0%       ~ (p=1.000 n=7)
geomean                        387.0k        387.0k       -0.01%

```


## Compiling wazero compiled as Wasm
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │  old.txt   │              new.txt              │
               │   sec/op   │   sec/op    vs base               │
Compilation-10   3.304 ± 2%   2.533 ± 1%  -23.33% (p=0.001 n=7)

               │   old.txt    │            new.txt            │
               │     B/op     │     B/op      vs base         │
Compilation-10   354.6Mi ± 0%   354.6Mi ± 0%  ~ (p=0.383 n=7)

               │   old.txt   │           new.txt            │
               │  allocs/op  │  allocs/op   vs base         │
Compilation-10   694.9k ± 0%   694.6k ± 0%  ~ (p=0.259 n=7)
```