### PR TITLE
wazevo(amd64): reserve dx when calling memmove to support go 1.24

### DIFF
--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -1918,6 +1918,9 @@ func (m *machine) lowerCall(si *ssa.Instruction) {
 		for i := regalloc.RealReg(0); i < 16; i++ {
 			m.insert(m.allocateInstr().asDefineUninitializedReg(regInfo.RealRegToVReg[xmm0+i]))
 		}
+		// Since Go 1.24 it may also use DX, which is not reserved for the function call's 3 args.
+		// https://github.com/golang/go/blob/go1.24.0/src/runtime/memmove_amd64.s#L123
+		m.insert(m.allocateInstr().asDefineUninitializedReg(regInfo.RealRegToVReg[rdx]))
 	}
 
 	if isDirectCall {
@@ -1933,6 +1936,7 @@ func (m *machine) lowerCall(si *ssa.Instruction) {
 		for i := regalloc.RealReg(0); i < 16; i++ {
 			m.insert(m.allocateInstr().asNopUseReg(regInfo.RealRegToVReg[xmm0+i]))
 		}
+		m.insert(m.allocateInstr().asNopUseReg(regInfo.RealRegToVReg[rdx]))
 	}
 
 	var index int


### PR DESCRIPTION
Fixes #2375

Go 1.24 changed memmove implementation on amd64, which resulted in an extra register allocation. This makes sure to reserve it for memmove invocation. While this could be a regression on go 1.23, it seems not significant enough to have version-specific code for this especially since it will go out-of-date soon.

Originally, @mathetake had suggested vendoring in the working go 1.23's memmove implementation, which both fixes and ensures forward compatibility, but I couldn't let go of the 30% perf gain from the change. After this, someone may want to try vendoring 1.24's implementation (it's not trivial due to needing to read many cpu flags), for forward compatibility, but before it I would check whether it's worth using the direct call to save on host function call overhead if implemented with normal `copy`.

https://github.com/golang/go/commit/601ea46a5308876e4460a1662718a9cd2c6ac2e3