### PR TITLE
wazevoapi: use copy instead of loops

### DIFF
--- a/internal/engine/wazevo/frontend/frontend.go
+++ b/internal/engine/wazevo/frontend/frontend.go
@@ -469,7 +469,7 @@ func (c *Compiler) allocateVarLengthValues(_cap int, vs ...ssa.Value) ssa.Values
 	builder := c.ssaBuilder
 	pool := builder.VarLengthPool()
 	args := pool.Allocate(_cap)
-	args = args.Append(builder.VarLengthPool(), vs...)
+	args = args.Append(pool, vs...)
 	return args
 }
 

--- a/internal/engine/wazevo/frontend/lower.go
+++ b/internal/engine/wazevo/frontend/lower.go
@@ -123,8 +123,7 @@ func (c *Compiler) nPeekDup(n int) ssa.Values {
 	l := c.state()
 	tail := len(l.values)
 
-	args := c.allocateVarLengthValues(n)
-	args = args.Append(c.ssaBuilder.VarLengthPool(), l.values[tail-n:tail]...)
+	args := c.allocateVarLengthValues(n, l.values[tail-n:tail]...)
 	return args
 }
 
@@ -1171,7 +1170,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 				ssa.TypeI64,
 			).Insert(builder).Return()
 
-		args := c.allocateVarLengthValues(1, c.execCtxPtrValue, pages)
+		args := c.allocateVarLengthValues(2, c.execCtxPtrValue, pages)
 		callGrowRet := builder.
 			AllocateInstruction().
 			AsCallIndirect(memoryGrowPtr, &c.memoryGrowSig, args).
@@ -1341,8 +1340,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 			blockType:                    bt,
 		})
 
-		args := c.allocateVarLengthValues(originalLen)
-		args = args.Append(builder.VarLengthPool(), state.values[originalLen:]...)
+		args := c.allocateVarLengthValues(len(bt.Params), state.values[originalLen:]...)
 
 		// Insert the jump to the header of loop.
 		br := builder.AllocateInstruction()
@@ -1381,8 +1379,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 		// multiple definitions (one in Then and another in Else blocks).
 		c.addBlockParamsFromWasmTypes(bt.Results, followingBlk)
 
-		args := c.allocateVarLengthValues(len(bt.Params))
-		args = args.Append(builder.VarLengthPool(), state.values[len(state.values)-len(bt.Params):]...)
+		args := c.allocateVarLengthValues(len(bt.Params), state.values[len(state.values)-len(bt.Params):]...)
 
 		// Insert the conditional jump to the Else block.
 		brz := builder.AllocateInstruction()
@@ -3125,7 +3122,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 					ssa.TypeI64,
 				).Insert(builder).Return()
 
-			args := c.allocateVarLengthValues(3, c.execCtxPtrValue, timeout, exp, addr)
+			args := c.allocateVarLengthValues(4, c.execCtxPtrValue, timeout, exp, addr)
 			memoryWaitRet := builder.AllocateInstruction().
 				AsCallIndirect(memoryWaitPtr, sig, args).
 				Insert(builder).Return()
@@ -3146,7 +3143,7 @@ func (c *Compiler) lowerCurrentOpcode() {
 					wazevoapi.ExecutionContextOffsetMemoryNotifyTrampolineAddress.U32(),
 					ssa.TypeI64,
 				).Insert(builder).Return()
-			args := c.allocateVarLengthValues(2, c.execCtxPtrValue, count, addr)
+			args := c.allocateVarLengthValues(3, c.execCtxPtrValue, count, addr)
 			memoryNotifyRet := builder.AllocateInstruction().
 				AsCallIndirect(memoryNotifyPtr, &c.memoryNotifySig, args).
 				Insert(builder).Return()

