### PR TITLE
Ensure interpreter.Engine is empty after closing

### DIFF
--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -43,6 +43,7 @@ func NewEngine(_ context.Context, enabledFeatures api.CoreFeatures, _ filecache.
 
 // Close implements the same method as documented on wasm.Engine.
 func (e *engine) Close() (err error) {
+	clear(e.compiledFunctions)
 	return
 }
 


### PR DESCRIPTION
If the compiler is not supported on the current platform, then `TestCompilationCache/non-host module` will load the interpreter instead. At the end of the test, it checks that the cache is empty, but that was not previously the case for the interpreter.