### PR TITLE
Prevent module from closing when `proc_exit` is called with a 0 exit code

### DIFF
--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -28,13 +28,12 @@ var procExit = &wasm.HostFunc{
 
 func procExitFn(ctx context.Context, mod api.Module, params []uint64) {
 	exitCode := uint32(params[0])
-	// TinyGo 0.35.0 calls proc_exit from _start, even for exit code 0.
-	if exitCode == 0 {
-		return
-	}
 
-	// Ensure other callers see the exit code.
-	_ = mod.CloseWithExitCode(ctx, exitCode)
+	// TinyGo 0.35.0 calls proc_exit from _start, even for exit code 0.
+	if exitCode != 0 {
+		// Ensure other callers see the exit code.
+		_ = mod.CloseWithExitCode(ctx, exitCode)
+	}
 
 	// Prevent any code from executing after this function. For example, LLVM
 	// inserts unreachable instructions after calls to exit.

--- a/imports/wasi_snapshot_preview1/proc.go
+++ b/imports/wasi_snapshot_preview1/proc.go
@@ -28,6 +28,10 @@ var procExit = &wasm.HostFunc{
 
 func procExitFn(ctx context.Context, mod api.Module, params []uint64) {
 	exitCode := uint32(params[0])
+	// TinyGo 0.35.0 calls proc_exit from _start, even for exit code 0.
+	if exitCode == 0 {
+		return
+	}
 
 	// Ensure other callers see the exit code.
 	_ = mod.CloseWithExitCode(ctx, exitCode)

--- a/imports/wasi_snapshot_preview1/proc_test.go
+++ b/imports/wasi_snapshot_preview1/proc_test.go
@@ -19,9 +19,11 @@ func Test_procExit(t *testing.T) {
 		expectedLog string
 	}{
 		{
-			name:        "success (exitcode 0)",
-			exitCode:    0,
-			expectedLog: ``,
+			name:     "success (exitcode 0)",
+			exitCode: 0,
+			expectedLog: `
+==> wasi_snapshot_preview1.proc_exit(rval=0)
+`,
 		},
 		{
 			name:     "arbitrary non-zero exitcode",

--- a/imports/wasi_snapshot_preview1/proc_test.go
+++ b/imports/wasi_snapshot_preview1/proc_test.go
@@ -19,11 +19,9 @@ func Test_procExit(t *testing.T) {
 		expectedLog string
 	}{
 		{
-			name:     "success (exitcode 0)",
-			exitCode: 0,
-			expectedLog: `
-==> wasi_snapshot_preview1.proc_exit(rval=0)
-`,
+			name:        "success (exitcode 0)",
+			exitCode:    0,
+			expectedLog: ``,
 		},
 		{
 			name:     "arbitrary non-zero exitcode",
@@ -42,11 +40,15 @@ func Test_procExit(t *testing.T) {
 
 			// Since procExit panics, any opcodes afterwards cannot be reached.
 			_, err := mod.ExportedFunction(wasip1.ProcExitName).Call(testCtx, uint64(tc.exitCode))
-			require.Error(t, err)
-			sysErr, ok := err.(*sys.ExitError)
-			require.True(t, ok, err)
-			require.Equal(t, tc.exitCode, sysErr.ExitCode())
-			require.Equal(t, tc.expectedLog, "\n"+log.String())
+			if tc.expectedLog != "" {
+				require.Error(t, err)
+				sysErr, ok := err.(*sys.ExitError)
+				require.True(t, ok, err)
+				require.Equal(t, tc.exitCode, sysErr.ExitCode())
+				require.Equal(t, tc.expectedLog, "\n"+log.String())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The latest stable release of TinyGo (0.35.0) invokes the WASI `proc_exit` syscall when the `_start` function is complete, even if the exit code is 0. Frameworks that use wazero likely expect an empty `main()` and call other exported functions. Because the module closes, this is broken in TinyGo 0.35.0. Any call thereafter also return `sys.ExitError` and basic host calls like `fmt.Println` are likely to panic. 

This PR fixes the issue by returning out of `procExitFn` before closing the module if the exit code is 0.
Fixes #2357

The host program may still need to handle `sys.ExitError` being returned from `_start`. That does not change.