### PR TITLE
Runs the test case previously failing due to a bug in Rosseta 2

### DIFF
--- a/internal/integration_test/fuzzcases/fuzzcases_test.go
+++ b/internal/integration_test/fuzzcases/fuzzcases_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"runtime"
 	"testing"
 
 	"github.com/tetratelabs/wazero"
@@ -886,9 +885,6 @@ func Test2017(t *testing.T) {
 func Test2031(t *testing.T) {
 	if !platform.CompilerSupported() {
 		return
-	}
-	if runtime.GOARCH == "amd64" && runtime.GOOS == "darwin" {
-		t.Skip()
 	}
 	run(t, func(t *testing.T, r wazero.Runtime) {
 		mod, err := r.Instantiate(ctx, getWasmBinary(t, "2031"))


### PR DESCRIPTION
This case has been skipped due to a bug I found in Rosetta 2.
The bug was fixed in the latest macOS, so enable it now.

See https://x.com/mathetake/status/1761175001070477392

