### PR TITLE
Consolidate code sections.

### DIFF
--- a/internal/engine/wazevo/engine_test.go
+++ b/internal/engine/wazevo/engine_test.go
@@ -16,41 +16,12 @@ import (
 func Test_sharedFunctionsFinalizer(t *testing.T) {
 	sf := &sharedFunctions{}
 
-	b1, err := platform.MmapCodeSegment(100)
+	buf, err := platform.MmapCodeSegment(100)
 	require.NoError(t, err)
-	b2, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-	b3, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-	b6, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-	b7, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-	b8, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-	b9, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-	b10, err := platform.MmapCodeSegment(100)
-	require.NoError(t, err)
-
-	sf.memoryGrowExecutable = b1
-	sf.stackGrowExecutable = b2
-	sf.checkModuleExitCode = b3
-	sf.tableGrowExecutable = b6
-	sf.refFuncExecutable = b7
-	sf.memoryWait32Executable = b8
-	sf.memoryWait64Executable = b9
-	sf.memoryNotifyExecutable = b10
+	sf.executable = buf
 
 	sharedFunctionsFinalizer(sf)
-	require.Nil(t, sf.memoryGrowExecutable)
-	require.Nil(t, sf.stackGrowExecutable)
-	require.Nil(t, sf.checkModuleExitCode)
-	require.Nil(t, sf.tableGrowExecutable)
-	require.Nil(t, sf.refFuncExecutable)
-	require.Nil(t, sf.memoryWait32Executable)
-	require.Nil(t, sf.memoryWait64Executable)
-	require.Nil(t, sf.memoryNotifyExecutable)
+	require.Nil(t, sf.executable)
 }
 
 func Test_executablesFinalizer(t *testing.T) {

--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -174,20 +174,21 @@ func (m *moduleEngine) NewFunction(index wasm.Index) api.Function {
 		indexInModule:          index,
 		executable:             &p.executable[offset],
 		parent:                 m,
-		preambleExecutable:     &m.parent.entryPreambles[typIndex][0],
+		preambleExecutable:     p.entryPreamblesPtrs[typIndex],
 		sizeOfParamResultSlice: sizeOfParamResultSlice,
 		requiredParams:         typ.ParamNumInUint64,
 		numberOfResults:        typ.ResultNumInUint64,
 	}
 
-	ce.execCtx.memoryGrowTrampolineAddress = &m.parent.sharedFunctions.memoryGrowExecutable[0]
-	ce.execCtx.stackGrowCallTrampolineAddress = &m.parent.sharedFunctions.stackGrowExecutable[0]
-	ce.execCtx.checkModuleExitCodeTrampolineAddress = &m.parent.sharedFunctions.checkModuleExitCode[0]
-	ce.execCtx.tableGrowTrampolineAddress = &m.parent.sharedFunctions.tableGrowExecutable[0]
-	ce.execCtx.refFuncTrampolineAddress = &m.parent.sharedFunctions.refFuncExecutable[0]
-	ce.execCtx.memoryWait32TrampolineAddress = &m.parent.sharedFunctions.memoryWait32Executable[0]
-	ce.execCtx.memoryWait64TrampolineAddress = &m.parent.sharedFunctions.memoryWait64Executable[0]
-	ce.execCtx.memoryNotifyTrampolineAddress = &m.parent.sharedFunctions.memoryNotifyExecutable[0]
+	sharedFunctions := p.sharedFunctions
+	ce.execCtx.memoryGrowTrampolineAddress = sharedFunctions.memoryGrowAddress
+	ce.execCtx.stackGrowCallTrampolineAddress = sharedFunctions.stackGrowAddress
+	ce.execCtx.checkModuleExitCodeTrampolineAddress = sharedFunctions.checkModuleExitCodeAddress
+	ce.execCtx.tableGrowTrampolineAddress = sharedFunctions.tableGrowAddress
+	ce.execCtx.refFuncTrampolineAddress = sharedFunctions.refFuncAddress
+	ce.execCtx.memoryWait32TrampolineAddress = sharedFunctions.memoryWait32Address
+	ce.execCtx.memoryWait64TrampolineAddress = sharedFunctions.memoryWait64Address
+	ce.execCtx.memoryNotifyTrampolineAddress = sharedFunctions.memoryNotifyAddress
 	ce.execCtx.memmoveAddress = memmovPtr
 	ce.init()
 	return ce


### PR DESCRIPTION
This consolidates code sections used by entry preambles, shared functions, and to a lesser extent listener trampolines into fewer memory pages.

Currently, all of these take up one page (4K, sometimes 16K; depends on the OS). I logged the sizes of these, and haven't seen any above 512 bytes; many are under 32 bytes, so lots of wasted space.

With this change, in particular, shared functions take a single page (~1500 bytes), and most modules will make do with a single page for all entry preambles.

No measurable effect on compilation time, or runtime (but mmaped memory is not visible to the Go runtime, so this simply means the way I'm shuffling memory around doesn't make things worse):

```sh
% benchstat head mmap   
goos: darwin
goarch: amd64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
                             │    head     │                mmap                 │
                             │   sec/op    │   sec/op     vs base                │
Zig/Compile/test-opt.wasm-12   5.410 ± ∞ ¹   5.311 ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Run/test-opt.wasm-12       34.74 ± ∞ ¹   34.74 ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Compile/test.wasm-12       5.978 ± ∞ ¹   6.024 ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Run/test.wasm-12           35.67 ± ∞ ¹   35.82 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                        14.15         14.12        -0.17%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                             │     head      │                 mmap                  │
                             │     B/op      │     B/op       vs base                │
Zig/Compile/test-opt.wasm-12   359.5Mi ± ∞ ¹   359.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Run/test-opt.wasm-12       741.8Mi ± ∞ ¹   741.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Compile/test.wasm-12       574.3Mi ± ∞ ¹   574.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Run/test.wasm-12           1.297Gi ± ∞ ¹   1.297Gi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                        671.5Mi         671.5Mi        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                             │     head     │                 mmap                 │
                             │  allocs/op   │  allocs/op    vs base                │
Zig/Compile/test-opt.wasm-12   336.2k ± ∞ ¹   336.3k ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Run/test-opt.wasm-12       52.00k ± ∞ ¹   52.00k ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Compile/test.wasm-12       289.7k ± ∞ ¹   289.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
Zig/Run/test.wasm-12           2.156M ± ∞ ¹   2.156M ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                        323.3k         323.3k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```