### PR TITLE
regalloc: removes unnecessary Instruction.Uses

### DIFF
--- a/internal/engine/wazevo/backend/regalloc/regalloc.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc.go
@@ -754,7 +754,8 @@ func (a *Allocator) allocBlock(f Function, blk Block) {
 		killSet := a.reals[:0]
 
 		// Gather the set of registers that will be used in the current instruction.
-		for _, use := range instr.Uses(&a.vs) {
+		uses := instr.Uses(&a.vs)
+		for _, use := range uses {
 			if use.IsRealReg() {
 				r := use.RealReg()
 				currentUsedSet = currentUsedSet.add(r)
@@ -769,7 +770,7 @@ func (a *Allocator) allocBlock(f Function, blk Block) {
 			}
 		}
 
-		for i, use := range instr.Uses(&a.vs) {
+		for i, use := range uses {
 			if !use.IsRealReg() {
 				vs := s.getVRegState(use.ID())
 				killed := vs.lastUse == pc

--- a/internal/engine/wazevo/wazevoapi/pool.go
+++ b/internal/engine/wazevo/wazevoapi/pool.go
@@ -69,7 +69,7 @@ type IDedPool[T any] struct {
 
 // NewIDedPool returns a new IDedPool.
 func NewIDedPool[T any](resetFn func(*T)) IDedPool[T] {
-	return IDedPool[T]{pool: NewPool[T](resetFn)}
+	return IDedPool[T]{pool: NewPool[T](resetFn), maxIDEncountered: -1}
 }
 
 // GetOrAllocate returns the T with the given id.
@@ -97,7 +97,7 @@ func (p *IDedPool[T]) Get(id int) *T {
 // Reset resets the pool.
 func (p *IDedPool[T]) Reset() {
 	p.pool.Reset()
-	for i := range p.idToItems {
+	for i := 0; i <= p.maxIDEncountered; i++ {
 		p.idToItems[i] = nil
 	}
 	p.maxIDEncountered = -1


### PR DESCRIPTION
This also early stops resetting IDedPool.

### Zig stdlib

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │ old_zig.txt │           new_zig.txt            │
               │   sec/op    │   sec/op    vs base              │
Compilation-10    4.540 ± 0%   4.380 ± 1%  -3.51% (p=0.001 n=7)

               │ old_zig.txt  │          new_zig.txt          │
               │     B/op     │     B/op      vs base         │
Compilation-10   599.3Mi ± 0%   599.3Mi ± 0%  ~ (p=0.383 n=7)

               │ old_zig.txt │         new_zig.txt          │
               │  allocs/op  │  allocs/op   vs base         │
Compilation-10   288.0k ± 0%   288.0k ± 0%  ~ (p=0.805 n=7)
```

### wazero compiled as a wasip1 binary

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │  old.txt   │             new.txt              │
               │   sec/op   │   sec/op    vs base              │
Compilation-10   2.264 ± 1%   2.224 ± 0%  -1.80% (p=0.001 n=7)

               │   old.txt    │            new.txt            │
               │     B/op     │     B/op      vs base         │
Compilation-10   337.3Mi ± 0%   337.3Mi ± 0%  ~ (p=0.318 n=7)

               │   old.txt   │           new.txt            │
               │  allocs/op  │  allocs/op   vs base         │
Compilation-10   593.7k ± 0%   593.6k ± 0%  ~ (p=0.456 n=7)
```

#2182 
