### PR TITLE
Support `fd_sync` for stdout/stderr writers via optional interface

### DIFF
--- a/internal/sys/stdio.go
+++ b/internal/sys/stdio.go
@@ -36,6 +36,19 @@ func (f *writerFile) Write(buf []byte) (int, experimentalsys.Errno) {
 	return n, experimentalsys.UnwrapOSError(err)
 }
 
+// syncer is a writer that support flushing for fd_sync
+type syncer interface {
+	Sync() error
+}
+
+// Sync implements the same method as documented on sys.File
+func (f *writerFile) Sync() experimentalsys.Errno {
+	if s, ok := f.w.(syncer); ok {
+		return experimentalsys.UnwrapOSError(s.Sync())
+	}
+	return 0
+}
+
 // noopStdinFile is a fs.ModeDevice file for use implementing FdStdin. This is
 // safer than reading from os.DevNull as it can never overrun operating system
 // file descriptors.


### PR DESCRIPTION
As far as I know, when an arbitrary `io.Writer` is passed for the module's stdout/stderr, it's not possible to hook into `fd_sync` when it is called on the respective file descriptor.

I've extended `writerFile` struct to attempt to call a `Sync` method on the inner writer interface, if it passes the type assertion.

My use case is as follows:
1. For the module's `WithStdout`, I'm passing in a wrapper `http.ResponseWriter`.
2. When the guest calls `os.Stdout.Sync()` I want to invoke `http.Flusher.Flush()` on the guest.

As long as the writer decides to implement this simple interface:

```go
type syncer interface {
	Sync() error
}
```

The host can hook into whenever the client flushes the fd.

---

Also, thanks for this amazing project, I've been meaning to dive into wazero ever since I saw Takeshi's talk at GopherCon '22 in person 😄 