### PR TITLE
compiler: ResolveImportedFunction should infer the typeID from the importing module

### DIFF
--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -487,7 +487,7 @@ func (e *engine) setLabelAddress(op *uint64, label label, labelAddressResolution
 }
 
 // ResolveImportedFunction implements wasm.ModuleEngine.
-func (e *moduleEngine) ResolveImportedFunction(index, indexInImportedModule wasm.Index, importedModuleEngine wasm.ModuleEngine) {
+func (e *moduleEngine) ResolveImportedFunction(index, descFunc, indexInImportedModule wasm.Index, importedModuleEngine wasm.ModuleEngine) {
 	imported := importedModuleEngine.(*moduleEngine)
 	e.functions[index] = imported.functions[indexInImportedModule]
 }

--- a/internal/wasm/engine.go
+++ b/internal/wasm/engine.go
@@ -44,9 +44,10 @@ type ModuleEngine interface {
 
 	// ResolveImportedFunction is used to add imported functions needed to make this ModuleEngine fully functional.
 	// 	- `index` is the function Index of this imported function.
+	// 	- `descFunc` is the type Index in Module.TypeSection of this imported function. It corresponds to Import.DescFunc.
 	// 	- `indexInImportedModule` is the function Index of the imported function in the imported module.
 	//	- `importedModuleEngine` is the ModuleEngine for the imported ModuleInstance.
-	ResolveImportedFunction(index, indexInImportedModule Index, importedModuleEngine ModuleEngine)
+	ResolveImportedFunction(index, descFunc, indexInImportedModule Index, importedModuleEngine ModuleEngine)
 
 	// ResolveImportedMemory is called when this module imports a memory from another module.
 	ResolveImportedMemory(importedModuleEngine ModuleEngine)

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -446,7 +446,7 @@ func (m *ModuleInstance) resolveImports(ctx context.Context, module *Module) (er
 					return
 				}
 
-				m.Engine.ResolveImportedFunction(i.IndexPerType, imported.Index, importedModule.Engine)
+				m.Engine.ResolveImportedFunction(i.IndexPerType, i.DescFunc, imported.Index, importedModule.Engine)
 			case ExternTypeTable:
 				expected := i.DescTable
 				importedTable := importedModule.Tables[imported.Index]

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -341,7 +341,7 @@ func TestStore_Instantiate_Errors(t *testing.T) {
 				importedModuleName: {{Type: ExternTypeFunc, Module: importedModuleName, Name: "fn", DescFunc: 0}},
 				"non-exist":        {{Name: "fn", DescFunc: 0}},
 			},
-		}, importingModuleName, nil, nil)
+		}, importingModuleName, nil, []FunctionTypeID{0})
 		require.EqualError(t, err, "module[non-exist] not instantiated")
 	})
 
@@ -485,7 +485,7 @@ func (e *mockModuleEngine) FunctionInstanceReference(i Index) Reference {
 }
 
 // ResolveImportedFunction implements the same method as documented on wasm.ModuleEngine.
-func (e *mockModuleEngine) ResolveImportedFunction(index, importedIndex Index, _ ModuleEngine) {
+func (e *mockModuleEngine) ResolveImportedFunction(index, _, importedIndex Index, _ ModuleEngine) {
 	e.resolveImportsCalled[index] = importedIndex
 }
 
@@ -742,7 +742,7 @@ func Test_resolveImports(t *testing.T) {
 				},
 			}
 
-			m := &ModuleInstance{Engine: &mockModuleEngine{resolveImportsCalled: map[Index]Index{}}, s: s, Source: module}
+			m := &ModuleInstance{Engine: &mockModuleEngine{resolveImportsCalled: map[Index]Index{}}, s: s, Source: module, TypeIDs: []FunctionTypeID{0, 1}}
 			err := m.resolveImports(context.Background(), module)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Fixes #2313.

This changes the signature for `ResolveImportedFunction()` so that it takes an additional index into the typeID section of the "current" module, i.e. the subject of the import.

The current behavior is to search for the import recursively into the chain of dependencies; however, this resolves to a typeID that is specific to _that_ module. For instance:

- consider the case of a module `m` declaring an import `m2inst.sym`.
- let be `m2inst.sym` an import with type `t` with ID `tid` 
- let be `m2inst` be linked to an instance of module `m2` with type `t2` and ID `t2id`.

Now: we want `t` to be compatible with `t2`; this we verify at:

https://github.com/tetratelabs/wazero/blob/6bb9899ea4c745a4ae23179a34fac0540c2ce551/internal/wasm/store.go#L441-L447

The current behavior is for `ResolveImportedFunction()` to resolve recursively a reference to a function so that we can then jump precisely to its address at runtime; however, we should _not_ carry on its type ID, and instead use the type ID of the import.

In other words, even if the types are compatible, we should be still referring to type `t` with ID `tid` from `m`, and _not_ type ID `t2id`, because, of course, the index `t2id` might be different from the local index `tid`.

The solution is to add another `descFunc Index` (from the name of the field `Import.DescFunc`) to the signature of  `ResolveImportedFunction()`, so that the typeID is correctly resolved from `moduleEngine.module.TypeIDs[descFunc]` (i.e. the typeID defined in the module that is requiring the imported function).

The tests are adjusted accordingly; notably, this also means that, in order for `m.ResolveImportedFunction()` to work properly, `m` must be correctly initialized with an `m.module` being the module that is performing the import, so the initialization of `moduleEngine` is pushed down, after the declaration of the "`imported`" and "`importing`" modules.

Let me know if you think it is worth adding more tests!

@zshipko please double-check that this is fixing your issue (I have slightly changed my original approach)
@ncruces would you like to double-check this against your sqlite lib?
@anuraaga if you spare any time, would you take a look too? :P




