### PR TITLE
bench: disable TestOpenFileCreateExclDanglingSymlink on Windows

### DIFF
--- a/internal/integration_test/stdlibs/bench_test.go
+++ b/internal/integration_test/stdlibs/bench_test.go
@@ -112,6 +112,7 @@ var (
 				skip = append(skip, "TestRenameCaseDifference/dir", "TestDirFSPathsValid", "TestDirFS",
 					"TestDevNullFile", "TestOpenError", "TestSymlinkWithTrailingSlash", "TestCopyFS",
 					"TestRoot", "TestOpenInRoot", "ExampleAfterFunc_connection", "TestOpenFileDevNull",
+					"TestOpenFileCreateExclDanglingSymlink",
 				)
 			}
 			args = append(args, "-test.skip="+strings.Join(skip, "|"))


### PR DESCRIPTION
test is currently failing consistently, let's disable it for now