### PR TITLE
regalloc: removes the last use of map for faster allocation

### DIFF
--- a/internal/engine/wazevo/backend/regalloc/regalloc.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc.go
@@ -60,9 +60,8 @@ type (
 		phiDefInstListPool       wazevoapi.Pool[phiDefInstList]
 
 		// Followings are re-used during various places.
-		blks             []Block
-		reals            []RealReg
-		currentOccupants regInUseSet
+		blks  []Block
+		reals []RealReg
 
 		// Following two fields are updated while iterating the blocks in the reverse postorder.
 		state       state
@@ -979,27 +978,15 @@ func (a *Allocator) fixMergeState(f Function, blk Block) {
 	}
 
 	s.currentBlockID = bID
-	a.updateLiveInVRState(a.getOrAllocateBlockState(bID))
+	a.updateLiveInVRState(blkSt)
 
-	currentOccupants := &a.currentOccupants
 	for i := 0; i < preds; i++ {
-		currentOccupants.reset()
 		if i == blkSt.startFromPredIndex {
 			continue
 		}
 
-		currentOccupantsRev := make(map[VReg]RealReg)
 		pred := blk.Pred(i)
 		predSt := a.getOrAllocateBlockState(pred.ID())
-		for r := RealReg(0); r < 64; r++ {
-			if v := predSt.endRegs.get(r); v.Valid() {
-				if _v := blkSt.startRegs.get(r); !_v.Valid() {
-					continue
-				}
-				currentOccupants.add(r, v)
-				currentOccupantsRev[v] = r
-			}
-		}
 
 		s.resetAt(predSt)
 
@@ -1016,17 +1003,13 @@ func (a *Allocator) fixMergeState(f Function, blk Block) {
 			floatTmp = FromRealReg(floatFree, RegTypeFloat)
 		}
 
-		if wazevoapi.RegAllocLoggingEnabled {
-			fmt.Println("\t", pred.ID(), ":", currentOccupants.format(a.regInfo))
-		}
-
 		for r := RealReg(0); r < 64; r++ {
 			desiredVReg := desiredOccupants.get(r)
 			if !desiredVReg.Valid() {
 				continue
 			}
 
-			currentVReg := currentOccupants.get(r)
+			currentVReg := s.regsInUse.get(r)
 			if desiredVReg.ID() == currentVReg.ID() {
 				continue
 			}
@@ -1038,7 +1021,7 @@ func (a *Allocator) fixMergeState(f Function, blk Block) {
 			} else {
 				tmpRealReg = floatTmp
 			}
-			a.reconcileEdge(f, r, pred, currentOccupants, currentOccupantsRev, currentVReg, desiredVReg, tmpRealReg, typ)
+			a.reconcileEdge(f, r, pred, currentVReg, desiredVReg, tmpRealReg, typ)
 		}
 	}
 }
