### PR TITLE
sysfs: disallow absolute symlinks

### DIFF
--- a/internal/sysfs/dirfs_supported.go
+++ b/internal/sysfs/dirfs_supported.go
@@ -5,6 +5,7 @@ package sysfs
 import (
 	"io/fs"
 	"os"
+	"path"
 
 	experimentalsys "github.com/tetratelabs/wazero/experimental/sys"
 )
@@ -34,6 +35,11 @@ func (d *dirFS) Chmod(path string, perm fs.FileMode) experimentalsys.Errno {
 
 // Symlink implements the same method as documented on sys.FS
 func (d *dirFS) Symlink(oldName, link string) experimentalsys.Errno {
+	// Creating a symlink with an absolute path string fails with a "not permitted" error.
+	// https://github.com/WebAssembly/wasi-filesystem/blob/v0.2.0/path-resolution.md#symlinks
+	if path.IsAbs(oldName) {
+		return experimentalsys.EPERM
+	}
 	// Note: do not resolve `oldName` relative to this dirFS. The link result is always resolved
 	// when dereference the `link` on its usage (e.g. readlink, read, etc).
 	// https://github.com/bytecodealliance/cap-std/blob/v1.0.4/cap-std/src/fs/dir.rs#L404-L409

--- a/internal/sysfs/dirfs_test.go
+++ b/internal/sysfs/dirfs_test.go
@@ -747,6 +747,7 @@ func TestDirFS_Symlink(t *testing.T) {
 
 	testFS := DirFS(tmpDir)
 
+	require.EqualErrno(t, sys.EPERM, testFS.Symlink("/test.txt", "sub/test.txt"))
 	require.EqualErrno(t, sys.EEXIST, testFS.Symlink("sub/test.txt", "sub/test.txt"))
 	// Non-existing old name is allowed.
 	require.EqualErrno(t, 0, testFS.Symlink("non-existing", "aa"))


### PR DESCRIPTION
This implements this bit of the [path resolution specification](https://github.com/WebAssembly/wasi-filesystem/blob/v0.2.0/path-resolution.md#symlinks) (see #2323), and seems like a good idea regardless.