### PR TITLE
fix: compilation cache should store catch clause table (EH)

### DIFF
--- a/internal/engine/wazevo/engine_cache.go
+++ b/internal/engine/wazevo/engine_cache.go
@@ -182,6 +182,16 @@ func serializeCompiledModule(wazeroVersion string, cm *compiledModule) io.Reader
 	} else {
 		buf.WriteByte(0) // indicates that source map is not present.
 	}
+	// Catch clause table: number of try_tables (4 bytes), then for each:
+	//   clause count (4 bytes), then for each clause: kind (1 byte) + tagIndex (4 bytes).
+	buf.Write(u32.LeBytes(uint32(len(cm.catchClauseTable))))
+	for _, clauses := range cm.catchClauseTable {
+		buf.Write(u32.LeBytes(uint32(len(clauses))))
+		for _, c := range clauses {
+			buf.WriteByte(c.Kind)
+			buf.Write(u32.LeBytes(c.TagIndex))
+		}
+	}
 	return bytes.NewReader(buf.Bytes())
 }
 
@@ -289,6 +299,32 @@ func deserializeCompiledModule(wazeroVersion string, reader io.ReadCloser) (cm *
 			sm.wasmBinaryOffsets = append(sm.wasmBinaryOffsets, wasmBinaryOffset)
 			// executableOffsets is absolute address, so we need to add executableOffset.
 			sm.executableOffsets = append(sm.executableOffsets, uintptr(executableRelativeOffset)+executableOffset)
+		}
+	}
+	// Catch clause table.
+	if _, err = io.ReadFull(reader, eightBytes[:4]); err != nil {
+		// Treat old cache entries without catch clause data as stale (trigger recompile).
+		return nil, true, nil
+	}
+	tableLen := binary.LittleEndian.Uint32(eightBytes[:4])
+	if tableLen > 0 {
+		cm.catchClauseTable = make([][]wazevoapi.CatchClauseInstance, tableLen)
+		for i := uint32(0); i < tableLen; i++ {
+			if _, err = io.ReadFull(reader, eightBytes[:4]); err != nil {
+				return nil, false, fmt.Errorf("compilationcache: error reading catch clause count for try_table[%d]: %v", i, err)
+			}
+			clauseCount := binary.LittleEndian.Uint32(eightBytes[:4])
+			clauses := make([]wazevoapi.CatchClauseInstance, clauseCount)
+			for j := uint32(0); j < clauseCount; j++ {
+				if _, err = io.ReadFull(reader, eightBytes[:5]); err != nil {
+					return nil, false, fmt.Errorf("compilationcache: error reading catch clause[%d][%d]: %v", i, j, err)
+				}
+				clauses[j] = wazevoapi.CatchClauseInstance{
+					Kind:     eightBytes[0],
+					TagIndex: binary.LittleEndian.Uint32(eightBytes[1:5]),
+				}
+			}
+			cm.catchClauseTable[i] = clauses
 		}
 	}
 	return

--- a/internal/engine/wazevo/engine_cache_test.go
+++ b/internal/engine/wazevo/engine_cache_test.go
@@ -40,6 +40,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5},       // code.
 				crcf([]byte{1, 2, 3, 4, 5}), // crc for the code.
 				[]byte{0},                   // no source map.
+				u32.LeBytes(0),              // empty catch clause table.
 			),
 		},
 		{
@@ -57,6 +58,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5},       // code.
 				crcf([]byte{1, 2, 3, 4, 5}), // crc for the code.
 				[]byte{0},                   // no source map.
+				u32.LeBytes(0),              // empty catch clause table.
 			),
 		},
 		{
@@ -78,6 +80,7 @@ func TestSerializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5, 1, 2, 3},       // code.
 				crcf([]byte{1, 2, 3, 4, 5, 1, 2, 3}), // crc for the code.
 				[]byte{0},                            // no source map.
+				u32.LeBytes(0),                       // empty catch clause table.
 			),
 		},
 	}
