### PR TITLE
Fix an error when importing functions which were re-exported.

### DIFF
--- a/internal/engine/wazevo/module_engine.go
+++ b/internal/engine/wazevo/module_engine.go
@@ -242,15 +242,13 @@ func (m *moduleEngine) ResolveImportedFunction(index, descFunc, indexInImportedM
 	executableOffset, moduleCtxOffset, typeIDOffset := m.parent.offsets.ImportedFunctionOffset(index)
 	importedME := importedModuleEngine.(*moduleEngine)
 
-	if int(indexInImportedModule) >= len(importedME.importedFunctions) {
-		indexInImportedModule -= wasm.Index(len(importedME.importedFunctions))
-	} else {
+	if int(indexInImportedModule) < len(importedME.importedFunctions) {
 		imported := &importedME.importedFunctions[indexInImportedModule]
 		m.ResolveImportedFunction(index, descFunc, imported.indexInModule, imported.me)
 		return // Recursively resolve the imported function.
 	}
 
-	offset := importedME.parent.functionOffsets[indexInImportedModule]
+	offset := importedME.parent.functionOffsets[indexInImportedModule-wasm.Index(len(importedME.importedFunctions))]
 	typeID := m.module.TypeIDs[descFunc]
 	executable := &importedME.parent.executable[offset]
 	// Write functionInstance.


### PR DESCRIPTION
When importing functions from a module which contained a mixture of imports and self defined functions and which _re-exports its own imports_, the incorrect function could be imported.

This happened because `importedFunction.indexInModule` should be the absolute function index as it is passed to `NewFunction`, which expects the absolute function index, not the index into the function table. `indexInModule` was incorrectly adjusted by the number of imports when recursively calling `ResolveImportedFunction` when a function mid chain contained a mix of imports and defined functions.