### PR TITLE
fix: `HostFunctionBuilder.WithFunc` works with negative int32

### DIFF
--- a/internal/integration_test/engine/adhoc_test.go
+++ b/internal/integration_test/engine/adhoc_test.go
@@ -502,8 +502,14 @@ func testHostFunctionNumericParameter(t *testing.T, r wazero.Runtime) {
 		"i32": func(ctx context.Context, p uint32) uint32 {
 			return p + 1
 		},
+		"i32n": func(ctx context.Context, p int32) int32 {
+			return p - 1
+		},
 		"i64": func(ctx context.Context, p uint64) uint64 {
 			return p + 1
+		},
+		"i64n": func(ctx context.Context, p int64) int64 {
+			return p - 1
 		},
 		"f32": func(ctx context.Context, p float32) float32 {
 			return p + 1
@@ -525,10 +531,22 @@ func testHostFunctionNumericParameter(t *testing.T, r wazero.Runtime) {
 			expected: math.MaxUint32,
 		},
 		{
+			name:     "i32n",
+			vt:       i32,
+			input:    api.EncodeI32(math.MinInt32 + 1),
+			expected: api.EncodeI32(math.MinInt32),
+		},
+		{
 			name:     "i64",
 			vt:       i64,
 			input:    math.MaxUint64 - 1,
 			expected: math.MaxUint64,
+		},
+		{
+			name:     "i64n",
+			vt:       i64,
+			input:    api.EncodeI64(math.MinInt64 + 1),
+			expected: api.EncodeI64(math.MinInt64),
 		},
 		{
 			name:     "f32",

--- a/internal/wasm/gofunc.go
+++ b/internal/wasm/gofunc.go
@@ -131,7 +131,9 @@ func callGoFunc(ctx context.Context, mod api.Module, fn *reflect.Value, stack []
 			stack[i] = math.Float64bits(ret.Float())
 		case reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			stack[i] = ret.Uint()
-		case reflect.Int32, reflect.Int64:
+		case reflect.Int32:
+			stack[i] = uint64(uint32(int32(ret.Int())))
+		case reflect.Int64:
 			stack[i] = uint64(ret.Int())
 		default:
 			panic(fmt.Errorf("BUG: result[%d] has an invalid type: %v", i, ret.Kind()))


### PR DESCRIPTION
According to the description, `HostFunctionBuilder.WithFunc` should correctly convert int32 to wasm-type. But int32 is extended to int64, which is incorrect for negative numbers.

Description of HostFunctionBuilder.WithFunc:
https://github.com/tetratelabs/wazero/blob/4231c48a9c9adf451efcacecfd82278cab2c43a4/builder.go#L92-L94

The correct conversion of int32 to i32 is `uint64(uint32(input))`:
https://github.com/tetratelabs/wazero/blob/4231c48a9c9adf451efcacecfd82278cab2c43a4/api/wasm.go#L715-L718
