### PR TITLE
fix: interpreter memory slicing overflow

### DIFF
--- a/internal/wasm/memory.go
+++ b/internal/wasm/memory.go
@@ -342,7 +342,7 @@ func (m *MemoryInstance) readUint32Le(offset uint32) (uint32, bool) {
 	if !m.hasSize(offset, 4) {
 		return 0, false
 	}
-	return binary.LittleEndian.Uint32(m.Buffer[offset : offset+4]), true
+	return binary.LittleEndian.Uint32(m.Buffer[offset:]), true
 }
 
 // readUint64Le implements ReadUint64Le without using a context. This is extracted as both ints and floats are stored in
@@ -351,7 +351,7 @@ func (m *MemoryInstance) readUint64Le(offset uint32) (uint64, bool) {
 	if !m.hasSize(offset, 8) {
 		return 0, false
 	}
-	return binary.LittleEndian.Uint64(m.Buffer[offset : offset+8]), true
+	return binary.LittleEndian.Uint64(m.Buffer[offset:]), true
 }
 
 // writeUint32Le implements WriteUint32Le without using a context. This is extracted as both ints and floats are stored


### PR DESCRIPTION
Upper bound could overflow to zero ever after `hasSize` check.

Issue only affects loads; tweaked code to match what's already done for stores.

Fixes: #2505