### PR TITLE
Add DragonFly, illumos, Solaris to CI.

### DIFF
--- a/.github/actions/vmactions/template.yml
+++ b/.github/actions/vmactions/template.yml
@@ -1,0 +1,24 @@
+name: VM Actions matrix
+description: VM Actions matrix template
+
+inputs:
+  run:
+    description: 'The CI command to run'
+    required: true
+  release:
+    description: 'The OS release version'
+    required: false
+  envs:
+    description: 'The envs to pass into vm'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: ${VMACTIONS}
+      with:
+        usesh: true
+        copyback: false
+        run: ${{inputs.run}}
+        envs: ${{inputs.envs}}
+        release: ${{inputs.release}}

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -189,6 +189,44 @@ jobs:
           # This runs all tests compiled above in sequence.
           run: find . -name "*.test" | xargs -Itestbin nice testbin -test.short
 
+  test_vm:
+    name: amd64, ${{ matrix.os.name }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false  # don't fail fast as sometimes failures are OS specific
+      matrix:
+        os:
+          - name: dragonfly
+            version: "6.4.0"
+            action: 'vmactions/dragonflybsd-vm@v1'
+          - name: illumos
+            version: "r151052"
+            action: 'vmactions/omnios-vm@v1'
+          - name: solaris
+            version: "11.4"
+            action: 'vmactions/solaris-vm@v1'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build test binaries
+        run: |
+          go list -f '{{.Dir}}' ./... | egrep -v 'imports|sysfs' | xargs -Ipkg go test pkg -c -o pkg.test
+          go build -o wazerocli ./cmd/wazero
+          envsubst < ./.github/actions/vmactions/template.yml > ./.github/actions/vmactions/action.yml
+        env:
+          GOOS: ${{ matrix.os.name }}
+          VMACTIONS: ${{ matrix.os.action }}
+
+      - name: Run built test binaries
+        uses: ./.github/actions/vmactions
+        env:
+          WAZEROCLI: ./wazerocli
+        with:
+          envs: WAZEROCLI
+          # This runs all tests compiled above in sequence.
+          run: find . -name "*.test" | xargs -Itestbin nice testbin -test.short
+
   # This ensures that internal/integration_test/fuzz is runnable, and is not intended to
   # run full-length fuzzing while trying to find low-hanging frontend bugs.
   fuzz:

--- a/README.md
+++ b/README.md
@@ -96,16 +96,20 @@ systems are ones we test, but that doesn't necessarily mean other operating
 system versions won't work.
 
 We currently test Linux (Ubuntu and scratch), MacOS and Windows as packaged by
-[GitHub Actions][11], as well compilation of 32-bit Linux and 64-bit FreeBSD.
+[GitHub Actions][11], as well as nested VMs running on Linux for FreeBSD, NetBSD,
+OpenBSD, DragonFly BSD, illumos and Solaris.
+
+We also test cross compilation for many `GOOS` and `GOARCH` combinations.
 
 * Interpreter
   * Linux is tested on amd64 (native) as well arm64 and riscv64 via emulation.
-  * MacOS and Windows are only tested on amd64.
-  * FreeBSD, NetBSD and OpenBSD are only tested on amd64.
+  * Windows, FreeBSD, NetBSD, OpenBSD, DragonFly BSD, illumos and Solaris are
+    tested only on amd64.
+  * macOS is tested only on arm64.
 * Compiler
   * Linux is tested on amd64 (native) as well arm64 via emulation.
-  * MacOS and Windows are only tested on amd64.
-  * FreeBSD is only tested on amd64.
+  * Windows and FreeBSD are only tested on amd64.
+  * macOS is tested only on arm64.
 
 wazero has no dependencies and doesn't require CGO. This means it can also be
 embedded in an application that doesn't use an operating system. This is a main


### PR DESCRIPTION
Hot on the heels of #2338, this adds more OSes using a different action.

The only note compared to the previous one is that, compared to [`cross-platform-actions/action`](https://github.com/cross-platform-actions/action), [`vmactions`](https://github.com/vmactions) has one action per OS, which is harder to configure, because [GitHub doesn't allow matrix runs to configure `uses` dependencies](https://github.com/orgs/community/discussions/9049).

So I had to create a custom action `template.yml`, and use `envsubst` to change the `uses` dependency.

The stretch goal is to, as a follow up, enable the compiler in many of these, confident that it works: https://github.com/ncruces/wazero/pull/3

I also fixed up the `README` because we're erroneously claiming we test macOS on `amd64`, but moving to `macos-14` runner, we actually test on `arm64`.