### PR TITLE
Fix path_symlink only works when dir mounted to /

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1951,16 +1951,16 @@ func pathSymlinkFn(_ context.Context, mod api.Module, params []uint64) experimen
 		return experimentalsys.EFAULT
 	}
 
-	newPathBuf, ok := mem.Read(newPath, newPathLen)
-	if !ok {
-		return experimentalsys.EFAULT
+	_, newPathName, errno := atPath(fsc, mod.Memory(), fd, newPath, newPathLen)
+	if errno != 0 {
+		return errno
 	}
 
 	return dir.FS.Symlink(
 		// Do not join old path since it's only resolved when dereference the link created here.
 		// And the dereference result depends on the opening directory's file descriptor at that point.
 		bufToStr(oldPathBuf),
-		path.Join(dir.Name, bufToStr(newPathBuf)),
+		newPathName,
 	)
 }
 

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -4497,7 +4497,7 @@ func Test_pathRemoveDirectory_Errors(t *testing.T) {
 	}
 }
 
-func Test_pathSymlink_errors(t *testing.T) {
+func Test_pathSymlink(t *testing.T) {
 	tmpDir := t.TempDir() // open before loop to ensure no locking problems.
 
 	dirName := "dir"

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -4525,7 +4525,7 @@ func Test_pathSymlink_errors(t *testing.T) {
 	ok = mem.Write(link, []byte(linkName))
 	require.True(t, ok)
 
-	success_cases := []struct {
+	successCases := []struct {
 		name    string
 		fd      int32
 		oldPath string
@@ -4545,7 +4545,7 @@ func Test_pathSymlink_errors(t *testing.T) {
 		},
 	}
 
-	for _, tt := range success_cases {
+	for _, tt := range successCases {
 		tc := tt
 
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This commit fixes `path_symlink` not working when `-mount` is not supplied with a mapped directory.

fixes #2228