### PR TITLE
bench: skip TestOpenFileDevNull on Windows

### DIFF
--- a/internal/integration_test/stdlibs/bench_test.go
+++ b/internal/integration_test/stdlibs/bench_test.go
@@ -111,7 +111,8 @@ var (
 
 				skip = append(skip, "TestRenameCaseDifference/dir", "TestDirFSPathsValid", "TestDirFS",
 					"TestDevNullFile", "TestOpenError", "TestSymlinkWithTrailingSlash", "TestCopyFS",
-					"TestRoot", "TestOpenInRoot", "ExampleAfterFunc_connection")
+					"TestRoot", "TestOpenInRoot", "ExampleAfterFunc_connection", "TestOpenFileDevNull",
+				)
 			}
 			args = append(args, "-test.skip="+strings.Join(skip, "|"))
 			c = c.WithArgs(args...)


### PR DESCRIPTION
this test will not resolve DevNull to NUL on WASI, failing on Windows, so it is safe to skip.

It's a new test introduced with Go 1.24.1 released on March 4 (see https://github.com/golang/go/commit/30f4d9e117ba66f77bf9dc507da4ad35c747d0cb)
The CI implicitly picked up the update, causing other unrelated PRs to fail.