### PR TITLE
wazevo+wazevoapi: reduce mem by 10%

### DIFF
--- a/internal/engine/wazevo/engine.go
+++ b/internal/engine/wazevo/engine.go
@@ -234,7 +234,7 @@ func (e *engine) compileModule(ctx context.Context, module *wasm.Module, listene
 
 	needSourceInfo := module.DWARFLines != nil
 	if needSourceInfo {
-		estimatedOffsets := localFns * 20
+		estimatedOffsets := localFns * 150
 		cm.sourceMap.executableOffsets = make([]uintptr, 0, estimatedOffsets)
 		cm.sourceMap.wasmBinaryOffsets = make([]uint64, 0, estimatedOffsets)
 	}

--- a/internal/engine/wazevo/ssa/basic_block.go
+++ b/internal/engine/wazevo/ssa/basic_block.go
@@ -267,12 +267,12 @@ func (bb *basicBlock) Tail() *Instruction {
 func resetBasicBlock(bb *basicBlock) {
 	bb.params = ValuesNil
 	bb.rootInstr, bb.currentInstr = nil, nil
-	bb.preds = bb.preds[:0]
-	bb.success = bb.success[:0]
+	bb.preds = wazevoapi.ResetSlice(bb.preds, 2)
+	bb.success = wazevoapi.ResetSlice(bb.success, 2)
 	bb.invalid, bb.sealed = false, false
 	bb.singlePred = nil
-	bb.unknownValues = bb.unknownValues[:0]
-	bb.lastDefinitions = wazevoapi.ResetMap(bb.lastDefinitions)
+	bb.unknownValues = wazevoapi.ResetSlice(bb.unknownValues, 0)
+	bb.lastDefinitions = wazevoapi.ResetMap(bb.lastDefinitions, 8)
 	bb.reversePostOrder = -1
 	bb.visited = 0
 	bb.loopNestingForestChildren = basicBlockVarLengthNil

--- a/internal/engine/wazevo/wazevoapi/resetmap.go
+++ b/internal/engine/wazevo/wazevoapi/resetmap.go
@@ -1,11 +1,20 @@
 package wazevoapi
 
 // ResetMap resets the map to an empty state, or creates a new map if it is nil.
-func ResetMap[K comparable, V any](m map[K]V) map[K]V {
+// If the map is nil, it is created with the specified capacity hint.
+func ResetMap[K comparable, V any](m map[K]V, capacityHint int) map[K]V {
 	if m == nil {
-		m = make(map[K]V)
+		m = make(map[K]V, capacityHint)
 	} else {
 		clear(m)
 	}
 	return m
+}
+
+// ResetSlice resets the slice to empty, or creates a new slice with the specified capacity if it is nil.
+func ResetSlice[T any](s []T, capacityHint int) []T {
+	if s == nil {
+		return make([]T, 0, capacityHint)
+	}
+	return s[:0]
 }


### PR DESCRIPTION
```
maanas@maanas wazero % ~/go/bin/benchstat baseline.txt current.txt
goos: darwin
goarch: arm64
pkg: github.com/tetratelabs/wazero/internal/integration_test/stdlibs
cpu: Apple M1 Pro
                         │ baseline.txt │         current.txt         │
                         │    sec/op    │   sec/op    vs base         │
Zig/Compile/test.wasm-10     3.464 ± 3%   3.452 ± 7%  ~ (p=1.000 n=6)

                         │ baseline.txt │            current.txt             │
                         │     B/op     │     B/op      vs base              │
Zig/Compile/test.wasm-10   466.9Mi ± 0%   420.5Mi ± 0%  -9.93% (p=0.002 n=6)

                         │ baseline.txt │            current.txt            │
                         │  allocs/op   │  allocs/op   vs base              │
Zig/Compile/test.wasm-10    228.2k ± 0%   225.8k ± 0%  -1.06% (p=0.002 n=6)
```

ResetSlice/ResetMap calls were allocating with zero capacity, causing multiple reallocations as slices grew.
Added capacity hints based on known sizes (e.g. number of functions, estimated source map entries) when calling ResetSlice/ResetMap to pre-allocate to appropriate sizes and avoid reallocation overhead.

These, imo, are the last remaining "gimmes". Profiling revealed VarLengthPool and slice growth as top allocators during compilation, consuming ~110MB and ~58MB respectively. Without addressing these, we're likely attempting to draw water from stone at this point.