### PR TITLE
compiler: memory usage optimization around br_table

### DIFF
--- a/internal/engine/wazevo/backend/compiler_lower.go
+++ b/internal/engine/wazevo/backend/compiler_lower.go
@@ -105,11 +105,12 @@ func (c *compiler) lowerBranches(br0, br1 *ssa.Instruction) {
 	}
 
 	if br0.Opcode() == ssa.OpcodeJump {
-		_, args, target := br0.BranchData()
+		_, args, targetBlockID := br0.BranchData()
 		argExists := len(args) != 0
 		if argExists && br1 != nil {
 			panic("BUG: critical edge split failed")
 		}
+		target := c.ssaBuilder.BasicBlock(targetBlockID)
 		if argExists && target.ReturnBlock() {
 			if len(args) > 0 {
 				c.mach.LowerReturns(args)

--- a/internal/engine/wazevo/backend/isa/arm64/util_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/util_test.go
@@ -36,6 +36,7 @@ func newSetupWithMockContext() (*mockCompiler, ssa.Builder, *machine) {
 	m := NewBackend().(*machine)
 	m.SetCompiler(ctx)
 	ssaB := ssa.NewBuilder()
+	ctx.ssaBuilder = ssaB
 	blk := ssaB.AllocateBasicBlock()
 	ssaB.SetCurrentBlock(blk)
 	return ctx, ssaB, m
@@ -57,6 +58,7 @@ type mockCompiler struct {
 	definitions map[ssa.Value]*backend.SSAValueDefinition
 	sigs        map[ssa.SignatureID]*ssa.Signature
 	typeOf      map[regalloc.VRegID]ssa.Type
+	ssaBuilder  ssa.Builder
 	relocs      []backend.RelocationInfo
 	buf         []byte
 }
@@ -68,7 +70,7 @@ func (m *mockCompiler) GetFunctionABI(sig *ssa.Signature) *backend.FunctionABI {
 	panic("implement me")
 }
 
-func (m *mockCompiler) SSABuilder() ssa.Builder { return nil }
+func (m *mockCompiler) SSABuilder() ssa.Builder { return m.ssaBuilder }
 
 func (m *mockCompiler) LoopNestingForestRoots() []ssa.BasicBlock { panic("TODO") }
 

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -4068,13 +4068,14 @@ func (c *Compiler) lowerBrTable(labels []uint32, index ssa.Value) {
 		numArgs = len(f.blockType.Results)
 	}
 
-	targets := make([]ssa.BasicBlock, len(labels))
+	varPool := builder.VarLengthPool()
+	trampolineBlockIDs := varPool.Allocate(len(labels))
 
 	// We need trampoline blocks since depending on the target block structure, we might end up inserting moves before jumps,
 	// which cannot be done with br_table. Instead, we can do such per-block moves in the trampoline blocks.
 	// At the linking phase (very end of the backend), we can remove the unnecessary jumps, and therefore no runtime overhead.
 	currentBlk := builder.CurrentBlock()
-	for i, l := range labels {
+	for _, l := range labels {
 		// Args are always on the top of the stack. Note that we should not share the args slice
 		// among the jump instructions since the args are modified during passes (e.g. redundant phi elimination).
 		args := c.nPeekDup(numArgs)
@@ -4082,17 +4083,17 @@ func (c *Compiler) lowerBrTable(labels []uint32, index ssa.Value) {
 		trampoline := builder.AllocateBasicBlock()
 		builder.SetCurrentBlock(trampoline)
 		c.insertJumpToBlock(args, targetBlk)
-		targets[i] = trampoline
+		trampolineBlockIDs = trampolineBlockIDs.Append(builder.VarLengthPool(), ssa.Value(trampoline.ID()))
 	}
 	builder.SetCurrentBlock(currentBlk)
 
 	// If the target block has no arguments, we can just jump to the target block.
 	brTable := builder.AllocateInstruction()
-	brTable.AsBrTable(index, targets)
+	brTable.AsBrTable(index, trampolineBlockIDs)
 	builder.InsertInstruction(brTable)
 
-	for _, trampoline := range targets {
-		builder.Seal(trampoline)
+	for _, trampolineID := range trampolineBlockIDs.View() {
+		builder.Seal(builder.BasicBlock(ssa.BasicBlockID(trampolineID)))
 	}
 }
 

--- a/internal/engine/wazevo/ssa/builder.go
+++ b/internal/engine/wazevo/ssa/builder.go
@@ -129,6 +129,9 @@ type Builder interface {
 
 	// InsertZeroValue inserts a zero value constant instruction of the given type.
 	InsertZeroValue(t Type)
+
+	// BasicBlock returns the BasicBlock of the given ID.
+	BasicBlock(id BasicBlockID) BasicBlock
 }
 
 // NewBuilder returns a new Builder implementation.
@@ -212,6 +215,18 @@ type redundantParam struct {
 	index int
 	// uniqueValue is the Value which is passed to the redundant parameter.
 	uniqueValue Value
+}
+
+// BasicBlock implements Builder.BasicBlock.
+func (b *builder) BasicBlock(id BasicBlockID) BasicBlock {
+	return b.basicBlock(id)
+}
+
+func (b *builder) basicBlock(id BasicBlockID) *basicBlock {
+	if id == basicBlockIDReturnBlock {
+		return b.returnBlk
+	}
+	return b.basicBlocksPool.View(int(id))
 }
 
 // InsertZeroValue implements Builder.InsertZeroValue.
@@ -362,7 +377,7 @@ func (b *builder) Idom(blk BasicBlock) BasicBlock {
 
 // InsertInstruction implements Builder.InsertInstruction.
 func (b *builder) InsertInstruction(instr *Instruction) {
-	b.currentBB.InsertInstruction(instr)
+	b.currentBB.insertInstruction(b, instr)
 
 	if l := b.currentSourceOffset; l.Valid() {
 		// Emit the source offset info only when the instruction has side effect because

--- a/internal/engine/wazevo/ssa/instructions.go
+++ b/internal/engine/wazevo/ssa/instructions.go
@@ -25,11 +25,13 @@ type Instruction struct {
 	v3         Value
 	vs         Values
 	typ        Type
-	blk        BasicBlock
-	targets    []BasicBlock
 	prev, next *Instruction
 
-	rValue         Value
+	// rValue is the (first) return value of this instruction.
+	// For branching instructions except for OpcodeBrTable, they hold BlockID to jump cast to Value.
+	rValue Value
+	// rValues are the rest of the return values of this instruction.
+	// For OpcodeBrTable, it holds the list of BlockID to jump cast to Value.
 	rValues        Values
 	gid            InstructionGroupID
 	sourceOffset   SourceOffset
@@ -105,6 +107,9 @@ type InstructionGroupID uint32
 // Returns Value(s) produced by this instruction if any.
 // The `first` is the first return value, and `rest` is the rest of the values.
 func (i *Instruction) Returns() (first Value, rest []Value) {
+	if i.IsBranching() {
+		return ValueInvalid, nil
+	}
 	return i.rValue, i.rValues.View()
 }
 
@@ -2077,7 +2082,7 @@ func (i *Instruction) InvertBrx() {
 }
 
 // BranchData returns the branch data for this instruction necessary for backends.
-func (i *Instruction) BranchData() (condVal Value, blockArgs []Value, target BasicBlock) {
+func (i *Instruction) BranchData() (condVal Value, blockArgs []Value, target BasicBlockID) {
 	switch i.opcode {
 	case OpcodeJump:
 		condVal = ValueInvalid
@@ -2087,17 +2092,17 @@ func (i *Instruction) BranchData() (condVal Value, blockArgs []Value, target Bas
 		panic("BUG")
 	}
 	blockArgs = i.vs.View()
-	target = i.blk
+	target = BasicBlockID(i.rValue)
 	return
 }
 
 // BrTableData returns the branch table data for this instruction necessary for backends.
-func (i *Instruction) BrTableData() (index Value, targets []BasicBlock) {
+func (i *Instruction) BrTableData() (index Value, targets Values) {
 	if i.opcode != OpcodeBrTable {
 		panic("BUG: BrTableData only available for OpcodeBrTable")
 	}
 	index = i.v
-	targets = i.targets
+	targets = i.rValues
 	return
 }
 
@@ -2105,7 +2110,7 @@ func (i *Instruction) BrTableData() (index Value, targets []BasicBlock) {
 func (i *Instruction) AsJump(vs Values, target BasicBlock) *Instruction {
 	i.opcode = OpcodeJump
 	i.vs = vs
-	i.blk = target
+	i.rValue = Value(target.ID())
 	return i
 }
 
@@ -2130,7 +2135,7 @@ func (i *Instruction) AsBrz(v Value, args Values, target BasicBlock) {
 	i.opcode = OpcodeBrz
 	i.v = v
 	i.vs = args
-	i.blk = target
+	i.rValue = Value(target.ID())
 }
 
 // AsBrnz initializes this instruction as a branch-if-not-zero instruction with OpcodeBrnz.
@@ -2138,15 +2143,16 @@ func (i *Instruction) AsBrnz(v Value, args Values, target BasicBlock) *Instructi
 	i.opcode = OpcodeBrnz
 	i.v = v
 	i.vs = args
-	i.blk = target
+	i.rValue = Value(target.ID())
 	return i
 }
 
 // AsBrTable initializes this instruction as a branch-table instruction with OpcodeBrTable.
-func (i *Instruction) AsBrTable(index Value, targets []BasicBlock) {
+// targets is a list of basic block IDs cast to Values.
+func (i *Instruction) AsBrTable(index Value, targets Values) {
 	i.opcode = OpcodeBrTable
 	i.v = index
-	i.targets = targets
+	i.rValues = targets
 }
 
 // AsCall initializes this instruction as a call instruction with OpcodeCall.
@@ -2531,7 +2537,8 @@ func (i *Instruction) Format(b Builder) string {
 		if i.IsFallthroughJump() {
 			vs[0] = " fallthrough"
 		} else {
-			vs[0] = " " + i.blk.(*basicBlock).Name()
+			blockId := BasicBlockID(i.rValue)
+			vs[0] = " " + b.BasicBlock(blockId).Name()
 		}
 		for idx := range view {
 			vs[idx+1] = view[idx].Format(b)
@@ -2542,7 +2549,8 @@ func (i *Instruction) Format(b Builder) string {
 		view := i.vs.View()
 		vs := make([]string, len(view)+2)
 		vs[0] = " " + i.v.Format(b)
-		vs[1] = i.blk.(*basicBlock).Name()
+		blockId := BasicBlockID(i.rValue)
+		vs[1] = b.BasicBlock(blockId).Name()
 		for idx := range view {
 			vs[idx+2] = view[idx].Format(b)
 		}
@@ -2551,8 +2559,8 @@ func (i *Instruction) Format(b Builder) string {
 		// `BrTable index, [label1, label2, ... labelN]`
 		instSuffix = fmt.Sprintf(" %s", i.v.Format(b))
 		instSuffix += ", ["
-		for i, target := range i.targets {
-			blk := target.(*basicBlock)
+		for i, target := range i.rValues.View() {
+			blk := b.BasicBlock(BasicBlockID(target))
 			if i == 0 {
 				instSuffix += blk.Name()
 			} else {
@@ -2621,11 +2629,12 @@ func (i *Instruction) Format(b Builder) string {
 	instr := i.opcode.String() + instSuffix
 
 	var rvs []string
-	if rv := i.rValue; rv.Valid() {
-		rvs = append(rvs, rv.formatWithType(b))
+	r1, rs := i.Returns()
+	if r1.Valid() {
+		rvs = append(rvs, r1.formatWithType(b))
 	}
 
-	for _, v := range i.rValues.View() {
+	for _, v := range rs {
 		rvs = append(rvs, v.formatWithType(b))
 	}
 

--- a/internal/engine/wazevo/ssa/pass_blk_layouts_test.go
+++ b/internal/engine/wazevo/ssa/pass_blk_layouts_test.go
@@ -120,9 +120,9 @@ func Test_maybeInvertBranch(t *testing.T) {
 				require.Equal(t, tail, next.preds[0].branch)
 				verify = func(t *testing.T) {
 					require.Equal(t, OpcodeJump, tail.opcode)
-					require.Equal(t, OpcodeBrnz, conditionalBr.opcode) // inversion.
-					require.Equal(t, loopHeader, tail.blk)             // swapped.
-					require.Equal(t, next, conditionalBr.blk)          // swapped.
+					require.Equal(t, OpcodeBrnz, conditionalBr.opcode)                       // inversion.
+					require.Equal(t, loopHeader, b.basicBlock(BasicBlockID(tail.rValue)))    // swapped.
+					require.Equal(t, next, b.basicBlock(BasicBlockID(conditionalBr.rValue))) // swapped.
 					require.Equal(t, conditionalBr, tail.prev)
 
 					// Predecessor info should correctly point to the inverted jump instruction.
@@ -150,9 +150,9 @@ func Test_maybeInvertBranch(t *testing.T) {
 
 				verify = func(t *testing.T) {
 					require.Equal(t, OpcodeJump, tail.opcode)
-					require.Equal(t, OpcodeBrnz, conditionalBr.opcode) // inversion.
-					require.Equal(t, next, tail.blk)                   // swapped.
-					require.Equal(t, nowTarget, conditionalBr.blk)     // swapped.
+					require.Equal(t, OpcodeBrnz, conditionalBr.opcode)                            // inversion.
+					require.Equal(t, next, b.basicBlock(BasicBlockID(tail.rValue)))               // swapped.
+					require.Equal(t, nowTarget, b.basicBlock(BasicBlockID(conditionalBr.rValue))) // swapped.
 					require.Equal(t, conditionalBr, tail.prev)
 
 					require.Equal(t, conditionalBr, nowTarget.preds[0].branch)
@@ -166,7 +166,7 @@ func Test_maybeInvertBranch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			b := NewBuilder().(*builder)
 			now, next, verify := tc.setup(b)
-			actual := maybeInvertBranches(now, next)
+			actual := maybeInvertBranches(b, now, next)
 			verify(t)
 			require.Equal(t, tc.exp, actual)
 		})
@@ -202,7 +202,7 @@ func TestBuilder_splitCriticalEdge(t *testing.T) {
 
 	replacedBrz := predBlk.rootInstr.next
 	require.Equal(t, OpcodeBrz, replacedBrz.opcode)
-	require.Equal(t, trampoline, replacedBrz.blk)
+	require.Equal(t, trampoline, b.basicBlock(BasicBlockID(replacedBrz.rValue)))
 }
 
 func Test_swapInstruction(t *testing.T) {


### PR DESCRIPTION
This optimizes the memory usage during compilation for 
br_table instructions. As you can see in the bench results below,
for some cases where lots of br_tables exists (the case named `zz`),
the compilation uses 10% less allocations and 5% less memory, hence
the slightly faster compilation.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   2.015 ± 2%   1.993 ± 0%  -1.09% (p=0.002 n=6)
Compilation/zig-10      4.200 ± 0%   4.161 ± 1%  -0.93% (p=0.004 n=6)
Compilation/zz-10       18.70 ± 0%   18.57 ± 0%  -0.69% (p=0.002 n=6)
geomean                 5.409        5.360       -0.90%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   297.5Mi ± 0%   287.1Mi ± 0%  -3.48% (p=0.002 n=6)
Compilation/zig-10      593.9Mi ± 0%   590.3Mi ± 0%  -0.61% (p=0.002 n=6)
Compilation/zz-10       582.6Mi ± 0%   553.7Mi ± 0%  -4.96% (p=0.002 n=6)
geomean                 468.7Mi        454.4Mi       -3.03%

                      │   old.txt   │              new.txt               │
                      │  allocs/op  │  allocs/op   vs base               │
Compilation/wazero-10   457.0k ± 0%   449.1k ± 0%   -1.72% (p=0.002 n=6)
Compilation/zig-10      275.8k ± 0%   273.8k ± 0%   -0.70% (p=0.002 n=6)
Compilation/zz-10       926.5k ± 0%   830.9k ± 0%  -10.32% (p=0.002 n=6)
geomean                 488.7k        467.5k        -4.35%
```