### PR TITLE
fix: remove misleading comment

### DIFF
--- a/examples/allocation/tinygo/greet.go
+++ b/examples/allocation/tinygo/greet.go
@@ -12,8 +12,6 @@ import (
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
-// greetWasm was compiled using `tinygo build -o greet.wasm -scheduler=none --no-debug -target=wasi greet.go`
-//
 //go:embed testdata/greet.wasm
 var greetWasm []byte
 


### PR DESCRIPTION
### Summary

Using the command end up getting an error:

```
tinygo build -o greet.wasm -scheduler=none --no-debug -target=wasi greet.go
```

```
panic: wasm error: unreachable
        wasm stack trace:
                main.runtime.runtimePanicAt(i32,i32)
                main.runtime.runtimePanic(i32,i32)
                main.main.say#wasmexport() i32

```
