### PR TITLE
Change version policy to two versions.

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -71,7 +71,7 @@ jobs:
           arch: arm64
         go-version:
           - "1.25"  # Current Go version
-          - "1.23"  # Floor Go version of wazero (current - 2)
+          - "1.24"  # Floor Go version of wazero (current - 1)
 
     steps:
 
@@ -112,7 +112,7 @@ jobs:
       matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
           - "1.25"  # Current Go version
-          - "1.23"  # Floor Go version of wazero (current - 2)
+          - "1.24"  # Floor Go version of wazero (current - 1)
         platform:
           - os: ubuntu-24.04
             arch: amd64
@@ -168,11 +168,11 @@ jobs:
       matrix:
         os:
           - name: freebsd
-            version: "14.1"
+            version: "14.3"
           - name: openbsd
-            version: "7.5"
+            version: "7.8"
           - name: netbsd
-            version: "10.0"
+            version: "10.1"
 
     steps:
       - uses: actions/checkout@v4
@@ -190,7 +190,7 @@ jobs:
           GOOS: ${{ matrix.os.name }}
 
       - name: Run built test binaries
-        uses: cross-platform-actions/action@v0.25.0
+        uses: cross-platform-actions/action@v0.30.0
         env:
           WAZEROCLI: ./wazerocli
         with:
@@ -210,10 +210,10 @@ jobs:
       matrix:
         os:
           - name: dragonfly
-            version: "6.4.0"
+            version: "6.4.2"
             action: 'vmactions/dragonflybsd-vm@v1'
           - name: illumos
-            version: "r151052"
+            version: "r151054"
             action: 'vmactions/omnios-vm@v1'
           - name: solaris
             version: "11.4"

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         go-version:
           - "1.25" # Max version supported by TinyGo 0.39.0
-          - "1.23"
+          - "1.24"
 
     steps:
       - name: Checkout

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -176,7 +176,7 @@ jobs:
             -r ../.github/wasi_testsuite_adapter.py
 
   go_tests:
-    # Due to the embedding of the GOROOT of the building env(https://github.com/golang/go/blob/3c59639b902fada0a2e5a6a35bafd10fc9183b89/src/os/os_test.go#L112),
+    # Due to the embedding of the GOROOT of the building env (https://github.com/golang/go/blob/go1.24.0/src/os/os_test.go#L115),
     # we have to build and cache on each OS unlike others in this file.
     name: Go-${{ matrix.go-version }} (${{ matrix.os.name }}, ${{ matrix.os.arch }})
     runs-on: ${{ matrix.os.version }}
@@ -197,7 +197,7 @@ jobs:
           arch: amd64
         go-version:
           - "1.25"
-          - "1.23"
+          - "1.24"
 
     steps:
       - id: setup-go

--- a/README.md
+++ b/README.md
@@ -83,12 +83,6 @@ wazero follows the same version policy as Go's [Release Policy][5]: two
 versions. wazero will ensure these versions work and bugs are valid if there's
 an issue with a current Go version.
 
-Additionally, wazero intentionally delays usage of language or standard library
-features one additional version. For example, when Go 1.29 is released, wazero
-can use language features or standard libraries added in 1.27. This is a
-convenience for embedders who have a slower version policy than Go. However,
-only supported Go versions may be used to raise support issues.
-
 ### Platform
 
 wazero has two runtime modes: Interpreter and Compiler. The only supported operating

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/tetratelabs/wazero
 
-// Floor Go version of wazero (current - 2)
-go 1.23.0
+// Floor Go version of wazero (current - 1)
+go 1.24.0
 
 // All the beta tags are retracted and replaced with "pre" to prevent users
 // from accidentally upgrading into the broken beta 1.

