### PR TITLE
wasi: `path_open` should accept a dir with RIGHT_FD_WRITE

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -1708,7 +1708,6 @@ func openFlags(dirflags, oflags, fdflags uint16, rights uint32) (openFlags exper
 	}
 	if oflags&wasip1.O_DIRECTORY != 0 {
 		openFlags |= experimentalsys.O_DIRECTORY
-		return // Early return for directories as the rest of flags doesn't make sense for it.
 	} else if oflags&wasip1.O_EXCL != 0 {
 		openFlags |= experimentalsys.O_EXCL
 	}

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -3939,6 +3939,18 @@ func Test_pathOpen(t *testing.T) {
 <== (opened_fd=4,errno=ESUCCESS)
 `,
 		},
+		{
+			name:          "sysfs.DirFS file O_DIRECTORY RIGHTS_FD_WRITE",
+			fs:            writeFS,
+			path:          func(*testing.T) string { return fileName },
+			oflags:        wasip1.O_DIRECTORY,
+			rights:        wasip1.RIGHT_FD_WRITE,
+			expectedErrno: wasip1.ErrnoNotdir,
+			expectedLog: `
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=file,oflags=DIRECTORY,fs_rights_base=FD_WRITE,fs_rights_inheriting=,fdflags=)
+<== (opened_fd=,errno=ENOTDIR)
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/imports/wasi_snapshot_preview1/fs_test.go
+++ b/imports/wasi_snapshot_preview1/fs_test.go
@@ -3951,6 +3951,18 @@ func Test_pathOpen(t *testing.T) {
 <== (opened_fd=,errno=ENOTDIR)
 `,
 		},
+		{
+			name:          "sysfs.DirFS dir O_DIRECTORY RIGHTS_FD_WRITE",
+			fs:            writeFS,
+			path:          func(*testing.T) string { return dirName },
+			oflags:        wasip1.O_DIRECTORY,
+			rights:        wasip1.RIGHT_FD_WRITE,
+			expectedErrno: wasip1.ErrnoIsdir,
+			expectedLog: `
+==> wasi_snapshot_preview1.path_open(fd=3,dirflags=,path=dir,oflags=DIRECTORY,fs_rights_base=FD_WRITE,fs_rights_inheriting=,fdflags=)
+<== (opened_fd=,errno=EISDIR)
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sysfs/file.go
+++ b/internal/sysfs/file.go
@@ -38,9 +38,6 @@ func NewStdioFile(stdin bool, f fs.File) (fsapi.File, error) {
 }
 
 func OpenFile(path string, flag experimentalsys.Oflag, perm fs.FileMode) (*os.File, experimentalsys.Errno) {
-	if flag&experimentalsys.O_DIRECTORY != 0 && flag&(experimentalsys.O_WRONLY|experimentalsys.O_RDWR) != 0 {
-		return nil, experimentalsys.EISDIR // invalid to open a directory writeable
-	}
 	return openFile(path, flag, perm)
 }
 


### PR DESCRIPTION
This commit fixes a `path_open` behavior that allows a directory to be `path_open`ed with the `rights::fd_write` flag.  Since Wazero considers it to be an error to open a directory with the write flag normally, it is safe to treat this as a bug.  Although rights/capability system is being scrapped, we still use the `fd_read` and `fd_write` flag to determine if write permission needs to be set.

fixes #2243