### PR TITLE
wazevoapi: pre-allocate VarLength slice capacity to eliminate repeated allocations

### DIFF
--- a/internal/engine/wazevo/wazevoapi/pool.go
+++ b/internal/engine/wazevo/wazevoapi/pool.go
@@ -155,6 +155,9 @@ func (p *VarLengthPool[T]) Allocate(knownMin int) VarLength[T] {
 		return VarLength[T]{arr: arr}
 	}
 	slc := p.slicePool.Allocate()
+	if cap(*slc) < knownMin {
+		*slc = make([]T, 0, knownMin)
+	}
 	return VarLength[T]{slc: slc}
 }
 


### PR DESCRIPTION
motivated by some of my findings in https://github.com/wazero/wazero/pull/2381, VarLengthPool.Allocate() now pre-allocates slice capacity when knownMin > arraySize. Previously, pooled slices were reused with zero capacity, causing repeated reallocations during subsequent Append() calls. This resulted in 230MB of unnecessary allocations (35% of total) during bounds checking finalization.

The fix checks if the pooled slice has sufficient capacity for the known minimum size. If not, it reallocates with the requested capacity before returning.

The optimization targets the hot path in finalizeKnownSafeBoundsAtTheEndOfBlock() where callers pass the exact required size, then immediately append that many elements.

**Before**
```
maanas@maanas wazero % go test -bench='^BenchmarkZig/Compile/test.wasm$' -benchmem -count=3 ./internal/integration_test/stdlibs
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
cpu: Apple M1 Pro
BenchmarkZig/Compile/test.wasm-10                      1        3521891833 ns/op        623518536 B/op    275792 allocs/op
BenchmarkZig/Compile/test.wasm-10                      1        3433791000 ns/op        623494128 B/op    275694 allocs/op
BenchmarkZig/Compile/test.wasm-10                      1        3423325542 ns/op        623474640 B/op    275350 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/stdlibs 10.841s
maanas@maanas wazero % 
```

**After**
```
maanas@maanas wazero % go test -bench='^BenchmarkZig/Compile/test.wasm$' -benchmem -count=3 ./internal/integration_test/stdlibs
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
cpu: Apple M1 Pro
BenchmarkZig/Compile/test.wasm-10                      1        3469627667 ns/op        492012336 B/op    229406 allocs/op
BenchmarkZig/Compile/test.wasm-10                      1        3402812166 ns/op        491993064 B/op    229380 allocs/op
BenchmarkZig/Compile/test.wasm-10                      1        3415170791 ns/op        491991592 B/op    229381 allocs/op
PASS
ok      github.com/tetratelabs/wazero/internal/integration_test/stdlibs 10.602s
```
