### PR TITLE
Disallow empty path on path_open

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1596,6 +1596,10 @@ func pathOpenFn(_ context.Context, mod api.Module, params []uint64) experimental
 		return errno
 	}
 
+	if pathLen == 0 {
+		return experimentalsys.EINVAL
+	}
+
 	fileOpenFlags := openFlags(dirflags, oflags, fdflags, rights)
 	isDir := fileOpenFlags&experimentalsys.O_DIRECTORY != 0
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -4098,6 +4098,17 @@ func Test_pathOpen_Errors(t *testing.T) {
 `,
 		},
 		{
+			name:          "empty path",
+			fd:            sys.FdPreopen,
+			path:          0,
+			pathLen:       0,
+			expectedErrno: wasip1.ErrnoInval,
+			expectedLog: `
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=,oflags=,fs_rights_base=,fs_rights_inheriting=,fdflags=)
+<== (opened_fd=,errno=EINVAL)
+`,
+		},
+		{
 			name:          "out-of-memory reading pathLen",
 			fd:            sys.FdPreopen,
 			path:          0,


### PR DESCRIPTION
This commit makes `path_open` return `inval` when passed an empty path. This behavior is consistent with other Wasm runtimes (Wasmtime, Wasmer, Node, WAMR, WasmEdge).

fixes #2222