### PR TITLE
backend: removes unnecessary ValueDefinition fields

### DIFF
--- a/internal/engine/wazevo/backend/compiler.go
+++ b/internal/engine/wazevo/backend/compiler.go
@@ -222,14 +222,13 @@ func (c *compiler) assignVirtualRegisters() {
 			typ := p.Type()
 			vreg := c.AllocateVReg(typ)
 			c.ssaValueToVRegs[pid] = vreg
-			c.ssaValueDefinitions[pid] = SSAValueDefinition{BlockParamValue: p, BlkParamVReg: vreg}
+			c.ssaValueDefinitions[pid] = SSAValueDefinition{V: p}
 			c.ssaTypeOfVRegID[vreg.ID()] = p.Type()
 		}
 
 		// Assigns each value to a virtual register produced by instructions.
 		for cur := blk.Root(); cur != nil; cur = cur.Next() {
 			r, rs := cur.Returns()
-			var N int
 			if r.Valid() {
 				id := r.ID()
 				ssaTyp := r.Type()
@@ -238,11 +237,10 @@ func (c *compiler) assignVirtualRegisters() {
 				c.ssaValueToVRegs[id] = vReg
 				c.ssaValueDefinitions[id] = SSAValueDefinition{
 					Instr:    cur,
-					N:        0,
+					V:        r,
 					RefCount: refCounts[id].RefCount,
 				}
 				c.ssaTypeOfVRegID[vReg.ID()] = ssaTyp
-				N++
 			}
 			for _, r := range rs {
 				id := r.ID()
@@ -251,11 +249,10 @@ func (c *compiler) assignVirtualRegisters() {
 				c.ssaValueToVRegs[id] = vReg
 				c.ssaValueDefinitions[id] = SSAValueDefinition{
 					Instr:    cur,
-					N:        N,
+					V:        r,
 					RefCount: refCounts[id].RefCount,
 				}
 				c.ssaTypeOfVRegID[vReg.ID()] = ssaTyp
-				N++
 			}
 		}
 	}

--- a/internal/engine/wazevo/backend/isa/amd64/lower_mem.go
+++ b/internal/engine/wazevo/backend/isa/amd64/lower_mem.go
@@ -131,8 +131,8 @@ func (m *machine) lowerAddendsToAmode(x, y addend, offBase uint32) *amode {
 }
 
 func (m *machine) lowerAddend(x *backend.SSAValueDefinition) addend {
-	if x.IsFromBlockParam() {
-		return addend{x.BlkParamVReg, 0, 0}
+	if !x.IsFromInstr() {
+		return addend{m.c.VRegOf(x.V), 0, 0}
 	}
 	// Ensure the addend is not referenced in multiple places; we will discard nested Iadds.
 	op := m.c.MatchInstrOneOf(x, addendsMatchOpcodes[:])

--- a/internal/engine/wazevo/backend/isa/amd64/lower_mem_test.go
+++ b/internal/engine/wazevo/backend/isa/amd64/lower_mem_test.go
@@ -53,7 +53,8 @@ func TestMachine_lowerToAddressMode(t *testing.T) {
 				ptr = iadd.Return()
 				offset = 3
 				ctx.definitions[iconst1.Return()] = &backend.SSAValueDefinition{Instr: iconst1}
-				ctx.definitions[p] = &backend.SSAValueDefinition{BlockParamValue: p, BlkParamVReg: raxVReg}
+				ctx.vRegMap[p] = raxVReg
+				ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 				ctx.definitions[ptr] = &backend.SSAValueDefinition{Instr: iadd}
 				return
 			},
@@ -67,8 +68,10 @@ func TestMachine_lowerToAddressMode(t *testing.T) {
 				iadd := b.AllocateInstruction().AsIadd(p1, p2).Insert(b)
 				ptr = iadd.Return()
 				offset = 3
-				ctx.definitions[p1] = &backend.SSAValueDefinition{BlockParamValue: p1, BlkParamVReg: raxVReg}
-				ctx.definitions[p2] = &backend.SSAValueDefinition{BlockParamValue: p2, BlkParamVReg: rcxVReg}
+				ctx.vRegMap[p1] = raxVReg
+				ctx.definitions[p1] = &backend.SSAValueDefinition{V: p1}
+				ctx.vRegMap[p2] = rcxVReg
+				ctx.definitions[p2] = &backend.SSAValueDefinition{V: p2}
 				ctx.definitions[ptr] = &backend.SSAValueDefinition{Instr: iadd}
 				return
 			},
@@ -79,7 +82,8 @@ func TestMachine_lowerToAddressMode(t *testing.T) {
 			in: func(ctx *mockCompiler, b ssa.Builder, m *machine) (ptr ssa.Value, offset uint32) {
 				ptr = b.CurrentBlock().AddParam(b, ssa.TypeI64)
 				offset = 1 << 31
-				ctx.definitions[ptr] = &backend.SSAValueDefinition{BlockParamValue: ptr, BlkParamVReg: raxVReg}
+				ctx.vRegMap[ptr] = raxVReg
+				ctx.definitions[ptr] = &backend.SSAValueDefinition{V: ptr}
 				return
 			},
 			insts: []string{
@@ -109,7 +113,8 @@ func TestMachine_lowerToAddressMode(t *testing.T) {
 				p := b.CurrentBlock().AddParam(b, ssa.TypeI64)
 				iconst64 := b.AllocateInstruction().AsIconst64(2).Insert(b)
 				ishl := b.AllocateInstruction().AsIshl(p, iconst64.Return()).Insert(b)
-				ctx.definitions[p] = &backend.SSAValueDefinition{BlockParamValue: p, BlkParamVReg: raxVReg}
+				ctx.vRegMap[p] = raxVReg
+				ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 				ctx.definitions[iconst64.Return()] = &backend.SSAValueDefinition{Instr: iconst64}
 				ctx.definitions[ishl.Return()] = &backend.SSAValueDefinition{Instr: ishl}
 				return ishl.Return(), 1 << 30
@@ -127,8 +132,10 @@ func TestMachine_lowerToAddressMode(t *testing.T) {
 				const2 := b.AllocateInstruction().AsIconst64(2).Insert(b)
 				ishl := b.AllocateInstruction().AsIshl(p1, const2.Return()).Insert(b)
 				iadd := b.AllocateInstruction().AsIadd(p2, ishl.Return()).Insert(b)
-				ctx.definitions[p1] = &backend.SSAValueDefinition{BlockParamValue: p1, BlkParamVReg: raxVReg}
-				ctx.definitions[p2] = &backend.SSAValueDefinition{BlockParamValue: p2, BlkParamVReg: rcxVReg}
+				ctx.vRegMap[p1] = raxVReg
+				ctx.definitions[p1] = &backend.SSAValueDefinition{V: p1}
+				ctx.vRegMap[p2] = rcxVReg
+				ctx.definitions[p2] = &backend.SSAValueDefinition{V: p2}
 				ctx.definitions[const2.Return()] = &backend.SSAValueDefinition{Instr: const2}
 				ctx.definitions[ishl.Return()] = &backend.SSAValueDefinition{Instr: ishl}
 				ctx.definitions[iadd.Return()] = &backend.SSAValueDefinition{Instr: iadd}
@@ -181,7 +188,8 @@ func TestMachine_lowerAddendFromInstr(t *testing.T) {
 			name: "uextend const64",
 			in: func(ctx *mockCompiler, b ssa.Builder, m *machine) *ssa.Instruction {
 				p := b.CurrentBlock().AddParam(b, ssa.TypeI32)
-				ctx.definitions[p] = &backend.SSAValueDefinition{BlkParamVReg: raxVReg, BlockParamValue: p}
+				ctx.vRegMap[p] = raxVReg
+				ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 				return b.AllocateInstruction().AsUExtend(p, 32, 64).Insert(b)
 			},
 			exp: addend{raxVReg, 0, 0},
@@ -190,7 +198,8 @@ func TestMachine_lowerAddendFromInstr(t *testing.T) {
 			name: "uextend param i32",
 			in: func(ctx *mockCompiler, b ssa.Builder, m *machine) *ssa.Instruction {
 				p := b.CurrentBlock().AddParam(b, ssa.TypeI32)
-				ctx.definitions[p] = &backend.SSAValueDefinition{BlkParamVReg: raxVReg, BlockParamValue: p}
+				ctx.vRegMap[p] = raxVReg
+				ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 				return b.AllocateInstruction().AsUExtend(p, 32, 64).Insert(b)
 			},
 			exp: addend{raxVReg, 0, 0},
@@ -208,7 +217,8 @@ func TestMachine_lowerAddendFromInstr(t *testing.T) {
 			name: "sextend const64",
 			in: func(ctx *mockCompiler, b ssa.Builder, m *machine) *ssa.Instruction {
 				p := b.CurrentBlock().AddParam(b, ssa.TypeI32)
-				ctx.definitions[p] = &backend.SSAValueDefinition{BlkParamVReg: raxVReg, BlockParamValue: p}
+				ctx.vRegMap[p] = raxVReg
+				ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 				return b.AllocateInstruction().AsSExtend(p, 32, 64).Insert(b)
 			},
 			exp: addend{raxVReg, 0, 0},
@@ -217,7 +227,8 @@ func TestMachine_lowerAddendFromInstr(t *testing.T) {
 			name: "sextend param i32",
 			in: func(ctx *mockCompiler, b ssa.Builder, m *machine) *ssa.Instruction {
 				p := b.CurrentBlock().AddParam(b, ssa.TypeI32)
-				ctx.definitions[p] = &backend.SSAValueDefinition{BlkParamVReg: raxVReg, BlockParamValue: p}
+				ctx.vRegMap[p] = raxVReg
+				ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 				return b.AllocateInstruction().AsSExtend(p, 32, 64).Insert(b)
 			},
 			exp: addend{raxVReg, 0, 0},

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_operands.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_operands.go
@@ -163,8 +163,8 @@ func (o operand) assignReg(v regalloc.VReg) operand {
 // `mode` is used to extend the operand if the bit length is smaller than mode.bits().
 // If the operand can be expressed as operandKindImm12, `mode` is ignored.
 func (m *machine) getOperand_Imm12_ER_SR_NR(def *backend.SSAValueDefinition, mode extMode) (op operand) {
-	if def.IsFromBlockParam() {
-		return operandNR(def.BlkParamVReg)
+	if !def.IsFromInstr() {
+		return operandNR(m.compiler.VRegOf(def.V))
 	}
 
 	instr := def.Instr
@@ -180,8 +180,8 @@ func (m *machine) getOperand_Imm12_ER_SR_NR(def *backend.SSAValueDefinition, mod
 // getOperand_MaybeNegatedImm12_ER_SR_NR is almost the same as getOperand_Imm12_ER_SR_NR, but this might negate the immediate value.
 // If the immediate value is negated, the second return value is true, otherwise always false.
 func (m *machine) getOperand_MaybeNegatedImm12_ER_SR_NR(def *backend.SSAValueDefinition, mode extMode) (op operand, negatedImm12 bool) {
-	if def.IsFromBlockParam() {
-		return operandNR(def.BlkParamVReg), false
+	if !def.IsFromInstr() {
+		return operandNR(m.compiler.VRegOf(def.V)), false
 	}
 
 	instr := def.Instr
@@ -193,7 +193,7 @@ func (m *machine) getOperand_MaybeNegatedImm12_ER_SR_NR(def *backend.SSAValueDef
 		}
 
 		signExtended := int64(c)
-		if def.SSAValue().Type().Bits() == 32 {
+		if def.V.Type().Bits() == 32 {
 			signExtended = (signExtended << 32) >> 32
 		}
 		negatedWithoutSign := -signExtended
@@ -209,8 +209,8 @@ func (m *machine) getOperand_MaybeNegatedImm12_ER_SR_NR(def *backend.SSAValueDef
 //
 // `mode` is used to extend the operand if the bit length is smaller than mode.bits().
 func (m *machine) getOperand_ER_SR_NR(def *backend.SSAValueDefinition, mode extMode) (op operand) {
-	if def.IsFromBlockParam() {
-		return operandNR(def.BlkParamVReg)
+	if !def.IsFromInstr() {
+		return operandNR(m.compiler.VRegOf(def.V))
 	}
 
 	if m.compiler.MatchInstr(def, ssa.OpcodeSExtend) || m.compiler.MatchInstr(def, ssa.OpcodeUExtend) {
@@ -252,8 +252,8 @@ func (m *machine) getOperand_ER_SR_NR(def *backend.SSAValueDefinition, mode extM
 //
 // `mode` is used to extend the operand if the bit length is smaller than mode.bits().
 func (m *machine) getOperand_SR_NR(def *backend.SSAValueDefinition, mode extMode) (op operand) {
-	if def.IsFromBlockParam() {
-		return operandNR(def.BlkParamVReg)
+	if !def.IsFromInstr() {
+		return operandNR(m.compiler.VRegOf(def.V))
 	}
 
 	if m.compiler.MatchInstr(def, ssa.OpcodeIshl) {
@@ -274,8 +274,8 @@ func (m *machine) getOperand_SR_NR(def *backend.SSAValueDefinition, mode extMode
 
 // getOperand_ShiftImm_NR returns an operand of either operandKindShiftImm or operandKindNR from the given value (defined by `def).
 func (m *machine) getOperand_ShiftImm_NR(def *backend.SSAValueDefinition, mode extMode, shiftBitWidth byte) (op operand) {
-	if def.IsFromBlockParam() {
-		return operandNR(def.BlkParamVReg)
+	if !def.IsFromInstr() {
+		return operandNR(m.compiler.VRegOf(def.V))
 	}
 
 	instr := def.Instr
@@ -291,26 +291,16 @@ func (m *machine) getOperand_ShiftImm_NR(def *backend.SSAValueDefinition, mode e
 // `mode` is used to extend the operand if the bit length is smaller than mode.bits().
 func (m *machine) getOperand_NR(def *backend.SSAValueDefinition, mode extMode) (op operand) {
 	var v regalloc.VReg
-	if def.IsFromBlockParam() {
-		v = def.BlkParamVReg
+	if def.IsFromInstr() && def.Instr.Constant() {
+		// We inline all the constant instructions so that we could reduce the register usage.
+		v = m.lowerConstant(def.Instr)
+		def.Instr.MarkLowered()
 	} else {
-		instr := def.Instr
-		if instr.Constant() {
-			// We inline all the constant instructions so that we could reduce the register usage.
-			v = m.lowerConstant(instr)
-			instr.MarkLowered()
-		} else {
-			if n := def.N; n == 0 {
-				v = m.compiler.VRegOf(instr.Return())
-			} else {
-				_, rs := instr.Returns()
-				v = m.compiler.VRegOf(rs[n-1])
-			}
-		}
+		v = m.compiler.VRegOf(def.V)
 	}
 
 	r := v
-	switch inBits := def.SSAValue().Type().Bits(); {
+	switch inBits := def.V.Type().Bits(); {
 	case mode == extModeNone:
 	case inBits == 32 && (mode == extModeZeroExtend32 || mode == extModeSignExtend32):
 	case inBits == 32 && mode == extModeZeroExtend64:

--- a/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_instr_test.go
@@ -46,8 +46,8 @@ func TestMachine_LowerConditionalBranch(t *testing.T) {
 		cmpVal := cmpInstr.Return()
 		ctx.vRegMap[cmpVal] = 3
 
-		ctx.definitions[val1] = &backend.SSAValueDefinition{BlkParamVReg: ctx.vRegMap[val1], BlockParamValue: val1}
-		ctx.definitions[val2] = &backend.SSAValueDefinition{BlkParamVReg: ctx.vRegMap[val2], BlockParamValue: val2}
+		ctx.definitions[val1] = &backend.SSAValueDefinition{V: val1}
+		ctx.definitions[val2] = &backend.SSAValueDefinition{V: val2}
 		ctx.definitions[cmpVal] = &backend.SSAValueDefinition{Instr: cmpInstr}
 		b := builder.AllocateInstruction()
 		if brz {
@@ -74,7 +74,7 @@ func TestMachine_LowerConditionalBranch(t *testing.T) {
 		icmp.AsIcmp(v1, v2, ssa.IntegerCmpCondEqual)
 		builder.InsertInstruction(icmp)
 		icmpVal := icmp.Return()
-		ctx.definitions[v1] = &backend.SSAValueDefinition{BlkParamVReg: intToVReg(1), BlockParamValue: v1}
+		ctx.definitions[v1] = &backend.SSAValueDefinition{V: v1}
 		ctx.definitions[v2] = &backend.SSAValueDefinition{Instr: iconst}
 		ctx.definitions[icmpVal] = &backend.SSAValueDefinition{Instr: icmp}
 		ctx.vRegMap[v1], ctx.vRegMap[v2], ctx.vRegMap[icmpVal] = intToVReg(1), intToVReg(2), intToVReg(3)
@@ -105,7 +105,7 @@ func TestMachine_LowerConditionalBranch(t *testing.T) {
 				icmp.AsIcmp(v1, v2, ssa.IntegerCmpCondEqual)
 				builder.InsertInstruction(icmp)
 				icmpVal := icmp.Return()
-				ctx.definitions[icmpVal] = &backend.SSAValueDefinition{Instr: icmp}
+				ctx.definitions[icmpVal] = &backend.SSAValueDefinition{Instr: icmp, V: icmpVal}
 				ctx.vRegMap[v1], ctx.vRegMap[v2], ctx.vRegMap[icmpVal] = intToVReg(1), intToVReg(2), intToVReg(3)
 
 				brz := builder.AllocateInstruction()

--- a/internal/engine/wazevo/backend/isa/arm64/lower_mem_test.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_mem_test.go
@@ -296,7 +296,8 @@ func TestMachine_collectAddends(t *testing.T) {
 	v1000, v2000 := regalloc.VReg(1000).SetRegType(regalloc.RegTypeInt), regalloc.VReg(2000).SetRegType(regalloc.RegTypeInt)
 	addParam := func(ctx *mockCompiler, b ssa.Builder, typ ssa.Type) ssa.Value {
 		p := b.CurrentBlock().AddParam(b, typ)
-		ctx.definitions[p] = &backend.SSAValueDefinition{BlockParamValue: p, BlkParamVReg: v1000}
+		ctx.vRegMap[p] = v1000
+		ctx.definitions[p] = &backend.SSAValueDefinition{V: p}
 		return p
 	}
 	insertI32Const := func(m *mockCompiler, b ssa.Builder, v uint32) *ssa.Instruction {
@@ -310,14 +311,14 @@ func TestMachine_collectAddends(t *testing.T) {
 		inst := b.AllocateInstruction()
 		inst.AsIconst64(v)
 		b.InsertInstruction(inst)
-		m.definitions[inst.Return()] = &backend.SSAValueDefinition{Instr: inst}
+		m.definitions[inst.Return()] = &backend.SSAValueDefinition{Instr: inst, V: inst.Return()}
 		return inst
 	}
 	insertIadd := func(m *mockCompiler, b ssa.Builder, lhs, rhs ssa.Value) *ssa.Instruction {
 		inst := b.AllocateInstruction()
 		inst.AsIadd(lhs, rhs)
 		b.InsertInstruction(inst)
-		m.definitions[inst.Return()] = &backend.SSAValueDefinition{Instr: inst}
+		m.definitions[inst.Return()] = &backend.SSAValueDefinition{Instr: inst, V: inst.Return()}
 		return inst
 	}
 	insertExt := func(m *mockCompiler, b ssa.Builder, v ssa.Value, from, to byte, signed bool) *ssa.Instruction {
@@ -328,7 +329,7 @@ func TestMachine_collectAddends(t *testing.T) {
 			inst.AsUExtend(v, from, to)
 		}
 		b.InsertInstruction(inst)
-		m.definitions[inst.Return()] = &backend.SSAValueDefinition{Instr: inst}
+		m.definitions[inst.Return()] = &backend.SSAValueDefinition{Instr: inst, V: v}
 		return inst
 	}
 

--- a/internal/engine/wazevo/backend/vdef.go
+++ b/internal/engine/wazevo/backend/vdef.go
@@ -1,43 +1,19 @@
 package backend
 
 import (
-	"github.com/tetratelabs/wazero/internal/engine/wazevo/backend/regalloc"
 	"github.com/tetratelabs/wazero/internal/engine/wazevo/ssa"
 )
 
 // SSAValueDefinition represents a definition of an SSA value.
+// TODO: this eventually should be deleted.
 type SSAValueDefinition struct {
-	// BlockParamValue is valid if Instr == nil
-	BlockParamValue ssa.Value
-
-	// BlkParamVReg is valid if Instr == nil
-	BlkParamVReg regalloc.VReg
-
+	V ssa.Value
 	// Instr is not nil if this is a definition from an instruction.
 	Instr *ssa.Instruction
-	// N is the index of the return value in the instr's return values list.
-	N int
 	// RefCount is the number of references to the result.
 	RefCount uint32
 }
 
 func (d *SSAValueDefinition) IsFromInstr() bool {
 	return d.Instr != nil
-}
-
-func (d *SSAValueDefinition) IsFromBlockParam() bool {
-	return d.Instr == nil
-}
-
-func (d *SSAValueDefinition) SSAValue() ssa.Value {
-	if d.IsFromBlockParam() {
-		return d.BlockParamValue
-	} else {
-		r, rs := d.Instr.Returns()
-		if d.N == 0 {
-			return r
-		} else {
-			return rs[d.N-1]
-		}
-	}
 }


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero
                      │  old.txt   │             new.txt              │
                      │   sec/op   │   sec/op    vs base              │
Compilation/wazero-10   1.541 ± 0%   1.535 ± 0%  -0.37% (p=0.015 n=6)
Compilation/zig-10      3.422 ± 0%   3.413 ± 0%  -0.27% (p=0.004 n=6)
Compilation/zz-10       14.10 ± 0%   14.08 ± 0%       ~ (p=0.310 n=6)
geomean                 4.205        4.194       -0.25%

                      │   old.txt    │              new.txt               │
                      │     B/op     │     B/op      vs base              │
Compilation/wazero-10   283.0Mi ± 0%   273.4Mi ± 0%  -3.38% (p=0.002 n=6)
Compilation/zig-10      596.7Mi ± 0%   594.7Mi ± 0%  -0.32% (p=0.002 n=6)
Compilation/zz-10       536.5Mi ± 0%   532.4Mi ± 0%  -0.76% (p=0.002 n=6)
geomean                 449.1Mi        442.4Mi       -1.50%

                      │   old.txt   │              new.txt              │
                      │  allocs/op  │  allocs/op   vs base              │
Compilation/wazero-10   485.4k ± 0%   485.2k ± 0%       ~ (p=0.394 n=6)
Compilation/zig-10      275.5k ± 0%   275.5k ± 0%       ~ (p=0.974 n=6)
Compilation/zz-10       627.0k ± 0%   627.1k ± 0%       ~ (p=0.145 n=6)
geomean                 437.7k        437.6k       -0.01%
```

#2182 