### PR TITLE
Adds _initiialize for c-shared wasm with go

### DIFF
--- a/config.go
+++ b/config.go
@@ -689,7 +689,7 @@ type moduleConfig struct {
 // NewModuleConfig returns a ModuleConfig that can be used for configuring module instantiation.
 func NewModuleConfig() ModuleConfig {
 	return &moduleConfig{
-		startFunctions: []string{"_start"},
+		startFunctions: []string{"_start", "_initialize"},
 		environKeys:    map[string]int{},
 	}
 }


### PR DESCRIPTION
In the recently merged proposal for wasm export with the go compiler https://github.com/golang/go/issues/65199, when you compile with wasm export and the build mode to `c-shared`there is no `_start`function exported but a `_initialize`function.

As the startFunctions is verified before being called, it should not impact any body if the _initialize is not defined.