### PR TITLE
Optimize/streamline fill operations

### DIFF
--- a/internal/wasm/table.go
+++ b/internal/wasm/table.go
@@ -326,10 +326,14 @@ func (t *TableInstance) Grow(delta uint32, initialRef Reference) (currentLen uin
 	newLen >= math.MaxUint32 || (t.Max != nil && newLen > int64(*t.Max)) {
 		return 0xffffffff // = -1 in signed 32-bit integer.
 	}
+
 	t.References = append(t.References, make([]uintptr, delta)...)
+	if initialRef == 0 {
+		return
+	}
 
 	// Uses the copy trick for faster filling the new region with the initial value.
-	// https://gist.github.com/taylorza/df2f89d5f9ab3ffd06865062a4cf015d
+	// https://github.com/golang/go/blob/go1.24.0/src/slices/slices.go#L514-L517
 	newRegion := t.References[currentLen:]
 	newRegion[0] = initialRef
 	for i := 1; i < len(newRegion); i *= 2 {


### PR DESCRIPTION
This optimizes/streamlines fill operations.

#### Backstory:
- since 1.21 we have a [`clear`](https://tip.golang.org/doc/go1.21#language) builtin which is faster than `copy` when zeroing memory
- [`slices.Repeat`](https://github.com/golang/go/blob/go1.24.0/src/slices/slices.go#L514-L517) uses a `copy` loop very similar to the one we're using
- [`bytes.Repeat`](https://github.com/golang/go/blob/go1.24.0/src/bytes/bytes.go#L664-L673) does the same, but adds an 8KB maximum to the chunk size
- the existing generated code could be streamlined

#### Intuition:
- rare that tables are much larger than 8KB
- using `clear` (actually `runtime.memclrNoHeapPointers`) from native code is harder
- favor smaller/simpler code for tables, faster code for memory (like the standard library)

#### For the compiler:
- streamline/simplify `table.fill`
- optimize `memory.fill` using the 8KB maximum chunk size

#### For the interpreter:
- keep `table.fill` unchanged
- optimize `memory.fill` with both `clear` and maximum chunk size

#### For `table.Grow`:
- recognize that zero initialization is already done

#### Results:
I could measure an over 2x improvement filling megabytes of memory, with no degradation in performance at small sizes. No increase of generated code size.

#### Future work:
Using `memory.fill` to zero memory is _very_ common. If we could access `runtime.memclrNoHeapPointers` in the compiler, we could potentially gain another 25% there (especially if we optimized this when zero is known at compile time).
