### PR TITLE
fix: add wrapper for osfile.Truncate for TinyGo 0.33

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -152,6 +152,20 @@ jobs:
         # This runs all tests compiled above in sequence. Note: This mounts /tmp to allow t.TempDir() in tests.
         run: find . -name "*.test" | xargs -Itestbin docker run --platform linux/${{ matrix.arch }} -v $(pwd)/testbin:/test -v $(pwd)/wazerocli:/wazero -e WAZEROCLI=/wazero --tmpfs /tmp --rm -t wazero:test
 
+  test_tinygo:
+    name: "TinyGo on Ubuntu"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:  # Use version consistent with TinyGo.
+          go-version: "1.23"
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: "0.33.0"
+      - run: tinygo build ./cmd/wazero
+      - run: tinygo build -size short -target pico -stack-size=8kb ./cmd/wazero
+
   # This ensures that internal/integration_test/fuzz is runnable, and is not intended to
   # run full-length fuzzing while trying to find low-hanging frontend bugs.
   fuzz:

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -254,7 +254,7 @@ func (f *osFile) Pwrite(buf []byte, off int64) (n int, errno experimentalsys.Err
 
 // Truncate implements the same method as documented on sys.File
 func (f *osFile) Truncate(size int64) (errno experimentalsys.Errno) {
-	if errno = experimentalsys.UnwrapOSError(f.file.Truncate(size)); errno != 0 {
+	if errno = experimentalsys.UnwrapOSError(truncate(f.file, size)); errno != 0 {
 		// Defer validation overhead until we've already had an error.
 		errno = fileError(f, f.closed, errno)
 	}

--- a/internal/sysfs/truncate.go
+++ b/internal/sysfs/truncate.go
@@ -1,0 +1,9 @@
+//go:build !tinygo
+
+package sysfs
+
+import "os"
+
+func truncate(file *os.File, size int64) error {
+	return file.Truncate(size)
+}

--- a/internal/sysfs/truncate_tinygo.go
+++ b/internal/sysfs/truncate_tinygo.go
@@ -1,0 +1,9 @@
+//go:build tinygo
+
+package sysfs
+
+import "os"
+
+func truncate(file *os.File, size int64) error {
+	return nil
+}


### PR DESCRIPTION
This PR adds a wrapper for the `osfile` `Truncate()` functions to restore ability to build Wazero on bare metal using TinyGo 0.33

UPDATE: I have added a second commit to this PR that adds back the TinyGo 0.33 to CI, which also should demonstrate that this fix does what it is supposed to.