### PR TITLE
arm64: fix relocation bug when number of args > 8

### DIFF
--- a/internal/engine/wazevo/backend/isa/arm64/machine.go
+++ b/internal/engine/wazevo/backend/isa/arm64/machine.go
@@ -370,14 +370,14 @@ func (m *machine) resolveAddressingMode(arg0offset, ret0offset int64, i *instruc
 
 // resolveRelativeAddresses resolves the relative addresses before encoding.
 func (m *machine) resolveRelativeAddresses(ctx context.Context) {
-	for {
-		if len(m.unresolvedAddressModes) > 0 {
-			arg0offset, ret0offset := m.arg0OffsetFromSP(), m.ret0OffsetFromSP()
-			for _, i := range m.unresolvedAddressModes {
-				m.resolveAddressingMode(arg0offset, ret0offset, i)
-			}
+	if len(m.unresolvedAddressModes) > 0 {
+		arg0offset, ret0offset := m.arg0OffsetFromSP(), m.ret0OffsetFromSP()
+		for _, i := range m.unresolvedAddressModes {
+			m.resolveAddressingMode(arg0offset, ret0offset, i)
 		}
-
+		m.unresolvedAddressModes = m.unresolvedAddressModes[:0]
+	}
+	for {
 		// Reuse the slice to gather the unresolved conditional branches.
 		m.condBrRelocs = m.condBrRelocs[:0]
 

--- a/internal/engine/wazevo/e2e_test.go
+++ b/internal/engine/wazevo/e2e_test.go
@@ -952,6 +952,13 @@ func TestE2E(t *testing.T) {
 				{params: []uint64{1}, expResults: []uint64{99}}, // tail-call path: return_call $target → 99
 			},
 		},
+		{
+			name: "large_method_body_many_args", m: testcases.LargeMethodBodyWithManyArgs.Module,
+			calls: []callCase{{
+				params:     []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+				expResults: []uint64{9},
+			}},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/engine/wazevo/testcases/testcases.go
+++ b/internal/engine/wazevo/testcases/testcases.go
@@ -1,8 +1,10 @@
 package testcases
 
 import (
+	"bytes"
 	"math"
 
+	"github.com/tetratelabs/wazero/internal/leb128"
 	"github.com/tetratelabs/wazero/internal/wasm"
 )
 
@@ -3086,6 +3088,41 @@ var TryTableCatchWithReturnCall = TestCase{
 			}},
 		},
 		ExportSection: []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 1}},
+	},
+}
+
+var LargeMethodBodyWithManyArgs = TestCase{
+	Name: "large_method_body_with_many_args",
+	Module: &wasm.Module{
+		TypeSection:     []wasm.FunctionType{{Params: []wasm.ValueType{i32, i32, i32, i32, i32, i32, i32, i32, i32}, Results: []wasm.ValueType{i32}}},
+		ExportSection:   []wasm.Export{{Name: ExportedFunctionName, Type: wasm.ExternTypeFunc, Index: 0}},
+		MemorySection:   &wasm.Memory{Min: 1},
+		FunctionSection: []wasm.Index{0},
+		CodeSection: []wasm.Code{{
+			Body: func() []byte {
+				var body bytes.Buffer
+				body.WriteByte(wasm.OpcodeLocalGet)
+				body.Write(leb128.EncodeUint32(8))
+				body.WriteByte(wasm.OpcodeIf)
+				body.WriteByte(blockSignature_vv)
+
+				for i := 0; i < 14000; i++ { // 14000 is an arbitrary number large enough to ensure that arm64 needs to introduce conditional branch trampolines
+					body.WriteByte(wasm.OpcodeI32Const)
+					body.Write(leb128.EncodeInt32(int32((i * 4) & 0xfffc))) // arbitrary constant that depends on the loop index
+					body.WriteByte(wasm.OpcodeLocalGet)
+					body.Write(leb128.EncodeUint32(8))
+					body.WriteByte(wasm.OpcodeI32Store)
+					body.WriteByte(2) // align (log2)
+					body.WriteByte(0) // offset
+				}
+				body.WriteByte(wasm.OpcodeEnd) // end if
+				body.WriteByte(wasm.OpcodeLocalGet)
+				body.Write(leb128.EncodeUint32(8))
+				body.WriteByte(wasm.OpcodeEnd) // end function
+
+				return body.Bytes()
+			}(),
+		}},
 	},
 }
 


### PR DESCRIPTION
On ARM64, when there were more than 8 parameters, and conditional branch trampolines needed to be inserted in a method body, resolveAddressingMode would be called multiple times, resulting in a panic when an already resolved addressing mode was re-resolved.

Move the addressing mode resolution out of the conditional branch loop to resolve.