### PR TITLE
regalloc: removes map from RegAllocFunction

### DIFF
--- a/internal/engine/wazevo/backend/regalloc.go
+++ b/internal/engine/wazevo/backend/regalloc.go
@@ -35,7 +35,7 @@ type (
 		iter                   int
 		reversePostOrderBlocks []RegAllocBlock[I, m]
 		// labelToRegAllocBlockIndex maps label to the index of reversePostOrderBlocks.
-		labelToRegAllocBlockIndex map[Label]int
+		labelToRegAllocBlockIndex [] /* Label to */ int
 		loopNestingForestRoots    []ssa.BasicBlock
 	}
 
@@ -56,10 +56,9 @@ type (
 // NewRegAllocFunction returns a new RegAllocFunction.
 func NewRegAllocFunction[I regalloc.InstrConstraint, M RegAllocFunctionMachine[I]](m M, ssb ssa.Builder, c Compiler) *RegAllocFunction[I, M] {
 	return &RegAllocFunction[I, M]{
-		m:                         m,
-		ssb:                       ssb,
-		c:                         c,
-		labelToRegAllocBlockIndex: make(map[Label]int),
+		m:   m,
+		ssb: ssb,
+		c:   c,
 	}
 }
 
@@ -74,6 +73,9 @@ func (f *RegAllocFunction[I, M]) AddBlock(sb ssa.BasicBlock, l Label, begin, end
 		end:   end,
 		id:    int(sb.ID()),
 	})
+	if len(f.labelToRegAllocBlockIndex) <= int(l) {
+		f.labelToRegAllocBlockIndex = append(f.labelToRegAllocBlockIndex, make([]int, int(l)-len(f.labelToRegAllocBlockIndex)+1)...)
+	}
 	f.labelToRegAllocBlockIndex[l] = i
 }
 


### PR DESCRIPTION
This improves the compilation slightly as below:

###  wazero compiled as a wasip1
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │ old_zig.txt │           new_zig.txt            │
               │   sec/op    │   sec/op    vs base              │
Compilation-10    2.227 ± 0%   2.184 ± 1%  -1.96% (p=0.001 n=7)

               │ old_zig.txt  │            new_zig.txt             │
               │     B/op     │     B/op      vs base              │
Compilation-10   337.2Mi ± 0%   337.3Mi ± 0%  +0.02% (p=0.001 n=7)

               │ old_zig.txt │            new_zig.txt            │
               │  allocs/op  │  allocs/op   vs base              │
Compilation-10   593.5k ± 0%   592.9k ± 0%  -0.10% (p=0.001 n=7)
```

### Zig stdlib

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
               │  old.txt   │             new.txt              │
               │   sec/op   │   sec/op    vs base              │
Compilation-10   4.371 ± 1%   4.329 ± 0%  -0.96% (p=0.001 n=7)

               │   old.txt    │              new.txt               │
               │     B/op     │     B/op      vs base              │
Compilation-10   599.3Mi ± 0%   599.3Mi ± 0%  -0.00% (p=0.002 n=7)

               │   old.txt   │           new.txt            │
               │  allocs/op  │  allocs/op   vs base         │
Compilation-10   287.9k ± 0%   287.9k ± 0%  ~ (p=0.053 n=7)
```

#2182 