### PR TITLE
Update golang.org/x/sys

### DIFF
--- a/.github/workflows/clear_cache.yaml
+++ b/.github/workflows/clear_cache.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cleanup
         run: |

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -36,14 +36,14 @@ jobs:
           wabt_url=https://github.com/WebAssembly/wabt/releases/download/${wabt_version}/wabt-${wabt_version}-linux-x64.tar.gz
           curl -sSL ${wabt_url} | tar --strip-components 2 -C /usr/local/bin -xzf - wabt-${wabt_version}/bin/wast2json
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:  # not cache: true as we also need to cache golint
           cache: false
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -75,15 +75,15 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       # Ensure the pagefile is large enough to execute tests like TestStore_hammer_close on Windows.
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.4
+        uses: al-cheb/configure-pagefile-action@v1.5
         if: runner.os == 'Windows'
         with:
           minimum-size: 8GB
@@ -127,9 +127,9 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.platform.qemu }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:  # Avoid docker.io rate-limits; built with internal-images.yml
           image: ghcr.io/tetratelabs/wazero/internal-binfmt
           platforms: ${{ matrix.arch }}
@@ -195,7 +195,7 @@ jobs:
             version: "10.1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build test binaries
         run: |
@@ -210,7 +210,7 @@ jobs:
           GOOS: ${{ matrix.os.name }}
 
       - name: Run built test binaries
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v0.32.0
         env:
           WAZEROCLI: ./wazerocli
         with:
@@ -240,7 +240,7 @@ jobs:
             action: 'vmactions/solaris-vm@v1'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build test binaries
         run: |
@@ -280,12 +280,12 @@ jobs:
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           # Cache corpus and artifacts so that we don't start from scratch but rather with a meaningful corpus

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,7 +14,7 @@ on:
       - 'netlify.toml'
 
 env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 defaults:
   run:  # use bash for all operating systems unless overridden
@@ -70,8 +70,8 @@ jobs:
         - os: macos-14
           arch: arm64
         go-version:
-          - "1.25"  # Current Go version
-          - "1.24"  # Floor Go version of wazero (current - 1)
+          - "1.26"  # Current Go version
+          - "1.25"  # Floor Go version of wazero (current - 1)
 
     steps:
 
@@ -111,8 +111,8 @@ jobs:
       fail-fast: false  # don't fail fast as sometimes failures are arch/OS specific
       matrix:  # Use versions consistent with wazero's Go support policy.
         go-version:
-          - "1.25"  # Current Go version
-          - "1.24"  # Floor Go version of wazero (current - 1)
+          - "1.26"  # Current Go version
+          - "1.25"  # Floor Go version of wazero (current - 1)
         platform:
           - os: ubuntu-24.04
             arch: amd64

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -121,9 +121,8 @@ jobs:
             no_prot_exec: true
           - os: ubuntu-24.04-arm
             arch: arm64
-          - os: ubuntu-24.04
+          - os: ubuntu-24.04-riscv
             arch: riscv64
-            qemu: true
 
     steps:
 
@@ -145,13 +144,6 @@ jobs:
         env:
           GOARCH: ${{ matrix.platform.arch }}
           CGO_ENABLED: 0
-
-      - name: Set up QEMU
-        if: ${{ matrix.platform.qemu }}
-        uses: docker/setup-qemu-action@v4
-        with:  # Avoid docker.io rate-limits; built with internal-images.yml
-          image: ghcr.io/tetratelabs/wazero/internal-binfmt
-          platforms: ${{ matrix.arch }}
 
       - name: Build scratch container
         run: |

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -35,7 +35,6 @@ jobs:
       matrix:
         go-version:
           - "1.25" # Max version supported by TinyGo 0.39.0
-          - "1.24"
 
     steps:
       - name: Checkout

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -38,9 +38,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -58,14 +58,14 @@ jobs:
 
       - name: Cache Emscripten
         id: cache-emsdk
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: emsdk
           key: ${{ runner.os }}-emcc-${{env.EMSDK_VERSION}}
 
       - name: Checkout Emscripten
         if: steps.cache-emsdk.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: emscripten-core/emsdk
           path: emsdk

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -39,9 +39,9 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -97,9 +97,9 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: binary-cache
         with:
           # Use share the cache containing archives across OSes.
@@ -110,7 +110,7 @@ jobs:
           path:
             ${{ env.STDLIB_TESTS }}/testdata/zig
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -128,25 +128,25 @@ jobs:
         os: [ubuntu-24.04, macos-14, windows-2022]
 
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           path:
             ~/go/pkg/mod
           key: integration-test-wasi-testsuite-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Checkout wazero
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install wazero
         run: go install ./cmd/wazero
 
       - name: Checkout wasi-testsuite
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: WebAssembly/wasi-testsuite
           # prod/testsuite-base branch, as of May 12, 2023.
@@ -155,7 +155,7 @@ jobs:
           path: wasi-testsuite
 
       - name: Initialize Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11' # latest version of python 3
           cache: pip
@@ -201,16 +201,16 @@ jobs:
 
     steps:
       - id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout wazero
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Go test binaries
         id: cache-go-test-binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path:
             ${{ env.STDLIB_TESTS }}/testdata/go
@@ -252,13 +252,13 @@ jobs:
 
     steps:
       - name: Checkout wazero
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ defaults:
     shell: bash
 
 env:  # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   ZIG_VERSION: "0.11.0"
   BINARYEN_VERSION: "116"
   STDLIB_TESTS: "internal/integration_test/stdlibs"
@@ -196,8 +196,8 @@ jobs:
           name: Windows
           arch: amd64
         go-version:
