### PR TITLE
regalloc: complete de-virtualization

### DIFF
--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -18,7 +18,7 @@ import (
 func NewBackend() backend.Machine {
 	m := &machine{
 		cpuFeatures:                         platform.CpuFeatures,
-		regAlloc:                            regalloc.NewAllocator[*instruction, *labelPosition](regInfo),
+		regAlloc:                            regalloc.NewAllocator[*instruction, *labelPosition, *regAllocFn](regInfo),
 		spillSlots:                          map[regalloc.VRegID]int64{},
 		amodePool:                           wazevoapi.NewPool[amode](nil),
 		labelPositionPool:                   wazevoapi.NewIDedPool[labelPosition](resetLabelPosition),
@@ -51,7 +51,7 @@ type (
 
 		cpuFeatures platform.CpuFeatureFlags
 
-		regAlloc        regalloc.Allocator[*instruction, *labelPosition]
+		regAlloc        regalloc.Allocator[*instruction, *labelPosition, *regAllocFn]
 		regAllocFn      regAllocFn
 		regAllocStarted bool
 

--- a/internal/engine/wazevo/backend/isa/arm64/machine.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine.go
@@ -40,7 +40,7 @@ type (
 		// maxSSABlockID is the maximum ssa.BasicBlockID in the current function.
 		maxSSABlockID label
 
-		regAlloc   regalloc.Allocator[*instruction, *labelPosition]
+		regAlloc   regalloc.Allocator[*instruction, *labelPosition, *regAllocFn]
 		regAllocFn regAllocFn
 
 		amodePool wazevoapi.Pool[addressMode]
@@ -156,7 +156,7 @@ func resetLabelPosition(l *labelPosition) {
 func NewBackend() backend.Machine {
 	m := &machine{
 		spillSlots:        make(map[regalloc.VRegID]int64),
-		regAlloc:          regalloc.NewAllocator[*instruction, *labelPosition](regInfo),
+		regAlloc:          regalloc.NewAllocator[*instruction, *labelPosition, *regAllocFn](regInfo),
 		amodePool:         wazevoapi.NewPool[addressMode](resetAddressMode),
 		instrPool:         wazevoapi.NewPool[instruction](resetInstruction),
 		labelPositionPool: wazevoapi.NewIDedPool[labelPosition](resetLabelPosition),

--- a/internal/engine/wazevo/backend/regalloc/regset.go
+++ b/internal/engine/wazevo/backend/regalloc/regset.go
@@ -46,21 +46,21 @@ func (rs RegSet) Range(f func(allocatedRealReg RealReg)) {
 	}
 }
 
-type regInUseSet[I Instr, B Block[I]] [64]*vrState[I, B]
+type regInUseSet[I Instr, B Block[I], F Function[I, B]] [64]*vrState[I, B, F]
 
-func newRegInUseSet[I Instr, B Block[I]]() regInUseSet[I, B] {
-	var ret regInUseSet[I, B]
+func newRegInUseSet[I Instr, B Block[I], F Function[I, B]]() regInUseSet[I, B, F] {
+	var ret regInUseSet[I, B, F]
 	ret.reset()
 	return ret
 }
 
-func (rs *regInUseSet[I, B]) reset() {
+func (rs *regInUseSet[I, B, F]) reset() {
 	for i := range rs {
 		rs[i] = nil
 	}
 }
 
-func (rs *regInUseSet[I, B]) format(info *RegisterInfo) string { //nolint:unused
+func (rs *regInUseSet[I, B, F]) format(info *RegisterInfo) string { //nolint:unused
 	var ret []string
 	for i, vr := range rs {
 		if vr != nil {
@@ -70,26 +70,26 @@ func (rs *regInUseSet[I, B]) format(info *RegisterInfo) string { //nolint:unused
 	return strings.Join(ret, ", ")
 }
 
-func (rs *regInUseSet[I, B]) has(r RealReg) bool {
+func (rs *regInUseSet[I, B, F]) has(r RealReg) bool {
 	return r < 64 && rs[r] != nil
 }
 
-func (rs *regInUseSet[I, B]) get(r RealReg) *vrState[I, B] {
+func (rs *regInUseSet[I, B, F]) get(r RealReg) *vrState[I, B, F] {
 	return rs[r]
 }
 
-func (rs *regInUseSet[I, B]) remove(r RealReg) {
+func (rs *regInUseSet[I, B, F]) remove(r RealReg) {
 	rs[r] = nil
 }
 
-func (rs *regInUseSet[I, B]) add(r RealReg, vr *vrState[I, B]) {
+func (rs *regInUseSet[I, B, F]) add(r RealReg, vr *vrState[I, B, F]) {
 	if r >= 64 {
 		return
 	}
 	rs[r] = vr
 }
 
-func (rs *regInUseSet[I, B]) range_(f func(allocatedRealReg RealReg, vr *vrState[I, B])) {
+func (rs *regInUseSet[I, B, F]) range_(f func(allocatedRealReg RealReg, vr *vrState[I, B, F])) {
 	for i, vr := range rs {
 		if vr != nil {
 			f(RealReg(i), vr)


### PR DESCRIPTION
This is a follow-up on https://github.com/tetratelabs/wazero/pull/2265.
It basically removes the interface invocation completely, but the 
benchmark result doesn't show any diff, so this is more of a cleanup 
and consistency in the codebase.