### PR TITLE
Fix fd_prestat_get integer overflow on 32-bit platforms

### DIFF
--- a/imports/wasi_snapshot_preview1/fs.go
+++ b/imports/wasi_snapshot_preview1/fs.go
@@ -616,7 +616,7 @@ func fdPrestatGetFn(_ context.Context, mod api.Module, params []uint64) experime
 
 	// Upper 32-bits are zero because...
 	// * Zero-value 8-bit tag, and 3-byte zero-value padding
-	prestat := uint64(len(name) << 32)
+	prestat := uint64(len(name)) << 32
 	if !mod.Memory().WriteUint64Le(resultPrestat, prestat) {
 		return experimentalsys.EFAULT
 	}


### PR DESCRIPTION
On 32-bit platforms (e.g., ARM/v7), len(name) returns a 32-bit int. The expression `uint64(len(name) << 32)` causes the shift to overflow to 0 before the uint64 cast, making fd_prestat_get report dir_name_len=0 for preopened directories. This breaks all WASI filesystem operations (mkdir, open, stat, etc.) with EBADF.

Fix: cast to uint64 before shifting — `uint64(len(name)) << 32`.

More: https://github.com/mimusic-org/mimusic/issues/29