### PR TITLE
ssa: reuses slices for basicBlock.params

### DIFF
--- a/internal/engine/wazevo/ssa/builder.go
+++ b/internal/engine/wazevo/ssa/builder.go
@@ -543,7 +543,7 @@ func (b *builder) findValue(typ Type, variable Variable, blk *basicBlock) Value 
 		// Otherwise, add the tmpValue to this block as a parameter which may or may not be redundant, but
 		// later we eliminate trivial params in an optimization pass. This must be done before finding the
 		// definitions in the predecessors so that we can break the cycle.
-		blk.addParamOn(tmpValue)
+		blk.addParamOn(b, tmpValue)
 		// After the new param is added, we have to manipulate the original branching instructions
 		// in predecessors so that they would pass the definition of `variable` as the argument to
 		// the newly added PHI.
@@ -567,7 +567,7 @@ func (b *builder) Seal(raw BasicBlock) {
 	for _, v := range blk.unknownValues {
 		variable, phiValue := v.variable, v.value
 		typ := b.definedVariableType(variable)
-		blk.addParamOn(phiValue)
+		blk.addParamOn(b, phiValue)
 		for i := range blk.preds {
 			pred := &blk.preds[i]
 			predValue := b.findValue(typ, variable, pred.blk)

--- a/internal/engine/wazevo/ssa/pass_blk_layouts.go
+++ b/internal/engine/wazevo/ssa/pass_blk_layouts.go
@@ -303,7 +303,7 @@ func (b *builder) splitCriticalEdge(pred, succ *basicBlock, predInfo *basicBlock
 		trampoline.validate(b)
 	}
 
-	if len(trampoline.params) > 0 {
+	if len(trampoline.params.View()) > 0 {
 		panic("trampoline should not have params")
 	}
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   2.004 ± 2%   2.001 ± 0%       ~ (p=0.620 n=7)
Compilation/zig-10      4.164 ± 1%   4.174 ± 3%       ~ (p=0.097 n=7)
geomean                 2.888        2.890       +0.06%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   297.7Mi ± 0%   297.5Mi ± 0%  -0.06% (p=0.001 n=7)
Compilation/zig-10      594.0Mi ± 0%   593.9Mi ± 0%  -0.01% (p=0.001 n=7)
geomean                 420.5Mi        420.3Mi       -0.03%

                      │   old.txt   │              new.txt              │
                      │  allocs/op  │  allocs/op   vs base              │
Compilation/wazero-10   472.5k ± 0%   457.1k ± 0%  -3.25% (p=0.001 n=7)
Compilation/zig-10      277.2k ± 0%   275.7k ± 0%  -0.53% (p=0.001 n=7)
geomean                 361.9k        355.0k       -1.90%
```