### PR TITLE
sysfs: support IsNonblock/SetNonblock on fs.FS-backed files

### DIFF
--- a/internal/sysfs/file.go
+++ b/internal/sysfs/file.go
@@ -367,6 +367,35 @@ func (f *fsFile) close() experimentalsys.Errno {
 	return experimentalsys.UnwrapOSError(f.file.Close())
 }
 
+// nonblocker is a subset of PollableFile for checking non-blocking mode on
+// an fs.File. fs.File cannot implement PollableFile due to conflicting Close
+// signatures (error vs Errno), so we use this narrower interface.
+type nonblocker interface {
+	IsNonblock() bool
+	SetNonblock(enable bool) experimentalsys.Errno
+}
+
+// IsNonblock implements experimentalsys.PollableFile by forwarding to the
+// underlying fs.File if it supports it.
+func (f *fsFile) IsNonblock() bool {
+	if nb, ok := f.file.(nonblocker); ok {
+		return nb.IsNonblock()
+	}
+	return false
+}
+
+// SetNonblock implements experimentalsys.PollableFile by forwarding to the
+// underlying fs.File if it supports it.
+func (f *fsFile) SetNonblock(enable bool) experimentalsys.Errno {
+	if nb, ok := f.file.(nonblocker); ok {
+		return nb.SetNonblock(enable)
+	}
+	if !enable {
+		return 0 // disabling nonblock on a file that doesn't support it is a no-op
+	}
+	return experimentalsys.ENOSYS
+}
+
 // Poll implements experimentalsys.Pollable by forwarding to the underlying
 // fs.File if it supports polling.
 //

--- a/internal/sysfs/file_test.go
+++ b/internal/sysfs/file_test.go
@@ -418,6 +418,21 @@ func (f *pollableFsFile) Poll(flag experimentalsys.Pflag, timeoutMillis int32) (
 	return f.pollReady, f.pollErrno
 }
 
+// nonblockFsFile extends pollableFsFile with IsNonblock/SetNonblock support.
+type nonblockFsFile struct {
+	pollableFsFile
+	nonblock bool
+}
+
+func (f *nonblockFsFile) IsNonblock() bool {
+	return f.nonblock
+}
+
+func (f *nonblockFsFile) SetNonblock(enable bool) experimentalsys.Errno {
+	f.nonblock = enable
+	return 0
+}
+
 func TestFsFilePoll_Pollable(t *testing.T) {
 	timeout := int32(0) // return immediately
 
@@ -445,6 +460,38 @@ func TestFsFilePoll_Pollable(t *testing.T) {
 	ready, errno = f.Poll(experimentalsys.POLLIN, timeout)
 	require.EqualErrno(t, experimentalsys.ENOTSUP, errno)
 	require.False(t, ready)
+}
+
+func TestFsFileNonblock(t *testing.T) {
+	memFS := gofstest.MapFS{"test.txt": {Data: []byte("wazero")}}
+	memFile, err := memFS.Open("test.txt")
+	require.NoError(t, err)
+	defer memFile.Close()
+
+	// An fs.File implementing IsNonblock/SetNonblock gets forwarded.
+	nbf := &nonblockFsFile{pollableFsFile: pollableFsFile{File: memFile}}
+	f := &fsFile{file: nbf}
+
+	require.False(t, f.IsNonblock())
+	require.EqualErrno(t, 0, f.SetNonblock(true))
+	require.True(t, f.IsNonblock())
+	require.EqualErrno(t, 0, f.SetNonblock(false))
+	require.False(t, f.IsNonblock())
+}
+
+func TestFsFileNonblock_NotSupported(t *testing.T) {
+	memFS := gofstest.MapFS{"test.txt": {Data: []byte("wazero")}}
+	memFile, err := memFS.Open("test.txt")
+	require.NoError(t, err)
+	defer memFile.Close()
+
+	// A plain fs.File without nonblock support returns defaults.
+	f := &fsFile{file: memFile}
+	require.False(t, f.IsNonblock())
+	require.EqualErrno(t, experimentalsys.ENOSYS, f.SetNonblock(true))
+
+	// Disabling nonblock on a file that doesn't support it is a no-op.
+	require.EqualErrno(t, 0, f.SetNonblock(false))
 }
 
 func TestFsFilePoll_NonPollable(t *testing.T) {


### PR DESCRIPTION
OpenFSFile returns fsFile which wraps an fs.File. Previously fsFile only forwarded Poll but not IsNonblock/SetNonblock, so files opened from custom fs.FS mounts (e.g. virtual /dev/tcp/) could not participate in non-blocking I/O.

Changes:
- Add nonblocker interface to forward IsNonblock/SetNonblock through fsFile to the underlying fs.File (PollableFile cannot be used due to conflicting Close signatures between fs.File and sys.File)
- Add tests for fsFile IsNonblock/SetNonblock forwarding