### PR TITLE
chore: update action deps

### DIFF
--- a/.github/workflows/clear_cache.yaml
+++ b/.github/workflows/clear_cache.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -37,14 +37,14 @@ jobs:
           wabt_url=https://github.com/WebAssembly/wabt/releases/download/${wabt_version}/wabt-${wabt_version}-ubuntu.tar.gz
           curl -sSL ${wabt_url} | tar --strip-components 2 -C /usr/local/bin -xzf - wabt-${wabt_version}/bin/wast2json
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:  # not cache: true as we also need to cache golint
           cache: false
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -76,15 +76,15 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       # Ensure the pagefile is large enough to execute tests like TestStore_hammer_close on Windows.
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.4
         if: runner.os == 'Windows'
         with:
           minimum-size: 8GB
@@ -121,9 +121,9 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.arch != 'amd64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:  # Avoid docker.io rate-limits; built with internal-images.yml
           image: ghcr.io/tetratelabs/wazero/internal-binfmt
           platforms: ${{ matrix.arch }}
@@ -167,7 +167,7 @@ jobs:
             version: "10.0"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build test binaries
         run: |
@@ -207,7 +207,7 @@ jobs:
             action: 'vmactions/solaris-vm@v1'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build test binaries
         run: |
@@ -242,12 +242,12 @@ jobs:
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           # Cache corpus and artifacts so that we don't start from scratch but rather with a meaningful corpus

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -39,9 +39,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -59,14 +59,14 @@ jobs:
 
       - name: Cache Emscripten
         id: cache-emsdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: emsdk
           key: ${{ runner.os }}-emcc-${{env.EMSDK_VERSION}}
 
       - name: Checkout Emscripten
         if: steps.cache-emsdk.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: emscripten-core/emsdk
           path: emsdk

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -76,11 +76,11 @@ jobs:
         run: |
           ./emsdk/emsdk install ${{env.EMSDK_VERSION}}
 
-      - name: Install wasm32-wasi target
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          target: wasm32-wasi
+          targets: wasm32-unknown-unknown, wasm32-wasi
 
       - name: Build TinyGo examples
         run: make build.examples.tinygo

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -40,9 +40,9 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -98,9 +98,9 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -111,7 +111,7 @@ jobs:
           path:
             ${{ env.STDLIB_TESTS }}/testdata/zig
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -125,9 +125,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -144,7 +144,7 @@ jobs:
           echo "TINYGOROOT=/usr/local/tinygo" >> $GITHUB_ENV
           echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         if: steps.binary-cache.outputs.cache-hit != 'true'
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -177,9 +177,9 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -190,7 +190,7 @@ jobs:
           path:
             ${{ env.STDLIB_TESTS }}/testdata/tinygo
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -208,25 +208,25 @@ jobs:
         os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           path:
             ~/go/pkg/mod
           key: integration-test-wasi-testsuite-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install wazero
         run: go install ./cmd/wazero
 
       - name: Checkout wasi-testsuite
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: WebAssembly/wasi-testsuite
           # prod/testsuite-base branch, as of May 12, 2023.
@@ -235,7 +235,7 @@ jobs:
           path: wasi-testsuite
 
       - name: Initialize Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11' # latest version of python 3
           cache: pip
@@ -281,16 +281,16 @@ jobs:
 
     steps:
       - id: setup-go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Go test binaries
         id: cache-go-test-binaries
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path:
             ${{ env.STDLIB_TESTS }}/testdata/go
@@ -332,9 +332,9 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -345,7 +345,7 @@ jobs:
           path:
             ${{ env.STDLIB_TESTS }}/testdata/tinygo
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
       - name: "Login into GitHub Container Registry"
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,14 +31,14 @@ jobs:
     outputs:
       VERSION: ${{ steps.output-version.outputs.VERSION }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           cache: false
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -100,7 +100,7 @@ jobs:
       # Downside of this is that, we pressure the cache capacity set per repository. We delete all caches created
       # on PRs on close. See .github/workflows/clear_cache.yaml. On main branch, in any way this cache will be deleted
       # in 7 days, also this at most a few MB, so this won't be an issue.
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           # Use share the cache containing archives across OSes.
@@ -121,9 +121,9 @@ jobs:
         os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           # We need this cache to run tests.
@@ -163,11 +163,11 @@ jobs:
     name: Release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:  # Ensure release_notes.sh can see prior commits
           fetch-depth: 0
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           fail-on-cache-miss: true


### PR DESCRIPTION
This updates dependent actions on CI, most of which have seen significant upgrades.

Most noteworthy is that [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) has been archived over a year ago. Seems the community has moved to [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) so I moved to it.

Most runs of `make build.examples.rust` do nothing (_make: Nothing to be done for..._), but I manually confirmed the new action works.