### PR TITLE
Skip custom context host test if compiler unsupported

### DIFF
--- a/runtime_test.go
+++ b/runtime_test.go
@@ -625,6 +625,9 @@ func TestHostFunctionWithCustomContext(t *testing.T) {
 		{name: "interpreter", config: NewRuntimeConfigInterpreter()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "compiler" && !platform.CompilerSupported() {
+				t.Skip("Compiler is not supported on this host")
+			}
 			const fistString = "hello"
 			const secondString = "hello call"
 			hostCtx := &HostContext{fistString}


### PR DESCRIPTION
Otherwise, this will panic on an unsupported architecture:
```
--- FAIL: TestHostFunctionWithCustomContext (0.00s)
    --- FAIL: TestHostFunctionWithCustomContext/compiler (0.00s)
panic: unsupported architecture [recovered]
	panic: unsupported architecture
goroutine 179 [running]:
testing.tRunner.func1.2({0x10038ebc0, 0x1003ed4d0})
	/usr/lib/golang/src/testing/testing.go:1734 +0x1ec
testing.tRunner.func1()
	/usr/lib/golang/src/testing/testing.go:1737 +0x350
panic({0x10038ebc0?, 0x1003ed4d0?})
	/usr/lib/golang/src/runtime/panic.go:792 +0x168
github.com/tetratelabs/wazero/internal/engine/wazevo.newMachine(...)
	.../wazero/internal/engine/wazevo/isa_other.go:10
github.com/tetratelabs/wazero/internal/engine/wazevo.NewEngine({0x1003fc600?, 0x10?}, 0x1003a8f60?, {0x1003fc600?, 0x1?})
	.../wazero/internal/engine/wazevo/engine.go:105 +0x4c
github.com/tetratelabs/wazero.NewRuntimeWithConfig({0x1003ef200?, 0xc0002eb450?}, {0x1003ef970?, 0xc0003507c0})
	.../wazero/runtime.go:178 +0x110
github.com/tetratelabs/wazero.TestHostFunctionWithCustomContext.func1(0xc00034ea80)
	.../wazero/runtime_test.go:631 +0x98
testing.tRunner(0xc00034ea80, 0xc00033fe90)
	/usr/lib/golang/src/testing/testing.go:1792 +0x124
created by testing.(*T).Run in goroutine 178
	/usr/lib/golang/src/testing/testing.go:1851 +0x400
exit status 2
```