### PR TITLE
Fix error when using host modules with ImportResolver.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -352,6 +352,10 @@ func (h hostModuleInstance) ExportedFunction(name string) api.Function {
 	panic("calling ExportedFunction is forbidden on host modules. See the note on ExportedFunction interface")
 }
 
+func (h hostModuleInstance) WrappedModule() api.Module {
+	return h.Module
+}
+
 // Instantiate implements HostModuleBuilder.Instantiate
 func (b *hostModuleBuilder) Instantiate(ctx context.Context) (api.Module, error) {
 	if compiled, err := b.Compile(ctx); err != nil {

--- a/internal/wasm/store.go
+++ b/internal/wasm/store.go
@@ -419,6 +419,12 @@ func (m *ModuleInstance) resolveImports(ctx context.Context, module *Module) (er
 		var importedModule *ModuleInstance
 		if resolveImport != nil {
 			if v := resolveImport(moduleName); v != nil {
+				type wrappedModule interface {
+					WrappedModule() api.Module
+				}
+				if wm, ok := v.(wrappedModule); ok {
+					v = wm.WrappedModule()
+				}
 				importedModule = v.(*ModuleInstance)
 			}
 		}


### PR DESCRIPTION
When attempting to supply a host module created via HostModuleBuilder.Instantiate(), a panic occurred since hostModuleInstance could not be cast to *ModuleInstance.

This PR adds a method that can be used to test if the module supplied by the import resolver is a wrapper module, and if so, unwraps it before casting to *ModuleInstance.