### PR TITLE
avoid fmt.Errorf calls for an error that is never read (reduce useless memory allocs)

### DIFF
--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -285,14 +285,19 @@ func (m *ModuleInstance) applyData(data []DataSegment) error {
 	return nil
 }
 
+var (
+	ErrModuleNotExported       = errors.New("module not exported")
+	ErrModuleWrongExternalType = errors.New("module has wrong external type")
+)
+
 // GetExport returns an export of the given name and type or errs if not exported or the wrong type.
 func (m *ModuleInstance) getExport(name string, et ExternType) (*Export, error) {
 	exp, ok := m.Exports[name]
 	if !ok {
-		return nil, fmt.Errorf("%q is not exported in module %q", name, m.ModuleName)
+		return nil, ErrModuleNotExported
 	}
 	if exp.Type != et {
-		return nil, fmt.Errorf("export %q in module %q is a %s, not a %s", name, m.ModuleName, ExternTypeName(exp.Type), ExternTypeName(et))
+		return nil, ErrModuleWrongExternalType
 	}
 	return exp, nil
 }

--- a/internal/wasm/store_test.go
+++ b/internal/wasm/store_test.go
@@ -708,7 +708,7 @@ func Test_resolveImports(t *testing.T) {
 		m := &ModuleInstance{s: newStore()}
 		m.s.nameToModule[moduleName] = &ModuleInstance{Exports: map[string]*Export{}, ModuleName: moduleName}
 		err := m.resolveImports(context.Background(), &Module{ImportPerModule: map[string][]*Import{moduleName: {{Name: "unknown"}}}})
-		require.EqualError(t, err, "\"unknown\" is not exported in module \"test\"")
+		require.EqualError(t, err, ErrModuleNotExported.Error())
 	})
 	t.Run("func", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {


### PR DESCRIPTION
While chasing memory allocations (heavy usage of WASM modules, leading to thrashing golang garbage collector ...),
I found a lot of fmt.Errorf() called, without any error resurfacing.

The content of these errors are always ignored, so it makes more sense to reuse the same `error` object, saving a lot of object memory allocations.