### PR TITLE
docs: add yoke to community users

### DIFF
--- a/site/content/community/users.md
+++ b/site/content/community/users.md
@@ -35,6 +35,12 @@ considering their efforts before starting your own!
 | [waPC][5]                      | implements [Apex][6] interfaces with WebAssembly via code generation          |
 | [wazero-emscripten-embind][36] | Emscripten [Embind][37] and code generation support for Wazero                |
 
+### Infrastructure-as-Code
+
+| Name                   | Description                                        |
+|:-----------------------|----------------------------------------------------|
+| [yoke][47] | A WebAssembly-based package deployer for Kubernetes, enabling declarative and programmable deployments with Wasm |
+
 ### Middleware
 
 | Name                   | Description                                        |
@@ -174,3 +180,5 @@ experience.
 [45]: https://docs.redpanda.com/redpanda-connect/components/processors/redpanda_data_transform/
 
 [46]: https://github.com/hypermodeinc/modus
+
+[47]: https://github.com/yokecd/yoke


### PR DESCRIPTION
Context from the wazero slack channel: https://gophers.slack.com/archives/C040AKTNTE0/p1739635237444679

Abridged version:

> The project is called [Yoke](https://github.com/yokecd/yoke), and it is a [Candidate to become a CNCF Sandbox project](https://github.com/cncf/sandbox/issues/317).
>Yoke is a modern alternative to helm. It is a package manager for Kubernetes, but instead of writing Helm charts (which are collections of templated YAML files), you define your package's logic in code. The code is then packaged into a single portable executable wasip1/wasm executable.


I would be honoured if my project could be added to the list of wazero community projects.