### PR TITLE
ssa: removes map use for Value aliasing

### DIFF
--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -128,8 +128,6 @@ type compiler struct {
 	ssaValueToVRegs [] /* VRegID to */ regalloc.VReg
 	// ssaValueDefinitions maps ssa.ValueID to its definition.
 	ssaValueDefinitions []SSAValueDefinition
-	// ssaValueRefCounts is a cached list obtained by ssa.Builder.ValueRefCounts().
-	ssaValueRefCounts []int
 	// returnVRegs is the list of virtual registers that store the return values.
 	returnVRegs  []regalloc.VReg
 	varEdges     [][2]regalloc.VReg
@@ -206,8 +204,7 @@ func (c *compiler) setCurrentGroupID(gid ssa.InstructionGroupID) {
 // assignVirtualRegisters assigns a virtual register to each ssa.ValueID Valid in the ssa.Builder.
 func (c *compiler) assignVirtualRegisters() {
 	builder := c.ssaBuilder
-	refCounts := builder.ValueRefCounts()
-	c.ssaValueRefCounts = refCounts
+	refCounts := builder.ValuesInfo()
 
 	need := len(refCounts)
 	if need >= len(c.ssaValueToVRegs) {
@@ -242,7 +239,7 @@ func (c *compiler) assignVirtualRegisters() {
 				c.ssaValueDefinitions[id] = SSAValueDefinition{
 					Instr:    cur,
 					N:        0,
-					RefCount: refCounts[id],
+					RefCount: refCounts[id].RefCount,
 				}
 				c.ssaTypeOfVRegID[vReg.ID()] = ssaTyp
 				N++
@@ -255,7 +252,7 @@ func (c *compiler) assignVirtualRegisters() {
 				c.ssaValueDefinitions[id] = SSAValueDefinition{
 					Instr:    cur,
 					N:        N,
-					RefCount: refCounts[id],
+					RefCount: refCounts[id].RefCount,
 				}
 				c.ssaTypeOfVRegID[vReg.ID()] = ssaTyp
 				N++

--- a/internal/engine/wazevo/backend/compiler_lower.go
+++ b/internal/engine/wazevo/backend/compiler_lower.go
@@ -124,9 +124,10 @@ func (c *compiler) lowerFunctionArguments(entry ssa.BasicBlock) {
 	mach := c.mach
 
 	c.tmpVals = c.tmpVals[:0]
+	data := c.ssaBuilder.ValuesInfo()
 	for i := 0; i < entry.Params(); i++ {
 		p := entry.Param(i)
-		if c.ssaValueRefCounts[p.ID()] > 0 {
+		if data[p.ID()].RefCount > 0 {
 			c.tmpVals = append(c.tmpVals, p)
 		} else {
 			// If the argument is not used, we can just pass an invalid value.

--- a/internal/engine/wazevo/backend/vdef.go
+++ b/internal/engine/wazevo/backend/vdef.go
@@ -18,7 +18,7 @@ type SSAValueDefinition struct {
 	// N is the index of the return value in the instr's return values list.
 	N int
 	// RefCount is the number of references to the result.
-	RefCount int
+	RefCount uint32
 }
 
 func (d *SSAValueDefinition) IsFromInstr() bool {

--- a/internal/engine/wazevo/ssa/builder_test.go
+++ b/internal/engine/wazevo/ssa/builder_test.go
@@ -1,0 +1,26 @@
+package ssa
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
+)
+
+func TestBuilder_resolveAlias(t *testing.T) {
+	b := NewBuilder().(*builder)
+	v1 := b.allocateValue(TypeI32)
+	v2 := b.allocateValue(TypeI32)
+	v3 := b.allocateValue(TypeI32)
+	v4 := b.allocateValue(TypeI32)
+	v5 := b.allocateValue(TypeI32)
+
+	b.alias(v1, v2)
+	b.alias(v2, v3)
+	b.alias(v3, v4)
+	b.alias(v4, v5)
+	require.Equal(t, v5, b.resolveAlias(v1))
+	require.Equal(t, v5, b.resolveAlias(v2))
+	require.Equal(t, v5, b.resolveAlias(v3))
+	require.Equal(t, v5, b.resolveAlias(v4))
+	require.Equal(t, v5, b.resolveAlias(v5))
+}

--- a/internal/engine/wazevo/ssa/pass_test.go
+++ b/internal/engine/wazevo/ssa/pass_test.go
@@ -264,9 +264,9 @@ blk2: () <-- (blk1)
 					require.True(t, jmp.live)
 					require.True(t, ret.live)
 
-					require.Equal(t, 1, b.valueRefCounts[refOnceVal.ID()])
-					require.Equal(t, 1, b.valueRefCounts[addRes.ID()])
-					require.Equal(t, 3, b.valueRefCounts[refThriceVal.ID()])
+					require.Equal(t, uint32(1), b.valuesInfo[refOnceVal.ID()].RefCount)
+					require.Equal(t, uint32(1), b.valuesInfo[addRes.ID()].RefCount)
+					require.Equal(t, uint32(3), b.valuesInfo[refThriceVal.ID()].RefCount)
 				}
 			},
 			before: `

--- a/internal/engine/wazevo/ssa/vs.go
+++ b/internal/engine/wazevo/ssa/vs.go
@@ -67,7 +67,7 @@ func (v Value) formatWithType(b Builder) (ret string) {
 	if wazevoapi.SSALoggingEnabled { // This is useful to check live value analysis bugs.
 		if bd := b.(*builder); bd.donePostBlockLayoutPasses {
 			id := v.ID()
-			ret += fmt.Sprintf("(ref=%d)", bd.valueRefCounts[id])
+			ret += fmt.Sprintf("(ref=%d)", bd.valuesInfo[id].RefCount)
 		}
 	}
 	return ret


### PR DESCRIPTION
This improves the compilation perf by up to ~30% without 
runtime perf impacts.

```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
                                            │   old.txt    │              new.txt               │
                                            │    sec/op    │   sec/op     vs base               │
Zig/Compile/test-opt.wasm-10                    2.683 ± 1%    2.591 ± 1%   -3.44% (p=0.002 n=6)
Zig/Run/test-opt.wasm-10                        18.75 ± 0%    19.03 ± 1%   +1.48% (p=0.004 n=6)
Zig/Compile/test.wasm-10                        3.529 ± 0%    3.516 ± 1%        ~ (p=0.180 n=6)
Zig/Run/test.wasm-10                            19.55 ± 2%    19.48 ± 1%        ~ (p=0.310 n=6)
TinyGo/Compile/container_heap.test-10          298.1m ± 1%   210.1m ± 0%  -29.51% (p=0.002 n=6)
TinyGo/Run/container_heap.test-10              14.59m ± 2%   14.55m ± 1%        ~ (p=0.310 n=6)
TinyGo/Compile/container_list.test-10          290.6m ± 0%   208.6m ± 0%  -28.20% (p=0.002 n=6)
TinyGo/Run/container_list.test-10              14.47m ± 1%   14.40m ± 0%        ~ (p=0.132 n=6)
TinyGo/Compile/container_ring.test-10          286.4m ± 0%   205.1m ± 0%  -28.42% (p=0.002 n=6)
TinyGo/Run/container_ring.test-10              14.36m ± 1%   14.42m ± 1%        ~ (p=0.180 n=6)
TinyGo/Compile/crypto_des.test-10              296.6m ± 0%   214.2m ± 2%  -27.77% (p=0.002 n=6)
TinyGo/Run/crypto_des.test-10                  18.70m ± 4%   18.64m ± 0%        ~ (p=0.132 n=6)
TinyGo/Compile/crypto_md5.test-10              295.8m ± 5%   211.4m ± 0%  -28.53% (p=0.002 n=6)
TinyGo/Run/crypto_md5.test-10                  21.72m ± 1%   20.67m ± 1%   -4.85% (p=0.002 n=6)
TinyGo/Compile/crypto_rc4.test-10              291.4m ± 2%   203.4m ± 0%  -30.20% (p=0.002 n=6)
TinyGo/Run/crypto_rc4.test-10                  161.0m ± 1%   160.7m ± 1%        ~ (p=0.818 n=6)
TinyGo/Compile/crypto_sha1.test-10             296.0m ± 0%   211.9m ± 1%  -28.43% (p=0.002 n=6)
TinyGo/Run/crypto_sha1.test-10                 16.14m ± 1%   16.17m ± 1%        ~ (p=0.485 n=6)
TinyGo/Compile/crypto_sha256.test-10           301.0m ± 1%   216.1m ± 1%  -28.21% (p=0.002 n=6)
TinyGo/Run/crypto_sha256.test-10               16.21m ± 1%   16.27m ± 1%        ~ (p=0.310 n=6)
Wasip1/Compile/src_archive_tar.test-10          1.596 ± 0%    1.490 ± 0%   -6.63% (p=0.002 n=6)
Wasip1/Run/src_archive_tar.test-10             396.5m ± 0%   396.5m ± 1%        ~ (p=0.818 n=6)
Wasip1/Compile/src_bufio.test-10                1.089 ± 0%    1.008 ± 0%   -7.44% (p=0.002 n=6)
Wasip1/Run/src_bufio.test-10                   121.4m ± 0%   121.5m ± 0%        ~ (p=0.240 n=6)
Wasip1/Compile/src_bytes.test-10                1.127 ± 0%    1.038 ± 0%   -7.91% (p=0.002 n=6)
Wasip1/Run/src_bytes.test-10                   468.1m ± 1%   466.8m ± 1%        ~ (p=0.132 n=6)
Wasip1/Compile/src_context.test-10              1.213 ± 1%    1.119 ± 0%   -7.76% (p=0.002 n=6)
Wasip1/Run/src_context.test-10                 33.69m ± 1%   33.57m ± 0%   -0.33% (p=0.026 n=6)
Wasip1/Compile/src_encoding_ascii85.test-10    979.9m ± 0%   905.5m ± 0%   -7.59% (p=0.002 n=6)
Wasip1/Run/src_encoding_ascii85.test-10        7.320m ± 1%   7.324m ± 3%        ~ (p=0.589 n=6)
Wasip1/Compile/src_encoding_asn1.test-10        1.128 ± 1%    1.043 ± 0%   -7.48% (p=0.002 n=6)
Wasip1/Run/src_encoding_asn1.test-10           8.221m ± 2%   8.239m ± 1%        ~ (p=0.394 n=6)
Wasip1/Compile/src_encoding_base32.test-10    1019.3m ± 1%   940.4m ± 0%   -7.74% (p=0.002 n=6)
Wasip1/Run/src_encoding_base32.test-10         28.57m ± 1%   28.78m ± 0%   +0.74% (p=0.041 n=6)
Wasip1/Compile/src_encoding_base64.test-10    1024.8m ± 1%   945.4m ± 0%   -7.75% (p=0.002 n=6)
Wasip1/Run/src_encoding_base64.test-10         11.78m ± 1%   11.80m ± 4%        ~ (p=0.589 n=6)
```

#2182 