### PR TITLE
regalloc: use less memory in liveness analysis

### DIFF
--- a/internal/engine/wazevo/backend/regalloc/regalloc.go
+++ b/internal/engine/wazevo/backend/regalloc/regalloc.go
@@ -432,7 +432,7 @@ func (a *Allocator) livenessAnalysis(f Function) {
 			}
 
 			for _, st := range succInfo.liveIns {
-				if st.phiBlk() != succ {
+				if st.phiBlk() != succ && st.spilled != flagLive { //nolint:gosimple
 					// We use .spilled field to store the flag.
 					st.spilled = flagLive
 					a.ss = append(a.ss, st)
@@ -448,17 +448,18 @@ func (a *Allocator) livenessAnalysis(f Function) {
 				if !def.IsRealReg() {
 					st := s.getOrAllocateVRegState(def)
 					defIsPhi = st.isPhi
-					// We use .spilled field to store the flag.
+					// Note: We use .spilled field to store the flag.
 					st.spilled = flagDeleted
-					a.ss = append(a.ss, st)
 				}
 			}
 			for _, use = range instr.Uses(&a.vs) {
 				if !use.IsRealReg() {
 					st := s.getOrAllocateVRegState(use)
-					// We use .spilled field to store the flag.
-					st.spilled = flagLive
-					a.ss = append(a.ss, st)
+					// Note: We use .spilled field to store the flag.
+					if st.spilled != flagLive { //nolint:gosimple
+						st.spilled = flagLive
+						a.ss = append(a.ss, st)
+					}
 				}
 			}
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   1.721 ± 0%   1.721 ± 0%       ~ (p=0.818 n=6)
Compilation/zig-10      3.764 ± 3%   3.765 ± 0%       ~ (p=0.818 n=6)
Compilation/zz-10       16.06 ± 5%   16.00 ± 0%  -0.40% (p=0.015 n=6)
geomean                 4.703        4.697       -0.13%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   291.0Mi ± 0%   286.8Mi ± 0%  -1.47% (p=0.002 n=6)
Compilation/zig-10      610.0Mi ± 0%   601.7Mi ± 0%  -1.37% (p=0.002 n=6)
Compilation/zz-10       538.8Mi ± 0%   538.2Mi ± 0%  -0.12% (p=0.002 n=6)
geomean                 457.3Mi        452.8Mi       -0.99%

                      │   old.txt   │              new.txt              │
                      │  allocs/op  │  allocs/op   vs base              │
Compilation/wazero-10   448.5k ± 0%   448.5k ± 0%       ~ (p=0.589 n=6)
Compilation/zig-10      274.7k ± 0%   274.8k ± 0%       ~ (p=0.818 n=6)
Compilation/zz-10       618.5k ± 0%   618.6k ± 0%       ~ (p=0.699 n=6)
geomean                 424.0k        424.0k       +0.01%
```