### PR TITLE
cache/memory: Disable cache for host modules

### DIFF
--- a/internal/engine/wazevo/engine_cache.go
+++ b/internal/engine/wazevo/engine_cache.go
@@ -43,8 +43,11 @@ func fileCacheKey(m *wasm.Module) (ret filecache.Key) {
 }
 
 func (e *engine) addCompiledModule(module *wasm.Module, cm *compiledModule) (err error) {
+	if module.IsHostModule {
+		return
+	}
 	e.addCompiledModuleToMemory(module, cm)
-	if !module.IsHostModule && e.fileCache != nil {
+	if e.fileCache != nil {
 		err = e.addCompiledModuleToCache(module, cm)
 	}
 	return
@@ -86,6 +89,9 @@ func (e *engine) getCompiledModule(module *wasm.Module, listeners []experimental
 }
 
 func (e *engine) addCompiledModuleToMemory(m *wasm.Module, cm *compiledModule) {
+	if m.IsHostModule {
+		return
+	}
 	e.mux.Lock()
 	defer e.mux.Unlock()
 	e.compiledModules[m.ID] = cm
@@ -95,6 +101,9 @@ func (e *engine) addCompiledModuleToMemory(m *wasm.Module, cm *compiledModule) {
 }
 
 func (e *engine) getCompiledModuleFromMemory(module *wasm.Module) (cm *compiledModule, ok bool) {
+	if module.IsHostModule {
+		return
+	}
 	e.mux.RLock()
 	defer e.mux.RUnlock()
 	cm, ok = e.compiledModules[module.ID]


### PR DESCRIPTION
I wanted to understand how cache grows overtime I realized it kept growing because of host modules. I assume this is because they [won't have same IDs across multiple runs](https://github.com/tetratelabs/wazero/blob/cc40233f33197942e79997c3e6fccbe453ddb535/internal/wasm/host.go#L69) so I wanted to propose to disable it like [we did for file system cache](https://github.com/tetratelabs/wazero/pull/949). Having said that I am not calling close on the runtime. Let me know if I am missing something perhaps there is a use-case I am over looking? 

Following is the screenshot from the debugger where I saw `compiledModules` kept on growing:

![Screenshot from 2025-03-05 10-18-28](https://github.com/user-attachments/assets/680cc78f-0067-434a-9108-4dd291a5aae2)


![Screenshot from 2025-03-05 10-19-06](https://github.com/user-attachments/assets/b534e517-529c-44e9-aef6-5025fb8a6052)
