### PR TITLE
runtime: return nil interface not nil pointer on error

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -325,7 +325,7 @@ func (r *runtime) InstantiateModule(
 
 	var sysCtx *internalsys.Context
 	if sysCtx, err = config.toSysContext(); err != nil {
-		return
+		return nil, err
 	}
 
 	name := config.name
@@ -340,7 +340,7 @@ func (r *runtime) InstantiateModule(
 		if code.closeWithModule {
 			_ = code.Close(ctx) // don't overwrite the error
 		}
-		return
+		return nil, err
 	}
 
 	if closeNotifier, ok := ctx.Value(expctxkeys.CloseNotifierKey{}).(experimentalapi.CloseNotifier); ok {


### PR DESCRIPTION
Fixes #2353, supersedes #2354.

Returning a `nil` pointer to a struct implementing the interface is bad form, and a bug (the `nil` doesn't actually implement the interface: it panics).

I don't love naked returns in this big a function either, but the rest of the assumptions in #2354 were problematic, and were blocking the fix.