### PR TITLE
ssa: removes valueIDToInstruction slice

### DIFF
--- a/internal/engine/wazevo/ssa/vs.go
+++ b/internal/engine/wazevo/ssa/vs.go
@@ -38,7 +38,8 @@ func (v Variable) getType() Type {
 // Value represents an SSA value with a type information. The relationship with Variable is 1: N (including 0),
 // that means there might be multiple Variable(s) for a Value.
 //
-// Higher 32-bit is used to store Type for this value.
+// 32 to 59-bit is used to store the unique identifier of the Instruction that generates this value if any.
+// 60 to 63-bit is used to store Type for this value.
 type Value uint64
 
 // ValueID is the lower 32bit of Value, which is the pure identifier of Value without type info.
@@ -80,7 +81,7 @@ func (v Value) Valid() bool {
 
 // Type returns the Type of this value.
 func (v Value) Type() Type {
-	return Type(v >> 32)
+	return Type(v >> 60)
 }
 
 // ID returns the valueID of this value.
@@ -90,7 +91,20 @@ func (v Value) ID() ValueID {
 
 // setType sets a type to this Value and returns the updated Value.
 func (v Value) setType(typ Type) Value {
-	return v | Value(typ)<<32
+	return v | Value(typ)<<60
+}
+
+// setInstructionID sets an Instruction.id to this Value and returns the updated Value.
+func (v Value) setInstructionID(id int) Value {
+	if id < 0 || uint(id) >= 1<<28 {
+		panic(fmt.Sprintf("Too large instruction ID: %d", id))
+	}
+	return v | Value(id)<<32
+}
+
+// instructionID() returns the Instruction.id of this Value.
+func (v Value) instructionID() int {
+	return int(v>>32) & 0x0fffffff
 }
 
 // Values is a slice of Value. Use this instead of []Value to reuse the underlying memory.

--- a/internal/engine/wazevo/ssa/vs_test.go
+++ b/internal/engine/wazevo/ssa/vs_test.go
@@ -1,8 +1,9 @@
 package ssa
 
 import (
-	"github.com/tetratelabs/wazero/internal/testing/require"
 	"testing"
+
+	"github.com/tetratelabs/wazero/internal/testing/require"
 )
 
 func TestValue_InstructionID(t *testing.T) {

--- a/internal/engine/wazevo/ssa/vs_test.go
+++ b/internal/engine/wazevo/ssa/vs_test.go
@@ -1,0 +1,13 @@
+package ssa
+
+import (
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"testing"
+)
+
+func TestValue_InstructionID(t *testing.T) {
+	v := Value(1234).setType(TypeI32).setInstructionID(5678)
+	require.Equal(t, ValueID(1234), v.ID())
+	require.Equal(t, 5678, v.instructionID())
+	require.Equal(t, TypeI32, v.Type())
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   1.564 ± 0%   1.536 ± 1%  -1.78% (p=0.002 n=6)
Compilation/zig-10      3.461 ± 0%   3.421 ± 0%  -1.13% (p=0.002 n=6)
Compilation/zz-10       14.28 ± 0%   14.06 ± 1%  -1.57% (p=0.002 n=6)
geomean                 4.260        4.196       -1.49%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   286.2Mi ± 0%   283.0Mi ± 0%  -1.13% (p=0.002 n=6)
Compilation/zig-10      598.2Mi ± 0%   596.7Mi ± 0%  -0.25% (p=0.002 n=6)
Compilation/zz-10       538.0Mi ± 0%   536.5Mi ± 0%  -0.28% (p=0.002 n=6)
geomean                 451.6Mi        449.1Mi       -0.55%

                      │   old.txt   │              new.txt              │
                      │  allocs/op  │  allocs/op   vs base              │
Compilation/wazero-10   485.5k ± 0%   485.3k ± 0%       ~ (p=0.394 n=6)
Compilation/zig-10      275.5k ± 0%   275.5k ± 0%       ~ (p=0.937 n=6)
Compilation/zz-10       627.0k ± 0%   627.0k ± 0%       ~ (p=0.589 n=6)
geomean                 437.7k        437.7k       -0.01%
```

#2182 