### PR TITLE
sysfs: reopening file doesn't update fd

### DIFF
--- a/internal/sysfs/file.go
+++ b/internal/sysfs/file.go
@@ -418,13 +418,6 @@ func seek(s io.Seeker, offset int64, whence int) (int64, experimentalsys.Errno) 
 	return newOffset, experimentalsys.UnwrapOSError(err)
 }
 
-// reopenFile allows re-opening a file for reasons such as applying flags or
-// directory iteration.
-type reopenFile func() experimentalsys.Errno
-
-// compile-time check to ensure fsFile.reopen implements reopenFile.
-var _ reopenFile = (*fsFile)(nil).reopen
-
 // reopen implements the same method as documented on reopenFile.
 func (f *fsFile) reopen() experimentalsys.Errno {
 	_ = f.close()

--- a/internal/sysfs/file.go
+++ b/internal/sysfs/file.go
@@ -269,7 +269,7 @@ func (f *fsFile) Readdir(n int) (dirents []experimentalsys.Dirent, errno experim
 
 	if f.reopenDir { // re-open the directory if needed.
 		f.reopenDir = false
-		if errno = adjustReaddirErr(f, f.closed, f.reopen()); errno != 0 {
+		if errno = adjustReaddirErr(f, f.closed, f.rewindDir()); errno != 0 {
 			return
 		}
 	}
@@ -418,12 +418,25 @@ func seek(s io.Seeker, offset int64, whence int) (int64, experimentalsys.Errno) 
 	return newOffset, experimentalsys.UnwrapOSError(err)
 }
 
-// reopen implements the same method as documented on reopenFile.
-func (f *fsFile) reopen() experimentalsys.Errno {
-	_ = f.close()
-	var err error
-	f.file, err = f.fs.Open(f.name)
-	return experimentalsys.UnwrapOSError(err)
+func (f *fsFile) rewindDir() experimentalsys.Errno {
+	// Reopen the directory to rewind it.
+	file, err := f.fs.Open(f.name)
+	if err != nil {
+		return experimentalsys.UnwrapOSError(err)
+	}
+	fi, err := file.Stat()
+	if err != nil {
+		return experimentalsys.UnwrapOSError(err)
+	}
+	// Can't check if it's still the same file,
+	// but is it still a directory, at least?
+	if !fi.IsDir() {
+		return experimentalsys.ENOTDIR
+	}
+	// Only update f on success.
+	_ = f.file.Close()
+	f.file = file
+	return 0
 }
 
 // readdirFile allows masking the `Readdir` function on os.File.

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -116,6 +116,26 @@ func TestWriteFdNonblock(t *testing.T) {
 	t.Fatal("writeFd should return EAGAIN at some point")
 }
 
+func TestFileReopenFileUpdatesFD(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := path.Join(tmpDir, "file")
+
+	// Open the file twice. Closing the first file, frees its FD.
+	// Then reopening the second file will take over the first FD.
+	// If reopening the file doesn't update the FD, they won't match.
+	f0 := requireOpenFile(t, path, experimentalsys.O_RDWR|experimentalsys.O_CREAT, 0o600)
+	f1 := requireOpenFile(t, path, experimentalsys.O_RDWR|experimentalsys.O_CREAT, 0o600)
+	defer f1.Close()
+	f0.Close()
+
+	of, ok := f1.(*osFile)
+	require.True(t, ok)
+
+	errno := of.reopen()
+	require.EqualErrno(t, 0, errno)
+	require.Equal(t, of.file.Fd(), of.fd)
+}
+
 func TestFileSetAppend(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -124,6 +144,7 @@ func TestFileSetAppend(t *testing.T) {
 
 	// Open without APPEND.
 	f, errno := OpenOSFile(fPath, experimentalsys.O_RDWR, 0o600)
+	defer f.Close()
 	require.EqualErrno(t, 0, errno)
 	require.False(t, f.IsAppend())
 

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -118,6 +118,7 @@ func (f *osFile) reopen() (errno experimentalsys.Errno) {
 
 	_ = f.close()
 	f.file, errno = OpenFile(f.path, f.flag, f.perm)
+	f.fd = f.file.Fd()
 	if errno != 0 {
 		return errno
 	}

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -91,9 +91,6 @@ func (f *osFile) SetAppend(enable bool) (errno experimentalsys.Errno) {
 	return fileError(f, f.closed, f.reopen())
 }
 
-// compile-time check to ensure osFile.reopen implements reopenFile.
-var _ reopenFile = (*osFile)(nil).reopen
-
 func (f *osFile) reopen() (errno experimentalsys.Errno) {
 	// Clear any create flag, as we are re-opening, not re-creating.
 	f.flag &= ^experimentalsys.O_CREAT

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -83,11 +83,8 @@ func (f *osFile) SetAppend(enable bool) (errno experimentalsys.Errno) {
 		f.flag &= ^experimentalsys.O_APPEND
 	}
 
-	// Clear any create or trunc flag, as we are re-opening, not re-creating.
-	f.flag &= ^(experimentalsys.O_CREAT | experimentalsys.O_TRUNC)
-
-	// appendMode (bool) cannot be changed later, so we have to re-open the
-	// file. https://github.com/golang/go/blob/go1.23/src/os/file_unix.go#L60
+	// appendMode cannot be changed later, so we have to re-open the file
+	// https://github.com/golang/go/blob/go1.23/src/os/file_unix.go#L60
 	return fileError(f, f.closed, f.reopen())
 }
 
@@ -110,8 +107,8 @@ func (f *osFile) reopen() (errno experimentalsys.Errno) {
 		}
 	}
 
-	// Clear any create flag, as we are re-opening, not re-creating.
-	flag := f.flag &^ experimentalsys.O_CREAT
+	// Clear any create or trunc flag, as we are re-opening, not re-creating.
+	flag := f.flag &^ (experimentalsys.O_CREAT | experimentalsys.O_TRUNC)
 	file, errno := OpenFile(f.path, flag, f.perm)
 	if errno != 0 {
 		return errno

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -87,7 +87,7 @@ func (f *osFile) SetAppend(enable bool) (errno experimentalsys.Errno) {
 	f.flag &= ^(experimentalsys.O_CREAT | experimentalsys.O_TRUNC)
 
 	// appendMode (bool) cannot be changed later, so we have to re-open the
-	// file. https://github.com/golang/go/blob/go1.20/src/os/file_unix.go#L60
+	// file. https://github.com/golang/go/blob/go1.23/src/os/file_unix.go#L60
 	return fileError(f, f.closed, f.reopen())
 }
 

--- a/sys/stat.go
+++ b/sys/stat.go
@@ -29,9 +29,7 @@ type EpochNanos = int64
 // # Notes
 //
 //   - This is used for WebAssembly ABI emulating the POSIX `stat` system call.
-//     Fields included are required for WebAssembly ABI including wasip1
-//     (a.k.a. wasix) and wasi-filesystem (a.k.a. wasip2). See
-//     https://pubs.opengroup.org/onlinepubs/9699919799/functions/stat.html
+//     See https://pubs.opengroup.org/onlinepubs/9699919799/functions/stat.html
 //   - Fields here are required for WebAssembly ABI including wasip1
 //     (a.k.a. wasix) and wasi-filesystem (a.k.a. wasip2).
 //   - This isn't the same as syscall.Stat_t because wazero supports Windows,


### PR DESCRIPTION
Fixes #2318.

Reopening the file was erroneously not updating the `fd` field.
Also, reopening is risky, because the file have been deleted/renamed (yes, even on Windows, because we're using `FILE_SHARE_DELETE`).

In theory, on POSIX, we'd never need to reopen (hence why WASI provides this, it tries to offer much of what POSIX allows, neglecting that lots of it is hard to emulate). But... reopen is only is only really used in two places: seeking directories (to rewind them), and setting the file's append flag.

For directory rewind, it's _already_ just a fallback:
https://github.com/tetratelabs/wazero/blob/6bb9899ea4c745a4ae23179a34fac0540c2ce551/internal/sysfs/osfile.go#L196-L209

If seeking works, it's used. So, no point in trying to "fix" that one.

For setting the append flag, reopen is always used, for good reason:
https://github.com/tetratelabs/wazero/blob/6bb9899ea4c745a4ae23179a34fac0540c2ce551/internal/sysfs/osfile.go#L78-L92

That link is still valid in [1.23](https://github.com/golang/go/blob/go1.23.1/src/os/file_unix.go). Go's `os.File` caches this, most importantly, to return a specific error on `WriteAt`. There's a good reason for this. The Open Group specifies that `pwrite` should work with, and ignore, `O_APPEND`, but Linux does the opposite and appends, which is a [bug](https://linux.die.net/man/2/pwrite).

So (IMO) we do need to reopen for `SetAppend`, and the best we can do, is check if the new file is still the same file, and error out otherwise.

That's what this PR does for `osFile`:
1. fix the `fd` not being updated issue
2. check that reopen gets the same file

For `fsFile`, this is only used to rewind directories, so:
1. own that
2. check that the reopened file is still a directory