+          - "1.26"
           - "1.25"
-          - "1.24"
 
     steps:
       - id: setup-go

--- a/.github/workflows/internal-images.yml
+++ b/.github/workflows/internal-images.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Same as doing this locally: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_TOKEN}" --password-stdin
       - name: "Login into GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
     tags: 'v[0-9]+.[0-9]+.[0-9]+**'  # Ex. v0.2.0 v0.2.1-rc2
 
 env: # Update this prior to requiring a higher minor version in go.mod
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 defaults:
   run:  # use bash for all operating systems unless overridden

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,14 +30,14 @@ jobs:
     outputs:
       VERSION: ${{ steps.output-version.outputs.VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           cache: false
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/go/pkg/mod
@@ -72,7 +72,7 @@ jobs:
       # Downside of this is that, we pressure the cache capacity set per repository. We delete all caches created
       # on PRs on close. See .github/workflows/clear_cache.yaml. On main branch, in any way this cache will be deleted
       # in 7 days, also this at most a few MB, so this won't be an issue.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           # Use share the cache containing archives across OSes.
@@ -93,9 +93,9 @@ jobs:
         os: [ubuntu-24.04, macos-14, windows-2025]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           # We need this cache to run tests.
@@ -135,11 +135,11 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:  # Ensure release_notes.sh can see prior commits
           fetch-depth: 0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           fail-on-cache-miss: true

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ OpenBSD, DragonFly BSD, illumos and Solaris.
 We also test cross compilation for many `GOOS` and `GOARCH` combinations.
 
 * Interpreter
-  * Linux is tested on amd64 and arm64 (native) as well as riscv64 via emulation.
+  * Linux is tested on amd64, arm64 and riscv64.
   * Windows, FreeBSD, NetBSD, OpenBSD, DragonFly BSD, illumos and Solaris are
     tested only on amd64.
   * macOS is tested only on arm64.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/tetratelabs/wazero
 
 // Floor Go version of wazero (current - 1)
-go 1.24.0
+go 1.25.0
 
 // All the beta tags are retracted and replaced with "pre" to prevent users
 // from accidentally upgrading into the broken beta 1.
@@ -12,4 +12,4 @@ retract (
 	v1.0.0-beta.1
 )
 
-require golang.org/x/sys v0.41.0
+require golang.org/x/sys v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/integration_test/fuzz/go.mod
+++ b/internal/integration_test/fuzz/go.mod
@@ -1,9 +1,9 @@
 module github.com/tetratelabs/wazero/internal/integration_test/fuzz
 
-go 1.24.0
+go 1.25.0
 
 require github.com/tetratelabs/wazero v0.0.0
 
-require golang.org/x/sys v0.41.0 // indirect
+require golang.org/x/sys v0.43.0 // indirect
 
 replace github.com/tetratelabs/wazero => ../../../

--- a/internal/integration_test/fuzz/go.sum
+++ b/internal/integration_test/fuzz/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/platform/cpuid_arm64.go
+++ b/internal/platform/cpuid_arm64.go
@@ -1,19 +1,12 @@
 package platform
 
-import (
-	"runtime"
-
-	"golang.org/x/sys/cpu"
-)
+import "golang.org/x/sys/cpu"
 
 // CpuFeatures exposes the capabilities for this CPU, queried via the Has method.
 var CpuFeatures = loadCpuFeatureFlags()
 
 func loadCpuFeatureFlags() (flags CpuFeatureFlags) {
-	if cpu.ARM64.HasATOMICS || runtime.GOOS == "darwin" {
-		// macOS does not allow userland to read the instruction set attribute registers,
-		// but all M-series SoCs support LSE (atomics); some A-series SoCs don't,
-		// but then runtime.GOOS is "ios".
+	if cpu.ARM64.HasATOMICS {
 		flags |= CpuFeatureArm64Atomic
 	}
 	return

--- a/internal/platform/cpuid_arm64.go
+++ b/internal/platform/cpuid_arm64.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package platform
 
 import "golang.org/x/sys/cpu"

--- a/internal/platform/cpuid_arm64_windows.go
+++ b/internal/platform/cpuid_arm64_windows.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package platform
+
+import "golang.org/x/sys/windows"
+
+// CpuFeatures exposes the capabilities for this CPU, queried via the Has method.
+var CpuFeatures = loadCpuFeatureFlags()
+
+func loadCpuFeatureFlags() (flags CpuFeatureFlags) {
+	// See: go.dev/cl/757482
+	// golang.org/x/sys/cpu can't import golang.org/x/sys/windows and can't do this yet.
+	if windows.IsProcessorFeaturePresent(windows.PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) {
+		flags |= CpuFeatureArm64Atomic
+	}
+	return
+}

--- a/internal/platform/cpuid_windows_arm64.go
+++ b/internal/platform/cpuid_windows_arm64.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package platform
 
 import "golang.org/x/sys/windows"

--- a/internal/version/testdata/go.mod
+++ b/internal/version/testdata/go.mod
@@ -1,9 +1,9 @@
 module github.com/tetratelabs/wazero/internal/version/testdata
 
-go 1.24.0
+go 1.25.0
 
 require github.com/tetratelabs/wazero v0.0.0-20220818123113-1948909ec0b1
 
-require golang.org/x/sys v0.41.0 // indirect
+require golang.org/x/sys v0.43.0 // indirect
 
 replace github.com/tetratelabs/wazero => ../../..

--- a/internal/version/testdata/go.sum
+++ b/internal/version/testdata/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
Also updates minimum Go to 1.25, as per the policy defined in #2434.