@@ -1046,8 +1029,6 @@ func (a *Allocator) fixMergeState(f Function, blk Block) {
 func (a *Allocator) reconcileEdge(f Function,
 	r RealReg,
 	pred Block,
-	currentOccupants *regInUseSet,
-	currentOccupantsRev map[VReg]RealReg,
 	currentVReg, desiredVReg VReg,
 	freeReg VReg,
 	typ RegType,
@@ -1055,8 +1036,9 @@ func (a *Allocator) reconcileEdge(f Function,
 	s := &a.state
 	if currentVReg.Valid() {
 		// Both are on reg.
-		er, ok := currentOccupantsRev[desiredVReg]
-		if !ok {
+		desiredState := s.getVRegState(desiredVReg.ID())
+		er := desiredState.r
+		if er == RealRegInvalid {
 			if wazevoapi.RegAllocLoggingEnabled {
 				fmt.Printf("\t\tv%d is desired to be on %s, but currently on the stack\n",
 					desiredVReg.ID(), a.regInfo.RealRegName(r),
@@ -1066,12 +1048,11 @@ func (a *Allocator) reconcileEdge(f Function,
 			// We need to move the current value to the stack, and reload the desired value.
 			// TODO: we can do better here.
 			f.StoreRegisterBefore(currentVReg.SetRealReg(r), pred.LastInstrForInsertion())
-			delete(currentOccupantsRev, currentVReg)
+			s.releaseRealReg(r)
 
 			s.getVRegState(desiredVReg.ID()).recordReload(f, pred)
 			f.ReloadRegisterBefore(desiredVReg.SetRealReg(r), pred.LastInstrForInsertion())
-			currentOccupants.add(r, desiredVReg)
-			currentOccupantsRev[desiredVReg] = r
+			s.useRealReg(r, desiredVReg)
 			return
 		}
 
@@ -1087,10 +1068,10 @@ func (a *Allocator) reconcileEdge(f Function,
 			pred.LastInstrForInsertion(),
 		)
 		s.allocatedRegSet = s.allocatedRegSet.add(freeReg.RealReg())
-		currentOccupantsRev[desiredVReg] = r
-		currentOccupantsRev[currentVReg] = er
-		currentOccupants.add(r, desiredVReg)
-		currentOccupants.add(er, currentVReg)
+		s.releaseRealReg(r)
+		s.releaseRealReg(er)
+		s.useRealReg(r, desiredVReg)
+		s.useRealReg(er, currentVReg)
 		if wazevoapi.RegAllocLoggingEnabled {
 			fmt.Printf("\t\tv%d previously on %s moved to %s\n", currentVReg.ID(), a.regInfo.RealRegName(r), a.regInfo.RealRegName(er))
 		}
@@ -1101,23 +1082,18 @@ func (a *Allocator) reconcileEdge(f Function,
 				desiredVReg.ID(), a.regInfo.RealRegName(r),
 			)
 		}
-		if currentReg, ok := currentOccupantsRev[desiredVReg]; ok {
+		if currentReg := s.getVRegState(desiredVReg.ID()).r; currentReg != RealRegInvalid {
 			f.InsertMoveBefore(
 				FromRealReg(r, typ),
 				desiredVReg.SetRealReg(currentReg),
 				pred.LastInstrForInsertion(),
 			)
-			currentOccupants.remove(currentReg)
+			s.releaseRealReg(currentReg)
 		} else {
 			s.getVRegState(desiredVReg.ID()).recordReload(f, pred)
 			f.ReloadRegisterBefore(desiredVReg.SetRealReg(r), pred.LastInstrForInsertion())
 		}
-		currentOccupantsRev[desiredVReg] = r
-		currentOccupants.add(r, desiredVReg)
-	}
-
-	if wazevoapi.RegAllocLoggingEnabled {
-		fmt.Println("\t", pred.ID(), ":", currentOccupants.format(a.regInfo))
+		s.useRealReg(r, desiredVReg)
 	}
 }
 

--- a/internal/engine/wazevo/backend/regalloc/regalloc.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc.go
@@ -1026,6 +1026,12 @@ func (a *Allocator) fixMergeState(f Function, blk Block) {
 	}
 }
 
+// reconcileEdge reconciles the register state between the current block and the predecessor for the real register `r`.
+//
+//   - currentVReg is the current VReg value that sits on the register `r`. This can be VRegInvalid if the register is not used at the end of the predecessor.
+//   - desiredVReg is the desired VReg value that should be on the register `r`.
+//   - freeReg is the temporary register that can be used to swap the values, which may or may not be used.
+//   - typ is the register type of the `r`.
 func (a *Allocator) reconcileEdge(f Function,
 	r RealReg,
 	pred Block,
@@ -1033,19 +1039,24 @@ func (a *Allocator) reconcileEdge(f Function,
 	freeReg VReg,
 	typ RegType,
 ) {
+	// There are four cases to consider:
+	// 1. currentVReg is valid, but desiredVReg is on the stack.
+	// 2. Both currentVReg and desiredVReg are valid.
+	// 3. Desired is on a different register than `r` and currentReg is not valid.
+	// 4. Desired is on the stack and currentReg is not valid.
+
 	s := &a.state
 	if currentVReg.Valid() {
-		// Both are on reg.
 		desiredState := s.getVRegState(desiredVReg.ID())
 		er := desiredState.r
 		if er == RealRegInvalid {
+			// Case 1: currentVReg is valid, but desiredVReg is on the stack.
 			if wazevoapi.RegAllocLoggingEnabled {
 				fmt.Printf("\t\tv%d is desired to be on %s, but currently on the stack\n",
 					desiredVReg.ID(), a.regInfo.RealRegName(r),
 				)
 			}
-			// This case is that the desired value is on the stack, but currentVReg is on the target register.
-			// We need to move the current value to the stack, and reload the desired value.
+			// We need to move the current value to the stack, and reload the desired value into the register.
 			// TODO: we can do better here.
 			f.StoreRegisterBefore(currentVReg.SetRealReg(r), pred.LastInstrForInsertion())
 			s.releaseRealReg(r)
@@ -1054,35 +1065,38 @@ func (a *Allocator) reconcileEdge(f Function,
 			f.ReloadRegisterBefore(desiredVReg.SetRealReg(r), pred.LastInstrForInsertion())
 			s.useRealReg(r, desiredVReg)
 			return
-		}
-
-		if wazevoapi.RegAllocLoggingEnabled {
-			fmt.Printf("\t\tv%d is desired to be on %s, but currently on %s\n",
-				desiredVReg.ID(), a.regInfo.RealRegName(r), a.regInfo.RealRegName(er),
+		} else {
+			// Case 2: Both currentVReg and desiredVReg are valid.
+			if wazevoapi.RegAllocLoggingEnabled {
+				fmt.Printf("\t\tv%d is desired to be on %s, but currently on %s\n",
+					desiredVReg.ID(), a.regInfo.RealRegName(r), a.regInfo.RealRegName(er),
+				)
+			}
+			// This case, we need to swap the values between the current and desired values.
+			f.SwapBefore(
+				currentVReg.SetRealReg(r),
+				desiredVReg.SetRealReg(er),
+				freeReg,
+				pred.LastInstrForInsertion(),
 			)
-		}
-		f.SwapBefore(
-			currentVReg.SetRealReg(r),
-			desiredVReg.SetRealReg(er),
-			freeReg,
-			pred.LastInstrForInsertion(),
-		)
-		s.allocatedRegSet = s.allocatedRegSet.add(freeReg.RealReg())
-		s.releaseRealReg(r)
-		s.releaseRealReg(er)
-		s.useRealReg(r, desiredVReg)
-		s.useRealReg(er, currentVReg)
-		if wazevoapi.RegAllocLoggingEnabled {
-			fmt.Printf("\t\tv%d previously on %s moved to %s\n", currentVReg.ID(), a.regInfo.RealRegName(r), a.regInfo.RealRegName(er))
+			s.allocatedRegSet = s.allocatedRegSet.add(freeReg.RealReg())
+			s.releaseRealReg(r)
+			s.releaseRealReg(er)
+			s.useRealReg(r, desiredVReg)
+			s.useRealReg(er, currentVReg)
+			if wazevoapi.RegAllocLoggingEnabled {
+				fmt.Printf("\t\tv%d previously on %s moved to %s\n", currentVReg.ID(), a.regInfo.RealRegName(r), a.regInfo.RealRegName(er))
+			}
 		}
 	} else {
-		// Desired is on reg, but currently the target register is not used.
 		if wazevoapi.RegAllocLoggingEnabled {
 			fmt.Printf("\t\tv%d is desired to be on %s, current not used\n",
 				desiredVReg.ID(), a.regInfo.RealRegName(r),
 			)
 		}
 		if currentReg := s.getVRegState(desiredVReg.ID()).r; currentReg != RealRegInvalid {
+			// Case 3: Desired is on a different register than `r` and currentReg is not valid.
+			// We simply need to move the desired value to the register.
 			f.InsertMoveBefore(
 				FromRealReg(r, typ),
 				desiredVReg.SetRealReg(currentReg),
@@ -1090,6 +1104,8 @@ func (a *Allocator) reconcileEdge(f Function,
 			)
 			s.releaseRealReg(currentReg)
 		} else {
+			// Case 4: Both currentVReg and desiredVReg are not valid.
+			// We simply need to reload the desired value into the register.
 			s.getVRegState(desiredVReg.ID()).recordReload(f, pred)
 			f.ReloadRegisterBefore(desiredVReg.SetRealReg(r), pred.LastInstrForInsertion())
 		}


### PR DESCRIPTION
This refactors `fixMergeState` function to remove the last use of map,
which previously caused a lot of allocations.

As a result, this improves the compilation time ~2% and makes it to use
less memory allocations. The blow is the benchmark results for the 
standard libraries as well as compiling wazero itself.

### Zig

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                             │ old_zig.txt │           new_zig.txt            │
                             │   sec/op    │   sec/op    vs base              │
Zig/Compile/test-opt.wasm-10    4.503 ± 1%   4.497 ± 1%       ~ (p=0.902 n=7)
Zig/Run/test-opt.wasm-10        19.09 ± 1%   18.79 ± 1%  -1.56% (p=0.001 n=7)
Zig/Compile/test.wasm-10        5.739 ± 2%   5.712 ± 0%  -0.47% (p=0.002 n=7)
Zig/Run/test.wasm-10            19.36 ± 1%   19.17 ± 1%       ~ (p=0.097 n=7)
geomean                         9.886        9.808       -0.79%

                             │ old_zig.txt  │            new_zig.txt             │
                             │     B/op     │     B/op      vs base              │
Zig/Compile/test-opt.wasm-10   400.3Mi ± 0%   398.0Mi ± 0%  -0.58% (p=0.001 n=7)
Zig/Run/test-opt.wasm-10       741.7Mi ± 0%   741.7Mi ± 0%       ~ (p=0.932 n=7)
Zig/Compile/test.wasm-10       672.8Mi ± 0%   672.5Mi ± 0%  -0.04% (p=0.001 n=7)
Zig/Run/test.wasm-10           1.296Gi ± 0%   1.296Gi ± 0%       ~ (p=0.958 n=7)
geomean                        717.6Mi        716.5Mi       -0.16%

                             │ old_zig.txt │            new_zig.txt            │
                             │  allocs/op  │  allocs/op   vs base              │
Zig/Compile/test-opt.wasm-10   387.1k ± 0%   370.3k ± 0%  -4.35% (p=0.001 n=7)
Zig/Run/test-opt.wasm-10       51.58k ± 0%   51.58k ± 0%       ~ (p=0.735 n=7)
Zig/Compile/test.wasm-10       521.2k ± 0%   518.9k ± 0%  -0.43% (p=0.001 n=7)
Zig/Run/test.wasm-10           2.156M ± 0%   2.156M ± 0%       ~ (p=1.000 n=7)
geomean                        387.0k        382.3k       -1.21%
```

### wasip1

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                                            │ old_wasip1.txt │            new_wasip1.txt             │
                                            │     sec/op     │    sec/op      vs base                │
Wasip1/Compile/src_archive_tar.test-10          2.306 ± 1%      2.257 ± 1%    -2.09% (p=0.001 n=7)
Wasip1/Run/src_archive_tar.test-10             397.8m ± 0%     398.9m ± 1%    +0.28% (p=0.002 n=7)
Wasip1/Compile/src_bufio.test-10                1.565 ± 0%      1.531 ± 3%    -2.16% (p=0.026 n=7)
Wasip1/Run/src_bufio.test-10                   120.7m ± 1%     121.2m ± 0%    +0.40% (p=0.026 n=7)
Wasip1/Compile/src_bytes.test-10                1.622 ± 0%      1.584 ± 0%    -2.32% (p=0.001 n=7)
Wasip1/Run/src_bytes.test-10                   469.2m ± 0%     467.3m ± 1%         ~ (p=0.259 n=7)
Wasip1/Compile/src_context.test-10              1.749 ± 1%      1.709 ± 0%    -2.28% (p=0.001 n=7)
Wasip1/Run/src_context.test-10                 31.54m ± 1%     31.59m ± 1%         ~ (p=0.805 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10     1.409 ± 0%      1.376 ± 0%    -2.35% (p=0.001 n=7)
Wasip1/Run/src_encoding_ascii85.test-10        7.563m ± 1%     7.169m ± 2%    -5.21% (p=0.001 n=7)
Wasip1/Compile/src_encoding_asn1.test-10        1.617 ± 3%      1.585 ± 0%    -1.97% (p=0.001 n=7)
Wasip1/Run/src_encoding_asn1.test-10           8.321m ± 2%     8.196m ± 2%         ~ (p=0.053 n=7)
Wasip1/Compile/src_encoding_base32.test-10      1.459 ± 0%      1.425 ± 0%    -2.28% (p=0.001 n=7)
Wasip1/Run/src_encoding_base32.test-10         28.81m ± 3%     28.11m ± 1%    -2.40% (p=0.038 n=7)
Wasip1/Compile/src_encoding_base64.test-10      1.476 ± 0%      1.439 ± 0%    -2.46% (p=0.001 n=7)
Wasip1/Run/src_encoding_base64.test-10         11.92m ± 3%     11.86m ± 2%         ~ (p=0.209 n=7)
Wasip1/Compile/src_encoding_binary.test-10      1.508 ± 0%      1.476 ± 0%    -2.17% (p=0.001 n=7)
Wasip1/Run/src_encoding_binary.test-10         9.437m ± 3%     9.254m ± 2%    -1.94% (p=0.017 n=7)
Wasip1/Compile/src_encoding_csv.test-10         1.471 ± 0%      1.433 ± 1%    -2.60% (p=0.001 n=7)
Wasip1/Run/src_encoding_csv.test-10            20.05m ± 4%     19.55m ± 1%    -2.50% (p=0.001 n=7)
Wasip1/Compile/src_encoding_gob.test-10         1.991 ± 0%      1.952 ± 0%    -1.97% (p=0.001 n=7)
Wasip1/Run/src_encoding_gob.test-10             9.970 ±  ∞ ¹    9.764 ±  ∞ ¹  -2.07% (p=0.016 n=4+5)
geomean                                        309.9m          304.2m         -1.84%
¹ need >= 6 samples for confidence interval at level 0.95

                                            │ old_wasip1.txt  │             new_wasip1.txt              │
                                            │      B/op       │      B/op       vs base                 │
Wasip1/Compile/src_archive_tar.test-10        104.22Mi ± 0%     93.65Mi ± 0%    -10.14% (p=0.001 n=7)
Wasip1/Run/src_archive_tar.test-10             286.0Mi ± 0%     286.0Mi ± 0%          ~ (p=0.971 n=7)
Wasip1/Compile/src_bufio.test-10               81.91Mi ± 0%     74.57Mi ± 0%     -8.95% (p=0.001 n=7)
Wasip1/Run/src_bufio.test-10                   105.3Mi ± 0%     105.3Mi ± 0%          ~ (p=0.135 n=7)
Wasip1/Compile/src_bytes.test-10               83.42Mi ± 0%     75.77Mi ± 0%     -9.17% (p=0.001 n=7)
Wasip1/Run/src_bytes.test-10                   605.0Mi ± 0%     605.0Mi ± 0%          ~ (p=0.890 n=7)
Wasip1/Compile/src_context.test-10             86.57Mi ± 0%     78.52Mi ± 0%     -9.30% (p=0.001 n=7)
Wasip1/Run/src_context.test-10                 71.52Mi ± 0%     71.52Mi ± 0%          ~ (p=0.737 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10    77.77Mi ± 0%     70.83Mi ± 0%     -8.92% (p=0.001 n=7)
Wasip1/Run/src_encoding_ascii85.test-10        69.21Mi ± 0%     69.21Mi ± 0%     -0.00% (p=0.001 n=7)
Wasip1/Compile/src_encoding_asn1.test-10       84.42Mi ± 0%     75.93Mi ± 0%    -10.06% (p=0.001 n=7)
Wasip1/Run/src_encoding_asn1.test-10           70.30Mi ± 0%     70.30Mi ± 0%     -0.00% (p=0.011 n=7)
Wasip1/Compile/src_encoding_base32.test-10     79.55Mi ± 0%     72.31Mi ± 0%     -9.10% (p=0.001 n=7)
Wasip1/Run/src_encoding_base32.test-10         104.4Mi ± 0%     104.4Mi ± 0%          ~ (p=0.109 n=7)
Wasip1/Compile/src_encoding_base64.test-10     79.99Mi ± 0%     72.55Mi ± 0%     -9.30% (p=0.001 n=7)
Wasip1/Run/src_encoding_base64.test-10         69.50Mi ± 0%     69.50Mi ± 0%     -0.00% (p=0.002 n=7)
Wasip1/Compile/src_encoding_binary.test-10     80.86Mi ± 0%     73.49Mi ± 0%     -9.11% (p=0.001 n=7)
Wasip1/Run/src_encoding_binary.test-10         69.78Mi ± 0%     69.78Mi ± 0%          ~ (p=0.333 n=7)
Wasip1/Compile/src_encoding_csv.test-10        79.89Mi ± 0%     72.49Mi ± 0%     -9.26% (p=0.001 n=7)
Wasip1/Run/src_encoding_csv.test-10            69.51Mi ± 0%     69.51Mi ± 0%     -0.00% (p=0.001 n=7)
Wasip1/Compile/src_encoding_gob.test-10        93.46Mi ± 0%     84.85Mi ± 0%     -9.21% (p=0.001 n=7)
Wasip1/Run/src_encoding_gob.test-10            4.784Gi ±  ∞ ¹   4.784Gi ±  ∞ ¹        ~ (p=0.524 n=4+5)
geomean                                        113.7Mi          108.3Mi          -4.78%
¹ need >= 6 samples for confidence interval at level 0.95

                                            │ old_wasip1.txt │              new_wasip1.txt              │
                                            │   allocs/op    │   allocs/op    vs base                   │
Wasip1/Compile/src_archive_tar.test-10         335.0k ± 0%     266.5k ± 0%    -20.45% (p=0.001 n=7)
Wasip1/Run/src_archive_tar.test-10             7.837k ± 0%     7.836k ± 0%          ~ (p=0.409 n=7)
Wasip1/Compile/src_bufio.test-10               243.5k ± 0%     196.1k ± 0%    -19.45% (p=0.001 n=7)
Wasip1/Run/src_bufio.test-10                   3.728k ± 0%     3.728k ± 0%          ~ (p=1.000 n=7)   ¹
Wasip1/Compile/src_bytes.test-10               254.2k ± 0%     204.6k ± 0%    -19.51% (p=0.001 n=7)
Wasip1/Run/src_bytes.test-10                   6.377k ± 0%     6.377k ± 0%          ~ (p=1.000 n=7)
Wasip1/Compile/src_context.test-10             274.4k ± 0%     222.4k ± 0%    -18.98% (p=0.001 n=7)
Wasip1/Run/src_context.test-10                 3.814k ± 1%     3.814k ± 1%          ~ (p=1.000 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10    227.8k ± 0%     183.1k ± 0%    -19.63% (p=0.001 n=7)
Wasip1/Run/src_encoding_ascii85.test-10        2.707k ± 0%     2.705k ± 0%     -0.07% (p=0.001 n=7)
Wasip1/Compile/src_encoding_asn1.test-10       254.4k ± 0%     199.7k ± 0%    -21.52% (p=0.001 n=7)
Wasip1/Run/src_encoding_asn1.test-10           2.990k ± 0%     2.989k ± 0%          ~ (p=0.086 n=7)
Wasip1/Compile/src_encoding_base32.test-10     233.5k ± 0%     186.8k ± 0%    -20.01% (p=0.001 n=7)
Wasip1/Run/src_encoding_base32.test-10         2.978k ± 0%     2.972k ± 0%          ~ (p=0.070 n=7)
Wasip1/Compile/src_encoding_base64.test-10     235.7k ± 0%     187.6k ± 0%    -20.39% (p=0.001 n=7)
Wasip1/Run/src_encoding_base64.test-10         2.912k ± 0%     2.910k ± 0%     -0.07% (p=0.008 n=7)
Wasip1/Compile/src_encoding_binary.test-10     241.0k ± 0%     193.0k ± 0%    -19.91% (p=0.001 n=7)
Wasip1/Run/src_encoding_binary.test-10         3.069k ± 0%     3.069k ± 0%          ~ (p=0.583 n=7)
Wasip1/Compile/src_encoding_csv.test-10        236.2k ± 0%     188.3k ± 0%    -20.30% (p=0.001 n=7)
Wasip1/Run/src_encoding_csv.test-10            2.938k ± 0%     2.933k ± 0%     -0.17% (p=0.001 n=7)
Wasip1/Compile/src_encoding_gob.test-10        286.7k ± 0%     231.2k ± 0%    -19.37% (p=0.001 n=7)
Wasip1/Run/src_encoding_gob.test-10            10.66k ±  ∞ ²   10.66k ±  ∞ ²        ~ (p=0.524 n=4+5)
geomean                                        32.13k          28.74k         -10.56%
¹ all samples are equal
² need >= 6 samples for confidence interval at level 0.95
```


### TinyGo
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                                        │ old_tinygo.txt │            new_tinygo.txt             │
                                        │     sec/op     │    sec/op      vs base                │
TinyGo/Compile/container_heap.test-10      427.7m ± 1%     419.5m ± 2%    -1.92% (p=0.001 n=7)
TinyGo/Run/container_heap.test-10          14.33m ± 0%     14.36m ± 1%         ~ (p=0.259 n=7)
TinyGo/Compile/container_list.test-10      425.5m ± 2%     418.0m ± 0%    -1.76% (p=0.001 n=7)
TinyGo/Run/container_list.test-10          14.15m ± 1%     14.19m ± 0%         ~ (p=0.710 n=7)
TinyGo/Compile/container_ring.test-10      419.0m ± 5%     411.9m ± 1%    -1.69% (p=0.001 n=7)
TinyGo/Run/container_ring.test-10          14.19m ± 0%     14.15m ± 1%         ~ (p=0.097 n=7)
TinyGo/Compile/crypto_des.test-10          435.9m ± 1%     427.5m ± 0%    -1.94% (p=0.001 n=7)
TinyGo/Run/crypto_des.test-10              18.16m ± 1%     18.16m ± 4%         ~ (p=0.902 n=7)
TinyGo/Compile/crypto_md5.test-10          433.8m ± 1%     425.7m ± 0%    -1.88% (p=0.001 n=7)
TinyGo/Run/crypto_md5.test-10              20.44m ± 0%     20.48m ± 0%         ~ (p=0.318 n=7)
TinyGo/Compile/crypto_rc4.test-10          417.4m ± 0%     410.0m ± 1%    -1.79% (p=0.001 n=7)
TinyGo/Run/crypto_rc4.test-10              160.4m ± 0%     161.0m ± 0%         ~ (p=0.073 n=7)
TinyGo/Compile/crypto_sha1.test-10         432.5m ± 0%     425.1m ± 1%    -1.71% (p=0.001 n=7)
TinyGo/Run/crypto_sha1.test-10             15.98m ± 1%     15.96m ± 1%         ~ (p=0.710 n=7)
TinyGo/Compile/crypto_sha256.test-10       439.4m ± 0%     432.2m ± 1%    -1.64% (p=0.001 n=7)
TinyGo/Run/crypto_sha256.test-10           16.08m ± 1%     16.14m ± 1%         ~ (p=0.318 n=7)
TinyGo/Compile/crypto_sha512.test-10       440.6m ± 0%     433.1m ± 3%    -1.71% (p=0.026 n=7)
TinyGo/Run/crypto_sha512.test-10           18.77m ± 4%     18.66m ± 0%         ~ (p=0.128 n=7)
TinyGo/Compile/encoding_ascii85.test-10    431.0m ± 0%     423.7m ± 0%    -1.68% (p=0.001 n=7)
TinyGo/Run/encoding_ascii85.test-10        14.83m ± 0%     14.86m ± 2%         ~ (p=0.902 n=7)
TinyGo/Compile/encoding_base32.test-10      1.098 ± 1%      1.095 ± 1%    -0.21% (p=0.007 n=7)
TinyGo/Run/encoding_base32.test-10         85.30m ± 1%     90.91m ± 4%    +6.57% (p=0.001 n=7)
TinyGo/Compile/encoding_csv.test-10        467.7m ± 0%     462.8m ± 4%         ~ (p=0.209 n=7)
TinyGo/Run/encoding_csv.test-10            22.70m ± 1%     22.93m ± 3%    +1.03% (p=0.002 n=7)
TinyGo/Compile/encoding_hex.test-10        448.6m ± 0%     440.9m ± 0%    -1.71% (p=0.001 n=7)
TinyGo/Run/encoding_hex.test-10           10.081m ± 1%     9.986m ± 1%    -0.94% (p=0.001 n=7)
TinyGo/Compile/go_scanner.test-10          477.1m ± 0%     467.6m ± 1%    -1.99% (p=0.001 n=7)
TinyGo/Run/go_scanner.test-10              16.84m ± 1%     16.85m ± 0%         ~ (p=1.000 n=7)
TinyGo/Compile/hash.test-10                683.4m ± 2%     671.7m ± 1%    -1.72% (p=0.001 n=7)
TinyGo/Run/hash.test-10                    16.31m ± 0%     16.31m ± 1%         ~ (p=0.805 n=7)
TinyGo/Compile/hash_adler32.test-10        417.2m ± 0%     410.1m ± 3%    -1.70% (p=0.026 n=7)
TinyGo/Run/hash_adler32.test-10            24.49m ± 0%     24.71m ± 0%    +0.89% (p=0.001 n=7)
TinyGo/Compile/hash_crc64.test-10          644.9m ± 1%     637.8m ± 1%    -1.09% (p=0.001 n=7)
TinyGo/Run/hash_crc64.test-10              17.52m ± 1%     17.46m ± 1%         ~ (p=0.165 n=7)
TinyGo/Compile/hash_fnv.test-10            438.7m ± 0%     430.5m ± 2%    -1.87% (p=0.001 n=7)
TinyGo/Run/hash_fnv.test-10                14.86m ± 1%     14.77m ± 0%    -0.62% (p=0.002 n=7)
TinyGo/Compile/html.test-10                 2.193 ± 1%      2.173 ± 1%         ~ (p=0.128 n=7)
TinyGo/Run/html.test-10                    16.00m ± 2%     16.04m ± 1%         ~ (p=0.710 n=7)
TinyGo/Compile/internal_itoa.test-10       415.9m ± 4%     407.4m ± 1%    -2.04% (p=0.001 n=7)
TinyGo/Run/internal_itoa.test-10           14.32m ±  ∞ ¹   14.24m ±  ∞ ¹       ~ (p=0.800 n=4+1)
geomean                                    101.3m          100.7m         -0.64%
¹ need >= 6 samples for confidence interval at level 0.95

                                        │ old_tinygo.txt │             new_tinygo.txt             │
                                        │      B/op      │      B/op       vs base                │
TinyGo/Compile/container_heap.test-10     53.28Mi ± 0%     49.21Mi ± 0%    -7.63% (p=0.001 n=7)
TinyGo/Run/container_heap.test-10         16.63Mi ± 0%     16.63Mi ± 0%         ~ (p=0.535 n=7)
TinyGo/Compile/container_list.test-10     53.23Mi ± 0%     49.18Mi ± 0%    -7.61% (p=0.001 n=7)
TinyGo/Run/container_list.test-10         16.40Mi ± 0%     16.40Mi ± 0%         ~ (p=1.000 n=7)
TinyGo/Compile/container_ring.test-10     52.47Mi ± 0%     48.43Mi ± 0%    -7.70% (p=0.001 n=7)
TinyGo/Run/container_ring.test-10         16.30Mi ± 0%     16.30Mi ± 0%         ~ (p=0.902 n=7)
TinyGo/Compile/crypto_des.test-10         53.43Mi ± 0%     49.31Mi ± 0%    -7.70% (p=0.001 n=7)
TinyGo/Run/crypto_des.test-10             16.76Mi ± 0%     16.76Mi ± 0%         ~ (p=0.073 n=7)
TinyGo/Compile/crypto_md5.test-10         53.55Mi ± 0%     49.39Mi ± 0%    -7.76% (p=0.001 n=7)
TinyGo/Run/crypto_md5.test-10             44.97Mi ± 0%     44.97Mi ± 0%         ~ (p=0.833 n=7)
TinyGo/Compile/crypto_rc4.test-10         52.45Mi ± 0%     48.41Mi ± 0%    -7.71% (p=0.001 n=7)
TinyGo/Run/crypto_rc4.test-10             29.28Mi ± 0%     29.28Mi ± 0%         ~ (p=0.477 n=7)
TinyGo/Compile/crypto_sha1.test-10        53.76Mi ± 0%     49.63Mi ± 0%    -7.69% (p=0.001 n=7)
TinyGo/Run/crypto_sha1.test-10            17.44Mi ± 0%     17.44Mi ± 0%         ~ (p=1.000 n=7)
TinyGo/Compile/crypto_sha256.test-10      53.61Mi ± 0%     49.47Mi ± 0%    -7.72% (p=0.001 n=7)
TinyGo/Run/crypto_sha256.test-10          17.53Mi ± 0%     17.53Mi ± 0%         ~ (p=1.000 n=7)
TinyGo/Compile/crypto_sha512.test-10      53.59Mi ± 0%     49.47Mi ± 0%    -7.69% (p=0.001 n=7)
TinyGo/Run/crypto_sha512.test-10          17.82Mi ± 0%     17.82Mi ± 0%         ~ (p=0.165 n=7)
TinyGo/Compile/encoding_ascii85.test-10   53.38Mi ± 0%     49.25Mi ± 0%    -7.74% (p=0.001 n=7)
TinyGo/Run/encoding_ascii85.test-10       16.54Mi ± 0%     16.54Mi ± 0%         ~ (p=0.175 n=7)
TinyGo/Compile/encoding_base32.test-10    60.78Mi ± 0%     56.25Mi ± 0%    -7.45% (p=0.001 n=7)
TinyGo/Run/encoding_base32.test-10        23.75Mi ± 0%     23.75Mi ± 0%         ~ (p=0.682 n=7)
TinyGo/Compile/encoding_csv.test-10       54.34Mi ± 0%     49.87Mi ± 0%    -8.23% (p=0.001 n=7)
TinyGo/Run/encoding_csv.test-10           11.71Mi ± 0%     11.71Mi ± 0%         ~ (p=0.221 n=7)
TinyGo/Compile/encoding_hex.test-10       53.78Mi ± 0%     49.54Mi ± 0%    -7.88% (p=0.001 n=7)
TinyGo/Run/encoding_hex.test-10           8.264Mi ± 0%     8.263Mi ± 0%         ~ (p=0.209 n=7)
TinyGo/Compile/go_scanner.test-10         55.27Mi ± 0%     50.76Mi ± 0%    -8.16% (p=0.001 n=7)
TinyGo/Run/go_scanner.test-10             18.52Mi ± 0%     18.52Mi ± 0%         ~ (p=0.535 n=7)
TinyGo/Compile/hash.test-10               58.10Mi ± 0%     53.50Mi ± 0%    -7.93% (p=0.001 n=7)
TinyGo/Run/hash.test-10                   18.22Mi ± 0%     18.22Mi ± 0%         ~ (p=0.209 n=7)
TinyGo/Compile/hash_adler32.test-10       52.85Mi ± 0%     48.79Mi ± 0%    -7.69% (p=0.001 n=7)
TinyGo/Run/hash_adler32.test-10           21.36Mi ± 0%     21.36Mi ± 0%         ~ (p=0.318 n=7)
TinyGo/Compile/hash_crc64.test-10         57.30Mi ± 0%     53.08Mi ± 0%    -7.36% (p=0.001 n=7)
TinyGo/Run/hash_crc64.test-10             16.47Mi ± 0%     16.47Mi ± 0%    -0.00% (p=0.017 n=7)
TinyGo/Compile/hash_fnv.test-10           53.50Mi ± 0%     49.35Mi ± 0%    -7.75% (p=0.001 n=7)
TinyGo/Run/hash_fnv.test-10               16.69Mi ± 0%     16.69Mi ± 0%    +0.00% (p=0.017 n=7)
TinyGo/Compile/html.test-10               163.8Mi ± 0%     159.8Mi ± 0%    -2.45% (p=0.001 n=7)
TinyGo/Run/html.test-10                   18.69Mi ± 0%     18.69Mi ± 0%         ~ (p=0.710 n=7)
TinyGo/Compile/internal_itoa.test-10      52.37Mi ± 0%     48.35Mi ± 0%    -7.67% (p=0.001 n=7)
TinyGo/Run/internal_itoa.test-10          16.16Mi ±  ∞ ¹   16.16Mi ±  ∞ ¹       ~ (p=0.800 n=4+1)
geomean                                   32.08Mi          30.86Mi         -3.81%
¹ need >= 6 samples for confidence interval at level 0.95

                                        │ old_tinygo.txt │             new_tinygo.txt             │
                                        │   allocs/op    │   allocs/op    vs base                 │
TinyGo/Compile/container_heap.test-10     110.19k ± 0%     85.06k ± 0%    -22.80% (p=0.001 n=7)
TinyGo/Run/container_heap.test-10          374.9k ± 0%     374.9k ± 0%          ~ (p=0.869 n=7)
TinyGo/Compile/container_list.test-10     109.76k ± 0%     84.83k ± 0%    -22.71% (p=0.001 n=7)
TinyGo/Run/container_list.test-10          370.0k ± 0%     370.0k ± 0%          ~ (p=0.636 n=7)
TinyGo/Compile/container_ring.test-10     109.61k ± 0%     84.69k ± 0%    -22.73% (p=0.001 n=7)
TinyGo/Run/container_ring.test-10          367.6k ± 0%     367.6k ± 0%          ~ (p=0.213 n=7)
TinyGo/Compile/crypto_des.test-10         110.51k ± 0%     85.08k ± 0%    -23.01% (p=0.001 n=7)
TinyGo/Run/crypto_des.test-10              378.1k ± 0%     378.1k ± 0%          ~ (p=0.286 n=7)
TinyGo/Compile/crypto_md5.test-10         110.78k ± 0%     85.27k ± 0%    -23.03% (p=0.001 n=7)
TinyGo/Run/crypto_md5.test-10              393.3k ± 0%     393.3k ± 0%          ~ (p=1.000 n=7)
TinyGo/Compile/crypto_rc4.test-10         109.68k ± 0%     84.82k ± 0%    -22.67% (p=0.001 n=7)
TinyGo/Run/crypto_rc4.test-10              367.1k ± 0%     367.1k ± 0%          ~ (p=0.396 n=7)
TinyGo/Compile/crypto_sha1.test-10        110.95k ± 0%     85.47k ± 0%    -22.96% (p=0.001 n=7)
TinyGo/Run/crypto_sha1.test-10             392.7k ± 0%     392.7k ± 0%          ~ (p=0.266 n=7)
TinyGo/Compile/crypto_sha256.test-10      110.80k ± 0%     85.32k ± 0%    -23.00% (p=0.001 n=7)
TinyGo/Run/crypto_sha256.test-10           394.5k ± 0%     394.5k ± 0%          ~ (p=1.000 n=7)
TinyGo/Compile/crypto_sha512.test-10      110.87k ± 0%     85.34k ± 0%    -23.02% (p=0.001 n=7)
TinyGo/Run/crypto_sha512.test-10           397.2k ± 0%     397.2k ± 0%          ~ (p=1.000 n=7)
TinyGo/Compile/encoding_ascii85.test-10   110.44k ± 0%     84.90k ± 0%    -23.13% (p=0.001 n=7)
TinyGo/Run/encoding_ascii85.test-10        373.0k ± 0%     373.0k ± 0%          ~ (p=0.636 n=7)
TinyGo/Compile/encoding_base32.test-10    116.55k ± 0%     88.68k ± 0%    -23.91% (p=0.001 n=7)
TinyGo/Run/encoding_base32.test-10         397.6k ± 0%     397.7k ± 0%          ~ (p=0.551 n=7)
TinyGo/Compile/encoding_csv.test-10       113.67k ± 0%     86.20k ± 0%    -24.16% (p=0.001 n=7)
TinyGo/Run/encoding_csv.test-10            213.4k ± 0%     213.4k ± 0%          ~ (p=1.000 n=7)
TinyGo/Compile/encoding_hex.test-10       111.61k ± 0%     85.39k ± 0%    -23.49% (p=0.001 n=7)
TinyGo/Run/encoding_hex.test-10            178.4k ± 0%     178.4k ± 0%     -0.00% (p=0.021 n=7)
TinyGo/Compile/go_scanner.test-10         114.33k ± 0%     86.48k ± 0%    -24.37% (p=0.001 n=7)
TinyGo/Run/go_scanner.test-10              420.7k ± 0%     420.7k ± 0%          ~ (p=0.298 n=7)
TinyGo/Compile/hash.test-10               118.17k ± 0%     89.60k ± 0%    -24.17% (p=0.001 n=7)
TinyGo/Run/hash.test-10                    410.7k ± 0%     410.7k ± 0%          ~ (p=0.714 n=7)
TinyGo/Compile/hash_adler32.test-10       109.75k ± 0%     84.65k ± 0%    -22.87% (p=0.001 n=7)
TinyGo/Run/hash_adler32.test-10            368.6k ± 0%     368.6k ± 0%          ~ (p=0.147 n=7)
TinyGo/Compile/hash_crc64.test-10         113.59k ± 0%     87.48k ± 0%    -22.99% (p=0.001 n=7)
TinyGo/Run/hash_crc64.test-10              371.1k ± 0%     371.1k ± 0%          ~ (p=0.122 n=7)
TinyGo/Compile/hash_fnv.test-10           110.77k ± 0%     85.18k ± 0%    -23.11% (p=0.001 n=7)
TinyGo/Run/hash_fnv.test-10                376.0k ± 0%     376.0k ± 0%          ~ (p=0.462 n=7)
TinyGo/Compile/html.test-10                327.9k ± 0%     302.4k ± 0%     -7.79% (p=0.001 n=7)
TinyGo/Run/html.test-10                    414.3k ± 0%     414.3k ± 0%          ~ (p=0.702 n=7)
TinyGo/Compile/internal_itoa.test-10      109.25k ± 0%     84.56k ± 0%    -22.59% (p=0.001 n=7)
TinyGo/Run/internal_itoa.test-10           364.4k ±  ∞ ¹   364.4k ±  ∞ ¹        ~ (p=1.200 n=4+1)
geomean                                    205.8k          181.2k         -11.96%
¹ need >= 6 samples for confidence interval at level 0.95
```

### Compiling wazero (compiled as wasip1) itself
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │  old.txt   │             new.txt              │
               │   sec/op   │   sec/op    vs base              │
Compilation-10   2.537 ± 1%   2.485 ± 0%  -2.04% (p=0.001 n=7)

               │   old.txt    │              new.txt               │
               │     B/op     │     B/op      vs base              │
Compilation-10   354.6Mi ± 0%   341.0Mi ± 0%  -3.83% (p=0.001 n=7)

               │   old.txt   │              new.txt               │
               │  allocs/op  │  allocs/op   vs base               │
Compilation-10   694.6k ± 0%   606.8k ± 0%  -12.64% (p=0.001 n=7)
```