@@ -153,6 +156,7 @@ func TestDeserializeCompiledModule(t *testing.T) {
 				[]byte{1, 2, 3, 4, 5},       // machine code.
 				crcf([]byte{1, 2, 3, 4, 5}), // machine code.
 				[]byte{0},                   // no source map.
+				u32.LeBytes(0),              // empty catch clause table.
 			),
 			expCompiledModule: &compiledModule{
 				executables:     &executables{executable: []byte{1, 2, 3, 4, 5}},
@@ -176,7 +180,8 @@ func TestDeserializeCompiledModule(t *testing.T) {
 				u64.LeBytes(10),                             // size.
 				[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},       // machine code.
 				crcf([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), // crc for machine code.
-				[]byte{0}, // no source map.
+				[]byte{0},      // no source map.
+				u32.LeBytes(0), // empty catch clause table.
 			),
 			importedFunctionCount: 1,
 			expCompiledModule: &compiledModule{
@@ -185,6 +190,23 @@ func TestDeserializeCompiledModule(t *testing.T) {
 			},
 			expStaleCache: false,
 			expErr:        "",
+		},
+		{
+			name: "old cache without catch clause table (stale)",
+			in: concat(
+				magic,
+				[]byte{byte(len(testVersion))},
+				[]byte(testVersion),
+				u32.LeBytes(1), // number of functions.
+				u64.LeBytes(0), // offset.
+				// Executable.
+				u64.LeBytes(5),              // size.
+				[]byte{1, 2, 3, 4, 5},       // machine code.
+				crcf([]byte{1, 2, 3, 4, 5}), // machine code.
+				[]byte{0},                   // no source map.
+				// no catch clause table — old format.
+			),
+			expStaleCache: true,
 		},
 		{
 			name: "reading executable offset",

--- a/internal/integration_test/engine/exceptions_test.go
+++ b/internal/integration_test/engine/exceptions_test.go
@@ -185,3 +185,63 @@ func testBrStaleHandler(t *testing.T, cfg wazero.RuntimeConfig) {
 	require.NoError(t, err)
 	require.Equal(t, int32(1), api.DecodeI32(res[0]))
 }
+
+// TestExceptionHandlingCompilationCache verifies that
+// the compilation cache round-trips the catchClauseTable correctly.
+func TestExceptionHandlingCompilationCache(t *testing.T) {
+	if !platform.CompilerSupported() {
+		t.Skip()
+	}
+
+	cacheDir := t.TempDir()
+
+	for _, tc := range []struct {
+		name string
+		wasm []byte
+		fn   string
+		args []uint64
+		want int32
+	}{
+		{"cross_frame_catch", ehCrossCallnativeWasm, "test_cross_frame_catch", nil, 1},
+		{"pdfium_rethrow", ehPdfiumWasm, "test_one_level_rethrow", nil, 1},
+		{"br_exits_try_table", ehBrOrphanWasm, "test", nil, 1},
+		{"br_stale_handler", ehBrStaleHandlerWasm, "test", nil, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// First: compile fresh and populate the file cache.
+			cache1, err := wazero.NewCompilationCacheWithDir(cacheDir)
+			require.NoError(t, err)
+			cfg1 := wazero.NewRuntimeConfigCompiler().
+				WithCoreFeatures(api.CoreFeaturesV2 | experimental.CoreFeaturesExceptionHandling).
+				WithCompilationCache(cache1)
+			r1 := wazero.NewRuntimeWithConfig(ctx, cfg1)
+			mod1, err := r1.InstantiateWithConfig(ctx, tc.wasm,
+				wazero.NewModuleConfig().WithStartFunctions())
+			require.NoError(t, err)
+			res, err := mod1.ExportedFunction(tc.fn).Call(ctx, tc.args...)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, api.DecodeI32(res[0]))
+			r1.Close(ctx)
+			cache1.Close(ctx)
+
+			// Second: new runtime loading from file cache.
+			// Without the fix, catchClauseTable is empty → panic.
+			cache2, err := wazero.NewCompilationCacheWithDir(cacheDir)
+			require.NoError(t, err)
+			cfg2 := wazero.NewRuntimeConfigCompiler().
+				WithCoreFeatures(api.CoreFeaturesV2 | experimental.CoreFeaturesExceptionHandling).
+				WithCompilationCache(cache2)
+			r2 := wazero.NewRuntimeWithConfig(ctx, cfg2)
+			mod2, err := r2.InstantiateWithConfig(ctx, tc.wasm,
+				wazero.NewModuleConfig().WithStartFunctions())
+			require.NoError(t, err)
+			res, err = mod2.ExportedFunction(tc.fn).Call(ctx, tc.args...)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, api.DecodeI32(res[0]))
+			r2.Close(ctx)
+			cache2.Close(ctx)
+		})
+	}
+}


### PR DESCRIPTION
In #2489 we did not account for the compilation cache, so the new `catchClauseTable` was just being silently dropped!

Fixes #2496.

