### PR TITLE
frontend: reuses br_table tmp slice correctly

### DIFF
--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -1538,8 +1538,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 		builder.SetCurrentBlock(elseBlk)
 
 	case wasm.OpcodeBrTable:
-		labels := state.tmpForBrTable
-		labels = labels[:0]
+		labels := state.tmpForBrTable[:0]
 		labelCount := c.readI32u()
 		for i := 0; i < int(labelCount); i++ {
 			labels = append(labels, c.readI32u())
@@ -1557,6 +1556,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 		} else {
 			c.lowerBrTable(labels, index)
 		}
+		state.tmpForBrTable = labels // reuse the temporary slice for next use.
 		state.unreachable = true
 
 	case wasm.OpcodeNop:


### PR DESCRIPTION
Previously, the `tmpForBrTable` slice hadn't been
correctly reused, and this fixes it.
As a result, for br_table heavy cases, we see the huge
drop in the number of allocations:

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   1.995 ± 0%   1.999 ± 1%       ~ (p=0.394 n=6)
Compilation/zig-10      4.169 ± 0%   4.168 ± 1%       ~ (p=0.589 n=6)
Compilation/zz-10       18.55 ± 0%   18.55 ± 0%       ~ (p=0.818 n=6)
geomean                 5.363        5.367       +0.06%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   286.8Mi ± 0%   285.4Mi ± 0%  -0.46% (p=0.002 n=6)
Compilation/zig-10      590.3Mi ± 0%   590.1Mi ± 0%  -0.03% (p=0.002 n=6)
Compilation/zz-10       549.4Mi ± 0%   537.7Mi ± 0%  -2.12% (p=0.002 n=6)
geomean                 453.0Mi        449.1Mi       -0.88%

                      │   old.txt   │              new.txt               │
                      │  allocs/op  │  allocs/op   vs base               │
Compilation/wazero-10   445.3k ± 0%   429.0k ± 0%   -3.66% (p=0.002 n=6)
Compilation/zig-10      273.0k ± 0%   269.6k ± 0%   -1.26% (p=0.002 n=6)
Compilation/zz-10       783.3k ± 0%   605.8k ± 0%  -22.66% (p=0.002 n=6)
geomean                 456.7k        412.2k        -9.73%
```

#2182 