### PR TITLE
validation: avoids allocation per br_table

### DIFF
--- a/internal/wasm/func_validation.go
+++ b/internal/wasm/func_validation.go
@@ -451,14 +451,14 @@ func (m *Module) validateFunctionWithMaxStackValues(
 				return fmt.Errorf("read immediate: %w", err)
 			}
 
-			list := make([]uint32, nl)
+			sts.ls = sts.ls[:0]
 			for i := uint32(0); i < nl; i++ {
 				l, n, err := leb128.DecodeUint32(br)
 				if err != nil {
 					return fmt.Errorf("read immediate: %w", err)
 				}
 				num += n
-				list[i] = l
+				sts.ls = append(sts.ls, l)
 			}
 			ln, n, err := leb128.DecodeUint32(br)
 			if err != nil {
@@ -511,7 +511,7 @@ func (m *Module) validateFunctionWithMaxStackValues(
 				}
 			}
 
-			for _, l := range list {
+			for _, l := range sts.ls {
 				if int(l) >= len(controlBlockStack.stack) {
 					return fmt.Errorf("invalid l param given for %s", OpcodeBrTableName)
 				}
@@ -2003,6 +2003,8 @@ var vecSplatValueTypes = [...]ValueType{
 type stacks struct {
 	vs valueTypeStack
 	cs controlBlockStack
+	// ls is the label slice that is reused for each br_table instruction.
+	ls []uint32
 }
 
 func (sts *stacks) reset(functionType *FunctionType) {
@@ -2012,6 +2014,7 @@ func (sts *stacks) reset(functionType *FunctionType) {
 	sts.vs.maximumStackPointer = 0
 	sts.cs.stack = sts.cs.stack[:0]
 	sts.cs.stack = append(sts.cs.stack, controlBlock{blockType: functionType})
+	sts.ls = sts.ls[:0]
 }
 
 type controlBlockStack struct {


### PR DESCRIPTION
This eliminates the allocation that previously happened
per br_table instruction during function validation.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   1.993 ± 0%   1.995 ± 0%       ~ (p=0.485 n=6)
Compilation/zig-10      4.161 ± 1%   4.169 ± 0%       ~ (p=0.699 n=6)
Compilation/zz-10       18.57 ± 0%   18.55 ± 0%       ~ (p=0.240 n=6)
geomean                 5.360        5.363       +0.06%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   287.1Mi ± 0%   286.8Mi ± 0%  -0.13% (p=0.002 n=6)
Compilation/zig-10      590.3Mi ± 0%   590.3Mi ± 0%  -0.01% (p=0.002 n=6)
Compilation/zz-10       553.7Mi ± 0%   549.4Mi ± 0%  -0.78% (p=0.002 n=6)
geomean                 454.4Mi        453.0Mi       -0.31%

                      │   old.txt   │              new.txt              │
                      │  allocs/op  │  allocs/op   vs base              │
Compilation/wazero-10   449.1k ± 0%   445.3k ± 0%  -0.84% (p=0.002 n=6)
Compilation/zig-10      273.8k ± 0%   273.0k ± 0%  -0.30% (p=0.002 n=6)
Compilation/zz-10       830.9k ± 0%   783.3k ± 0%  -5.72% (p=0.002 n=6)
geomean                 467.5k        456.7k       -2.32%
```

#2182 