--- a/internal/engine/wazevo/wazevoapi/pool.go
+++ b/internal/engine/wazevo/wazevoapi/pool.go
@@ -69,7 +69,7 @@ type IDedPool[T any] struct {
 
 // NewIDedPool returns a new IDedPool.
 func NewIDedPool[T any](resetFn func(*T)) IDedPool[T] {
-	return IDedPool[T]{pool: NewPool[T](resetFn), maxIDEncountered: -1}
+	return IDedPool[T]{pool: NewPool(resetFn), maxIDEncountered: -1}
 }
 
 // GetOrAllocate returns the T with the given id.
@@ -134,10 +134,10 @@ type VarLength[T any] struct {
 // NewVarLengthPool returns a new VarLengthPool.
 func NewVarLengthPool[T any]() VarLengthPool[T] {
 	return VarLengthPool[T]{
-		arrayPool: NewPool[varLengthPoolArray[T]](func(v *varLengthPoolArray[T]) {
+		arrayPool: NewPool(func(v *varLengthPoolArray[T]) {
 			v.next = 0
 		}),
-		slicePool: NewPool[[]T](func(i *[]T) {
+		slicePool: NewPool(func(i *[]T) {
 			*i = (*i)[:0]
 		}),
 	}
@@ -169,39 +169,36 @@ func (p *VarLengthPool[T]) Reset() {
 
 // Append appends items to the backing slice just like the `append` builtin function in Go.
 func (i VarLength[T]) Append(p *VarLengthPool[T], items ...T) VarLength[T] {
-	if i.slc != nil {
-		*i.slc = append(*i.slc, items...)
+	slc := i.slc
+	if slc != nil {
+		*slc = append(*slc, items...)
 		return i
 	}
 
-	if i.arr == nil {
-		i.arr = p.arrayPool.Allocate()
+	arr := i.arr
+	if arr == nil {
+		arr = p.arrayPool.Allocate()
+		i.arr = arr
 	}
 
-	arr := i.arr
 	if arr.next+len(items) <= arraySize {
-		for _, item := range items {
-			arr.arr[arr.next] = item
-			arr.next++
-		}
+		arr.next += copy(arr.arr[arr.next:], items)
 	} else {
-		slc := p.slicePool.Allocate()
+		slc = p.slicePool.Allocate()
 		// Copy the array to the slice.
-		for ptr := 0; ptr < arr.next; ptr++ {
-			*slc = append(*slc, arr.arr[ptr])
-		}
+		*slc = append(*slc, arr.arr[:arr.next]...)
+		*slc = append(*slc, items...)
 		i.slc = slc
-		*i.slc = append(*i.slc, items...)
 	}
 	return i
 }
 
 // View returns the backing slice.
 func (i VarLength[T]) View() []T {
-	if i.slc != nil {
+	if slc := i.slc; slc != nil {
 		return *i.slc
-	} else if i.arr != nil {
-		arr := i.arr
+	}
+	if arr := i.arr; arr != nil {
 		return arr.arr[:arr.next]
 	}
 	return nil
@@ -210,9 +207,9 @@ func (i VarLength[T]) View() []T {
 // Cut cuts the backing slice to the given length.
 // Precondition: n <= len(i.backing).
 func (i VarLength[T]) Cut(n int) {
-	if i.slc != nil {
-		*i.slc = (*i.slc)[:n]
-	} else if i.arr != nil {
-		i.arr.next = n
+	if slc := i.slc; slc != nil {
+		*slc = (*slc)[:n]
+	} else if arr := i.arr; arr != nil {
+		arr.next = n
 	}
 }


### PR DESCRIPTION
Follow up to reviewing #2430.

We can use `copy` instead of loops in `wazevoapi.VarLength.Append`.
Also fixup some usages of `allocateVarLengthValues` with wrong caps.
And remove unnecessary type arguments which give me warnings in VS Code.

Small performance win:
```sh
$ benchstat main this 
                             │    main    │               this               │
                             │   sec/op   │   sec/op    vs base              │
Zig/Compile/test-opt.wasm-12   5.178 ± 2%   4.923 ± 2%  -4.91% (p=0.002 n=6)
Zig/Compile/test.wasm-12       6.328 ± 4%   5.851 ± 2%  -7.54% (p=0.002 n=6)
geomean                        5.724        5.367       -6.24%

                             │     main     │                this                │
                             │     B/op     │     B/op      vs base              │
Zig/Compile/test-opt.wasm-12   357.9Mi ± 0%   357.8Mi ± 0%  -0.02% (p=0.002 n=6)
Zig/Compile/test.wasm-12       451.2Mi ± 0%   451.2Mi ± 0%       ~ (p=1.000 n=6)
geomean                        401.9Mi        401.8Mi       -0.01%

                             │    main     │               this                │
                             │  allocs/op  │  allocs/op   vs base              │
Zig/Compile/test-opt.wasm-12   329.8k ± 0%   326.9k ± 0%  -0.88% (p=0.002 n=6)
Zig/Compile/test.wasm-12       243.6k ± 0%   242.4k ± 0%  -0.46% (p=0.002 n=6)
geomean                        283.4k        281.5k       -0.67%
```