### PR TITLE
Allow custom memory allocator Reallocate to fail

### DIFF
--- a/experimental/memory.go
+++ b/experimental/memory.go
@@ -35,6 +35,8 @@ type LinearMemory interface {
 	// Notes:
 	//   - To back a shared memory, Reallocate can't change the address of the
 	//     backing []byte (only its length/capacity may change).
+	//   - Reallocate may return nil if fails to grow the LinearMemory. This
+	//     condition may or may not be handled gracefully by the Wasm module.
 	Reallocate(size uint64) []byte
 	// Free the backing memory buffer.
 	Free()

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -239,14 +239,13 @@ func (m *MemoryInstance) Grow(delta uint32) (result uint32, ok bool) {
 		return currentPages, true
 	}
 
-	// If exceeds the max of memory size, we push -1 according to the spec.
 	newPages := currentPages + delta
 	if newPages > m.Max || int32(delta) < 0 {
 		return 0, false
 	} else if m.expBuffer != nil {
 		buffer := m.expBuffer.Reallocate(MemoryPagesToBytesNum(newPages))
-		// If the allocator fails to grow, we push -1 according to the spec.
 		if buffer == nil {
+			// Allocator failed to grow.
 			return 0, false
 		}
 		if m.Shared {


### PR DESCRIPTION
Hey! 👋

This is just an idea, but the change was small enough that I decided to just try it.

How would we feel about allowing the custom allocator to return `nil` to signal it can't grow the linear memory?

In Go, a failure to allocate memory is a fatal condition, so it makes sense that we don't think about this when using `append` to grow the linear memory.

But custom allocators can handle this, it doesn't need to be a fatal condition. Also Wasm modules can deal with it: e.g. for `wasi-lib`, if `sbrk` fails, `malloc` just returns `NULL`, and (e.g.) SQLite can deal with that by freeing caches and trying again (if configured to do so).

cc: @anuraaga