### PR TITLE
Fix integration tests.

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -315,6 +315,7 @@ jobs:
           go test -bench='BenchmarkWasip1' -timeout=20m -benchtime=1x
 
   libsodium:
+    needs: build_tinygo_test_binary
     name: libsodium (${{ matrix.os.name }}, ${{ matrix.os.arch }})
     runs-on: ${{ matrix.os.version }}
     strategy:


### PR DESCRIPTION
libsodium was failing across the board because of a not explicit dependency on tinygo.