--- a/imports/wasi_snapshot_preview1/example/cat_test.go
+++ b/imports/wasi_snapshot_preview1/example/cat_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/tetratelabs/wazero/internal/testing/maintester"
@@ -76,13 +75,11 @@ func Test_cli(t *testing.T) {
 
 					// We can't invoke go run in our docker based cross-architecture tests. We do want to use
 					// otherwise so running unit tests normally does not require special build steps.
-					var cmdExe string
-					var cmdArgs []string
+					cmdExe := "go"
+					cmdArgs := []string{"run", "../../../cmd/wazero"}
 					if cmdPath := os.Getenv("WAZEROCLI"); cmdPath != "" {
 						cmdExe = cmdPath
-					} else {
-						cmdExe = filepath.Join(runtime.GOROOT(), "bin", "go")
-						cmdArgs = []string{"run", "../../../cmd/wazero"}
+						cmdArgs = nil
 					}
 
 					cmdArgs = append(cmdArgs, "run",

--- a/imports/wasi_snapshot_preview1/testdata/go/wasi.go
+++ b/imports/wasi_snapshot_preview1/testdata/go/wasi.go
@@ -143,7 +143,7 @@ func mainSock() error {
 }
 
 // Adapted from nonblock.go
-// https://github.com/golang/go/blob/0fcc70ecd56e3b5c214ddaee4065ea1139ae16b5/src/runtime/internal/wasitest/testdata/nonblock.go
+// https://github.com/golang/go/blob/go1.24.0/src/runtime/internal/wasitest/testdata/nonblock.go
 func mainNonblock(mode string, files []string) error {
 	ready := make(chan struct{})
 

--- a/imports/wasi_snapshot_preview1/wasi_stdlib_unix_test.go
+++ b/imports/wasi_snapshot_preview1/wasi_stdlib_unix_test.go
@@ -79,7 +79,7 @@ func Test_NonblockGo(t *testing.T) {
 	// If I/O was blocking, all goroutines would be blocked waiting for one read call
 	// to return, and the output order wouldn't match.
 	//
-	// Adapted from https://github.com/golang/go/blob/0fcc70ecd56e3b5c214ddaee4065ea1139ae16b5/src/runtime/internal/wasitest/nonblock_test.go
+	// Adapted from https://github.com/golang/go/blob/go1.24.0/src/runtime/internal/wasitest/nonblock_test.go
 
 	if wasmGo == nil {
 		t.Skip("skipping because wasi.go was not compiled (go missing or compilation error)")

--- a/internal/engine/interpreter/interpreter.go
+++ b/internal/engine/interpreter/interpreter.go
@@ -250,7 +250,7 @@ func functionFromUintptr(ptr uintptr) *function {
 	//
 	// For example, if we have (*function)(unsafe.Pointer(ptr)) instead, then the race detector's "checkptr"
 	// subroutine wanrs as "checkptr: pointer arithmetic result points to invalid allocation"
-	// https://github.com/golang/go/blob/1ce7fcf139417d618c2730010ede2afb41664211/src/runtime/checkptr.go#L69
+	// https://github.com/golang/go/blob/go1.24.0/src/runtime/checkptr.go#L69
 	var wrapped *uintptr = &ptr
 	return *(**function)(unsafe.Pointer(wrapped))
 }

--- a/internal/engine/wazevo/backend/isa/amd64/abi.go
+++ b/internal/engine/wazevo/backend/isa/amd64/abi.go
@@ -7,7 +7,7 @@ import (
 )
 
 // For the details of the ABI, see:
-// https://github.com/golang/go/blob/49d42128fd8594c172162961ead19ac95e247d24/src/cmd/compile/abi-internal.md#amd64-architecture
+// https://github.com/golang/go/blob/go1.24.0/src/cmd/compile/abi-internal.md#amd64-architecture
 
 var (
 	intArgResultRegs   = []regalloc.RealReg{rax, rbx, rcx, rdi, rsi, r8, r9, r10, r11}

--- a/internal/engine/wazevo/backend/isa/amd64/machine.go
+++ b/internal/engine/wazevo/backend/isa/amd64/machine.go
@@ -1067,7 +1067,7 @@ func (m *machine) LowerInstr(instr *ssa.Instruction) {
 		dst := m.c.VRegOf(instr.Return())
 
 		// At this point, the ptr is ensured to be aligned, so using a normal load is atomic.
-		// https://github.com/golang/go/blob/adead1a93f472affa97c494ef19f2f492ee6f34a/src/runtime/internal/atomic/atomic_amd64.go#L30
+		// https://github.com/golang/go/blob/go1.24.0/src/internal/runtime/atomic/atomic_amd64.go#L29
 		mem := newOperandMem(m.lowerToAddressMode(ptr, 0))
 		load := m.allocateInstr()
 		switch size {
@@ -1892,8 +1892,8 @@ func (m *machine) lowerCall(si *ssa.Instruction) {
 
 	if isMemmove {
 		// Go's memmove *might* use all xmm0-xmm15, so we need to release them.
-		// https://github.com/golang/go/blob/49d42128fd8594c172162961ead19ac95e247d24/src/cmd/compile/abi-internal.md#architecture-specifics
-		// https://github.com/golang/go/blob/49d42128fd8594c172162961ead19ac95e247d24/src/runtime/memmove_amd64.s#L271-L286
+		// https://github.com/golang/go/blob/go1.24.0/src/cmd/compile/abi-internal.md#architecture-specifics
+		// https://github.com/golang/go/blob/go1.24.0/src/runtime/memmove_amd64.s#L286-L301
 		for i := regalloc.RealReg(0); i < 16; i++ {
 			m.insert(m.allocateInstr().asDefineUninitializedReg(regInfo.RealRegToVReg[xmm0+i]))
 		}

--- a/internal/engine/wazevo/backend/isa/arm64/abi.go
+++ b/internal/engine/wazevo/backend/isa/arm64/abi.go
@@ -7,7 +7,7 @@ import (
 )
 
 // References:
-// * https://github.com/golang/go/blob/49d42128fd8594c172162961ead19ac95e247d24/src/cmd/compile/abi-internal.md#arm64-architecture
+// * https://github.com/golang/go/blob/go1.24.0/src/cmd/compile/abi-internal.md#arm64-architecture
 // * https://developer.arm.com/documentation/102374/0101/Procedure-Call-Standard
 
 var (

--- a/internal/engine/wazevo/backend/isa/arm64/lower_constant.go
+++ b/internal/engine/wazevo/backend/isa/arm64/lower_constant.go
@@ -96,7 +96,7 @@ func (m *machine) lowerConstantI32(dst regalloc.VReg, c int32) {
 
 func (m *machine) lowerConstantI64(dst regalloc.VReg, c int64) {
 	// Following the logic here:
-	// https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L1798-L1852
+	// https://github.com/golang/go/blob/go1.24.0/src/cmd/internal/obj/arm64/asm7.go#L2161-L2215
 	if c >= 0 && (c <= 0xfff || (c&0xfff) == 0 && (uint64(c>>12) <= 0xfff)) {
 		if isBitMaskImmediate(uint64(c), true) {
 			m.lowerConstViaBitMaskImmediate(uint64(c), dst, true)
@@ -188,7 +188,7 @@ func const16bitAligned(v int64) (ret int) {
 // load64bitConst loads a 64-bit constant into the register, following the same logic to decide how to load large 64-bit
 // consts as in the Go assembler.
 //
-// See https://github.com/golang/go/blob/release-branch.go1.15/src/cmd/internal/obj/arm64/asm7.go#L6632-L6759
+// See https://github.com/golang/go/blob/go1.24.0/src/cmd/internal/obj/arm64/asm7.go#L7555-L7682
 func (m *machine) load64bitConst(c int64, dst regalloc.VReg) {
 	var bits [4]uint64
 	var zeros, negs int

--- a/internal/engine/wazevo/backend/isa/arm64/reg.go
+++ b/internal/engine/wazevo/backend/isa/arm64/reg.go
@@ -160,8 +160,8 @@ var (
 	// tmpReg is used to perform spill/load on large stack offsets, and load large constants.
 	// Therefore, be cautious to use this register in the middle of the compilation, especially before the register allocation.
 	// This is the same as golang/go, but it's only described in the source code:
-	// https://github.com/golang/go/blob/18e17e2cb12837ea2c8582ecdb0cc780f49a1aac/src/cmd/compile/internal/ssa/_gen/ARM64Ops.go#L59
-	// https://github.com/golang/go/blob/18e17e2cb12837ea2c8582ecdb0cc780f49a1aac/src/cmd/compile/internal/ssa/_gen/ARM64Ops.go#L13-L15
+	// https://github.com/golang/go/blob/go1.24.0/src/cmd/compile/internal/ssa/_gen/ARM64Ops.go#L59
+	// https://github.com/golang/go/blob/go1.24.0/src/cmd/compile/internal/ssa/_gen/ARM64Ops.go#L13-L15
 	tmpRegVReg = regalloc.FromRealReg(tmp, regalloc.RegTypeInt)
 	v28VReg    = regalloc.FromRealReg(v28, regalloc.RegTypeFloat)
 	v29VReg    = regalloc.FromRealReg(v29, regalloc.RegTypeFloat)

--- a/internal/engine/wazevo/wazevoapi/ptr.go
+++ b/internal/engine/wazevo/wazevoapi/ptr.go
@@ -8,8 +8,8 @@ func PtrFromUintptr[T any](ptr uintptr) *T {
 	// Wraps ptrs as the double pointer in order to avoid the unsafe access as detected by race detector.
 	//
 	// For example, if we have (*function)(unsafe.Pointer(ptr)) instead, then the race detector's "checkptr"
-	// subroutine wanrs as "checkptr: pointer arithmetic result points to invalid allocation"
-	// https://github.com/golang/go/blob/1ce7fcf139417d618c2730010ede2afb41664211/src/runtime/checkptr.go#L69
+	// subroutine warns as "checkptr: pointer arithmetic result points to invalid allocation"
+	// https://github.com/golang/go/blob/go1.24.0/src/runtime/checkptr.go#L69
 	var wrapped *uintptr = &ptr
 	return *(**T)(unsafe.Pointer(wrapped))
 }

--- a/internal/integration_test/fuzz/go.mod
+++ b/internal/integration_test/fuzz/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/integration_test/fuzz
 
-go 1.23.0
+go 1.24.0
 
 require github.com/tetratelabs/wazero v0.0.0
 

--- a/internal/integration_test/stdlibs/bench_test.go
+++ b/internal/integration_test/stdlibs/bench_test.go
@@ -1,10 +1,12 @@
 package wazevo_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -54,9 +56,15 @@ var (
 			if err != nil {
 				return nil, nil, nil, nil, err
 			}
+			out, err := exec.Command("go", "env", "GOROOT").Output()
+			if err != nil {
+				return nil, nil, nil, nil, err
+			}
+			goroot := string(bytes.TrimRight(out, "\n"))
+
 			fsuffixstripped := strings.ReplaceAll(fname, ".test", "")
 			inferredpath := strings.ReplaceAll(fsuffixstripped, "_", "/")
-			testdir := filepath.Join(runtime.GOROOT(), "src", inferredpath)
+			testdir := filepath.Join(goroot, "src", inferredpath)
 			err = os.Chdir(testdir)
 
 			sysroot := filepath.VolumeName(testdir) + string(os.PathSeparator)
@@ -89,7 +97,7 @@ var (
 				)
 			case "windows":
 				c = c.
-					WithEnv("GOROOT", normalizeOsPath(runtime.GOROOT()))
+					WithEnv("GOROOT", normalizeOsPath(goroot))
 				skip = append(skip, "TestRenameCaseDifference/dir", "TestDirFSPathsValid", "TestDirFS",
 					"TestDevNullFile", "TestOpenError", "TestSymlinkWithTrailingSlash", "TestCopyFS",
 					"TestRoot", "TestOpenInRoot", "ExampleAfterFunc_connection", "TestOpenFileDevNull",

--- a/internal/leb128/leb128.go
+++ b/internal/leb128/leb128.go
@@ -109,7 +109,7 @@ func LoadUint32(buf []byte) (ret uint32, bytesRead uint64, err error) {
 }
 
 func decodeUint32(next nextByte) (ret uint32, bytesRead uint64, err error) {
-	// Derived from https://github.com/golang/go/blob/go1.20/src/encoding/binary/varint.go
+	// Derived from https://github.com/golang/go/blob/go1.24.0/src/encoding/binary/varint.go
 	// with the modification on the overflow handling tailored for 32-bits.
 	var s uint32
 	for i := 0; i < maxVarintLen32; i++ {
@@ -124,7 +124,7 @@ func decodeUint32(next nextByte) (ret uint32, bytesRead uint64, err error) {
 			}
 			return ret | uint32(b)<<s, uint64(i) + 1, nil
 		}
-		ret |= (uint32(b) & 0x7f) << s
+		ret |= uint32(b&0x7f) << s
 		s += 7
 	}
 	return 0, 0, errOverflow32
@@ -136,7 +136,7 @@ func LoadUint64(buf []byte) (ret uint64, bytesRead uint64, err error) {
 		return 0, 0, io.EOF
 	}
 
-	// Derived from https://github.com/golang/go/blob/go1.20/src/encoding/binary/varint.go
+	// Derived from https://github.com/golang/go/blob/go1.24.0/src/encoding/binary/varint.go
 	var s uint64
 	for i := 0; i < maxVarintLen64; i++ {
 		if i >= bufLen {
@@ -150,7 +150,7 @@ func LoadUint64(buf []byte) (ret uint64, bytesRead uint64, err error) {
 			}
 			return ret | uint64(b)<<s, uint64(i) + 1, nil
 		}
-		ret |= (uint64(b) & 0x7f) << s
+		ret |= uint64(b&0x7f) << s
 		s += 7
 	}
 	return 0, 0, errOverflow64

--- a/internal/platform/time_windows.go
+++ b/internal/platform/time_windows.go
@@ -21,13 +21,11 @@ func init() {
 
 // On Windows, time.Time handled in time package cannot have the nanosecond precision.
 // The reason is that by default, it doesn't use QueryPerformanceCounter[1], but instead, use "interrupt time"
-// which doesn't support nanoseconds precision (though it is a monotonic) [2, 3, 4, 5].
+// which doesn't support nanoseconds precision (though it is a monotonic) [2, 3].
 //
 // [1] https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
-// [2] https://github.com/golang/go/blob/0cd309e12818f988693bf8e4d9f1453331dcf9f2/src/runtime/sys_windows_amd64.s#L297-L298
-// [3] https://github.com/golang/go/blob/0cd309e12818f988693bf8e4d9f1453331dcf9f2/src/runtime/os_windows.go#L549-L551
-// [4] https://github.com/golang/go/blob/master/src/runtime/time_windows.h#L7-L13
-// [5] http://web.archive.org/web/20210411000829/https://wrkhpi.wordpress.com/2007/08/09/getting-os-information-the-kuser_shared_data-structure/
+// [2] https://github.com/golang/go/blob/go1.24.0/src/runtime/sys_windows_amd64.s#L279-L284
+// [3] https://github.com/golang/go/blob/go1.24.0/src/runtime/time_windows.h#L7-L13
 //
 // Therefore, on Windows, we directly invoke the syscall for QPC instead of time.Now or runtime.nanotime.
 // See https://github.com/golang/go/issues/31160 for example.

--- a/internal/sysfs/open_file_windows.go
+++ b/internal/sysfs/open_file_windows.go
@@ -57,7 +57,7 @@ func openFile(path string, oflag sys.Oflag, perm fs.FileMode) (*os.File, sys.Err
 
 const supportedSyscallOflag = sys.O_NONBLOCK
 
-// Map to synthetic values here https://github.com/golang/go/blob/go1.20/src/syscall/types_windows.go#L34-L48
+// Map to synthetic values here https://github.com/golang/go/blob/go1.24.0/src/syscall/types_windows.go#L35-L52
 func withSyscallOflag(oflag sys.Oflag, flag int) int {
 	// O_DIRECTORY not defined in windows
 	// O_DSYNC not defined in windows

--- a/internal/sysfs/osfile.go
+++ b/internal/sysfs/osfile.go
@@ -89,7 +89,7 @@ func (f *osFile) SetAppend(enable bool) (errno experimentalsys.Errno) {
 	}
 
 	// appendMode cannot be changed later, so we have to re-open the file
-	// https://github.com/golang/go/blob/go1.23/src/os/file_unix.go#L60
+	// https://github.com/golang/go/blob/go1.24.0/src/os/file_unix.go#L65
 	return fileError(f, f.closed, f.reopen())
 }
 

--- a/internal/version/testdata/go.mod
+++ b/internal/version/testdata/go.mod
@@ -1,6 +1,6 @@
 module github.com/tetratelabs/wazero/internal/version/testdata
 
-go 1.23.0
+go 1.24.0
 
 require github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1 // indirect
 

--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -87,8 +87,7 @@ func NewMemoryInstance(memSec *Memory, allocator experimental.MemoryAllocator, m
 		//
 		// Also, allocating Max here isn't harmful as the Go runtime uses mmap for large allocations, therefore,
 		// the memory buffer allocation here is virtual and doesn't consume physical memory until it's used.
-		// 	* https://github.com/golang/go/blob/8121604559035734c9677d5281bbdac8b1c17a1e/src/runtime/malloc.go#L1059
-		//	* https://github.com/golang/go/blob/8121604559035734c9677d5281bbdac8b1c17a1e/src/runtime/malloc.go#L1165
+		// 	* https://github.com/golang/go/blob/go1.24.0/src/runtime/malloc.go#L1059
 		buffer = make([]byte, minBytes, maxBytes)
 	} else {
 		buffer = make([]byte, minBytes, capBytes)


### PR DESCRIPTION
As discussed in #2434. This is just raising the minimum Go version, not adding dependencies.

I fixed some deprecations that caused actual CI breakages, and adjusted comments mentioning specific Go versions (also checked nothing important changed).

Since I was touching the yaml file, I updated OS versions we test against (for the BSD, etc).