### PR TITLE
Fix typo in memory fill.

### DIFF
--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -770,7 +770,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 			dstAddr := builder.AllocateInstruction().AsIadd(addr, loopVar).Insert(builder).Return()
 
 			// chunk := ((i - 1) & 8191) + 1
-			mask := builder.AllocateInstruction().AsIconst64(16383).Insert(builder).Return()
+			mask := builder.AllocateInstruction().AsIconst64(8191).Insert(builder).Return()
 			tmp1 := builder.AllocateInstruction().AsIsub(loopVar, one).Insert(builder).Return()
 			tmp2 := builder.AllocateInstruction().AsBand(tmp1, mask).Insert(builder).Return()
 			chunk := builder.AllocateInstruction().AsIadd(tmp2, one).Insert(builder).Return()


### PR DESCRIPTION
PR https://github.com/tetratelabs/wazero/pull/2395 was merged with a typo.

I also compared this with the conditional move approach (i.e. `chunk := min(i, 8192)` instead of `chunk := ((i - 1) & 8191) + 1`). In terms of performance and code size it's a wash.

But if you prefer it for clarity (and consistency with [`bytes.Repeat`](https://github.com/golang/go/blob/go1.24.0/src/bytes/bytes.go#L664-L673)), I can happily do the change here.