### PR TITLE
internal/sysfs: add missing tinygo tags

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -15,6 +15,7 @@ on:
 
 env:  # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.23"
+  TINYGO_VERSION: "0.34.0"
 
 defaults:
   run:  # use bash for all operating systems unless overridden
@@ -151,6 +152,20 @@ jobs:
       - name: Run built test binaries
         # This runs all tests compiled above in sequence. Note: This mounts /tmp to allow t.TempDir() in tests.
         run: find . -name "*.test" | xargs -Itestbin docker run --platform linux/${{ matrix.arch }} -v $(pwd)/testbin:/test -v $(pwd)/wazerocli:/wazero -e WAZEROCLI=/wazero --tmpfs /tmp --rm -t wazero:test
+
+  test_tinygo:
+    name: "TinyGo on Ubuntu"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:  # Use version consistent with TinyGo.
+          go-version: ${{ env.GO_VERSION }}
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: ${{ env.TINYGO_VERSION }}
+      - run: tinygo build ./cmd/wazero
+      - run: tinygo build -size short -target pico -stack-size=8kb ./cmd/wazero
 
   # This ensures that internal/integration_test/fuzz is runnable, and is not intended to
   # run full-length fuzzing while trying to find low-hanging frontend bugs.

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -17,7 +17,7 @@ on:
 
 env:
   EMSDK_VERSION: "3.1.40"
-  TINYGO_VERSION: "0.33.0"
+  TINYGO_VERSION: "0.34.0"
   ZIG_VERSION: "0.11.0"
 
 concurrency:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -19,7 +19,7 @@ defaults:
 
 env:  # Update this prior to requiring a higher minor version in go.mod
   GO_VERSION: "1.23"
-  TINYGO_VERSION: "0.33.0"
+  TINYGO_VERSION: "0.34.0"
   ZIG_VERSION: "0.11.0"
   BINARYEN_VERSION: "116"
   STDLIB_TESTS: "internal/integration_test/stdlibs"

--- a/internal/sysfs/datasync_unsupported.go
+++ b/internal/sysfs/datasync_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !tinygo
 
 package sysfs
 

--- a/internal/sysfs/open_file_unsupported.go
+++ b/internal/sysfs/open_file_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux && !windows && !illumos && !solaris && !freebsd
+//go:build !darwin && !linux && !windows && !illumos && !solaris && !freebsd && !tinygo
 
 package sysfs
 


### PR DESCRIPTION
This enables running wazero under `tinygo -target=wasip1` (wasm in wasm). To test:

```console
tinygo run -target=wasip1 examples/basic/add.go 7 9
```