### PR TITLE
compiler: removes unnecessary code paths

### DIFF
--- a/internal/engine/wazevo/ssa/builder.go
+++ b/internal/engine/wazevo/ssa/builder.go
@@ -294,10 +294,6 @@ func (b *builder) Init(s *Signature) {
 	b.nextValueID = 0
 	b.reversePostOrderedBasicBlocks = b.reversePostOrderedBasicBlocks[:0]
 	b.doneBlockLayout = false
-	for i := range b.valueRefCounts {
-		b.valueRefCounts[i] = 0
-	}
-
 	b.currentSourceOffset = sourceOffsetUnknown
 }
 


### PR DESCRIPTION
This removes the unnecessary code paths in a various places,
and the below is the result:

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   1.634 ± 0%   1.626 ± 0%  -0.51% (p=0.002 n=6)
Compilation/zig-10      3.588 ± 0%   3.538 ± 2%       ~ (p=0.065 n=6)
Compilation/zz-10       15.25 ± 0%   14.87 ± 1%  -2.46% (p=0.002 n=6)
geomean                 4.472        4.406       -1.46%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   271.2Mi ± 0%   271.2Mi ± 0%       ~ (p=1.000 n=6)
Compilation/zig-10      596.3Mi ± 0%   596.3Mi ± 0%       ~ (p=0.699 n=6)
Compilation/zz-10       528.9Mi ± 0%   528.9Mi ± 0%       ~ (p=0.818 n=6)
geomean                 440.6Mi        440.6Mi       +0.00%

                      │   old.txt   │              new.txt              │
                      │  allocs/op  │  allocs/op   vs base              │
Compilation/wazero-10   448.5k ± 0%   448.5k ± 0%       ~ (p=0.937 n=6)
Compilation/zig-10      274.8k ± 0%   274.7k ± 0%       ~ (p=1.000 n=6)
Compilation/zz-10       618.3k ± 0%   618.4k ± 0%       ~ (p=0.818 n=6)
geomean                 423.9k        423.9k       -0.00%
```