### PR TITLE
regalloc: fast access to vrState

### DIFF
--- a/internal/engine/wazevo/backend/regalloc/regset.go
+++ b/internal/engine/wazevo/backend/regalloc/regset.go
@@ -46,7 +46,7 @@ func (rs RegSet) Range(f func(allocatedRealReg RealReg)) {
 	}
 }
 
-type regInUseSet [64]VReg
+type regInUseSet [64]*vrState
 
 func newRegInUseSet() regInUseSet {
 	var ret regInUseSet
@@ -56,42 +56,42 @@ func newRegInUseSet() regInUseSet {
 
 func (rs *regInUseSet) reset() {
 	for i := range rs {
-		rs[i] = VRegInvalid
+		rs[i] = nil
 	}
 }
 
 func (rs *regInUseSet) format(info *RegisterInfo) string { //nolint:unused
 	var ret []string
 	for i, vr := range rs {
-		if vr != VRegInvalid {
-			ret = append(ret, fmt.Sprintf("(%s->v%d)", info.RealRegName(RealReg(i)), vr.ID()))
+		if vr != nil {
+			ret = append(ret, fmt.Sprintf("(%s->v%d)", info.RealRegName(RealReg(i)), vr.v.ID()))
 		}
 	}
 	return strings.Join(ret, ", ")
 }
 
 func (rs *regInUseSet) has(r RealReg) bool {
-	return r < 64 && rs[r] != VRegInvalid
+	return r < 64 && rs[r] != nil
 }
 
-func (rs *regInUseSet) get(r RealReg) VReg {
+func (rs *regInUseSet) get(r RealReg) *vrState {
 	return rs[r]
 }
 
 func (rs *regInUseSet) remove(r RealReg) {
-	rs[r] = VRegInvalid
+	rs[r] = nil
 }
 
-func (rs *regInUseSet) add(r RealReg, vr VReg) {
+func (rs *regInUseSet) add(r RealReg, vr *vrState) {
 	if r >= 64 {
 		return
 	}
 	rs[r] = vr
 }
 
-func (rs *regInUseSet) range_(f func(allocatedRealReg RealReg, vr VReg)) {
+func (rs *regInUseSet) range_(f func(allocatedRealReg RealReg, vr *vrState)) {
 	for i, vr := range rs {
-		if vr != VRegInvalid {
+		if vr != nil {
 			f(RealReg(i), vr)
 		}
 	}


### PR DESCRIPTION
This refactors the regalloc code and makes the access to
vrState pointers really fast and reduce the unnecessary 
function calls that cannot be inlined. As a result, overall
compilation perfomance improves +10% with a slight cost
of memory usage without any impact on the runtime performance.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                                                   │    old.txt    │              new.txt               │
                                                   │    sec/op     │   sec/op     vs base               │
Zig/Compile/test-opt.wasm-10                           3.280 ±  1%    2.976 ± 1%   -9.25% (p=0.001 n=7)
Zig/Compile/test.wasm-10                               4.078 ±  1%    3.771 ± 2%   -7.51% (p=0.001 n=7)
TinyGo/Compile/container_heap.test-10                 299.6m ±  2%   266.1m ± 1%  -11.18% (p=0.001 n=7)
TinyGo/Compile/container_list.test-10                 297.9m ±  0%   264.9m ± 0%  -11.07% (p=0.001 n=7)
TinyGo/Compile/container_ring.test-10                 292.4m ±  0%   260.8m ± 2%  -10.82% (p=0.001 n=7)
TinyGo/Compile/crypto_des.test-10                     304.9m ±  1%   270.8m ± 3%  -11.17% (p=0.001 n=7)
TinyGo/Compile/crypto_md5.test-10                     302.8m ±  0%   269.4m ± 1%  -11.02% (p=0.001 n=7)
TinyGo/Compile/crypto_rc4.test-10                     291.7m ±  0%   259.1m ± 1%  -11.18% (p=0.001 n=7)
TinyGo/Compile/crypto_sha1.test-10                    302.9m ±  2%   269.5m ± 0%  -11.04% (p=0.001 n=7)
TinyGo/Compile/crypto_sha256.test-10                  308.3m ±  1%   274.5m ± 1%  -10.97% (p=0.001 n=7)
TinyGo/Compile/crypto_sha512.test-10                  309.9m ±  0%   276.0m ± 0%  -10.95% (p=0.001 n=7)
TinyGo/Compile/encoding_ascii85.test-10               302.2m ±  1%   269.1m ± 0%  -10.94% (p=0.001 n=7)
TinyGo/Compile/encoding_base32.test-10                641.2m ±  0%   594.4m ± 0%   -7.29% (p=0.001 n=7)
TinyGo/Compile/encoding_csv.test-10                   325.8m ±  0%   289.4m ± 0%  -11.17% (p=0.001 n=7)
TinyGo/Compile/encoding_hex.test-10                   313.8m ±  1%   279.2m ± 0%  -11.05% (p=0.001 n=7)
TinyGo/Compile/go_scanner.test-10                     336.1m ±  4%   298.5m ± 0%  -11.20% (p=0.001 n=7)
TinyGo/Compile/hash.test-10                           402.6m ±  0%   363.3m ± 0%   -9.78% (p=0.001 n=7)
TinyGo/Compile/hash_adler32.test-10                   291.4m ±  2%   259.3m ± 1%  -11.00% (p=0.001 n=7)
TinyGo/Compile/hash_crc64.test-10                     378.3m ±  0%   342.2m ± 0%   -9.52% (p=0.001 n=7)
TinyGo/Compile/hash_fnv.test-10                       306.0m ±  1%   271.7m ± 1%  -11.20% (p=0.001 n=7)
TinyGo/Compile/html.test-10                            2.018 ±  1%    1.971 ± 2%   -2.32% (p=0.001 n=7)
TinyGo/Compile/internal_itoa.test-10                  288.5m ± 10%   257.8m ± 1%  -10.66% (p=0.001 n=7)
TinyGo/Compile/internal_profile.test-10               409.4m ±  1%   364.0m ± 1%  -11.08% (p=0.001 n=7)
TinyGo/Compile/math.test-10                           388.6m ±  0%   345.4m ± 1%  -11.10% (p=0.001 n=7)
TinyGo/Compile/math_cmplx.test-10                     330.9m ±  0%   294.2m ± 0%  -11.08% (p=0.001 n=7)
TinyGo/Compile/net.test-10                            343.9m ±  1%   306.5m ± 1%  -10.86% (p=0.001 n=7)
TinyGo/Compile/net_http_internal_ascii.test-10        288.2m ±  0%   256.9m ± 1%  -10.85% (p=0.001 n=7)
TinyGo/Compile/net_mail.test-10                       386.6m ±  1%   344.2m ± 0%  -10.97% (p=0.001 n=7)
TinyGo/Compile/os.test-10                             362.2m ±  0%   321.3m ± 0%  -11.31% (p=0.001 n=7)
TinyGo/Compile/path.test-10                           297.7m ±  0%   265.7m ± 0%  -10.72% (p=0.001 n=7)
TinyGo/Compile/reflect.test-10                        406.3m ±  1%   360.4m ± 1%  -11.30% (p=0.001 n=7)
TinyGo/Compile/sync.test-10                           302.8m ±  0%   269.9m ± 1%  -10.89% (p=0.001 n=7)
TinyGo/Compile/testing.test-10                        331.0m ±  3%   293.5m ± 0%  -11.31% (p=0.001 n=7)
TinyGo/Compile/testing_iotest.test-10                 315.1m ±  0%   281.5m ± 1%  -10.66% (p=0.001 n=7)
TinyGo/Compile/text_scanner.test-10                   322.0m ±  0%   286.7m ± 0%  -10.97% (p=0.001 n=7)
TinyGo/Compile/unicode.test-10                        304.7m ±  0%   271.6m ± 0%  -10.86% (p=0.001 n=7)
TinyGo/Compile/unicode_utf16.test-10                  303.9m ±  0%   271.2m ± 2%  -10.75% (p=0.001 n=7)
TinyGo/Compile/unicode_utf8.test-10                   300.8m ±  1%   268.2m ± 0%  -10.86% (p=0.001 n=7)
Wasip1/Compile/src_archive_tar.test-10                 1.869 ±  1%    1.643 ± 0%  -12.08% (p=0.001 n=7)
Wasip1/Compile/src_bufio.test-10                       1.268 ±  4%    1.115 ± 1%  -12.04% (p=0.001 n=7)
Wasip1/Compile/src_bytes.test-10                       1.307 ±  1%    1.152 ± 0%  -11.85% (p=0.001 n=7)
Wasip1/Compile/src_context.test-10                     1.407 ±  0%    1.243 ± 1%  -11.66% (p=0.001 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10            1.136 ±  1%    1.002 ± 1%  -11.81% (p=0.001 n=7)
Wasip1/Compile/src_encoding_asn1.test-10               1.301 ±  0%    1.148 ± 1%  -11.80% (p=0.001 n=7)
Wasip1/Compile/src_encoding_base32.test-10             1.180 ±  1%    1.041 ± 1%  -11.80% (p=0.001 n=7)
Wasip1/Compile/src_encoding_base64.test-10             1.186 ±  0%    1.046 ± 0%  -11.76% (p=0.001 n=7)
Wasip1/Compile/src_encoding_binary.test-10             1.216 ±  0%    1.072 ± 1%  -11.88% (p=0.001 n=7)
Wasip1/Compile/src_encoding_csv.test-10                1.182 ±  0%    1.042 ± 0%  -11.81% (p=0.001 n=7)
Wasip1/Compile/src_encoding_gob.test-10                1.612 ±  0%    1.424 ± 4%  -11.69% (p=0.001 n=7)
Wasip1/Compile/src_encoding_hex.test-10                1.153 ±  0%    1.018 ± 1%  -11.70% (p=0.001 n=7)
Wasip1/Compile/src_encoding_json.test-10               3.412 ±  1%    3.013 ± 0%  -11.69% (p=0.001 n=7)
Wasip1/Compile/src_encoding_pem.test-10                1.494 ±  0%    1.319 ± 1%  -11.68% (p=0.001 n=7)
Wasip1/Compile/src_encoding_xml.test-10                1.400 ±  0%    1.236 ± 2%  -11.76% (p=0.001 n=7)
Wasip1/Compile/src_errors.test-10                      1.178 ±  0%    1.038 ± 0%  -11.83% (p=0.001 n=7)
Wasip1/Compile/src_expvar.test-10                      1.751 ±  0%    1.543 ± 0%  -11.87% (p=0.001 n=7)
Wasip1/Compile/src_flag.test-10                        1.279 ±  0%    1.127 ± 0%  -11.89% (p=0.001 n=7)
Wasip1/Compile/src_fmt.test-10                         1.291 ±  0%    1.143 ± 1%  -11.50% (p=0.001 n=7)
Wasip1/Compile/src_hash.test-10                        1.160 ±  0%    1.022 ± 0%  -11.83% (p=0.001 n=7)
Wasip1/Compile/src_hash_adler32.test-10              1170.5m ±  4%   996.2m ± 2%  -14.88% (p=0.001 n=7)
Wasip1/Compile/src_hash_crc32.test-10                  1.188 ±  0%    1.008 ± 0%  -15.17% (p=0.001 n=7)
Wasip1/Compile/src_hash_crc64.test-10                  1.136 ±  4%    1.000 ± 0%  -12.00% (p=0.001 n=7)
Wasip1/Compile/src_hash_fnv.test-10                    1.141 ±  0%    1.002 ± 0%  -12.18% (p=0.001 n=7)
Wasip1/Compile/src_hash_maphash.test-10                1.151 ±  0%    1.010 ± 0%  -12.25% (p=0.001 n=7)
Wasip1/Compile/src_io.test-10                          1.264 ±  0%    1.110 ± 0%  -12.20% (p=0.001 n=7)
Wasip1/Compile/src_io_fs.test-10                       1.248 ±  1%    1.101 ± 0%  -11.75% (p=0.001 n=7)
Wasip1/Compile/src_io_ioutil.test-10                   1.166 ±  0%    1.028 ± 1%  -11.86% (p=0.001 n=7)
Wasip1/Compile/src_log.test-10                         1.145 ±  0%    1.009 ± 0%  -11.95% (p=0.001 n=7)
Wasip1/Compile/src_log_syslog.test-10                  1.133 ±  0%    1.001 ± 0%  -11.66% (p=0.001 n=7)
Wasip1/Compile/src_maps.test-10                        1.144 ±  0%    1.010 ± 0%  -11.77% (p=0.001 n=7)
Wasip1/Compile/src_math.test-10                        1.248 ±  0%    1.102 ± 0%  -11.68% (p=0.001 n=7)
Wasip1/Compile/src_math_big.test-10                    2.368 ±  1%    2.082 ± 0%  -12.07% (p=0.001 n=7)
Wasip1/Compile/src_math_bits.test-10                   1.158 ±  0%    1.022 ± 0%  -11.71% (p=0.001 n=7)
Wasip1/Compile/src_math_cmplx.test-10                  1.176 ±  0%    1.035 ± 0%  -12.00% (p=0.001 n=7)
Wasip1/Compile/src_math_rand.test-10                   1.871 ±  1%    1.649 ± 2%  -11.88% (p=0.001 n=7)
Wasip1/Compile/src_mime.test-10                        1.237 ±  0%    1.089 ± 0%  -11.99% (p=0.001 n=7)
Wasip1/Compile/src_mime_multipart.test-10              1.412 ±  0%    1.239 ± 0%  -12.26% (p=0.001 n=7)
Wasip1/Compile/src_mime_quotedprintable.test-10        1.192 ±  0%    1.049 ± 0%  -11.96% (p=0.001 n=7)
Wasip1/Compile/src_os.test-10                          1.598 ±  0%    1.409 ± 0%  -11.82% (p=0.001 n=7)
Wasip1/Compile/src_os_exec.test-10                     3.080 ±  0%    2.706 ± 5%  -12.15% (p=0.001 n=7)
Wasip1/Compile/src_os_signal.test-10                 1121.0m ±  0%   987.4m ± 0%  -11.92% (p=0.001 n=7)
Wasip1/Compile/src_os_user.test-10                     1.151 ±  0%    1.014 ± 1%  -11.86% (p=0.001 n=7)
Wasip1/Compile/src_path.test-10                        1.138 ±  0%    1.002 ± 0%  -11.89% (p=0.001 n=7)
Wasip1/Compile/src_reflect.test-10                     2.507 ±  0%    2.215 ± 0%  -11.67% (p=0.001 n=7)
Wasip1/Compile/src_regexp.test-10                      1.348 ±  0%    1.185 ± 0%  -12.09% (p=0.001 n=7)
Wasip1/Compile/src_regexp_syntax.test-10               1.156 ±  0%    1.017 ± 0%  -12.04% (p=0.001 n=7)
Wasip1/Compile/src_runtime.test-10                     4.018 ±  0%    3.543 ± 1%  -11.83% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_atomic.test-10     1.143 ±  0%    1.007 ± 1%  -11.86% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_math.test-10     1120.5m ±  0%   987.9m ± 4%  -11.84% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_sys.test-10      1120.5m ±  1%   986.7m ± 0%  -11.94% (p=0.001 n=7)
Wasip1/Compile/src_slices.test-10                      1.278 ±  0%    1.122 ± 0%  -12.19% (p=0.001 n=7)
Wasip1/Compile/src_sort.test-10                        1.201 ±  0%    1.057 ± 0%  -11.99% (p=0.001 n=7)
Wasip1/Compile/src_strconv.test-10                     1.270 ±  1%    1.118 ± 0%  -11.95% (p=0.001 n=7)
Wasip1/Compile/src_strings.test-10                     1.309 ±  0%    1.150 ± 0%  -12.11% (p=0.001 n=7)
Wasip1/Compile/src_sync.test-10                        1.302 ±  0%    1.148 ± 1%  -11.84% (p=0.001 n=7)
Wasip1/Compile/src_sync_atomic.test-10                 1.212 ±  1%    1.069 ± 0%  -11.83% (p=0.001 n=7)
Wasip1/Compile/src_syscall.test-10                   1127.6m ±  0%   997.3m ± 6%  -11.55% (p=0.001 n=7)
Wasip1/Compile/src_testing.test-10                     1.707 ±  0%    1.506 ± 0%  -11.78% (p=0.001 n=7)
Wasip1/Compile/src_testing_fstest.test-10              1.278 ±  0%    1.129 ± 0%  -11.65% (p=0.001 n=7)
Wasip1/Compile/src_testing_iotest.test-10              1.168 ±  1%    1.029 ± 0%  -11.85% (p=0.001 n=7)
Wasip1/Compile/src_testing_quick.test-10               1.183 ±  2%    1.041 ± 0%  -11.94% (p=0.001 n=7)
Wasip1/Compile/src_time.test-10                        1.990 ±  2%    1.756 ± 0%  -11.80% (p=0.001 n=7)
geomean                                               852.1m         754.8m       -11.42%

                                                   │   old.txt    │              new.txt               │
                                                   │     B/op     │     B/op      vs base              │
Zig/Compile/test-opt.wasm-10                         372.3Mi ± 0%   391.4Mi ± 0%  +5.13% (p=0.001 n=7)
Zig/Compile/test.wasm-10                             593.3Mi ± 0%   610.0Mi ± 0%  +2.82% (p=0.001 n=7)
TinyGo/Compile/container_heap.test-10                43.22Mi ± 0%   45.19Mi ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/container_list.test-10                43.19Mi ± 0%   45.17Mi ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/container_ring.test-10                42.44Mi ± 0%   44.41Mi ± 0%  +4.66% (p=0.001 n=7)
TinyGo/Compile/crypto_des.test-10                    43.33Mi ± 0%   45.30Mi ± 0%  +4.55% (p=0.001 n=7)
TinyGo/Compile/crypto_md5.test-10                    43.33Mi ± 0%   45.31Mi ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/crypto_rc4.test-10                    42.42Mi ± 0%   44.39Mi ± 0%  +4.65% (p=0.001 n=7)
TinyGo/Compile/crypto_sha1.test-10                   43.58Mi ± 0%   45.53Mi ± 0%  +4.48% (p=0.001 n=7)
TinyGo/Compile/crypto_sha256.test-10                 43.41Mi ± 0%   45.37Mi ± 0%  +4.50% (p=0.001 n=7)
TinyGo/Compile/crypto_sha512.test-10                 43.46Mi ± 0%   45.43Mi ± 0%  +4.55% (p=0.001 n=7)
TinyGo/Compile/encoding_ascii85.test-10              43.25Mi ± 0%   45.23Mi ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/encoding_base32.test-10               49.04Mi ± 0%   51.33Mi ± 0%  +4.66% (p=0.001 n=7)
TinyGo/Compile/encoding_csv.test-10                  43.74Mi ± 0%   45.71Mi ± 0%  +4.50% (p=0.001 n=7)
TinyGo/Compile/encoding_hex.test-10                  43.44Mi ± 0%   45.45Mi ± 0%  +4.63% (p=0.001 n=7)
TinyGo/Compile/go_scanner.test-10                    44.21Mi ± 0%   46.46Mi ± 0%  +5.08% (p=0.001 n=7)
TinyGo/Compile/hash.test-10                          45.52Mi ± 0%   47.84Mi ± 0%  +5.10% (p=0.001 n=7)
TinyGo/Compile/hash_adler32.test-10                  42.80Mi ± 0%   44.78Mi ± 0%  +4.62% (p=0.001 n=7)
TinyGo/Compile/hash_crc64.test-10                    45.29Mi ± 0%   47.27Mi ± 0%  +4.37% (p=0.001 n=7)
TinyGo/Compile/hash_fnv.test-10                      43.33Mi ± 0%   45.31Mi ± 0%  +4.56% (p=0.001 n=7)
TinyGo/Compile/html.test-10                          143.8Mi ± 0%   147.9Mi ± 0%  +2.82% (p=0.001 n=7)
TinyGo/Compile/internal_itoa.test-10                 42.37Mi ± 0%   44.34Mi ± 0%  +4.65% (p=0.001 n=7)
TinyGo/Compile/internal_profile.test-10              32.76Mi ± 0%   34.56Mi ± 0%  +5.48% (p=0.001 n=7)
TinyGo/Compile/math.test-10                          46.45Mi ± 0%   48.47Mi ± 0%  +4.34% (p=0.001 n=7)
TinyGo/Compile/math_cmplx.test-10                    44.33Mi ± 0%   46.34Mi ± 0%  +4.53% (p=0.001 n=7)
TinyGo/Compile/net.test-10                           44.95Mi ± 0%   46.92Mi ± 0%  +4.38% (p=0.001 n=7)
TinyGo/Compile/net_http_internal_ascii.test-10       42.38Mi ± 0%   44.36Mi ± 0%  +4.66% (p=0.001 n=7)
TinyGo/Compile/net_mail.test-10                      46.72Mi ± 0%   49.15Mi ± 0%  +5.20% (p=0.001 n=7)
TinyGo/Compile/os.test-10                            45.43Mi ± 0%   47.40Mi ± 0%  +4.34% (p=0.001 n=7)
TinyGo/Compile/path.test-10                          43.18Mi ± 0%   45.16Mi ± 0%  +4.58% (p=0.001 n=7)
TinyGo/Compile/reflect.test-10                       45.09Mi ± 0%   47.81Mi ± 0%  +6.03% (p=0.001 n=7)
TinyGo/Compile/sync.test-10                          43.56Mi ± 0%   45.53Mi ± 0%  +4.54% (p=0.001 n=7)
TinyGo/Compile/testing.test-10                       37.62Mi ± 0%   39.84Mi ± 0%  +5.89% (p=0.001 n=7)
TinyGo/Compile/testing_iotest.test-10                43.53Mi ± 0%   45.50Mi ± 0%  +4.54% (p=0.001 n=7)
TinyGo/Compile/text_scanner.test-10                  43.99Mi ± 0%   46.22Mi ± 0%  +5.08% (p=0.001 n=7)
TinyGo/Compile/unicode.test-10                       43.32Mi ± 0%   45.29Mi ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/unicode_utf16.test-10                 40.82Mi ± 0%   42.82Mi ± 0%  +4.89% (p=0.001 n=7)
TinyGo/Compile/unicode_utf8.test-10                  43.55Mi ± 0%   45.53Mi ± 0%  +4.53% (p=0.001 n=7)
Wasip1/Compile/src_archive_tar.test-10               84.13Mi ± 0%   84.86Mi ± 0%  +0.87% (p=0.001 n=7)
Wasip1/Compile/src_bufio.test-10                     65.31Mi ± 0%   65.96Mi ± 0%  +0.99% (p=0.001 n=7)
Wasip1/Compile/src_bytes.test-10                     66.39Mi ± 0%   67.03Mi ± 0%  +0.97% (p=0.001 n=7)
Wasip1/Compile/src_context.test-10                   68.90Mi ± 0%   69.55Mi ± 0%  +0.94% (p=0.001 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10          61.91Mi ± 0%   62.56Mi ± 0%  +1.05% (p=0.001 n=7)
Wasip1/Compile/src_encoding_asn1.test-10             66.47Mi ± 0%   67.15Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_encoding_base32.test-10           63.29Mi ± 0%   63.94Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_encoding_base64.test-10           63.46Mi ± 0%   64.11Mi ± 0%  +1.01% (p=0.001 n=7)
Wasip1/Compile/src_encoding_binary.test-10           64.29Mi ± 0%   64.94Mi ± 0%  +1.01% (p=0.001 n=7)
Wasip1/Compile/src_encoding_csv.test-10              63.43Mi ± 0%   64.07Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_encoding_gob.test-10              74.53Mi ± 0%   75.34Mi ± 0%  +1.08% (p=0.001 n=7)
Wasip1/Compile/src_encoding_hex.test-10              62.37Mi ± 0%   63.02Mi ± 0%  +1.03% (p=0.001 n=7)
Wasip1/Compile/src_encoding_json.test-10             146.6Mi ± 0%   147.6Mi ± 0%  +0.62% (p=0.001 n=7)
Wasip1/Compile/src_encoding_pem.test-10              71.95Mi ± 0%   72.65Mi ± 0%  +0.97% (p=0.001 n=7)
Wasip1/Compile/src_encoding_xml.test-10              69.11Mi ± 0%   69.90Mi ± 0%  +1.15% (p=0.001 n=7)
Wasip1/Compile/src_errors.test-10                    63.27Mi ± 0%   63.92Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_expvar.test-10                    77.27Mi ± 0%   77.96Mi ± 0%  +0.89% (p=0.001 n=7)
Wasip1/Compile/src_flag.test-10                      65.94Mi ± 0%   66.62Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_fmt.test-10                       66.26Mi ± 0%   66.91Mi ± 0%  +0.98% (p=0.001 n=7)
Wasip1/Compile/src_hash.test-10                      62.62Mi ± 0%   63.26Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_hash_adler32.test-10              61.74Mi ± 0%   62.38Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_hash_crc32.test-10                62.09Mi ± 0%   62.73Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_hash_crc64.test-10                61.82Mi ± 0%   62.46Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_hash_fnv.test-10                  62.04Mi ± 0%   62.68Mi ± 0%  +1.05% (p=0.001 n=7)
Wasip1/Compile/src_hash_maphash.test-10              62.17Mi ± 0%   62.81Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_io.test-10                        65.26Mi ± 0%   65.90Mi ± 0%  +0.99% (p=0.001 n=7)
Wasip1/Compile/src_io_fs.test-10                     64.96Mi ± 0%   65.60Mi ± 0%  +0.99% (p=0.001 n=7)
Wasip1/Compile/src_io_ioutil.test-10                 62.60Mi ± 0%   63.24Mi ± 0%  +1.03% (p=0.001 n=7)
Wasip1/Compile/src_log.test-10                       62.21Mi ± 0%   62.85Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_log_syslog.test-10                61.85Mi ± 0%   62.49Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_maps.test-10                      62.07Mi ± 0%   62.72Mi ± 0%  +1.03% (p=0.001 n=7)
Wasip1/Compile/src_math.test-10                      65.72Mi ± 0%   66.68Mi ± 0%  +1.46% (p=0.001 n=7)
Wasip1/Compile/src_math_big.test-10                  92.21Mi ± 0%   93.01Mi ± 0%  +0.87% (p=0.001 n=7)
Wasip1/Compile/src_math_bits.test-10                 62.60Mi ± 0%   63.24Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_math_cmplx.test-10                63.26Mi ± 0%   64.12Mi ± 0%  +1.36% (p=0.001 n=7)
Wasip1/Compile/src_math_rand.test-10                 80.80Mi ± 0%   81.61Mi ± 0%  +1.00% (p=0.001 n=7)
Wasip1/Compile/src_mime.test-10                      64.63Mi ± 0%   65.28Mi ± 0%  +1.00% (p=0.001 n=7)
Wasip1/Compile/src_mime_multipart.test-10            68.30Mi ± 0%   68.95Mi ± 0%  +0.95% (p=0.001 n=7)
Wasip1/Compile/src_mime_quotedprintable.test-10      63.50Mi ± 0%   64.15Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_os.test-10                        73.36Mi ± 0%   74.00Mi ± 0%  +0.88% (p=0.001 n=7)
Wasip1/Compile/src_os_exec.test-10                   108.8Mi ± 0%   109.4Mi ± 0%  +0.63% (p=0.001 n=7)
Wasip1/Compile/src_os_signal.test-10                 61.50Mi ± 0%   62.15Mi ± 0%  +1.05% (p=0.001 n=7)
Wasip1/Compile/src_os_user.test-10                   62.22Mi ± 0%   62.87Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_path.test-10                      61.88Mi ± 0%   62.52Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_reflect.test-10                   272.3Mi ± 0%   274.1Mi ± 0%  +0.66% (p=0.001 n=7)
Wasip1/Compile/src_regexp.test-10                    81.61Mi ± 0%   82.41Mi ± 0%  +0.99% (p=0.001 n=7)
Wasip1/Compile/src_regexp_syntax.test-10             62.32Mi ± 0%   62.97Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_runtime.test-10                   151.9Mi ± 0%   153.3Mi ± 0%  +0.90% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_atomic.test-10   62.09Mi ± 0%   62.73Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_math.test-10     61.53Mi ± 0%   62.17Mi ± 0%  +1.05% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_sys.test-10      61.53Mi ± 0%   62.17Mi ± 0%  +1.05% (p=0.001 n=7)
Wasip1/Compile/src_slices.test-10                    65.41Mi ± 0%   66.05Mi ± 0%  +0.99% (p=0.001 n=7)
Wasip1/Compile/src_sort.test-10                      64.00Mi ± 0%   64.65Mi ± 0%  +1.01% (p=0.001 n=7)
Wasip1/Compile/src_strconv.test-10                   65.78Mi ± 0%   66.55Mi ± 0%  +1.18% (p=0.001 n=7)
Wasip1/Compile/src_strings.test-10                   67.37Mi ± 0%   68.11Mi ± 0%  +1.09% (p=0.001 n=7)
Wasip1/Compile/src_sync.test-10                      66.84Mi ± 0%   67.52Mi ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_sync_atomic.test-10               64.23Mi ± 0%   64.88Mi ± 0%  +1.01% (p=0.001 n=7)
Wasip1/Compile/src_syscall.test-10                   61.74Mi ± 0%   62.38Mi ± 0%  +1.04% (p=0.001 n=7)
Wasip1/Compile/src_testing.test-10                   76.64Mi ± 0%   77.33Mi ± 0%  +0.91% (p=0.001 n=7)
Wasip1/Compile/src_testing_fstest.test-10            65.58Mi ± 0%   66.22Mi ± 0%  +0.98% (p=0.001 n=7)
Wasip1/Compile/src_testing_iotest.test-10            62.60Mi ± 0%   63.24Mi ± 0%  +1.03% (p=0.001 n=7)
Wasip1/Compile/src_testing_quick.test-10             63.74Mi ± 0%   64.42Mi ± 0%  +1.07% (p=0.001 n=7)
Wasip1/Compile/src_time.test-10                      84.31Mi ± 0%   85.01Mi ± 0%  +0.83% (p=0.001 n=7)
geomean                                              62.04Mi        63.50Mi       +2.35%

                                                   │   old.txt   │              new.txt              │
                                                   │  allocs/op  │  allocs/op   vs base              │
Zig/Compile/test-opt.wasm-10                         310.0k ± 0%   330.3k ± 0%  +6.53% (p=0.001 n=7)
Zig/Compile/test.wasm-10                             269.7k ± 0%   274.8k ± 0%  +1.90% (p=0.001 n=7)
TinyGo/Compile/container_heap.test-10                66.48k ± 0%   69.39k ± 0%  +4.38% (p=0.001 n=7)
TinyGo/Compile/container_list.test-10                66.29k ± 0%   69.26k ± 0%  +4.48% (p=0.001 n=7)
TinyGo/Compile/container_ring.test-10                66.19k ± 0%   69.19k ± 0%  +4.54% (p=0.001 n=7)
TinyGo/Compile/crypto_des.test-10                    66.57k ± 0%   69.52k ± 0%  +4.43% (p=0.001 n=7)
TinyGo/Compile/crypto_md5.test-10                    66.48k ± 0%   69.52k ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/crypto_rc4.test-10                    66.22k ± 0%   69.18k ± 0%  +4.47% (p=0.001 n=7)
TinyGo/Compile/crypto_sha1.test-10                   66.79k ± 0%   69.78k ± 0%  +4.48% (p=0.001 n=7)
TinyGo/Compile/crypto_sha256.test-10                 66.60k ± 0%   69.58k ± 0%  +4.47% (p=0.001 n=7)
TinyGo/Compile/crypto_sha512.test-10                 66.71k ± 0%   69.66k ± 0%  +4.42% (p=0.001 n=7)
TinyGo/Compile/encoding_ascii85.test-10              66.33k ± 0%   69.31k ± 0%  +4.50% (p=0.001 n=7)
TinyGo/Compile/encoding_base32.test-10               69.12k ± 0%   71.97k ± 0%  +4.12% (p=0.001 n=7)
TinyGo/Compile/encoding_csv.test-10                  67.27k ± 0%   70.28k ± 0%  +4.48% (p=0.001 n=7)
TinyGo/Compile/encoding_hex.test-10                  66.63k ± 0%   69.62k ± 0%  +4.49% (p=0.001 n=7)
TinyGo/Compile/go_scanner.test-10                    67.24k ± 0%   70.18k ± 0%  +4.37% (p=0.001 n=7)
TinyGo/Compile/hash.test-10                          69.05k ± 0%   71.65k ± 0%  +3.76% (p=0.001 n=7)
TinyGo/Compile/hash_adler32.test-10                  66.18k ± 0%   69.18k ± 0%  +4.55% (p=0.001 n=7)
TinyGo/Compile/hash_crc64.test-10                    68.02k ± 0%   70.42k ± 0%  +3.54% (p=0.001 n=7)
TinyGo/Compile/hash_fnv.test-10                      66.53k ± 0%   69.54k ± 0%  +4.52% (p=0.001 n=7)
TinyGo/Compile/html.test-10                          243.2k ± 0%   261.6k ± 0%  +7.58% (p=0.001 n=7)
TinyGo/Compile/internal_itoa.test-10                 66.09k ± 0%   69.09k ± 0%  +4.53% (p=0.001 n=7)
TinyGo/Compile/internal_profile.test-10              53.79k ± 0%   55.89k ± 0%  +3.91% (p=0.001 n=7)
TinyGo/Compile/math.test-10                          68.08k ± 0%   71.07k ± 0%  +4.40% (p=0.001 n=7)
TinyGo/Compile/math_cmplx.test-10                    67.92k ± 0%   70.93k ± 0%  +4.43% (p=0.001 n=7)
TinyGo/Compile/net.test-10                           67.30k ± 0%   70.21k ± 0%  +4.32% (p=0.001 n=7)
TinyGo/Compile/net_http_internal_ascii.test-10       66.15k ± 0%   69.12k ± 0%  +4.49% (p=0.001 n=7)
TinyGo/Compile/net_mail.test-10                      70.15k ± 0%   73.05k ± 0%  +4.13% (p=0.001 n=7)
TinyGo/Compile/os.test-10                            68.04k ± 0%   70.95k ± 0%  +4.27% (p=0.001 n=7)
TinyGo/Compile/path.test-10                          66.32k ± 0%   69.34k ± 0%  +4.56% (p=0.001 n=7)
TinyGo/Compile/reflect.test-10                       67.83k ± 0%   70.85k ± 0%  +4.45% (p=0.001 n=7)
TinyGo/Compile/sync.test-10                          66.61k ± 0%   69.58k ± 0%  +4.46% (p=0.001 n=7)
TinyGo/Compile/testing.test-10                       59.47k ± 0%   62.05k ± 0%  +4.34% (p=0.001 n=7)
TinyGo/Compile/testing_iotest.test-10                66.83k ± 0%   69.83k ± 0%  +4.48% (p=0.001 n=7)
TinyGo/Compile/text_scanner.test-10                  66.81k ± 0%   69.77k ± 0%  +4.42% (p=0.001 n=7)
TinyGo/Compile/unicode.test-10                       66.53k ± 0%   69.52k ± 0%  +4.49% (p=0.001 n=7)
TinyGo/Compile/unicode_utf16.test-10                 67.56k ± 0%   70.65k ± 0%  +4.57% (p=0.001 n=7)
TinyGo/Compile/unicode_utf8.test-10                  66.43k ± 0%   69.39k ± 0%  +4.46% (p=0.001 n=7)
Wasip1/Compile/src_archive_tar.test-10               221.2k ± 0%   224.2k ± 0%  +1.33% (p=0.001 n=7)
Wasip1/Compile/src_bufio.test-10                     159.0k ± 0%   161.9k ± 0%  +1.83% (p=0.001 n=7)
Wasip1/Compile/src_bytes.test-10                     165.7k ± 0%   168.7k ± 0%  +1.77% (p=0.001 n=7)
Wasip1/Compile/src_context.test-10                   180.5k ± 0%   183.5k ± 0%  +1.63% (p=0.001 n=7)
Wasip1/Compile/src_encoding_ascii85.test-10          148.6k ± 0%   151.6k ± 0%  +2.02% (p=0.001 n=7)
Wasip1/Compile/src_encoding_asn1.test-10             161.7k ± 0%   164.7k ± 0%  +1.81% (p=0.001 n=7)
Wasip1/Compile/src_encoding_base32.test-10           151.5k ± 0%   154.5k ± 0%  +1.99% (p=0.001 n=7)
Wasip1/Compile/src_encoding_base64.test-10           151.9k ± 0%   154.8k ± 0%  +1.91% (p=0.001 n=7)
Wasip1/Compile/src_encoding_binary.test-10           156.2k ± 0%   159.2k ± 0%  +1.91% (p=0.001 n=7)
Wasip1/Compile/src_encoding_csv.test-10              152.8k ± 0%   155.7k ± 0%  +1.93% (p=0.001 n=7)
Wasip1/Compile/src_encoding_gob.test-10              186.2k ± 0%   189.3k ± 0%  +1.65% (p=0.001 n=7)
Wasip1/Compile/src_encoding_hex.test-10              150.8k ± 0%   153.7k ± 0%  +1.92% (p=0.001 n=7)
Wasip1/Compile/src_encoding_json.test-10             300.9k ± 0%   305.5k ± 0%  +1.54% (p=0.001 n=7)
Wasip1/Compile/src_encoding_pem.test-10              172.8k ± 0%   175.8k ± 0%  +1.72% (p=0.001 n=7)
Wasip1/Compile/src_encoding_xml.test-10              172.8k ± 0%   175.8k ± 0%  +1.71% (p=0.001 n=7)
Wasip1/Compile/src_errors.test-10                    152.0k ± 0%   155.0k ± 0%  +1.96% (p=0.001 n=7)
Wasip1/Compile/src_expvar.test-10                    204.6k ± 0%   207.5k ± 0%  +1.43% (p=0.001 n=7)
Wasip1/Compile/src_flag.test-10                      160.9k ± 0%   163.9k ± 0%  +1.85% (p=0.001 n=7)
Wasip1/Compile/src_fmt.test-10                       165.5k ± 0%   168.5k ± 0%  +1.79% (p=0.001 n=7)
Wasip1/Compile/src_hash.test-10                      152.4k ± 0%   155.2k ± 0%  +1.89% (p=0.001 n=7)
Wasip1/Compile/src_hash_adler32.test-10              147.9k ± 0%   150.9k ± 0%  +2.00% (p=0.001 n=7)
Wasip1/Compile/src_hash_crc32.test-10                150.3k ± 0%   153.3k ± 0%  +1.95% (p=0.001 n=7)
Wasip1/Compile/src_hash_crc64.test-10                148.5k ± 0%   151.4k ± 0%  +1.96% (p=0.001 n=7)
Wasip1/Compile/src_hash_fnv.test-10                  150.5k ± 0%   153.5k ± 0%  +1.99% (p=0.001 n=7)
Wasip1/Compile/src_hash_maphash.test-10              150.3k ± 0%   153.2k ± 0%  +1.97% (p=0.001 n=7)
Wasip1/Compile/src_io.test-10                        162.8k ± 0%   165.8k ± 0%  +1.80% (p=0.001 n=7)
Wasip1/Compile/src_io_fs.test-10                     160.7k ± 0%   163.6k ± 0%  +1.81% (p=0.001 n=7)
Wasip1/Compile/src_io_ioutil.test-10                 152.0k ± 0%   155.0k ± 0%  +1.94% (p=0.001 n=7)
Wasip1/Compile/src_log.test-10                       150.5k ± 0%   153.5k ± 0%  +1.96% (p=0.001 n=7)
Wasip1/Compile/src_log_syslog.test-10                148.4k ± 0%   151.3k ± 0%  +1.97% (p=0.001 n=7)
Wasip1/Compile/src_maps.test-10                      148.7k ± 0%   151.6k ± 0%  +1.91% (p=0.001 n=7)
Wasip1/Compile/src_math.test-10                      157.8k ± 0%   160.9k ± 0%  +1.92% (p=0.001 n=7)
Wasip1/Compile/src_math_big.test-10                  253.0k ± 0%   255.9k ± 0%  +1.16% (p=0.001 n=7)
Wasip1/Compile/src_math_bits.test-10                 154.1k ± 0%   157.0k ± 0%  +1.86% (p=0.001 n=7)
Wasip1/Compile/src_math_cmplx.test-10                150.7k ± 0%   153.7k ± 0%  +1.98% (p=0.001 n=7)
Wasip1/Compile/src_math_rand.test-10                 242.7k ± 0%   245.8k ± 0%  +1.25% (p=0.001 n=7)
Wasip1/Compile/src_mime.test-10                      155.8k ± 0%   158.8k ± 0%  +1.92% (p=0.001 n=7)
Wasip1/Compile/src_mime_multipart.test-10            169.4k ± 0%   172.4k ± 0%  +1.76% (p=0.001 n=7)
Wasip1/Compile/src_mime_quotedprintable.test-10      152.7k ± 0%   155.7k ± 0%  +1.94% (p=0.001 n=7)
Wasip1/Compile/src_os.test-10                        187.4k ± 0%   190.4k ± 0%  +1.57% (p=0.001 n=7)
Wasip1/Compile/src_os_exec.test-10                   280.1k ± 0%   283.0k ± 0%  +1.02% (p=0.001 n=7)
Wasip1/Compile/src_os_signal.test-10                 147.1k ± 0%   150.1k ± 0%  +2.04% (p=0.001 n=7)
Wasip1/Compile/src_os_user.test-10                   150.2k ± 0%   153.3k ± 0%  +2.04% (p=0.001 n=7)
Wasip1/Compile/src_path.test-10                      148.6k ± 0%   151.5k ± 0%  +2.01% (p=0.001 n=7)
Wasip1/Compile/src_reflect.test-10                   405.2k ± 0%   421.0k ± 0%  +3.89% (p=0.001 n=7)
Wasip1/Compile/src_regexp.test-10                    180.3k ± 0%   185.2k ± 0%  +2.72% (p=0.001 n=7)
Wasip1/Compile/src_regexp_syntax.test-10             149.1k ± 0%   151.9k ± 0%  +1.92% (p=0.001 n=7)
Wasip1/Compile/src_runtime.test-10                   328.4k ± 0%   333.8k ± 0%  +1.64% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_atomic.test-10   150.8k ± 0%   153.8k ± 0%  +1.95% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_math.test-10     147.2k ± 0%   150.2k ± 0%  +2.05% (p=0.001 n=7)
Wasip1/Compile/src_runtime_internal_sys.test-10      147.3k ± 0%   150.2k ± 0%  +1.98% (p=0.001 n=7)
Wasip1/Compile/src_slices.test-10                    160.7k ± 0%   163.7k ± 0%  +1.88% (p=0.001 n=7)
Wasip1/Compile/src_sort.test-10                      159.8k ± 0%   162.7k ± 0%  +1.85% (p=0.001 n=7)
Wasip1/Compile/src_strconv.test-10                   160.5k ± 0%   163.5k ± 0%  +1.90% (p=0.001 n=7)
Wasip1/Compile/src_strings.test-10                   172.2k ± 0%   175.1k ± 0%  +1.71% (p=0.001 n=7)
Wasip1/Compile/src_sync.test-10                      174.6k ± 0%   177.6k ± 0%  +1.68% (p=0.001 n=7)
Wasip1/Compile/src_sync_atomic.test-10               158.9k ± 0%   161.9k ± 0%  +1.94% (p=0.001 n=7)
Wasip1/Compile/src_syscall.test-10                   148.5k ± 0%   151.3k ± 0%  +1.93% (p=0.001 n=7)
Wasip1/Compile/src_testing.test-10                   209.0k ± 0%   211.8k ± 0%  +1.35% (p=0.001 n=7)
Wasip1/Compile/src_testing_fstest.test-10            160.2k ± 0%   163.1k ± 0%  +1.81% (p=0.001 n=7)
Wasip1/Compile/src_testing_iotest.test-10            151.1k ± 0%   154.1k ± 0%  +1.98% (p=0.001 n=7)
Wasip1/Compile/src_testing_quick.test-10             154.7k ± 0%   157.6k ± 0%  +1.88% (p=0.001 n=7)
Wasip1/Compile/src_time.test-10                      232.6k ± 0%   235.6k ± 0%  +1.28% (p=0.001 n=7)
geomean                                              124.8k        128.3k       +2.82%
```

#2182 