### PR TITLE
Enable compiler on NetBSD, DragonFly, illumos and Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ We also test cross compilation for many `GOOS` and `GOARCH` combinations.
   * macOS is tested only on arm64.
 * Compiler
   * Linux is tested on amd64 (native) as well arm64 via emulation.
-  * Windows and FreeBSD are only tested on amd64.
+  * Windows, FreeBSD, NetBSD, DragonFly BSD, illumos and Solaris are
+    tested only on amd64.
   * macOS is tested only on arm64.
 
 wazero has no dependencies and doesn't require CGO. This means it can also be

--- a/config_supported.go
+++ b/config_supported.go
@@ -5,7 +5,7 @@
 //
 // Meanwhile, users who know their runtime.GOOS can operate with the compiler
 // may choose to use NewRuntimeConfigCompiler explicitly.
-//go:build (amd64 || arm64) && (darwin || linux || freebsd || windows)
+//go:build (amd64 || arm64) && (linux || darwin || freebsd || netbsd || dragonfly || windows)
 
 package wazero
 

--- a/config_supported.go
+++ b/config_supported.go
@@ -5,7 +5,7 @@
 //
 // Meanwhile, users who know their runtime.GOOS can operate with the compiler
 // may choose to use NewRuntimeConfigCompiler explicitly.
-//go:build (amd64 || arm64) && (linux || darwin || freebsd || netbsd || dragonfly || windows)
+//go:build (amd64 || arm64) && (linux || darwin || freebsd || netbsd || dragonfly || solaris || windows)
 
 package wazero
 

--- a/config_unsupported.go
+++ b/config_unsupported.go
@@ -1,5 +1,5 @@
 // This is the opposite constraint of config_supported.go
-//go:build !(amd64 || arm64) || !(darwin || linux || freebsd || windows)
+//go:build !(amd64 || arm64) || !(linux || darwin || freebsd || netbsd || dragonfly || windows)
 
 package wazero
 

--- a/config_unsupported.go
+++ b/config_unsupported.go
@@ -1,5 +1,5 @@
 // This is the opposite constraint of config_supported.go
-//go:build !(amd64 || arm64) || !(linux || darwin || freebsd || netbsd || dragonfly || windows)
+//go:build !(amd64 || arm64) || !(linux || darwin || freebsd || netbsd || dragonfly || solaris || windows)
 
 package wazero
 

--- a/internal/platform/mmap_other.go
+++ b/internal/platform/mmap_other.go
@@ -1,5 +1,5 @@
 // Separated from linux which has support for huge pages.
-//go:build darwin || freebsd
+//go:build darwin || freebsd || netbsd || dragonfly || solaris
 
 package platform
 

--- a/internal/platform/mmap_unix.go
+++ b/internal/platform/mmap_unix.go
@@ -1,10 +1,9 @@
-//go:build (darwin || linux || freebsd) && !tinygo
+//go:build (linux || darwin || freebsd || netbsd || dragonfly || solaris) && !tinygo
 
 package platform
 
 import (
 	"syscall"
-	"unsafe"
 )
 
 const (
@@ -30,18 +29,4 @@ func mmapCodeSegmentAMD64(size int) ([]byte, error) {
 func mmapCodeSegmentARM64(size int) ([]byte, error) {
 	// The region must be RW: RW for writing native codes.
 	return mmapCodeSegment(size, mmapProtARM64)
-}
-
-// MprotectRX is like syscall.Mprotect with RX permission, defined locally so that freebsd compiles.
-func MprotectRX(b []byte) (err error) {
-	var _p0 unsafe.Pointer
-	if len(b) > 0 {
-		_p0 = unsafe.Pointer(&b[0])
-	}
-	const prot = syscall.PROT_READ | syscall.PROT_EXEC
-	_, _, e1 := syscall.Syscall(syscall.SYS_MPROTECT, uintptr(_p0), uintptr(len(b)), uintptr(prot))
-	if e1 != 0 {
-		err = syscall.Errno(e1)
-	}
-	return
 }

--- a/internal/platform/mmap_unsupported.go
+++ b/internal/platform/mmap_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || linux || freebsd || windows) || tinygo
+//go:build !(linux || darwin || freebsd || netbsd || dragonfly || solaris || windows) || tinygo
 
 package platform
 

--- a/internal/platform/mprotect_bsd.go
+++ b/internal/platform/mprotect_bsd.go
@@ -1,0 +1,22 @@
+//go:build (freebsd || netbsd || dragonfly) && !tinygo
+
+package platform
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// MprotectRX is like syscall.Mprotect with RX permission, defined locally so that BSD compiles.
+func MprotectRX(b []byte) (err error) {
+	var _p0 unsafe.Pointer
+	if len(b) > 0 {
+		_p0 = unsafe.Pointer(&b[0])
+	}
+	const prot = syscall.PROT_READ | syscall.PROT_EXEC
+	_, _, e1 := syscall.Syscall(syscall.SYS_MPROTECT, uintptr(_p0), uintptr(len(b)), uintptr(prot))
+	if e1 != 0 {
+		err = syscall.Errno(e1)
+	}
+	return
+}

--- a/internal/platform/mprotect_syscall.go
+++ b/internal/platform/mprotect_syscall.go
@@ -1,0 +1,10 @@
+//go:build (linux || darwin) && !tinygo
+
+package platform
+
+import "syscall"
+
+// MprotectRX is like syscall.Mprotect with RX permission.
+func MprotectRX(b []byte) (err error) {
+	return syscall.Mprotect(b, syscall.PROT_READ|syscall.PROT_EXEC)
+}

--- a/internal/platform/mprotect_unsupported.go
+++ b/internal/platform/mprotect_unsupported.go
@@ -1,0 +1,9 @@
+//go:build solaris && !tinygo
+
+package platform
+
+import "syscall"
+
+func MprotectRX(b []byte) error {
+	return syscall.ENOTSUP
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -14,12 +14,13 @@ var archRequirementsVerified bool
 // CompilerSupported is exported for tests and includes constraints here and also the assembler.
 func CompilerSupported() bool {
 	switch runtime.GOOS {
-	case "darwin", "windows", "linux", "freebsd":
+	case "linux", "darwin", "freebsd", "netbsd", "dragonfly", "windows":
+		return archRequirementsVerified
+	case "solaris", "illumos":
+		return runtime.GOARCH == "amd64" && archRequirementsVerified
 	default:
 		return false
 	}
-
-	return archRequirementsVerified
 }
 
 // MmapCodeSegment copies the code into the executable region and returns the byte slice of the region.


### PR DESCRIPTION
This culminates this series of changes, enabling the compiler on:
- NetBSD `amd64` and `arm64`
- DragonFly BSD `amd64`
- illumos `amd64`
- Solaris `amd64`

We're not currently testing `arm64` for either FreeBSD or NetBSD, but I've tested them. The emulation is slow, I'm not sure if it's worth it. The others are not supported Go `arm64` targets.

OpenBSD was not added because it failed with an SIGSEGV. If anyone wants to take a stab at this, I'd welcome it.