### PR TITLE
sysfs: clean paths lexically before use

### DIFF
--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -51,7 +51,7 @@ func TestDirFS_join(t *testing.T) {
 	require.Equal(t, ".", testFS.join(""))
 	require.Equal(t, ".", testFS.join("."))
 	require.Equal(t, ".", testFS.join("/"))
-	require.Equal(t, "."+string(os.PathSeparator)+"tmp", testFS.join("tmp"))
+	require.Equal(t, "./tmp", testFS.join("tmp"))
 }
 
 func TestDirFS_String(t *testing.T) {


### PR DESCRIPTION
This is intended to close #2321.

W.r.t. security, after consulting the other maintainers, we must say that fully sandboxing our WASI implementation is beyond the current scope of the project. This will be made explicit in the documentation.

We consider Wasm a mature specification, and security issues against our implementation of it will be taken seriously. WASI is not as mature, nor is our implementation of WASI preview 1.

We also provide advanced enough APIs that you can use to implement your own, better locked down, alternative to our WASI implementation.

That said, this PR still sides with breaking POSIX path resolution semantics in WASI vs. allowing trivial root mount escapes, by using `path.Clean` to lexically clean all paths before use.

This is a judgement call.

Handling paths lexically is easier to reason about, easier to port, and idiomatic Go. Go provides  `path.Clean` and `filepath.Clean`; `fs.FS` is even stricter disallowing `..` entirely. It's also unlikely to break well, behaving, useful applications.