### PR TITLE
Don't use compiler when executable mmap is disabled 

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -105,7 +105,7 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
 
   test_scratch:
-    name: ${{ matrix.platform.arch }}, Linux (scratch), Go-${{ matrix.go-version }}
+    name: ${{ matrix.platform.arch }}, Linux (scratch), Go-${{ matrix.go-version }}${{ matrix.platform.no_prot_exec && ', no-prot-exec' }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific


### PR DESCRIPTION
Fixes #2470

The compiler may be selected based on platform and CPU restrictions but still fail when trying to actually execute generated code, which can be disabled in security-sensitive environments using seccomp. As `NewRuntimeConfig` is meant to detect compiler support based on the environment, I think it's appropriate to check this too, as usual a user that really needs compiler can / probably should use `NewRuntimeConfigCompiler` which will error out as expected.